### PR TITLE
refactor: type connector oauth credential results

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -4,7 +4,6 @@ import { zeroConnectorsSearchContract } from "@vm0/api-contracts/contracts/zero-
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -5,6 +5,9 @@ import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/con
 import {
   getConnectorOAuthConfig,
   getConnectorOAuthCredentials,
+  isStaticConfidentialConnectorOAuthCredentials,
+  isStaticConnectorOAuthCredentials,
+  type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -154,6 +157,22 @@ function redirectWithError(
   return response;
 }
 
+function getProviderCredentialArgs(credentials: ConnectorOAuthCredentials): {
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+} {
+  if (!isStaticConnectorOAuthCredentials(credentials)) {
+    return {};
+  }
+  if (isStaticConfidentialConnectorOAuthCredentials(credentials)) {
+    return {
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
+    };
+  }
+  return { clientId: credentials.clientId };
+}
+
 async function exchangeTokenForConnector(args: {
   readonly connectorType: OAuthConnectorType;
   readonly code: string;
@@ -172,8 +191,7 @@ async function exchangeTokenForConnector(args: {
   }
 
   return await provider.exchangeCode({
-    clientId: credentials.clientId,
-    clientSecret: credentials.clientSecret,
+    ...getProviderCredentialArgs(credentials),
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -18,6 +18,8 @@ import {
 import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
+  isStaticConnectorOAuthCredentials,
+  type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -196,6 +198,17 @@ async function buildProviderAuthorizeUrl(args: {
       state: args.state,
     }),
   );
+}
+
+function getAuthorizeClientId(
+  credentials: ConnectorOAuthCredentials,
+): string | undefined {
+  if (!credentials.configured) {
+    return undefined;
+  }
+  return isStaticConnectorOAuthCredentials(credentials)
+    ? credentials.clientId
+    : undefined;
 }
 
 function internalServerError(message: string) {
@@ -475,7 +488,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const authResult = await buildProviderAuthorizeUrl({
       type,
-      clientId: credentials.clientId,
+      clientId: getAuthorizeClientId(credentials),
       redirectUri,
       state,
     });
@@ -561,7 +574,7 @@ const startConnectorOauthInner$ = command(
 
     const authResult = await buildProviderAuthorizeUrl({
       type,
-      clientId: credentials.clientId,
+      clientId: getAuthorizeClientId(credentials),
       redirectUri,
       state,
     });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,7 +1,12 @@
 import { Buffer } from "node:buffer";
 
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
-import { getConnectorOAuthCredentials } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthCredentials,
+  isStaticConfidentialConnectorOAuthCredentials,
+  isStaticConnectorOAuthCredentials,
+  type ConnectorOAuthCredentials,
+} from "@vm0/connectors/connector-utils";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
@@ -173,6 +178,22 @@ interface PreparedRefreshTokenContext {
   readonly sourceType: OAuthSecretSource;
   readonly provider: OAuthRefreshProvider;
   readonly context: RefreshTokenContext;
+}
+
+function getRefreshCredentialArgs(credentials: ConnectorOAuthCredentials): {
+  readonly clientId: string | undefined;
+  readonly clientSecret: string | undefined;
+} {
+  if (!isStaticConnectorOAuthCredentials(credentials)) {
+    return { clientId: undefined, clientSecret: undefined };
+  }
+  if (isStaticConfidentialConnectorOAuthCredentials(credentials)) {
+    return {
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
+    };
+  }
+  return { clientId: credentials.clientId, clientSecret: undefined };
 }
 
 interface SyncRefreshTokensArgs {
@@ -634,11 +655,12 @@ function prepareRefreshTokenContext(
     return null;
   }
 
+  const credentialArgs = getRefreshCredentialArgs(credentials);
   const context: RefreshTokenContext = {
     refreshTokenSecret,
     currentRefreshToken,
-    clientId: credentials.clientId,
-    clientSecret: credentials.clientSecret,
+    clientId: credentialArgs.clientId,
+    clientSecret: credentialArgs.clientSecret,
     accessTokenSecret: provider.getSecretName(),
     secretUserId: resolveSecretUserId(
       args.sourceType,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -16,6 +16,8 @@ import {
   getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
   getRuntimeAvailableConnectorTypes,
+  isStaticConfidentialConnectorOAuthCredentials,
+  isStaticConnectorOAuthCredentials,
   isGoogleOAuthConnector,
   resolveConnectorOAuthClientCredentials,
 } from "../connector-utils";
@@ -420,7 +422,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(credentials).toStrictEqual({
       configured: false,
       client: getConnectorOAuthClientConfig("github"),
-      clientId: "github-client-id",
     });
   });
 
@@ -475,6 +476,60 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       configured: true,
       client,
     });
+  });
+
+  it("identifies static OAuth credential variants", () => {
+    const staticCredentials = getConnectorOAuthCredentials("github", (name) => {
+      return (
+        {
+          GH_OAUTH_CLIENT_ID: "github-client-id",
+          GH_OAUTH_CLIENT_SECRET: "github-client-secret",
+        } as Record<string, string>
+      )[name];
+    });
+    if (!staticCredentials) {
+      throw new Error("Expected GitHub OAuth credentials");
+    }
+    expect(isStaticConnectorOAuthCredentials(staticCredentials)).toBeTruthy();
+    expect(
+      isStaticConfidentialConnectorOAuthCredentials(staticCredentials),
+    ).toBeTruthy();
+    if (isStaticConfidentialConnectorOAuthCredentials(staticCredentials)) {
+      const clientSecret: string = staticCredentials.clientSecret;
+      expect(clientSecret).toBe("github-client-secret");
+    }
+
+    const publicCredentials = resolveConnectorOAuthClientCredentials(
+      {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientId: "public-client-id",
+      },
+      emptyEnv,
+    );
+    expect(isStaticConnectorOAuthCredentials(publicCredentials)).toBeTruthy();
+    expect(
+      isStaticConfidentialConnectorOAuthCredentials(publicCredentials),
+    ).toBeFalsy();
+    if (isStaticConnectorOAuthCredentials(publicCredentials)) {
+      const clientId: string = publicCredentials.clientId;
+      expect(clientId).toBe("public-client-id");
+    }
+
+    const dynamicClient = {
+      clientRegistration: "dynamic",
+      clientType: "public",
+      tokenEndpointAuthMethod: "none",
+    } as const;
+    const dynamicCredentials = resolveConnectorOAuthClientCredentials(
+      dynamicClient,
+      emptyEnv,
+    );
+    expect(isStaticConnectorOAuthCredentials(dynamicCredentials)).toBeFalsy();
+    expect(
+      isStaticConfidentialConnectorOAuthCredentials(dynamicCredentials),
+    ).toBeFalsy();
   });
 
   it("includes all connectors that share a configured OAuth app", () => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -9,8 +9,11 @@ import {
   type ConnectorCliAuthFlow,
   type ConnectorConfig,
   type ConnectorGenerationType,
+  type DynamicPublicConnectorOAuthClientConfig,
   type ConnectorOAuthClientConfig,
   type ConnectorOAuthConfig,
+  type StaticConfidentialConnectorOAuthClientConfig,
+  type StaticPublicConnectorOAuthClientConfig,
   type ConnectorType,
   type OAuthConnectorType,
 } from "./connectors";
@@ -172,11 +175,53 @@ export interface ConnectorOAuthEnvKeys {
   readonly clientSecret?: string;
 }
 
-export interface ConnectorOAuthCredentials {
-  readonly configured: boolean;
+export type UnconfiguredConnectorOAuthCredentials = {
+  readonly configured: false;
   readonly client: ConnectorOAuthClientConfig;
-  readonly clientId?: string;
-  readonly clientSecret?: string;
+};
+
+export type StaticConfidentialConnectorOAuthCredentials = {
+  readonly configured: true;
+  readonly client: StaticConfidentialConnectorOAuthClientConfig;
+  readonly clientId: string;
+  readonly clientSecret: string;
+};
+
+export type StaticPublicConnectorOAuthCredentials = {
+  readonly configured: true;
+  readonly client: StaticPublicConnectorOAuthClientConfig;
+  readonly clientId: string;
+};
+
+export type DynamicPublicConnectorOAuthCredentials = {
+  readonly configured: true;
+  readonly client: DynamicPublicConnectorOAuthClientConfig;
+};
+
+export type StaticConnectorOAuthCredentials =
+  | StaticConfidentialConnectorOAuthCredentials
+  | StaticPublicConnectorOAuthCredentials;
+
+export type ConnectorOAuthCredentials =
+  | UnconfiguredConnectorOAuthCredentials
+  | StaticConnectorOAuthCredentials
+  | DynamicPublicConnectorOAuthCredentials;
+
+export function isStaticConnectorOAuthCredentials(
+  credentials: ConnectorOAuthCredentials,
+): credentials is StaticConnectorOAuthCredentials {
+  return (
+    credentials.configured && credentials.client.clientRegistration === "static"
+  );
+}
+
+export function isStaticConfidentialConnectorOAuthCredentials(
+  credentials: ConnectorOAuthCredentials,
+): credentials is StaticConfidentialConnectorOAuthCredentials {
+  return (
+    isStaticConnectorOAuthCredentials(credentials) &&
+    credentials.client.clientType === "confidential"
+  );
 }
 
 function hasEnvValue(readEnv: ConnectorEnvReader, name: string): boolean {
@@ -198,13 +243,15 @@ export function resolveConnectorOAuthClientCredentials(
   }
 
   if ("clientId" in client) {
-    return {
-      configured: true,
-      client,
-      clientId: client.clientId,
-      clientSecret:
-        client.clientType === "confidential" ? client.clientSecret : undefined,
-    };
+    if (client.clientType === "confidential") {
+      return {
+        configured: true,
+        client,
+        clientId: client.clientId,
+        clientSecret: client.clientSecret,
+      };
+    }
+    return { configured: true, client, clientId: client.clientId };
   }
 
   const clientId = readEnv(client.clientIdEnv);
@@ -218,7 +265,7 @@ export function resolveConnectorOAuthClientCredentials(
 
   const clientSecret = readEnv(client.clientSecretEnv);
   if (!clientSecret) {
-    return { configured: false, client, clientId };
+    return { configured: false, client };
   }
 
   return { configured: true, client, clientId, clientSecret };

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -291,6 +291,30 @@ export type ConnectorOAuthClientConfig =
       readonly tokenEndpointAuthMethod: "none";
     };
 
+export type StaticConfidentialConnectorOAuthClientConfig = Extract<
+  ConnectorOAuthClientConfig,
+  {
+    readonly clientRegistration: "static";
+    readonly clientType: "confidential";
+  }
+>;
+
+export type StaticPublicConnectorOAuthClientConfig = Extract<
+  ConnectorOAuthClientConfig,
+  {
+    readonly clientRegistration: "static";
+    readonly clientType: "public";
+  }
+>;
+
+export type DynamicPublicConnectorOAuthClientConfig = Extract<
+  ConnectorOAuthClientConfig,
+  {
+    readonly clientRegistration: "dynamic";
+    readonly clientType: "public";
+  }
+>;
+
 export interface ConnectorOAuthConfig {
   authorizationUrl?: string;
   tokenUrl: string;


### PR DESCRIPTION
## Summary
- return connector OAuth credential resolution as a discriminated union
- add static credential type guards and update OAuth callers to narrow before passing credentials
- update connector credential tests and remove a stale unused API test import surfaced by lint

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F api lint

Closes #14385