### PR TITLE
fix(mitm-addon): expose firewall block reasons

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -3,7 +3,7 @@
 Pure functions with no module-level state or I/O.
 """
 
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 from urllib.parse import urlsplit
 
 _SEGMENT_ERROR_HINT = 'use "{name}", "prefix{name}", "{name}suffix", or "prefix{name}suffix"'
@@ -69,6 +69,7 @@ class _CompiledApi(NamedTuple):
     raw_api_entry: dict
     base: _CompiledBase
     permissions: tuple[_CompiledPermission, ...]
+    # True when API compilation encountered malformed permissions/rules config.
     has_malformed_rules: bool
 
 
@@ -737,14 +738,22 @@ class FirewallAllow(NamedTuple):
     match_info: dict
 
 
+FirewallBlockReason = Literal[
+    "permission_denied",
+    "unknown_endpoint",
+    "malformed_firewall_config",
+]
+
+
 class FirewallBlock(NamedTuple):
-    """Base URL matched but no permission granted — return 403."""
+    """Base URL matched but the request should return 403."""
 
     base: str
     name: str
     method: str
     path: str
-    permissions: tuple[str, ...]  # denied permission names; empty for unknown-endpoint blocks
+    permissions: tuple[str, ...]  # denied/asked permission names only
+    reason: FirewallBlockReason
 
 
 def _build_block_set(
@@ -786,7 +795,14 @@ def match_compiled_firewall_request(
     compiled_firewalls: CompiledFirewallSet | None,
     network_policies: dict | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
-    """Match request against precompiled firewall permissions."""
+    """Match request against production precompiled firewall permissions.
+
+    Returns:
+      FirewallAllow — granted permission matched or unknown endpoint allowed
+      FirewallBlock — permission denied, unknown endpoint blocked, or matched
+        malformed firewall config failed closed
+      None — no base URL match (not a firewall request)
+    """
     if not compiled_firewalls:
         return None
 
@@ -864,9 +880,13 @@ def match_compiled_firewall_request(
 
     if blocked_base is not None:
         if denied_match is not None:
-            return FirewallBlock(*denied_match, tuple(denied_perm_names))
+            return FirewallBlock(
+                *denied_match,
+                tuple(denied_perm_names),
+                "permission_denied",
+            )
         if malformed_match is not None:
-            return FirewallBlock(*malformed_match, ())
+            return FirewallBlock(*malformed_match, (), "malformed_firewall_config")
         if _get_unknown_policy(blocked_name, network_policies) == "allow":
             return FirewallAllow(
                 first_matched_api_entry,
@@ -878,7 +898,14 @@ def match_compiled_firewall_request(
                     "rel_path": blocked_rel_path,
                 },
             )
-        return FirewallBlock(blocked_base, blocked_name, upper_method, blocked_rel_path, ())
+        return FirewallBlock(
+            blocked_base,
+            blocked_name,
+            upper_method,
+            blocked_rel_path,
+            (),
+            "unknown_endpoint",
+        )
     return None
 
 
@@ -889,6 +916,10 @@ def match_firewall_request(
     network_policies: dict | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
     """Match request against firewall permissions with three-level matching.
+
+    The compiled matcher is the production-authoritative path. This legacy
+    matcher is kept for direct raw-config comparisons and does not fail closed
+    on malformed compiled config.
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
@@ -983,7 +1014,11 @@ def match_firewall_request(
     if blocked_base is not None:
         # A non-granted permission matched — DENY takes priority over unknown.
         if denied_match is not None:
-            return FirewallBlock(*denied_match, tuple(denied_perm_names))
+            return FirewallBlock(
+                *denied_match,
+                tuple(denied_perm_names),
+                "permission_denied",
+            )
         # No permission rule matched — this is an "unknown" endpoint.
         # "ask" is treated as "deny" at the proxy level (same as ask permissions).
         if _get_unknown_policy(blocked_name, network_policies) == "allow":
@@ -997,5 +1032,12 @@ def match_firewall_request(
                     "rel_path": blocked_rel_path,
                 },
             )
-        return FirewallBlock(blocked_base, blocked_name, upper_method, blocked_rel_path, ())
+        return FirewallBlock(
+            blocked_base,
+            blocked_name,
+            upper_method,
+            blocked_rel_path,
+            (),
+            "unknown_endpoint",
+        )
     return None

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -216,6 +216,7 @@ async def request(flow: http.HTTPFlow) -> None:
                     f"{result.name}: no matching permission for {result.method} {result.path}",
                     type="firewall_block",
                     name=result.name,
