### PR TITLE
fix: show runner stdout stream loss in system log

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -15,9 +15,9 @@
 //! user-visible completion signal is not blocked on best-effort uploads.
 
 use std::collections::HashMap;
-use std::io;
+use std::io::{self, SeekFrom};
 use std::panic::AssertUnwindSafe;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -30,6 +30,7 @@ use sandbox::{
     ProcessControlMode, ProcessOutputMode, ProcessOutputReceiver, Sandbox, SandboxConfig,
     SandboxFactory, SandboxId, StartProcessRequest,
 };
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -45,6 +46,10 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
 const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const STDOUT_STREAM_LIMIT_MARKER: &[u8] =
+    b"[vm0] stdout stream reached the guest stream limit; later output was omitted\n";
+const STDOUT_STREAM_OVERFLOW_MARKER: &[u8] =
+    b"[vm0] stdout stream overflowed the host queue; some output was dropped\n";
 const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
@@ -148,13 +153,29 @@ impl ExecutionFailure {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct AgentStdoutStreamDiagnostics {
+    chunk_truncated: bool,
+    stream_overflowed: bool,
+}
+
+impl AgentStdoutStreamDiagnostics {
+    fn is_empty(self) -> bool {
+        !self.chunk_truncated && !self.stream_overflowed
+    }
+}
+
 struct AgentExecutionResult {
     failure: Option<ExecutionFailure>,
+    stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
 }
 
 impl AgentExecutionResult {
     fn success() -> Self {
-        Self { failure: None }
+        Self {
+            failure: None,
+            stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
+        }
     }
 
     fn failure(
@@ -164,6 +185,7 @@ impl AgentExecutionResult {
     ) -> Self {
         Self {
             failure: Some(ExecutionFailure::new(exit_code, error, diagnostic)),
+            stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
         }
     }
 
@@ -173,6 +195,11 @@ impl AgentExecutionResult {
 
     fn exit_code(&self) -> i32 {
         self.failure.as_ref().map_or(0, |failure| failure.exit_code)
+    }
+
+    fn with_stdout_stream_diagnostics(mut self, diagnostics: AgentStdoutStreamDiagnostics) -> Self {
+        self.stdout_stream_diagnostics = diagnostics;
+        self
     }
 }
 
@@ -411,6 +438,11 @@ async fn execute_new_sandbox(
     )
     .await;
 
+    let stdout_stream_diagnostics = result.as_ref().map_or_else(
+        |_| AgentStdoutStreamDiagnostics::default(),
+        |result| result.stdout_stream_diagnostics,
+    );
+
     // Post-job: copy logs + unregister proxy registry (sandbox stays alive for possible reuse)
     post_job_cleanup(
         sandbox.as_ref(),
@@ -418,6 +450,7 @@ async fn execute_new_sandbox(
         context,
         &source_ip,
         cancel.is_cancelled(),
+        stdout_stream_diagnostics,
     )
     .await;
 
@@ -493,6 +526,11 @@ async fn execute_reused_sandbox(
     )
     .await;
 
+    let stdout_stream_diagnostics = result.as_ref().map_or_else(
+        |_| AgentStdoutStreamDiagnostics::default(),
+        |result| result.stdout_stream_diagnostics,
+    );
+
     // Post-job cleanup (copy logs to host, unregister proxy registry)
     post_job_cleanup(
         sandbox.as_ref(),
@@ -500,6 +538,7 @@ async fn execute_reused_sandbox(
         context,
         source_ip,
         cancel.is_cancelled(),
+        stdout_stream_diagnostics,
     )
     .await;
 
@@ -586,8 +625,15 @@ async fn post_job_cleanup(
     context: &ExecutionContext,
     source_ip: &str,
     cancelled: bool,
+    stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
 ) {
     copy_guest_logs(sandbox, context, &config.log_paths, cancelled).await;
+    append_stdout_stream_diagnostics_to_system_log(
+        context.run_id,
+        &config.log_paths.system_log(context.run_id),
+        stdout_stream_diagnostics,
+    )
+    .await;
     unregister_proxy_registry(config, context, source_ip).await;
 }
 
@@ -737,13 +783,16 @@ async fn run_in_sandbox(
     // Wait for streaming to finish (channel closes when process exits).
     // On cancel/timeout/crash the stream channel may not close — abort to
     // prevent blocking indefinitely on the drain task.
+    let mut stdout_drain_report = StdoutDrainReport::default();
     if let Some(task) = stream_task {
         if cancel.is_cancelled() || result.is_err() {
             task.abort();
             let _ = task.await;
         } else {
             match task.await {
-                Ok(Ok(())) => {}
+                Ok(Ok(report)) => {
+                    stdout_drain_report = report;
+                }
                 Ok(Err(e)) => {
                     warn!(run_id = %context.run_id, error = %e, "stdout stream task failed");
                 }
@@ -776,6 +825,10 @@ async fn run_in_sandbox(
     if exit.stream_overflowed {
         warn!(run_id = %context.run_id, "agent stdout stream overflowed before process exit");
     }
+    let stdout_stream_diagnostics = AgentStdoutStreamDiagnostics {
+        chunk_truncated: stdout_drain_report.chunk_truncated,
+        stream_overflowed: exit.stream_overflowed,
+    };
     if !exit.diagnostic.is_empty() {
         warn!(
             run_id = %context.run_id,
@@ -810,7 +863,8 @@ async fn run_in_sandbox(
                 // so callers see a clear error rather than an opaque signal code.
                 let error = "Agent process killed by OOM killer";
                 telemetry.record("agent_execute", t.elapsed(), false, Some(error));
-                return Ok(AgentExecutionResult::failure(1, error, None));
+                return Ok(AgentExecutionResult::failure(1, error, None)
+                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics));
             }
             Err(e) => {
                 warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
@@ -847,8 +901,10 @@ async fn run_in_sandbox(
     let agent_result = match failure {
         Some(failure) => AgentExecutionResult {
             failure: Some(failure),
+            stdout_stream_diagnostics,
         },
-        None => AgentExecutionResult::success(),
+        None => AgentExecutionResult::success()
+            .with_stdout_stream_diagnostics(stdout_stream_diagnostics),
     };
     telemetry.record(
         "agent_execute",
@@ -1011,11 +1067,16 @@ enum StdoutDrainError {
     Flush { path: PathBuf, source: io::Error },
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct StdoutDrainReport {
+    chunk_truncated: bool,
+}
+
 /// Drain stdout chunks from the process receiver and write them to a host file.
 async fn drain_stdout_to_file(
     mut rx: ProcessOutputReceiver,
     path: PathBuf,
-) -> Result<(), StdoutDrainError> {
+) -> Result<StdoutDrainReport, StdoutDrainError> {
     let file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -1027,21 +1088,74 @@ async fn drain_stdout_to_file(
             return Err(StdoutDrainError::Open { path, source: e });
         }
     };
+    let mut report = StdoutDrainReport::default();
     while let Some(chunk) = rx.recv().await {
         if chunk.truncated {
+            report.chunk_truncated = true;
             warn!(path = %path.display(), "stdout stream chunk was truncated before host log write");
         }
-        if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &chunk.bytes).await {
+        if let Err(e) = file.write_all(&chunk.bytes).await {
             return Err(StdoutDrainError::Write { path, source: e });
         }
     }
     // Flush to ensure the last blocking write completes before we return.
     // tokio::fs::File::poll_write returns Ready before the blocking write finishes,
     // so without flush the caller may observe incomplete file contents.
-    if let Err(e) = tokio::io::AsyncWriteExt::flush(&mut file).await {
+    if let Err(e) = file.flush().await {
         return Err(StdoutDrainError::Flush { path, source: e });
     }
-    Ok(())
+    Ok(report)
+}
+
+async fn append_stdout_stream_diagnostics_to_system_log(
+    run_id: RunId,
+    path: &Path,
+    diagnostics: AgentStdoutStreamDiagnostics,
+) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    if let Err(e) = append_stdout_stream_diagnostics(path, diagnostics).await {
+        warn!(
+            run_id = %run_id,
+            path = %path.display(),
+            error = %e,
+            "failed to append stdout stream diagnostic marker to host system log"
+        );
+    }
+}
+
+async fn append_stdout_stream_diagnostics(
+    path: &Path,
+    diagnostics: AgentStdoutStreamDiagnostics,
+) -> io::Result<()> {
+    if diagnostics.is_empty() {
+        return Ok(());
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .read(true)
+        .open(path)
+        .await?;
+
+    if file.metadata().await?.len() > 0 {
+        file.seek(SeekFrom::End(-1)).await?;
+        let mut last = [0u8; 1];
+        file.read_exact(&mut last).await?;
+        if last[0] != b'\n' {
+            file.write_all(b"\n").await?;
+        }
+    }
+    if diagnostics.chunk_truncated {
+        file.write_all(STDOUT_STREAM_LIMIT_MARKER).await?;
+    }
+    if diagnostics.stream_overflowed {
+        file.write_all(STDOUT_STREAM_OVERFLOW_MARKER).await?;
+    }
+    file.flush().await
 }
 
 /// Guest log file path prefixes. Each turn creates files named
@@ -2705,8 +2819,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use sandbox::{
-        ExecResult, ProcessOutputChunk, SandboxError, SandboxInitializationPhase, SandboxOperation,
-        SandboxOperationReason,
+        ExecResult, ProcessExit, ProcessOutputChunk, SandboxError, SandboxInitializationPhase,
+        SandboxOperation, SandboxOperationReason,
     };
     use sandbox_mock::MockSandbox;
 
@@ -3255,6 +3369,39 @@ mod tests {
         assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
     }
 
+    #[tokio::test]
+    async fn post_job_cleanup_appends_stream_markers_after_guest_log_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let sandbox = MockSandbox::new("test");
+        let ctx = minimal_context();
+        let system_log_path = config.log_paths.system_log(ctx.run_id);
+
+        tokio::fs::write(&system_log_path, b"transient host-streamed stdout\n")
+            .await
+            .unwrap();
+        sandbox.push_copy_file_result(Ok(b"guest system log".to_vec()));
+
+        post_job_cleanup(
+            &sandbox,
+            &config,
+            &ctx,
+            "10.0.0.1",
+            false,
+            AgentStdoutStreamDiagnostics {
+                chunk_truncated: true,
+                stream_overflowed: true,
+            },
+        )
+        .await;
+
+        let system_log = tokio::fs::read(&system_log_path).await.unwrap();
+        let mut expected = b"guest system log\n".to_vec();
+        expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
+        expected.extend_from_slice(STDOUT_STREAM_OVERFLOW_MARKER);
+        assert_eq!(system_log, expected);
+    }
+
     // -----------------------------------------------------------------------
     // drain_stdout_to_file tests
     // -----------------------------------------------------------------------
@@ -3279,10 +3426,32 @@ mod tests {
         .unwrap();
         drop(tx); // close channel
 
-        drain_stdout_to_file(rx, path.clone()).await.unwrap();
+        let report = drain_stdout_to_file(rx, path.clone()).await.unwrap();
 
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(content, "chunk 1\nchunk 2\n");
+        assert!(!report.chunk_truncated);
+    }
+
+    #[tokio::test]
+    async fn drain_stdout_reports_truncated_chunk_without_changing_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout.log");
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        tx.send(ProcessOutputChunk {
+            bytes: b"partial chunk".to_vec(),
+            truncated: true,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        let report = drain_stdout_to_file(rx, path.clone()).await.unwrap();
+
+        let content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(content, b"partial chunk");
+        assert!(report.chunk_truncated);
     }
 
     #[tokio::test]
@@ -3293,10 +3462,11 @@ mod tests {
         let (_tx, rx) = tokio::sync::mpsc::channel::<ProcessOutputChunk>(1);
         drop(_tx);
 
-        drain_stdout_to_file(rx, path.clone()).await.unwrap();
+        let report = drain_stdout_to_file(rx, path.clone()).await.unwrap();
 
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(content.is_empty());
+        assert!(!report.chunk_truncated);
     }
 
     #[tokio::test]
@@ -3307,6 +3477,43 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(error, StdoutDrainError::Open { .. }));
+    }
+
+    #[tokio::test]
+    async fn append_stdout_stream_diagnostics_noops_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout.log");
+
+        append_stdout_stream_diagnostics(&path, AgentStdoutStreamDiagnostics::default())
+            .await
+            .unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn append_stdout_stream_diagnostics_writes_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout.log");
+        tokio::fs::write(&path, b"guest system log without newline")
+            .await
+            .unwrap();
+
+        append_stdout_stream_diagnostics(
+            &path,
+            AgentStdoutStreamDiagnostics {
+                chunk_truncated: true,
+                stream_overflowed: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let content = tokio::fs::read(&path).await.unwrap();
+        let mut expected = b"guest system log without newline\n".to_vec();
+        expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
+        expected.extend_from_slice(STDOUT_STREAM_OVERFLOW_MARKER);
+        assert_eq!(content, expected);
     }
 
     // -----------------------------------------------------------------------
@@ -3479,6 +3686,53 @@ mod tests {
                 .unwrap();
         assert_eq!(exit_code, 0);
         assert!(error_msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_inner_appends_stream_overflow_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let mut exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+        exit.stream_overflowed = true;
+        overrides.push_wait_process_exit(exit);
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+        let ctx = minimal_context();
+        let system_log_path = config.log_paths.system_log(ctx.run_id);
+
+        let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+            .await
+            .unwrap();
+
+        assert_eq!(exit_code, 0);
+        assert!(error_msg.is_none());
+        let system_log = tokio::fs::read(&system_log_path).await.unwrap();
+        assert_eq!(system_log, STDOUT_STREAM_OVERFLOW_MARKER);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_appends_stream_limit_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_process_stdout_chunks(vec![ProcessOutputChunk {
+            bytes: b"partial stdout".to_vec(),
+            truncated: true,
+        }]);
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+        let ctx = minimal_context();
+        let system_log_path = config.log_paths.system_log(ctx.run_id);
+
+        let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+            .await
+            .unwrap();
+
+        assert_eq!(exit_code, 0);
+        assert!(error_msg.is_none());
+        let system_log = tokio::fs::read(&system_log_path).await.unwrap();
+        let mut expected = b"partial stdout\n".to_vec();
+        expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
+        assert_eq!(system_log, expected);
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -772,11 +772,11 @@ async fn run_in_sandbox(
     // 6. Wait for exit (or cancellation).
     // On cancel we return immediately — the caller (execute_new_sandbox) will
     // call sandbox.stop() + factory.destroy() in its cleanup path.
-    let result = tokio::select! {
-        result = sandbox.wait_process(handle, JOB_TIMEOUT) => result,
+    let (result, wait_cancelled) = tokio::select! {
+        result = sandbox.wait_process(handle, JOB_TIMEOUT) => (result, false),
         () = cancel.cancelled() => {
             info!(run_id = %context.run_id, "cancel received, aborting sandbox wait");
-            Ok(sandbox::ProcessExit::new(0, EXIT_SIGKILL, Vec::new(), Vec::new()))
+            (Ok(sandbox::ProcessExit::new(0, EXIT_SIGKILL, Vec::new(), Vec::new())), true)
         }
     };
 
@@ -785,7 +785,7 @@ async fn run_in_sandbox(
     // prevent blocking indefinitely on the drain task.
     let mut stdout_drain_report = StdoutDrainReport::default();
     if let Some(task) = stream_task {
-        if cancel.is_cancelled() || result.is_err() {
+        if wait_cancelled || result.is_err() {
             task.abort();
             let _ = task.await;
         } else {
@@ -846,9 +846,7 @@ async fn run_in_sandbox(
     // Check for OOM kill when process was terminated by SIGKILL.
     // Skip when cancelled — the SIGKILL exit code is synthetic and dmesg
     // would run against a sandbox that hasn't been stopped yet.
-    if !cancel.is_cancelled()
-        && (exit.exit_code == EXIT_SIGKILL || exit.exit_code == EXIT_SIGNAL_KILL)
-    {
+    if !wait_cancelled && (exit.exit_code == EXIT_SIGKILL || exit.exit_code == EXIT_SIGNAL_KILL) {
         let dmesg_req = ExecRequest {
             cmd: "dmesg | tail -20 2>/dev/null",
             timeout: Duration::from_secs(5),
@@ -873,7 +871,7 @@ async fn run_in_sandbox(
         }
     }
 
-    let failure = if cancel.is_cancelled() {
+    let failure = if wait_cancelled {
         // Skip guest file reads — sandbox hasn't been stopped yet.
         Some(ExecutionFailure::cancelled())
     } else if exit.exit_code != 0 {
@@ -3650,6 +3648,84 @@ mod tests {
         )
     }
 
+    struct CancelAfterWaitSandbox {
+        inner: Box<dyn Sandbox>,
+        cancel: tokio_util::sync::CancellationToken,
+    }
+
+    #[async_trait]
+    impl Sandbox for CancelAfterWaitSandbox {
+        fn id(&self) -> &str {
+            self.inner.id()
+        }
+
+        fn source_ip(&self) -> &str {
+            self.inner.source_ip()
+        }
+
+        fn process_pid(&self) -> Option<u32> {
+            self.inner.process_pid()
+        }
+
+        async fn start(&mut self) -> sandbox::Result<()> {
+            self.inner.start().await
+        }
+
+        async fn stop(&mut self) -> sandbox::Result<()> {
+            self.inner.stop().await
+        }
+
+        async fn kill(&mut self) -> sandbox::Result<()> {
+            self.inner.kill().await
+        }
+
+        async fn park(&mut self) -> sandbox::Result<()> {
+            self.inner.park().await
+        }
+
+        async fn unpark(&mut self) -> sandbox::Result<()> {
+            self.inner.unpark().await
+        }
+
+        async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+            self.inner.exec(request).await
+        }
+
+        async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
+            self.inner.read_file(path, max_bytes).await
+        }
+
+        async fn copy_file(
+            &self,
+            path: &str,
+            host_path: &std::path::Path,
+            options: CopyFileOptions,
+        ) -> sandbox::Result<sandbox::CopyFileResult> {
+            self.inner.copy_file(path, host_path, options).await
+        }
+
+        async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+            self.inner.write_file(path, content).await
+        }
+
+        async fn start_process(
+            &self,
+            request: &StartProcessRequest<'_>,
+        ) -> sandbox::Result<sandbox::GuestProcessHandle> {
+            self.inner.start_process(request).await
+        }
+
+        async fn wait_process(
+            &self,
+            handle: sandbox::GuestProcessHandle,
+            timeout: Duration,
+        ) -> sandbox::Result<ProcessExit> {
+            let result = self.inner.wait_process(handle, timeout).await;
+            self.cancel.cancel();
+            result
+        }
+    }
+
     async fn run_execute_inner(
         factory: &MockSandboxFactory,
         ctx: &ExecutionContext,
@@ -3672,6 +3748,60 @@ mod tests {
         )
         .await?;
         Ok((outcome.exit_code(), outcome.error().map(ToOwned::to_owned)))
+    }
+
+    #[tokio::test]
+    async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_process_stdout_chunks(vec![ProcessOutputChunk {
+            bytes: b"partial stdout".to_vec(),
+            truncated: true,
+        }]);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let factory = MockSandboxFactory::with_overrides(overrides);
+        let sandbox = CancelAfterWaitSandbox {
+            inner: factory
+                .create(SandboxConfig {
+                    id: SandboxId::new_v4(),
+                    resources: sandbox::ResourceLimits {
+                        cpu_count: 2,
+                        memory_mb: 2048,
+                    },
+                    device_rate_limits: None,
+                })
+                .await
+                .unwrap(),
+            cancel: cancel.clone(),
+        };
+        let ctx = minimal_context();
+        let mut telemetry = test_telemetry(&config, &ctx);
+
+        let result = run_in_sandbox(
+            &sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            cancel.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert!(cancel.is_cancelled());
+        assert!(result.failure.is_none());
+        assert_eq!(
+            result.stdout_stream_diagnostics,
+            AgentStdoutStreamDiagnostics {
+                chunk_truncated: true,
+                stream_overflowed: false,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3866,6 +3866,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_inner_appends_stream_limit_marker_after_oom_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_process_stdout_chunks(vec![ProcessOutputChunk {
+            bytes: b"partial stdout".to_vec(),
+            truncated: true,
+        }]);
+        overrides.push_wait_process_exit(ProcessExit::new(1, EXIT_SIGKILL, Vec::new(), Vec::new()));
+        overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+            pattern: "dmesg".to_string(),
+            exit_code: 0,
+            stdout: b"Out of memory: Killed process 1234".to_vec(),
+            stderr: Vec::new(),
+        });
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+        let ctx = minimal_context();
+        let system_log_path = config.log_paths.system_log(ctx.run_id);
+
+        let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+            .await
+            .unwrap();
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(
+            error_msg.as_deref(),
+            Some("Agent process killed by OOM killer")
+        );
+        let system_log = tokio::fs::read(&system_log_path).await.unwrap();
+        let mut expected = b"partial stdout\n".to_vec();
+        expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
+        assert_eq!(system_log, expected);
+    }
+
+    #[tokio::test]
     async fn execute_inner_passes_device_rate_limits_to_sandbox_create() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
-//! results, shared lifecycle behavior queues, custom `wait_process` exit codes,
+//! results, shared lifecycle behavior queues, custom `wait_process` exits,
 //! and durable [`MockLifecycleGate`] gates for lifecycle and cancellation
 //! testing.
 //!
@@ -283,6 +283,9 @@ pub struct MockSandboxOverrides {
     /// simulate timeout or crash. The stdout channel sender is also kept alive
     /// in `MockSandbox` so the drain task would block without the fix.
     wait_process_error: Option<String>,
+    /// FIFO queue of full wait_process exits consumed by factory-created
+    /// sandboxes. Empty queue follows the existing default/override behavior.
+    wait_process_exits: Mutex<VecDeque<ProcessExit>>,
     /// FIFO queue of create results consumed by every factory built with
     /// these overrides. Empty queue → default Ok(()).
     create_results: Mutex<VecDeque<Result<()>>>,
@@ -311,6 +314,9 @@ pub struct MockSandboxOverrides {
     /// Recorded start_process output modes across all sandboxes built from
     /// this override set.
     start_process_calls: Mutex<Vec<StartProcessCall>>,
+    /// FIFO queue of stdout chunk batches emitted by factory-created
+    /// sandboxes during streaming start_process calls.
+    start_process_stdout_chunks: Mutex<VecDeque<Vec<ProcessOutputChunk>>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -327,6 +333,7 @@ impl MockSandboxOverrides {
             wait_process_code: None,
             wait_process_gate: None,
             wait_process_error: None,
+            wait_process_exits: Mutex::new(VecDeque::new()),
             create_results: Mutex::new(VecDeque::new()),
             create_configs: Mutex::new(Vec::new()),
             start_results: Mutex::new(VecDeque::new()),
@@ -337,6 +344,7 @@ impl MockSandboxOverrides {
             destroy_gate: Mutex::new(None),
             destroy_behaviors: Mutex::new(VecDeque::new()),
             start_process_calls: Mutex::new(Vec::new()),
+            start_process_stdout_chunks: Mutex::new(VecDeque::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
             destroy_calls: Mutex::new(0),
@@ -367,6 +375,15 @@ impl MockSandboxOverrides {
             wait_process_error: Some(msg.into()),
             ..Self::new()
         }
+    }
+
+    /// Queue a full `wait_process` exit applied to the next matching wait call.
+    /// Consumed FIFO across all sandboxes; empty queue follows the existing
+    /// default/override behavior.
+    pub fn push_wait_process_exit(&self, exit: ProcessExit) {
+        self.wait_process_exits
+            .lock_ignoring_poison()
+            .push_back(exit);
     }
 
     /// Register a pattern matcher consumed on first match.
@@ -511,6 +528,14 @@ impl MockSandboxOverrides {
     /// override set, in call order.
     pub fn start_process_calls(&self) -> Vec<StartProcessCall> {
         self.start_process_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Queue stdout chunks emitted by the next streaming `start_process` call.
+    /// Consumed FIFO across all sandboxes; empty queue emits no chunks.
+    pub fn push_start_process_stdout_chunks(&self, chunks: Vec<ProcessOutputChunk>) {
+        self.start_process_stdout_chunks
+            .lock_ignoring_poison()
+            .push_back(chunks);
     }
 }
 
@@ -897,20 +922,45 @@ impl Sandbox for MockSandbox {
                     control: request.control,
                 });
         }
-        let (tx, rx) = match request.output {
+        let (mut tx, rx) = match request.output {
             ProcessOutputMode::Stream { queue_capacity, .. } => {
                 let (tx, rx) = tokio::sync::mpsc::channel(queue_capacity.max(1));
                 (Some(tx), Some(rx))
             }
             ProcessOutputMode::Buffered { .. } => (None, None),
         };
+        if let Some(overrides) = &self.overrides {
+            let chunks = overrides
+                .start_process_stdout_chunks
+                .lock_ignoring_poison()
+                .pop_front();
+            if let Some(chunks) = chunks {
+                let Some(sender) = tx.as_ref() else {
+                    return Err(SandboxError::Operation {
+                        operation: SandboxOperation::StartProcess,
+                        reason: SandboxOperationReason::Other,
+                        message: "mock stdout chunks require streaming output".to_string(),
+                    });
+                };
+                for chunk in chunks {
+                    sender
+                        .try_send(chunk)
+                        .map_err(|_| SandboxError::Operation {
+                            operation: SandboxOperation::StartProcess,
+                            reason: SandboxOperationReason::Other,
+                            message: "mock stdout chunks exceeded process stream capacity"
+                                .to_string(),
+                        })?;
+                }
+            }
+        }
         // When simulating wait_process error (timeout/crash), keep the sender
         // alive so the stdout channel never closes — reproducing the real bug.
         if self
             .overrides
             .as_ref()
             .is_some_and(|o| o.wait_process_error.is_some())
-            && let Some(tx) = tx
+            && let Some(tx) = tx.take()
         {
             *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
@@ -962,6 +1012,13 @@ impl Sandbox for MockSandbox {
             // Return override exit code when configured.
             if let Some(code) = overrides.wait_process_code {
                 return Ok(ProcessExit::new(handle.pid, code, Vec::new(), Vec::new()));
+            }
+            if let Some(exit) = overrides
+                .wait_process_exits
+                .lock_ignoring_poison()
+                .pop_front()
+            {
+                return Ok(exit);
             }
         }
         Ok(ProcessExit::new(handle.pid, 0, Vec::new(), Vec::new()))
@@ -2251,6 +2308,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn start_process_emits_queued_stdout_chunks() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_start_process_stdout_chunks(vec![ProcessOutputChunk {
+            bytes: b"partial".to_vec(),
+            truncated: true,
+        }]);
+        let sandbox = MockSandbox::with_overrides("test", overrides);
+        let mut handle = sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::stream(),
+                control: ProcessControlMode::None,
+            })
+            .await
+            .unwrap();
+        let mut stdout_rx = handle.take_stdout_receiver().unwrap();
+
+        let chunk = stdout_rx.recv().await.unwrap();
+
+        assert_eq!(chunk.bytes, b"partial");
+        assert!(chunk.truncated);
+        assert!(stdout_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
     async fn start_process_returns_control_handle_when_requested() {
         let runtime = MockSandboxRuntime::new();
         let factory = runtime.create_factory(test_factory_config()).await.unwrap();
@@ -2363,6 +2448,64 @@ mod tests {
             }
             Err(other) => panic!("expected wait_process operation error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn wait_process_returns_queued_process_exit() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
+        let mut exit = ProcessExit::new(77, 0, b"out".to_vec(), b"err".to_vec());
+        exit.stream_overflowed = true;
+        overrides.push_wait_process_exit(exit);
+        let handle = sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::None,
+            })
+            .await
+            .unwrap();
+
+        let result = sandbox
+            .wait_process(handle, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(result.pid, 77);
+        assert_eq!(result.stdout, b"out");
+        assert_eq!(result.stderr, b"err");
+        assert!(result.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn wait_process_default_exit_is_unchanged_without_queued_exit() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let sandbox = MockSandbox::with_overrides("test", overrides);
+        let handle = sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::None,
+            })
+            .await
+            .unwrap();
+
+        let result = sandbox
+            .wait_process(handle, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(result.pid, 1);
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.is_empty());
+        assert!(result.stderr.is_empty());
+        assert!(!result.stream_overflowed);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- collect runner stdout stream diagnostics for guest stream-limit truncation and host queue overflow
- append distinct fixed markers to the final host system log after guest log copy completes
- preserve completed wait results when a cancel token arrives after `wait_process` wins, so stdout drain and diagnostics are not aborted late
- extend sandbox-mock so runner tests can exercise queued stdout chunks and custom process exits

Closes #14375

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner drain_stdout`
- `cargo test --manifest-path crates/Cargo.toml -p runner post_job_cleanup_appends_stream_markers_after_guest_log_copy`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_appends_stream_overflow_marker`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_appends_stream_limit_marker`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_appends_stream_limit_marker_after_oom_rewrite`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_appends_stream`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_aborts_drain_task_on_wait_process_error`
- `cargo test --manifest-path crates/Cargo.toml -p runner append_stdout_stream_diagnostics`
- `cargo test --manifest-path crates/Cargo.toml -p runner cancel`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock wait_process`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock start_process_emits_queued_stdout_chunks`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p sandbox-mock --all-targets --all-features -- -D warnings`