### PR TITLE
feat: add github label listeners

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { describe, expect, it, beforeEach } from "vitest";
 
 import { createApp } from "../../../app-factory";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -40,6 +40,7 @@ async function requestAuthorize(
 
 describe("GET /api/connectors/:type/authorize", () => {
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", BASE_URL);
     mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
     mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "test-client-secret");
     mockOptionalEnv("DOCUSIGN_OAUTH_CLIENT_ID", "docusign-test-client-id");

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -6,9 +6,12 @@ import {
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
@@ -17,7 +20,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
@@ -1170,6 +1173,7 @@ describe("GET /api/connectors/:type/callback", () => {
   let restoreDynamicTestOAuthExchange: (() => void) | undefined;
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", BASE_URL);
     mockOAuthEnv();
   });
 
@@ -1183,8 +1187,12 @@ describe("GET /api/connectors/:type/callback", () => {
     while (orgIds.length > 0) {
       const orgId = orgIds.pop();
       if (orgId) {
+        await db
+          .delete(githubInstallations)
+          .where(eq(githubInstallations.orgId, orgId));
         await db.delete(connectors).where(eq(connectors.orgId, orgId));
         await db.delete(secrets).where(eq(secrets.orgId, orgId));
+        await db.delete(agentComposes).where(eq(agentComposes.orgId, orgId));
       }
     }
     while (sessionIds.length > 0) {
@@ -1410,7 +1418,7 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
-  it("uses the web rewrite origin for callback error redirects", async () => {
+  it("uses VM0_WEB_URL for callback error redirects", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
@@ -1430,7 +1438,7 @@ describe("GET /api/connectors/:type/callback", () => {
     const location = response.headers.get("location");
     expect(location).not.toBeNull();
     const url = new URL(location!);
-    expect(url.origin).toBe(WEB_ORIGIN);
+    expect(url.origin).toBe(BASE_URL);
     expect(url.pathname).toBe("/connector/error");
     expect(url.searchParams.get("type")).toBe("github");
     expect(url.searchParams.get("message")).toBe(
@@ -1554,6 +1562,60 @@ describe("GET /api/connectors/:type/callback", () => {
       .where(eq(connectorSessions.id, sessionId));
     expect(session?.status).toBe("complete");
     expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("links a GitHub integration after GitHub connector OAuth completes", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const db = store.set(writeDb$);
+    const composeId = randomUUID();
+    await db.insert(agentComposes).values({
+      id: composeId,
+      orgId,
+      userId,
+      name: `github-callback-${composeId}`,
+    });
+    const [installation] = await db
+      .insert(githubInstallations)
+      .values({
+        installationId: "123456789",
+        status: "active",
+        orgId,
+        targetType: "Organization",
+        targetId: "98765",
+        targetName: "vm0-test",
+        defaultComposeId: composeId,
+      })
+      .returning({ id: githubInstallations.id });
+    if (!installation) {
+      throw new Error("Expected GitHub installation insert to return a row");
+    }
+    mockGitHubOAuth({
+      accessToken: "github-token",
+      userId: 98_765,
+      username: "octocat",
+      email: "octocat@example.com",
+    });
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expect(response.status).toBe(307);
+    const links = await db
+      .select()
+      .from(githubUserLinks)
+      .where(
+        and(
+          eq(githubUserLinks.installationId, installation.id),
+          eq(githubUserLinks.vm0UserId, userId),
+        ),
+      );
+    expect(links).toMatchObject([{ githubUserId: "98765" }]);
   });
 
   it("stores a connector from a server-side OAuth handoff without Clerk cookies", async () => {
@@ -1958,7 +2020,7 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
-  it("uses the web rewrite origin for token exchange and success redirects", async () => {
+  it("uses VM0_WEB_URL for token exchange and success redirects", async () => {
     const dynamicOAuth = useDynamicTestOAuthExchange();
     restoreDynamicTestOAuthExchange = dynamicOAuth.restore;
     const { exchanges } = dynamicOAuth;
@@ -1982,12 +2044,12 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(response.status).toBe(307);
     expect(exchanges).toHaveLength(1);
     expect(exchanges[0]?.redirectUri).toBe(
-      `${WEB_ORIGIN}/api/connectors/test-oauth/callback`,
+      `${BASE_URL}/api/connectors/test-oauth/callback`,
     );
     const location = response.headers.get("location");
     expect(location).not.toBeNull();
     const url = new URL(location!);
-    expect(url.origin).toBe(WEB_ORIGIN);
+    expect(url.origin).toBe(BASE_URL);
     expect(url.pathname).toBe("/connector/success");
     expect(url.searchParams.get("type")).toBe("test-oauth");
     expect(url.searchParams.get("username")).toBe("dynamic-user");

--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -663,6 +663,39 @@ describe("GitHub OAuth API routes", () => {
     expect(linkedInstallation?.status).toBe("active");
   });
 
+  it("does not link an installation that belongs to another organization", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const otherFixture = await seedComposeFixture(cleanup);
+    await seedOrgMembership({ fixture, role: "admin" });
+    const installationId = "987654322";
+    const githubUserId = newGithubUserId();
+    await seedGithubConnector({ fixture, githubUserId });
+    await store.set(writeDb$).insert(githubInstallations).values({
+      installationId,
+      status: "active",
+      orgId: otherFixture.orgId,
+      adminGithubUserId: null,
+      defaultComposeId: otherFixture.composeId,
+    });
+    cleanup.installationIds.push(installationId);
+    mockGitHubInstallationsList([
+      {
+        id: installationId,
+        targetId: newGithubUserId(),
+      },
+    ]);
+
+    const response = await appRequest(
+      `/api/github/oauth/install?vm0UserId=${fixture.userId}&orgId=${fixture.orgId}&composeId=${fixture.composeId}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe("https://github.com");
+    expect(location.pathname).toBe(`/apps/${APP_SLUG}/installations/new`);
+    await expect(findLinksForUser(fixture.userId)).resolves.toHaveLength(0);
+  });
+
   it("creates and links a missing local installation during install from GitHub API data", async () => {
     const fixture = await seedComposeFixture(cleanup);
     await seedOrgMembership({ fixture, role: "admin" });

--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -10,12 +10,14 @@ import { createStore } from "ccstate";
 import { connectors } from "@vm0/db/schema/connector";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { eq, inArray } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
 
 import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
@@ -31,6 +33,12 @@ const APP_ID = "123456";
 const APP_SLUG = "vm0-test";
 const API_ORIGIN = "https://api.vm0.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
+const APP_ORIGIN = "https://app.vm0.ai";
+const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
+const GITHUB_APP_CLIENT_ID = "github-app-client-id";
+const GITHUB_APP_CLIENT_SECRET = "github-app-client-secret";
+const GH_OAUTH_CLIENT_ID = "github-oauth-client-id";
+const GH_OAUTH_CLIENT_SECRET = "github-oauth-client-secret";
 const TARGET_LOGIN = "test-org";
 const TARGET_TYPE = "Organization";
 
@@ -68,6 +76,7 @@ function mockGithubAppEnv(
   args: {
     readonly slug?: boolean;
     readonly credentials?: boolean;
+    readonly oauthCredentials?: boolean;
   } = {},
 ): void {
   if (args.slug !== false) {
@@ -82,6 +91,31 @@ function mockGithubAppEnv(
     mockOptionalEnv("GITHUB_APP_ID", undefined);
     mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", undefined);
   }
+  if (args.oauthCredentials !== false) {
+    mockOptionalEnv("GITHUB_APP_CLIENT_ID", GITHUB_APP_CLIENT_ID);
+    mockOptionalEnv("GITHUB_APP_CLIENT_SECRET", GITHUB_APP_CLIENT_SECRET);
+  } else {
+    mockOptionalEnv("GITHUB_APP_CLIENT_ID", undefined);
+    mockOptionalEnv("GITHUB_APP_CLIENT_SECRET", undefined);
+  }
+}
+
+function mockGithubUserOauthEnv(): void {
+  mockOptionalEnv("GH_OAUTH_CLIENT_ID", GH_OAUTH_CLIENT_ID);
+  mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", GH_OAUTH_CLIENT_SECRET);
+}
+
+function mockSession(
+  userId: string,
+  orgId: string,
+  orgRole: "org:admin" | "org:member" = "org:admin",
+): void {
+  context.mocks.clerk.authenticateRequest.mockResolvedValue({
+    isAuthenticated: true,
+    toAuth: () => {
+      return { userId, orgId, orgRole };
+    },
+  });
 }
 
 function newGithubUserId(): string {
@@ -132,6 +166,38 @@ function buildSignedState(args: {
   return JSON.stringify({
     vm0UserId: args.userId,
     composeId: args.composeId,
+    sig,
+  });
+}
+
+function buildSignedOrgState(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly composeId: string;
+}): string {
+  const payload = `${args.userId}:${args.orgId}:${args.composeId}`;
+  const sig = createHmac("sha256", "a".repeat(64))
+    .update(payload)
+    .digest("hex");
+  return JSON.stringify({
+    vm0UserId: args.userId,
+    orgId: args.orgId,
+    composeId: args.composeId,
+    sig,
+  });
+}
+
+function buildUserConnectState(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const payload = `${args.userId}:${args.orgId}:`;
+  const sig = createHmac("sha256", "a".repeat(64))
+    .update(payload)
+    .digest("hex");
+  return JSON.stringify({
+    vm0UserId: args.userId,
+    orgId: args.orgId,
     sig,
   });
 }
@@ -211,6 +277,63 @@ async function seedGithubConnector(args: {
   });
 }
 
+async function seedOrgMembership(args: {
+  readonly fixture: ComposeFixture;
+  readonly role: "admin" | "member";
+}): Promise<void> {
+  await store.set(writeDb$).insert(orgMembersCache).values({
+    orgId: args.fixture.orgId,
+    userId: args.fixture.userId,
+    role: args.role,
+    cachedAt: nowDate(),
+  });
+}
+
+function mockGithubUserOAuth(args: {
+  readonly code: string;
+  readonly accessToken?: string;
+  readonly expectedClientId?: string;
+  readonly expectedClientSecret?: string;
+  readonly expectedRedirectUri?: string | null;
+  readonly githubUserId: string;
+  readonly login?: string;
+}): void {
+  server.use(
+    http.post("https://github.com/login/oauth/access_token", async (info) => {
+      const body = new URLSearchParams(await info.request.text());
+      expect(body.get("client_id")).toBe(
+        args.expectedClientId ?? GH_OAUTH_CLIENT_ID,
+      );
+      expect(body.get("client_secret")).toBe(
+        args.expectedClientSecret ?? GH_OAUTH_CLIENT_SECRET,
+      );
+      expect(body.get("code")).toBe(args.code);
+      if (args.expectedRedirectUri === null) {
+        expect(body.has("redirect_uri")).toBeFalsy();
+      } else {
+        expect(body.get("redirect_uri")).toBe(
+          args.expectedRedirectUri ??
+            `${WEB_ORIGIN}/api/zero/github/oauth/connect/callback`,
+        );
+      }
+      return HttpResponse.json({
+        access_token: args.accessToken ?? "gho_user_oauth_token",
+        scope: "repo,project,workflow",
+      });
+    }),
+    http.get("https://api.github.com/user", ({ request }) => {
+      expect(request.headers.get("authorization")).toBe(
+        `Bearer ${args.accessToken ?? "gho_user_oauth_token"}`,
+      );
+      return HttpResponse.json({
+        id: Number(args.githubUserId),
+        login: args.login ?? "octocat",
+        email: null,
+      });
+    }),
+  );
+}
+
 async function findInstallationByRemoteId(installationId: string) {
   return await store
     .set(writeDb$)
@@ -240,7 +363,10 @@ describe("GitHub OAuth API routes", () => {
 
   beforeEach(() => {
     mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
+    mockEnv("APP_URL", APP_ORIGIN);
     mockGithubAppEnv();
+    mockGithubUserOauthEnv();
   });
 
   afterEach(async () => {
@@ -273,6 +399,9 @@ describe("GitHub OAuth API routes", () => {
     while (cleanup.composeFixtures.length > 0) {
       const fixture = cleanup.composeFixtures.pop();
       if (fixture) {
+        await db
+          .delete(orgMembersCache)
+          .where(eq(orgMembersCache.orgId, fixture.orgId));
         await store.set(
           deleteUsageInsightFixture$,
           { orgId: fixture.orgId, userId: fixture.userId },
@@ -298,7 +427,7 @@ describe("GitHub OAuth API routes", () => {
     expect(location.origin).toBe("https://github.com");
     expect(location.pathname).toBe(`/apps/${APP_SLUG}/installations/new`);
     expect(location.searchParams.get("redirect_uri")).toBe(
-      "http://localhost:3000/api/github/oauth/callback",
+      `${WEB_ORIGIN}${GITHUB_APP_SETUP_CALLBACK_PATH}`,
     );
     const state = JSON.parse(location.searchParams.get("state")!) as {
       readonly vm0UserId: string;
@@ -330,7 +459,7 @@ describe("GitHub OAuth API routes", () => {
     expect(response.status).toBe(307);
     const location = new URL(response.headers.get("location")!);
     expect(location.searchParams.get("redirect_uri")).toBe(
-      `${WEB_ORIGIN}/api/github/oauth/callback`,
+      `${WEB_ORIGIN}${GITHUB_APP_SETUP_CALLBACK_PATH}`,
     );
   });
 
@@ -346,7 +475,7 @@ describe("GitHub OAuth API routes", () => {
     expect(response.status).toBe(307);
     const location = new URL(response.headers.get("location")!);
     expect(location.searchParams.get("redirect_uri")).toBe(
-      "http://localhost:3000/api/github/oauth/callback",
+      `${WEB_ORIGIN}${GITHUB_APP_SETUP_CALLBACK_PATH}`,
     );
   });
 
@@ -370,8 +499,118 @@ describe("GitHub OAuth API routes", () => {
     expect(location.origin).toBe("https://github.com");
     expect(location.searchParams.has("state")).toBeFalsy();
     expect(location.searchParams.get("redirect_uri")).toBe(
-      "http://localhost:3000/api/github/oauth/callback",
+      `${WEB_ORIGIN}${GITHUB_APP_SETUP_CALLBACK_PATH}`,
     );
+  });
+
+  it("starts GitHub user OAuth for integration account linking", async () => {
+    mockSession("user-1", "org-1");
+
+    const response = await appRequest("/api/zero/github/oauth/connect", {
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(WEB_ORIGIN);
+    expect(location.pathname).toBe("/api/zero/connectors/github/authorize");
+  });
+
+  it("links a GitHub integration user from OAuth and connects the GitHub connector", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const githubUserId = newGithubUserId();
+    const [installation] = await store
+      .set(writeDb$)
+      .insert(githubInstallations)
+      .values({
+        installationId: "987650001",
+        status: "active",
+        orgId: fixture.orgId,
+        defaultComposeId: fixture.composeId,
+      })
+      .returning({ id: githubInstallations.id });
+    expect(installation).toBeDefined();
+    cleanup.installationRowIds.push(installation!.id);
+    const state = buildUserConnectState({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    mockGithubUserOAuth({ code: "oauth-code-1", githubUserId });
+
+    const response = await appRequest(
+      `/api/zero/github/oauth/connect/callback?code=oauth-code-1&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.get("github")).toBe("connected");
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.githubUserId).toBe(githubUserId);
+    const connectorRows = await store
+      .set(writeDb$)
+      .select()
+      .from(connectors)
+      .where(eq(connectors.userId, fixture.userId));
+    expect(connectorRows).toHaveLength(1);
+    expect(connectorRows[0]).toMatchObject({
+      type: "github",
+      authMethod: "oauth",
+      externalId: githubUserId,
+      externalUsername: "octocat",
+      oauthScopes: JSON.stringify(["repo", "project", "workflow"]),
+    });
+  });
+
+  it("updates an existing GitHub connector after integration OAuth reconnect", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const oldGithubUserId = newGithubUserId();
+    const nextGithubUserId = newGithubUserId();
+    await seedGithubConnector({ fixture, githubUserId: oldGithubUserId });
+    const [installation] = await store
+      .set(writeDb$)
+      .insert(githubInstallations)
+      .values({
+        installationId: "987650002",
+        status: "active",
+        orgId: fixture.orgId,
+        defaultComposeId: fixture.composeId,
+      })
+      .returning({ id: githubInstallations.id });
+    expect(installation).toBeDefined();
+    cleanup.installationRowIds.push(installation!.id);
+    const state = buildUserConnectState({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    mockGithubUserOAuth({
+      code: "oauth-code-2",
+      githubUserId: nextGithubUserId,
+    });
+
+    const response = await appRequest(
+      `/api/zero/github/oauth/connect/callback?code=oauth-code-2&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const connectorRows = await store
+      .set(writeDb$)
+      .select()
+      .from(connectors)
+      .where(eq(connectors.userId, fixture.userId));
+    expect(connectorRows).toHaveLength(1);
+    expect(connectorRows[0]).toMatchObject({
+      type: "github",
+      authMethod: "oauth",
+      externalId: nextGithubUserId,
+      externalUsername: "octocat",
+      oauthScopes: JSON.stringify(["repo", "project", "workflow"]),
+    });
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.githubUserId).toBe(nextGithubUserId);
   });
 
   it("returns 503 when GitHub App slug is not configured", async () => {
@@ -387,6 +626,7 @@ describe("GitHub OAuth API routes", () => {
 
   it("links a local active installation during install", async () => {
     const fixture = await seedComposeFixture(cleanup);
+    await seedOrgMembership({ fixture, role: "admin" });
     const githubUserId = newGithubUserId();
     await seedGithubConnector({ fixture, githubUserId });
     const [installation] = await store
@@ -409,6 +649,7 @@ describe("GitHub OAuth API routes", () => {
 
     expect(response.status).toBe(307);
     const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
     expect(location.pathname).toBe("/works");
     expect(location.searchParams.get("github")).toBe("connected");
     const links = await findLinksForUser(fixture.userId);
@@ -424,6 +665,7 @@ describe("GitHub OAuth API routes", () => {
 
   it("creates and links a missing local installation during install from GitHub API data", async () => {
     const fixture = await seedComposeFixture(cleanup);
+    await seedOrgMembership({ fixture, role: "admin" });
     const installationId = "123450001";
     const targetId = newGithubUserId();
     cleanup.installationIds.push(installationId);
@@ -455,11 +697,28 @@ describe("GitHub OAuth API routes", () => {
     expect(links).toHaveLength(1);
   });
 
+  it("rejects GitHub app install for org members", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    await seedOrgMembership({ fixture, role: "member" });
+
+    const response = await appRequest(
+      `/api/github/oauth/install?vm0UserId=${fixture.userId}&orgId=${fixture.orgId}&composeId=${fixture.composeId}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.get("error")).toBe(
+      "Only organization admins can install GitHub",
+    );
+  });
+
   it("redirects callback with an error when app credentials are missing", async () => {
     mockOptionalEnv("GITHUB_APP_ID", undefined);
     mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", undefined);
 
-    const response = await appRequest("/api/github/oauth/callback");
+    const response = await appRequest(GITHUB_APP_SETUP_CALLBACK_PATH);
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
@@ -471,18 +730,19 @@ describe("GitHub OAuth API routes", () => {
 
   it("redirects callback update actions without an error", async () => {
     const response = await appRequest(
-      "/api/github/oauth/callback?installation_id=12345&setup_action=update",
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=12345&setup_action=update`,
     );
 
     expect(response.status).toBe(307);
-    const location = response.headers.get("location");
-    expect(location).toContain("/works");
-    expect(location).not.toContain("error=");
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.get("github")).toBe("installed");
+    expect(location.searchParams.has("error")).toBeFalsy();
   });
 
   it("redirects direct API host callback requests to the canonical web route", async () => {
-    const path =
-      "/api/github/oauth/callback?installation_id=12345&setup_action=update";
+    const path = `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=12345&setup_action=update`;
     const response = await appRequest(path, { origin: API_ORIGIN });
 
     expect(response.status).toBe(307);
@@ -492,7 +752,7 @@ describe("GitHub OAuth API routes", () => {
 
   it("redirects callback with an error for invalid JSON state", async () => {
     const response = await appRequest(
-      "/api/github/oauth/callback?installation_id=12345&setup_action=install&state=not-json",
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=12345&setup_action=install&state=not-json`,
     );
 
     expect(response.status).toBe(307);
@@ -509,7 +769,7 @@ describe("GitHub OAuth API routes", () => {
     });
 
     const response = await appRequest(
-      `/api/github/oauth/callback?installation_id=12345&setup_action=install&state=${encodeURIComponent(state)}`,
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=12345&setup_action=install&state=${encodeURIComponent(state)}`,
     );
 
     expect(response.status).toBe(307);
@@ -520,7 +780,7 @@ describe("GitHub OAuth API routes", () => {
 
   it("redirects callback with an error when no default compose is configured", async () => {
     const response = await appRequest(
-      "/api/github/oauth/callback?installation_id=12345&setup_action=install",
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=12345&setup_action=install`,
     );
 
     expect(response.status).toBe(307);
@@ -539,11 +799,14 @@ describe("GitHub OAuth API routes", () => {
     });
 
     const response = await appRequest(
-      `/api/github/oauth/callback?setup_action=request&target_id=${targetId}&target_type=Organization&state=${encodeURIComponent(state)}`,
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?setup_action=request&target_id=${targetId}&target_type=Organization&state=${encodeURIComponent(state)}`,
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toContain("/works?github=pending");
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.get("github")).toBe("pending");
     const installations = await findInstallationByTargetId(targetId);
     expect(installations).toHaveLength(1);
     expect(installations[0]).toMatchObject({
@@ -565,7 +828,7 @@ describe("GitHub OAuth API routes", () => {
     });
 
     const response = await appRequest(
-      `/api/github/oauth/callback?setup_action=install&state=${encodeURIComponent(state)}`,
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?setup_action=install&state=${encodeURIComponent(state)}`,
     );
 
     expect(response.status).toBe(307);
@@ -591,13 +854,14 @@ describe("GitHub OAuth API routes", () => {
     });
 
     const response = await appRequest(
-      `/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
     );
 
     expect(response.status).toBe(307);
-    const location = response.headers.get("location");
-    expect(location).toContain("/works");
-    expect(location).not.toContain("error=");
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.has("error")).toBeFalsy();
     const installations = await findInstallationByRemoteId(installationId);
     expect(installations).toHaveLength(1);
     expect(installations[0]).toMatchObject({
@@ -615,6 +879,63 @@ describe("GitHub OAuth API routes", () => {
     const links = await findLinksForUser(fixture.userId);
     expect(links).toHaveLength(1);
     expect(links[0]!.githubUserId).toBe(targetId);
+  });
+
+  it("connects the installing user when setup callback includes an OAuth code", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    await seedOrgMembership({ fixture, role: "admin" });
+    const installationId = "223344557";
+    const targetId = "112233446";
+    const githubUserId = newGithubUserId();
+    cleanup.installationIds.push(installationId);
+    mockGitHubInstallation({
+      installationId,
+      targetId,
+      token: "ghs_setup_code_installation_token",
+    });
+    mockGithubUserOAuth({
+      code: "setup-oauth-code-1",
+      githubUserId,
+      expectedClientId: GITHUB_APP_CLIENT_ID,
+      expectedClientSecret: GITHUB_APP_CLIENT_SECRET,
+      expectedRedirectUri: null,
+    });
+    const state = buildSignedOrgState({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      composeId: fixture.composeId,
+    });
+
+    const response = await appRequest(
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=${installationId}&setup_action=install&code=setup-oauth-code-1&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe(APP_ORIGIN);
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.get("github")).toBe("connected");
+    const installations = await findInstallationByRemoteId(installationId);
+    expect(installations).toHaveLength(1);
+    expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
+      "ghs_setup_code_installation_token",
+    );
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.githubUserId).toBe(githubUserId);
+    const connectorRows = await store
+      .set(writeDb$)
+      .select()
+      .from(connectors)
+      .where(eq(connectors.userId, fixture.userId));
+    expect(connectorRows).toHaveLength(1);
+    expect(connectorRows[0]).toMatchObject({
+      type: "github",
+      authMethod: "oauth",
+      externalId: githubUserId,
+      externalUsername: "octocat",
+      oauthScopes: JSON.stringify(["repo", "project", "workflow"]),
+    });
   });
 
   it("reuses an existing installation during callback", async () => {
@@ -641,7 +962,7 @@ describe("GitHub OAuth API routes", () => {
     });
 
     const response = await appRequest(
-      `/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
     );
 
     expect(response.status).toBe(307);
@@ -671,7 +992,7 @@ describe("GitHub OAuth API routes", () => {
     );
 
     const response = await appRequest(
-      `/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
+      `${GITHUB_APP_SETUP_CALLBACK_PATH}?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
     );
 
     expect(response.status).toBe(500);

--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -309,7 +309,7 @@ describe("GitHub OAuth API routes", () => {
     expect(state.composeId).toBe("compose-1");
     expect(state.sig).toBe(
       createHmac("sha256", "a".repeat(64))
-        .update("user-1:compose-1")
+        .update("user-1::compose-1")
         .digest("hex"),
     );
   });
@@ -395,6 +395,7 @@ describe("GitHub OAuth API routes", () => {
       .values({
         installationId: "987654321",
         status: "active",
+        orgId: fixture.orgId,
         adminGithubUserId: null,
         defaultComposeId: fixture.composeId,
       })
@@ -403,13 +404,13 @@ describe("GitHub OAuth API routes", () => {
     cleanup.installationRowIds.push(installation!.id);
 
     const response = await appRequest(
-      `/api/github/oauth/install?vm0UserId=${fixture.userId}&composeId=${fixture.composeId}`,
+      `/api/github/oauth/install?vm0UserId=${fixture.userId}&orgId=${fixture.orgId}&composeId=${fixture.composeId}`,
     );
 
     expect(response.status).toBe(307);
     const location = new URL(response.headers.get("location")!);
-    expect(location.pathname).toBe("/settings");
-    expect(location.searchParams.get("tab")).toBe("integrations");
+    expect(location.pathname).toBe("/works");
+    expect(location.searchParams.get("github")).toBe("connected");
     const links = await findLinksForUser(fixture.userId);
     expect(links).toHaveLength(1);
     expect(links[0]!.githubUserId).toBe(githubUserId);
@@ -437,13 +438,11 @@ describe("GitHub OAuth API routes", () => {
     });
 
     const response = await appRequest(
-      `/api/github/oauth/install?vm0UserId=${fixture.userId}&composeId=${fixture.composeId}`,
+      `/api/github/oauth/install?vm0UserId=${fixture.userId}&orgId=${fixture.orgId}&composeId=${fixture.composeId}`,
     );
 
     expect(response.status).toBe(307);
-    expect(new URL(response.headers.get("location")!).pathname).toBe(
-      "/settings",
-    );
+    expect(new URL(response.headers.get("location")!).pathname).toBe("/works");
     const installations = await findInstallationByRemoteId(installationId);
     expect(installations).toHaveLength(1);
     expect(installations[0]!.defaultComposeId).toBe(fixture.composeId);
@@ -544,7 +543,7 @@ describe("GitHub OAuth API routes", () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toContain("/works?pending=true");
+    expect(response.headers.get("location")).toContain("/works?github=pending");
     const installations = await findInstallationByTargetId(targetId);
     expect(installations).toHaveLength(1);
     expect(installations[0]).toMatchObject({
@@ -553,6 +552,7 @@ describe("GitHub OAuth API routes", () => {
       status: "pending",
       targetId,
       targetType: "Organization",
+      orgId: fixture.orgId,
       defaultComposeId: fixture.composeId,
     });
   });
@@ -606,6 +606,7 @@ describe("GitHub OAuth API routes", () => {
       targetType: TARGET_TYPE,
       targetId,
       targetName: TARGET_LOGIN,
+      orgId: fixture.orgId,
       defaultComposeId: fixture.composeId,
     });
     expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
@@ -625,6 +626,7 @@ describe("GitHub OAuth API routes", () => {
       .values({
         installationId,
         status: "active",
+        orgId: fixture.orgId,
         targetType: TARGET_TYPE,
         targetId: "101010101",
         defaultComposeId: fixture.composeId,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-delete.test.ts
@@ -53,6 +53,7 @@ async function seedGithubInstallation(args: {
   readonly linkedGithubUserId?: string;
   readonly adminGithubUserId?: string | null;
   readonly remoteInstallationId?: string | null;
+  readonly link?: boolean;
 }): Promise<GithubInstallationFixture> {
   const orgId = `org_${randomUUID()}`;
   const userId = args.userId ?? `user_${randomUUID()}`;
@@ -79,11 +80,13 @@ async function seedGithubInstallation(args: {
     throw new Error("Expected GitHub installation insert to return a row");
   }
 
-  await db.insert(githubUserLinks).values({
-    githubUserId,
-    installationId: installation.id,
-    vm0UserId: userId,
-  });
+  if (args.link !== false) {
+    await db.insert(githubUserLinks).values({
+      githubUserId,
+      installationId: installation.id,
+      vm0UserId: userId,
+    });
+  }
 
   return { orgId, userId, installationRowId: installation.id };
 }
@@ -178,12 +181,34 @@ describe("DELETE /api/integrations/github", () => {
     await expect(
       installationExists(fixture.installationRowId),
     ).resolves.toBeFalsy();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "github:changed",
+      null,
+    );
   });
 
-  it("returns 403 and keeps the installation when adminGithubUserId is null", async () => {
-    const fixture = await seedGithubInstallation({ adminGithubUserId: null });
+  it("deletes the installation for an org admin before GitHub is connected", async () => {
+    const fixture = await seedGithubInstallation({ link: false });
     fixtures.push(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true });
+    await expect(
+      installationExists(fixture.installationRowId),
+    ).resolves.toBeFalsy();
+  });
+
+  it("returns 403 and keeps the installation for an org member when adminGithubUserId is null", async () => {
+    const fixture = await seedGithubInstallation({ adminGithubUserId: null });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const app = createApp({ signal: context.signal });
 
     const response = await app.request(ROUTE_PATH, {
@@ -194,7 +219,7 @@ describe("DELETE /api/integrations/github", () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "Only the installation admin can uninstall",
+        message: "Only organization admins can uninstall GitHub",
         code: "FORBIDDEN",
       },
     });
@@ -203,13 +228,30 @@ describe("DELETE /api/integrations/github", () => {
     ).resolves.toBeTruthy();
   });
 
-  it("returns 403 and keeps the installation when a non-admin user deletes", async () => {
+  it("returns 403 and keeps the installation when a non-admin org member deletes", async () => {
     const fixture = await seedGithubInstallation({
       adminGithubUserId: newGithubUserId(),
       linkedGithubUserId: newGithubUserId(),
     });
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(
+      installationExists(fixture.installationRowId),
+    ).resolves.toBeTruthy();
+  });
+
+  it("returns 403 when the GitHub installation admin is not an org admin", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const app = createApp({ signal: context.signal });
 
     const response = await app.request(ROUTE_PATH, {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-delete.test.ts
@@ -70,6 +70,7 @@ async function seedGithubInstallation(args: {
     .insert(githubInstallations)
     .values({
       installationId: args.remoteInstallationId ?? newRemoteInstallationId(),
+      orgId,
       adminGithubUserId,
       defaultComposeId: composeId,
     })
@@ -144,7 +145,7 @@ describe("DELETE /api/integrations/github", () => {
   });
 
   it("returns 404 when the authenticated user has no GitHub installation", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const app = createApp({ signal: context.signal });
 
     const response = await app.request(ROUTE_PATH, {
@@ -164,7 +165,7 @@ describe("DELETE /api/integrations/github", () => {
   it("deletes the linked admin installation and returns ok", async () => {
     const fixture = await seedGithubInstallation({});
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, null);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
     const app = createApp({ signal: context.signal });
 
     const response = await app.request(ROUTE_PATH, {
@@ -182,7 +183,7 @@ describe("DELETE /api/integrations/github", () => {
   it("returns 403 and keeps the installation when adminGithubUserId is null", async () => {
     const fixture = await seedGithubInstallation({ adminGithubUserId: null });
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, null);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
     const app = createApp({ signal: context.signal });
 
     const response = await app.request(ROUTE_PATH, {
@@ -208,7 +209,7 @@ describe("DELETE /api/integrations/github", () => {
       linkedGithubUserId: newGithubUserId(),
     });
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, null);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
     const app = createApp({ signal: context.signal });
 
     const response = await app.request(ROUTE_PATH, {
@@ -226,7 +227,7 @@ describe("DELETE /api/integrations/github", () => {
     const remoteInstallationId = newRemoteInstallationId();
     const fixture = await seedGithubInstallation({ remoteInstallationId });
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, null);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
     mockOptionalEnv("GITHUB_APP_ID", "123456");
     mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", newPrivateKeyBase64());
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
@@ -16,13 +16,16 @@ import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
 
 const context = testContext();
 const store = createStore();
 const writeDb = store.set(writeDb$);
 const WEB_ORIGIN = "https://www.vm0.ai";
+const GH_OAUTH_CLIENT_ID = "github-oauth-client-id";
+const GH_OAUTH_CLIENT_SECRET = "github-oauth-client-secret";
+const SECRETS_ENCRYPTION_KEY = "a".repeat(64);
 
 interface GithubFixture {
   readonly orgId: string;
@@ -41,10 +44,41 @@ interface SeedGithubFixtureOptions {
   readonly admin?: "matching" | "none" | "other";
   readonly composeName?: string;
   readonly content?: Record<string, unknown>;
+  readonly link?: boolean;
 }
 
 function authHeaders(): Record<string, string> {
   return { authorization: "Bearer clerk-session" };
+}
+
+function expectGithubInstallUrl(
+  installUrl: string | null,
+  fixture: DefaultAgentFixture,
+): void {
+  if (installUrl === null) {
+    throw new Error("Expected GitHub install URL");
+  }
+  const url = new URL(installUrl);
+  expect(url.origin).toBe("https://github.com");
+  expect(url.pathname).toBe("/apps/vm0-test/installations/new");
+  expect(url.searchParams.get("redirect_uri")).toBe(
+    `${WEB_ORIGIN}/api/github/app/setup/callback`,
+  );
+  expect(JSON.parse(url.searchParams.get("state") ?? "")).toMatchObject({
+    vm0UserId: fixture.userId,
+    orgId: fixture.orgId,
+    composeId: fixture.composeId,
+    sig: expect.any(String),
+  });
+}
+
+function expectGithubConnectUrl(
+  connectUrl: string,
+  _fixture: GithubFixture,
+): void {
+  const url = new URL(connectUrl);
+  expect(url.origin).toBe(WEB_ORIGIN);
+  expect(url.pathname).toBe("/api/zero/connectors/github/authorize");
 }
 
 function mockSession(
@@ -130,11 +164,13 @@ async function seedGithubFixture(
     throw new Error("Expected GitHub installation insert to return a row");
   }
 
-  await writeDb.insert(githubUserLinks).values({
-    githubUserId: linkedGithubUserId,
-    installationId: installation.id,
-    vm0UserId: userId,
-  });
+  if (options.link !== false) {
+    await writeDb.insert(githubUserLinks).values({
+      githubUserId: linkedGithubUserId,
+      installationId: installation.id,
+      vm0UserId: userId,
+    });
+  }
 
   return {
     orgId,
@@ -254,6 +290,11 @@ describe("GET /api/integrations/github", () => {
   const defaultAgentFixtures: DefaultAgentFixture[] = [];
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
+    mockEnv("SECRETS_ENCRYPTION_KEY", SECRETS_ENCRYPTION_KEY);
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", GH_OAUTH_CLIENT_ID);
+    mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", GH_OAUTH_CLIENT_SECRET);
+    mockOptionalEnv("GITHUB_APP_SLUG", undefined);
     context.mocks.clerk.authenticateRequest.mockReset();
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
@@ -301,18 +342,29 @@ describe("GET /api/integrations/github", () => {
 
     const response = await accept(client.getInstallation({ headers }), [404]);
 
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "No GitHub installation found",
-        code: "NOT_FOUND",
-      },
-      installUrl: `${WEB_ORIGIN}/api/github/oauth/install?vm0UserId=${encodeURIComponent(
-        fixture.userId,
-      )}&orgId=${encodeURIComponent(fixture.orgId)}&composeId=${fixture.composeId}`,
+    expect(response.body.error).toStrictEqual({
+      message: "No GitHub installation found",
+      code: "NOT_FOUND",
     });
+    expectGithubInstallUrl(response.body.installUrl, fixture);
   });
 
-  it("ignores untrusted web origins when building installUrl", async () => {
+  it("does not return an installUrl for org members", async () => {
+    const fixture = await seedDefaultAgentFixture();
+    defaultAgentFixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId, "org:member");
+    mockOptionalEnv("GITHUB_APP_SLUG", "vm0-test");
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [404],
+    );
+
+    expect(response.body.installUrl).toBeNull();
+  });
+
+  it("uses the configured web origin when building installUrl", async () => {
     const fixture = await seedDefaultAgentFixture();
     defaultAgentFixtures.push(fixture);
     mockSession(fixture.userId, fixture.orgId);
@@ -325,11 +377,7 @@ describe("GET /api/integrations/github", () => {
 
     const response = await accept(client.getInstallation({ headers }), [404]);
 
-    expect(response.body.installUrl).toBe(
-      `http://api.test/api/github/oauth/install?vm0UserId=${encodeURIComponent(
-        fixture.userId,
-      )}&orgId=${encodeURIComponent(fixture.orgId)}&composeId=${fixture.composeId}`,
-    );
+    expectGithubInstallUrl(response.body.installUrl, fixture);
   });
 
   it("returns linked installation data and agent data", async () => {
@@ -337,6 +385,10 @@ describe("GET /api/integrations/github", () => {
       composeName: "github-support-agent",
     });
     fixtures.push(fixture);
+    await seedGithubConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+    });
     mockSession(fixture.userId, fixture.orgId);
     const client = setupApp({ context })(integrationsGithubContract);
 
@@ -354,7 +406,8 @@ describe("GET /api/integrations/github", () => {
     });
     expect(response.body.installation.installationId).toBeTruthy();
     expect(response.body.isConnected).toBeTruthy();
-    expect(response.body.connectUrl).toBe("/connectors/github/connect");
+    expect(response.body.connectedGithubUsername).toBe("octocat");
+    expectGithubConnectUrl(response.body.connectUrl, fixture);
     expect(response.body.labelListeners).toStrictEqual([]);
     expect(response.body.agent).toStrictEqual({
       id: fixture.composeId,
@@ -368,10 +421,48 @@ describe("GET /api/integrations/github", () => {
     });
   });
 
-  it("returns isAdmin false when the linked GitHub user is not the installation admin", async () => {
+  it("disconnects the GitHub integration without deleting the GitHub connector", async () => {
+    const fixture = await seedGithubFixture();
+    fixtures.push(fixture);
+    await seedGithubConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+    });
+    mockSession(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.disconnectUser({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ ok: true });
+    const links = await writeDb
+      .select()
+      .from(githubUserLinks)
+      .where(eq(githubUserLinks.vm0UserId, fixture.userId));
+    expect(links).toStrictEqual([]);
+    const connectorRows = await writeDb
+      .select()
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, fixture.orgId),
+          eq(connectors.userId, fixture.userId),
+          eq(connectors.type, "github"),
+        ),
+      );
+    expect(connectorRows).toHaveLength(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "github:changed",
+      null,
+    );
+  });
+
+  it("returns isAdmin false for an org member when the linked GitHub user is not the installation admin", async () => {
     const fixture = await seedGithubFixture({ admin: "other" });
     fixtures.push(fixture);
-    mockSession(fixture.userId, fixture.orgId);
+    mockSession(fixture.userId, fixture.orgId, "org:member");
     const client = setupApp({ context })(integrationsGithubContract);
 
     const response = await accept(
@@ -382,10 +473,41 @@ describe("GET /api/integrations/github", () => {
     expect(response.body.installation.isAdmin).toBeFalsy();
   });
 
-  it("returns isAdmin false when the installation has no admin GitHub user", async () => {
-    const fixture = await seedGithubFixture({ admin: "none" });
+  it("returns isAdmin false for an org member even when the linked GitHub user installed the app", async () => {
+    const fixture = await seedGithubFixture();
+    fixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.installation.isAdmin).toBeFalsy();
+  });
+
+  it("allows an org admin to manage an installation before connecting GitHub", async () => {
+    const fixture = await seedGithubFixture({ link: false });
     fixtures.push(fixture);
     mockSession(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.isConnected).toBeFalsy();
+    expect(response.body.connectedGithubUserId).toBeNull();
+    expect(response.body.connectedGithubUsername).toBeNull();
+    expect(response.body.installation.isAdmin).toBeTruthy();
+  });
+
+  it("returns isAdmin false for an org member when the installation has no admin GitHub user", async () => {
+    const fixture = await seedGithubFixture({ admin: "none" });
+    fixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId, "org:member");
     const client = setupApp({ context })(integrationsGithubContract);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
@@ -119,6 +119,7 @@ async function seedGithubFixture(
     .insert(githubInstallations)
     .values({
       installationId: remoteInstallationId(),
+      orgId,
       adminGithubUserId,
       defaultComposeId: composeId,
       targetName: "vm0-test",
@@ -307,7 +308,7 @@ describe("GET /api/integrations/github", () => {
       },
       installUrl: `${WEB_ORIGIN}/api/github/oauth/install?vm0UserId=${encodeURIComponent(
         fixture.userId,
-      )}&composeId=${fixture.composeId}`,
+      )}&orgId=${encodeURIComponent(fixture.orgId)}&composeId=${fixture.composeId}`,
     });
   });
 
@@ -327,7 +328,7 @@ describe("GET /api/integrations/github", () => {
     expect(response.body.installUrl).toBe(
       `http://api.test/api/github/oauth/install?vm0UserId=${encodeURIComponent(
         fixture.userId,
-      )}&composeId=${fixture.composeId}`,
+      )}&orgId=${encodeURIComponent(fixture.orgId)}&composeId=${fixture.composeId}`,
     );
   });
 
@@ -352,6 +353,9 @@ describe("GET /api/integrations/github", () => {
       isAdmin: true,
     });
     expect(response.body.installation.installationId).toBeTruthy();
+    expect(response.body.isConnected).toBeTruthy();
+    expect(response.body.connectUrl).toBe("/connectors/github/connect");
+    expect(response.body.labelListeners).toStrictEqual([]);
     expect(response.body.agent).toStrictEqual({
       id: fixture.composeId,
       name: "github-support-agent",

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
@@ -204,6 +204,50 @@ describe("GitHub label listener integration routes", () => {
     await expect(listenerRows(fixture)).resolves.toHaveLength(0);
   });
 
+  it("allows another org member to update and delete a label listener", async () => {
+    const fixture = await seedFixture();
+    fixtures.push(fixture);
+    const db = store.set(writeDb$);
+    const [listener] = await db
+      .insert(githubLabelListeners)
+      .values({
+        installationId: fixture.installationId,
+        orgId: fixture.orgId,
+        createdByUserId: fixture.userId,
+        labelName: "Ready",
+        labelNameNormalized: "ready",
+        triggerMode: "created_by_me",
+        prompt: "Handle it",
+        composeId: fixture.composeId,
+      })
+      .returning({ id: githubLabelListeners.id });
+    if (!listener) {
+      throw new Error("Expected label listener insert to return a row");
+    }
+    const otherUserId = `user_${randomUUID()}`;
+    mocks.clerk.session(otherUserId, fixture.orgId, "org:member");
+    const app = createApp({ signal: context.signal });
+
+    const updateResponse = await app.request(`${ROUTE_PATH}/${listener.id}`, {
+      method: "PATCH",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(updateResponse.status).toBe(200);
+    await expect(listenerRows(fixture)).resolves.toMatchObject([
+      { enabled: false },
+    ]);
+
+    const deleteResponse = await app.request(`${ROUTE_PATH}/${listener.id}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(deleteResponse.status).toBe(200);
+    await expect(listenerRows(fixture)).resolves.toHaveLength(0);
+  });
+
   it("rejects duplicate labels for one installation", async () => {
     const fixture = await seedFixture();
     fixtures.push(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+} from "./helpers/zero-usage-insight";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const ROUTE_PATH = "/api/integrations/github/label-listeners";
+
+interface GithubListenerFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly installationId: string;
+}
+
+function authHeaders(): Record<string, string> {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function newRemoteInstallationId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+async function seedFixture(
+  args: {
+    readonly linked?: boolean;
+  } = {},
+): Promise<GithubListenerFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId,
+      userId,
+      name: `github-listener-${randomUUID().slice(0, 8)}`,
+    },
+    context.signal,
+  );
+  const db = store.set(writeDb$);
+  const [installation] = await db
+    .insert(githubInstallations)
+    .values({
+      installationId: newRemoteInstallationId(),
+      orgId,
+      status: "active",
+      defaultComposeId: composeId,
+    })
+    .returning({ id: githubInstallations.id });
+  if (!installation) {
+    throw new Error("Expected GitHub installation insert to return a row");
+  }
+
+  if (args.linked ?? true) {
+    await db.insert(githubUserLinks).values({
+      githubUserId: `gh_${randomUUID().replaceAll("-", "")}`,
+      installationId: installation.id,
+      vm0UserId: userId,
+    });
+  }
+
+  return { orgId, userId, composeId, installationId: installation.id };
+}
+
+async function cleanupFixture(fixture: GithubListenerFixture): Promise<void> {
+  await store
+    .set(writeDb$)
+    .delete(githubInstallations)
+    .where(eq(githubInstallations.id, fixture.installationId));
+  await store.set(
+    deleteUsageInsightFixture$,
+    { orgId: fixture.orgId, userId: fixture.userId },
+    context.signal,
+  );
+}
+
+async function listenerRows(fixture: GithubListenerFixture) {
+  return await store
+    .set(writeDb$)
+    .select()
+    .from(githubLabelListeners)
+    .where(eq(githubLabelListeners.installationId, fixture.installationId));
+}
+
+describe("GitHub label listener integration routes", () => {
+  const fixtures: GithubListenerFixture[] = [];
+
+  beforeEach(() => {
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await cleanupFixture(fixture);
+      }
+    }
+  });
+
+  it("creates, updates, and deletes a GitHub label listener", async () => {
+    const fixture = await seedFixture();
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const app = createApp({ signal: context.signal });
+
+    const createResponse = await app.request(ROUTE_PATH, {
+      method: "POST",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({
+        labelName: "Ready For Zero",
+        triggerMode: "anyone",
+        prompt: "Handle this issue",
+        agentId: fixture.composeId,
+      }),
+    });
+
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as {
+      readonly listener: { readonly id: string };
+    };
+    await expect(listenerRows(fixture)).resolves.toMatchObject([
+      {
+        labelName: "Ready For Zero",
+        labelNameNormalized: "ready for zero",
+        triggerMode: "anyone",
+        prompt: "Handle this issue",
+      },
+    ]);
+
+    const updateResponse = await app.request(
+      `${ROUTE_PATH}/${created.listener.id}`,
+      {
+        method: "PATCH",
+        headers: { ...authHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({
+          labelName: "Needs Agent",
+          triggerMode: "created_by_me",
+          prompt: "Review and fix",
+          enabled: false,
+        }),
+      },
+    );
+
+    expect(updateResponse.status).toBe(200);
+    await expect(listenerRows(fixture)).resolves.toMatchObject([
+      {
+        labelName: "Needs Agent",
+        labelNameNormalized: "needs agent",
+        triggerMode: "created_by_me",
+        prompt: "Review and fix",
+        enabled: false,
+      },
+    ]);
+
+    const deleteResponse = await app.request(
+      `${ROUTE_PATH}/${created.listener.id}`,
+      {
+        method: "DELETE",
+        headers: authHeaders(),
+      },
+    );
+
+    expect(deleteResponse.status).toBe(200);
+    await expect(listenerRows(fixture)).resolves.toHaveLength(0);
+  });
+
+  it("requires a GitHub user link for created-by-me listeners", async () => {
+    const fixture = await seedFixture({ linked: false });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "POST",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({
+        labelName: "Ready",
+        triggerMode: "created_by_me",
+        prompt: "Handle it",
+        agentId: fixture.composeId,
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(listenerRows(fixture)).resolves.toHaveLength(0);
+  });
+
+  it("rejects duplicate labels for one installation", async () => {
+    const fixture = await seedFixture();
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const db = store.set(writeDb$);
+    await db.insert(githubLabelListeners).values({
+      installationId: fixture.installationId,
+      orgId: fixture.orgId,
+      createdByUserId: fixture.userId,
+      labelName: "Ready",
+      labelNameNormalized: "ready",
+      triggerMode: "created_by_me",
+      prompt: "Handle it",
+      composeId: fixture.composeId,
+    });
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "POST",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({
+        labelName: " ready ",
+        triggerMode: "anyone",
+        prompt: "Handle it again",
+        agentId: fixture.composeId,
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(
+      db
+        .select()
+        .from(githubLabelListeners)
+        .where(
+          and(
+            eq(githubLabelListeners.installationId, fixture.installationId),
+            eq(githubLabelListeners.labelNameNormalized, "ready"),
+          ),
+        ),
+    ).resolves.toHaveLength(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-patch.test.ts
@@ -44,6 +44,7 @@ async function seedGithubInstallation(args: {
   readonly linkedGithubUserId?: string;
   readonly adminGithubUserId?: string | null;
   readonly defaultComposeName?: string;
+  readonly link?: boolean;
 }): Promise<GithubInstallationFixture> {
   const orgId = `org_${randomUUID()}`;
   const userId = args.userId ?? `user_${randomUUID()}`;
@@ -74,11 +75,13 @@ async function seedGithubInstallation(args: {
     throw new Error("Expected GitHub installation insert to return a row");
   }
 
-  await db.insert(githubUserLinks).values({
-    githubUserId,
-    installationId: installation.id,
-    vm0UserId: userId,
-  });
+  if (args.link !== false) {
+    await db.insert(githubUserLinks).values({
+      githubUserId,
+      installationId: installation.id,
+      vm0UserId: userId,
+    });
+  }
 
   return {
     orgId,
@@ -225,10 +228,10 @@ describe("PATCH /api/integrations/github", () => {
     });
   });
 
-  it("returns 403 when adminGithubUserId is null", async () => {
+  it("returns 403 for an org member when adminGithubUserId is null", async () => {
     const fixture = await seedGithubInstallation({ adminGithubUserId: null });
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
     const response = await patchGithub(
       JSON.stringify({ agentName: "test-agent" }),
@@ -238,7 +241,7 @@ describe("PATCH /api/integrations/github", () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "Only the installation admin can change the default agent",
+        message: "Only organization admins can change the default agent",
         code: "FORBIDDEN",
       },
     });
@@ -247,13 +250,13 @@ describe("PATCH /api/integrations/github", () => {
     );
   });
 
-  it("returns 403 when a non-admin user updates the installation", async () => {
+  it("returns 403 when a non-admin org member updates the installation", async () => {
     const fixture = await seedGithubInstallation({
       adminGithubUserId: newGithubUserId(),
       linkedGithubUserId: newGithubUserId(),
     });
     fixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
     const response = await patchGithub(
       JSON.stringify({ agentName: "test-agent" }),
@@ -263,10 +266,26 @@ describe("PATCH /api/integrations/github", () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "Only the installation admin can change the default agent",
+        message: "Only organization admins can change the default agent",
         code: "FORBIDDEN",
       },
     });
+    await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
+      fixture.defaultComposeId,
+    );
+  });
+
+  it("returns 403 when the GitHub installation admin is not an org admin", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "test-agent" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(403);
     await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
       fixture.defaultComposeId,
     );
@@ -312,6 +331,29 @@ describe("PATCH /api/integrations/github", () => {
 
   it("updates the default agent", async () => {
     const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    const targetName = `github-target-${randomUUID()}`;
+    const target = await seedAgent({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: targetName,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: targetName }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true });
+    await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
+      target.composeId,
+    );
+  });
+
+  it("updates the default agent for an org admin before GitHub is connected", async () => {
+    const fixture = await seedGithubInstallation({ link: false });
     fixtures.push(fixture);
     const targetName = `github-target-${randomUUID()}`;
     const target = await seedAgent({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-patch.test.ts
@@ -65,6 +65,7 @@ async function seedGithubInstallation(args: {
     .insert(githubInstallations)
     .values({
       installationId: newRemoteInstallationId(),
+      orgId,
       adminGithubUserId,
       defaultComposeId: composeId,
     })

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
@@ -6,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
@@ -164,9 +165,18 @@ async function seedGithubInstallation(args: {
   readonly installationId: string | null;
 }> {
   const writeDb = store.set(writeDb$);
+  const [compose] = await writeDb
+    .select({ orgId: agentComposes.orgId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, args.composeId))
+    .limit(1);
+  if (!compose) {
+    throw new Error("seedGithubInstallation: compose not found");
+  }
   const [row] = await writeDb
     .insert(githubInstallations)
     .values({
+      orgId: compose.orgId,
       defaultComposeId: args.composeId,
       installationId:
         args.installationId === undefined

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -1401,13 +1401,52 @@ describe("POST /api/webhooks/github", () => {
     expect(response.body).toBe("OK");
   });
 
-  it("ignores non-created installation events", async () => {
+  it("cleans up installations after deleted installation events", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
     mockGitHubWebhookEnv();
 
     const response = await postGitHubWebhook({
       event: "installation",
       payload: buildGitHubInstallationPayload({
         action: "deleted",
+        installationId: fixture.remoteInstallationId,
+        targetId: remoteGitHubId(),
+      }),
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+
+    const db = store.set(writeDb$);
+    const installations = await db
+      .select({ id: githubInstallations.id })
+      .from(githubInstallations)
+      .where(eq(githubInstallations.id, fixture.installationDbId));
+    expect(installations).toHaveLength(0);
+
+    const links = await db
+      .select({ id: githubUserLinks.id })
+      .from(githubUserLinks)
+      .where(eq(githubUserLinks.installationId, fixture.installationDbId));
+    expect(links).toHaveLength(0);
+
+    const listeners = await db
+      .select({ id: githubLabelListeners.id })
+      .from(githubLabelListeners)
+      .where(eq(githubLabelListeners.installationId, fixture.installationDbId));
+    expect(listeners).toHaveLength(0);
+  });
+
+  it("ignores unhandled installation events", async () => {
+    mockGitHubWebhookEnv();
+
+    const response = await postGitHubWebhook({
+      event: "installation",
+      payload: buildGitHubInstallationPayload({
+        action: "suspend",
         installationId: remoteGitHubId(),
         targetId: remoteGitHubId(),
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -16,6 +16,7 @@ import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connec
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
@@ -111,6 +112,15 @@ interface GitHubInstallationRefPayload {
 interface GitHubIssuesPayload {
   readonly action: string;
   readonly issue: GitHubIssuePayload;
+  readonly label?: GitHubLabelPayload;
+  readonly repository: GitHubRepositoryPayload;
+  readonly installation: GitHubInstallationRefPayload;
+  readonly sender: GitHubUserPayload;
+}
+
+interface GitHubPullRequestPayload {
+  readonly action: string;
+  readonly pull_request: GitHubIssuePayload;
   readonly label?: GitHubLabelPayload;
   readonly repository: GitHubRepositoryPayload;
   readonly installation: GitHubInstallationRefPayload;
@@ -358,6 +368,26 @@ function buildGitHubIssuesPayload(
   return {
     action: overrides.action ?? "opened",
     issue: buildGitHubIssuePayload(fixture, overrides),
+    ...(overrides.label ? { label: overrides.label } : {}),
+    repository: { full_name: overrides.repo ?? "vm0-ai/vm0" },
+    installation: {
+      id: Number(overrides.installationId ?? fixture.remoteInstallationId),
+    },
+    sender,
+  };
+}
+
+function buildGitHubPullRequestPayload(
+  fixture: GitHubWebhookFixture,
+  overrides: GitHubIssuesPayloadOverrides = {},
+): GitHubPullRequestPayload {
+  const sender = githubUser({ id: overrides.senderId ?? fixture.githubUserId });
+  return {
+    action: overrides.action ?? "opened",
+    pull_request: buildGitHubIssuePayload(fixture, {
+      ...overrides,
+      issueTitle: overrides.issueTitle ?? "Test Pull Request",
+    }),
     ...(overrides.label ? { label: overrides.label } : {}),
     repository: { full_name: overrides.repo ?? "vm0-ai/vm0" },
     installation: {
@@ -744,6 +774,7 @@ const seedGitHubWebhookFixture$ = command(
       .values({
         installationId: remoteInstallationId,
         status: "active",
+        orgId: fixture.orgId,
         defaultComposeId: compose.id,
       })
       .returning({ id: githubInstallations.id });
@@ -756,6 +787,17 @@ const seedGitHubWebhookFixture$ = command(
       githubUserId,
       installationId: installation.id,
       vm0UserId: fixture.userId,
+    });
+    signal.throwIfAborted();
+    await db.insert(githubLabelListeners).values({
+      installationId: installation.id,
+      orgId: fixture.orgId,
+      createdByUserId: fixture.userId,
+      labelName: GITHUB_APP_SLUG,
+      labelNameNormalized: GITHUB_APP_SLUG.toLowerCase(),
+      triggerMode: "created_by_me",
+      prompt: "Handle this labeled GitHub work",
+      composeId: compose.id,
     });
     signal.throwIfAborted();
 
@@ -1011,12 +1053,11 @@ describe("POST /api/webhooks/github", () => {
 
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
-    expect(runs[0]?.prompt).toContain(
-      "Based on the GitHub issue above and its discussion",
-    );
+    expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
     expect(runs[0]?.appendSystemPrompt).toContain(
       "You are currently running inside: GitHub",
     );
+    expect(runs[0]?.appendSystemPrompt).toContain("Matched label: vm0-agent");
     expect(runs[0]?.appendSystemPrompt).toContain("This is a test issue body");
     expect(runs[0]?.appendSystemPrompt).toContain("Earlier discussion");
     expect(runs[0]?.triggerSource).toBe("github");
@@ -1056,7 +1097,77 @@ describe("POST /api/webhooks/github", () => {
 
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
-    expect(runs[0]?.prompt).toBe("This is a test issue body");
+    expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
+  });
+
+  it("dispatches pull requests with a matching label listener", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockGitHubWebhookEnv();
+    mockGitHubAppCredentials();
+    setupGitHubApiMocks({
+      installationId: fixture.remoteInstallationId,
+      comments: [],
+    });
+
+    const response = await postGitHubWebhook({
+      event: "pull_request",
+      payload: buildGitHubPullRequestPayload(fixture, {
+        action: "labeled",
+        labels: [
+          { id: 1, name: GITHUB_APP_SLUG },
+          { id: 2, name: "enhancement" },
+        ],
+        label: { id: 1, name: GITHUB_APP_SLUG },
+      }),
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+
+    const runs = await selectGitHubRuns(fixture);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
+    expect(runs[0]?.appendSystemPrompt).toContain("Pull Request: #42");
+  });
+
+  it("respects the label listener trigger mode", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockGitHubWebhookEnv();
+    const otherGithubUserId = remoteGitHubId();
+
+    const createdByMeResponse = await postGitHubWebhook({
+      event: "issues",
+      payload: buildGitHubIssuesPayload(fixture, {
+        action: "opened",
+        senderId: otherGithubUserId,
+      }),
+    });
+    await clearAllDetached();
+    expect(createdByMeResponse.status).toBe(200);
+    await expect(selectGitHubRuns(fixture)).resolves.toHaveLength(0);
+
+    await store
+      .set(writeDb$)
+      .update(githubLabelListeners)
+      .set({ triggerMode: "anyone" })
+      .where(eq(githubLabelListeners.installationId, fixture.installationDbId));
+
+    const anyoneResponse = await postGitHubWebhook({
+      event: "issues",
+      payload: buildGitHubIssuesPayload(fixture, {
+        action: "opened",
+        senderId: otherGithubUserId,
+      }),
+    });
+    await clearAllDetached();
+
+    expect(anyoneResponse.status).toBe(200);
+    await expect(selectGitHubRuns(fixture)).resolves.toHaveLength(1);
   });
 
   it("does not dispatch ignored issue actions or non-matching labels", async () => {
@@ -1127,7 +1238,7 @@ describe("POST /api/webhooks/github", () => {
     );
   });
 
-  it("dispatches GitHub issue comments through API-native run creation", async () => {
+  it("acknowledges GitHub issue comments without triggering mention runs", async () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
@@ -1143,18 +1254,7 @@ describe("POST /api/webhooks/github", () => {
     expect(response.body).toBe("OK");
 
     const runs = await selectGitHubRuns(fixture);
-    expect(runs).toHaveLength(1);
-    expect(runs[0]?.prompt).toBe(`@${GITHUB_APP_SLUG}[bot] please handle this`);
-    expect(runs[0]?.triggerSource).toBe("github");
-
-    const callbacks = await selectGitHubCallbacks(runs[0]?.id ?? "");
-    expect(callbacks).toHaveLength(1);
-    expect(callbacks[0]?.payload).toMatchObject({
-      repo: "vm0-ai/vm0",
-      issueNumber: 42,
-      triggerCommentId: "77",
-      triggerCommentBody: `@${GITHUB_APP_SLUG}[bot] please handle this`,
-    });
+    expect(runs).toHaveLength(0);
   });
 
   it("does not dispatch ignored issue comments", async () => {
@@ -1241,6 +1341,7 @@ describe("POST /api/webhooks/github", () => {
     const installationId = remoteGitHubId();
     await db.insert(githubInstallations).values({
       status: "pending",
+      orgId: fixture.orgId,
       targetId,
       targetType: "Organization",
       targetName: "pending-org",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -29,6 +29,8 @@ const mocks = createZeroRouteMocks(context);
 const BASE_URL = "https://app.vm0.test";
 const API_ORIGIN = "https://api.vm0.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
+const LOCAL_ORIGIN = "http://localhost:3000";
+const LOCAL_WEB_ORIGIN = "https://www.vm0.ai:8443";
 
 function authorizeUrl(
   type: string,
@@ -168,6 +170,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
   let restoreDynamicTestOAuthAuthorize: (() => void) | undefined;
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     mockOAuthEnv();
   });
 
@@ -202,7 +205,9 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(location).not.toBeNull();
     const url = new URL(location!);
     expect(url.pathname).toBe("/sign-in");
-    expect(url.searchParams.get("redirect_url")).toBe(authorizeUrl("github"));
+    expect(url.searchParams.get("redirect_url")).toBe(
+      authorizeUrl("github", undefined, WEB_ORIGIN),
+    );
   });
 
   it("redirects unauthenticated users to sign-in on the web rewrite origin", async () => {
@@ -246,7 +251,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     );
     expect(url.searchParams.get("client_id")).toBe("test-client-id");
     expect(url.searchParams.get("redirect_uri")).toBe(
-      `${BASE_URL}/api/connectors/github/callback`,
+      `${WEB_ORIGIN}/api/connectors/github/callback`,
     );
     expect(url.searchParams.get("scope")).toBe("repo project workflow");
     expect(url.searchParams.get("state")).toMatch(/^[0-9a-f]{64}$/);
@@ -315,7 +320,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     );
     expect(url.searchParams.get("client_id")).toBe("google-test-client-id");
     expect(url.searchParams.get("redirect_uri")).toBe(
-      `${BASE_URL}/api/connectors/google-drive/callback`,
+      `${WEB_ORIGIN}/api/connectors/google-drive/callback`,
     );
     const scopes = new Set(url.searchParams.get("scope")?.split(" ") ?? []);
     expect(scopes.has("https://www.googleapis.com/auth/drive")).toBeTruthy();
@@ -627,6 +632,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
   const stateIds: string[] = [];
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     mockOAuthEnv();
   });
 
@@ -693,6 +699,41 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
       consumedAt: null,
     });
     expect(storedState!.expiresAt.getTime()).toBeGreaterThan(now());
+  });
+
+  it("uses the configured web origin for local OAuth callback URLs", async () => {
+    mockEnv("VM0_WEB_URL", LOCAL_WEB_ORIGIN);
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    mocks.clerk.session(userId, orgId);
+
+    const response = await requestOauthStart("github", {
+      headers: { authorization: "Bearer clerk-session" },
+      origin: LOCAL_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      readonly authorizationUrl: string;
+    };
+    const authorizationUrl = new URL(body.authorizationUrl);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      `${LOCAL_WEB_ORIGIN}/api/connectors/github/callback`,
+    );
+    const state = authorizationUrl.searchParams.get("state");
+    expect(state).toMatch(/^[0-9a-f]{64}$/);
+
+    const db = store.set(writeDb$);
+    const [storedState] = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.state, state!));
+    expect(storedState).toBeDefined();
+    stateIds.push(storedState!.id);
+    expect(storedState!.redirectUri).toBe(
+      `${LOCAL_WEB_ORIGIN}/api/connectors/github/callback`,
+    );
   });
 
   it("stores provider PKCE context for server-side OAuth handoff", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
@@ -383,6 +383,10 @@ describe("/api/integrations/agentphone/link", () => {
 
     expect(response.body).toBeUndefined();
     await expect(findAgentPhoneUserLink(phone)).resolves.toBeUndefined();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "agentphone:changed",
+      null,
+    );
   });
 
   it("requires authentication", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -534,6 +534,10 @@ describe("DELETE /api/zero/integrations/slack", () => {
         }),
       }),
     );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "slack:changed",
+      null,
+    );
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
@@ -109,6 +109,7 @@ describe("Slack OAuth API routes", () => {
   });
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     mockSlackEnv();
     context.mocks.slack.chat.postMessage.mockResolvedValue({
       ok: true,
@@ -136,7 +137,7 @@ describe("Slack OAuth API routes", () => {
         "test-slack-client-id",
       );
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        "http://api.test/api/zero/slack/oauth/callback",
+        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
       );
       const scopes = redirectUrl.searchParams.get("scope")?.split(",") ?? [];
       expect(scopes).toContain("app_mentions:read");
@@ -283,7 +284,7 @@ describe("Slack OAuth API routes", () => {
       expect(response.status).toBe(307);
       const redirectUrl = new URL(response.headers.get("location")!);
       expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-        "http://api.test/api/zero/slack/oauth/callback",
+        `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
       );
       expect(redirectUrl.searchParams.get("user_scope")).toBe("identity.basic");
       expect(redirectUrl.searchParams.get("team")).toBe(
@@ -497,7 +498,7 @@ describe("Slack OAuth API routes", () => {
       );
       expect(context.mocks.slack.oauth.v2.access).toHaveBeenCalledWith(
         expect.objectContaining({
-          redirect_uri: "http://api.test/api/zero/slack/oauth/callback",
+          redirect_uri: `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
         }),
       );
 
@@ -1050,7 +1051,7 @@ describe("Slack OAuth API routes", () => {
       );
       expect(slackError.status).toBe(307);
       expect(slackError.headers.get("location")).toBe(
-        "http://localhost:3001/slack/failed?error=access_denied",
+        `${WEB_ORIGIN}/slack/failed?error=access_denied`,
       );
     });
   });

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -10,6 +10,7 @@ import {
 import {
   connectorTypeSchema,
   type OAuthAuthorizationCodeConnectorType,
+  type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorOAuthCode,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -24,6 +24,7 @@ import { requiredAuthContext$ } from "../auth/auth-context";
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { nowDate } from "../../lib/time";
 import { optionalEnv } from "../../lib/env";
 import {
@@ -32,6 +33,10 @@ import {
   type StoredOAuthState,
 } from "../services/connector-oauth-state.service";
 import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import {
+  linkGithubVm0User,
+  loadActiveGithubInstallationForOrg,
+} from "../services/github-oauth.service";
 import { settle } from "../utils";
 import type { RouteEntry } from "../route";
 import {
@@ -330,6 +335,40 @@ async function markConnectorSessionError(
   signal.throwIfAborted();
 }
 
+async function linkGithubIntegrationAfterConnectorConnect(args: {
+  readonly db: Db;
+  readonly connectorType: OAuthConnectorType;
+  readonly identity: CallbackIdentity;
+  readonly token: OAuthTokenResult;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (args.connectorType !== "github") {
+    return;
+  }
+
+  const installation = await loadActiveGithubInstallationForOrg({
+    db: args.db,
+    orgId: args.identity.orgId,
+    signal: args.signal,
+  });
+  if (!installation) {
+    return;
+  }
+
+  const githubUserId = await linkGithubVm0User({
+    db: args.db,
+    installRecordId: installation.id,
+    vm0UserId: args.identity.userId,
+    knownGithubUserId: args.token.userInfo.id,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  if (githubUserId) {
+    await publishUserSignal([args.identity.userId], "github:changed");
+  }
+}
+
 function successRedirectResponse(args: {
   readonly origin: string;
   readonly type: string;
@@ -382,7 +421,17 @@ const completeOAuthCallback$ = command(
     );
     signal.throwIfAborted();
 
-    await completeConnectorSession(set(writeDb$), args.sessionId, signal);
+    const db = set(writeDb$);
+    await linkGithubIntegrationAfterConnectorConnect({
+      db,
+      connectorType: args.connectorType,
+      identity: args.identity,
+      token,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    await completeConnectorSession(db, args.sessionId, signal);
     return successRedirectResponse({
       origin: args.origin,
       type: args.type,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -16,6 +16,7 @@ import {
   linkGithubVm0User,
   loadComposeFeatureSwitchContext,
   parseGithubOauthState,
+  resolveGithubOauthOrgId,
   tryLinkGithubFromLocalRecord,
   tryLinkGithubFromRemoteInstallations,
 } from "../services/github-oauth.service";
@@ -82,21 +83,25 @@ const installGithubOauth$ = command(
 
     if (appId && privateKey && query.vm0UserId) {
       const db = set(writeDb$);
-      const linkedFromLocal = await tryLinkGithubFromLocalRecord({
-        db,
-        vm0UserId: query.vm0UserId,
-        signal,
-      });
+      const linkedFromLocal = query.orgId
+        ? await tryLinkGithubFromLocalRecord({
+            db,
+            orgId: query.orgId,
+            vm0UserId: query.vm0UserId,
+            signal,
+          })
+        : false;
       signal.throwIfAborted();
 
       if (linkedFromLocal) {
-        return redirectResponse(appUrl("/settings?tab=integrations"));
+        return redirectResponse(appUrl("/works?github=connected"));
       }
 
       const linkedFromRemote = await tryLinkGithubFromRemoteInstallations({
         db,
         appId,
         privateKey,
+        orgId: query.orgId ?? null,
         vm0UserId: query.vm0UserId,
         composeId: query.composeId ?? null,
         signal,
@@ -104,12 +109,13 @@ const installGithubOauth$ = command(
       signal.throwIfAborted();
 
       if (linkedFromRemote) {
-        return redirectResponse(appUrl("/settings?tab=integrations"));
+        return redirectResponse(appUrl("/works?github=connected"));
       }
     }
 
     const state = await buildGithubOauthState({
       vm0UserId: query.vm0UserId,
+      orgId: query.orgId,
       composeId: query.composeId,
       secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
     });
@@ -145,7 +151,7 @@ const callbackGithubOauth$ = command(
     const query = get(queryOf(githubOauthContract.callback));
 
     if (query.setup_action === "update") {
-      return redirectResponse(appUrl("/works"));
+      return redirectResponse(appUrl("/works?github=installed"));
     }
 
     const secretsEncryptionKey = env("SECRETS_ENCRYPTION_KEY");
@@ -175,17 +181,25 @@ const callbackGithubOauth$ = command(
     }
 
     const db = set(writeDb$);
+    const orgId = await resolveGithubOauthOrgId({
+      db,
+      orgId: state.orgId,
+      composeId,
+      signal,
+    });
+    signal.throwIfAborted();
 
     if (query.setup_action === "request") {
       await createPendingGithubInstallation({
         db,
+        orgId,
         targetId: query.target_id ?? null,
         targetType: query.target_type ?? "Organization",
         composeId,
         signal,
       });
 
-      return redirectResponse(appUrl("/works?pending=true"));
+      return redirectResponse(appUrl("/works?github=pending"));
     }
 
     const installationId = query.installation_id;
@@ -196,6 +210,7 @@ const callbackGithubOauth$ = command(
     const existing = await findGithubInstallationByInstallationId({
       db,
       installationId,
+      orgId,
       signal,
     });
     if (existing) {
@@ -207,7 +222,7 @@ const callbackGithubOauth$ = command(
           signal,
         });
       }
-      return redirectResponse(appUrl("/works"));
+      return redirectResponse(appUrl("/works?github=connected"));
     }
 
     const installInfo = await getGithubInstallationInfo({
@@ -236,6 +251,7 @@ const callbackGithubOauth$ = command(
     });
     const installRecordId = await createOrActivateGithubInstallation({
       db,
+      orgId,
       installationId,
       installInfo,
       encryptedAccessToken: await encryptPersistentSecretValue(
@@ -257,7 +273,7 @@ const callbackGithubOauth$ = command(
       });
     }
 
-    return redirectResponse(appUrl("/works"));
+    return redirectResponse(appUrl("/works?github=installed"));
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -1,10 +1,28 @@
 import { command } from "ccstate";
-import { githubOauthContract } from "@vm0/api-contracts/contracts/github-oauth";
+import {
+  githubOauthContract,
+  type GithubAppSetupCallbackQuery,
+} from "@vm0/api-contracts/contracts/github-oauth";
+import {
+  getConnectorOAuthConfig,
+  getConnectorOAuthCredentials,
+  isStaticConfidentialConnectorOAuthCredentials,
+  type StaticConfidentialConnectorOAuthCredentials,
+} from "@vm0/connectors/connector-utils";
+import { exchangeConnectorOAuthCode } from "@vm0/connectors/oauth-providers";
+import {
+  exchangeGitHubCode,
+  fetchGitHubUserInfo,
+} from "@vm0/connectors/oauth-providers/providers/github";
 
+import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import { request$ } from "../context/hono";
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
 import {
   buildGithubOauthState,
   createOrActivateGithubInstallation,
@@ -14,6 +32,7 @@ import {
   getGithubInstallationInfo,
   isGithubOauthStateSignatureValid,
   linkGithubVm0User,
+  loadActiveGithubInstallationForOrg,
   loadComposeFeatureSwitchContext,
   parseGithubOauthState,
   resolveGithubOauthOrgId,
@@ -21,6 +40,8 @@ import {
   tryLinkGithubFromRemoteInstallations,
 } from "../services/github-oauth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
+import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import { settle } from "../utils";
 import type { RouteEntry } from "../route";
 import {
   getOAuthCanonicalRedirectUrl,
@@ -28,6 +49,8 @@ import {
 } from "./oauth-web-origin";
 
 const REDIRECT_STATUS = 307;
+const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
+const L = logger("GithubOAuthRoute");
 
 function redirectResponse(url: string): Response {
   return new Response(null, {
@@ -51,17 +74,435 @@ function jsonErrorResponse(error: string, status: number): Response {
 }
 
 function appUrl(path: string): string {
-  return `${env("VM0_WEB_URL")}${path}`;
+  return `${env("APP_URL").replace(/\/$/u, "")}${path}`;
 }
 
-function callbackRedirectUri(origin: string): string {
-  return `${origin}/api/github/oauth/callback`;
+function githubAppSetupCallbackRedirectUri(origin: string): string {
+  return `${origin}${GITHUB_APP_SETUP_CALLBACK_PATH}`;
+}
+
+function userConnectCallbackRedirectUri(origin: string): string {
+  return `${origin}/api/zero/github/oauth/connect/callback`;
+}
+
+function githubUserOauthCredentials():
+  | StaticConfidentialConnectorOAuthCredentials
+  | undefined {
+  const credentials = getConnectorOAuthCredentials("github", optionalEnv);
+  if (!credentials?.configured) {
+    return undefined;
+  }
+  if (!isStaticConfidentialConnectorOAuthCredentials(credentials)) {
+    return undefined;
+  }
+  return credentials;
+}
+
+function githubAppUserOauthCredentials():
+  | { readonly clientId: string; readonly clientSecret: string }
+  | undefined {
+  const clientId = optionalEnv("GITHUB_APP_CLIENT_ID");
+  const clientSecret = optionalEnv("GITHUB_APP_CLIENT_SECRET");
+  if (!clientId || !clientSecret) {
+    return undefined;
+  }
+  return { clientId, clientSecret };
 }
 
 function worksErrorRedirect(message: string): Response {
   return redirectResponse(
     appUrl(`/works?error=${encodeURIComponent(message)}`),
   );
+}
+
+function errorMessageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : "GitHub authorization failed";
+}
+
+const GITHUB_INSTALL_ADMIN_REQUIRED =
+  "Only organization admins can install GitHub";
+
+const GITHUB_SINGLE_INSTALLATION_REQUIRED =
+  "GitHub is already installed for this organization";
+
+type ParsedGithubOauthState = NonNullable<
+  ReturnType<typeof parseGithubOauthState>
+>;
+
+type GithubCallbackStateResolution =
+  | {
+      readonly ok: true;
+      readonly state: ParsedGithubOauthState;
+      readonly composeId: string;
+    }
+  | {
+      readonly ok: false;
+      readonly response: Response;
+    };
+
+type GithubCallbackAccessResolution =
+  | {
+      readonly ok: true;
+      readonly orgAlreadyHasActiveInstallation: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly response: Response;
+    };
+
+type GithubSetupUserConnectionResolution =
+  | {
+      readonly ok: true;
+      readonly connected: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly response: Response;
+    };
+
+type GithubSetupUserConnectionArgs = {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly installRecordId: string;
+  readonly ghInstallationId: string | null;
+  readonly state: ParsedGithubOauthState;
+  readonly code: string | undefined;
+  readonly knownGithubUserId: string | null;
+};
+
+function githubSetupCodeExchangeLogContext(
+  args: GithubSetupUserConnectionArgs,
+  vm0UserId: string,
+): {
+  readonly orgId: string;
+  readonly vm0UserId: string;
+  readonly ghInstallationId: string | null;
+  readonly installRecordId: string;
+} {
+  return {
+    orgId: args.orgId,
+    vm0UserId,
+    ghInstallationId: args.ghInstallationId,
+    installRecordId: args.installRecordId,
+  };
+}
+
+const isGithubInstallOrgAdmin$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string | null; readonly userId: string | null },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    if (!args.orgId || !args.userId) {
+      return false;
+    }
+    const membership = await set(
+      getMemberRoleAndUpdateCache$,
+      args.orgId,
+      args.userId,
+      signal,
+    );
+    signal.throwIfAborted();
+    return membership?.role === "admin";
+  },
+);
+
+const hasActiveGithubInstallationForOrg$ = command(
+  async ({ set }, orgId: string, signal: AbortSignal): Promise<boolean> => {
+    const db = set(writeDb$);
+    const installation = await loadActiveGithubInstallationForOrg({
+      db,
+      orgId,
+      signal,
+    });
+    return installation !== null;
+  },
+);
+
+async function resolveGithubCallbackState(args: {
+  readonly stateString: string | undefined;
+  readonly secretsEncryptionKey: string;
+}): Promise<GithubCallbackStateResolution> {
+  const state = parseGithubOauthState(args.stateString);
+  if (!state) {
+    return {
+      ok: false,
+      response: worksErrorRedirect(
+        "Invalid OAuth state. Please try installing again from the Platform.",
+      ),
+    };
+  }
+
+  if (
+    !(await isGithubOauthStateSignatureValid({
+      state,
+      secretsEncryptionKey: args.secretsEncryptionKey,
+    }))
+  ) {
+    return {
+      ok: false,
+      response: worksErrorRedirect(
+        "Invalid state signature. Please try installing again from the Platform.",
+      ),
+    };
+  }
+
+  if (!state.composeId) {
+    return {
+      ok: false,
+      response: worksErrorRedirect(
+        "Missing default agent. Please select an agent before connecting GitHub.",
+      ),
+    };
+  }
+
+  return { ok: true, state, composeId: state.composeId };
+}
+
+const resolveGithubCallbackAccess$ = command(
+  async (
+    { set },
+    args: {
+      readonly state: ParsedGithubOauthState;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<GithubCallbackAccessResolution> => {
+    if (
+      args.state.orgId &&
+      args.state.vm0UserId &&
+      !(await set(
+        isGithubInstallOrgAdmin$,
+        { orgId: args.state.orgId, userId: args.state.vm0UserId },
+        signal,
+      ))
+    ) {
+      return {
+        ok: false,
+        response: worksErrorRedirect(GITHUB_INSTALL_ADMIN_REQUIRED),
+      };
+    }
+
+    const orgAlreadyHasActiveInstallation = await set(
+      hasActiveGithubInstallationForOrg$,
+      args.orgId,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { ok: true, orgAlreadyHasActiveInstallation };
+  },
+);
+
+async function handlePendingGithubInstallation(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly composeId: string;
+  readonly query: GithubAppSetupCallbackQuery;
+  readonly signal: AbortSignal;
+}): Promise<Response> {
+  await createPendingGithubInstallation({
+    db: args.db,
+    orgId: args.orgId,
+    targetId: args.query.target_id ?? null,
+    targetType: args.query.target_type ?? "Organization",
+    composeId: args.composeId,
+    signal: args.signal,
+  });
+
+  return redirectResponse(appUrl("/works?github=pending"));
+}
+
+const connectGithubUserAfterSetup$ = command(
+  async (
+    { set },
+    args: GithubSetupUserConnectionArgs,
+    signal: AbortSignal,
+  ): Promise<GithubSetupUserConnectionResolution> => {
+    const vm0UserId = args.state.vm0UserId;
+    if (!vm0UserId) {
+      return { ok: true, connected: false };
+    }
+
+    const code = args.code;
+    if (code) {
+      const codeExchangeLogContext = githubSetupCodeExchangeLogContext(
+        args,
+        vm0UserId,
+      );
+      const credentials = githubAppUserOauthCredentials();
+      if (!credentials) {
+        L.warn(
+          "GitHub setup code exchange skipped: App OAuth is not configured",
+          {
+            ...codeExchangeLogContext,
+          },
+        );
+        return {
+          ok: false,
+          response: worksErrorRedirect("GitHub App OAuth is not configured"),
+        };
+      }
+
+      L.warn("Starting GitHub setup code exchange", {
+        ...codeExchangeLogContext,
+        client: "github_app",
+        sendsRedirectUri: false,
+      });
+
+      const tokenResult = await settle(
+        (async () => {
+          const { accessToken, scopes } = await exchangeGitHubCode(
+            credentials.clientId,
+            credentials.clientSecret,
+            code,
+          );
+          signal.throwIfAborted();
+          const userInfo = await fetchGitHubUserInfo(accessToken);
+          signal.throwIfAborted();
+          return { accessToken, scopes, userInfo };
+        })(),
+        signal,
+      );
+      signal.throwIfAborted();
+      if (!tokenResult.ok) {
+        L.warn("GitHub setup code exchange failed", {
+          ...codeExchangeLogContext,
+          error: errorMessageFromUnknown(tokenResult.error),
+        });
+        return {
+          ok: false,
+          response: worksErrorRedirect(
+            errorMessageFromUnknown(tokenResult.error),
+          ),
+        };
+      }
+      const { accessToken, scopes, userInfo } = tokenResult.value;
+      L.warn("GitHub setup code exchange succeeded", {
+        ...codeExchangeLogContext,
+        githubUserId: userInfo.id,
+        githubUsername: userInfo.username,
+        scopes,
+      });
+
+      await set(
+        upsertOAuthConnector$,
+        {
+          orgId: args.orgId,
+          userId: vm0UserId,
+          type: "github",
+          accessToken,
+          userInfo,
+          oauthScopes:
+            scopes.length > 0
+              ? scopes
+              : getConnectorOAuthConfig("github").scopes,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+
+      const githubUserId = await linkGithubVm0User({
+        db: args.db,
+        installRecordId: args.installRecordId,
+        vm0UserId,
+        knownGithubUserId: userInfo.id,
+        signal,
+      });
+      signal.throwIfAborted();
+
+      if (!githubUserId) {
+        return {
+          ok: false,
+          response: worksErrorRedirect(
+            "This GitHub account is already linked to the installation",
+          ),
+        };
+      }
+
+      await publishUserSignal([vm0UserId], "github:changed");
+      signal.throwIfAborted();
+
+      return { ok: true, connected: true };
+    }
+
+    const githubUserId = await linkGithubVm0User({
+      db: args.db,
+      installRecordId: args.installRecordId,
+      vm0UserId,
+      knownGithubUserId: args.knownGithubUserId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (githubUserId) {
+      await publishUserSignal([vm0UserId], "github:changed");
+      signal.throwIfAborted();
+    }
+
+    return { ok: true, connected: githubUserId !== null };
+  },
+);
+
+function githubSetupCompleteRedirect(connected: boolean): Response {
+  if (connected) {
+    return redirectResponse(appUrl("/works?github=connected"));
+  }
+  return redirectResponse(appUrl("/works?github=installed"));
+}
+
+async function createActiveGithubInstallationFromCallback(args: {
+  readonly db: Db;
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly orgId: string;
+  readonly composeId: string;
+  readonly installationId: string;
+  readonly state: ParsedGithubOauthState;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly installRecordId: string;
+  readonly adminGithubUserId: string | null;
+}> {
+  const installInfo = await getGithubInstallationInfo({
+    appId: args.appId,
+    privateKey: args.privateKey,
+    installationId: args.installationId,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  const { token } = await getGithubInstallationAccessToken({
+    appId: args.appId,
+    privateKey: args.privateKey,
+    installationId: args.installationId,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  const adminGithubUserId =
+    installInfo.targetType === "User" ? installInfo.targetId : null;
+  const featureSwitchContext = await loadComposeFeatureSwitchContext({
+    db: args.db,
+    composeId: args.composeId,
+    userId: args.state.vm0UserId,
+    signal: args.signal,
+  });
+  const installRecordId = await createOrActivateGithubInstallation({
+    db: args.db,
+    orgId: args.orgId,
+    installationId: args.installationId,
+    installInfo,
+    encryptedAccessToken: await encryptPersistentSecretValue(
+      token,
+      featureSwitchContext,
+    ),
+    adminGithubUserId,
+    composeId: args.composeId,
+    signal: args.signal,
+  });
+
+  return { installRecordId, adminGithubUserId };
 }
 
 const installGithubOauth$ = command(
@@ -80,6 +521,18 @@ const installGithubOauth$ = command(
     const query = get(queryOf(githubOauthContract.install));
     const appId = optionalEnv("GITHUB_APP_ID");
     const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+
+    if (
+      query.orgId &&
+      query.vm0UserId &&
+      !(await set(
+        isGithubInstallOrgAdmin$,
+        { orgId: query.orgId, userId: query.vm0UserId },
+        signal,
+      ))
+    ) {
+      return worksErrorRedirect(GITHUB_INSTALL_ADMIN_REQUIRED);
+    }
 
     if (appId && privateKey && query.vm0UserId) {
       const db = set(writeDb$);
@@ -127,9 +580,125 @@ const installGithubOauth$ = command(
     if (state) {
       installUrl.searchParams.set("state", state);
     }
-    installUrl.searchParams.set("redirect_uri", callbackRedirectUri(origin));
+    installUrl.searchParams.set(
+      "redirect_uri",
+      githubAppSetupCallbackRedirectUri(origin),
+    );
 
     return noStoreRedirect(installUrl.toString());
+  },
+);
+
+const connectGithubUserOauth$ = command(({ get }, _signal: AbortSignal) => {
+  const request = get(request$).raw;
+  const canonicalRedirectUrl = getOAuthCanonicalRedirectUrl(request);
+  if (canonicalRedirectUrl) {
+    return noStoreRedirect(canonicalRedirectUrl);
+  }
+
+  const origin = getOAuthWebOrigin(request);
+  return noStoreRedirect(
+    new URL("/api/zero/connectors/github/authorize", origin).toString(),
+  );
+});
+
+const callbackGithubUserOauth$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$).raw;
+    const canonicalRedirectUrl = getOAuthCanonicalRedirectUrl(request);
+    if (canonicalRedirectUrl) {
+      return noStoreRedirect(canonicalRedirectUrl);
+    }
+
+    const query = get(queryOf(githubOauthContract.connectCallback));
+    if (query.error) {
+      return worksErrorRedirect(
+        query.error_description || query.error || "GitHub authorization failed",
+      );
+    }
+    if (!query.code) {
+      return worksErrorRedirect("Missing authorization code from GitHub");
+    }
+
+    const state = parseGithubOauthState(query.state);
+    if (!state?.vm0UserId || !state.orgId) {
+      return worksErrorRedirect(
+        "Invalid OAuth state. Please try connecting again from the Platform.",
+      );
+    }
+
+    if (
+      !(await isGithubOauthStateSignatureValid({
+        state,
+        secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
+      }))
+    ) {
+      return worksErrorRedirect(
+        "Invalid state signature. Please try connecting again from the Platform.",
+      );
+    }
+
+    const credentials = githubUserOauthCredentials();
+    if (!credentials) {
+      return worksErrorRedirect("GitHub OAuth is not configured");
+    }
+
+    const origin = getOAuthWebOrigin(request);
+    const redirectUri = userConnectCallbackRedirectUri(origin);
+    const token = await exchangeConnectorOAuthCode({
+      type: "github",
+      credentials,
+      code: query.code,
+      redirectUri,
+      state: query.state,
+      codeVerifier: undefined,
+      oauthContext: undefined,
+    });
+    signal.throwIfAborted();
+
+    const db = set(writeDb$);
+    const installation = await loadActiveGithubInstallationForOrg({
+      db,
+      orgId: state.orgId,
+      signal,
+    });
+    if (!installation) {
+      return worksErrorRedirect("No GitHub installation found");
+    }
+
+    await set(
+      upsertOAuthConnector$,
+      {
+        orgId: state.orgId,
+        userId: state.vm0UserId,
+        type: "github",
+        accessToken: token.accessToken,
+        userInfo: token.userInfo,
+        oauthScopes: getConnectorOAuthConfig("github").scopes,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const githubUserId = await linkGithubVm0User({
+      db,
+      installRecordId: installation.id,
+      vm0UserId: state.vm0UserId,
+      knownGithubUserId: token.userInfo.id,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (!githubUserId) {
+      return worksErrorRedirect(
+        "This GitHub account is already linked to the installation",
+      );
+    }
+
+    await publishUserSignal([state.vm0UserId], "github:changed");
+    signal.throwIfAborted();
+
+    return redirectResponse(appUrl("/works?github=connected"));
   },
 );
 
@@ -148,37 +717,25 @@ const callbackGithubOauth$ = command(
       return worksErrorRedirect("GitHub App integration is not configured");
     }
 
-    const query = get(queryOf(githubOauthContract.callback));
-
+    const query = get(queryOf(githubOauthContract.setupCallback));
+    if (query.error) {
+      return worksErrorRedirect(
+        query.error_description || query.error || "GitHub authorization failed",
+      );
+    }
     if (query.setup_action === "update") {
       return redirectResponse(appUrl("/works?github=installed"));
     }
 
-    const secretsEncryptionKey = env("SECRETS_ENCRYPTION_KEY");
-    const state = parseGithubOauthState(query.state);
-    if (!state) {
-      return worksErrorRedirect(
-        "Invalid OAuth state. Please try installing again from the Platform.",
-      );
+    const stateResolution = await resolveGithubCallbackState({
+      stateString: query.state,
+      secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
+    });
+    signal.throwIfAborted();
+    if (!stateResolution.ok) {
+      return stateResolution.response;
     }
-
-    if (
-      !(await isGithubOauthStateSignatureValid({
-        state,
-        secretsEncryptionKey,
-      }))
-    ) {
-      return worksErrorRedirect(
-        "Invalid state signature. Please try installing again from the Platform.",
-      );
-    }
-
-    const composeId = state.composeId;
-    if (!composeId) {
-      return worksErrorRedirect(
-        "Missing default agent. Please select an agent before connecting GitHub.",
-      );
-    }
+    const { state, composeId } = stateResolution;
 
     const db = set(writeDb$);
     const orgId = await resolveGithubOauthOrgId({
@@ -189,17 +746,27 @@ const callbackGithubOauth$ = command(
     });
     signal.throwIfAborted();
 
+    const access = await set(
+      resolveGithubCallbackAccess$,
+      { state, orgId },
+      signal,
+    );
+    if (!access.ok) {
+      return access.response;
+    }
+
     if (query.setup_action === "request") {
-      await createPendingGithubInstallation({
+      if (access.orgAlreadyHasActiveInstallation) {
+        return worksErrorRedirect(GITHUB_SINGLE_INSTALLATION_REQUIRED);
+      }
+
+      return await handlePendingGithubInstallation({
         db,
         orgId,
-        targetId: query.target_id ?? null,
-        targetType: query.target_type ?? "Organization",
         composeId,
+        query,
         signal,
       });
-
-      return redirectResponse(appUrl("/works?github=pending"));
     }
 
     const installationId = query.installation_id;
@@ -214,66 +781,60 @@ const callbackGithubOauth$ = command(
       signal,
     });
     if (existing) {
-      if (state.vm0UserId) {
-        await linkGithubVm0User({
+      const connection = await set(
+        connectGithubUserAfterSetup$,
+        {
           db,
+          orgId,
           installRecordId: existing.id,
-          vm0UserId: state.vm0UserId,
-          signal,
-        });
-      }
-      return redirectResponse(appUrl("/works?github=connected"));
-    }
-
-    const installInfo = await getGithubInstallationInfo({
-      appId,
-      privateKey,
-      installationId,
-      signal,
-    });
-    signal.throwIfAborted();
-
-    const { token } = await getGithubInstallationAccessToken({
-      appId,
-      privateKey,
-      installationId,
-      signal,
-    });
-    signal.throwIfAborted();
-
-    const adminGithubUserId =
-      installInfo.targetType === "User" ? installInfo.targetId : null;
-    const featureSwitchContext = await loadComposeFeatureSwitchContext({
-      db,
-      composeId,
-      userId: state.vm0UserId,
-      signal,
-    });
-    const installRecordId = await createOrActivateGithubInstallation({
-      db,
-      orgId,
-      installationId,
-      installInfo,
-      encryptedAccessToken: await encryptPersistentSecretValue(
-        token,
-        featureSwitchContext,
-      ),
-      adminGithubUserId,
-      composeId,
-      signal,
-    });
-
-    if (state.vm0UserId) {
-      await linkGithubVm0User({
-        db,
-        installRecordId,
-        vm0UserId: state.vm0UserId,
-        knownGithubUserId: adminGithubUserId,
+          ghInstallationId: installationId,
+          state,
+          code: query.code,
+          knownGithubUserId: null,
+        },
         signal,
-      });
+      );
+      if (!connection.ok) {
+        return connection.response;
+      }
+
+      return githubSetupCompleteRedirect(connection.connected);
     }
 
-    return redirectResponse(appUrl("/works?github=installed"));
+    if (access.orgAlreadyHasActiveInstallation) {
+      return worksErrorRedirect(GITHUB_SINGLE_INSTALLATION_REQUIRED);
+    }
+
+    const installation = await createActiveGithubInstallationFromCallback({
+      db,
+      appId,
+      privateKey,
+      orgId,
+      composeId,
+      installationId,
+      state,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const connection = await set(
+      connectGithubUserAfterSetup$,
+      {
+        db,
+        orgId,
+        installRecordId: installation.installRecordId,
+        ghInstallationId: installationId,
+        state,
+        code: query.code,
+        knownGithubUserId: installation.adminGithubUserId,
+      },
+      signal,
+    );
+    if (!connection.ok) {
+      return connection.response;
+    }
+
+    return githubSetupCompleteRedirect(connection.connected);
   },
 );
 
@@ -283,7 +844,15 @@ export const githubOauthRoutes: readonly RouteEntry[] = [
     handler: installGithubOauth$,
   },
   {
-    route: githubOauthContract.callback,
+    route: githubOauthContract.connect,
+    handler: authRoute({ requireOrganization: true }, connectGithubUserOauth$),
+  },
+  {
+    route: githubOauthContract.connectCallback,
+    handler: callbackGithubUserOauth$,
+  },
+  {
+    route: githubOauthContract.setupCallback,
     handler: callbackGithubOauth$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/integrations-github.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github.ts
@@ -2,16 +2,33 @@ import { command } from "ccstate";
 import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
 
 import { authRoute } from "../auth/auth-route";
-import { bodyResultOf } from "../context/request";
+import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
+  connectGithubUser$,
+  createGithubLabelListener$,
+  deleteGithubLabelListener$,
   deleteGithubInstallation$,
+  disconnectGithubUser$,
   getGithubInstallation$,
+  updateGithubLabelListener$,
   updateGithubInstallation$,
 } from "../services/integrations-github.service";
 import type { RouteEntry } from "../route";
 
 const updateInstallationBody$ = bodyResultOf(
   integrationsGithubContract.updateInstallation,
+);
+const createLabelListenerBody$ = bodyResultOf(
+  integrationsGithubContract.createLabelListener,
+);
+const updateLabelListenerBody$ = bodyResultOf(
+  integrationsGithubContract.updateLabelListener,
+);
+const updateLabelListenerParams$ = pathParamsOf(
+  integrationsGithubContract.updateLabelListener,
+);
+const deleteLabelListenerParams$ = pathParamsOf(
+  integrationsGithubContract.deleteLabelListener,
 );
 
 const agentNameRequired = Object.freeze({
@@ -44,17 +61,103 @@ const updateGithubInstallationInner$ = command(
   },
 );
 
+const createGithubLabelListenerInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const body = await get(createLabelListenerBody$);
+    signal.throwIfAborted();
+
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await set(createGithubLabelListener$, body.data, signal);
+    signal.throwIfAborted();
+
+    return result;
+  },
+);
+
+const updateGithubLabelListenerInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const body = await get(updateLabelListenerBody$);
+    signal.throwIfAborted();
+    const params = get(updateLabelListenerParams$);
+
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await set(
+      updateGithubLabelListener$,
+      { listenerId: params.listenerId, body: body.data },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return result;
+  },
+);
+
+const deleteGithubLabelListenerInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const params = get(deleteLabelListenerParams$);
+    const result = await set(
+      deleteGithubLabelListener$,
+      { listenerId: params.listenerId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return result;
+  },
+);
+
 export const integrationsGithubRoutes: readonly RouteEntry[] = [
   {
     route: integrationsGithubContract.getInstallation,
-    handler: authRoute({}, getGithubInstallation$),
+    handler: authRoute({ requireOrganization: true }, getGithubInstallation$),
+  },
+  {
+    route: integrationsGithubContract.connectUser,
+    handler: authRoute({ requireOrganization: true }, connectGithubUser$),
+  },
+  {
+    route: integrationsGithubContract.disconnectUser,
+    handler: authRoute({ requireOrganization: true }, disconnectGithubUser$),
   },
   {
     route: integrationsGithubContract.deleteInstallation,
-    handler: authRoute({}, deleteGithubInstallation$),
+    handler: authRoute(
+      { requireOrganization: true },
+      deleteGithubInstallation$,
+    ),
   },
   {
     route: integrationsGithubContract.updateInstallation,
-    handler: authRoute({}, updateGithubInstallationInner$),
+    handler: authRoute(
+      { requireOrganization: true },
+      updateGithubInstallationInner$,
+    ),
+  },
+  {
+    route: integrationsGithubContract.createLabelListener,
+    handler: authRoute(
+      { requireOrganization: true },
+      createGithubLabelListenerInner$,
+    ),
+  },
+  {
+    route: integrationsGithubContract.updateLabelListener,
+    handler: authRoute(
+      { requireOrganization: true },
+      updateGithubLabelListenerInner$,
+    ),
+  },
+  {
+    route: integrationsGithubContract.deleteLabelListener,
+    handler: authRoute(
+      { requireOrganization: true },
+      deleteGithubLabelListenerInner$,
+    ),
   },
 ];

--- a/turbo/apps/api/src/signals/routes/oauth-web-origin.ts
+++ b/turbo/apps/api/src/signals/routes/oauth-web-origin.ts
@@ -1,8 +1,6 @@
-const WEB_ORIGIN_HEADER = "x-vm0-web-origin";
+import { env } from "../../lib/env";
 
-function isLocalhost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1";
-}
+const WEB_ORIGIN_HEADER = "x-vm0-web-origin";
 
 function isVm0WebHost(hostname: string): boolean {
   return (
@@ -24,7 +22,7 @@ function isTrustedWebOrigin(origin: string): boolean {
     return false;
   }
 
-  if (isLocalhost(url.hostname)) {
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
     return url.protocol === "http:" || url.protocol === "https:";
   }
 
@@ -52,14 +50,8 @@ function canonicalWebOriginForApiHost(url: URL): string | null {
   return webUrl.origin;
 }
 
-export function getOAuthWebOrigin(request: Request): string {
-  const webOrigin = request.headers.get(WEB_ORIGIN_HEADER);
-  if (webOrigin && isTrustedWebOrigin(webOrigin)) {
-    return new URL(webOrigin).origin;
-  }
-
-  const requestUrl = new URL(request.url);
-  return canonicalWebOriginForApiHost(requestUrl) ?? requestUrl.origin;
+export function getOAuthWebOrigin(_request: Request): string {
+  return new URL(env("VM0_WEB_URL")).origin;
 }
 
 export function getOAuthCanonicalRedirectUrl(request: Request): string | null {

--- a/turbo/apps/api/src/signals/routes/webhooks-github.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-github.ts
@@ -14,9 +14,11 @@ import {
   gitHubInstallationEventSchema,
   gitHubIssueCommentEventSchema,
   gitHubIssuesEventSchema,
+  gitHubPullRequestEventSchema,
   handleGithubInstallationEvent$,
   handleGithubIssueCommentEvent$,
   handleGithubIssuesEvent$,
+  handleGithubPullRequestEvent$,
 } from "../services/webhooks-github.service";
 
 const L = logger("WebhookGithubRoute");
@@ -67,7 +69,6 @@ const postGithubWebhook$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<Response> => {
     const apiStartTime = now();
     const webhookSecret = optionalEnv("GITHUB_APP_WEBHOOK_SECRET");
-    const appSlug = optionalEnv("GITHUB_APP_SLUG");
 
     if (!webhookSecret) {
       return jsonError("GitHub App integration is not configured", 503);
@@ -117,11 +118,35 @@ const postGithubWebhook$ = command(
         tapError(
           set(
             handleGithubIssuesEvent$,
-            { payload: parsed.data, appSlug, apiStartTime },
+            { payload: parsed.data, apiStartTime },
             signal,
           ),
           (error) => {
             L.error("Error handling issues event", { error });
+          },
+        ),
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    if (headers.event === "pull_request") {
+      const parsed = gitHubPullRequestEventSchema.safeParse(payload);
+      if (!parsed.success) {
+        L.error("Invalid pull_request event payload", {
+          error: parsed.error,
+        });
+        return jsonError("Invalid payload structure", 400);
+      }
+
+      waitUntil(
+        tapError(
+          set(
+            handleGithubPullRequestEvent$,
+            { payload: parsed.data, apiStartTime },
+            signal,
+          ),
+          (error) => {
+            L.error("Error handling pull_request event", { error });
           },
         ),
       );
@@ -141,7 +166,7 @@ const postGithubWebhook$ = command(
         tapError(
           set(
             handleGithubIssueCommentEvent$,
-            { payload: parsed.data, appSlug, apiStartTime },
+            { payload: parsed.data, apiStartTime },
             signal,
           ),
           (error) => {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
@@ -453,6 +453,9 @@ const unlink$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("No linked AgentPhone account");
   }
 
+  await publishAgentPhoneUserChanged(auth.userId);
+  signal.throwIfAborted();
+
   return { status: 204 as const, body: undefined };
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -35,6 +35,7 @@ import {
 } from "../external/slack-file-fetcher";
 import { createSlackClient } from "../external/slack-message-client";
 import { db$, writeDb$, type Db } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { zeroConnectorList } from "../services/zero-connector-data.service";
 import { userSecrets, userVariables } from "../services/zero-user-data.service";
 import { decryptPersistentSecretValue } from "../services/crypto.utils";
@@ -342,7 +343,10 @@ async function uninstallSlackIntegration(args: {
   }
 
   const connections = await args.db
-    .select({ slackUserId: slackOrgConnections.slackUserId })
+    .select({
+      slackUserId: slackOrgConnections.slackUserId,
+      vm0UserId: slackOrgConnections.vm0UserId,
+    })
     .from(slackOrgConnections)
     .where(
       eq(slackOrgConnections.slackWorkspaceId, installation.slackWorkspaceId),
@@ -382,6 +386,22 @@ async function uninstallSlackIntegration(args: {
   args.signal.throwIfAborted();
 
   await args.publishChanged();
+  args.signal.throwIfAborted();
+
+  await bestEffort(
+    publishUserSignal(
+      Array.from(
+        new Set([
+          args.userId,
+          ...connections.map((connection) => {
+            return connection.vm0UserId;
+          }),
+        ]),
+      ),
+      "slack:changed",
+    ),
+    args.signal,
+  );
   args.signal.throwIfAborted();
 
   return { status: 200 as const, body: { ok: true } };
@@ -446,6 +466,12 @@ async function disconnectSlackIntegration(args: {
         slackUserId: connection.slackUserId,
       }),
     ),
+  );
+  args.signal.throwIfAborted();
+
+  await bestEffort(
+    publishUserSignal([args.userId], "slack:changed"),
+    args.signal,
   );
   args.signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -541,16 +541,23 @@ export async function tryLinkGithubFromRemoteInstallations(args: {
     return false;
   }
 
+  let unclaimedInstallation: AppInstallation | undefined;
   for (const ghInstall of installations) {
     const ghInstallationId = String(ghInstall.id);
     const [existing] = await args.db
-      .select({ id: githubInstallations.id })
+      .select({
+        id: githubInstallations.id,
+        orgId: githubInstallations.orgId,
+      })
       .from(githubInstallations)
       .where(eq(githubInstallations.installationId, ghInstallationId))
       .limit(1);
     args.signal.throwIfAborted();
 
     if (existing) {
+      if (args.orgId && existing.orgId !== args.orgId) {
+        continue;
+      }
       const linked = await linkGithubVm0User({
         db: args.db,
         installRecordId: existing.id,
@@ -559,9 +566,11 @@ export async function tryLinkGithubFromRemoteInstallations(args: {
       });
       return linked !== null;
     }
+
+    unclaimedInstallation ??= ghInstall;
   }
 
-  const ghInstall = installations[0];
+  const ghInstall = unclaimedInstallation;
   if (!ghInstall) {
     return false;
   }

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -374,16 +374,47 @@ export async function linkGithubVm0User(args: {
   }
 
   await args.db
+    .delete(githubUserLinks)
+    .where(
+      and(
+        eq(githubUserLinks.installationId, args.installRecordId),
+        eq(githubUserLinks.vm0UserId, args.vm0UserId),
+      ),
+    );
+  args.signal.throwIfAborted();
+
+  const [link] = await args.db
     .insert(githubUserLinks)
     .values({
       githubUserId,
       installationId: args.installRecordId,
       vm0UserId: args.vm0UserId,
     })
-    .onConflictDoNothing();
+    .onConflictDoNothing()
+    .returning({ githubUserId: githubUserLinks.githubUserId });
   args.signal.throwIfAborted();
 
-  return githubUserId;
+  return link?.githubUserId ?? null;
+}
+
+export async function loadActiveGithubInstallationForOrg(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly id: string } | null> {
+  const [installation] = await args.db
+    .select({ id: githubInstallations.id })
+    .from(githubInstallations)
+    .where(
+      and(
+        eq(githubInstallations.orgId, args.orgId),
+        eq(githubInstallations.status, "active"),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return installation ?? null;
 }
 
 export async function tryLinkGithubFromLocalRecord(args: {

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -35,6 +35,7 @@ interface GitHubInstallationInfo {
 
 interface GithubOAuthState {
   readonly vm0UserId: string | null;
+  readonly orgId: string | null;
   readonly composeId: string | null;
   readonly sig: string | null;
 }
@@ -196,6 +197,30 @@ export async function getGithubInstallationAccessToken(args: {
 
 async function createGithubOauthStateSignature(args: {
   readonly vm0UserId: string;
+  readonly orgId: string | null;
+  readonly composeId: string | null;
+  readonly secretsEncryptionKey: string;
+}): Promise<string> {
+  const textEncoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(args.secretsEncryptionKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const payload = `${args.vm0UserId}:${args.orgId ?? ""}:${args.composeId ?? ""}`;
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    textEncoder.encode(payload),
+  );
+
+  return Buffer.from(signature).toString("hex");
+}
+
+async function createLegacyGithubOauthStateSignature(args: {
+  readonly vm0UserId: string;
   readonly composeId: string | null;
   readonly secretsEncryptionKey: string;
 }): Promise<string> {
@@ -217,18 +242,31 @@ async function createGithubOauthStateSignature(args: {
   return Buffer.from(signature).toString("hex");
 }
 
+function signaturesMatch(actual: string | null, expected: string): boolean {
+  return (
+    actual !== null &&
+    actual.length === expected.length &&
+    timingSafeEqual(Buffer.from(actual), Buffer.from(expected))
+  );
+}
+
 export async function buildGithubOauthState(args: {
   readonly vm0UserId?: string;
+  readonly orgId?: string;
   readonly composeId?: string;
   readonly secretsEncryptionKey: string;
 }): Promise<string> {
   const state: {
     vm0UserId?: string;
+    orgId?: string;
     composeId?: string;
     sig?: string;
   } = {};
   if (args.vm0UserId) {
     state.vm0UserId = args.vm0UserId;
+  }
+  if (args.orgId) {
+    state.orgId = args.orgId;
   }
   if (args.composeId) {
     state.composeId = args.composeId;
@@ -236,6 +274,7 @@ export async function buildGithubOauthState(args: {
   if (state.vm0UserId) {
     state.sig = await createGithubOauthStateSignature({
       vm0UserId: state.vm0UserId,
+      orgId: state.orgId ?? null,
       composeId: state.composeId ?? null,
       secretsEncryptionKey: args.secretsEncryptionKey,
     });
@@ -248,7 +287,7 @@ export function parseGithubOauthState(
   state: string | undefined,
 ): GithubOAuthState | null {
   if (!state) {
-    return { vm0UserId: null, composeId: null, sig: null };
+    return { vm0UserId: null, orgId: null, composeId: null, sig: null };
   }
 
   const parsed = safeJsonParse(state);
@@ -258,6 +297,7 @@ export function parseGithubOauthState(
 
   const stateObject = parsed as {
     readonly vm0UserId?: unknown;
+    readonly orgId?: unknown;
     readonly composeId?: unknown;
     readonly sig?: unknown;
   };
@@ -265,6 +305,7 @@ export function parseGithubOauthState(
   return {
     vm0UserId:
       typeof stateObject.vm0UserId === "string" ? stateObject.vm0UserId : null,
+    orgId: typeof stateObject.orgId === "string" ? stateObject.orgId : null,
     composeId:
       typeof stateObject.composeId === "string" ? stateObject.composeId : null,
     sig: typeof stateObject.sig === "string" ? stateObject.sig : null,
@@ -281,15 +322,26 @@ export async function isGithubOauthStateSignatureValid(args: {
 
   const expectedSig = await createGithubOauthStateSignature({
     vm0UserId: args.state.vm0UserId,
+    orgId: args.state.orgId,
     composeId: args.state.composeId,
     secretsEncryptionKey: args.secretsEncryptionKey,
   });
 
-  return (
-    args.state.sig !== null &&
-    args.state.sig.length === expectedSig.length &&
-    timingSafeEqual(Buffer.from(args.state.sig), Buffer.from(expectedSig))
-  );
+  if (signaturesMatch(args.state.sig, expectedSig)) {
+    return true;
+  }
+
+  if (args.state.orgId !== null) {
+    return false;
+  }
+
+  const legacyExpectedSig = await createLegacyGithubOauthStateSignature({
+    vm0UserId: args.state.vm0UserId,
+    composeId: args.state.composeId,
+    secretsEncryptionKey: args.secretsEncryptionKey,
+  });
+
+  return signaturesMatch(args.state.sig, legacyExpectedSig);
 }
 
 export async function linkGithubVm0User(args: {
@@ -336,6 +388,7 @@ export async function linkGithubVm0User(args: {
 
 export async function tryLinkGithubFromLocalRecord(args: {
   readonly db: Db;
+  readonly orgId: string;
   readonly vm0UserId: string;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
@@ -345,7 +398,12 @@ export async function tryLinkGithubFromLocalRecord(args: {
       adminGithubUserId: githubInstallations.adminGithubUserId,
     })
     .from(githubInstallations)
-    .where(eq(githubInstallations.status, "active"))
+    .where(
+      and(
+        eq(githubInstallations.orgId, args.orgId),
+        eq(githubInstallations.status, "active"),
+      ),
+    )
     .limit(1);
   args.signal.throwIfAborted();
 
@@ -399,10 +457,35 @@ export async function loadComposeFeatureSwitchContext(args: {
   );
 }
 
+export async function resolveGithubOauthOrgId(args: {
+  readonly db: Db;
+  readonly orgId: string | null;
+  readonly composeId: string;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  if (args.orgId) {
+    return args.orgId;
+  }
+
+  const [compose] = await args.db
+    .select({ orgId: agentComposes.orgId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, args.composeId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!compose) {
+    throw new Error(`Agent compose not found: composeId=${args.composeId}`);
+  }
+
+  return compose.orgId;
+}
+
 export async function tryLinkGithubFromRemoteInstallations(args: {
   readonly db: Db;
   readonly appId: string;
   readonly privateKey: string;
+  readonly orgId: string | null;
   readonly vm0UserId: string;
   readonly composeId: string | null;
   readonly signal: AbortSignal;
@@ -455,6 +538,12 @@ export async function tryLinkGithubFromRemoteInstallations(args: {
   if (!args.composeId) {
     return false;
   }
+  const orgId = await resolveGithubOauthOrgId({
+    db: args.db,
+    orgId: args.orgId,
+    composeId: args.composeId,
+    signal: args.signal,
+  });
   const featureSwitchContext = await loadComposeFeatureSwitchContext({
     db: args.db,
     composeId: args.composeId,
@@ -483,6 +572,7 @@ export async function tryLinkGithubFromRemoteInstallations(args: {
         featureSwitchContext,
       ),
       status: "active",
+      orgId,
       targetType: ghInstall.account.type,
       targetId: String(ghInstall.account.id),
       targetName: ghInstall.account.login,
@@ -513,12 +603,18 @@ export async function tryLinkGithubFromRemoteInstallations(args: {
 export async function findGithubInstallationByInstallationId(args: {
   readonly db: Db;
   readonly installationId: string;
+  readonly orgId: string | null;
   readonly signal: AbortSignal;
 }): Promise<{ readonly id: string } | null> {
+  const filters = [eq(githubInstallations.installationId, args.installationId)];
+  if (args.orgId) {
+    filters.push(eq(githubInstallations.orgId, args.orgId));
+  }
+
   const [existing] = await args.db
     .select({ id: githubInstallations.id })
     .from(githubInstallations)
-    .where(eq(githubInstallations.installationId, args.installationId))
+    .where(and(...filters))
     .limit(1);
   args.signal.throwIfAborted();
 
@@ -527,6 +623,7 @@ export async function findGithubInstallationByInstallationId(args: {
 
 export async function createPendingGithubInstallation(args: {
   readonly db: Db;
+  readonly orgId: string;
   readonly targetId: string | null;
   readonly targetType: string;
   readonly composeId: string;
@@ -536,6 +633,7 @@ export async function createPendingGithubInstallation(args: {
     installationId: null,
     encryptedAccessToken: null,
     status: "pending",
+    orgId: args.orgId,
     targetId: args.targetId,
     targetType: args.targetType,
     defaultComposeId: args.composeId,
@@ -545,6 +643,7 @@ export async function createPendingGithubInstallation(args: {
 
 export async function createOrActivateGithubInstallation(args: {
   readonly db: Db;
+  readonly orgId: string;
   readonly installationId: string;
   readonly installInfo: GitHubInstallationInfo;
   readonly encryptedAccessToken: string;
@@ -557,6 +656,7 @@ export async function createOrActivateGithubInstallation(args: {
     .from(githubInstallations)
     .where(
       and(
+        eq(githubInstallations.orgId, args.orgId),
         eq(githubInstallations.targetId, args.installInfo.targetId),
         eq(githubInstallations.status, "pending"),
       ),
@@ -588,6 +688,7 @@ export async function createOrActivateGithubInstallation(args: {
       installationId: args.installationId,
       encryptedAccessToken: args.encryptedAccessToken,
       status: "active",
+      orgId: args.orgId,
       targetType: args.installInfo.targetType,
       targetId: args.installInfo.targetId,
       targetName: args.installInfo.targetName,

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -25,12 +25,16 @@ import { and, asc, eq, ne } from "drizzle-orm";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { request$ } from "../context/hono";
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { tapError } from "../utils";
-import { optionalEnv } from "../../lib/env";
+import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { getOAuthWebOrigin } from "../routes/oauth-web-origin";
-import { linkGithubVm0User } from "./github-oauth.service";
+import {
+  buildGithubOauthState,
+  linkGithubVm0User,
+} from "./github-oauth.service";
 import { zeroConnectorList } from "./zero-connector-data.service";
 import { userSecrets, userVariables } from "./zero-user-data.service";
 
@@ -45,23 +49,57 @@ function errorResponse(
   return { status, body: { error: { message, code } } };
 }
 
-function githubInstallUrl(
-  userId: string,
-  orgId: string,
-  composeId: string | null,
-  origin: string,
-): string | null {
-  if (!optionalEnv("GITHUB_APP_SLUG")) {
+function githubAppSetupCallbackRedirectUri(origin: string): string {
+  return `${origin}/api/github/app/setup/callback`;
+}
+
+async function githubInstallUrl(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly composeId: string | null;
+  readonly origin: string;
+}): Promise<string | null> {
+  const appSlug = optionalEnv("GITHUB_APP_SLUG");
+  if (!appSlug) {
     return null;
   }
 
-  const url = new URL("/api/github/oauth/install", origin);
-  url.searchParams.set("vm0UserId", userId);
-  url.searchParams.set("orgId", orgId);
-  if (composeId) {
-    url.searchParams.set("composeId", composeId);
+  const state = await buildGithubOauthState({
+    vm0UserId: args.userId,
+    orgId: args.orgId,
+    composeId: args.composeId ?? undefined,
+    secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
+  });
+  const url = new URL(`https://github.com/apps/${appSlug}/installations/new`);
+  if (state) {
+    url.searchParams.set("state", state);
   }
+  url.searchParams.set(
+    "redirect_uri",
+    githubAppSetupCallbackRedirectUri(args.origin),
+  );
   return url.toString();
+}
+
+function githubConnectUrl(origin: string): string {
+  return `${origin}/api/zero/connectors/github/authorize`;
+}
+
+async function publishGithubChanged(userIds: readonly string[]): Promise<void> {
+  const uniqueUserIds = Array.from(new Set(userIds));
+  if (uniqueUserIds.length === 0) {
+    return;
+  }
+
+  await tapError(
+    publishUserSignal(uniqueUserIds, "github:changed"),
+    (error) => {
+      L.warn("Failed to publish GitHub integration changed signal", {
+        userIds: uniqueUserIds,
+        error,
+      });
+    },
+  );
 }
 
 function emptyEnvironment(): GithubInstallationResponse["environment"] {
@@ -215,24 +253,10 @@ function normalizeLabelName(labelName: string): string {
   return labelName.trim().toLowerCase();
 }
 
-function isInstallationAdmin(
-  installation: GitHubInstallationRecord,
-  link: GitHubUserLinkRecord | null,
-): boolean {
-  return (
-    installation.adminGithubUserId !== null &&
-    link?.githubUserId === installation.adminGithubUserId
-  );
-}
-
-function canManageListener(args: {
-  readonly createdByUserId: string;
-  readonly currentUserId: string;
+function canManageInstallation(args: {
   readonly orgRole: string | undefined;
 }): boolean {
-  return (
-    args.createdByUserId === args.currentUserId || args.orgRole === "org:admin"
-  );
+  return args.orgRole === "admin";
 }
 
 function serializeListener(row: ListenerRow): GithubLabelListener {
@@ -529,6 +553,9 @@ export const connectGithubUser$ = command(
       );
     }
 
+    await publishGithubChanged([auth.userId]);
+    signal.throwIfAborted();
+
     return { status: 200 as const, body: { ok: true as const } };
   },
 );
@@ -554,6 +581,9 @@ export const disconnectGithubUser$ = command(
       );
     signal.throwIfAborted();
 
+    await publishGithubChanged([auth.userId]);
+    signal.throwIfAborted();
+
     return { status: 200 as const, body: { ok: true as const } };
   },
 );
@@ -569,20 +599,19 @@ export const deleteGithubInstallation$ = command(
       return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
     }
 
-    const link = await loadUserGithubLink({
-      db,
-      installationId: installation.id,
-      userId: auth.userId,
-    });
-    signal.throwIfAborted();
-
-    if (!isInstallationAdmin(installation, link)) {
+    if (!canManageInstallation({ orgRole: auth.orgRole })) {
       return errorResponse(
         403,
-        "Only the installation admin can uninstall",
+        "Only organization admins can uninstall GitHub",
         "FORBIDDEN",
       );
     }
+
+    const linkedUsers = await db
+      .select({ vm0UserId: githubUserLinks.vm0UserId })
+      .from(githubUserLinks)
+      .where(eq(githubUserLinks.installationId, installation.id));
+    signal.throwIfAborted();
 
     await deleteRemoteGithubInstallationIfConfigured({
       installationId: installation.installationId,
@@ -592,6 +621,14 @@ export const deleteGithubInstallation$ = command(
     await db
       .delete(githubInstallations)
       .where(eq(githubInstallations.id, installation.id));
+    signal.throwIfAborted();
+
+    await publishGithubChanged([
+      auth.userId,
+      ...linkedUsers.map((link) => {
+        return link.vm0UserId;
+      }),
+    ]);
     signal.throwIfAborted();
 
     return { status: 200 as const, body: { ok: true as const } };
@@ -613,17 +650,10 @@ export const updateGithubInstallation$ = command(
       return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
     }
 
-    const link = await loadUserGithubLink({
-      db,
-      installationId: installation.id,
-      userId: auth.userId,
-    });
-    signal.throwIfAborted();
-
-    if (!isInstallationAdmin(installation, link)) {
+    if (!canManageInstallation({ orgRole: auth.orgRole })) {
       return errorResponse(
         403,
-        "Only the installation admin can change the default agent",
+        "Only organization admins can change the default agent",
         "FORBIDDEN",
       );
     }
@@ -772,20 +802,6 @@ export const updateGithubLabelListener$ = command(
       return errorResponse(404, "GitHub label listener not found", "NOT_FOUND");
     }
 
-    if (
-      !canManageListener({
-        createdByUserId: existing.createdByUserId,
-        currentUserId: auth.userId,
-        orgRole: auth.orgRole,
-      })
-    ) {
-      return errorResponse(
-        403,
-        "Only the listener creator or an org admin can update this listener",
-        "FORBIDDEN",
-      );
-    }
-
     const values: Partial<typeof githubLabelListeners.$inferInsert> = {
       updatedAt: nowDate(),
     };
@@ -894,20 +910,6 @@ export const deleteGithubLabelListener$ = command(
       return errorResponse(404, "GitHub label listener not found", "NOT_FOUND");
     }
 
-    if (
-      !canManageListener({
-        createdByUserId: existing.createdByUserId,
-        currentUserId: auth.userId,
-        orgRole: auth.orgRole,
-      })
-    ) {
-      return errorResponse(
-        403,
-        "Only the listener creator or an org admin can delete this listener",
-        "FORBIDDEN",
-      );
-    }
-
     await db
       .delete(githubLabelListeners)
       .where(eq(githubLabelListeners.id, existing.id));
@@ -923,6 +925,15 @@ export const getGithubInstallation$ = computed(async (get) => {
   const db = get(db$);
   const installation = await loadOrgGithubInstallation(db, auth.orgId);
   const defaultComposeId = await loadOrgDefaultComposeId(db, auth.orgId);
+  const installUrl =
+    auth.orgRole === "admin"
+      ? await githubInstallUrl({
+          userId: auth.userId,
+          orgId: auth.orgId,
+          composeId: defaultComposeId,
+          origin,
+        })
+      : null;
 
   if (!installation) {
     return {
@@ -932,12 +943,7 @@ export const getGithubInstallation$ = computed(async (get) => {
           message: "No GitHub installation found",
           code: "NOT_FOUND",
         },
-        installUrl: githubInstallUrl(
-          auth.userId,
-          auth.orgId,
-          defaultComposeId,
-          origin,
-        ),
+        installUrl,
       },
     };
   }
@@ -947,7 +953,7 @@ export const getGithubInstallation$ = computed(async (get) => {
     installationId: installation.id,
     userId: auth.userId,
   });
-  const isAdmin = isInstallationAdmin(installation, link);
+  const isAdmin = canManageInstallation({ orgRole: auth.orgRole });
   const compose = await loadComposeSummary({
     db,
     orgId: auth.orgId,
@@ -979,6 +985,11 @@ export const getGithubInstallation$ = computed(async (get) => {
       return variable.name;
     }),
   );
+  const githubConnector =
+    connectorList.connectors.find((connector) => {
+      return connector.type === "github";
+    }) ?? null;
+  const connectUrl = githubConnectUrl(origin);
 
   const body: GithubInstallationResponse = {
     installation: {
@@ -991,13 +1002,11 @@ export const getGithubInstallation$ = computed(async (get) => {
     },
     isConnected: link !== null,
     connectedGithubUserId: link?.githubUserId ?? null,
-    installUrl: githubInstallUrl(
-      auth.userId,
-      auth.orgId,
-      defaultComposeId,
-      origin,
-    ),
-    connectUrl: "/connectors/github/connect",
+    connectedGithubUsername: link
+      ? (githubConnector?.externalUsername ?? null)
+      : null,
+    installUrl,
+    connectUrl,
     agent: compose ? { id: compose.id, name: compose.name } : null,
     environment: {
       ...environment,

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -1,7 +1,12 @@
 import { Buffer } from "node:buffer";
 import { createSign } from "node:crypto";
 import { command, computed } from "ccstate";
-import type { GithubInstallationResponse } from "@vm0/api-contracts/contracts/integrations-github";
+import type {
+  CreateGithubLabelListenerBody,
+  GithubInstallationResponse,
+  GithubLabelListener,
+  UpdateGithubLabelListenerBody,
+} from "@vm0/api-contracts/contracts/integrations-github";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import { getConnectorProvidedSecretNames } from "@vm0/connectors/connector-utils";
 import {
@@ -9,18 +14,23 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
+import {
+  githubLabelListeners,
+  type GithubLabelTriggerMode,
+} from "@vm0/db/schema/github-label-listener";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq, ne } from "drizzle-orm";
 
-import { authContext$ } from "../auth/auth-context";
+import { organizationAuthContext$ } from "../auth/auth-context";
 import { request$ } from "../context/hono";
-import { db$, writeDb$ } from "../external/db";
+import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { tapError } from "../utils";
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { getOAuthWebOrigin } from "../routes/oauth-web-origin";
+import { linkGithubVm0User } from "./github-oauth.service";
 import { zeroConnectorList } from "./zero-connector-data.service";
 import { userSecrets, userVariables } from "./zero-user-data.service";
 
@@ -28,7 +38,7 @@ const INSTALLATION_ID_RE = /^\d+$/;
 const L = logger("IntegrationsGithub");
 
 function errorResponse(
-  status: 400 | 401 | 403 | 404 | 500,
+  status: 400 | 401 | 403 | 404 | 409 | 500,
   message: string,
   code: string,
 ) {
@@ -37,6 +47,7 @@ function errorResponse(
 
 function githubInstallUrl(
   userId: string,
+  orgId: string,
   composeId: string | null,
   origin: string,
 ): string | null {
@@ -46,6 +57,7 @@ function githubInstallUrl(
 
   const url = new URL("/api/github/oauth/install", origin);
   url.searchParams.set("vm0UserId", userId);
+  url.searchParams.set("orgId", orgId);
   if (composeId) {
     url.searchParams.set("composeId", composeId);
   }
@@ -175,35 +187,396 @@ async function deleteRemoteGithubInstallationIfConfigured(args: {
   args.signal.throwIfAborted();
 }
 
-export const deleteGithubInstallation$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const auth = get(authContext$);
-    const db = set(writeDb$);
+type GitHubInstallationRecord = typeof githubInstallations.$inferSelect;
 
-    const [result] = await db
-      .select({
-        id: githubInstallations.id,
-        githubInstallationId: githubInstallations.installationId,
-        adminGithubUserId: githubInstallations.adminGithubUserId,
-        githubUserId: githubUserLinks.githubUserId,
-      })
-      .from(githubUserLinks)
-      .innerJoin(
-        githubInstallations,
-        eq(githubInstallations.id, githubUserLinks.installationId),
-      )
-      .where(eq(githubUserLinks.vm0UserId, auth.userId))
-      .limit(1);
+interface GitHubUserLinkRecord {
+  readonly githubUserId: string;
+}
+
+interface ComposeSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly headVersionId: string | null;
+}
+
+interface ListenerRow {
+  readonly id: string;
+  readonly labelName: string;
+  readonly triggerMode: GithubLabelTriggerMode;
+  readonly prompt: string;
+  readonly enabled: boolean;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly agentId: string | null;
+  readonly agentName: string | null;
+}
+
+function normalizeLabelName(labelName: string): string {
+  return labelName.trim().toLowerCase();
+}
+
+function isInstallationAdmin(
+  installation: GitHubInstallationRecord,
+  link: GitHubUserLinkRecord | null,
+): boolean {
+  return (
+    installation.adminGithubUserId !== null &&
+    link?.githubUserId === installation.adminGithubUserId
+  );
+}
+
+function canManageListener(args: {
+  readonly createdByUserId: string;
+  readonly currentUserId: string;
+  readonly orgRole: string | undefined;
+}): boolean {
+  return (
+    args.createdByUserId === args.currentUserId || args.orgRole === "org:admin"
+  );
+}
+
+function serializeListener(row: ListenerRow): GithubLabelListener {
+  return {
+    id: row.id,
+    labelName: row.labelName,
+    triggerMode: row.triggerMode,
+    prompt: row.prompt,
+    enabled: row.enabled,
+    agent:
+      row.agentId && row.agentName
+        ? { id: row.agentId, name: row.agentName }
+        : null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+async function loadOrgDefaultComposeId(
+  db: ReadonlyDb,
+  orgId: string,
+): Promise<string | null> {
+  const [orgRow] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return orgRow?.defaultAgentId ?? null;
+}
+
+async function loadOrgGithubInstallation(
+  db: ReadonlyDb,
+  orgId: string,
+): Promise<GitHubInstallationRecord | null> {
+  const [installation] = await db
+    .select()
+    .from(githubInstallations)
+    .where(
+      and(
+        eq(githubInstallations.orgId, orgId),
+        eq(githubInstallations.status, "active"),
+      ),
+    )
+    .limit(1);
+
+  return installation ?? null;
+}
+
+async function loadUserGithubLink(args: {
+  readonly db: ReadonlyDb;
+  readonly installationId: string;
+  readonly userId: string;
+}): Promise<GitHubUserLinkRecord | null> {
+  const [link] = await args.db
+    .select({ githubUserId: githubUserLinks.githubUserId })
+    .from(githubUserLinks)
+    .where(
+      and(
+        eq(githubUserLinks.installationId, args.installationId),
+        eq(githubUserLinks.vm0UserId, args.userId),
+      ),
+    )
+    .limit(1);
+
+  return link ?? null;
+}
+
+async function loadComposeSummary(args: {
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly composeId: string;
+}): Promise<ComposeSummary | null> {
+  const [compose] = await args.db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, args.orgId),
+        eq(agentComposes.id, args.composeId),
+      ),
+    )
+    .limit(1);
+
+  return compose ?? null;
+}
+
+async function loadComposeByName(args: {
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly agentName: string;
+}): Promise<{ readonly id: string } | null> {
+  const [compose] = await args.db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, args.orgId),
+        eq(agentComposes.name, args.agentName),
+      ),
+    )
+    .limit(1);
+
+  return compose ?? null;
+}
+
+async function buildEnvironment(args: {
+  readonly db: ReadonlyDb;
+  readonly compose: ComposeSummary | null;
+}): Promise<GithubInstallationResponse["environment"]> {
+  if (!args.compose?.headVersionId) {
+    return emptyEnvironment();
+  }
+
+  const [version] = await args.db
+    .select({ content: agentComposeVersions.content })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, args.compose.headVersionId))
+    .limit(1);
+
+  if (!version) {
+    return emptyEnvironment();
+  }
+
+  const grouped = extractAndGroupVariables(version.content);
+  return {
+    requiredSecrets: grouped.secrets.map((secret) => {
+      return secret.name;
+    }),
+    requiredVars: grouped.vars.map((variable) => {
+      return variable.name;
+    }),
+    missingSecrets: [],
+    missingVars: [],
+  };
+}
+
+async function loadListeners(args: {
+  readonly db: ReadonlyDb;
+  readonly installationId: string;
+}): Promise<readonly GithubLabelListener[]> {
+  const rows = await args.db
+    .select({
+      id: githubLabelListeners.id,
+      labelName: githubLabelListeners.labelName,
+      triggerMode: githubLabelListeners.triggerMode,
+      prompt: githubLabelListeners.prompt,
+      enabled: githubLabelListeners.enabled,
+      createdAt: githubLabelListeners.createdAt,
+      updatedAt: githubLabelListeners.updatedAt,
+      agentId: agentComposes.id,
+      agentName: agentComposes.name,
+    })
+    .from(githubLabelListeners)
+    .leftJoin(
+      agentComposes,
+      eq(agentComposes.id, githubLabelListeners.composeId),
+    )
+    .where(eq(githubLabelListeners.installationId, args.installationId))
+    .orderBy(asc(githubLabelListeners.labelNameNormalized));
+
+  return rows.map((row) => {
+    return serializeListener(row);
+  });
+}
+
+async function loadListener(args: {
+  readonly db: ReadonlyDb;
+  readonly listenerId: string;
+  readonly orgId: string;
+}): Promise<
+  | (ListenerRow & {
+      readonly installationId: string;
+      readonly createdByUserId: string;
+    })
+  | null
+> {
+  const [row] = await args.db
+    .select({
+      id: githubLabelListeners.id,
+      installationId: githubLabelListeners.installationId,
+      createdByUserId: githubLabelListeners.createdByUserId,
+      labelName: githubLabelListeners.labelName,
+      triggerMode: githubLabelListeners.triggerMode,
+      prompt: githubLabelListeners.prompt,
+      enabled: githubLabelListeners.enabled,
+      createdAt: githubLabelListeners.createdAt,
+      updatedAt: githubLabelListeners.updatedAt,
+      agentId: agentComposes.id,
+      agentName: agentComposes.name,
+    })
+    .from(githubLabelListeners)
+    .leftJoin(
+      agentComposes,
+      eq(agentComposes.id, githubLabelListeners.composeId),
+    )
+    .where(
+      and(
+        eq(githubLabelListeners.id, args.listenerId),
+        eq(githubLabelListeners.orgId, args.orgId),
+      ),
+    )
+    .limit(1);
+
+  return row ?? null;
+}
+
+async function listenerLabelExists(args: {
+  readonly db: ReadonlyDb;
+  readonly installationId: string;
+  readonly labelNameNormalized: string;
+  readonly exceptListenerId?: string;
+}): Promise<boolean> {
+  const filters = [
+    eq(githubLabelListeners.installationId, args.installationId),
+    eq(githubLabelListeners.labelNameNormalized, args.labelNameNormalized),
+  ];
+  if (args.exceptListenerId) {
+    filters.push(ne(githubLabelListeners.id, args.exceptListenerId));
+  }
+
+  const [existing] = await args.db
+    .select({ id: githubLabelListeners.id })
+    .from(githubLabelListeners)
+    .where(and(...filters))
+    .limit(1);
+
+  return Boolean(existing);
+}
+
+async function validateTriggerModeLink(args: {
+  readonly db: ReadonlyDb;
+  readonly installationId: string;
+  readonly userId: string;
+  readonly triggerMode: GithubLabelTriggerMode;
+}): Promise<boolean> {
+  if (args.triggerMode !== "created_by_me") {
+    return true;
+  }
+
+  const link = await loadUserGithubLink({
+    db: args.db,
+    installationId: args.installationId,
+    userId: args.userId,
+  });
+  return link !== null;
+}
+
+async function loadCreatedListener(args: {
+  readonly db: ReadonlyDb;
+  readonly listenerId: string;
+  readonly orgId: string;
+}): Promise<GithubLabelListener> {
+  const listener = await loadListener({
+    db: args.db,
+    listenerId: args.listenerId,
+    orgId: args.orgId,
+  });
+
+  if (!listener) {
+    throw new Error(`GitHub label listener not found: ${args.listenerId}`);
+  }
+
+  return serializeListener(listener);
+}
+
+export const connectGithubUser$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const db = set(writeDb$);
+    const installation = await loadOrgGithubInstallation(db, auth.orgId);
     signal.throwIfAborted();
 
-    if (!result) {
+    if (!installation) {
       return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
     }
 
-    if (
-      !result.adminGithubUserId ||
-      result.githubUserId !== result.adminGithubUserId
-    ) {
+    const githubUserId = await linkGithubVm0User({
+      db,
+      installRecordId: installation.id,
+      vm0UserId: auth.userId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (!githubUserId) {
+      return errorResponse(
+        409,
+        "Connect your GitHub account before linking this installation",
+        "GITHUB_ACCOUNT_REQUIRED",
+      );
+    }
+
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);
+
+export const disconnectGithubUser$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const db = set(writeDb$);
+    const installation = await loadOrgGithubInstallation(db, auth.orgId);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
+    }
+
+    await db
+      .delete(githubUserLinks)
+      .where(
+        and(
+          eq(githubUserLinks.installationId, installation.id),
+          eq(githubUserLinks.vm0UserId, auth.userId),
+        ),
+      );
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);
+
+export const deleteGithubInstallation$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const db = set(writeDb$);
+    const installation = await loadOrgGithubInstallation(db, auth.orgId);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
+    }
+
+    const link = await loadUserGithubLink({
+      db,
+      installationId: installation.id,
+      userId: auth.userId,
+    });
+    signal.throwIfAborted();
+
+    if (!isInstallationAdmin(installation, link)) {
       return errorResponse(
         403,
         "Only the installation admin can uninstall",
@@ -212,13 +585,13 @@ export const deleteGithubInstallation$ = command(
     }
 
     await deleteRemoteGithubInstallationIfConfigured({
-      installationId: result.githubInstallationId,
+      installationId: installation.installationId,
       signal,
     });
 
     await db
       .delete(githubInstallations)
-      .where(eq(githubInstallations.id, result.id));
+      .where(eq(githubInstallations.id, installation.id));
     signal.throwIfAborted();
 
     return { status: 200 as const, body: { ok: true as const } };
@@ -231,32 +604,23 @@ export const updateGithubInstallation$ = command(
     args: { readonly agentName: string },
     signal: AbortSignal,
   ) => {
-    const auth = get(authContext$);
+    const auth = get(organizationAuthContext$);
     const db = set(writeDb$);
-
-    const [result] = await db
-      .select({
-        installationId: githubInstallations.id,
-        adminGithubUserId: githubInstallations.adminGithubUserId,
-        githubUserId: githubUserLinks.githubUserId,
-      })
-      .from(githubUserLinks)
-      .innerJoin(
-        githubInstallations,
-        eq(githubInstallations.id, githubUserLinks.installationId),
-      )
-      .where(eq(githubUserLinks.vm0UserId, auth.userId))
-      .limit(1);
+    const installation = await loadOrgGithubInstallation(db, auth.orgId);
     signal.throwIfAborted();
 
-    if (!result) {
+    if (!installation) {
       return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
     }
 
-    if (
-      !result.adminGithubUserId ||
-      result.githubUserId !== result.adminGithubUserId
-    ) {
+    const link = await loadUserGithubLink({
+      db,
+      installationId: installation.id,
+      userId: auth.userId,
+    });
+    signal.throwIfAborted();
+
+    if (!isInstallationAdmin(installation, link)) {
       return errorResponse(
         403,
         "Only the installation admin can change the default agent",
@@ -264,24 +628,11 @@ export const updateGithubInstallation$ = command(
       );
     }
 
-    if (!auth.orgId) {
-      return errorResponse(
-        400,
-        "Explicit org context required — ensure active org in session",
-        "BAD_REQUEST",
-      );
-    }
-
-    const [compose] = await db
-      .select({ id: agentComposes.id })
-      .from(agentComposes)
-      .where(
-        and(
-          eq(agentComposes.orgId, auth.orgId),
-          eq(agentComposes.name, args.agentName),
-        ),
-      )
-      .limit(1);
+    const compose = await loadComposeByName({
+      db,
+      orgId: auth.orgId,
+      agentName: args.agentName,
+    });
     signal.throwIfAborted();
 
     if (!compose) {
@@ -291,7 +642,275 @@ export const updateGithubInstallation$ = command(
     await db
       .update(githubInstallations)
       .set({ defaultComposeId: compose.id, updatedAt: nowDate() })
-      .where(eq(githubInstallations.id, result.installationId));
+      .where(eq(githubInstallations.id, installation.id));
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);
+
+export const createGithubLabelListener$ = command(
+  async (
+    { get, set },
+    args: CreateGithubLabelListenerBody,
+    signal: AbortSignal,
+  ) => {
+    const auth = get(organizationAuthContext$);
+    const db = set(writeDb$);
+    const installation = await loadOrgGithubInstallation(db, auth.orgId);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
+    }
+
+    const labelName = args.labelName.trim();
+    const labelNameNormalized = normalizeLabelName(args.labelName);
+    const prompt = args.prompt.trim();
+    if (!labelName || !labelNameNormalized || !prompt) {
+      return errorResponse(
+        400,
+        "Label name and prompt are required",
+        "BAD_REQUEST",
+      );
+    }
+
+    const compose = await loadComposeSummary({
+      db,
+      orgId: auth.orgId,
+      composeId: args.agentId,
+    });
+    signal.throwIfAborted();
+
+    if (!compose) {
+      return errorResponse(404, "Agent not found", "NOT_FOUND");
+    }
+
+    if (
+      !(await validateTriggerModeLink({
+        db,
+        installationId: installation.id,
+        userId: auth.userId,
+        triggerMode: args.triggerMode,
+      }))
+    ) {
+      return errorResponse(
+        409,
+        "Connect your GitHub account before using the created-by-me trigger mode",
+        "GITHUB_ACCOUNT_REQUIRED",
+      );
+    }
+    signal.throwIfAborted();
+
+    if (
+      await listenerLabelExists({
+        db,
+        installationId: installation.id,
+        labelNameNormalized,
+      })
+    ) {
+      return errorResponse(
+        409,
+        "A listener for this label already exists",
+        "DUPLICATE_LABEL",
+      );
+    }
+    signal.throwIfAborted();
+
+    const [listener] = await db
+      .insert(githubLabelListeners)
+      .values({
+        installationId: installation.id,
+        orgId: auth.orgId,
+        createdByUserId: auth.userId,
+        labelName,
+        labelNameNormalized,
+        triggerMode: args.triggerMode,
+        prompt,
+        composeId: compose.id,
+        enabled: args.enabled ?? true,
+      })
+      .returning({ id: githubLabelListeners.id });
+    signal.throwIfAborted();
+
+    if (!listener) {
+      throw new Error("Expected GitHub label listener insert to return a row");
+    }
+
+    return {
+      status: 201 as const,
+      body: {
+        listener: await loadCreatedListener({
+          db,
+          listenerId: listener.id,
+          orgId: auth.orgId,
+        }),
+      },
+    };
+  },
+);
+
+export const updateGithubLabelListener$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly listenerId: string;
+      readonly body: UpdateGithubLabelListenerBody;
+    },
+    signal: AbortSignal,
+  ) => {
+    const auth = get(organizationAuthContext$);
+    const db = set(writeDb$);
+    const existing = await loadListener({
+      db,
+      listenerId: args.listenerId,
+      orgId: auth.orgId,
+    });
+    signal.throwIfAborted();
+
+    if (!existing) {
+      return errorResponse(404, "GitHub label listener not found", "NOT_FOUND");
+    }
+
+    if (
+      !canManageListener({
+        createdByUserId: existing.createdByUserId,
+        currentUserId: auth.userId,
+        orgRole: auth.orgRole,
+      })
+    ) {
+      return errorResponse(
+        403,
+        "Only the listener creator or an org admin can update this listener",
+        "FORBIDDEN",
+      );
+    }
+
+    const values: Partial<typeof githubLabelListeners.$inferInsert> = {
+      updatedAt: nowDate(),
+    };
+
+    if (args.body.labelName !== undefined) {
+      const labelName = args.body.labelName.trim();
+      const labelNameNormalized = normalizeLabelName(args.body.labelName);
+      if (!labelName || !labelNameNormalized) {
+        return errorResponse(400, "Label name is required", "BAD_REQUEST");
+      }
+      if (
+        await listenerLabelExists({
+          db,
+          installationId: existing.installationId,
+          labelNameNormalized,
+          exceptListenerId: existing.id,
+        })
+      ) {
+        return errorResponse(
+          409,
+          "A listener for this label already exists",
+          "DUPLICATE_LABEL",
+        );
+      }
+      values.labelName = labelName;
+      values.labelNameNormalized = labelNameNormalized;
+    }
+
+    if (args.body.prompt !== undefined) {
+      const prompt = args.body.prompt.trim();
+      if (!prompt) {
+        return errorResponse(400, "Prompt is required", "BAD_REQUEST");
+      }
+      values.prompt = prompt;
+    }
+
+    if (args.body.agentId !== undefined) {
+      const compose = await loadComposeSummary({
+        db,
+        orgId: auth.orgId,
+        composeId: args.body.agentId,
+      });
+      signal.throwIfAborted();
+      if (!compose) {
+        return errorResponse(404, "Agent not found", "NOT_FOUND");
+      }
+      values.composeId = compose.id;
+    }
+
+    const nextTriggerMode = args.body.triggerMode ?? existing.triggerMode;
+    if (
+      !(await validateTriggerModeLink({
+        db,
+        installationId: existing.installationId,
+        userId: existing.createdByUserId,
+        triggerMode: nextTriggerMode,
+      }))
+    ) {
+      return errorResponse(
+        409,
+        "Connect your GitHub account before using the created-by-me trigger mode",
+        "GITHUB_ACCOUNT_REQUIRED",
+      );
+    }
+    values.triggerMode = nextTriggerMode;
+
+    if (args.body.enabled !== undefined) {
+      values.enabled = args.body.enabled;
+    }
+
+    await db
+      .update(githubLabelListeners)
+      .set(values)
+      .where(eq(githubLabelListeners.id, existing.id));
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        listener: await loadCreatedListener({
+          db,
+          listenerId: existing.id,
+          orgId: auth.orgId,
+        }),
+      },
+    };
+  },
+);
+
+export const deleteGithubLabelListener$ = command(
+  async (
+    { get, set },
+    args: { readonly listenerId: string },
+    signal: AbortSignal,
+  ) => {
+    const auth = get(organizationAuthContext$);
+    const db = set(writeDb$);
+    const existing = await loadListener({
+      db,
+      listenerId: args.listenerId,
+      orgId: auth.orgId,
+    });
+    signal.throwIfAborted();
+
+    if (!existing) {
+      return errorResponse(404, "GitHub label listener not found", "NOT_FOUND");
+    }
+
+    if (
+      !canManageListener({
+        createdByUserId: existing.createdByUserId,
+        currentUserId: auth.userId,
+        orgRole: auth.orgRole,
+      })
+    ) {
+      return errorResponse(
+        403,
+        "Only the listener creator or an org admin can delete this listener",
+        "FORBIDDEN",
+      );
+    }
+
+    await db
+      .delete(githubLabelListeners)
+      .where(eq(githubLabelListeners.id, existing.id));
     signal.throwIfAborted();
 
     return { status: 200 as const, body: { ok: true as const } };
@@ -299,41 +918,13 @@ export const updateGithubInstallation$ = command(
 );
 
 export const getGithubInstallation$ = computed(async (get) => {
-  const auth = get(authContext$);
+  const auth = get(organizationAuthContext$);
   const origin = getOAuthWebOrigin(get(request$).raw);
   const db = get(db$);
+  const installation = await loadOrgGithubInstallation(db, auth.orgId);
+  const defaultComposeId = await loadOrgDefaultComposeId(db, auth.orgId);
 
-  const [result] = await db
-    .select({
-      installation: {
-        id: githubInstallations.id,
-        installationId: githubInstallations.installationId,
-        status: githubInstallations.status,
-        targetName: githubInstallations.targetName,
-        targetType: githubInstallations.targetType,
-        adminGithubUserId: githubInstallations.adminGithubUserId,
-        defaultComposeId: githubInstallations.defaultComposeId,
-      },
-      githubUserId: githubUserLinks.githubUserId,
-    })
-    .from(githubUserLinks)
-    .innerJoin(
-      githubInstallations,
-      eq(githubInstallations.id, githubUserLinks.installationId),
-    )
-    .where(eq(githubUserLinks.vm0UserId, auth.userId))
-    .limit(1);
-
-  if (!result) {
-    const [orgRow] = auth.orgId
-      ? await db
-          .select({ defaultAgentId: orgMetadata.defaultAgentId })
-          .from(orgMetadata)
-          .where(eq(orgMetadata.orgId, auth.orgId))
-          .limit(1)
-      : [];
-    const defaultComposeId = orgRow?.defaultAgentId ?? null;
-
+  if (!installation) {
     return {
       status: 404 as const,
       body: {
@@ -341,63 +932,36 @@ export const getGithubInstallation$ = computed(async (get) => {
           message: "No GitHub installation found",
           code: "NOT_FOUND",
         },
-        installUrl: githubInstallUrl(auth.userId, defaultComposeId, origin),
+        installUrl: githubInstallUrl(
+          auth.userId,
+          auth.orgId,
+          defaultComposeId,
+          origin,
+        ),
       },
     };
   }
 
-  const installation = result.installation;
-  const isAdmin =
-    installation.adminGithubUserId !== null &&
-    result.githubUserId === installation.adminGithubUserId;
+  const link = await loadUserGithubLink({
+    db,
+    installationId: installation.id,
+    userId: auth.userId,
+  });
+  const isAdmin = isInstallationAdmin(installation, link);
+  const compose = await loadComposeSummary({
+    db,
+    orgId: auth.orgId,
+    composeId: installation.defaultComposeId,
+  });
+  const environment = await buildEnvironment({ db, compose });
 
-  const [compose] = await db
-    .select({
-      id: agentComposes.id,
-      name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, installation.defaultComposeId))
-    .limit(1);
-
-  let environment = emptyEnvironment();
-
-  if (compose?.headVersionId) {
-    const [version] = await db
-      .select({ content: agentComposeVersions.content })
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, compose.headVersionId))
-      .limit(1);
-
-    if (version) {
-      const grouped = extractAndGroupVariables(version.content);
-      environment = {
-        requiredSecrets: grouped.secrets.map((secret) => {
-          return secret.name;
-        }),
-        requiredVars: grouped.vars.map((variable) => {
-          return variable.name;
-        }),
-        missingSecrets: [],
-        missingVars: [],
-      };
-    }
-  }
-
-  if (!auth.orgId) {
-    return errorResponse(
-      400,
-      "Explicit org context required — ensure active org in session",
-      "BAD_REQUEST",
-    );
-  }
-
-  const [secretList, variableList, connectorList] = await Promise.all([
-    get(userSecrets({ orgId: auth.orgId, userId: auth.userId })),
-    get(userVariables({ orgId: auth.orgId, userId: auth.userId })),
-    get(zeroConnectorList({ orgId: auth.orgId, userId: auth.userId })),
-  ]);
+  const [secretList, variableList, connectorList, labelListeners] =
+    await Promise.all([
+      get(userSecrets({ orgId: auth.orgId, userId: auth.userId })),
+      get(userVariables({ orgId: auth.orgId, userId: auth.userId })),
+      get(zeroConnectorList({ orgId: auth.orgId, userId: auth.userId })),
+      loadListeners({ db, installationId: installation.id }),
+    ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(
     connectorList.connectors.map((connector) => {
@@ -425,6 +989,15 @@ export const getGithubInstallation$ = computed(async (get) => {
       targetType: installation.targetType,
       isAdmin,
     },
+    isConnected: link !== null,
+    connectedGithubUserId: link?.githubUserId ?? null,
+    installUrl: githubInstallUrl(
+      auth.userId,
+      auth.orgId,
+      defaultComposeId,
+      origin,
+    ),
+    connectUrl: "/connectors/github/connect",
     agent: compose ? { id: compose.id, name: compose.name } : null,
     environment: {
       ...environment,
@@ -435,6 +1008,7 @@ export const getGithubInstallation$ = computed(async (get) => {
         return !existingVarNames.has(name);
       }),
     },
+    labelListeners: [...labelListeners],
   };
 
   return { status: 200 as const, body };

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -8,10 +8,11 @@ import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
+import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command } from "ccstate";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -84,6 +85,15 @@ export const gitHubIssueCommentEventSchema = z.object({
   sender: gitHubUserSchema,
 });
 
+export const gitHubPullRequestEventSchema = z.object({
+  action: z.string(),
+  pull_request: gitHubIssueSchema,
+  label: gitHubLabelSchema.optional(),
+  repository: gitHubRepositorySchema,
+  installation: gitHubInstallationRefSchema,
+  sender: gitHubUserSchema,
+});
+
 const gitHubInstallationAccountSchema = z.object({
   id: z.number(),
   login: z.string(),
@@ -108,19 +118,24 @@ type GitHubIssue = z.infer<typeof gitHubIssueSchema>;
 type GitHubComment = z.infer<typeof gitHubCommentSchema>;
 type GitHubIssuesEvent = z.infer<typeof gitHubIssuesEventSchema>;
 type GitHubIssueCommentEvent = z.infer<typeof gitHubIssueCommentEventSchema>;
+type GitHubPullRequestEvent = z.infer<typeof gitHubPullRequestEventSchema>;
 type GitHubInstallationEvent = z.infer<typeof gitHubInstallationEventSchema>;
 type GitHubInstallationRecord = typeof githubInstallations.$inferSelect;
+type GitHubLabelListenerRecord = typeof githubLabelListeners.$inferSelect;
+type GitHubTriggerKind = "issue" | "pull_request";
 
 interface DispatchParams {
   readonly ghInstallationId: string;
   readonly repo: string;
   readonly issue: GitHubIssue;
-  readonly senderGithubUserId: string;
+  readonly subjectKind: GitHubTriggerKind;
+  readonly vm0UserId: string;
+  readonly composeId: string;
   readonly prompt: string;
+  readonly matchedLabelName: string;
   readonly commentId?: string;
   readonly comment?: GitHubComment;
   readonly forceNewSession?: boolean;
-  readonly appSlug?: string;
   readonly apiStartTime: number;
 }
 
@@ -154,34 +169,27 @@ function buildGitHubPrompt(issueContext: string): string {
     .join("\n\n");
 }
 
-function buildIssuePrompt(issue: GitHubIssue): string {
-  return issue.body ?? issue.title;
-}
-
-function buildCommentPrompt(comment: GitHubComment): string {
-  return comment.body;
+function normalizeLabelName(labelName: string): string {
+  return labelName.trim().toLowerCase();
 }
 
 function buildPromptParts(
   prompt: string,
   issueContext: string,
-  isCommentTrigger: boolean,
 ): {
   readonly prompt: string;
   readonly appendSystemPrompt: string | undefined;
 } {
   const appendSystemPrompt = buildGitHubPrompt(issueContext) || undefined;
-  const userPrompt = isCommentTrigger
-    ? prompt
-    : issueContext
-      ? "Based on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action."
-      : prompt;
 
-  return { prompt: userPrompt, appendSystemPrompt };
+  return { prompt, appendSystemPrompt };
 }
 
 function formatIssueContext(args: {
   readonly issue: GitHubIssue;
+  readonly subjectKind: GitHubTriggerKind;
+  readonly repo: string;
+  readonly matchedLabelName: string;
   readonly comments: readonly GithubIssueComment[];
   readonly lastCommentId: string | undefined;
   readonly currentCommentId: string | undefined;
@@ -202,7 +210,17 @@ function formatIssueContext(args: {
     return "";
   }
 
-  const parts: string[] = ["# GitHub Issue Context"];
+  const subjectLabel =
+    args.subjectKind === "pull_request" ? "Pull Request" : "Issue";
+  const parts: string[] = [
+    "# GitHub Label Trigger",
+    "",
+    `Repository: ${args.repo}`,
+    `${subjectLabel}: #${args.issue.number}`,
+    `Matched label: ${args.matchedLabelName}`,
+    "",
+    `# GitHub ${subjectLabel} Context`,
+  ];
 
   if (!args.lastCommentId) {
     parts.push(
@@ -445,30 +463,9 @@ async function maybeAddCommentReaction(args: {
   });
 }
 
-async function loadLinkedVm0UserId(args: {
-  readonly db: Db;
-  readonly githubUserId: string;
-  readonly installationDbId: string;
-  readonly signal: AbortSignal;
-}): Promise<string | undefined> {
-  const [userLink] = await args.db
-    .select({ vm0UserId: githubUserLinks.vm0UserId })
-    .from(githubUserLinks)
-    .where(
-      and(
-        eq(githubUserLinks.githubUserId, args.githubUserId),
-        eq(githubUserLinks.installationId, args.installationDbId),
-      ),
-    )
-    .limit(1);
-  args.signal.throwIfAborted();
-
-  return userLink?.vm0UserId;
-}
-
 async function loadGitHubRunTarget(args: {
   readonly db: Db;
-  readonly installation: GitHubInstallationRecord;
+  readonly composeId: string;
   readonly signal: AbortSignal;
 }): Promise<GitHubRunTarget> {
   const [compose] = await args.db
@@ -478,14 +475,12 @@ async function loadGitHubRunTarget(args: {
       orgId: agentComposes.orgId,
     })
     .from(agentComposes)
-    .where(eq(agentComposes.id, args.installation.defaultComposeId))
+    .where(eq(agentComposes.id, args.composeId))
     .limit(1);
   args.signal.throwIfAborted();
 
   if (!compose) {
-    throw new Error(
-      `Agent compose not found: composeId=${args.installation.defaultComposeId}`,
-    );
+    throw new Error(`Agent compose not found: composeId=${args.composeId}`);
   }
 
   const [agent] = await args.db
@@ -560,6 +555,9 @@ async function buildIssueContextForRun(args: {
 
   return formatIssueContext({
     issue: args.params.issue,
+    subjectKind: args.params.subjectKind,
+    repo: args.params.repo,
+    matchedLabelName: args.params.matchedLabelName,
     comments,
     lastCommentId: args.existingSessionId
       ? (args.lastCommentId ?? undefined)
@@ -614,45 +612,142 @@ async function updateExistingSessionComment(args: {
     );
 }
 
-export const handleGithubIssuesEvent$ = command(
+function labelsForAction(args: {
+  readonly action: string;
+  readonly labels: readonly z.infer<typeof gitHubLabelSchema>[];
+  readonly label: z.infer<typeof gitHubLabelSchema> | undefined;
+}): readonly string[] {
+  if (args.action === "labeled") {
+    return args.label ? [args.label.name] : [];
+  }
+
+  if (args.action === "opened") {
+    return args.labels.map((label) => {
+      return label.name;
+    });
+  }
+
+  return [];
+}
+
+async function loadMatchingLabelListener(args: {
+  readonly db: Db;
+  readonly installationId: string;
+  readonly labelNames: readonly string[];
+  readonly signal: AbortSignal;
+}): Promise<GitHubLabelListenerRecord | null> {
+  const normalizedLabels = new Set(
+    args.labelNames.map((labelName) => {
+      return normalizeLabelName(labelName);
+    }),
+  );
+  if (normalizedLabels.size === 0) {
+    return null;
+  }
+
+  const listeners = await args.db
+    .select()
+    .from(githubLabelListeners)
+    .where(
+      and(
+        eq(githubLabelListeners.installationId, args.installationId),
+        eq(githubLabelListeners.enabled, true),
+      ),
+    )
+    .orderBy(asc(githubLabelListeners.createdAt));
+  args.signal.throwIfAborted();
+
+  return (
+    listeners.find((listener) => {
+      return normalizedLabels.has(listener.labelNameNormalized);
+    }) ?? null
+  );
+}
+
+async function issueAuthorMatchesListenerCreator(args: {
+  readonly db: Db;
+  readonly listener: GitHubLabelListenerRecord;
+  readonly authorGithubUserId: string;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  if (args.listener.triggerMode !== "created_by_me") {
+    return true;
+  }
+
+  const [link] = await args.db
+    .select({ githubUserId: githubUserLinks.githubUserId })
+    .from(githubUserLinks)
+    .where(
+      and(
+        eq(githubUserLinks.installationId, args.listener.installationId),
+        eq(githubUserLinks.vm0UserId, args.listener.createdByUserId),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return link?.githubUserId === args.authorGithubUserId;
+}
+
+interface LabelTriggerEventParams {
+  readonly payload: {
+    readonly action: string;
+    readonly issue: GitHubIssue;
+    readonly label: z.infer<typeof gitHubLabelSchema> | undefined;
+    readonly repository: z.infer<typeof gitHubRepositorySchema>;
+    readonly installation: z.infer<typeof gitHubInstallationRefSchema>;
+  };
+  readonly subjectKind: GitHubTriggerKind;
+  readonly apiStartTime: number;
+}
+
+const dispatchMatchingLabelListener$ = command(
   async (
     { set },
-    args: {
-      readonly payload: GitHubIssuesEvent;
-      readonly appSlug: string | undefined;
-      readonly apiStartTime: number;
-    },
+    args: LabelTriggerEventParams,
     signal: AbortSignal,
   ): Promise<void> => {
-    const { action, issue, label, repository, installation, sender } =
-      args.payload;
-
+    const { action, issue, label, repository, installation } = args.payload;
     if (action !== "opened" && action !== "labeled") {
-      L.debug("Ignoring issues event", { action });
+      L.debug("Ignoring GitHub label trigger event", { action });
       return;
     }
 
-    if (!args.appSlug) {
-      L.debug("Ignoring issues event: app slug not configured");
-      return;
-    }
+    const labelNames = labelsForAction({ action, labels: issue.labels, label });
+    const db = set(writeDb$);
+    const installationRecord = await loadActiveInstallation({
+      db,
+      ghInstallationId: String(installation.id),
+      signal,
+    });
+    const listener = await loadMatchingLabelListener({
+      db,
+      installationId: installationRecord.id,
+      labelNames,
+      signal,
+    });
+    signal.throwIfAborted();
 
-    if (action === "labeled" && label?.name !== args.appSlug) {
-      L.debug("Ignoring label that is not app slug", {
-        label: label?.name,
-        expected: args.appSlug,
+    if (!listener) {
+      L.debug("Ignoring GitHub event without a matching label listener", {
+        action,
+        labels: labelNames,
       });
       return;
     }
 
     if (
-      action === "opened" &&
-      !issue.labels.some((candidate) => {
-        return candidate.name === args.appSlug;
-      })
+      !(await issueAuthorMatchesListenerCreator({
+        db,
+        listener,
+        authorGithubUserId: String(issue.user.id),
+        signal,
+      }))
     ) {
-      L.debug("Ignoring opened issue without app slug label", {
-        expected: args.appSlug,
+      L.debug("Ignoring GitHub event because trigger mode requires creator", {
+        listenerId: listener.id,
+        triggerMode: listener.triggerMode,
+        issueAuthorGithubUserId: issue.user.id,
       });
       return;
     }
@@ -663,10 +758,66 @@ export const handleGithubIssuesEvent$ = command(
         ghInstallationId: String(installation.id),
         repo: repository.full_name,
         issue,
-        senderGithubUserId: String(sender.id),
-        prompt: buildIssuePrompt(issue),
+        subjectKind: args.subjectKind,
+        vm0UserId: listener.createdByUserId,
+        composeId: listener.composeId,
+        prompt: listener.prompt,
+        matchedLabelName: listener.labelName,
         forceNewSession: true,
-        appSlug: args.appSlug,
+        apiStartTime: args.apiStartTime,
+      },
+      signal,
+    );
+  },
+);
+
+export const handleGithubIssuesEvent$ = command(
+  async (
+    { set },
+    args: {
+      readonly payload: GitHubIssuesEvent;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      dispatchMatchingLabelListener$,
+      {
+        payload: {
+          action: args.payload.action,
+          issue: args.payload.issue,
+          label: args.payload.label,
+          repository: args.payload.repository,
+          installation: args.payload.installation,
+        },
+        subjectKind: "issue",
+        apiStartTime: args.apiStartTime,
+      },
+      signal,
+    );
+  },
+);
+
+export const handleGithubPullRequestEvent$ = command(
+  async (
+    { set },
+    args: {
+      readonly payload: GitHubPullRequestEvent;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      dispatchMatchingLabelListener$,
+      {
+        payload: {
+          action: args.payload.action,
+          issue: args.payload.pull_request,
+          label: args.payload.label,
+          repository: args.payload.repository,
+          installation: args.payload.installation,
+        },
+        subjectKind: "pull_request",
         apiStartTime: args.apiStartTime,
       },
       signal,
@@ -675,54 +826,19 @@ export const handleGithubIssuesEvent$ = command(
 );
 
 export const handleGithubIssueCommentEvent$ = command(
-  async (
-    { set },
+  (
+    _ctx,
     args: {
       readonly payload: GitHubIssueCommentEvent;
-      readonly appSlug: string | undefined;
       readonly apiStartTime: number;
     },
-    signal: AbortSignal,
+    _signal: AbortSignal,
   ): Promise<void> => {
-    const { action, issue, comment, repository, installation, sender } =
-      args.payload;
-
-    if (action !== "created") {
-      L.debug("Ignoring issue_comment event", { action });
-      return;
-    }
-
-    if (sender.type === "Bot") {
-      L.debug("Ignoring comment from bot", { sender: sender.login });
-      return;
-    }
-
-    if (!args.appSlug) {
-      L.debug("Ignoring comment: app slug not configured");
-      return;
-    }
-
-    const botMention = `@${args.appSlug}[bot]`;
-    if (!comment.body.includes(botMention)) {
-      L.debug("Ignoring comment: no bot mention", { expected: botMention });
-      return;
-    }
-
-    await set(
-      dispatchGithubAgentRun$,
-      {
-        ghInstallationId: String(installation.id),
-        repo: repository.full_name,
-        issue,
-        senderGithubUserId: String(sender.id),
-        prompt: buildCommentPrompt(comment),
-        commentId: String(comment.id),
-        comment,
-        appSlug: args.appSlug,
-        apiStartTime: args.apiStartTime,
-      },
-      signal,
-    );
+    L.debug("Ignoring GitHub issue_comment event: mention triggers disabled", {
+      action: args.payload.action,
+      apiStartTime: args.apiStartTime,
+    });
+    return Promise.resolve();
   },
 );
 
@@ -751,28 +867,18 @@ const dispatchGithubAgentRun$ = command(
     });
     signal.throwIfAborted();
 
-    const vm0UserId = await loadLinkedVm0UserId({
+    const target = await loadGitHubRunTarget({
       db,
-      githubUserId: params.senderGithubUserId,
-      installationDbId: installation.id,
+      composeId: params.composeId,
       signal,
     });
-    if (!vm0UserId) {
-      L.warn("No VM0 user linked for GitHub user", {
-        githubUserId: params.senderGithubUserId,
-        installationId: installation.id,
-      });
-      return;
-    }
-
-    const target = await loadGitHubRunTarget({ db, installation, signal });
     const sessionResult = await resolveDispatchSession({
       db,
       params,
       installationDbId: installation.id,
       issueNumber,
       composeId: target.composeId,
-      vm0UserId,
+      vm0UserId: params.vm0UserId,
       signal,
     });
     if (sessionResult.kind === "duplicate") {
@@ -788,11 +894,7 @@ const dispatchGithubAgentRun$ = command(
       lastCommentId: sessionResult.lastCommentId,
       signal,
     });
-    const promptParts = buildPromptParts(
-      params.prompt,
-      issueContext,
-      Boolean(params.commentId),
-    );
+    const promptParts = buildPromptParts(params.prompt, issueContext);
 
     const callbackPayload = buildCallbackPayload({
       installationDbId: installation.id,
@@ -808,7 +910,7 @@ const dispatchGithubAgentRun$ = command(
         const result = await set(
           createZeroIntegrationRun$,
           {
-            userId: vm0UserId,
+            userId: params.vm0UserId,
             orgId: target.orgId,
             agentId: target.zeroAgentId,
             sessionId: existingSessionId,

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -10,6 +10,7 @@ import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
 import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command } from "ccstate";
 import { and, asc, eq } from "drizzle-orm";
@@ -18,6 +19,7 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
 import {
@@ -970,20 +972,105 @@ const dispatchGithubAgentRun$ = command(
   },
 );
 
+async function loadGithubChangedUserIds(args: {
+  readonly db: Db;
+  readonly installationId: string;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): Promise<readonly string[]> {
+  const links = await args.db
+    .select({ userId: githubUserLinks.vm0UserId })
+    .from(githubUserLinks)
+    .where(eq(githubUserLinks.installationId, args.installationId));
+  args.signal.throwIfAborted();
+
+  const admins = await args.db
+    .select({ userId: orgMembersCache.userId })
+    .from(orgMembersCache)
+    .where(
+      and(
+        eq(orgMembersCache.orgId, args.orgId),
+        eq(orgMembersCache.role, "admin"),
+      ),
+    );
+  args.signal.throwIfAborted();
+
+  return Array.from(
+    new Set(
+      [...links, ...admins].map((row) => {
+        return row.userId;
+      }),
+    ),
+  );
+}
+
+async function cleanupDeletedGithubInstallation(args: {
+  readonly db: Db;
+  readonly ghInstallationId: string;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const [installation] = await args.db
+    .select({ id: githubInstallations.id, orgId: githubInstallations.orgId })
+    .from(githubInstallations)
+    .where(eq(githubInstallations.installationId, args.ghInstallationId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!installation) {
+    L.debug("No GitHub installation found for deleted event", {
+      installationId: args.ghInstallationId,
+    });
+    return false;
+  }
+
+  const userIds = await loadGithubChangedUserIds({
+    db: args.db,
+    installationId: installation.id,
+    orgId: installation.orgId,
+    signal: args.signal,
+  });
+
+  await args.db
+    .delete(githubInstallations)
+    .where(eq(githubInstallations.id, installation.id));
+  args.signal.throwIfAborted();
+
+  if (userIds.length > 0) {
+    await publishUserSignal(userIds, "github:changed");
+    args.signal.throwIfAborted();
+  }
+
+  L.debug("Cleaned up deleted GitHub installation", {
+    installationId: args.ghInstallationId,
+    recordId: installation.id,
+  });
+  return true;
+}
+
 export const handleGithubInstallationEvent$ = command(
   async (
     { set },
     payload: GitHubInstallationEvent,
     signal: AbortSignal,
   ): Promise<void> => {
+    const db = set(writeDb$);
+    const ghInstallationId = String(payload.installation.id);
+
+    if (payload.action === "deleted") {
+      await cleanupDeletedGithubInstallation({
+        db,
+        ghInstallationId,
+        signal,
+      });
+      return;
+    }
+
     if (payload.action !== "created") {
       L.debug("Ignoring installation event", { action: payload.action });
       return;
     }
 
-    const db = set(writeDb$);
     const targetId = String(payload.installation.account.id);
-    const ghInstallationId = String(payload.installation.id);
 
     const [pending] = await db
       .select()

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
@@ -1,0 +1,280 @@
+import {
+  integrationsGithubContract,
+  type GithubInstallationNotFoundResponse,
+  type GithubInstallationResponse,
+  type GithubLabelListener,
+} from "@vm0/api-contracts/contracts/integrations-github";
+import { mockApi } from "../msw-contract.ts";
+
+const defaultMissingGithubIntegration: GithubInstallationNotFoundResponse = {
+  error: { message: "GitHub installation not found", code: "NOT_FOUND" },
+  installUrl: "/api/github/oauth/install?orgId=org_123",
+};
+
+const defaultGithubInstallation: GithubInstallationResponse = {
+  installation: {
+    id: "a0000000-0000-4000-a000-000000000001",
+    installationId: "123456",
+    status: "active",
+    targetName: "vm0-test",
+    targetType: "Organization",
+    isAdmin: true,
+  },
+  isConnected: true,
+  connectedGithubUserId: "98765",
+  installUrl: "/api/github/oauth/install?orgId=org_123",
+  connectUrl: "/connectors/github/connect",
+  agent: {
+    id: "c0000000-0000-4000-a000-000000000001",
+    name: "zero",
+  },
+  environment: {
+    requiredSecrets: [],
+    requiredVars: [],
+    missingSecrets: [],
+    missingVars: [],
+  },
+  labelListeners: [],
+};
+
+let mockGithubIntegration: GithubInstallationResponse | null = null;
+let mockGithubListenerCounter = 0;
+
+function normalizeLabelName(labelName: string): string {
+  return labelName.trim().toLowerCase();
+}
+
+function listenerAgentName(agentId: string): string {
+  return agentId === defaultGithubInstallation.agent?.id ? "zero" : agentId;
+}
+
+function createMockListener(
+  body: {
+    readonly labelName: string;
+    readonly agentId: string;
+    readonly triggerMode: GithubLabelListener["triggerMode"];
+    readonly prompt: string;
+    readonly enabled?: boolean;
+  },
+  id: string,
+): GithubLabelListener {
+  const now = new Date(0).toISOString();
+  return {
+    id,
+    labelName: body.labelName.trim(),
+    triggerMode: body.triggerMode,
+    prompt: body.prompt.trim(),
+    enabled: body.enabled ?? true,
+    agent: {
+      id: body.agentId,
+      name: listenerAgentName(body.agentId),
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function getExistingListener(labelName: string): GithubLabelListener | null {
+  const normalized = normalizeLabelName(labelName);
+  return (
+    mockGithubIntegration?.labelListeners.find((listener) => {
+      return normalizeLabelName(listener.labelName) === normalized;
+    }) ?? null
+  );
+}
+
+export function resetMockGithubIntegration(): void {
+  mockGithubIntegration = null;
+  mockGithubListenerCounter = 0;
+}
+
+export function setMockGithubIntegration(
+  integration: GithubInstallationResponse | null,
+): void {
+  mockGithubIntegration = integration ? structuredClone(integration) : null;
+}
+
+export function createDefaultMockGithubIntegration(
+  overrides: Partial<GithubInstallationResponse> = {},
+): GithubInstallationResponse {
+  return {
+    ...structuredClone(defaultGithubInstallation),
+    ...overrides,
+  };
+}
+
+export function getMockGithubIntegration(): GithubInstallationResponse | null {
+  return mockGithubIntegration ? structuredClone(mockGithubIntegration) : null;
+}
+
+export const apiIntegrationsGithubHandlers = [
+  mockApi(integrationsGithubContract.getInstallation, ({ respond }) => {
+    if (!mockGithubIntegration) {
+      return respond(404, defaultMissingGithubIntegration);
+    }
+    return respond(200, mockGithubIntegration);
+  }),
+
+  mockApi(integrationsGithubContract.connectUser, ({ respond }) => {
+    if (!mockGithubIntegration) {
+      return respond(404, {
+        error: { message: "GitHub installation not found", code: "NOT_FOUND" },
+      });
+    }
+    mockGithubIntegration = {
+      ...mockGithubIntegration,
+      isConnected: true,
+      connectedGithubUserId:
+        mockGithubIntegration.connectedGithubUserId ?? "98765",
+    };
+    return respond(200, { ok: true });
+  }),
+
+  mockApi(integrationsGithubContract.disconnectUser, ({ respond }) => {
+    if (!mockGithubIntegration) {
+      return respond(404, {
+        error: { message: "GitHub installation not found", code: "NOT_FOUND" },
+      });
+    }
+    mockGithubIntegration = {
+      ...mockGithubIntegration,
+      isConnected: false,
+      connectedGithubUserId: null,
+    };
+    return respond(200, { ok: true });
+  }),
+
+  mockApi(integrationsGithubContract.deleteInstallation, ({ respond }) => {
+    mockGithubIntegration = null;
+    return respond(200, { ok: true });
+  }),
+
+  mockApi(
+    integrationsGithubContract.updateInstallation,
+    ({ body, respond }) => {
+      if (!mockGithubIntegration) {
+        return respond(404, {
+          error: {
+            message: "GitHub installation not found",
+            code: "NOT_FOUND",
+          },
+        });
+      }
+      mockGithubIntegration = {
+        ...mockGithubIntegration,
+        agent: mockGithubIntegration.agent
+          ? { ...mockGithubIntegration.agent, name: body.agentName }
+          : null,
+      };
+      return respond(200, { ok: true });
+    },
+  ),
+
+  mockApi(
+    integrationsGithubContract.createLabelListener,
+    ({ body, respond }) => {
+      if (!mockGithubIntegration) {
+        return respond(404, {
+          error: {
+            message: "GitHub installation not found",
+            code: "NOT_FOUND",
+          },
+        });
+      }
+      if (getExistingListener(body.labelName)) {
+        return respond(409, {
+          error: { message: "Label listener already exists", code: "CONFLICT" },
+        });
+      }
+
+      mockGithubListenerCounter += 1;
+      const listener = createMockListener(
+        body,
+        `b0000000-0000-4000-a000-${String(mockGithubListenerCounter).padStart(
+          12,
+          "0",
+        )}`,
+      );
+      mockGithubIntegration = {
+        ...mockGithubIntegration,
+        labelListeners: [...mockGithubIntegration.labelListeners, listener],
+      };
+      return respond(201, { listener });
+    },
+  ),
+
+  mockApi(
+    integrationsGithubContract.updateLabelListener,
+    ({ params, body, respond }) => {
+      if (!mockGithubIntegration) {
+        return respond(404, {
+          error: {
+            message: "GitHub installation not found",
+            code: "NOT_FOUND",
+          },
+        });
+      }
+      const listener = mockGithubIntegration.labelListeners.find((item) => {
+        return item.id === params.listenerId;
+      });
+      if (!listener) {
+        return respond(404, {
+          error: { message: "Label listener not found", code: "NOT_FOUND" },
+        });
+      }
+      if (body.labelName) {
+        const duplicate = getExistingListener(body.labelName);
+        if (duplicate && duplicate.id !== listener.id) {
+          return respond(409, {
+            error: {
+              message: "Label listener already exists",
+              code: "CONFLICT",
+            },
+          });
+        }
+      }
+
+      const updated: GithubLabelListener = {
+        ...listener,
+        labelName: body.labelName?.trim() ?? listener.labelName,
+        triggerMode: body.triggerMode ?? listener.triggerMode,
+        prompt: body.prompt?.trim() ?? listener.prompt,
+        enabled: body.enabled ?? listener.enabled,
+        agent: body.agentId
+          ? { id: body.agentId, name: listenerAgentName(body.agentId) }
+          : listener.agent,
+        updatedAt: new Date(1).toISOString(),
+      };
+      mockGithubIntegration = {
+        ...mockGithubIntegration,
+        labelListeners: mockGithubIntegration.labelListeners.map((item) => {
+          return item.id === updated.id ? updated : item;
+        }),
+      };
+      return respond(200, { listener: updated });
+    },
+  ),
+
+  mockApi(
+    integrationsGithubContract.deleteLabelListener,
+    ({ params, respond }) => {
+      if (!mockGithubIntegration) {
+        return respond(404, {
+          error: {
+            message: "GitHub installation not found",
+            code: "NOT_FOUND",
+          },
+        });
+      }
+      mockGithubIntegration = {
+        ...mockGithubIntegration,
+        labelListeners: mockGithubIntegration.labelListeners.filter(
+          (listener) => {
+            return listener.id !== params.listenerId;
+          },
+        ),
+      };
+      return respond(200, { ok: true });
+    },
+  ),
+];

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
@@ -8,7 +8,7 @@ import { mockApi } from "../msw-contract.ts";
 
 const defaultMissingGithubIntegration: GithubInstallationNotFoundResponse = {
   error: { message: "GitHub installation not found", code: "NOT_FOUND" },
-  installUrl: "/api/github/oauth/install?orgId=org_123",
+  installUrl: "https://github.com/apps/vm0-test/installations/new?state=abc",
 };
 
 const defaultGithubInstallation: GithubInstallationResponse = {
@@ -22,8 +22,10 @@ const defaultGithubInstallation: GithubInstallationResponse = {
   },
   isConnected: true,
   connectedGithubUserId: "98765",
-  installUrl: "/api/github/oauth/install?orgId=org_123",
-  connectUrl: "/connectors/github/connect",
+  connectedGithubUsername: "octocat",
+  installUrl: "https://github.com/apps/vm0-test/installations/new?state=abc",
+  connectUrl:
+    "https://github.com/login/oauth/authorize?client_id=github-oauth-client-id",
   agent: {
     id: "c0000000-0000-4000-a000-000000000001",
     name: "zero",
@@ -126,6 +128,8 @@ export const apiIntegrationsGithubHandlers = [
       isConnected: true,
       connectedGithubUserId:
         mockGithubIntegration.connectedGithubUserId ?? "98765",
+      connectedGithubUsername:
+        mockGithubIntegration.connectedGithubUsername ?? "octocat",
     };
     return respond(200, { ok: true });
   }),
@@ -140,6 +144,7 @@ export const apiIntegrationsGithubHandlers = [
       ...mockGithubIntegration,
       isConnected: false,
       connectedGithubUserId: null,
+      connectedGithubUsername: null,
     };
     return respond(200, { ok: true });
   }),

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -56,6 +56,10 @@ import {
   resetMockAgentPhoneIntegration,
 } from "./api-integrations-agentphone.ts";
 import {
+  apiIntegrationsGithubHandlers,
+  resetMockGithubIntegration,
+} from "./api-integrations-github.ts";
+import {
   apiAgentsHandlers,
   resetMockComposesList,
   resetMockTeam,
@@ -117,6 +121,7 @@ export const handlers = [
   ...apiIntegrationsSlackOrgHandlers,
   ...apiIntegrationsTelegramHandlers,
   ...apiIntegrationsAgentPhoneHandlers,
+  ...apiIntegrationsGithubHandlers,
   ...apiAgentsHandlers,
   ...apiRunsHandlers,
   ...apiUserPreferencesHandlers,
@@ -144,6 +149,7 @@ export function resetAllMockHandlers(): void {
   resetMockSlackOrgIntegration();
   resetMockTelegramIntegration();
   resetMockAgentPhoneIntegration();
+  resetMockGithubIntegration();
   resetMockUserPreferences();
   resetMockUserModelPreference();
   resetMockOrgModelProviders();

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -18,6 +18,7 @@ import { setupGlobalMethod$ } from "./bootstrap/global-method.ts";
 import { setupLoggers$ } from "./bootstrap/loggers.ts";
 import { setupSlackConnectPage$ } from "./zero-page/slack-connect-page.ts";
 import { setupAgentPhoneConnectPage$ } from "./zero-page/agentphone-connect-page.ts";
+import { setupGithubSettingsPage$ } from "./zero-page/github-settings-page.ts";
 import { setupTelegramConnectPage$ } from "./zero-page/telegram-connect-page.ts";
 import { setupTelegramSettingsPage$ } from "./zero-page/telegram-settings-page.ts";
 import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
@@ -176,6 +177,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.settingsSlack,
     setup: setupAuthPageWrapper(setupSlackConnectPage$),
+  },
+  {
+    path: ROUTES.settingsGithub,
+    setup: setupAuthPageWrapper(setupGithubSettingsPage$),
   },
   {
     path: ROUTES.settingsTelegram,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -23,6 +23,7 @@ export const ROUTES = {
   directedAuthorize: "/connectors/:type/authorize",
   settings: "/settings",
   settingsSlack: "/settings/slack",
+  settingsGithub: "/settings/github",
   settingsTelegram: "/settings/telegram",
   telegramConnect: "/telegram/connect",
   agentphoneConnect: "/agentphone/connect",

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { ZeroWorksPage } from "../../views/zero-page/zero-works-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
@@ -7,27 +8,57 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import {
   initSlackOrg$,
-  pollSlackConnection$,
+  watchSlackConnection$,
 } from "../zero-page/zero-slack.ts";
-import { initGithubIntegration$ } from "../zero-page/zero-github.ts";
+import {
+  initGithubIntegration$,
+  watchGithubIntegration$,
+} from "../zero-page/zero-github.ts";
 import {
   resetAgentPhoneConnectUi$,
   setAgentPhoneConnectDialogOpen$,
+  watchAgentPhoneConnection$,
 } from "../zero-page/zero-agentphone.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { replaceSearchParams$, searchParams$ } from "../route.ts";
+import { detach, Reason } from "../utils.ts";
+
+const initWorksRedirect$ = command(({ get, set }) => {
+  const params = new URLSearchParams(get(searchParams$));
+  const error = params.get("error");
+  if (!error) {
+    return;
+  }
+
+  toast.error(error);
+  params.delete("error");
+  set(replaceSearchParams$, params);
+});
 
 export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(resetAgentPhoneConnectUi$);
   set(setAgentPhoneConnectDialogOpen$, false);
   set(updatePage$, createElement(ZeroWorksPage), "sidebar");
   set(updateDocumentTitle$, "Works");
+  set(initWorksRedirect$);
   set(initSlackOrg$);
   set(initGithubIntegration$);
+
+  // confirmed by ethan@vm0.ai
+  // eslint-disable-next-line ccstate/no-detach-in-signals -- route-scoped realtime subscriptions run until the /works route signal aborts
+  detach(
+    Promise.all([
+      set(watchSlackConnection$, signal),
+      set(watchGithubIntegration$, signal),
+      set(watchAgentPhoneConnection$, signal),
+    ]),
+    Reason.Entrance,
+    "works realtime subscriptions",
+  );
 
   await Promise.all([
     set(hideAppSkeleton$, signal),
     set(onboardGuard$, signal),
     set(reloadChatThreads$),
-    set(pollSlackConnection$, signal),
   ]);
 });

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -9,6 +9,7 @@ import {
   initSlackOrg$,
   pollSlackConnection$,
 } from "../zero-page/zero-slack.ts";
+import { initGithubIntegration$ } from "../zero-page/zero-github.ts";
 import {
   resetAgentPhoneConnectUi$,
   setAgentPhoneConnectDialogOpen$,
@@ -21,6 +22,7 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroWorksPage), "sidebar");
   set(updateDocumentTitle$, "Works");
   set(initSlackOrg$);
+  set(initGithubIntegration$);
 
   await Promise.all([
     set(hideAppSkeleton$, signal),

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/poll-slack-connection.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/poll-slack-connection.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { pollSlackConnection$ } from "../zero-slack.ts";
+import { watchSlackConnection$ } from "../zero-slack.ts";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { triggerAblyEvent, hasSubscription } from "../../../mocks/ably.ts";
@@ -56,25 +56,38 @@ function mockSlackEndpoint(getIsConnected: (callCount: number) => boolean) {
   return counter;
 }
 
-describe("pollSlackConnection$", () => {
-  it("should return immediately when already connected", async () => {
+describe("watchSlackConnection$", () => {
+  it("should subscribe even when already connected", async () => {
+    const abortController = new AbortController();
     const counter = mockSlackEndpoint(alwaysConnected);
 
     await setup();
 
-    await context.store.set(pollSlackConnection$, context.signal);
+    const watchPromise = context.store.set(
+      watchSlackConnection$,
+      abortController.signal,
+    );
 
-    // Initial slackOrgData$ read sees isConnected=true and returns without
-    // subscribing. Total: 1 fetch.
+    await vi.waitFor(() => {
+      expect(hasSubscription("slack:changed")).toBeTruthy();
+    });
     expect(counter.count).toBe(1);
+
+    abortController.abort();
+    await expect(watchPromise).rejects.toThrow();
+    expect(hasSubscription("slack:changed")).toBeFalsy();
   });
 
-  it("should subscribe and re-check on slack:changed events until connected", async () => {
+  it("should subscribe and re-check on slack:changed events", async () => {
+    const abortController = new AbortController();
     const counter = mockSlackEndpoint(connectedOnThirdCall);
 
     await setup();
 
-    const pollPromise = context.store.set(pollSlackConnection$, context.signal);
+    const watchPromise = context.store.set(
+      watchSlackConnection$,
+      abortController.signal,
+    );
 
     // Initial slackOrgData$ read is call #1. setAblyLoop$ does not prime the
     // body on subscribe; it waits for Ably events to re-check status.
@@ -91,9 +104,14 @@ describe("pollSlackConnection$", () => {
     // Second event re-runs as call #3 and sees connected.
     triggerAblyEvent("slack:changed");
 
-    await pollPromise;
+    await vi.waitFor(() => {
+      expect(counter.count).toBeGreaterThanOrEqual(3);
+    });
+    expect(hasSubscription("slack:changed")).toBeTruthy();
 
-    expect(counter.count).toBeGreaterThanOrEqual(3);
+    abortController.abort();
+    await expect(watchPromise).rejects.toThrow();
+    expect(hasSubscription("slack:changed")).toBeFalsy();
   });
 
   it("should stop subscribing when signal is aborted", async () => {
@@ -102,8 +120,8 @@ describe("pollSlackConnection$", () => {
 
     await setup();
 
-    const pollPromise = context.store.set(
-      pollSlackConnection$,
+    const watchPromise = context.store.set(
+      watchSlackConnection$,
       abortController.signal,
     );
 
@@ -114,7 +132,7 @@ describe("pollSlackConnection$", () => {
 
     abortController.abort();
 
-    await expect(pollPromise).rejects.toThrow();
+    await expect(watchPromise).rejects.toThrow();
     expect(counter.count).toBe(1);
     expect(hasSubscription("slack:changed")).toBeFalsy();
   });

--- a/turbo/apps/platform/src/signals/zero-page/github-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-settings-page.ts
@@ -5,11 +5,21 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
+import { watchGithubIntegration$ } from "./zero-github.ts";
+import { detach, Reason } from "../utils.ts";
 
 export const setupGithubSettingsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroGithubSettingsPage), "sidebar");
     set(updateDocumentTitle$, "GitHub");
+
+    // confirmed by ethan@vm0.ai
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- route-scoped realtime subscription runs until the /settings/github route signal aborts
+    detach(
+      set(watchGithubIntegration$, signal),
+      Reason.Entrance,
+      "github settings realtime subscription",
+    );
 
     await Promise.all([
       set(hideAppSkeleton$, signal),

--- a/turbo/apps/platform/src/signals/zero-page/github-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-settings-page.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroGithubSettingsPage } from "../../views/zero-page/zero-github-settings-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
+
+export const setupGithubSettingsPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroGithubSettingsPage), "sidebar");
+    set(updateDocumentTitle$, "GitHub");
+
+    await Promise.all([
+      set(hideAppSkeleton$, signal),
+      set(onboardGuard$, signal),
+    ]);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
@@ -14,6 +14,9 @@ const internalPhoneForm$ = state("");
 const internalConnectDialogOpen$ = state(false);
 const internalVerificationPhone$ = state<string | null>(null);
 const internalShowPhoneError$ = state(false);
+const internalAgentPhoneStatus$ = state<AgentPhoneLinkStatusResponse | null>(
+  null,
+);
 
 function normalizeAgentPhoneHandle(value: string): string {
   return value.trim().replace(/[^\d+]/gu, "");
@@ -100,6 +103,60 @@ const reloadAgentPhoneLinkStatus$ = command(({ set }) => {
   });
 });
 
+function hasAgentPhoneStatusChanged(
+  previous: AgentPhoneLinkStatusResponse | null,
+  next: AgentPhoneLinkStatusResponse,
+): previous is AgentPhoneLinkStatusResponse {
+  return previous !== null && previous.linked !== next.linked;
+}
+
+function toastAgentPhoneStatusChange(
+  previous: AgentPhoneLinkStatusResponse,
+  next: AgentPhoneLinkStatusResponse,
+): void {
+  if (next.linked && !previous.linked) {
+    toast.success("AgentPhone connected");
+    return;
+  }
+  if (!next.linked && previous.linked) {
+    toast.success("AgentPhone disconnected");
+  }
+}
+
+const refreshAgentPhoneFromChange$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    const previous = get(internalAgentPhoneStatus$);
+    set(reloadAgentPhoneLinkStatus$);
+    const data = await get(agentPhoneLinkStatus$);
+    signal.throwIfAborted();
+    set(internalAgentPhoneStatus$, data);
+
+    if (hasAgentPhoneStatusChanged(previous, data)) {
+      toastAgentPhoneStatusChange(previous, data);
+      if (data.linked) {
+        set(internalConnectDialogOpen$, false);
+        set(resetAgentPhoneConnectUi$);
+      }
+    }
+
+    return false;
+  },
+);
+
+export const watchAgentPhoneConnection$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const current = await get(agentPhoneLinkStatus$);
+    signal.throwIfAborted();
+    set(internalAgentPhoneStatus$, current);
+    await set(
+      setAblyLoop$,
+      "agentphone:changed",
+      refreshAgentPhoneFromChange$,
+      signal,
+    );
+  },
+);
+
 export const startAgentPhoneLink$ = command(
   async (
     { get, set },
@@ -130,37 +187,6 @@ export const startAgentPhoneLink$ = command(
   },
 );
 
-export const waitForAgentPhoneConnection$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const current = await get(agentPhoneLinkStatus$);
-    signal.throwIfAborted();
-    if (current.linked) {
-      return;
-    }
-
-    const onAgentPhoneChanged$ = command(
-      async ({ get, set }, sig: AbortSignal) => {
-        set(reloadAgentPhoneLinkStatus$);
-        const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract, {
-          apiBase: "api",
-        });
-        const result = await accept(
-          client.getLinkStatus({
-            headers: {},
-            fetchOptions: { signal: sig },
-          }),
-          [200],
-          { toast: false },
-        );
-        return result.body.linked;
-      },
-    );
-
-    await set(setAblyLoop$, "agentphone:changed", onAgentPhoneChanged$, signal);
-    toast.success("AgentPhone connected");
-  },
-);
-
 export const disconnectAgentPhone$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract, {
@@ -175,6 +201,5 @@ export const disconnectAgentPhone$ = command(
     );
     signal.throwIfAborted();
     set(reloadAgentPhoneLinkStatus$);
-    toast.success("AgentPhone disconnected");
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -7,7 +7,6 @@ import {
   type GithubLabelTriggerMode,
   type UpdateGithubLabelListenerBody,
 } from "@vm0/api-contracts/contracts/integrations-github";
-import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -233,22 +232,10 @@ export const watchGithubIntegration$ = command(
 );
 
 export const connectGithubInstallation$ = command(
-  async ({ get }, _connectUrl: string, signal: AbortSignal): Promise<void> => {
-    const authWindow = openGithubOAuthWindow();
-    const startClient = get(zeroClient$)(zeroConnectorOauthStartContract, {
-      apiBase: "www",
-    });
-    const startResult = await accept(
-      startClient.start({
-        params: { type: "github" },
-        body: {},
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
+  (_ctx, connectUrl: string, signal: AbortSignal): void => {
     signal.throwIfAborted();
-
-    const fresh = new URL(startResult.body.authorizationUrl);
+    const authWindow = openGithubOAuthWindow();
+    const fresh = new URL(connectUrl, window.location.origin);
     fresh.searchParams.set("_t", String(Date.now()));
     authWindow.location.href = fresh.toString();
   },

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -7,15 +7,18 @@ import {
   type GithubLabelTriggerMode,
   type UpdateGithubLabelListenerBody,
 } from "@vm0/api-contracts/contracts/integrations-github";
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 
 interface GithubIntegrationMissingData extends GithubInstallationNotFoundResponse {
   readonly isInstalled: false;
   readonly installation: null;
   readonly isConnected: false;
   readonly connectedGithubUserId: null;
+  readonly connectedGithubUsername: null;
   readonly connectUrl: string;
   readonly agent: null;
   readonly environment: GithubInstallationResponse["environment"];
@@ -38,14 +41,24 @@ interface UpdateGithubLabelListenerInput {
   readonly body: UpdateGithubLabelListenerBody;
 }
 
+interface GithubIntegrationStatus {
+  readonly isInstalled: boolean;
+  readonly isConnected: boolean;
+}
+
 const internalReload$ = state(0);
-const internalManageDialogOpen$ = state(false);
+const internalAddListenerDialogOpen$ = state(false);
+const internalGithubIntegrationStatus$ = state<GithubIntegrationStatus | null>(
+  null,
+);
 const internalLabelListenerForm$ = state<GithubLabelListenerForm>({
   labelName: "",
   agentId: "",
   triggerMode: "created_by_me",
   prompt: "",
 });
+
+const GITHUB_CHANGED_TOPIC = "github:changed";
 
 function emptyEnvironment(): GithubInstallationResponse["environment"] {
   return {
@@ -75,7 +88,8 @@ export const githubIntegrationData$ = computed(
         installation: null,
         isConnected: false,
         connectedGithubUserId: null,
-        connectUrl: "/connectors/github/connect",
+        connectedGithubUsername: null,
+        connectUrl: "https://github.com/login/oauth/authorize",
         agent: null,
         environment: emptyEnvironment(),
         labelListeners: [],
@@ -92,17 +106,62 @@ const reloadGithubIntegration$ = command(({ set }) => {
   });
 });
 
-export const githubManageDialogOpen$ = computed((get) => {
-  return get(internalManageDialogOpen$);
-});
+function githubIntegrationStatus(
+  data: GithubIntegrationData,
+): GithubIntegrationStatus {
+  return {
+    isInstalled: data.isInstalled,
+    isConnected: data.isConnected,
+  };
+}
+
+function hasGithubIntegrationStatusChanged(
+  previous: GithubIntegrationStatus | null,
+  next: GithubIntegrationStatus,
+): previous is GithubIntegrationStatus {
+  return (
+    previous !== null &&
+    (previous.isInstalled !== next.isInstalled ||
+      previous.isConnected !== next.isConnected)
+  );
+}
+
+function toastGithubIntegrationChange(
+  previous: GithubIntegrationStatus,
+  next: GithubIntegrationStatus,
+): void {
+  if (next.isConnected && !previous.isConnected) {
+    toast.success("GitHub connected successfully");
+    return;
+  }
+  if (next.isInstalled && !previous.isInstalled) {
+    toast.success("GitHub installed successfully");
+    return;
+  }
+  if (!next.isInstalled && previous.isInstalled) {
+    toast.success("GitHub installation removed");
+    return;
+  }
+  if (!next.isConnected && previous.isConnected) {
+    toast.success("GitHub disconnected");
+    return;
+  }
+  toast.success("GitHub updated");
+}
 
 export const githubLabelListenerForm$ = computed((get) => {
   return get(internalLabelListenerForm$);
 });
 
-export const setGithubManageDialogOpen$ = command(({ set }, value: boolean) => {
-  set(internalManageDialogOpen$, value);
+export const githubAddListenerDialogOpen$ = computed((get) => {
+  return get(internalAddListenerDialogOpen$);
 });
+
+export const setGithubAddListenerDialogOpen$ = command(
+  ({ set }, open: boolean) => {
+    set(internalAddListenerDialogOpen$, open);
+  },
+);
 
 export const setGithubLabelListenerForm$ = command(
   ({ set }, patch: Partial<GithubLabelListenerForm>) => {
@@ -121,18 +180,77 @@ export const resetGithubLabelListenerForm$ = command(({ set }) => {
   });
 });
 
-export const connectGithubInstallation$ = command(
+function isStandaloneMode(): boolean {
+  return window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+}
+
+function openGithubOAuthWindow(): Pick<Window, "closed" | "location"> {
+  const standalone = isStandaloneMode();
+  const popupFeatures = standalone ? undefined : "width=600,height=700";
+  const authWindow = window.open("about:blank", "_blank", popupFeatures);
+
+  if (!authWindow && !standalone) {
+    throw new Error("Failed to open authorization window");
+  }
+
+  if (authWindow) {
+    return authWindow;
+  }
+
+  return window;
+}
+
+const refreshGithubIntegrationFromChange$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    const previous = get(internalGithubIntegrationStatus$);
+    set(reloadGithubIntegration$);
+    const data = await get(githubIntegrationData$);
+    signal.throwIfAborted();
+    const next = githubIntegrationStatus(data);
+    set(internalGithubIntegrationStatus$, next);
+
+    if (hasGithubIntegrationStatusChanged(previous, next)) {
+      toastGithubIntegrationChange(previous, next);
+    }
+
+    return false;
+  },
+);
+
+export const watchGithubIntegration$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const client = get(zeroClient$)(integrationsGithubContract, {
-      apiBase: "api",
+    const current = await get(githubIntegrationData$);
+    signal.throwIfAborted();
+    set(internalGithubIntegrationStatus$, githubIntegrationStatus(current));
+
+    await set(
+      setAblyLoop$,
+      GITHUB_CHANGED_TOPIC,
+      refreshGithubIntegrationFromChange$,
+      signal,
+    );
+  },
+);
+
+export const connectGithubInstallation$ = command(
+  async ({ get }, _connectUrl: string, signal: AbortSignal): Promise<void> => {
+    const authWindow = openGithubOAuthWindow();
+    const startClient = get(zeroClient$)(zeroConnectorOauthStartContract, {
+      apiBase: "www",
     });
-    await accept(
-      client.connectUser({ headers: {}, fetchOptions: { signal } }),
+    const startResult = await accept(
+      startClient.start({
+        params: { type: "github" },
+        body: {},
+        fetchOptions: { signal },
+      }),
       [200],
     );
     signal.throwIfAborted();
-    set(reloadGithubIntegration$);
-    toast.success("GitHub connected");
+
+    const fresh = new URL(startResult.body.authorizationUrl);
+    fresh.searchParams.set("_t", String(Date.now()));
+    authWindow.location.href = fresh.toString();
   },
 );
 
@@ -147,7 +265,6 @@ export const disconnectGithubInstallation$ = command(
     );
     signal.throwIfAborted();
     set(reloadGithubIntegration$);
-    toast.success("GitHub disconnected");
   },
 );
 
@@ -162,7 +279,6 @@ export const uninstallGithubInstallation$ = command(
     );
     signal.throwIfAborted();
     set(reloadGithubIntegration$);
-    toast.success("GitHub installation removed");
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -1,0 +1,226 @@
+import { command, computed, state } from "ccstate";
+import {
+  integrationsGithubContract,
+  type CreateGithubLabelListenerBody,
+  type GithubInstallationNotFoundResponse,
+  type GithubInstallationResponse,
+  type GithubLabelTriggerMode,
+} from "@vm0/api-contracts/contracts/integrations-github";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
+
+interface GithubIntegrationMissingData extends GithubInstallationNotFoundResponse {
+  readonly isInstalled: false;
+  readonly installation: null;
+  readonly isConnected: false;
+  readonly connectedGithubUserId: null;
+  readonly connectUrl: string;
+  readonly agent: null;
+  readonly environment: GithubInstallationResponse["environment"];
+  readonly labelListeners: readonly [];
+}
+
+export type GithubIntegrationData =
+  | (GithubInstallationResponse & { readonly isInstalled: true })
+  | GithubIntegrationMissingData;
+
+export interface GithubLabelListenerForm {
+  readonly labelName: string;
+  readonly agentId: string;
+  readonly triggerMode: GithubLabelTriggerMode;
+  readonly prompt: string;
+}
+
+const internalReload$ = state(0);
+const internalManageDialogOpen$ = state(false);
+const internalLabelListenerForm$ = state<GithubLabelListenerForm>({
+  labelName: "",
+  agentId: "",
+  triggerMode: "created_by_me",
+  prompt: "",
+});
+
+function emptyEnvironment(): GithubInstallationResponse["environment"] {
+  return {
+    requiredSecrets: [],
+    requiredVars: [],
+    missingSecrets: [],
+    missingVars: [],
+  };
+}
+
+export const githubIntegrationData$ = computed(
+  async (get): Promise<GithubIntegrationData> => {
+    get(internalReload$);
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    const result = await accept(
+      client.getInstallation({ headers: {} }),
+      [200, 404],
+      { toast: false },
+    );
+
+    if (result.status === 404) {
+      return {
+        ...result.body,
+        isInstalled: false,
+        installation: null,
+        isConnected: false,
+        connectedGithubUserId: null,
+        connectUrl: "/connectors/github/connect",
+        agent: null,
+        environment: emptyEnvironment(),
+        labelListeners: [],
+      };
+    }
+
+    return { ...result.body, isInstalled: true };
+  },
+);
+
+const reloadGithubIntegration$ = command(({ set }) => {
+  set(internalReload$, (previous) => {
+    return previous + 1;
+  });
+});
+
+export const githubManageDialogOpen$ = computed((get) => {
+  return get(internalManageDialogOpen$);
+});
+
+export const githubLabelListenerForm$ = computed((get) => {
+  return get(internalLabelListenerForm$);
+});
+
+export const setGithubManageDialogOpen$ = command(({ set }, value: boolean) => {
+  set(internalManageDialogOpen$, value);
+});
+
+export const setGithubLabelListenerForm$ = command(
+  ({ set }, patch: Partial<GithubLabelListenerForm>) => {
+    set(internalLabelListenerForm$, (previous) => {
+      return { ...previous, ...patch };
+    });
+  },
+);
+
+export const resetGithubLabelListenerForm$ = command(({ set }) => {
+  set(internalLabelListenerForm$, {
+    labelName: "",
+    agentId: "",
+    triggerMode: "created_by_me",
+    prompt: "",
+  });
+});
+
+export const connectGithubInstallation$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.connectUser({ headers: {}, fetchOptions: { signal } }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadGithubIntegration$);
+    toast.success("GitHub connected");
+  },
+);
+
+export const disconnectGithubInstallation$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.disconnectUser({ headers: {}, fetchOptions: { signal } }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadGithubIntegration$);
+    toast.success("GitHub disconnected");
+  },
+);
+
+export const uninstallGithubInstallation$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.deleteInstallation({ headers: {}, fetchOptions: { signal } }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadGithubIntegration$);
+    toast.success("GitHub installation removed");
+  },
+);
+
+export const createGithubLabelListener$ = command(
+  async (
+    { get, set },
+    body: CreateGithubLabelListenerBody,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.createLabelListener({
+        headers: {},
+        body,
+        fetchOptions: { signal },
+      }),
+      [201],
+    );
+    signal.throwIfAborted();
+    set(reloadGithubIntegration$);
+    toast.success("GitHub label listener added");
+  },
+);
+
+export const deleteGithubLabelListener$ = command(
+  async (
+    { get, set },
+    listenerId: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.deleteLabelListener({
+        headers: {},
+        params: { listenerId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadGithubIntegration$);
+    toast.success("GitHub label listener removed");
+  },
+);
+
+export const initGithubIntegration$ = command(({ set }) => {
+  const params = new URLSearchParams(window.location.search);
+  const status = params.get("github");
+  if (status === "installed") {
+    toast.success("GitHub installed successfully");
+    set(reloadGithubIntegration$);
+    window.history.replaceState({}, "", window.location.pathname);
+  } else if (status === "connected") {
+    toast.success("GitHub connected successfully");
+    set(reloadGithubIntegration$);
+    window.history.replaceState({}, "", window.location.pathname);
+  } else if (status === "pending") {
+    toast.success("GitHub installation request sent");
+    window.history.replaceState({}, "", window.location.pathname);
+  }
+});
+
+export type { GithubLabelTriggerMode };

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -5,6 +5,7 @@ import {
   type GithubInstallationNotFoundResponse,
   type GithubInstallationResponse,
   type GithubLabelTriggerMode,
+  type UpdateGithubLabelListenerBody,
 } from "@vm0/api-contracts/contracts/integrations-github";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
@@ -30,6 +31,11 @@ export interface GithubLabelListenerForm {
   readonly agentId: string;
   readonly triggerMode: GithubLabelTriggerMode;
   readonly prompt: string;
+}
+
+interface UpdateGithubLabelListenerInput {
+  readonly listenerId: string;
+  readonly body: UpdateGithubLabelListenerBody;
 }
 
 const internalReload$ = state(0);
@@ -180,6 +186,30 @@ export const createGithubLabelListener$ = command(
     signal.throwIfAborted();
     set(reloadGithubIntegration$);
     toast.success("GitHub label listener added");
+  },
+);
+
+export const updateGithubLabelListener$ = command(
+  async (
+    { get, set },
+    input: UpdateGithubLabelListenerInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(integrationsGithubContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.updateLabelListener({
+        headers: {},
+        params: { listenerId: input.listenerId },
+        body: input.body,
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadGithubIntegration$);
+    toast.success("GitHub label listener updated");
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -1,11 +1,15 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
+import {
+  zeroIntegrationsSlackContract,
+  type SlackOrgStatus,
+} from "@vm0/api-contracts/contracts/zero-integrations-slack";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 
 const internalReload$ = state(0);
+const internalSlackStatus$ = state<SlackOrgStatus | null>(null);
 
 export const slackOrgData$ = computed(async (get) => {
   get(internalReload$);
@@ -19,6 +23,40 @@ const reloadSlackOrg$ = command(({ set }) => {
     return prev + 1;
   });
 });
+
+function hasSlackStatusChanged(
+  previous: SlackOrgStatus | null,
+  next: SlackOrgStatus,
+): previous is SlackOrgStatus {
+  return (
+    previous !== null &&
+    (previous.isInstalled !== next.isInstalled ||
+      previous.isConnected !== next.isConnected)
+  );
+}
+
+function toastSlackStatusChange(
+  previous: SlackOrgStatus,
+  next: SlackOrgStatus,
+): void {
+  if (next.isConnected && !previous.isConnected) {
+    toast.success("Slack connected successfully");
+    return;
+  }
+  if (next.isInstalled && !previous.isInstalled) {
+    toast.success("Slack installed successfully");
+    return;
+  }
+  if (!next.isInstalled && previous.isInstalled) {
+    toast.success("Slack workspace uninstalled");
+    return;
+  }
+  if (!next.isConnected && previous.isConnected) {
+    toast.success("Disconnected from Slack");
+    return;
+  }
+  toast.success("Slack updated");
+}
 
 /** True when the org-scoped Slack installation has outdated bot scopes (admin-only). */
 export const slackOrgScopeMismatch$ = computed(async (get) => {
@@ -47,13 +85,7 @@ export const disconnectSlackOrg$ = command(
     const client = get(zeroClient$)(zeroIntegrationsSlackContract);
     await accept(client.disconnect(), [200]);
     signal.throwIfAborted();
-    toast.success("Disconnected from Slack");
-    // Re-start the Ably subscription so the card picks up when the user
-    // re-connects via the OAuth tab.
-    await Promise.all([
-      set(reloadSlackOrg$),
-      set(pollSlackConnection$, signal),
-    ]);
+    set(reloadSlackOrg$);
   },
 );
 
@@ -62,40 +94,34 @@ export const uninstallSlackOrg$ = command(
     const client = get(zeroClient$)(zeroIntegrationsSlackContract);
     await accept(client.disconnect({ query: { action: "uninstall" } }), [200]);
     signal.throwIfAborted();
-    toast.success("Slack workspace uninstalled");
     set(reloadSlackOrg$);
   },
 );
 
 /**
- * Subscribe to Slack connection changes until connected or aborted.
- * Used on the works page so that after the user completes OAuth in another
- * tab, the UI updates automatically without a manual refresh. Reconnect
- * signals are fanned out only to org admins (connect/disconnect is an
- * admin-only action).
+ * Subscribe to Slack connection changes for the /works route lifetime.
  */
-export const pollSlackConnection$ = command(
+export const watchSlackConnection$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    // Already connected — nothing to wait for.
     const current = await get(slackOrgData$);
     signal.throwIfAborted();
-    if (current.isConnected) {
-      return;
-    }
+    set(internalSlackStatus$, current);
 
     const onSlackChanged$ = command(async ({ get, set }, sig: AbortSignal) => {
+      const previous = get(internalSlackStatus$);
       set(reloadSlackOrg$);
-      const client = get(zeroClient$)(zeroIntegrationsSlackContract);
-      const result = await accept(
-        client.getStatus({ fetchOptions: { signal: sig } }),
-        [200],
-      );
-      return result.body.isConnected;
+      const next = await get(slackOrgData$);
+      sig.throwIfAborted();
+      set(internalSlackStatus$, next);
+
+      if (hasSlackStatusChanged(previous, next)) {
+        toastSlackStatusChange(previous, next);
+      }
+
+      return false;
     });
 
     await set(setAblyLoop$, "slack:changed", onSlackChanged$, signal);
-
-    toast.success("Slack connected successfully");
   },
 );
 
@@ -110,10 +136,6 @@ export const initSlackOrg$ = command((_ctx) => {
   }
   if (params.get("connected") === "1") {
     toast.success("Slack connected successfully");
-    window.history.replaceState({}, "", window.location.pathname);
-  }
-  if (params.get("error")) {
-    toast.error(params.get("error")!);
     window.history.replaceState({}, "", window.location.pathname);
   }
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  click,
+  detachedSetupPage,
+  fill,
+} from "../../../__tests__/page-helper.ts";
+import {
+  createDefaultMockGithubIntegration,
+  getMockGithubIntegration,
+  setMockGithubIntegration,
+} from "../../../mocks/handlers/api-integrations-github.ts";
+import { pathname$ } from "../../../signals/route.ts";
+
+const context = testContext();
+
+function setupGithubPage() {
+  detachedSetupPage({
+    context,
+    path: "/settings/github",
+  });
+}
+
+describe("github settings page", () => {
+  it("does not show the connected GitHub username in the header", async () => {
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        isConnected: true,
+        connectedGithubUsername: "octocat",
+      }),
+    );
+
+    setupGithubPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Connected (@octocat)")).not.toBeInTheDocument();
+    expect(screen.getByText("Connected as @octocat")).toBeInTheDocument();
+  });
+
+  it("returns to the integrations list from the header", async () => {
+    setMockGithubIntegration(createDefaultMockGithubIntegration());
+    setupGithubPage();
+
+    click(await screen.findByText("Back to integrations"));
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/works");
+    });
+  });
+
+  it("shows connection and danger zone action cards", async () => {
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        isConnected: false,
+        connectedGithubUserId: null,
+        connectedGithubUsername: null,
+      }),
+    );
+    setupGithubPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Connection")).toBeInTheDocument();
+      expect(screen.getByText("Danger zone")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
+      expect(screen.getByText("Uninstall")).toBeInTheDocument();
+    });
+  });
+
+  it("disconnects the GitHub account from the connection card", async () => {
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        isConnected: true,
+        connectedGithubUserId: "98765",
+        connectedGithubUsername: "octocat",
+      }),
+    );
+    setupGithubPage();
+
+    click(await screen.findByText("Disconnect"));
+
+    await waitFor(() => {
+      expect(getMockGithubIntegration()?.isConnected).toBeFalsy();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
+    });
+  });
+
+  it("uninstalls GitHub from the danger zone", async () => {
+    setMockGithubIntegration(createDefaultMockGithubIntegration());
+    setupGithubPage();
+
+    click(await screen.findByText("Uninstall"));
+    const dialog = await screen.findByRole("dialog");
+    click(within(dialog).getByText("Uninstall"));
+
+    await waitFor(() => {
+      expect(getMockGithubIntegration()).toBeNull();
+      expect(screen.getByText("GitHub is not installed.")).toBeInTheDocument();
+    });
+  });
+
+  it("creates a GitHub label listener with the any-label trigger mode", async () => {
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        labelListeners: [],
+      }),
+    );
+    setupGithubPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Label listeners")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Add a label listener to run an agent when a GitHub issue or pull request gets a matching label.",
+        ),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByText("Add listener"));
+
+    const dialog = await screen.findByRole("dialog");
+    await fill(within(dialog).getByLabelText("Label"), "ready-for-zero");
+    await fill(
+      within(dialog).getByLabelText("Prompt"),
+      "Review the labeled issue or pull request.",
+    );
+
+    click(within(dialog).getByRole("combobox", { name: "Trigger mode" }));
+    click(screen.getByRole("option", { name: "Any issue/PR with this label" }));
+
+    click(within(dialog).getByText("Add listener"));
+
+    await waitFor(() => {
+      const integration = getMockGithubIntegration();
+      expect(integration?.labelListeners).toHaveLength(1);
+      expect(integration?.labelListeners[0]?.triggerMode).toBe("anyone");
+    });
+    expect(screen.getByText("ready-for-zero")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Any issue\/PR with this label/u).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("toggles a GitHub label listener", async () => {
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        labelListeners: [
+          {
+            id: "b0000000-0000-4000-a000-000000000001",
+            labelName: "ready-for-zero",
+            triggerMode: "created_by_me",
+            prompt: "Review the labeled issue or pull request.",
+            enabled: true,
+            agent: {
+              id: "c0000000-0000-4000-a000-000000000001",
+              name: "zero",
+            },
+            createdAt: new Date(0).toISOString(),
+            updatedAt: new Date(0).toISOString(),
+          },
+        ],
+      }),
+    );
+    setupGithubPage();
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Toggle ready-for-zero listener",
+    });
+    expect(toggle).toBeChecked();
+    click(toggle);
+
+    await waitFor(() => {
+      const integration = getMockGithubIntegration();
+      expect(integration?.labelListeners[0]?.enabled).toBeFalsy();
+      expect(screen.getByText("Disabled")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
@@ -12,6 +12,7 @@ import {
   setMockGithubIntegration,
 } from "../../../mocks/handlers/api-integrations-github.ts";
 import { pathname$ } from "../../../signals/route.ts";
+import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 
 const context = testContext();
 
@@ -66,6 +67,33 @@ describe("github settings page", () => {
       expect(screen.getByText("Danger zone")).toBeInTheDocument();
       expect(screen.getByText("Connect")).toBeInTheDocument();
       expect(screen.getByText("Uninstall")).toBeInTheDocument();
+    });
+  });
+
+  it("refreshes from the route-level GitHub realtime subscription", async () => {
+    const integration = createDefaultMockGithubIntegration({
+      isConnected: false,
+      connectedGithubUserId: null,
+      connectedGithubUsername: null,
+    });
+    setMockGithubIntegration(integration);
+    setupGithubPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect")).toBeInTheDocument();
+      expect(hasSubscription("github:changed")).toBeTruthy();
+    });
+
+    setMockGithubIntegration({
+      ...integration,
+      isConnected: true,
+      connectedGithubUserId: "98765",
+      connectedGithubUsername: "octocat",
+    });
+    triggerAblyEvent("github:changed");
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected as @octocat")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -82,6 +82,19 @@ describe("telegram settings page", () => {
     resetMockOrg();
   });
 
+  it("returns to the integrations list from the header", async () => {
+    setMockTelegramIntegration({
+      statuses: [telegramStatus("alpha", { username: "alpha_bot" })],
+    });
+    setupTelegramPage();
+
+    click(await screen.findByText("Back to integrations"));
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/works");
+    });
+  });
+
   it("lists multiple Telegram bots", async () => {
     const alphaAvatarPath = `/${[
       "api",
@@ -118,9 +131,8 @@ describe("telegram settings page", () => {
       expect(
         screen.getByTestId("telegram-bot-avatar-fallback-beta"),
       ).toBeInTheDocument();
-      expect(screen.getByTestId("telegram-bot-count")).toHaveTextContent(
-        "This organization has 2 Telegram bots",
-      );
+      expect(screen.getByText("Telegram bots")).toBeInTheDocument();
+      expect(screen.queryByText(/This organization has/u)).toBeNull();
     });
 
     const alphaAvatar = screen.getByTestId("telegram-bot-avatar-alpha");
@@ -184,9 +196,7 @@ describe("telegram settings page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("No Telegram bots yet")).toBeInTheDocument();
-      expect(screen.getByTestId("telegram-bot-count")).toHaveTextContent(
-        "This organization has no Telegram bots",
-      );
+      expect(screen.queryByText(/This organization has/u)).toBeNull();
     });
 
     click(screen.getByText("Add bot"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -23,7 +23,6 @@ import {
   zeroIntegrationsSlackContract,
   type SlackOrgStatus,
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
-import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -41,8 +40,6 @@ const context = testContext();
 const mockApi = createMockApi(context);
 const GITHUB_CONNECT_URL =
   "https://github.com/login/oauth/authorize?client_id=github-oauth-client-id";
-const GITHUB_START_AUTHORIZATION_URL =
-  "https://github.com/login/oauth/authorize?client_id=github-oauth-client-id&redirect_uri=https%3A%2F%2Fwww.vm0.ai%2Fapi%2Fconnectors%2Fgithub%2Fcallback";
 
 function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
   const defaults: SlackOrgStatus = {
@@ -65,17 +62,6 @@ function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
   server.use(
     mockApi(zeroIntegrationsSlackContract.getStatus, ({ respond }) => {
       return respond(200, { ...defaults, ...overrides });
-    }),
-  );
-}
-
-function mockGithubConnectorOauthStart(): void {
-  server.use(
-    mockApi(zeroConnectorOauthStartContract.start, ({ params, respond }) => {
-      expect(params.type).toBe("github");
-      return respond(200, {
-        authorizationUrl: GITHUB_START_AUTHORIZATION_URL,
-      });
     }),
   );
 }
@@ -264,7 +250,6 @@ describe("works page - GitHub integration card", () => {
     });
     setMockGithubIntegration(integration);
     setMockConnectors([]);
-    mockGithubConnectorOauthStart();
     const mockWindow = createMockAuthWindow();
     vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
@@ -308,7 +293,6 @@ describe("works page - GitHub integration card", () => {
     });
     setMockGithubIntegration(integration);
     setMockConnectors([createGithubConnector()]);
-    mockGithubConnectorOauthStart();
     const mockWindow = createMockAuthWindow();
     vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -10,6 +10,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
@@ -60,8 +61,14 @@ function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
   );
 }
 
-function renderWorksPage() {
-  detachedSetupPage({ context, path: "/works" });
+function renderWorksPage(options?: {
+  readonly featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+}) {
+  detachedSetupPage({
+    context,
+    path: "/works",
+    featureSwitches: options?.featureSwitches,
+  });
 }
 
 function getGithubCard(): HTMLElement {
@@ -120,9 +127,21 @@ describe("works page - slack integration status display", () => {
 });
 
 describe("works page - GitHub integration card", () => {
-  it("shows the GitHub install action when no installation exists", async () => {
+  it("hides the GitHub card when the feature switch is off", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     renderWorksPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+      expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows the GitHub install action when no installation exists", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
 
     await waitFor(() => {
       expect(
@@ -138,7 +157,9 @@ describe("works page - GitHub integration card", () => {
         labelListeners: [],
       }),
     );
-    renderWorksPage();
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
 
     await waitFor(() => {
       expect(within(getGithubCard()).getByText("Manage")).toBeInTheDocument();
@@ -195,7 +216,9 @@ describe("works page - GitHub integration card", () => {
         ],
       }),
     );
-    renderWorksPage();
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
 
     await waitFor(() => {
       expect(within(getGithubCard()).getByText("Manage")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -23,9 +23,13 @@ import {
   zeroIntegrationsSlackContract,
   type SlackOrgStatus,
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
-import { pathname$ } from "../../../signals/route.ts";
+import { pathname$, searchParams$ } from "../../../signals/route.ts";
 import { setMockAgentPhoneIntegration } from "../../../mocks/handlers/api-integrations-agentphone.ts";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import {
   createDefaultMockGithubIntegration,
   getMockGithubIntegration,
@@ -35,6 +39,10 @@ import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
+const GITHUB_CONNECT_URL =
+  "https://github.com/login/oauth/authorize?client_id=github-oauth-client-id";
+const GITHUB_START_AUTHORIZATION_URL =
+  "https://github.com/login/oauth/authorize?client_id=github-oauth-client-id&redirect_uri=https%3A%2F%2Fwww.vm0.ai%2Fapi%2Fconnectors%2Fgithub%2Fcallback";
 
 function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
   const defaults: SlackOrgStatus = {
@@ -61,6 +69,17 @@ function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
   );
 }
 
+function mockGithubConnectorOauthStart(): void {
+  server.use(
+    mockApi(zeroConnectorOauthStartContract.start, ({ params, respond }) => {
+      expect(params.type).toBe("github");
+      return respond(200, {
+        authorizationUrl: GITHUB_START_AUTHORIZATION_URL,
+      });
+    }),
+  );
+}
+
 function renderWorksPage(options?: {
   readonly featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
 }) {
@@ -77,6 +96,25 @@ function getGithubCard(): HTMLElement {
     throw new Error("GitHub card not found");
   }
   return card;
+}
+
+function createMockAuthWindow() {
+  return { closed: false, close: vi.fn(), location: { href: "" } };
+}
+
+function createGithubConnector(): ConnectorResponse {
+  return {
+    id: "d0000000-0000-4000-a000-000000000001",
+    type: "github",
+    authMethod: "oauth",
+    externalId: "98765",
+    externalUsername: "testuser",
+    externalEmail: "test@example.com",
+    oauthScopes: ["repo", "project", "workflow"],
+    needsReconnect: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
 }
 
 describe("works page - slack integration status display", () => {
@@ -127,6 +165,27 @@ describe("works page - slack integration status display", () => {
 });
 
 describe("works page - GitHub integration card", () => {
+  it("shows an error toast from the redirect query and clears it", async () => {
+    const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+      return "" as ReturnType<typeof toast.error>;
+    });
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+
+    detachedSetupPage({
+      context,
+      path: "/works?error=The+code+passed+is+incorrect+or+expired.",
+    });
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        "The code passed is incorrect or expired.",
+      );
+    });
+    expect(context.store.get(searchParams$).has("error")).toBeFalsy();
+
+    errorSpy.mockRestore();
+  });
+
   it("hides the GitHub card when the feature switch is off", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     renderWorksPage();
@@ -147,73 +206,178 @@ describe("works page - GitHub integration card", () => {
       expect(
         within(getGithubCard()).getByText("Install GitHub"),
       ).toBeInTheDocument();
-    });
-  });
-
-  it("creates a GitHub label listener with the any-label trigger mode", async () => {
-    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
-    setMockGithubIntegration(
-      createDefaultMockGithubIntegration({
-        labelListeners: [],
-      }),
-    );
-    renderWorksPage({
-      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
-    });
-
-    await waitFor(() => {
-      expect(within(getGithubCard()).getByText("Manage")).toBeInTheDocument();
-    });
-    click(within(getGithubCard()).getByText("Manage"));
-
-    const dialog = await screen.findByRole("dialog");
-    await fill(within(dialog).getByLabelText("Label"), "ready-for-zero");
-    await fill(
-      within(dialog).getByLabelText("Prompt"),
-      "Review the labeled issue or pull request.",
-    );
-
-    const triggerModeSelect = within(dialog).getAllByRole("combobox")[1];
-    click(triggerModeSelect);
-    await waitFor(() => {
       expect(
-        screen.getByRole("option", { name: "Any issue/PR with this label" }),
+        within(getGithubCard()).getByText(
+          "Run agents from GitHub issue and PR labels",
+        ),
       ).toBeInTheDocument();
     });
-    click(screen.getByRole("option", { name: "Any issue/PR with this label" }));
-
-    click(within(dialog).getByText("Add listener"));
-
-    await waitFor(() => {
-      const integration = getMockGithubIntegration();
-      expect(integration?.labelListeners).toHaveLength(1);
-      expect(integration?.labelListeners[0]?.triggerMode).toBe("anyone");
-    });
-    expect(screen.getByText("ready-for-zero")).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/Any issue\/PR with this label/u).length,
-    ).toBeGreaterThan(0);
   });
 
-  it("toggles a GitHub label listener from the manage dialog", async () => {
+  it("refreshes the GitHub card from the page-level realtime subscription", async () => {
+    const successSpy = vi.spyOn(toast, "success").mockImplementation(() => {
+      return "" as ReturnType<typeof toast.success>;
+    });
+    const integration = createDefaultMockGithubIntegration({
+      isConnected: false,
+      connectedGithubUserId: null,
+      connectedGithubUsername: null,
+      connectUrl: GITHUB_CONNECT_URL,
+    });
+    setMockGithubIntegration(integration);
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
+
+    await waitFor(() => {
+      expect(within(getGithubCard()).getByText("Connect")).toBeInTheDocument();
+      expect(hasSubscription("github:changed")).toBeTruthy();
+    });
+
+    setMockGithubIntegration({
+      ...integration,
+      isConnected: true,
+      connectedGithubUserId: "98765",
+      connectedGithubUsername: "octocat",
+    });
+    triggerAblyEvent("github:changed");
+
+    await waitFor(() => {
+      expect(
+        within(getGithubCard()).getByTestId("github-connected-indicator"),
+      ).toHaveTextContent("Connected (@octocat)");
+    });
+    await waitFor(() => {
+      expect(successSpy).toHaveBeenCalledWith("GitHub connected successfully");
+      expect(hasSubscription("github:changed")).toBeTruthy();
+    });
+    successSpy.mockRestore();
+  });
+
+  it("connects the GitHub integration through the integration OAuth flow", async () => {
+    const integration = createDefaultMockGithubIntegration({
+      isConnected: false,
+      connectedGithubUserId: null,
+      connectUrl: GITHUB_CONNECT_URL,
+    });
+    setMockGithubIntegration(integration);
+    setMockConnectors([]);
+    mockGithubConnectorOauthStart();
+    const mockWindow = createMockAuthWindow();
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
+
+    await waitFor(() => {
+      expect(within(getGithubCard()).getByText("Connect")).toBeInTheDocument();
+    });
+    click(within(getGithubCard()).getByText("Connect"));
+
+    await waitFor(() => {
+      const openedUrl = new URL(mockWindow.location.href);
+      expect(openedUrl.origin).toBe("https://github.com");
+      expect(openedUrl.pathname).toBe("/login/oauth/authorize");
+      expect(hasSubscription("github:changed")).toBeTruthy();
+    });
+
+    setMockGithubIntegration({
+      ...integration,
+      isConnected: true,
+      connectedGithubUserId: "98765",
+    });
+    triggerAblyEvent("github:changed");
+
+    await waitFor(() => {
+      expect(getMockGithubIntegration()?.isConnected).toBeTruthy();
+      expect(
+        within(getGithubCard()).getByTestId("github-connected-indicator"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("reconnects GitHub OAuth when the GitHub connector already exists", async () => {
+    const integration = createDefaultMockGithubIntegration({
+      isConnected: false,
+      connectedGithubUserId: null,
+      connectUrl: GITHUB_CONNECT_URL,
+    });
+    setMockGithubIntegration(integration);
+    setMockConnectors([createGithubConnector()]);
+    mockGithubConnectorOauthStart();
+    const mockWindow = createMockAuthWindow();
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
+
+    await waitFor(() => {
+      expect(within(getGithubCard()).getByText("Connect")).toBeInTheDocument();
+    });
+    click(within(getGithubCard()).getByText("Connect"));
+
+    await waitFor(() => {
+      const openedUrl = new URL(mockWindow.location.href);
+      expect(openedUrl.origin).toBe("https://github.com");
+      expect(openedUrl.pathname).toBe("/login/oauth/authorize");
+      expect(hasSubscription("github:changed")).toBeTruthy();
+    });
+
+    setMockGithubIntegration({
+      ...integration,
+      isConnected: true,
+      connectedGithubUserId: "98765",
+    });
+    triggerAblyEvent("github:changed");
+
+    await waitFor(() => {
+      expect(getMockGithubIntegration()?.isConnected).toBeTruthy();
+      expect(
+        within(getGithubCard()).getByTestId("github-connected-indicator"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows GitHub uninstall when the installation is not connected", async () => {
+    const integration = createDefaultMockGithubIntegration({
+      isConnected: false,
+      connectedGithubUserId: null,
+    });
+    setMockGithubIntegration({
+      ...integration,
+      installation: { ...integration.installation, isAdmin: true },
+    });
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        within(getGithubCard()).getByLabelText("GitHub options"),
+      ).toBeInTheDocument();
+    });
+    click(within(getGithubCard()).getByLabelText("GitHub options"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Uninstall")).toBeInTheDocument();
+      expect(screen.queryByText("Disconnect")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows the connected GitHub username", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     setMockGithubIntegration(
       createDefaultMockGithubIntegration({
-        labelListeners: [
-          {
-            id: "b0000000-0000-4000-a000-000000000001",
-            labelName: "ready-for-zero",
-            triggerMode: "created_by_me",
-            prompt: "Review the labeled issue or pull request.",
-            enabled: true,
-            agent: {
-              id: "c0000000-0000-4000-a000-000000000001",
-              name: "zero",
-            },
-            createdAt: new Date(0).toISOString(),
-            updatedAt: new Date(0).toISOString(),
-          },
-        ],
+        isConnected: true,
+        connectedGithubUsername: "octocat",
       }),
     );
     renderWorksPage({
@@ -221,21 +385,33 @@ describe("works page - GitHub integration card", () => {
     });
 
     await waitFor(() => {
-      expect(within(getGithubCard()).getByText("Manage")).toBeInTheDocument();
+      expect(
+        within(getGithubCard()).getByText("Connected (@octocat)"),
+      ).toBeInTheDocument();
     });
-    click(within(getGithubCard()).getByText("Manage"));
+  });
 
-    const dialog = await screen.findByRole("dialog");
-    const toggle = within(dialog).getByRole("switch", {
-      name: "Toggle ready-for-zero listener",
+  it("opens GitHub settings from the options menu", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        isConnected: true,
+      }),
+    );
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
     });
-    expect(toggle).toBeChecked();
-    click(toggle);
 
     await waitFor(() => {
-      const integration = getMockGithubIntegration();
-      expect(integration?.labelListeners[0]?.enabled).toBeFalsy();
-      expect(within(dialog).getByText("Disabled")).toBeInTheDocument();
+      expect(
+        within(getGithubCard()).getByLabelText("GitHub options"),
+      ).toBeInTheDocument();
+    });
+    click(within(getGithubCard()).getByLabelText("GitHub options"));
+    click(await screen.findByLabelText("Manage GitHub"));
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/settings/github");
     });
   });
 });
@@ -248,6 +424,9 @@ describe("works page - telegram integration card", () => {
     await waitFor(() => {
       expect(screen.getByText("Slack")).toBeInTheDocument();
       expect(screen.getByText("Telegram")).toBeInTheDocument();
+      expect(
+        screen.getByText("Route Telegram messages to agents"),
+      ).toBeInTheDocument();
       expect(screen.queryByTestId("telegram-beta-badge")).toBeNull();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -173,6 +173,48 @@ describe("works page - GitHub integration card", () => {
       screen.getAllByText(/Any issue\/PR with this label/u).length,
     ).toBeGreaterThan(0);
   });
+
+  it("toggles a GitHub label listener from the manage dialog", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        labelListeners: [
+          {
+            id: "b0000000-0000-4000-a000-000000000001",
+            labelName: "ready-for-zero",
+            triggerMode: "created_by_me",
+            prompt: "Review the labeled issue or pull request.",
+            enabled: true,
+            agent: {
+              id: "c0000000-0000-4000-a000-000000000001",
+              name: "zero",
+            },
+            createdAt: new Date(0).toISOString(),
+            updatedAt: new Date(0).toISOString(),
+          },
+        ],
+      }),
+    );
+    renderWorksPage();
+
+    await waitFor(() => {
+      expect(within(getGithubCard()).getByText("Manage")).toBeInTheDocument();
+    });
+    click(within(getGithubCard()).getByText("Manage"));
+
+    const dialog = await screen.findByRole("dialog");
+    const toggle = within(dialog).getByRole("switch", {
+      name: "Toggle ready-for-zero listener",
+    });
+    expect(toggle).toBeChecked();
+    click(toggle);
+
+    await waitFor(() => {
+      const integration = getMockGithubIntegration();
+      expect(integration?.labelListeners[0]?.enabled).toBeFalsy();
+      expect(within(dialog).getByText("Disabled")).toBeInTheDocument();
+    });
+  });
 });
 
 describe("works page - telegram integration card", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -25,6 +25,11 @@ import {
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { pathname$ } from "../../../signals/route.ts";
 import { setMockAgentPhoneIntegration } from "../../../mocks/handlers/api-integrations-agentphone.ts";
+import {
+  createDefaultMockGithubIntegration,
+  getMockGithubIntegration,
+  setMockGithubIntegration,
+} from "../../../mocks/handlers/api-integrations-github.ts";
 import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 
 const context = testContext();
@@ -57,6 +62,14 @@ function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
 
 function renderWorksPage() {
   detachedSetupPage({ context, path: "/works" });
+}
+
+function getGithubCard(): HTMLElement {
+  const card = screen.getByText("GitHub").closest(".zero-card");
+  if (!(card instanceof HTMLElement)) {
+    throw new Error("GitHub card not found");
+  }
+  return card;
 }
 
 describe("works page - slack integration status display", () => {
@@ -103,6 +116,62 @@ describe("works page - slack integration status display", () => {
     await waitFor(() => {
       expect(screen.getByText(/update permissions/i)).toBeInTheDocument();
     });
+  });
+});
+
+describe("works page - GitHub integration card", () => {
+  it("shows the GitHub install action when no installation exists", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        within(getGithubCard()).getByText("Install GitHub"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("creates a GitHub label listener with the any-label trigger mode", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        labelListeners: [],
+      }),
+    );
+    renderWorksPage();
+
+    await waitFor(() => {
+      expect(within(getGithubCard()).getByText("Manage")).toBeInTheDocument();
+    });
+    click(within(getGithubCard()).getByText("Manage"));
+
+    const dialog = await screen.findByRole("dialog");
+    await fill(within(dialog).getByLabelText("Label"), "ready-for-zero");
+    await fill(
+      within(dialog).getByLabelText("Prompt"),
+      "Review the labeled issue or pull request.",
+    );
+
+    const triggerModeSelect = within(dialog).getAllByRole("combobox")[1];
+    click(triggerModeSelect);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", { name: "Any issue/PR with this label" }),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByRole("option", { name: "Any issue/PR with this label" }));
+
+    click(within(dialog).getByText("Add listener"));
+
+    await waitFor(() => {
+      const integration = getMockGithubIntegration();
+      expect(integration?.labelListeners).toHaveLength(1);
+      expect(integration?.labelListeners[0]?.triggerMode).toBe("anyone");
+    });
+    expect(screen.getByText("ready-for-zero")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Any issue\/PR with this label/u).length,
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
@@ -50,7 +50,6 @@ import {
   setAgentPhoneShowPhoneError$,
   setAgentPhoneVerificationPhone$,
   startAgentPhoneLink$,
-  waitForAgentPhoneConnection$,
 } from "../../signals/zero-page/zero-agentphone.ts";
 import { AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE } from "../../signals/zero-page/agentphone-connect-params.ts";
 import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
@@ -185,11 +184,9 @@ function AgentPhoneConnectDialog() {
   const resetConnectUi = useSet(resetAgentPhoneConnectUi$);
   const pageSignal = useGet(pageSignal$);
   const [startLoadable, startLink] = useLoadableSet(startAgentPhoneLink$);
-  const [connectLoadable, waitForConnection] = useLoadableSet(
-    waitForAgentPhoneConnection$,
-  );
+  const status = useLastResolved(agentPhoneLinkStatus$);
   const starting = startLoadable.state === "loading";
-  const connecting = connectLoadable.state === "loading";
+  const connecting = verificationPhone !== null && status?.linked !== true;
   const busy = starting || connecting;
   const visiblePhoneError = showPhoneError ? phoneError : null;
 
@@ -215,10 +212,6 @@ function AgentPhoneConnectDialog() {
       (async () => {
         const result = await startLink(pageSignal);
         setVerificationPhone(result.phoneHandle);
-        await waitForConnection(pageSignal);
-        if (!pageSignal.aborted) {
-          close(false);
-        }
       })(),
       Reason.DomCallback,
     );

--- a/turbo/apps/platform/src/views/zero-page/github-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/github-card.tsx
@@ -1,0 +1,568 @@
+import type { FormEvent } from "react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import {
+  IconCircleCheck,
+  IconDotsVertical,
+  IconLoader2,
+  IconPlus,
+  IconSettings,
+  IconTrash,
+} from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { Input } from "@vm0/ui/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@vm0/ui/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import { sortedAgents$ } from "../../signals/agent.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  connectGithubInstallation$,
+  createGithubLabelListener$,
+  deleteGithubLabelListener$,
+  disconnectGithubInstallation$,
+  githubIntegrationData$,
+  githubLabelListenerForm$,
+  githubManageDialogOpen$,
+  resetGithubLabelListenerForm$,
+  setGithubLabelListenerForm$,
+  setGithubManageDialogOpen$,
+  uninstallGithubInstallation$,
+  type GithubIntegrationData,
+  type GithubLabelListenerForm,
+  type GithubLabelTriggerMode,
+} from "../../signals/zero-page/zero-github.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import githubIconImg from "./components/settings/icons/github.svg";
+
+type GithubListener = GithubIntegrationData["labelListeners"][number];
+
+interface GithubAgentOption {
+  readonly id: string;
+  readonly displayName?: string | null;
+}
+
+function getTriggerModeLabel(mode: GithubLabelTriggerMode): string {
+  if (mode === "created_by_me") {
+    return "Only issues/PRs I create";
+  }
+  return "Any issue/PR with this label";
+}
+
+function openFreshOAuth(url: string) {
+  const fresh = new URL(url, window.location.origin);
+  fresh.searchParams.set("_t", String(Date.now()));
+  window.open(fresh.toString(), "_blank");
+}
+
+function GithubListenerList({
+  listeners,
+}: {
+  readonly listeners: readonly GithubListener[];
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [deleteLoadable, deleteListener] = useLoadableSet(
+    deleteGithubLabelListener$,
+  );
+  const deleting = deleteLoadable.state === "loading";
+
+  if (listeners.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-3 py-4 text-sm text-muted-foreground">
+        No label listeners configured.
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y rounded-lg border border-border">
+      {listeners.map((listener) => {
+        return (
+          <div
+            key={listener.id}
+            className="flex items-center gap-3 px-3 py-2.5"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="truncate text-sm font-medium text-foreground">
+                  {listener.labelName}
+                </span>
+                {!listener.enabled ? (
+                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                    Disabled
+                  </span>
+                ) : null}
+              </div>
+              <div className="truncate text-xs text-muted-foreground">
+                {listener.agent?.name ?? "Unknown agent"} ·{" "}
+                {getTriggerModeLabel(listener.triggerMode)}
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              disabled={deleting}
+              aria-label={`Delete ${listener.labelName}`}
+              onClick={() => {
+                detach(
+                  deleteListener(listener.id, pageSignal),
+                  Reason.DomCallback,
+                );
+              }}
+            >
+              {deleting ? (
+                <IconLoader2 size={15} className="animate-spin" />
+              ) : (
+                <IconTrash size={15} />
+              )}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function GithubListenerPrimaryFields({
+  agents,
+  creating,
+  form,
+  selectedAgentId,
+  setForm,
+}: {
+  readonly agents: readonly GithubAgentOption[];
+  readonly creating: boolean;
+  readonly form: GithubLabelListenerForm;
+  readonly selectedAgentId: string;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-[1fr_1fr]">
+      <label className="grid gap-1.5 text-sm font-medium text-foreground">
+        Label
+        <Input
+          value={form.labelName}
+          placeholder="ready-for-zero"
+          disabled={creating}
+          onChange={(event) => {
+            setForm({ labelName: event.target.value });
+          }}
+        />
+      </label>
+      <label className="grid gap-1.5 text-sm font-medium text-foreground">
+        Agent
+        <Select
+          value={selectedAgentId}
+          disabled={creating || agents.length === 0}
+          onValueChange={(agentId) => {
+            setForm({ agentId });
+          }}
+        >
+          <SelectTrigger className="h-9">
+            <SelectValue placeholder="Select agent" />
+          </SelectTrigger>
+          <SelectContent>
+            {agents.map((agent) => {
+              return (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agent.displayName ?? agent.id}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </label>
+    </div>
+  );
+}
+
+function GithubTriggerModeField({
+  creating,
+  triggerMode,
+  setForm,
+}: {
+  readonly creating: boolean;
+  readonly triggerMode: GithubLabelTriggerMode;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  return (
+    <label className="grid gap-1.5 text-sm font-medium text-foreground">
+      Trigger mode
+      <Select
+        value={triggerMode}
+        disabled={creating}
+        onValueChange={(value) => {
+          setForm({ triggerMode: value as GithubLabelTriggerMode });
+        }}
+      >
+        <SelectTrigger className="h-9">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="created_by_me">
+            {getTriggerModeLabel("created_by_me")}
+          </SelectItem>
+          <SelectItem value="anyone">
+            {getTriggerModeLabel("anyone")}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </label>
+  );
+}
+
+function GithubPromptField({
+  creating,
+  prompt,
+  setForm,
+}: {
+  readonly creating: boolean;
+  readonly prompt: string;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  return (
+    <label className="grid gap-1.5 text-sm font-medium text-foreground">
+      Prompt
+      <textarea
+        value={prompt}
+        disabled={creating}
+        rows={4}
+        className="min-h-24 resize-y rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        placeholder="Review the labeled issue or PR and take the next appropriate action."
+        onChange={(event) => {
+          setForm({ prompt: event.target.value });
+        }}
+      />
+    </label>
+  );
+}
+
+function GithubListenerForm({
+  agents,
+  onClose,
+}: {
+  readonly agents: readonly GithubAgentOption[];
+  readonly onClose: () => void;
+}) {
+  const form = useGet(githubLabelListenerForm$);
+  const setForm = useSet(setGithubLabelListenerForm$);
+  const resetForm = useSet(resetGithubLabelListenerForm$);
+  const pageSignal = useGet(pageSignal$);
+  const [createLoadable, createListener] = useLoadableSet(
+    createGithubLabelListener$,
+  );
+  const creating = createLoadable.state === "loading";
+  const selectedAgentId = form.agentId || agents[0]?.id || "";
+  const canCreate = Boolean(
+    form.labelName.trim() && form.prompt.trim() && selectedAgentId,
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const labelName = form.labelName.trim();
+    const prompt = form.prompt.trim();
+    if (!labelName || !prompt || !selectedAgentId || creating) {
+      return;
+    }
+
+    detach(
+      (async () => {
+        await createListener(
+          {
+            labelName,
+            agentId: selectedAgentId,
+            triggerMode: form.triggerMode,
+            prompt,
+          },
+          pageSignal,
+        );
+        resetForm();
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <form className="grid gap-3" onSubmit={submit}>
+      <GithubListenerPrimaryFields
+        agents={agents}
+        creating={creating}
+        form={form}
+        selectedAgentId={selectedAgentId}
+        setForm={setForm}
+      />
+      <GithubTriggerModeField
+        creating={creating}
+        triggerMode={form.triggerMode}
+        setForm={setForm}
+      />
+      <GithubPromptField
+        creating={creating}
+        prompt={form.prompt}
+        setForm={setForm}
+      />
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={creating}
+          onClick={onClose}
+        >
+          Close
+        </Button>
+        <Button type="submit" disabled={!canCreate || creating}>
+          {creating ? (
+            <IconLoader2 size={14} className="animate-spin" />
+          ) : (
+            <IconPlus size={14} />
+          )}
+          Add listener
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function GithubListenerDialog() {
+  const open = useGet(githubManageDialogOpen$);
+  const setOpen = useSet(setGithubManageDialogOpen$);
+  const data = useLastResolved(githubIntegrationData$);
+  const agents = useLastResolved(sortedAgents$) ?? [];
+  const listeners = data?.labelListeners ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>GitHub label listeners</DialogTitle>
+          <DialogDescription>
+            Configure labels that start an agent run from GitHub issues and pull
+            requests.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          <GithubListenerList listeners={listeners} />
+          <GithubListenerForm
+            agents={agents}
+            onClose={() => {
+              setOpen(false);
+            }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GithubConnectedBadge({ connected }: { readonly connected: boolean }) {
+  if (!connected) {
+    return null;
+  }
+
+  return (
+    <span
+      data-testid="github-connected-indicator"
+      className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
+    >
+      <IconCircleCheck className="h-3 w-3 text-green-600" />
+      <span className="min-w-0 truncate">Connected</span>
+    </span>
+  );
+}
+
+function GithubOptionsPopover({
+  canUninstall,
+  disconnecting,
+  isConnected,
+  uninstalling,
+  onDisconnect,
+  onUninstall,
+}: {
+  readonly canUninstall: boolean;
+  readonly disconnecting: boolean;
+  readonly isConnected: boolean;
+  readonly uninstalling: boolean;
+  readonly onDisconnect: () => void;
+  readonly onUninstall: () => void;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label="GitHub options"
+        >
+          <IconDotsVertical size={16} stroke={1.5} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex w-44 flex-col gap-0.5 p-2">
+        {isConnected ? (
+          <button
+            type="button"
+            disabled={disconnecting}
+            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+            onClick={onDisconnect}
+          >
+            {disconnecting ? "Disconnecting..." : "Disconnect"}
+          </button>
+        ) : null}
+        {canUninstall ? (
+          <button
+            type="button"
+            disabled={uninstalling}
+            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-destructive transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+            onClick={onUninstall}
+          >
+            {uninstalling ? "Uninstalling..." : "Uninstall"}
+          </button>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function GithubCardActions({
+  data,
+}: {
+  readonly data: GithubIntegrationData | null;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const setManageOpen = useSet(setGithubManageDialogOpen$);
+  const [connectLoadable, connect] = useLoadableSet(connectGithubInstallation$);
+  const [disconnectLoadable, disconnect] = useLoadableSet(
+    disconnectGithubInstallation$,
+  );
+  const [uninstallLoadable, uninstall] = useLoadableSet(
+    uninstallGithubInstallation$,
+  );
+  const connecting = connectLoadable.state === "loading";
+  const disconnecting = disconnectLoadable.state === "loading";
+  const uninstalling = uninstallLoadable.state === "loading";
+  const busy = connecting || disconnecting || uninstalling;
+  const isInstalled = data?.isInstalled ?? false;
+  const isConnected = data?.isConnected ?? false;
+  const installUrl = isInstalled ? null : data?.installUrl;
+  const canUninstall = Boolean(data?.isInstalled && data.installation.isAdmin);
+
+  if (installUrl) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 shrink-0 gap-1.5 rounded-lg"
+        disabled={busy}
+        onClick={() => {
+          openFreshOAuth(installUrl);
+        }}
+      >
+        Install GitHub
+      </Button>
+    );
+  }
+
+  if (!isInstalled) {
+    return null;
+  }
+
+  return (
+    <>
+      {!isConnected ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5 rounded-lg"
+          disabled={busy}
+          onClick={() => {
+            detach(connect(pageSignal), Reason.DomCallback);
+          }}
+        >
+          {connecting ? "Connecting..." : "Connect"}
+        </Button>
+      ) : null}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 shrink-0 gap-1.5 rounded-lg"
+        onClick={() => {
+          setManageOpen(true);
+        }}
+      >
+        <IconSettings size={14} stroke={1.5} />
+        Manage
+      </Button>
+      <GithubOptionsPopover
+        canUninstall={canUninstall}
+        disconnecting={disconnecting}
+        isConnected={isConnected}
+        uninstalling={uninstalling}
+        onDisconnect={() => {
+          detach(disconnect(pageSignal), Reason.DomCallback);
+        }}
+        onUninstall={() => {
+          detach(uninstall(pageSignal), Reason.DomCallback);
+        }}
+      />
+    </>
+  );
+}
+
+export function GithubCard() {
+  const dataLoadable = useLastLoadable(githubIntegrationData$);
+  const data = dataLoadable.state === "hasData" ? dataLoadable.data : null;
+  const isInstalled = data?.isInstalled ?? false;
+  const listenerCount = data?.labelListeners.length ?? 0;
+  const summary = isInstalled
+    ? `${listenerCount} label ${listenerCount === 1 ? "listener" : "listeners"}`
+    : "Run agents from GitHub issue and PR labels";
+
+  return (
+    <>
+      <div className="zero-card flex flex-col">
+        <div className="flex items-center gap-4 p-4">
+          <div className="shrink-0 inline-flex h-7 w-7 items-center justify-center overflow-hidden">
+            <img src={githubIconImg} alt="" className="h-7 w-7" />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="text-sm font-medium text-foreground">GitHub</div>
+            <div className="truncate text-sm text-muted-foreground">
+              {summary}
+            </div>
+          </div>
+          <GithubConnectedBadge connected={data?.isConnected ?? false} />
+          <GithubCardActions data={data} />
+        </div>
+      </div>
+
+      <GithubListenerDialog />
+    </>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/github-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/github-card.tsx
@@ -50,11 +50,13 @@ import {
   setGithubLabelListenerForm$,
   setGithubManageDialogOpen$,
   uninstallGithubInstallation$,
+  updateGithubLabelListener$,
   type GithubIntegrationData,
   type GithubLabelListenerForm,
   type GithubLabelTriggerMode,
 } from "../../signals/zero-page/zero-github.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import githubIconImg from "./components/settings/icons/github.svg";
 
 type GithubListener = GithubIntegrationData["labelListeners"][number];
@@ -86,7 +88,11 @@ function GithubListenerList({
   const [deleteLoadable, deleteListener] = useLoadableSet(
     deleteGithubLabelListener$,
   );
+  const [updateLoadable, updateListener] = useLoadableSet(
+    updateGithubLabelListener$,
+  );
   const deleting = deleteLoadable.state === "loading";
+  const updating = updateLoadable.state === "loading";
 
   if (listeners.length === 0) {
     return (
@@ -120,12 +126,27 @@ function GithubListenerList({
                 {getTriggerModeLabel(listener.triggerMode)}
               </div>
             </div>
+            <LoadingSwitch
+              checked={listener.enabled}
+              loading={updating}
+              size="sm"
+              ariaLabel={`Toggle ${listener.labelName} listener`}
+              onCheckedChange={(enabled) => {
+                detach(
+                  updateListener(
+                    { listenerId: listener.id, body: { enabled } },
+                    pageSignal,
+                  ),
+                  Reason.DomCallback,
+                );
+              }}
+            />
             <Button
               type="button"
               variant="ghost"
               size="icon"
               className="h-8 w-8 shrink-0"
-              disabled={deleting}
+              disabled={deleting || updating}
               aria-label={`Delete ${listener.labelName}`}
               onClick={() => {
                 detach(

--- a/turbo/apps/platform/src/views/zero-page/github-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/github-card.tsx
@@ -1,77 +1,24 @@
-import type { FormEvent } from "react";
-import {
-  useGet,
-  useLastLoadable,
-  useLastResolved,
-  useSet,
-} from "ccstate-react";
+import { useGet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import {
-  IconCircleCheck,
-  IconDotsVertical,
-  IconLoader2,
-  IconPlus,
-  IconSettings,
-  IconTrash,
-} from "@tabler/icons-react";
+import { IconCircleCheck, IconDotsVertical } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@vm0/ui/components/ui/dialog";
-import { Input } from "@vm0/ui/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@vm0/ui/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@vm0/ui/components/ui/select";
-import { sortedAgents$ } from "../../signals/agent.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   connectGithubInstallation$,
-  createGithubLabelListener$,
-  deleteGithubLabelListener$,
   disconnectGithubInstallation$,
   githubIntegrationData$,
-  githubLabelListenerForm$,
-  githubManageDialogOpen$,
-  resetGithubLabelListenerForm$,
-  setGithubLabelListenerForm$,
-  setGithubManageDialogOpen$,
   uninstallGithubInstallation$,
-  updateGithubLabelListener$,
   type GithubIntegrationData,
-  type GithubLabelListenerForm,
-  type GithubLabelTriggerMode,
 } from "../../signals/zero-page/zero-github.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { LoadingSwitch } from "../components/loading-switch.tsx";
+import { Link } from "../router/link.tsx";
 import githubIconImg from "./components/settings/icons/github.svg";
-
-type GithubListener = GithubIntegrationData["labelListeners"][number];
-
-interface GithubAgentOption {
-  readonly id: string;
-  readonly displayName?: string | null;
-}
-
-function getTriggerModeLabel(mode: GithubLabelTriggerMode): string {
-  if (mode === "created_by_me") {
-    return "Only issues/PRs I create";
-  }
-  return "Any issue/PR with this label";
-}
 
 function openFreshOAuth(url: string) {
   const fresh = new URL(url, window.location.origin);
@@ -79,331 +26,28 @@ function openFreshOAuth(url: string) {
   window.open(fresh.toString(), "_blank");
 }
 
-function GithubListenerList({
-  listeners,
-}: {
-  readonly listeners: readonly GithubListener[];
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const [deleteLoadable, deleteListener] = useLoadableSet(
-    deleteGithubLabelListener$,
-  );
-  const [updateLoadable, updateListener] = useLoadableSet(
-    updateGithubLabelListener$,
-  );
-  const deleting = deleteLoadable.state === "loading";
-  const updating = updateLoadable.state === "loading";
-
-  if (listeners.length === 0) {
-    return (
-      <div className="rounded-lg border border-dashed border-border px-3 py-4 text-sm text-muted-foreground">
-        No label listeners configured.
-      </div>
-    );
+function formatGithubUsername(
+  username: string | null | undefined,
+): string | null {
+  const trimmed = username?.trim();
+  if (!trimmed) {
+    return null;
   }
-
-  return (
-    <div className="divide-y rounded-lg border border-border">
-      {listeners.map((listener) => {
-        return (
-          <div
-            key={listener.id}
-            className="flex items-center gap-3 px-3 py-2.5"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 items-center gap-2">
-                <span className="truncate text-sm font-medium text-foreground">
-                  {listener.labelName}
-                </span>
-                {!listener.enabled ? (
-                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                    Disabled
-                  </span>
-                ) : null}
-              </div>
-              <div className="truncate text-xs text-muted-foreground">
-                {listener.agent?.name ?? "Unknown agent"} ·{" "}
-                {getTriggerModeLabel(listener.triggerMode)}
-              </div>
-            </div>
-            <LoadingSwitch
-              checked={listener.enabled}
-              loading={updating}
-              size="sm"
-              ariaLabel={`Toggle ${listener.labelName} listener`}
-              onCheckedChange={(enabled) => {
-                detach(
-                  updateListener(
-                    { listenerId: listener.id, body: { enabled } },
-                    pageSignal,
-                  ),
-                  Reason.DomCallback,
-                );
-              }}
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 shrink-0"
-              disabled={deleting || updating}
-              aria-label={`Delete ${listener.labelName}`}
-              onClick={() => {
-                detach(
-                  deleteListener(listener.id, pageSignal),
-                  Reason.DomCallback,
-                );
-              }}
-            >
-              {deleting ? (
-                <IconLoader2 size={15} className="animate-spin" />
-              ) : (
-                <IconTrash size={15} />
-              )}
-            </Button>
-          </div>
-        );
-      })}
-    </div>
-  );
+  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
 }
 
-function GithubListenerPrimaryFields({
-  agents,
-  creating,
-  form,
-  selectedAgentId,
-  setForm,
+function GithubConnectedBadge({
+  connected,
+  username,
 }: {
-  readonly agents: readonly GithubAgentOption[];
-  readonly creating: boolean;
-  readonly form: GithubLabelListenerForm;
-  readonly selectedAgentId: string;
-  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+  readonly connected: boolean;
+  readonly username: string | null | undefined;
 }) {
-  return (
-    <div className="grid gap-2 sm:grid-cols-[1fr_1fr]">
-      <label className="grid gap-1.5 text-sm font-medium text-foreground">
-        Label
-        <Input
-          value={form.labelName}
-          placeholder="ready-for-zero"
-          disabled={creating}
-          onChange={(event) => {
-            setForm({ labelName: event.target.value });
-          }}
-        />
-      </label>
-      <label className="grid gap-1.5 text-sm font-medium text-foreground">
-        Agent
-        <Select
-          value={selectedAgentId}
-          disabled={creating || agents.length === 0}
-          onValueChange={(agentId) => {
-            setForm({ agentId });
-          }}
-        >
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select agent" />
-          </SelectTrigger>
-          <SelectContent>
-            {agents.map((agent) => {
-              return (
-                <SelectItem key={agent.id} value={agent.id}>
-                  {agent.displayName ?? agent.id}
-                </SelectItem>
-              );
-            })}
-          </SelectContent>
-        </Select>
-      </label>
-    </div>
-  );
-}
-
-function GithubTriggerModeField({
-  creating,
-  triggerMode,
-  setForm,
-}: {
-  readonly creating: boolean;
-  readonly triggerMode: GithubLabelTriggerMode;
-  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
-}) {
-  return (
-    <label className="grid gap-1.5 text-sm font-medium text-foreground">
-      Trigger mode
-      <Select
-        value={triggerMode}
-        disabled={creating}
-        onValueChange={(value) => {
-          setForm({ triggerMode: value as GithubLabelTriggerMode });
-        }}
-      >
-        <SelectTrigger className="h-9">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="created_by_me">
-            {getTriggerModeLabel("created_by_me")}
-          </SelectItem>
-          <SelectItem value="anyone">
-            {getTriggerModeLabel("anyone")}
-          </SelectItem>
-        </SelectContent>
-      </Select>
-    </label>
-  );
-}
-
-function GithubPromptField({
-  creating,
-  prompt,
-  setForm,
-}: {
-  readonly creating: boolean;
-  readonly prompt: string;
-  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
-}) {
-  return (
-    <label className="grid gap-1.5 text-sm font-medium text-foreground">
-      Prompt
-      <textarea
-        value={prompt}
-        disabled={creating}
-        rows={4}
-        className="min-h-24 resize-y rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-        placeholder="Review the labeled issue or PR and take the next appropriate action."
-        onChange={(event) => {
-          setForm({ prompt: event.target.value });
-        }}
-      />
-    </label>
-  );
-}
-
-function GithubListenerForm({
-  agents,
-  onClose,
-}: {
-  readonly agents: readonly GithubAgentOption[];
-  readonly onClose: () => void;
-}) {
-  const form = useGet(githubLabelListenerForm$);
-  const setForm = useSet(setGithubLabelListenerForm$);
-  const resetForm = useSet(resetGithubLabelListenerForm$);
-  const pageSignal = useGet(pageSignal$);
-  const [createLoadable, createListener] = useLoadableSet(
-    createGithubLabelListener$,
-  );
-  const creating = createLoadable.state === "loading";
-  const selectedAgentId = form.agentId || agents[0]?.id || "";
-  const canCreate = Boolean(
-    form.labelName.trim() && form.prompt.trim() && selectedAgentId,
-  );
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const labelName = form.labelName.trim();
-    const prompt = form.prompt.trim();
-    if (!labelName || !prompt || !selectedAgentId || creating) {
-      return;
-    }
-
-    detach(
-      (async () => {
-        await createListener(
-          {
-            labelName,
-            agentId: selectedAgentId,
-            triggerMode: form.triggerMode,
-            prompt,
-          },
-          pageSignal,
-        );
-        resetForm();
-      })(),
-      Reason.DomCallback,
-    );
-  };
-
-  return (
-    <form className="grid gap-3" onSubmit={submit}>
-      <GithubListenerPrimaryFields
-        agents={agents}
-        creating={creating}
-        form={form}
-        selectedAgentId={selectedAgentId}
-        setForm={setForm}
-      />
-      <GithubTriggerModeField
-        creating={creating}
-        triggerMode={form.triggerMode}
-        setForm={setForm}
-      />
-      <GithubPromptField
-        creating={creating}
-        prompt={form.prompt}
-        setForm={setForm}
-      />
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={creating}
-          onClick={onClose}
-        >
-          Close
-        </Button>
-        <Button type="submit" disabled={!canCreate || creating}>
-          {creating ? (
-            <IconLoader2 size={14} className="animate-spin" />
-          ) : (
-            <IconPlus size={14} />
-          )}
-          Add listener
-        </Button>
-      </DialogFooter>
-    </form>
-  );
-}
-
-function GithubListenerDialog() {
-  const open = useGet(githubManageDialogOpen$);
-  const setOpen = useSet(setGithubManageDialogOpen$);
-  const data = useLastResolved(githubIntegrationData$);
-  const agents = useLastResolved(sortedAgents$) ?? [];
-  const listeners = data?.labelListeners ?? [];
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>GitHub label listeners</DialogTitle>
-          <DialogDescription>
-            Configure labels that start an agent run from GitHub issues and pull
-            requests.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="grid gap-4">
-          <GithubListenerList listeners={listeners} />
-          <GithubListenerForm
-            agents={agents}
-            onClose={() => {
-              setOpen(false);
-            }}
-          />
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function GithubConnectedBadge({ connected }: { readonly connected: boolean }) {
   if (!connected) {
     return null;
   }
+
+  const connectedDetail = formatGithubUsername(username);
 
   return (
     <span
@@ -411,7 +55,9 @@ function GithubConnectedBadge({ connected }: { readonly connected: boolean }) {
       className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
     >
       <IconCircleCheck className="h-3 w-3 text-green-600" />
-      <span className="min-w-0 truncate">Connected</span>
+      <span className="min-w-0 truncate">
+        {connectedDetail ? `Connected (${connectedDetail})` : "Connected"}
+      </span>
     </span>
   );
 }
@@ -443,6 +89,13 @@ function GithubOptionsPopover({
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="flex w-44 flex-col gap-0.5 p-2">
+        <Link
+          pathname={ROUTES.settingsGithub}
+          aria-label="Manage GitHub"
+          className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-foreground no-underline transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          Manage
+        </Link>
         {isConnected ? (
           <button
             type="button"
@@ -474,7 +127,6 @@ function GithubCardActions({
   readonly data: GithubIntegrationData | null;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const setManageOpen = useSet(setGithubManageDialogOpen$);
   const [connectLoadable, connect] = useLoadableSet(connectGithubInstallation$);
   const [disconnectLoadable, disconnect] = useLoadableSet(
     disconnectGithubInstallation$,
@@ -489,6 +141,7 @@ function GithubCardActions({
   const isInstalled = data?.isInstalled ?? false;
   const isConnected = data?.isConnected ?? false;
   const installUrl = isInstalled ? null : data?.installUrl;
+  const connectUrl = data?.connectUrl ?? null;
   const canUninstall = Boolean(data?.isInstalled && data.installation.isAdmin);
 
   if (installUrl) {
@@ -514,7 +167,7 @@ function GithubCardActions({
 
   return (
     <>
-      {!isConnected ? (
+      {!isConnected && connectUrl ? (
         <Button
           type="button"
           variant="outline"
@@ -522,24 +175,12 @@ function GithubCardActions({
           className="h-8 shrink-0 gap-1.5 rounded-lg"
           disabled={busy}
           onClick={() => {
-            detach(connect(pageSignal), Reason.DomCallback);
+            detach(connect(connectUrl, pageSignal), Reason.DomCallback);
           }}
         >
           {connecting ? "Connecting..." : "Connect"}
         </Button>
       ) : null}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-8 shrink-0 gap-1.5 rounded-lg"
-        onClick={() => {
-          setManageOpen(true);
-        }}
-      >
-        <IconSettings size={14} stroke={1.5} />
-        Manage
-      </Button>
       <GithubOptionsPopover
         canUninstall={canUninstall}
         disconnecting={disconnecting}
@@ -559,31 +200,25 @@ function GithubCardActions({
 export function GithubCard() {
   const dataLoadable = useLastLoadable(githubIntegrationData$);
   const data = dataLoadable.state === "hasData" ? dataLoadable.data : null;
-  const isInstalled = data?.isInstalled ?? false;
-  const listenerCount = data?.labelListeners.length ?? 0;
-  const summary = isInstalled
-    ? `${listenerCount} label ${listenerCount === 1 ? "listener" : "listeners"}`
-    : "Run agents from GitHub issue and PR labels";
 
   return (
-    <>
-      <div className="zero-card flex flex-col">
-        <div className="flex items-center gap-4 p-4">
-          <div className="shrink-0 inline-flex h-7 w-7 items-center justify-center overflow-hidden">
-            <img src={githubIconImg} alt="" className="h-7 w-7" />
-          </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <div className="text-sm font-medium text-foreground">GitHub</div>
-            <div className="truncate text-sm text-muted-foreground">
-              {summary}
-            </div>
-          </div>
-          <GithubConnectedBadge connected={data?.isConnected ?? false} />
-          <GithubCardActions data={data} />
+    <div className="zero-card flex flex-col">
+      <div className="flex items-center gap-4 p-4">
+        <div className="shrink-0 inline-flex h-7 w-7 items-center justify-center overflow-hidden">
+          <img src={githubIconImg} alt="" className="h-7 w-7" />
         </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="text-sm font-medium text-foreground">GitHub</div>
+          <div className="truncate text-sm text-muted-foreground">
+            Run agents from GitHub issue and PR labels
+          </div>
+        </div>
+        <GithubConnectedBadge
+          connected={data?.isConnected ?? false}
+          username={data?.connectedGithubUsername}
+        />
+        <GithubCardActions data={data} />
       </div>
-
-      <GithubListenerDialog />
-    </>
+    </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-settings-page.tsx
@@ -1,0 +1,707 @@
+import type { FormEvent } from "react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import {
+  IconArrowLeft,
+  IconLoader2,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react";
+import { Button, Card, CardContent } from "@vm0/ui";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@vm0/ui/components/ui/dialog";
+import { Input } from "@vm0/ui/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import { sortedAgents$ } from "../../signals/agent.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
+import {
+  connectGithubInstallation$,
+  createGithubLabelListener$,
+  deleteGithubLabelListener$,
+  disconnectGithubInstallation$,
+  githubAddListenerDialogOpen$,
+  githubIntegrationData$,
+  githubLabelListenerForm$,
+  resetGithubLabelListenerForm$,
+  setGithubAddListenerDialogOpen$,
+  setGithubLabelListenerForm$,
+  uninstallGithubInstallation$,
+  updateGithubLabelListener$,
+  type GithubIntegrationData,
+  type GithubLabelListenerForm,
+  type GithubLabelTriggerMode,
+} from "../../signals/zero-page/zero-github.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
+import { Link } from "../router/link.tsx";
+import githubIconImg from "./components/settings/icons/github.svg";
+
+type GithubListener = GithubIntegrationData["labelListeners"][number];
+
+const ZERO_BORDER = {
+  border: "0.7px solid hsl(var(--gray-400))",
+} as const;
+
+interface GithubAgentOption {
+  readonly id: string;
+  readonly displayName?: string | null;
+}
+
+function getTriggerModeLabel(mode: GithubLabelTriggerMode): string {
+  if (mode === "created_by_me") {
+    return "Only issues/PRs I create";
+  }
+  return "Any issue/PR with this label";
+}
+
+function GithubSettingsSkeleton() {
+  return (
+    <div className="flex flex-col gap-4" data-testid="github-settings-loading">
+      <Skeleton className="h-4 w-64 max-w-full" />
+      <div className="zero-card p-4">
+        <Skeleton className="h-5 w-36" />
+        <div className="mt-4 space-y-3">
+          <Skeleton className="h-14 w-full rounded-lg" />
+          <Skeleton className="h-14 w-full rounded-lg" />
+        </div>
+      </div>
+      <div className="zero-card p-4">
+        <Skeleton className="h-5 w-28" />
+        <div className="mt-4 grid gap-3">
+          <Skeleton className="h-9 w-full rounded-md" />
+          <Skeleton className="h-24 w-full rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GithubListenerList({
+  listeners,
+}: {
+  readonly listeners: readonly GithubListener[];
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [deleteLoadable, deleteListener] = useLoadableSet(
+    deleteGithubLabelListener$,
+  );
+  const [updateLoadable, updateListener] = useLoadableSet(
+    updateGithubLabelListener$,
+  );
+  const deleting = deleteLoadable.state === "loading";
+  const updating = updateLoadable.state === "loading";
+
+  if (listeners.length === 0) {
+    return (
+      <div className="max-w-xl px-4 py-6 text-sm text-muted-foreground">
+        Add a label listener to run an agent when a GitHub issue or pull request
+        gets a matching label.
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-border/50">
+      {listeners.map((listener) => {
+        return (
+          <div
+            key={listener.id}
+            className="flex items-center gap-3 px-3 py-2.5"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="truncate text-sm font-medium text-foreground">
+                  {listener.labelName}
+                </span>
+                {!listener.enabled ? (
+                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                    Disabled
+                  </span>
+                ) : null}
+              </div>
+              <div className="truncate text-xs text-muted-foreground">
+                {listener.agent?.name ?? "Unknown agent"} -{" "}
+                {getTriggerModeLabel(listener.triggerMode)}
+              </div>
+            </div>
+            <LoadingSwitch
+              checked={listener.enabled}
+              loading={updating}
+              size="sm"
+              ariaLabel={`Toggle ${listener.labelName} listener`}
+              onCheckedChange={(enabled) => {
+                detach(
+                  updateListener(
+                    { listenerId: listener.id, body: { enabled } },
+                    pageSignal,
+                  ),
+                  Reason.DomCallback,
+                );
+              }}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              disabled={deleting || updating}
+              aria-label={`Delete ${listener.labelName}`}
+              onClick={() => {
+                detach(
+                  deleteListener(listener.id, pageSignal),
+                  Reason.DomCallback,
+                );
+              }}
+            >
+              {deleting ? (
+                <IconLoader2 size={15} className="animate-spin" />
+              ) : (
+                <IconTrash size={15} />
+              )}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function GithubListenerPrimaryFields({
+  agents,
+  creating,
+  form,
+  selectedAgentId,
+  setForm,
+}: {
+  readonly agents: readonly GithubAgentOption[];
+  readonly creating: boolean;
+  readonly form: GithubLabelListenerForm;
+  readonly selectedAgentId: string;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+        Label
+        <Input
+          value={form.labelName}
+          placeholder="ready-for-zero"
+          disabled={creating}
+          className="h-10 rounded-lg"
+          onChange={(event) => {
+            setForm({ labelName: event.target.value });
+          }}
+        />
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+        Agent
+        <Select
+          value={selectedAgentId}
+          disabled={creating || agents.length === 0}
+          onValueChange={(agentId) => {
+            setForm({ agentId });
+          }}
+        >
+          <SelectTrigger className="h-10 rounded-lg" style={ZERO_BORDER}>
+            <SelectValue placeholder="Select agent" />
+          </SelectTrigger>
+          <SelectContent>
+            {agents.map((agent) => {
+              return (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agent.displayName ?? agent.id}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </label>
+    </div>
+  );
+}
+
+function GithubTriggerModeField({
+  creating,
+  triggerMode,
+  setForm,
+}: {
+  readonly creating: boolean;
+  readonly triggerMode: GithubLabelTriggerMode;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  const choices: readonly {
+    readonly value: GithubLabelTriggerMode;
+    readonly label: string;
+  }[] = [
+    {
+      value: "created_by_me",
+      label: getTriggerModeLabel("created_by_me"),
+    },
+    {
+      value: "anyone",
+      label: getTriggerModeLabel("anyone"),
+    },
+  ];
+
+  return (
+    <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+      Trigger mode
+      <Select
+        value={triggerMode}
+        disabled={creating}
+        onValueChange={(value) => {
+          const choice = choices.find((item) => {
+            return item.value === value;
+          });
+          if (!choice) {
+            throw new Error(`Unknown GitHub trigger mode: ${value}`);
+          }
+          setForm({ triggerMode: choice.value });
+        }}
+      >
+        <SelectTrigger
+          aria-label="Trigger mode"
+          className="h-10 rounded-lg"
+          style={ZERO_BORDER}
+        >
+          <SelectValue placeholder="Select trigger mode" />
+        </SelectTrigger>
+        <SelectContent>
+          {choices.map((choice) => {
+            return (
+              <SelectItem key={choice.value} value={choice.value}>
+                {choice.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </label>
+  );
+}
+
+function GithubPromptField({
+  creating,
+  prompt,
+  setForm,
+}: {
+  readonly creating: boolean;
+  readonly prompt: string;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+      Prompt
+      <textarea
+        value={prompt}
+        disabled={creating}
+        rows={4}
+        className="min-h-24 resize-y rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        placeholder="Review the labeled issue or PR and take the next appropriate action."
+        onChange={(event) => {
+          setForm({ prompt: event.target.value });
+        }}
+      />
+    </label>
+  );
+}
+
+function GithubListenerForm({
+  agents,
+  onCancel,
+  onCreated,
+}: {
+  readonly agents: readonly GithubAgentOption[];
+  readonly onCancel: () => void;
+  readonly onCreated: () => void;
+}) {
+  const form = useGet(githubLabelListenerForm$);
+  const setForm = useSet(setGithubLabelListenerForm$);
+  const resetForm = useSet(resetGithubLabelListenerForm$);
+  const pageSignal = useGet(pageSignal$);
+  const [createLoadable, createListener] = useLoadableSet(
+    createGithubLabelListener$,
+  );
+  const creating = createLoadable.state === "loading";
+  const selectedAgentId = form.agentId || agents[0]?.id || "";
+  const canCreate = Boolean(
+    form.labelName.trim() && form.prompt.trim() && selectedAgentId,
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const labelName = form.labelName.trim();
+    const prompt = form.prompt.trim();
+    if (!labelName || !prompt || !selectedAgentId || creating) {
+      return;
+    }
+
+    detach(
+      (async () => {
+        await createListener(
+          {
+            labelName,
+            agentId: selectedAgentId,
+            triggerMode: form.triggerMode,
+            prompt,
+          },
+          pageSignal,
+        );
+        resetForm();
+        onCreated();
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <form className="flex flex-col gap-5" onSubmit={submit}>
+      <GithubListenerPrimaryFields
+        agents={agents}
+        creating={creating}
+        form={form}
+        selectedAgentId={selectedAgentId}
+        setForm={setForm}
+      />
+      <GithubTriggerModeField
+        creating={creating}
+        triggerMode={form.triggerMode}
+        setForm={setForm}
+      />
+      <GithubPromptField
+        creating={creating}
+        prompt={form.prompt}
+        setForm={setForm}
+      />
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={creating}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canCreate || creating}>
+          {creating ? "Adding..." : "Add listener"}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function AddGithubListenerDialog({
+  agents,
+  disabled,
+}: {
+  readonly agents: readonly GithubAgentOption[];
+  readonly disabled: boolean;
+}) {
+  const open = useGet(githubAddListenerDialogOpen$);
+  const setOpen = useSet(setGithubAddListenerDialogOpen$);
+  const resetForm = useSet(resetGithubLabelListenerForm$);
+
+  const close = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          resetForm();
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled}
+          className="h-8 gap-2 rounded-lg px-3 text-sm"
+        >
+          <IconPlus size={14} stroke={1.8} />
+          Add listener
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add GitHub label listener</DialogTitle>
+          <DialogDescription>
+            Create a label trigger for GitHub issues and pull requests.
+          </DialogDescription>
+        </DialogHeader>
+        <GithubListenerForm
+          agents={agents}
+          onCancel={close}
+          onCreated={close}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GithubLabelListenersCard({
+  agents,
+  agentsLoading,
+  listeners,
+}: {
+  readonly agents: readonly GithubAgentOption[];
+  readonly agentsLoading: boolean;
+  readonly listeners: readonly GithubListener[];
+}) {
+  return (
+    <section className="zero-card overflow-hidden">
+      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <h2 className="text-sm font-medium text-foreground">Label listeners</h2>
+        <AddGithubListenerDialog agents={agents} disabled={agentsLoading} />
+      </div>
+      <GithubListenerList listeners={listeners} />
+    </section>
+  );
+}
+
+function GithubNotInstalled() {
+  return (
+    <div className="zero-card px-6 py-10 text-center text-sm text-muted-foreground">
+      GitHub is not installed.
+    </div>
+  );
+}
+
+function githubConnectedUserLabel(data: GithubIntegrationData): string | null {
+  if (!data.isConnected) {
+    return null;
+  }
+
+  const username = data.connectedGithubUsername?.trim().replace(/^@+/, "");
+  if (username) {
+    return `@${username}`;
+  }
+
+  return data.connectedGithubUserId;
+}
+
+function GithubConnectionCard({
+  data,
+}: {
+  readonly data: GithubIntegrationData & { readonly isInstalled: true };
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [connectLoadable, connect] = useLoadableSet(connectGithubInstallation$);
+  const [disconnectLoadable, disconnect] = useLoadableSet(
+    disconnectGithubInstallation$,
+  );
+  const connecting = connectLoadable.state === "loading";
+  const disconnecting = disconnectLoadable.state === "loading";
+  const busy = connecting || disconnecting;
+  const connectedUser = githubConnectedUserLabel(data);
+
+  return (
+    <section className="zero-card p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">Connection</div>
+          <div className="mt-1 text-sm text-muted-foreground">
+            {connectedUser
+              ? `Connected as ${connectedUser}`
+              : data.isConnected
+                ? "GitHub account connected"
+                : "Connect a GitHub account to use user-specific triggers"}
+          </div>
+        </div>
+        {data.isConnected ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="h-9 shrink-0"
+            disabled={busy}
+            onClick={() => {
+              detach(disconnect(pageSignal), Reason.DomCallback);
+            }}
+          >
+            {disconnecting ? "Disconnecting..." : "Disconnect"}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            className="h-9 shrink-0"
+            disabled={busy}
+            onClick={() => {
+              detach(connect(data.connectUrl, pageSignal), Reason.DomCallback);
+            }}
+          >
+            {connecting ? "Connecting..." : "Connect"}
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function GithubDangerZoneCard({
+  data,
+}: {
+  readonly data: GithubIntegrationData & { readonly isInstalled: true };
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [uninstallLoadable, uninstall] = useLoadableSet(
+    uninstallGithubInstallation$,
+  );
+  const uninstalling = uninstallLoadable.state === "loading";
+  const canUninstall = data.installation.isAdmin;
+
+  return (
+    <Card className="zero-card overflow-hidden border-destructive/20">
+      <CardContent className="p-4 sm:p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+          <div className="min-w-0 sm:max-w-[46%]">
+            <h3 className="text-sm font-medium text-foreground">Danger zone</h3>
+            <p className="mt-1 text-xs leading-snug text-muted-foreground">
+              Uninstall GitHub for this workspace. This removes label triggers
+              and cannot be undone.
+            </p>
+          </div>
+          <div className="flex w-full shrink-0 justify-end sm:w-auto">
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9 gap-2 rounded-lg border-destructive/40 px-4 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  disabled={!canUninstall || uninstalling}
+                >
+                  <IconTrash size={14} stroke={1.5} />
+                  Uninstall
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Uninstall GitHub?</DialogTitle>
+                  <DialogDescription>
+                    This will remove the GitHub integration for this workspace.
+                    Label listeners will stop triggering agent runs. This action
+                    cannot be undone.
+                  </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                  <DialogClose asChild>
+                    <Button variant="outline" size="sm">
+                      Cancel
+                    </Button>
+                  </DialogClose>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    disabled={uninstalling}
+                    onClick={() => {
+                      detach(uninstall(pageSignal), Reason.DomCallback);
+                    }}
+                  >
+                    {uninstalling ? "Uninstalling..." : "Uninstall"}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ZeroGithubSettingsPage() {
+  const dataLoadable = useLastLoadable(githubIntegrationData$);
+  const agentsLoadable = useLastLoadable(sortedAgents$);
+  const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
+  const data = dataLoadable.state === "hasData" ? dataLoadable.data : null;
+  const loading = dataLoadable.state === "loading" && !data;
+  const hasError =
+    dataLoadable.state === "hasError" || agentsLoadable.state === "hasError";
+  const installedData = data?.isInstalled ? data : null;
+  const isInstalled = installedData !== null;
+  const listeners = installedData?.labelListeners ?? [];
+  const agentsLoading = agentsLoadable.state === "loading";
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="shrink-0 bg-transparent px-4 pb-3 pt-10 sm:px-6">
+        <div className="mx-auto max-w-[900px]">
+          <div className="mb-4">
+            <Button
+              asChild
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-2 px-2 text-muted-foreground hover:text-foreground"
+            >
+              <Link pathname={ROUTES.works} title="Back to integrations">
+                <IconArrowLeft size={17} stroke={1.8} />
+                Back to integrations
+              </Link>
+            </Button>
+          </div>
+          <div className="flex items-start gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted">
+                <img src={githubIconImg} alt="" className="h-7 w-7" />
+              </span>
+              <div className="min-w-0">
+                <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
+                  GitHub
+                </h1>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  Run agents from GitHub issue and PR labels
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
+        <div className="mx-auto flex max-w-[900px] flex-col gap-4">
+          {hasError ? (
+            <div className="zero-card px-6 py-10 text-center text-sm text-destructive">
+              Couldn&apos;t load GitHub settings.
+            </div>
+          ) : loading ? (
+            <GithubSettingsSkeleton />
+          ) : !isInstalled ? (
+            <GithubNotInstalled />
+          ) : (
+            <>
+              <GithubLabelListenersCard
+                agents={agents}
+                agentsLoading={agentsLoading}
+                listeners={listeners}
+              />
+              <GithubConnectionCard data={installedData} />
+              <GithubDangerZoneCard data={installedData} />
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -208,25 +208,7 @@ function TelegramSettingsSkeleton() {
 }
 
 function AddTelegramBotButtonSkeleton() {
-  return <Skeleton className="h-10 w-[105px] shrink-0 rounded-md" />;
-}
-
-function telegramBotCountLabel(count: number): string {
-  if (count === 0) {
-    return "This organization has no Telegram bots";
-  }
-  return `This organization has ${String(count)} Telegram ${count === 1 ? "bot" : "bots"}`;
-}
-
-function TelegramBotCount({ count }: { count: number }) {
-  return (
-    <div
-      data-testid="telegram-bot-count"
-      className="text-sm text-muted-foreground"
-    >
-      {telegramBotCountLabel(count)}
-    </div>
-  );
+  return <Skeleton className="h-8 w-[105px] shrink-0 rounded-md" />;
 }
 
 function telegramConnectedUserLabel(bot: TelegramBot): string | null {
@@ -911,18 +893,17 @@ function AddTelegramBotDialogFrame({
 }: AddTelegramBotDialogFrameProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <div className="flex shrink-0 justify-end">
-        <DialogTrigger asChild>
-          <Button
-            type="button"
-            disabled={disabled}
-            className="h-10 shrink-0 gap-2"
-          >
-            <IconPlus size={16} />
-            Add bot
-          </Button>
-        </DialogTrigger>
-      </div>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled}
+          className="h-8 gap-2 rounded-lg px-3 text-sm"
+        >
+          <IconPlus size={14} stroke={1.8} />
+          Add bot
+        </Button>
+      </DialogTrigger>
       <DialogContent className="sm:max-w-[640px]">
         <DialogHeader>
           <DialogTitle>Add Telegram bot</DialogTitle>
@@ -1828,7 +1809,7 @@ function TelegramBotList({
 }) {
   if (bots.length === 0) {
     return (
-      <div className="zero-card px-6 py-12 text-center">
+      <div className="px-6 py-12 text-center">
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-[#2AABEE]/10">
           <img src={telegramIconImg} alt="" className="h-8 w-8" />
         </div>
@@ -1843,7 +1824,7 @@ function TelegramBotList({
   }
 
   return (
-    <div className="zero-card overflow-hidden">
+    <div>
       {bots.map((bot, index) => {
         const isOfficial = isOfficialTelegramBot(bot);
         return (
@@ -1862,6 +1843,48 @@ function TelegramBotList({
         );
       })}
     </div>
+  );
+}
+
+function TelegramBotsCard({
+  bots,
+  agents,
+  defaultAgent,
+  isAdmin,
+  agentsLoading,
+  loading,
+  hasError,
+}: {
+  bots: TelegramBot[];
+  agents: TeamComposeItem[];
+  defaultAgent: DefaultAgentLabel;
+  isAdmin: boolean;
+  agentsLoading: boolean;
+  loading: boolean;
+  hasError: boolean;
+}) {
+  return (
+    <section className="zero-card overflow-hidden">
+      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <h2 className="text-sm font-medium text-foreground">Telegram bots</h2>
+        {!hasError && loading ? (
+          <AddTelegramBotButtonSkeleton />
+        ) : !hasError ? (
+          <AddTelegramBotDialog
+            agents={agents}
+            defaultAgent={defaultAgent}
+            disabled={agentsLoading}
+          />
+        ) : null}
+      </div>
+      <TelegramBotList
+        bots={bots}
+        agents={agents}
+        defaultAgent={defaultAgent}
+        isAdmin={isAdmin}
+        agentsLoading={agentsLoading}
+      />
+    </section>
   );
 }
 
@@ -1904,6 +1927,20 @@ export function ZeroTelegramSettingsPage() {
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 pt-10 pb-3 sm:px-6">
         <div className="mx-auto max-w-[900px]">
+          <div className="mb-4">
+            <Button
+              asChild
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-2 px-2 text-muted-foreground hover:text-foreground"
+            >
+              <Link pathname={ROUTES.works} title="Back to integrations">
+                <IconArrowLeft size={17} stroke={1.8} />
+                Back to integrations
+              </Link>
+            </Button>
+          </div>
           <div className="flex items-start justify-between gap-3">
             <div className="flex min-w-0 items-center gap-3">
               <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-[#2AABEE]/10">
@@ -1920,15 +1957,6 @@ export function ZeroTelegramSettingsPage() {
                 </p>
               </div>
             </div>
-            {!hasError && loading ? (
-              <AddTelegramBotButtonSkeleton />
-            ) : !hasError ? (
-              <AddTelegramBotDialog
-                agents={agents}
-                defaultAgent={defaultAgent}
-                disabled={agentsLoading}
-              />
-            ) : null}
           </div>
         </div>
       </header>
@@ -1943,13 +1971,14 @@ export function ZeroTelegramSettingsPage() {
             <TelegramSettingsSkeleton />
           ) : (
             <>
-              <TelegramBotCount count={bots.length} />
-              <TelegramBotList
+              <TelegramBotsCard
                 bots={bots}
                 agents={agents}
                 defaultAgent={defaultAgent}
                 isAdmin={isAdmin}
                 agentsLoading={agentsLoading}
+                loading={loading}
+                hasError={hasError}
               />
               <TelegramUninstallDialog bot={uninstallBot} />
               <TelegramReinstallDialog bot={reinstallBot} />

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconAlertTriangle,
@@ -30,6 +31,7 @@ import {
   showUninstallDialog$,
   setShowUninstallDialog$,
 } from "../../signals/zero-page/zero-slack.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { telegramBots$ } from "../../signals/zero-page/zero-telegram.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
@@ -323,6 +325,8 @@ export function ZeroWorksPage() {
     displayNameLoadable.state === "hasData"
       ? (displayNameLoadable.data ?? "Zero")
       : "Zero";
+  const features = useGet(featureSwitch$);
+  const showGithubCard = features[FeatureSwitchKey.GitHubIntegration] ?? false;
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -340,7 +344,7 @@ export function ZeroWorksPage() {
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-3 pb-8">
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
-          <GithubCard />
+          {showGithubCard ? <GithubCard /> : null}
           <TelegramCard />
           <AgentPhoneCard />
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -32,7 +32,6 @@ import {
   setShowUninstallDialog$,
 } from "../../signals/zero-page/zero-slack.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { telegramBots$ } from "../../signals/zero-page/zero-telegram.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -280,16 +279,6 @@ function SlackCard({ displayName }: { displayName: string }) {
 }
 
 function TelegramCard() {
-  const botsLoadable = useLastLoadable(telegramBots$);
-  const bots = botsLoadable.state === "hasData" ? botsLoadable.data : [];
-  const connectedCount = bots.filter((bot) => {
-    return bot.isConnected;
-  }).length;
-  const summary =
-    botsLoadable.state === "hasData"
-      ? `${bots.length} ${bots.length === 1 ? "bot" : "bots"} - ${connectedCount} connected`
-      : "Manage Telegram bots and agent routing";
-
   return (
     <Link
       pathname={ROUTES.settingsTelegram}
@@ -307,7 +296,7 @@ function TelegramCard() {
             </div>
           </div>
           <div className="truncate text-sm text-muted-foreground">
-            {summary}
+            Route Telegram messages to agents
           </div>
         </div>
         <span className="shrink-0 inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -35,6 +35,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { AgentPhoneCard } from "./agentphone-card.tsx";
+import { GithubCard } from "./github-card.tsx";
 import slackIconImg from "./components/settings/icons/slack.svg";
 import telegramIconImg from "./components/settings/icons/telegram.svg";
 
@@ -339,6 +340,7 @@ export function ZeroWorksPage() {
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-3 pb-8">
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
+          <GithubCard />
           <TelegramCard />
           <AgentPhoneCard />
         </div>

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1533,16 +1533,14 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/generate")).toBe(false);
   });
 
-  it("matches the GitHub OAuth callback rewrite path exactly", () => {
-    expect(matchesApiBackendRewritePath("/api/github/oauth/callback")).toBe(
+  it("matches the GitHub App setup callback rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/github/app/setup/callback")).toBe(
       true,
     );
     expect(
-      matchesApiBackendRewritePath("/api/github/oauth/callback/extra"),
+      matchesApiBackendRewritePath("/api/github/app/setup/callback/extra"),
     ).toBe(false);
-    expect(matchesApiBackendRewritePath("/api/github/oauth/callbacks")).toBe(
-      false,
-    );
+    expect(matchesApiBackendRewritePath("/api/github/app/setup")).toBe(false);
     expect(matchesApiBackendRewritePath("/api/github/oauth")).toBe(false);
   });
 
@@ -1556,22 +1554,44 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/github/oauth")).toBe(false);
   });
 
-  it("matches GitHub OAuth web-origin rewrite paths exactly", () => {
-    expect(matchesGithubOAuthRewritePath("/api/github/oauth/callback")).toBe(
+  it("matches the zero GitHub OAuth connect rewrite paths exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/zero/github/oauth/connect")).toBe(
       true,
     );
+    expect(
+      matchesApiBackendRewritePath("/api/zero/github/oauth/connect/callback"),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/github/oauth/connect/callback/extra",
+      ),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/zero/github/oauth")).toBe(false);
+  });
+
+  it("matches GitHub OAuth web-origin rewrite paths exactly", () => {
+    expect(
+      matchesGithubOAuthRewritePath("/api/github/app/setup/callback"),
+    ).toBe(true);
     expect(matchesGithubOAuthRewritePath("/api/github/oauth/install")).toBe(
       true,
     );
+    expect(
+      matchesGithubOAuthRewritePath("/api/zero/github/oauth/connect"),
+    ).toBe(true);
+    expect(
+      matchesGithubOAuthRewritePath("/api/zero/github/oauth/connect/callback"),
+    ).toBe(true);
     expect(matchesGithubOAuthRewritePath("/api/integrations/github")).toBe(
       true,
     );
     expect(
-      matchesGithubOAuthRewritePath("/api/github/oauth/callback/extra"),
+      matchesGithubOAuthRewritePath("/api/github/app/setup/callback/extra"),
     ).toBe(false);
     expect(
       matchesGithubOAuthRewritePath("/api/integrations/github/extra"),
     ).toBe(false);
+    expect(matchesGithubOAuthRewritePath("/api/zero/github/oauth")).toBe(false);
   });
 
   it("matches the logs search rewrite path exactly", () => {

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -637,18 +637,34 @@ const GENERATE_IMAGE_NEXT_NEGATIVE_PATHS = [
   "/api/generate-image/extra",
   "/api/generate",
 ] as const;
-const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
-const GITHUB_OAUTH_CALLBACK_PATH = "/api/github/oauth/callback";
-const GITHUB_OAUTH_CALLBACK_NEXT_NEGATIVE_PATHS = [
-  "/api/github/oauth/callback/extra",
-  "/api/github/oauth/install",
-  "/api/github/oauth",
+const GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE =
+  "/api/github/app/setup/callback";
+const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
+const GITHUB_APP_SETUP_CALLBACK_NEXT_NEGATIVE_PATHS = [
+  "/api/github/app/setup/callback/extra",
+  "/api/github/app/setup",
+  "/api/github/app",
 ] as const;
 const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
 const GITHUB_OAUTH_INSTALL_PATH = "/api/github/oauth/install";
 const GITHUB_OAUTH_INSTALL_NEXT_NEGATIVE_PATHS = [
   "/api/github/oauth/install/extra",
   "/api/github/oauth",
+] as const;
+const ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE =
+  "/api/zero/github/oauth/connect";
+const ZERO_GITHUB_OAUTH_CONNECT_PATH = "/api/zero/github/oauth/connect";
+const ZERO_GITHUB_OAUTH_CONNECT_NEXT_NEGATIVE_PATHS = [
+  "/api/zero/github/oauth/connect/extra",
+  "/api/zero/github/oauth",
+] as const;
+const ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE =
+  "/api/zero/github/oauth/connect/callback";
+const ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_PATH =
+  "/api/zero/github/oauth/connect/callback";
+const ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_NEXT_NEGATIVE_PATHS = [
+  "/api/zero/github/oauth/connect/callback/extra",
+  "/api/zero/github/oauth/connect/callbacks",
 ] as const;
 const LOGS_SEARCH_REWRITE_SOURCE = "/api/logs/search";
 const LOGS_SEARCH_PATH = "/api/logs/search";
@@ -2178,12 +2194,21 @@ describe("API backend rewrites", () => {
           destination: "https://api.example.test/api/generate-image",
         },
         {
-          source: GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE,
-          destination: "https://api.example.test/api/github/oauth/callback",
+          source: GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/github/app/setup/callback",
         },
         {
           source: GITHUB_OAUTH_INSTALL_REWRITE_SOURCE,
           destination: "https://api.example.test/api/github/oauth/install",
+        },
+        {
+          source: ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/zero/github/oauth/connect",
+        },
+        {
+          source: ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/zero/github/oauth/connect/callback",
         },
         {
           source: LOGS_SEARCH_REWRITE_SOURCE,
@@ -4820,25 +4845,75 @@ describe("API backend rewrites", () => {
     }
   });
 
-  it("should match only the exact GitHub OAuth callback rewrite", async () => {
+  it("should match only the exact zero GitHub OAuth connect rewrites", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const connectRewrite = rewrites.find((entry) => {
+      return entry.source === ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE;
+    });
+    expect(connectRewrite).toStrictEqual({
+      source: ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/zero/github/oauth/connect",
+    });
+
+    const connectMatcher = getPathMatch(
+      ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE,
+      {
+        removeUnnamedParams: true,
+        strict: true,
+      },
+    );
+
+    expect(connectMatcher(ZERO_GITHUB_OAUTH_CONNECT_PATH)).toStrictEqual({});
+    for (const pathname of ZERO_GITHUB_OAUTH_CONNECT_NEXT_NEGATIVE_PATHS) {
+      expect(connectMatcher(pathname)).toBe(false);
+    }
+
+    const callbackRewrite = rewrites.find((entry) => {
+      return entry.source === ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE;
+    });
+    expect(callbackRewrite).toStrictEqual({
+      source: ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE,
+      destination:
+        "https://api.example.test/api/zero/github/oauth/connect/callback",
+    });
+
+    const callbackMatcher = getPathMatch(
+      ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE,
+      {
+        removeUnnamedParams: true,
+        strict: true,
+      },
+    );
+
+    expect(
+      callbackMatcher(ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_PATH),
+    ).toStrictEqual({});
+    for (const pathname of ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_NEXT_NEGATIVE_PATHS) {
+      expect(callbackMatcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact GitHub App setup callback rewrite", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
 
     const rewrites = await getBeforeFileRewrites();
     const rewrite = rewrites.find((entry) => {
-      return entry.source === GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE;
+      return entry.source === GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE;
     });
     expect(rewrite).toStrictEqual({
-      source: GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE,
-      destination: "https://api.example.test/api/github/oauth/callback",
+      source: GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/github/app/setup/callback",
     });
 
-    const matcher = getPathMatch(GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, {
+    const matcher = getPathMatch(GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE, {
       removeUnnamedParams: true,
       strict: true,
     });
 
-    expect(matcher(GITHUB_OAUTH_CALLBACK_PATH)).toStrictEqual({});
-    for (const pathname of GITHUB_OAUTH_CALLBACK_NEXT_NEGATIVE_PATHS) {
+    expect(matcher(GITHUB_APP_SETUP_CALLBACK_PATH)).toStrictEqual({});
+    for (const pathname of GITHUB_APP_SETUP_CALLBACK_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -158,6 +158,13 @@ const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
 const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
 const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
 const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
+const INTEGRATIONS_GITHUB_LINK_REWRITE_SOURCE = "/api/integrations/github/link";
+const INTEGRATIONS_GITHUB_LABEL_LISTENERS_REWRITE_SOURCE =
+  "/api/integrations/github/label-listeners";
+const INTEGRATIONS_GITHUB_LABEL_LISTENER_REWRITE_SOURCE =
+  "/api/integrations/github/label-listeners/:listenerId";
+const INTEGRATIONS_GITHUB_LABEL_LISTENER_PATH_RE =
+  /^\/api\/integrations\/github\/label-listeners\/[^/]+$/;
 const BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE = `/api/webhooks/built-in-generations/fal/:generationId(${UUID_PATH_SEGMENT_PATTERN})`;
 const BUILT_IN_GENERATIONS_FAL_WEBHOOK_PATH_RE = new RegExp(
   `^/api/webhooks/built-in-generations/fal/${UUID_PATH_SEGMENT_PATTERN}$`,
@@ -477,6 +484,16 @@ export const API_BACKEND_REWRITES = [
   [GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/github/oauth/callback"],
   [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],
   [INTEGRATIONS_GITHUB_REWRITE_SOURCE, "/api/integrations/github"],
+  [INTEGRATIONS_GITHUB_LINK_REWRITE_SOURCE, "/api/integrations/github/link"],
+  [
+    INTEGRATIONS_GITHUB_LABEL_LISTENERS_REWRITE_SOURCE,
+    "/api/integrations/github/label-listeners",
+  ],
+  [
+    INTEGRATIONS_GITHUB_LABEL_LISTENER_REWRITE_SOURCE,
+    "/api/integrations/github/label-listeners/:listenerId",
+    INTEGRATIONS_GITHUB_LABEL_LISTENER_PATH_RE,
+  ],
   [AGENT_COMPLETE_REWRITE_SOURCE, "/api/webhooks/agent/complete"],
   [AGENT_EVENTS_REWRITE_SOURCE, "/api/webhooks/agent/events"],
   [AGENT_FIREWALL_AUTH_REWRITE_SOURCE, "/api/webhooks/agent/firewall/auth"],

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -154,9 +154,17 @@ const AGENTPHONE_CONNECT_REWRITE_SOURCE = "/api/agentphone/connect";
 const AGENTPHONE_WEBHOOK_REWRITE_SOURCE = "/api/agentphone/webhook";
 const RUNNERS_JOB_CLAIM_REWRITE_SOURCE = "/api/runners/jobs/:id/claim";
 const RUNNERS_JOB_CLAIM_PATH_RE = /^\/api\/runners\/jobs\/[^/]+\/claim$/;
-const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
+const GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE =
+  "/api/github/app/setup/callback";
 const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
-const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
+const GITHUB_OAUTH_PATH_RE =
+  /^\/api\/github\/(?:app\/setup\/callback|oauth\/install)$/;
+const ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE =
+  "/api/zero/github/oauth/connect";
+const ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE =
+  "/api/zero/github/oauth/connect/callback";
+const ZERO_GITHUB_OAUTH_PATH_RE =
+  /^\/api\/zero\/github\/oauth\/connect(?:\/callback)?$/;
 const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
 const INTEGRATIONS_GITHUB_LINK_REWRITE_SOURCE = "/api/integrations/github/link";
 const INTEGRATIONS_GITHUB_LABEL_LISTENERS_REWRITE_SOURCE =
@@ -481,8 +489,13 @@ export const API_BACKEND_REWRITES = [
   ],
   [ZERO_EMAIL_INBOUND_REWRITE_SOURCE, "/api/zero/email/inbound"],
   ["/api/generate-image", "/api/generate-image"],
-  [GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/github/oauth/callback"],
+  [GITHUB_APP_SETUP_CALLBACK_REWRITE_SOURCE, "/api/github/app/setup/callback"],
   [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],
+  [ZERO_GITHUB_OAUTH_CONNECT_REWRITE_SOURCE, "/api/zero/github/oauth/connect"],
+  [
+    ZERO_GITHUB_OAUTH_CONNECT_CALLBACK_REWRITE_SOURCE,
+    "/api/zero/github/oauth/connect/callback",
+  ],
   [INTEGRATIONS_GITHUB_REWRITE_SOURCE, "/api/integrations/github"],
   [INTEGRATIONS_GITHUB_LINK_REWRITE_SOURCE, "/api/integrations/github/link"],
   [
@@ -1141,6 +1154,7 @@ export function matchesConnectorOAuthRewritePath(pathname) {
 export function matchesGithubOAuthRewritePath(pathname) {
   return (
     GITHUB_OAUTH_PATH_RE.test(pathname) ||
+    ZERO_GITHUB_OAUTH_PATH_RE.test(pathname) ||
     pathname === INTEGRATIONS_GITHUB_REWRITE_SOURCE
   );
 }

--- a/turbo/apps/web/src/db/migrations/0392_cute_spectrum.sql
+++ b/turbo/apps/web/src/db/migrations/0392_cute_spectrum.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "github_label_listeners" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"installation_id" uuid NOT NULL,
+	"org_id" text NOT NULL,
+	"created_by_user_id" text NOT NULL,
+	"label_name" varchar(255) NOT NULL,
+	"label_name_normalized" varchar(255) NOT NULL,
+	"trigger_mode" varchar(32) DEFAULT 'created_by_me' NOT NULL,
+	"prompt" text NOT NULL,
+	"compose_id" uuid NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "github_installations" ADD COLUMN "org_id" text;--> statement-breakpoint
+UPDATE "github_installations"
+SET "org_id" = "agent_composes"."org_id"
+FROM "agent_composes"
+WHERE "github_installations"."default_compose_id" = "agent_composes"."id";--> statement-breakpoint
+ALTER TABLE "github_installations" ALTER COLUMN "org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_label_listeners" ADD CONSTRAINT "github_label_listeners_installation_id_github_installations_id_fk" FOREIGN KEY ("installation_id") REFERENCES "public"."github_installations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_label_listeners" ADD CONSTRAINT "github_label_listeners_compose_id_agent_composes_id_fk" FOREIGN KEY ("compose_id") REFERENCES "public"."agent_composes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_github_label_listeners_installation_label" ON "github_label_listeners" USING btree ("installation_id","label_name_normalized");--> statement-breakpoint
+CREATE INDEX "idx_github_label_listeners_org" ON "github_label_listeners" USING btree ("org_id");--> statement-breakpoint
+CREATE INDEX "idx_github_label_listeners_installation" ON "github_label_listeners" USING btree ("installation_id");--> statement-breakpoint
+CREATE INDEX "idx_github_installations_org" ON "github_installations" USING btree ("org_id");

--- a/turbo/apps/web/src/db/migrations/meta/0392_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0392_snapshot.json
@@ -1,0 +1,13845 @@
+{
+  "id": "a668ab09-99cf-4bcd-992f-ca11a52e9f47",
+  "prevId": "cc1810d7-e4d4-4226-90a8-c6ee411c3cd2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_volumes": {
+          "name": "additional_volumes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_reuse_result": {
+          "name": "sandbox_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_session": {
+          "name": "idx_agent_runs_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_completed_org_user": {
+          "name": "idx_agent_runs_completed_org_user",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"completed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": [
+            "agent_compose_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_session_id_agent_sessions_id_fk": {
+          "name": "agent_runs_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose": {
+          "name": "idx_agent_sessions_user_compose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_messages": {
+      "name": "agentphone_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_message_id": {
+          "name": "agentphone_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_messages_agentphone_message": {
+          "name": "idx_agentphone_messages_agentphone_message",
+          "columns": [
+            {
+              "expression": "agentphone_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_webhook_id": {
+          "name": "idx_agentphone_messages_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "webhook_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_handle_created": {
+          "name": "idx_agentphone_messages_handle_created",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_user_link": {
+          "name": "idx_agentphone_messages_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_messages",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_thread_sessions": {
+      "name": "agentphone_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_thread_sessions_link_root": {
+          "name": "idx_agentphone_thread_sessions_link_root",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_thread_sessions_user_link": {
+          "name": "idx_agentphone_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_agent_preferences": {
+      "name": "agentphone_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "agentphone_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentphone_user_agent_preferences_pkey": {
+          "name": "agentphone_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_links": {
+      "name": "agentphone_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_user_links_phone_handle": {
+          "name": "idx_agentphone_user_links_phone_handle",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_vm0_org": {
+          "name": "idx_agentphone_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_org": {
+          "name": "idx_agentphone_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_verification_send_cooldowns": {
+      "name": "agentphone_verification_send_cooldowns",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentphone_verification_send_cooldowns_pkey": {
+          "name": "agentphone_verification_send_cooldowns_pkey",
+          "columns": [
+            "scope",
+            "scope_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._archive_2026_06_14_agent_run_events": {
+      "name": "_archive_2026_06_14_agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_archive_2026_06_14_agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "_archive_2026_06_14_agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "_archive_2026_06_14_agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archived_task_runs": {
+      "name": "archived_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_run_id": {
+          "name": "archived_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_archived_task_runs_unique": {
+          "name": "idx_archived_task_runs_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_generation_jobs": {
+      "name": "built_in_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_built_in_generation_jobs_user_created": {
+          "name": "idx_built_in_generation_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_org_status": {
+          "name": "idx_built_in_generation_jobs_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_run": {
+          "name": "idx_built_in_generation_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "built_in_generation_jobs_run_id_agent_runs_id_fk": {
+          "name": "built_in_generation_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "built_in_generation_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokes_message_id": {
+          "name": "revokes_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupts_run_id": {
+          "name": "interrupts_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_id": {
+          "name": "run_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_files": {
+          "name": "attach_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_remaining_turns": {
+          "name": "goal_remaining_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_origin_message_id": {
+          "name": "goal_origin_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_continuation_of_run_id": {
+          "name": "goal_continuation_of_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_thread_created": {
+          "name": "idx_chat_messages_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_run_id": {
+          "name": "idx_chat_messages_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_revokes_message_id_unique": {
+          "name": "chat_messages_revokes_message_id_unique",
+          "columns": [
+            {
+              "expression": "revokes_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_interrupts_run_id_unique": {
+          "name": "chat_messages_interrupts_run_id_unique",
+          "columns": [
+            {
+              "expression": "interrupts_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_seq_unique": {
+          "name": "chat_messages_run_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_goal_origin": {
+          "name": "idx_chat_messages_goal_origin",
+          "columns": [
+            {
+              "expression": "goal_origin_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_goal_continuation_run_unique": {
+          "name": "chat_messages_goal_continuation_run_unique",
+          "columns": [
+            {
+              "expression": "goal_continuation_of_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_revokes_message_id_chat_messages_id_fk": {
+          "name": "chat_messages_revokes_message_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "revokes_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_interrupts_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_interrupts_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "interrupts_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_goal_origin_message_id_chat_messages_id_fk": {
+          "name": "chat_messages_goal_origin_message_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "goal_origin_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_goal_continuation_of_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_goal_continuation_of_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "goal_continuation_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_schedule_run_id": {
+          "name": "source_schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read": {
+          "name": "idx_chat_threads_user_last_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read_message": {
+          "name": "idx_chat_threads_user_last_read_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_pinned": {
+          "name": "idx_chat_threads_user_compose_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshots": {
+          "name": "artifact_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_command_audit_events": {
+      "name": "computer_use_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_command_audit_command": {
+          "name": "idx_computer_use_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_org_user": {
+          "name": "idx_computer_use_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_created": {
+          "name": "idx_computer_use_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_command_audit_events_command_id_computer_use_commands_id_fk": {
+          "name": "computer_use_command_audit_events_command_id_computer_use_commands_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_commands": {
+      "name": "computer_use_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_commands_host_status": {
+          "name": "idx_computer_use_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_org_user": {
+          "name": "idx_computer_use_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_created": {
+          "name": "idx_computer_use_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_commands_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_commands_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_commands",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"accessibility\":false,\"screenRecording\":false}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_token_hash": {
+          "name": "idx_computer_use_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_last_seen": {
+          "name": "idx_computer_use_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_cli_auth_sessions": {
+      "name": "connector_cli_auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_cli_auth_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initializing'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_url": {
+          "name": "approval_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_cli_auth_sessions_owner_status": {
+          "name": "idx_connector_cli_auth_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_cli_auth_sessions_expiration": {
+          "name": "idx_connector_cli_auth_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_cli_auth_sessions_sandbox": {
+          "name": "idx_connector_cli_auth_sessions_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connector_cli_auth_sessions\".\"sandbox_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_device_authorization_sessions": {
+      "name": "connector_oauth_device_authorization_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_oauth_device_authorization_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_user_authorization'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri_complete": {
+          "name": "verification_uri_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_device_authorization_sessions_token": {
+          "name": "idx_connector_oauth_device_authorization_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_owner_status": {
+          "name": "idx_connector_oauth_device_authorization_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_expiration": {
+          "name": "idx_connector_oauth_device_authorization_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_states": {
+      "name": "connector_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_context": {
+          "name": "oauth_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_states_state": {
+          "name": "idx_connector_oauth_states_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_user_org": {
+          "name": "idx_connector_oauth_states_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_expires_at": {
+          "name": "idx_connector_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_starter_grant": {
+          "name": "uq_credit_expires_starter_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'starter_grant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_auth_handoff_codes": {
+      "name": "desktop_auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_auth_handoff_codes_expires": {
+          "name": "idx_desktop_auth_handoff_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_auth_handoff_codes_user_created": {
+          "name": "idx_desktop_auth_handoff_codes_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_auth_handoff_codes_code_hash_unique": {
+          "name": "desktop_auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ble_session_nonce": {
+          "name": "ble_session_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_token_hash": {
+          "name": "poll_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_token_id": {
+          "name": "cli_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_slack_mock_call_log": {
+      "name": "e2e_slack_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_slack_mock_call_log_created_at": {
+          "name": "idx_e2e_slack_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_slack_mock_call_log_method": {
+          "name": "idx_e2e_slack_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_telegram_mock_call_log": {
+      "name": "e2e_telegram_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_telegram_mock_call_log_created_at": {
+          "name": "idx_e2e_telegram_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_method": {
+          "name": "idx_e2e_telegram_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_chat_id": {
+          "name": "idx_e2e_telegram_mock_call_log_chat_id",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": [
+            "email_thread_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_agent_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_org": {
+          "name": "idx_github_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_label_listeners": {
+      "name": "github_label_listeners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name_normalized": {
+          "name": "label_name_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created_by_me'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_label_listeners_installation_label": {
+          "name": "idx_github_label_listeners_installation_label",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_label_listeners_org": {
+          "name": "idx_github_label_listeners_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_label_listeners_installation": {
+          "name": "idx_github_label_listeners_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_label_listeners_installation_id_github_installations_id_fk": {
+          "name": "github_label_listeners_installation_id_github_installations_id_fk",
+          "tableFrom": "github_label_listeners",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_label_listeners_compose_id_agent_composes_id_fk": {
+          "name": "github_label_listeners_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_label_listeners",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_deployments": {
+      "name": "hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_deployments_site": {
+          "name": "idx_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_org": {
+          "name": "idx_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_status": {
+          "name": "idx_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_sites": {
+      "name": "hosted_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_run_id": {
+          "name": "created_from_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_sites_org": {
+          "name": "idx_hosted_sites_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_slug": {
+          "name": "idx_hosted_sites_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_public_slug": {
+          "name": "idx_hosted_sites_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_daily": {
+      "name": "insights_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_insights_daily_org_user_date": {
+          "name": "uq_insights_daily_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insights_daily_org_user_date_desc": {
+          "name": "idx_insights_daily_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_agent_device_codes": {
+      "name": "remote_agent_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_token_hash": {
+          "name": "poll_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_backends": {
+          "name": "supported_backends",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_remote_agent_device_codes_code_hash": {
+          "name": "idx_remote_agent_device_codes_code_hash",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_device_codes_poll": {
+          "name": "idx_remote_agent_device_codes_poll",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "poll_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_device_codes_org_user": {
+          "name": "idx_remote_agent_device_codes_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_device_codes_expires": {
+          "name": "idx_remote_agent_device_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_agent_device_codes_host_id_remote_agent_hosts_id_fk": {
+          "name": "remote_agent_device_codes_host_id_remote_agent_hosts_id_fk",
+          "tableFrom": "remote_agent_device_codes",
+          "tableTo": "remote_agent_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_agent_hosts": {
+      "name": "remote_agent_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_backends": {
+          "name": "supported_backends",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_remote_agent_hosts_token_hash": {
+          "name": "idx_remote_agent_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_hosts_org_user": {
+          "name": "idx_remote_agent_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_hosts_last_seen": {
+          "name": "idx_remote_agent_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_agent_jobs": {
+      "name": "remote_agent_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_remote_agent_jobs_host_status": {
+          "name": "idx_remote_agent_jobs_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_jobs_org_user": {
+          "name": "idx_remote_agent_jobs_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_remote_agent_jobs_created": {
+          "name": "idx_remote_agent_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_agent_jobs_host_id_remote_agent_hosts_id_fk": {
+          "name": "remote_agent_jobs_host_id_remote_agent_hosts_id_fk",
+          "tableFrom": "remote_agent_jobs",
+          "tableTo": "remote_agent_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_browser_command_audit_events": {
+      "name": "local_browser_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tab_id": {
+          "name": "tab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_local_browser_command_audit_command": {
+          "name": "idx_local_browser_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_command_audit_org_user": {
+          "name": "idx_local_browser_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_command_audit_created": {
+          "name": "idx_local_browser_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "local_browser_command_audit_events_command_id_local_browser_commands_id_fk": {
+          "name": "local_browser_command_audit_events_command_id_local_browser_commands_id_fk",
+          "tableFrom": "local_browser_command_audit_events",
+          "tableTo": "local_browser_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "local_browser_command_audit_events_host_id_local_browser_hosts_id_fk": {
+          "name": "local_browser_command_audit_events_host_id_local_browser_hosts_id_fk",
+          "tableFrom": "local_browser_command_audit_events",
+          "tableTo": "local_browser_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_browser_commands": {
+      "name": "local_browser_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_local_browser_commands_host_status": {
+          "name": "idx_local_browser_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_commands_org_user": {
+          "name": "idx_local_browser_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_commands_created": {
+          "name": "idx_local_browser_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "local_browser_commands_host_id_local_browser_hosts_id_fk": {
+          "name": "local_browser_commands_host_id_local_browser_hosts_id_fk",
+          "tableFrom": "local_browser_commands",
+          "tableTo": "local_browser_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_browser_device_codes": {
+      "name": "local_browser_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_token_hash": {
+          "name": "poll_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extension_version": {
+          "name": "extension_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_local_browser_device_codes_code_hash": {
+          "name": "idx_local_browser_device_codes_code_hash",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_device_codes_poll": {
+          "name": "idx_local_browser_device_codes_poll",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "poll_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_device_codes_org_user": {
+          "name": "idx_local_browser_device_codes_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_device_codes_expires": {
+          "name": "idx_local_browser_device_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "local_browser_device_codes_host_id_local_browser_hosts_id_fk": {
+          "name": "local_browser_device_codes_host_id_local_browser_hosts_id_fk",
+          "tableFrom": "local_browser_device_codes",
+          "tableTo": "local_browser_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_browser_hosts": {
+      "name": "local_browser_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extension_version": {
+          "name": "extension_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_local_browser_hosts_token_hash": {
+          "name": "idx_local_browser_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_hosts_org_user": {
+          "name": "idx_local_browser_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_browser_hosts_last_seen": {
+          "name": "idx_local_browser_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_one_default_per_user": {
+          "name": "idx_model_providers_one_default_per_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stat": {
+      "name": "model_stat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hour_start": {
+          "name": "hour_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "org_count": {
+          "name": "org_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_count": {
+          "name": "user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_stat_hour_model_provider": {
+          "name": "uq_model_stat_hour_model_provider",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_hour_start": {
+          "name": "idx_model_stat_hour_start",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_model_hour": {
+          "name": "idx_model_stat_model_hour",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_secrets": {
+      "name": "org_custom_connector_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_secrets_connector": {
+          "name": "idx_org_custom_connector_secrets_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_user": {
+          "name": "idx_org_custom_connector_secrets_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_connector_user": {
+          "name": "idx_org_custom_connector_secrets_connector_user",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connectors": {
+      "name": "org_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefixes": {
+          "name": "prefixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_template": {
+          "name": "header_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connectors_org": {
+          "name": "idx_org_custom_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_org_slug": {
+          "name": "idx_org_custom_connectors_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "credit_cap": {
+          "name": "credit_cap",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_enabled": {
+          "name": "credit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "capture_network_bodies_remaining": {
+          "name": "capture_network_bodies_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agent_composes_id_fk": {
+          "name": "org_metadata_default_agent_id_agent_composes_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_model_policies": {
+      "name": "org_model_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_provider_type": {
+          "name": "default_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_model_policies_org_model": {
+          "name": "idx_org_model_policies_org_model",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_one_default_per_org": {
+          "name": "idx_org_model_policies_one_default_per_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_provider": {
+          "name": "idx_org_model_policies_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_model_policies_model_provider_id_model_providers_id_fk": {
+          "name": "org_model_policies_model_provider_id_model_providers_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_model_policies_credential_scope": {
+          "name": "chk_org_model_policies_credential_scope",
+          "value": "credential_scope IN ('org', 'member')"
+        },
+        "chk_org_model_policies_member_scope_no_provider_id": {
+          "name": "chk_org_model_policies_member_scope_no_provider_id",
+          "value": "credential_scope <> 'member' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_builtin_route_no_provider_id": {
+          "name": "chk_org_model_policies_builtin_route_no_provider_id",
+          "value": "default_provider_type <> 'vm0' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_member_scope_oauth_provider": {
+          "name": "chk_org_model_policies_member_scope_oauth_provider",
+          "value": "credential_scope <> 'member' OR default_provider_type IN ('claude-code-oauth-token', 'codex-oauth-token')"
+        },
+        "chk_org_model_policies_oauth_provider_member_scope": {
+          "name": "chk_org_model_policies_oauth_provider_member_scope",
+          "value": "default_provider_type NOT IN ('claude-code-oauth-token', 'codex-oauth-token') OR credential_scope = 'member'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_promo_redemption": {
+      "name": "org_promo_redemption",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_promo_redemption": {
+          "name": "uq_org_promo_redemption",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_access_requests": {
+      "name": "permission_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_ref": {
+          "name": "connector_ref",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_permission_access_requests_agent_status": {
+          "name": "idx_permission_access_requests_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_permission_access_requests_org": {
+          "name": "idx_permission_access_requests_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_access_requests_agent_id_zero_agents_id_fk": {
+          "name": "permission_access_requests_agent_id_zero_agents_id_fk",
+          "tableFrom": "permission_access_requests",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_subscriptions_user_id": {
+          "name": "idx_push_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_push_subscriptions_endpoint": {
+          "name": "idx_push_subscriptions_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_built_in_admissions": {
+      "name": "run_built_in_admissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_run_builtin_admissions_run_status": {
+          "name": "idx_run_builtin_admissions_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_run_created": {
+          "name": "idx_run_builtin_admissions_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_expires_at": {
+          "name": "idx_run_builtin_admissions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_built_in_admissions_run_id_agent_runs_id_fk": {
+          "name": "run_built_in_admissions_run_id_agent_runs_id_fk",
+          "tableFrom": "run_built_in_admissions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_uploaded_files": {
+      "name": "run_uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_uploaded_files_run": {
+          "name": "idx_run_uploaded_files_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_run_source_external": {
+          "name": "idx_run_uploaded_files_run_source_external",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_source_external": {
+          "name": "idx_run_uploaded_files_source_external",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_uploaded_files_run_id_agent_runs_id_fk": {
+          "name": "run_uploaded_files_run_id_agent_runs_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_session_id_unclaimed_idx": {
+          "name": "runner_job_queue_session_id_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL AND session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_state": {
+      "name": "runner_state",
+      "schema": "",
+      "columns": {
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_name": {
+          "name": "runner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiles": {
+          "name": "profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_vcpu": {
+          "name": "total_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_memory_mb": {
+          "name": "total_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_vcpu": {
+          "name": "allocated_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_memory_mb": {
+          "name": "allocated_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "held_sessions": {
+          "name": "held_sessions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_state_group_idx": {
+          "name": "runner_state_group_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_state_last_seen_idx": {
+          "name": "runner_state_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": [
+            "slack_workspace_id"
+          ],
+          "columnsTo": [
+            "slack_workspace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_agent_preferences": {
+      "name": "slack_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "slack_user_agent_preferences_pkey": {
+          "name": "slack_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_owner": {
+          "name": "idx_telegram_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_org_id": {
+          "name": "official_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_user_link_id": {
+          "name": "official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_width": {
+          "name": "file_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_height": {
+          "name": "file_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_duration": {
+          "name": "file_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_unique": {
+          "name": "idx_telegram_messages_official_unique",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_chat": {
+          "name": "idx_telegram_messages_official_chat",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_messages_one_owner": {
+          "name": "chk_telegram_messages_one_owner",
+          "value": "(installation_id IS NOT NULL) <> (official_org_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_official_user_links": {
+      "name": "telegram_official_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_official_user_links_tg_user": {
+          "name": "idx_telegram_official_user_links_tg_user",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_vm0_org": {
+          "name": "idx_telegram_official_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_org": {
+          "name": "idx_telegram_official_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_official_user_link_id": {
+          "name": "telegram_official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_chat_official_link": {
+          "name": "idx_telegram_thread_sessions_chat_official_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_official_user_link": {
+          "name": "idx_telegram_thread_sessions_official_user_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "telegram_official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_thread_sessions_one_owner": {
+          "name": "chk_telegram_thread_sessions_one_owner",
+          "value": "(telegram_user_link_id IS NOT NULL) <> (telegram_official_user_link_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_agent_preferences": {
+      "name": "telegram_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "telegram_user_agent_preferences_pkey": {
+          "name": "telegram_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_user_links_vm0_installation": {
+          "name": "idx_telegram_user_links_vm0_installation",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_event": {
+      "name": "usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "billing_error": {
+          "name": "billing_error",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_usage_event_idempotency_key": {
+          "name": "uq_usage_event_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_run_id": {
+          "name": "idx_usage_event_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_status": {
+          "name": "idx_usage_event_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_created": {
+          "name": "idx_usage_event_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_model_created": {
+          "name": "idx_usage_event_model_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"kind\" = 'model'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_user_status_processed": {
+          "name": "idx_usage_event_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_processed_org_user": {
+          "name": "idx_usage_event_processed_org_user",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"status\" = 'processed' AND \"usage_event\".\"processed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_run_id_agent_runs_id_fk": {
+          "name": "usage_event_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_pricing": {
+      "name": "usage_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_size": {
+          "name": "unit_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pricing_kind_provider_category": {
+          "name": "uq_usage_pricing_kind_provider_category",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_count": {
+      "name": "user_behavior_count",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behavior_key": {
+          "name": "behavior_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_behavior_count_org_id_user_id_behavior_key_pk": {
+          "name": "user_behavior_count_org_id_user_id_behavior_key_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "behavior_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique": {
+          "name": "idx_user_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_custom_connectors": {
+      "name": "user_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_custom_connectors_unique": {
+          "name": "idx_user_custom_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_custom_connectors_agent_user": {
+          "name": "idx_user_custom_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_custom_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_custom_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk": {
+          "name": "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_switches": {
+      "name": "user_feature_switches",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "switches": {
+          "name": "switches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_feature_switches_org_id_user_id_pk": {
+          "name": "user_feature_switches_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_chat_items": {
+      "name": "voice_chat_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realtime_item_id": {
+          "name": "realtime_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_voice_chat_items_session_seq": {
+          "name": "idx_voice_chat_items_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_voice_chat_items_session_realtime": {
+          "name": "uq_voice_chat_items_session_realtime",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "realtime_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_chat_items_session_id_voice_chat_sessions_id_fk": {
+          "name": "voice_chat_items_session_id_voice_chat_sessions_id_fk",
+          "tableFrom": "voice_chat_items",
+          "tableTo": "voice_chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_chat_realtime_sessions": {
+      "name": "voice_chat_realtime_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voice_chat_session_id": {
+          "name": "voice_chat_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcription_model": {
+          "name": "transcription_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openai_session_id": {
+          "name": "openai_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openai_call_id": {
+          "name": "openai_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_usage_at": {
+          "name": "last_usage_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_vcrs_voice_chat_session": {
+          "name": "idx_vcrs_voice_chat_session",
+          "columns": [
+            {
+              "expression": "voice_chat_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vcrs_org_started": {
+          "name": "idx_vcrs_org_started",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_chat_realtime_sessions_voice_chat_session_id_voice_chat_sessions_id_fk": {
+          "name": "voice_chat_realtime_sessions_voice_chat_session_id_voice_chat_sessions_id_fk",
+          "tableFrom": "voice_chat_realtime_sessions",
+          "tableTo": "voice_chat_sessions",
+          "columnsFrom": [
+            "voice_chat_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_chat_sessions": {
+      "name": "voice_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "conversation_summary": {
+          "name": "conversation_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_tasks_summary": {
+          "name": "working_tasks_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_tasks_summary": {
+          "name": "finished_tasks_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_seq": {
+          "name": "summary_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_status": {
+          "name": "reasoning_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "reasoning_pending": {
+          "name": "reasoning_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_summary_at": {
+          "name": "last_summary_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reasoning_started_at": {
+          "name": "last_reasoning_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reasoning_duration_ms": {
+          "name": "last_reasoning_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_voice_chat_sessions_user": {
+          "name": "idx_voice_chat_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_voice_chat_sessions_user_agent_created": {
+          "name": "idx_voice_chat_sessions_user_agent_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_chat_sessions_agent_id_agent_composes_id_fk": {
+          "name": "voice_chat_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "voice_chat_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_chat_tasks": {
+      "name": "voice_chat_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_updated_at": {
+          "name": "result_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_messages": {
+          "name": "assistant_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_voice_chat_tasks_session_status_created": {
+          "name": "idx_voice_chat_tasks_session_status_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_chat_tasks_session_id_voice_chat_sessions_id_fk": {
+          "name": "voice_chat_tasks_session_id_voice_chat_sessions_id_fk",
+          "tableFrom": "voice_chat_tasks",
+          "tableTo": "voice_chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "voice_chat_tasks_run_id_agent_runs_id_fk": {
+          "name": "voice_chat_tasks_run_id_agent_runs_id_fk",
+          "tableFrom": "voice_chat_tasks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_schedules": {
+      "name": "zero_agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_schedules_zero_agent": {
+          "name": "idx_zero_agent_schedules_zero_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_org": {
+          "name": "idx_zero_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_agent_name_org_user": {
+          "name": "idx_zero_agent_schedules_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_next_run": {
+          "name": "idx_zero_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_user_org": {
+          "name": "idx_zero_agent_schedules_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_schedules_agent_id_agent_composes_id_fk": {
+          "name": "zero_agent_schedules_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_model_provider_id_model_providers_id_fk": {
+          "name": "zero_agent_schedules_model_provider_id_model_providers_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "zero_agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_policies": {
+          "name": "permission_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unknown_permission_policies": {
+          "name": "unknown_permission_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_skills": {
+          "name": "custom_skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agents_id_agent_composes_id_fk": {
+          "name": "zero_agents_id_agent_composes_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agents_model_provider_id_model_providers_id_fk": {
+          "name": "zero_agents_model_provider_id_model_providers_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_runs": {
+      "name": "zero_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_agent_id": {
+          "name": "trigger_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_zero_runs_schedule": {
+          "name": "idx_zero_runs_schedule",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_runs_chat_thread_id": {
+          "name": "idx_zero_runs_chat_thread_id",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "chat_thread_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_runs_id_agent_runs_id_fk": {
+          "name": "zero_runs_id_agent_runs_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_runs_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "zero_runs_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_trigger_agent_id_agent_composes_id_fk": {
+          "name": "zero_runs_trigger_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "trigger_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "zero_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_skills": {
+      "name": "zero_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_skills_org_name": {
+          "name": "idx_zero_skills_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_skills_org": {
+          "name": "idx_zero_skills_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_cli_auth_session_status": {
+      "name": "connector_cli_auth_session_status",
+      "schema": "public",
+      "values": [
+        "initializing",
+        "awaiting_user_approval",
+        "completing",
+        "imported",
+        "expired",
+        "cancelled",
+        "error"
+      ]
+    },
+    "public.connector_oauth_device_authorization_session_status": {
+      "name": "connector_oauth_device_authorization_session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_user_authorization",
+        "polling",
+        "complete",
+        "denied",
+        "expired",
+        "error"
+      ]
+    },
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "approved",
+        "consumed",
+        "expired",
+        "denied"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -2745,6 +2745,13 @@
       "when": 1779374635803,
       "tag": "0391_acoustic_microbe",
       "breakpoints": true
+    },
+    {
+      "idx": 392,
+      "version": "7",
+      "when": 1779417949963,
+      "tag": "0392_cute_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/packages/api-contracts/src/contracts/github-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/github-oauth.ts
@@ -8,6 +8,7 @@ const jsonErrorSchema = z.object({ error: z.string() });
 
 export const githubOauthInstallQuerySchema = z.object({
   vm0UserId: z.string().optional(),
+  orgId: z.string().optional(),
   composeId: z.string().optional(),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/github-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/github-oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
@@ -12,7 +13,17 @@ export const githubOauthInstallQuerySchema = z.object({
   composeId: z.string().optional(),
 });
 
-export const githubOauthCallbackQuerySchema = z.object({
+export const githubOauthConnectCallbackQuerySchema = z.object({
+  code: z.string().optional(),
+  state: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+export const githubAppSetupCallbackQuerySchema = z.object({
+  code: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
   installation_id: z.string().optional(),
   setup_action: z.string().optional(),
   state: z.string().optional(),
@@ -31,14 +42,33 @@ export const githubOauthContract = c.router({
     },
     summary: "Start GitHub App OAuth install",
   },
-  callback: {
+  connect: {
     method: "GET",
-    path: "/api/github/oauth/callback",
-    query: githubOauthCallbackQuerySchema,
+    path: "/api/zero/github/oauth/connect",
+    responses: {
+      307: c.noBody(),
+      401: apiErrorSchema,
+      503: jsonErrorSchema,
+    },
+    summary: "Start GitHub user OAuth for the GitHub integration",
+  },
+  connectCallback: {
+    method: "GET",
+    path: "/api/zero/github/oauth/connect/callback",
+    query: githubOauthConnectCallbackQuerySchema,
     responses: {
       307: c.noBody(),
     },
-    summary: "Handle GitHub App OAuth callback",
+    summary: "Handle GitHub user OAuth for the GitHub integration",
+  },
+  setupCallback: {
+    method: "GET",
+    path: "/api/github/app/setup/callback",
+    query: githubAppSetupCallbackQuerySchema,
+    responses: {
+      307: c.noBody(),
+    },
+    summary: "Handle GitHub App setup callback",
   },
 });
 
@@ -46,6 +76,9 @@ export type GithubOauthContract = typeof githubOauthContract;
 export type GithubOauthInstallQuery = z.infer<
   typeof githubOauthInstallQuerySchema
 >;
-export type GithubOauthCallbackQuery = z.infer<
-  typeof githubOauthCallbackQuerySchema
+export type GithubOauthConnectCallbackQuery = z.infer<
+  typeof githubOauthConnectCallbackQuerySchema
+>;
+export type GithubAppSetupCallbackQuery = z.infer<
+  typeof githubAppSetupCallbackQuerySchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1132,10 +1132,10 @@ export {
   type IntegrationsGithubContract,
 } from "./integrations-github";
 export {
+  githubAppSetupCallbackQuerySchema,
   githubOauthContract,
-  githubOauthCallbackQuerySchema,
   githubOauthInstallQuerySchema,
-  type GithubOauthCallbackQuery,
+  type GithubAppSetupCallbackQuery,
   type GithubOauthContract,
   type GithubOauthInstallQuery,
 } from "./github-oauth";

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -11,6 +11,30 @@ export const githubInstallationEnvironmentSchema = z.object({
   missingVars: z.array(z.string()),
 });
 
+export const githubLabelTriggerModeSchema = z.enum(["created_by_me", "anyone"]);
+
+export type GithubLabelTriggerMode = z.infer<
+  typeof githubLabelTriggerModeSchema
+>;
+
+export const githubLabelListenerSchema = z.object({
+  id: z.string(),
+  labelName: z.string(),
+  triggerMode: githubLabelTriggerModeSchema,
+  prompt: z.string(),
+  enabled: z.boolean(),
+  agent: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type GithubLabelListener = z.infer<typeof githubLabelListenerSchema>;
+
 export const githubInstallationResponseSchema = z.object({
   installation: z.object({
     id: z.string(),
@@ -20,6 +44,10 @@ export const githubInstallationResponseSchema = z.object({
     targetType: z.string().nullable(),
     isAdmin: z.boolean(),
   }),
+  isConnected: z.boolean(),
+  connectedGithubUserId: z.string().nullable(),
+  installUrl: z.string().nullable(),
+  connectUrl: z.string(),
   agent: z
     .object({
       id: z.string(),
@@ -27,6 +55,7 @@ export const githubInstallationResponseSchema = z.object({
     })
     .nullable(),
   environment: githubInstallationEnvironmentSchema,
+  labelListeners: z.array(githubLabelListenerSchema),
 });
 
 export type GithubInstallationResponse = z.infer<
@@ -65,6 +94,54 @@ export type UpdateGithubInstallationResponse = z.infer<
   typeof updateGithubInstallationResponseSchema
 >;
 
+export const githubIntegrationActionResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type GithubIntegrationActionResponse = z.infer<
+  typeof githubIntegrationActionResponseSchema
+>;
+
+export const createGithubLabelListenerBodySchema = z.object({
+  labelName: z.string().min(1).max(255),
+  triggerMode: githubLabelTriggerModeSchema,
+  prompt: z.string().min(1),
+  agentId: z.string().uuid(),
+  enabled: z.boolean().optional(),
+});
+
+export type CreateGithubLabelListenerBody = z.infer<
+  typeof createGithubLabelListenerBodySchema
+>;
+
+export const updateGithubLabelListenerBodySchema = z.object({
+  labelName: z.string().min(1).max(255).optional(),
+  triggerMode: githubLabelTriggerModeSchema.optional(),
+  prompt: z.string().min(1).optional(),
+  agentId: z.string().uuid().optional(),
+  enabled: z.boolean().optional(),
+});
+
+export type UpdateGithubLabelListenerBody = z.infer<
+  typeof updateGithubLabelListenerBodySchema
+>;
+
+export const createGithubLabelListenerResponseSchema = z.object({
+  listener: githubLabelListenerSchema,
+});
+
+export type CreateGithubLabelListenerResponse = z.infer<
+  typeof createGithubLabelListenerResponseSchema
+>;
+
+export const updateGithubLabelListenerResponseSchema = z.object({
+  listener: githubLabelListenerSchema,
+});
+
+export type UpdateGithubLabelListenerResponse = z.infer<
+  typeof updateGithubLabelListenerResponseSchema
+>;
+
 export const integrationsGithubContract = c.router({
   getInstallation: {
     method: "GET",
@@ -78,6 +155,37 @@ export const integrationsGithubContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Get the authenticated user's GitHub App installation",
+  },
+
+  connectUser: {
+    method: "POST",
+    path: "/api/integrations/github/link",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: githubIntegrationActionResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary:
+      "Link the authenticated VM0 user to the org GitHub App installation",
+  },
+
+  disconnectUser: {
+    method: "DELETE",
+    path: "/api/integrations/github/link",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: githubIntegrationActionResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary:
+      "Disconnect the authenticated VM0 user from the org GitHub App installation",
   },
 
   deleteInstallation: {
@@ -109,6 +217,56 @@ export const integrationsGithubContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Update the authenticated user's GitHub App installation",
+  },
+
+  createLabelListener: {
+    method: "POST",
+    path: "/api/integrations/github/label-listeners",
+    headers: authHeadersSchema,
+    body: createGithubLabelListenerBodySchema,
+    responses: {
+      201: createGithubLabelListenerResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create a GitHub label listener",
+  },
+
+  updateLabelListener: {
+    method: "PATCH",
+    path: "/api/integrations/github/label-listeners/:listenerId",
+    pathParams: z.object({ listenerId: z.string().uuid() }),
+    headers: authHeadersSchema,
+    body: updateGithubLabelListenerBodySchema,
+    responses: {
+      200: updateGithubLabelListenerResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update a GitHub label listener",
+  },
+
+  deleteLabelListener: {
+    method: "DELETE",
+    path: "/api/integrations/github/label-listeners/:listenerId",
+    pathParams: z.object({ listenerId: z.string().uuid() }),
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: githubIntegrationActionResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete a GitHub label listener",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -46,6 +46,7 @@ export const githubInstallationResponseSchema = z.object({
   }),
   isConnected: z.boolean(),
   connectedGithubUserId: z.string().nullable(),
+  connectedGithubUsername: z.string().nullable(),
   installUrl: z.string().nullable(),
   connectUrl: z.string(),
   agent: z

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -33,6 +33,7 @@ export enum FeatureSwitchKey {
   ResendConnector = "resendConnector",
   DataExport = "dataExport",
   SpotifyConnector = "spotifyConnector",
+  GitHubIntegration = "githubIntegration",
   ZeroDebug = "zeroDebug",
   ComputerUse = "computerUse",
   LocalBrowserUse = "localBrowserUse",

--- a/turbo/packages/connectors/src/oauth-providers/providers/github.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github.ts
@@ -38,21 +38,25 @@ export async function exchangeGitHubCode(
   clientId: string,
   clientSecret: string,
   code: string,
-  redirectUri: string,
+  redirectUri?: string,
 ): Promise<{ accessToken: string; scopes: string[] }> {
   const oauthConfig = getConnectorOAuthConfig("github");
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+  });
+  if (redirectUri) {
+    body.set("redirect_uri", redirectUri);
+  }
+
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: new URLSearchParams({
-      client_id: clientId,
-      client_secret: clientSecret,
-      code,
-      redirect_uri: redirectUri,
-    }),
+    body,
   });
 
   if (!response.ok) {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -178,6 +178,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Spotify connector integration",
     enabled: false,
   },
+  [FeatureSwitchKey.GitHubIntegration]: {
+    maintainer: "linghan@vm0.ai",
+    description:
+      "Show the GitHub integration card on the Works page for installing GitHub, connecting users, and managing label listeners.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.DataExport]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the data export option in account menu",

--- a/turbo/packages/db/src/index.ts
+++ b/turbo/packages/db/src/index.ts
@@ -32,6 +32,7 @@ import * as usageDailySchema from "./schema/usage-daily";
 import * as emailThreadSessionSchema from "./schema/email-thread-session";
 import * as emailReplyRequestSchema from "./schema/email-reply-request";
 import * as githubInstallationSchema from "./schema/github-installation";
+import * as githubLabelListenerSchema from "./schema/github-label-listener";
 import * as githubUserLinkSchema from "./schema/github-user-link";
 import * as githubIssueSessionSchema from "./schema/github-issue-session";
 import * as telegramInstallationSchema from "./schema/telegram-installation";
@@ -118,6 +119,7 @@ export const schema = {
   ...emailThreadSessionSchema,
   ...emailReplyRequestSchema,
   ...githubInstallationSchema,
+  ...githubLabelListenerSchema,
   ...githubUserLinkSchema,
   ...githubIssueSessionSchema,
   ...telegramInstallationSchema,

--- a/turbo/packages/db/src/schema/github-installation.ts
+++ b/turbo/packages/db/src/schema/github-installation.ts
@@ -6,6 +6,7 @@ import {
   timestamp,
   jsonb,
   uniqueIndex,
+  index,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { agentComposes } from "./agent-compose";
@@ -23,6 +24,7 @@ export const githubInstallations = pgTable(
     installationId: varchar("installation_id", { length: 255 }),
     encryptedAccessToken: text("encrypted_access_token"),
     status: varchar("status", { length: 20 }).notNull().default("active"),
+    orgId: text("org_id").notNull(),
     targetType: varchar("target_type", { length: 20 }),
     targetId: varchar("target_id", { length: 255 }),
     targetName: varchar("target_name", { length: 255 }),
@@ -44,6 +46,7 @@ export const githubInstallations = pgTable(
       uniqueIndex("github_installations_installation_id_unique")
         .on(table.installationId)
         .where(sql`installation_id IS NOT NULL`),
+      index("idx_github_installations_org").on(table.orgId),
     ];
   },
 );

--- a/turbo/packages/db/src/schema/github-label-listener.ts
+++ b/turbo/packages/db/src/schema/github-label-listener.ts
@@ -1,0 +1,65 @@
+import {
+  boolean,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { agentComposes } from "./agent-compose";
+import { githubInstallations } from "./github-installation";
+
+export type GithubLabelTriggerMode = "created_by_me" | "anyone";
+
+/**
+ * GitHub label listeners
+ * Runs a configured agent when an issue or pull request receives a matching label.
+ */
+export const githubLabelListeners = pgTable(
+  "github_label_listeners",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    installationId: uuid("installation_id")
+      .notNull()
+      .references(
+        () => {
+          return githubInstallations.id;
+        },
+        { onDelete: "cascade" },
+      ),
+    orgId: text("org_id").notNull(),
+    createdByUserId: text("created_by_user_id").notNull(),
+    labelName: varchar("label_name", { length: 255 }).notNull(),
+    labelNameNormalized: varchar("label_name_normalized", {
+      length: 255,
+    }).notNull(),
+    triggerMode: varchar("trigger_mode", { length: 32 })
+      .$type<GithubLabelTriggerMode>()
+      .notNull()
+      .default("created_by_me"),
+    prompt: text("prompt").notNull(),
+    composeId: uuid("compose_id")
+      .notNull()
+      .references(
+        () => {
+          return agentComposes.id;
+        },
+        { onDelete: "cascade" },
+      ),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => {
+    return [
+      uniqueIndex("idx_github_label_listeners_installation_label").on(
+        table.installationId,
+        table.labelNameNormalized,
+      ),
+      index("idx_github_label_listeners_org").on(table.orgId),
+      index("idx_github_label_listeners_installation").on(table.installationId),
+    ];
+  },
+);


### PR DESCRIPTION
## Summary
- add an org-scoped GitHub integration card on `/works` for install, connect, disconnect, uninstall, and label listener management
- add GitHub label listener storage, contracts, API routes, and web rewrites with agent, prompt, and trigger mode configuration
- dispatch issue and pull request label webhooks to configured agents, supporting `created_by_me` and `anyone` trigger modes while leaving mention triggers disabled

## Tests
- `pnpm db:generate`
- `pnpm db:migrate`
- `pnpm format`
- `pnpm check-types`
- `pnpm turbo run lint`
- `pnpm vitest`
- `pnpm knip`