+                    reason=result.reason,
                 )
                 flow.metadata["firewall_action"] = "DENY"
                 flow.metadata["firewall_base"] = result.base
@@ -228,6 +229,7 @@ async def request(flow: http.HTTPFlow) -> None:
                         "path": result.path,
                         "name": result.name,
                         "permissions": list(result.permissions),
+                        "reason": result.reason,
                         "base": result.base,
                     }
                 )

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -153,6 +153,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "unknown_endpoint"
         assert result.base == "https://api.github.com"
         assert result.name == "github"
         assert result.method == "GET"
@@ -3027,6 +3028,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "permission_denied"
 
     def test_denied_permission_blocked_with_case_mixed_static_host(self):
         policies = {
@@ -3040,6 +3042,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read",)
+        assert result.reason == "permission_denied"
 
     def test_uncategorized_permission_allowed(self):
         """Permission not in allow/deny/ask defaults to allowed."""
@@ -3065,6 +3068,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "permission_denied"
 
     def test_deny_and_ask_union(self):
         """Permissions in deny and ask are both blocked."""
@@ -3084,6 +3088,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "permission_denied"
         # repo-write in ask → blocked
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
@@ -3092,6 +3097,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "permission_denied"
 
     def test_unknown_policy_key_missing_defaults_to_allow(self):
         """Ref present but unknownPolicy key absent → defaults to allow."""
@@ -3117,6 +3123,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "permission_denied"
 
     def test_unknown_endpoint_allowed_when_unknown_policy_allow(self):
         policies = {
@@ -3143,6 +3150,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "unknown_endpoint"
 
     def test_unknown_endpoint_blocked_when_unknown_policy_ask(self):
         """unknownPolicy 'ask' is treated as deny at the proxy level."""
@@ -3156,6 +3164,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "unknown_endpoint"
 
     def test_name_absent_allows(self):
         """Name not in networkPolicies → fully permissive."""
@@ -3275,6 +3284,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read", "repo-admin")
+        assert result.reason == "permission_denied"
 
     def test_multi_firewall_different_names(self, headers):
         """Two firewalls with different names, each with own policies."""
@@ -3326,6 +3336,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "permission_denied"
 
         # Slack: unknown endpoint → ALLOW (unknownPolicy: allow)
         result = matching.match_firewall_request(
@@ -3362,6 +3373,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.reason == "unknown_endpoint"
 
         # Slack unknown → ALLOW (unknownPolicy: allow)
         result = matching.match_firewall_request(
@@ -3396,6 +3408,7 @@ class TestThreeLevelMatching:
         # repo-write explicitly denied → DENY, not overridden by unknownPolicy
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-write",)
+        assert result.reason == "permission_denied"
 
     def test_denied_permission_deduped_across_rules(self, headers):
         """Same permission with multiple matching rules appears once in permissions."""
@@ -3426,6 +3439,7 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read",)
+        assert result.reason == "permission_denied"
 
     def test_empty_permissions_list_denies_all_known(self, headers):
         """All permissions in deny list — all known endpoints denied."""
@@ -3734,6 +3748,7 @@ class TestCompiledFirewallMatching:
         )
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, FirewallBlock)
+        assert compiled.reason == "unknown_endpoint"
 
     def test_matches_raw_for_ask_permission_block(self):
         fws = _wrap_firewalls(
@@ -3769,6 +3784,7 @@ class TestCompiledFirewallMatching:
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, FirewallBlock)
         assert compiled.permissions == ("repo-read",)
+        assert compiled.reason == "permission_denied"
 
     def test_later_allowed_firewall_wins_after_earlier_unknown_match(self):
         fws = [
@@ -3917,6 +3933,7 @@ class TestCompiledFirewallMatching:
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, FirewallBlock)
         assert compiled.permissions == ("repo-read", "repo-admin")
+        assert compiled.reason == "permission_denied"
 
     def test_malformed_rule_fails_closed_without_allowing_permission(self):
         fws = _wrap_firewalls(
@@ -3942,6 +3959,7 @@ class TestCompiledFirewallMatching:
 
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ()
+        assert result.reason == "malformed_firewall_config"
 
     def test_malformed_rule_blocks_unknown_policy_allow(self):
         fws = _wrap_firewalls(
@@ -3967,6 +3985,40 @@ class TestCompiledFirewallMatching:
 
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ()
+        assert result.reason == "malformed_firewall_config"
+
+    def test_denied_match_takes_priority_over_malformed_config_reason(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "bad", "rules": ["GET /repos/{a}literal{b}"]},
+                        {"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {
+            "github": {
+                "allow": [],
+                "deny": ["repo-read"],
+                "unknownPolicy": "allow",
+            }
+        }
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, FirewallBlock)
+        assert result.permissions == ("repo-read",)
+        assert result.reason == "permission_denied"
 
     def test_valid_later_permission_can_still_allow_after_malformed_rule(self):
         fws = _wrap_firewalls(
@@ -4024,6 +4076,7 @@ class TestCompiledFirewallMatching:
 
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ()
+        assert result.reason == "malformed_firewall_config"
 
     def test_malformed_api_list_shape_is_skipped_without_compile_error(self):
         assert matching.compile_firewalls([{"name": "github", "apis": None}]) is None

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -301,6 +301,7 @@ class TestRequestHandler:
                     "billableFirewalls": [],
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
                     "firewalls": [
                         {
                             "name": "github",
@@ -356,7 +357,147 @@ class TestRequestHandler:
         assert body["path"] == "/orgs"
         assert body["name"] == "github"
         assert body["permissions"] == []
+        assert body["reason"] == "unknown_endpoint"
         assert body["base"] == "https://api.github.com"
+        proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        assert proxy_log_entry["type"] == "firewall_block"
+        assert proxy_log_entry["name"] == "github"
+        assert proxy_log_entry["reason"] == "unknown_endpoint"
+
+    async def test_firewall_malformed_config_block_reports_reason(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        """Malformed firewall config blocks fail closed with an explicit reason."""
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-conn-1",
+                    "billableFirewalls": [],
+                    "sandboxToken": "tok-conn",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {
+                                        "headers": {
+                                            "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                                        }
+                                    },
+                                    "permissions": [
+                                        {
+                                            "name": "read-repos",
+                                            "rules": ["GET /repos/{a}literal{b}"],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "github": {
+                            "allow": ["read-repos"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "allow",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos/org/repo",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "permission_denied"
+        assert body["permissions"] == []
+        assert body["reason"] == "malformed_firewall_config"
+        proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        assert proxy_log_entry["type"] == "firewall_block"
+        assert proxy_log_entry["reason"] == "malformed_firewall_config"
+
+    async def test_firewall_permission_denied_block_reports_reason(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        """Denied permission blocks include the explicit runtime reason."""
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-conn-1",
+                    "billableFirewalls": [],
+                    "sandboxToken": "tok-conn",
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                    "firewalls": [
+                        {
+                            "name": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {
+                                        "headers": {
+                                            "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                                        }
+                                    },
+                                    "permissions": [
+                                        {
+                                            "name": "read-repos",
+                                            "rules": ["GET /repos/{owner}/{repo}"],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "networkPolicies": {
+                        "github": {
+                            "allow": [],
+                            "deny": ["read-repos"],
+                            "ask": [],
+                            "unknownPolicy": "allow",
+                        },
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos/org/repo",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["permissions"] == ["read-repos"]
+        assert body["reason"] == "permission_denied"
+        proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        assert proxy_log_entry["type"] == "firewall_block"
+        assert proxy_log_entry["reason"] == "permission_denied"
 
     async def test_firewall_permission_allows_matched(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers


### PR DESCRIPTION
## Summary

- add an explicit `FirewallBlock.reason` for permission-denied, unknown-endpoint, and malformed-firewall-config blocks
- expose the reason in firewall block proxy logs and 403 JSON responses while keeping `error: "permission_denied"` unchanged
- document the compiled matcher contract and cover the new reason semantics in matcher and request-handler tests

## Tests

- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /tmp/vm0-mitm-addon-deps/bin/ruff check src/matching.py src/mitm_addon.py tests/test_connectors.py tests/test_handlers.py tests/test_registry.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /usr/bin/python3 -m pytest tests/test_connectors.py tests/test_handlers.py tests/test_registry.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /usr/bin/python3 -m pytest -q`
- `git diff --check`

Closes #14366
