### PR TITLE
fix: prevent webhook log payload collisions

### DIFF
--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -19,6 +19,24 @@ from logging_utils import log_proxy_entry
 from .counters import _decrement_reports, _increment_reports
 
 
+def _log_webhook_entry(
+    proxy_log_path: str,
+    level: str,
+    message: str,
+    url: str,
+    log_type: str,
+    payload: dict,
+    attempt: int | None = None,
+    error: str | None = None,
+) -> None:
+    extra: dict = {"type": log_type, "url": url, "payload": payload}
+    if attempt is not None:
+        extra["attempt"] = attempt
+    if error is not None:
+        extra["error"] = error
+    log_proxy_entry(proxy_log_path, level, message, **extra)
+
+
 def _post_webhook(url: str, sandbox_token: str, payload: dict) -> None:
     """POST JSON payload to a platform webhook.  Raises on failure."""
     data = json.dumps(payload).encode()
@@ -68,39 +86,39 @@ def _do_post_webhook_attempts(
     for attempt in range(max_retries + 1):
         try:
             _post_webhook(url, sandbox_token, payload)
-            log_proxy_entry(
+            _log_webhook_entry(
                 proxy_log_path,
                 "info",
                 f"Webhook POST to {url} succeeded",
-                type=log_type,
-                url=url,
+                url,
+                log_type,
+                payload,
                 attempt=attempt + 1,
-                **payload,
             )
             return
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             if attempt < max_retries:
-                log_proxy_entry(
+                _log_webhook_entry(
                     proxy_log_path,
                     "warn",
                     f"Webhook POST to {url} attempt {attempt + 1} failed, retrying: {exc}",
-                    type=log_type,
-                    url=url,
-                    error=str(exc),
+                    url,
+                    log_type,
+                    payload,
                     attempt=attempt + 1,
-                    **payload,
+                    error=str(exc),
                 )
                 time.sleep(0.5)
             else:
-                log_proxy_entry(
+                _log_webhook_entry(
                     proxy_log_path,
                     "error",
                     f"Webhook POST to {url} failed after {attempt + 1} attempts, giving up: {exc}",
-                    type=log_type,
-                    url=url,
-                    error=str(exc),
+                    url,
+                    log_type,
+                    payload,
                     attempt=attempt + 1,
-                    **payload,
+                    error=str(exc),
                 )
         except Exception as exc:
             # Catch-all by design: non-retryable failures (TypeError on
@@ -109,15 +127,15 @@ def _do_post_webhook_attempts(
             # being re-raised into ``ThreadPoolExecutor``'s Future, which
             # would otherwise swallow them silently.  Tightening to
             # specific types would regress this debuggability.
-            log_proxy_entry(
+            _log_webhook_entry(
                 proxy_log_path,
                 "error",
                 f"Webhook POST to {url} failed with non-retryable error: {exc}",
-                type=log_type,
-                url=url,
-                error=str(exc),
+                url,
+                log_type,
+                payload,
                 attempt=attempt + 1,
-                **payload,
+                error=str(exc),
             )
             raise
 
@@ -138,13 +156,13 @@ def _enqueue_webhook(
     falls back to synchronous delivery so the report is not silently lost.
     """
     copied = copy.deepcopy(payload)
-    log_proxy_entry(
+    _log_webhook_entry(
         proxy_log_path,
         "info",
         f"Webhook POST to {url} enqueued",
-        type=log_type,
-        url=url,
-        **copied,
+        url,
+        log_type,
+        copied,
     )
     _increment_reports()
     try:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -5333,6 +5333,26 @@ class TestUsageWebhookDelivery:
         assert "giving up" not in log_text
         assert "non-retryable" in log_text
 
+    def test_programming_error_with_payload_collision_preserves_original_error(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        with patch.object(usage.webhook, "_opener") as mock_opener:
+            mock_opener.open.side_effect = TypeError("boom")
+            with pytest.raises(TypeError, match="boom"):
+                usage.webhook._do_post_webhook_attempts(
+                    "https://api.vm0.ai/x",
+                    "tok",
+                    {"url": "payload-url", "runId": "run-1", "events": []},
+                    str(proxy_log),
+                    "usage",
+                    max_retries=1,
+                )
+            assert mock_opener.open.call_count == 1  # urllib external boundary (#9991)
+
+        entry = json.loads(proxy_log.read_text())
+        assert entry["url"] == "https://api.vm0.ai/x"
+        assert entry["payload"]["url"] == "payload-url"
+        assert "non-retryable" in entry["message"]
+
     def test_falls_back_to_sync_after_shutdown(self, tmp_path, real_flow, fresh_usage_executor):
         """After executor shutdown, delivery happens synchronously before return."""
         flow = self._model_flow(real_flow, tmp_path)
@@ -5701,6 +5721,38 @@ class TestUsagePendingCounter:
             }
         finally:
             usage.counters._decrement_reports()
+
+    def test_enqueue_logs_payload_collisions_under_payload(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        payload = {
+            "url": "payload-url",
+            "type": "payload-type",
+            "attempt": 99,
+            "error": "payload-error",
+            "runId": "run-1",
+            "events": [],
+        }
+
+        try:
+            with patch.object(usage.webhook.usage_executor, "submit") as mock_submit:
+                usage.webhook._enqueue_webhook(
+                    "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                    "tok",
+                    payload,
+                    str(proxy_log),
+                    "usage_event",
+                )
+            mock_submit.assert_called_once()
+        finally:
+            usage.counters._decrement_reports()
+
+        entry = json.loads(proxy_log.read_text())
+        assert entry["url"] == "https://api.vm0.ai/api/webhooks/agent/usage-event"
+        assert entry["type"] == "usage_event"
+        assert entry["payload"]["url"] == "payload-url"
+        assert entry["payload"]["type"] == "payload-type"
+        assert entry["payload"]["attempt"] == 99
+        assert entry["payload"]["error"] == "payload-error"
 
     def test_submit_failure_rolls_back_pending_report(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -5278,6 +5278,30 @@ class TestUsageWebhookDelivery:
 
         assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
 
+    def test_retry_with_payload_collision_logs_nested_payload(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        with (
+            patch.object(usage.webhook, "_opener") as mock_opener,
+            patch.object(usage.webhook.time, "sleep") as mock_sleep,
+        ):
+            mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
+            usage.webhook._do_post_webhook_attempts(
+                "https://api.vm0.ai/x",
+                "tok",
+                {"url": "payload-url", "type": "payload-type", "runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage",
+                max_retries=1,
+            )
+
+        mock_sleep.assert_called_once_with(0.5)  # syscall boundary; pins retry backoff (#9991)
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert [entry["level"] for entry in entries] == ["warn", "info"]
+        assert [entry["attempt"] for entry in entries] == [1, 2]
+        assert all(entry["url"] == "https://api.vm0.ai/x" for entry in entries)
+        assert all(entry["payload"]["url"] == "payload-url" for entry in entries)
+        assert all(entry["payload"]["type"] == "payload-type" for entry in entries)
+
     def test_gives_up_after_retry_budget(self, tmp_path, real_flow, fresh_usage_executor):
         """Default max_retries=1 → 2 total attempts before giving up."""
         flow = self._model_flow(real_flow, tmp_path)
@@ -5295,6 +5319,26 @@ class TestUsageWebhookDelivery:
         assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
         assert proxy_log.exists()
         assert "2 attempts" in proxy_log.read_text()
+
+    def test_give_up_with_payload_collision_logs_nested_payload(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        with patch.object(usage.webhook, "_opener") as mock_opener:
+            mock_opener.open.side_effect = ConnectionError("fail")
+            usage.webhook._do_post_webhook_attempts(
+                "https://api.vm0.ai/x",
+                "tok",
+                {"error": "payload-error", "attempt": 99, "runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage",
+                max_retries=0,
+            )
+
+        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert entry["level"] == "error"
+        assert entry["attempt"] == 1
+        assert entry["error"] == "fail"
+        assert entry["payload"]["error"] == "payload-error"
+        assert entry["payload"]["attempt"] == 99
 
     def test_sleeps_between_retries(self, tmp_path, real_flow, fresh_usage_executor):
         flow = self._model_flow(real_flow, tmp_path)


### PR DESCRIPTION
## Summary

- Add a webhook-specific diagnostic log helper that nests the delivered payload under `payload` instead of spreading it into log kwargs.
- Update webhook success, retry, give-up, non-retryable, and enqueue logs to use the helper.
- Add regression tests for payload key collisions and non-retryable error masking.

## Tests

- `python3 -m pytest tests/test_handlers.py -k "payload_collision or payload_collisions"`
- `python3 -m pytest tests/test_handlers.py -k "UsageWebhookDelivery or enqueue"`
- `python3 -m pytest tests/`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`

Closes #14369