### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,12 +111,12 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.145"
+CLAUDE_CODE_VERSION="2.1.146"
 CODEX_CLI_VERSION="0.132.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.0"
-PNPM_VERSION="10.33.4"
+PNPM_VERSION="11.1.3"
 
 # ---------------------------------------------------------------------------
 # Dependency checks

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1732,6 +1732,32 @@ mod tests {
         ]
     }
 
+    fn shell_quoted_var<'a>(script: &'a str, name: &str) -> Option<&'a str> {
+        let prefix = format!("{name}=\"");
+        script.lines().find_map(|line| {
+            let value = line.strip_prefix(&prefix)?;
+            value.strip_suffix('"')
+        })
+    }
+
+    fn is_numeric_semver(version: &str) -> bool {
+        let mut parts = version.split('.');
+        let Some(major) = parts.next() else {
+            return false;
+        };
+        let Some(minor) = parts.next() else {
+            return false;
+        };
+        let Some(patch) = parts.next() else {
+            return false;
+        };
+
+        parts.next().is_none()
+            && [major, minor, patch]
+                .iter()
+                .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+    }
+
     fn rootfs_input<'a>(
         home: &'a HomePaths,
         rootfs: &'a RootfsPaths,
@@ -4032,9 +4058,12 @@ exit 1
 
     #[test]
     fn template_installs_and_verifies_pnpm() {
+        let pnpm_version = shell_quoted_var(TEMPLATE_BUILD_SCRIPT, "PNPM_VERSION")
+            .expect("build-template.sh should declare PNPM_VERSION");
         assert!(
-            TEMPLATE_BUILD_SCRIPT.contains("PNPM_VERSION=\"10.33.4\""),
-            "build-template.sh should pin the pnpm version so template cache inputs are deterministic"
+            is_numeric_semver(pnpm_version),
+            "build-template.sh should pin PNPM_VERSION to an exact numeric semver so template \
+             cache inputs are deterministic"
         );
         assert!(
             TEMPLATE_BUILD_SCRIPT.contains("pnpm@${PNPM_VERSION}"),

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1755,7 +1755,7 @@ mod tests {
         parts.next().is_none()
             && [major, minor, patch]
                 .iter()
-                .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+                .all(|part| matches!(part.parse::<u32>(), Ok(value) if *part == value.to_string()))
     }
 
     fn rootfs_input<'a>(


### PR DESCRIPTION
Updates pinned package versions in `crates/runner/scripts/build-template.sh`.

## Updated

| Package | Old | New |
|---|---|---|
| Claude Code CLI | 2.1.145 | 2.1.146 |
| pnpm | 10.33.4 | 11.1.3 |

## Checked and already current

- Go: 1.26.3
- @openai/codex: 0.132.0
- @googleworkspace/cli: 0.22.5
- @xdevplatform/xurl: 1.0.3
- agent-browser: 0.27.0