### PR TITLE
chore(rust): update dependencies (2026-05-21)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.132.0"
+version = "1.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
+checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -563,13 +563,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1024,9 +1025,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -1176,9 +1177,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh for the `crates/` workspace. Ran `cargo update --verbose` against `crates/Cargo.toml`; only `Cargo.lock` changed.

### Updated dependencies

| Package | From | To |
|---|---|---|
| aws-runtime | 1.7.3 | 1.7.4 |
| aws-sdk-s3 | 1.132.0 | 1.133.0 |
| aws-sigv4 | 1.4.3 | 1.4.4 |
| aws-types | 1.3.15 | 1.3.16 |
| either | 1.15.0 | 1.16.0 |
| futures-timer | 3.0.3 | 3.0.4 |

### Dependencies that could not be updated

- **generic-array 0.14.7 → 0.14.9** — blocked by a transitive `=0.14.7` exact-version pin in `crypto-common 0.1.7` (reached via `digest 0.10.7` → `sha1`, `block-buffer`, `crc-fast 1.10.0` → `aws-smithy-checksums 0.64.8` → `aws-sdk-s3`, plus `tokio-tungstenite 0.29.0` → `tungstenite 0.29.0`). Not solvable from our workspace; will resolve when `crypto-common` ships a new release or when `aws-smithy-checksums` / `tungstenite` upgrade to a `digest` line that allows newer `generic-array`. No action needed.

### Manual version bumps

None. All `crates/Cargo.toml` workspace dependency specifiers already use major-only constraints (e.g. `aws-sdk-s3 = "1"`, `tokio = "1"`), so every available minor/patch flowed through `cargo update` without requiring `Cargo.toml` edits. Per task policy, no major-version bumps were attempted in this PR.

### Test status

`cargo test --workspace` — **all passing**, no failures introduced by the update.

- Built with `CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_TEST_STRIP=symbols cargo test --workspace --jobs 2` to fit the sandbox disk budget; this changes test binary layout only, not the workspace `Cargo.toml`.
- Full unit + integration + doc test suite across all 21 workspace crates: 0 failures.

## Test plan

- [x] `cargo build --workspace` succeeds against the updated lockfile
- [x] `cargo test --workspace` — 0 failures
- [ ] CI (merge queue) green before queueing