### PR TITLE
fix(mitm-addon): harden logging writes

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -10,39 +10,46 @@ import time
 
 from mitmproxy import ctx, http
 
+_PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
 
-def log_network_entry(log_path: str, entry: dict) -> None:
-    """Write a network log entry to the per-run JSONL file."""
+
+def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
+    """Best-effort JSONL write for proxy-hook logging paths."""
     if not log_path:
         return
     try:
+        line = (json.dumps(entry) + "\n").encode()
         fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
         try:
-            os.write(fd, (json.dumps(entry) + "\n").encode())
+            os.write(fd, line)
         finally:
             os.close(fd)
     except Exception as e:
-        ctx.log.warn(f"Failed to write network log: {e}")
+        ctx.log.warn(f"Failed to write {log_name} log: {e}")
 
 
-def log_proxy_entry(proxy_log_path: str, level: str, message: str, **extra: object) -> None:
+def log_network_entry(log_path: str, entry: dict) -> None:
+    """Write a network log entry to the per-run JSONL file."""
+    _write_jsonl_entry(log_path, entry, "network")
+
+
+def log_proxy_entry(
+    proxy_log_path: str,
+    log_level: str,
+    log_message: str,
+    /,
+    **extra: object,
+) -> None:
     """Write a diagnostic log entry to the per-job proxy log file (JSONL)."""
-    if not proxy_log_path:
-        return
     entry: dict = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
-        "level": level,
-        "message": message,
+        "level": log_level,
+        "message": log_message,
     }
-    entry.update(extra)
-    try:
-        fd = os.open(proxy_log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
-        try:
-            os.write(fd, (json.dumps(entry) + "\n").encode())
-        finally:
-            os.close(fd)
-    except Exception as e:
-        ctx.log.warn(f"Failed to write proxy log: {e}")
+    for key, value in extra.items():
+        if key not in _PROXY_LOG_RESERVED_FIELDS:
+            entry[key] = value
+    _write_jsonl_entry(proxy_log_path, entry, "proxy")
 
 
 def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -463,8 +463,12 @@ class TestLogNetworkEntry:
         assert len(lines) == 2
 
     def test_no_path_is_noop(self):
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_network_entry("", {"action": "ALLOW"})
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry("", {"payload": b"binary"})
+
+        log.warn.assert_not_called()
 
     def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
         log_path = tmp_path / "missing" / "net.jsonl"

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -465,3 +465,24 @@ class TestLogNetworkEntry:
     def test_no_path_is_noop(self):
         with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
             logging_utils.log_network_entry("", {"action": "ALLOW"})
+
+    def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
+        log_path = tmp_path / "missing" / "net.jsonl"
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+
+        log.warn.assert_called_once()
+        assert "Failed to write network log:" in log.warn.call_args.args[0]
+
+    def test_non_serializable_entry_warns_without_creating_file(self, tmp_path):
+        log_path = tmp_path / "net.jsonl"
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
+
+        log.warn.assert_called_once()
+        assert "Failed to write network log:" in log.warn.call_args.args[0]
+        assert not log_path.exists()

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -63,7 +63,14 @@ class TestLogProxyEntry:
         assert json.loads(lines[1])["message"] == "second"
 
     def test_empty_path_no_op(self, tmp_path):
-        logging_utils.log_proxy_entry("", "warn", "should not write")
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_proxy_entry(
+                "", "warn", "should not write", payload={"body": b"binary"}
+            )
+
+        log.warn.assert_not_called()
         assert not list(tmp_path.iterdir())
 
     def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
@@ -102,6 +109,7 @@ class TestLogProxyEntry:
     def test_extra_cannot_override_reserved_fields(self, tmp_path):
         proxy_path = tmp_path / "proxy-test.jsonl"
         extra = {
+            "proxy_log_path": "caller-proxy-log-path",
             "timestamp": "caller-timestamp",
             "level": "caller-level",
             "message": "caller-message",
@@ -116,6 +124,7 @@ class TestLogProxyEntry:
         assert entry["timestamp"] != "caller-timestamp"
         assert entry["level"] == "warn"
         assert entry["message"] == "logger-message"
+        assert entry["proxy_log_path"] == "caller-proxy-log-path"
         assert entry["log_level"] == "caller-log-level"
         assert entry["log_message"] == "caller-log-message"
         assert entry["extra_field"] == "value"

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -1,10 +1,12 @@
 """Tests for URL and logging utility functions."""
 
 import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from logging_utils import log_proxy_entry
+import logging_utils
 from url_utils import get_original_url
 
 
@@ -44,7 +46,7 @@ class TestGetOriginalUrl:
 class TestLogProxyEntry:
     def test_writes_jsonl(self, tmp_path):
         proxy_path = str(tmp_path / "proxy-test.jsonl")
-        log_proxy_entry(proxy_path, "warn", "test message", extra_field="value")
+        logging_utils.log_proxy_entry(proxy_path, "warn", "test message", extra_field="value")
         entry = json.loads((tmp_path / "proxy-test.jsonl").read_text().strip())
         assert entry["level"] == "warn"
         assert entry["message"] == "test message"
@@ -53,13 +55,67 @@ class TestLogProxyEntry:
 
     def test_appends_multiple_entries(self, tmp_path):
         proxy_path = str(tmp_path / "proxy-test.jsonl")
-        log_proxy_entry(proxy_path, "info", "first")
-        log_proxy_entry(proxy_path, "warn", "second")
+        logging_utils.log_proxy_entry(proxy_path, "info", "first")
+        logging_utils.log_proxy_entry(proxy_path, "warn", "second")
         lines = (tmp_path / "proxy-test.jsonl").read_text().strip().split("\n")
         assert len(lines) == 2
         assert json.loads(lines[0])["message"] == "first"
         assert json.loads(lines[1])["message"] == "second"
 
     def test_empty_path_no_op(self, tmp_path):
-        log_proxy_entry("", "warn", "should not write")
+        logging_utils.log_proxy_entry("", "warn", "should not write")
         assert not list(tmp_path.iterdir())
+
+    def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_proxy_entry(
+                str(tmp_path / "missing" / "proxy.jsonl"), "warn", "message"
+            )
+
+        log.warn.assert_called_once()
+        assert "Failed to write proxy log:" in log.warn.call_args.args[0]
+
+    def test_directory_path_warns_and_does_not_raise(self, tmp_path):
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_proxy_entry(str(tmp_path), "warn", "message")
+
+        log.warn.assert_called_once()
+        assert "Failed to write proxy log:" in log.warn.call_args.args[0]
+
+    def test_non_serializable_extra_warns_without_creating_file(self, tmp_path):
+        proxy_path = tmp_path / "proxy-test.jsonl"
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_proxy_entry(
+                str(proxy_path), "warn", "message", payload={"body": b"binary"}
+            )
+
+        log.warn.assert_called_once()
+        assert "Failed to write proxy log:" in log.warn.call_args.args[0]
+        assert not proxy_path.exists()
+
+    def test_extra_cannot_override_reserved_fields(self, tmp_path):
+        proxy_path = tmp_path / "proxy-test.jsonl"
+        extra = {
+            "timestamp": "caller-timestamp",
+            "level": "caller-level",
+            "message": "caller-message",
+            "log_level": "caller-log-level",
+            "log_message": "caller-log-message",
+            "extra_field": "value",
+        }
+
+        logging_utils.log_proxy_entry(str(proxy_path), "warn", "logger-message", **extra)
+
+        entry = json.loads(Path(proxy_path).read_text().strip())
+        assert entry["timestamp"] != "caller-timestamp"
+        assert entry["level"] == "warn"
+        assert entry["message"] == "logger-message"
+        assert entry["log_level"] == "caller-log-level"
+        assert entry["log_message"] == "caller-log-message"
+        assert entry["extra_field"] == "value"


### PR DESCRIPTION
## Summary

- route network and proxy JSONL logging through a shared best-effort writer
- serialize log entries before opening the destination file so serialization failures do not leave empty files
- keep proxy log reserved fields owned by the logger while preserving top-level extra fields
- cover missing-path, directory-path, non-serializable payload, and reserved-field regressions

## Tests

- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /tmp/vm0-mitm-addon-deps/bin/ruff check src/logging_utils.py tests/test_utils.py tests/test_registry.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /usr/bin/python3 -m pytest tests/test_utils.py tests/test_registry.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /usr/bin/python3 -m pytest -q`
- `git diff --check`

Closes #14371