### PR TITLE
fix(api): claim connector oauth states atomically

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1628,6 +1628,44 @@ describe("GET /api/connectors/:type/callback", () => {
     });
   });
 
+  it("consumes server-side OAuth handoff state when the provider returns an error", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: {
+        error: "access_denied",
+        error_description: "The user denied access",
+        state,
+      },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "The user denied access",
+    });
+
+    const db = store.set(writeDb$);
+    const [storedState] = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.id, oauthStateId));
+    expect(storedState?.consumedAt).toBeInstanceOf(Date);
+  });
+
   it("rejects an already consumed server-side OAuth handoff state", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
@@ -1743,6 +1781,34 @@ describe("GET /api/connectors/:type/callback", () => {
       .from(connectorOauthStates)
       .where(eq(connectorOauthStates.id, oauthStateId));
     expect(storedState?.consumedAt).toBeNull();
+  });
+
+  it("rejects an invalid server-side OAuth handoff state before missing code", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+      consumedAt: new Date(now()),
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { state },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "Invalid state - please try again",
+    });
   });
 
   it("uses cookie-backed direct callback state when no stored handoff state exists", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -138,6 +138,19 @@ async function requestCallback(args: {
   });
 }
 
+function expectConnectorErrorRedirect(
+  response: Response,
+  args: { readonly type: string; readonly message: string },
+): void {
+  expect(response.status).toBe(307);
+  const location = response.headers.get("location");
+  expect(location).not.toBeNull();
+  const url = new URL(location!);
+  expect(url.pathname).toBe("/connector/error");
+  expect(url.searchParams.get("type")).toBe(args.type);
+  expect(url.searchParams.get("message")).toBe(args.message);
+}
+
 function mockOAuthEnv(): void {
   mockOptionalEnv("DEEL_OAUTH_CLIENT_ID", "deel-client-id");
   mockOptionalEnv("DEEL_OAUTH_CLIENT_SECRET", "deel-client-secret");
@@ -927,6 +940,7 @@ async function seedOauthState(args: {
   readonly codeVerifier?: string;
   readonly oauthContext?: string;
   readonly expiresAt?: Date;
+  readonly consumedAt?: Date | null;
 }): Promise<string> {
   const db = store.set(writeDb$);
   const [oauthState] = await db
@@ -942,6 +956,7 @@ async function seedOauthState(args: {
       codeVerifier: args.codeVerifier,
       oauthContext: args.oauthContext,
       expiresAt: args.expiresAt ?? new Date(now() + 15 * 60 * 1000),
+      consumedAt: args.consumedAt,
     })
     .returning({ id: connectorOauthStates.id });
   expect(oauthState).toBeDefined();
@@ -1569,6 +1584,192 @@ describe("GET /api/connectors/:type/callback", () => {
       .from(connectorOauthStates)
       .where(eq(connectorOauthStates.id, oauthStateId));
     expect(storedState?.consumedAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects a reused server-side OAuth handoff state", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+    });
+    oauthStateIds.push(oauthStateId);
+    mockGitHubOAuth({
+      accessToken: "github-token",
+      userId: 98_765,
+      username: "octocat",
+      email: "octocat@example.com",
+    });
+
+    const first = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state },
+    });
+    expect(first.status).toBe(307);
+    expect(new URL(first.headers.get("location")!).pathname).toBe(
+      "/connector/success",
+    );
+
+    const second = await requestCallback({
+      type: "github",
+      query: { code: "code-456", state },
+    });
+
+    expectConnectorErrorRedirect(second, {
+      type: "github",
+      message: "Invalid state - please try again",
+    });
+  });
+
+  it("rejects an already consumed server-side OAuth handoff state", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+      consumedAt: new Date(now()),
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "Invalid state - please try again",
+    });
+  });
+
+  it("rejects an expired server-side OAuth handoff state", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+      expiresAt: new Date(now() - 1000),
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "Invalid state - please try again",
+    });
+  });
+
+  it("rejects a server-side OAuth handoff state for another connector type", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "slack",
+      userId,
+      orgId,
+      state,
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "Invalid state - please try again",
+    });
+  });
+
+  it("does not consume server-side OAuth handoff state when the code is missing", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { state },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "Missing authorization code",
+    });
+
+    const db = store.set(writeDb$);
+    const [storedState] = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.id, oauthStateId));
+    expect(storedState?.consumedAt).toBeNull();
+  });
+
+  it("uses cookie-backed direct callback state when no stored handoff state exists", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    mockGitHubOAuth({
+      accessToken: "github-token",
+      userId: 98_765,
+      username: "octocat",
+      email: "octocat@example.com",
+    });
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/success");
+    expect(url.searchParams.get("type")).toBe("github");
+    expect(url.searchParams.get("username")).toBe("octocat");
   });
 
   it("passes OAuth context to dynamic public connector exchange", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1257,6 +1257,7 @@ describe("GET /api/connectors/:type/callback", () => {
       query: {
         error: "access_denied",
         error_description: "The user denied access",
+        state: "state-123",
       },
       headers: callbackHeaders({ stateCookie: "state-123" }),
     });
@@ -1664,6 +1665,38 @@ describe("GET /api/connectors/:type/callback", () => {
       .from(connectorOauthStates)
       .where(eq(connectorOauthStates.id, oauthStateId));
     expect(storedState?.consumedAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects an invalid server-side OAuth handoff state before provider errors", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+      consumedAt: new Date(now()),
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: {
+        error: "access_denied",
+        error_description: "The user denied access",
+        state,
+      },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "Invalid state - please try again",
+    });
   });
 
   it("rejects an already consumed server-side OAuth handoff state", async () => {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -29,6 +29,7 @@ import { nowDate } from "../../lib/time";
 import { optionalEnv } from "../../lib/env";
 import {
   claimConnectorOAuthState,
+  getConnectorOAuthStateStatus,
   type StoredOAuthState,
 } from "../services/connector-oauth-state.service";
 import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
@@ -188,6 +189,26 @@ function getProviderCredentialArgs(credentials: ConnectorOAuthCredentials): {
   return { clientId: credentials.clientId };
 }
 
+function invalidStateRedirectResponse(origin: string, type: string): Response {
+  return redirectWithError(
+    origin,
+    type,
+    "Invalid state - please try again",
+    true,
+  );
+}
+
+function missingAuthorizationCodeRedirectResponse(
+  origin: string,
+  type: string,
+): Response {
+  return redirectWithError(origin, type, "Missing authorization code", true);
+}
+
+function missingStateRedirectResponse(origin: string, type: string): Response {
+  return redirectWithError(origin, type, "Missing state parameter", true);
+}
+
 async function exchangeTokenForConnector(args: {
   readonly connectorType: OAuthConnectorType;
   readonly code: string;
@@ -274,12 +295,7 @@ async function claimStoredOAuthStateForCallback(args: {
   if (storedStateResolution.kind === "invalid") {
     return {
       ok: false,
-      response: redirectWithError(
-        args.origin,
-        args.type,
-        "Invalid state - please try again",
-        true,
-      ),
+      response: invalidStateRedirectResponse(args.origin, args.type),
     };
   }
 
@@ -290,6 +306,26 @@ async function claimStoredOAuthStateForCallback(args: {
         ? storedStateResolution.state
         : undefined,
   };
+}
+
+async function rejectInvalidStoredOAuthStateForCallback(args: {
+  readonly db: Db;
+  readonly state: string;
+  readonly connectorType: OAuthConnectorType;
+  readonly origin: string;
+  readonly type: string;
+  readonly signal: AbortSignal;
+}): Promise<Response | undefined> {
+  const status = await getConnectorOAuthStateStatus(
+    args.db,
+    { state: args.state, connectorType: args.connectorType },
+    args.signal,
+  );
+  if (status.kind !== "invalid") {
+    return undefined;
+  }
+
+  return invalidStateRedirectResponse(args.origin, args.type);
 }
 
 async function completeConnectorSession(
@@ -483,17 +519,21 @@ const callbackConnectorInner$ = command(
     const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
     const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
     const state = query.state;
+    const storedStateCallbackArgs = {
+      db: writeDb,
+      connectorType,
+      origin,
+      type: params.type,
+      signal,
+    };
 
     if (query.error) {
       if (state) {
         const claimedState = await claimStoredOAuthStateForCallback({
-          db: writeDb,
+          ...storedStateCallbackArgs,
           state,
-          connectorType,
-          origin,
-          type: params.type,
-          signal,
         });
+        signal.throwIfAborted();
         if (!claimedState.ok) {
           return claimedState.response;
         }
@@ -508,31 +548,29 @@ const callbackConnectorInner$ = command(
 
     const code = query.code;
     if (!code) {
-      return redirectWithError(
-        origin,
-        params.type,
-        "Missing authorization code",
-        true,
-      );
+      if (state) {
+        const invalidStateResponse =
+          await rejectInvalidStoredOAuthStateForCallback({
+            ...storedStateCallbackArgs,
+            state,
+          });
+        signal.throwIfAborted();
+        if (invalidStateResponse) {
+          return invalidStateResponse;
+        }
+      }
+      return missingAuthorizationCodeRedirectResponse(origin, params.type);
     }
 
     if (!state) {
-      return redirectWithError(
-        origin,
-        params.type,
-        "Missing state parameter",
-        true,
-      );
+      return missingStateRedirectResponse(origin, params.type);
     }
 
     const claimedState = await claimStoredOAuthStateForCallback({
-      db: writeDb,
+      ...storedStateCallbackArgs,
       state,
-      connectorType,
-      origin,
-      type: params.type,
-      signal,
     });
+    signal.throwIfAborted();
     if (!claimedState.ok) {
       return claimedState.response;
     }

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -3,15 +3,14 @@ import { unescape as decodeCookieComponent } from "node:querystring";
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
-  getConnectorOAuthConfig,
   getConnectorOAuthCredentials,
+  getOAuthConnectorConfig,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type ConnectorType,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -19,7 +18,6 @@ import {
   CONNECTOR_OAUTH_PROVIDERS,
   type OAuthTokenResult,
 } from "@vm0/connectors/oauth-providers";
-import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { eq } from "drizzle-orm";
 
@@ -29,6 +27,10 @@ import { pathParamsOf, queryOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { optionalEnv } from "../../lib/env";
+import {
+  claimConnectorOAuthState,
+  type StoredOAuthState,
+} from "../services/connector-oauth-state.service";
 import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
 import { settle } from "../utils";
 import type { RouteEntry } from "../route";
@@ -42,8 +44,6 @@ const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const REDIRECT_STATUS = 307;
-
-type StoredOAuthState = typeof connectorOauthStates.$inferSelect;
 
 type CallbackIdentity = {
   readonly userId: string;
@@ -88,10 +88,25 @@ type ResolvedCallbackState =
       readonly response: Response;
     };
 
-type StoredOAuthStateResolution =
-  | { readonly kind: "missing" }
-  | { readonly kind: "invalid" }
-  | { readonly kind: "usable"; readonly state: StoredOAuthState };
+type ClaimedCallbackState =
+  | {
+      readonly ok: true;
+      readonly storedState: StoredOAuthState | undefined;
+    }
+  | {
+      readonly ok: false;
+      readonly response: Response;
+    };
+
+type ResolvedOAuthConnectorType =
+  | {
+      readonly ok: true;
+      readonly connectorType: OAuthConnectorType;
+    }
+  | {
+      readonly ok: false;
+      readonly response: Response;
+    };
 
 const connectorCallbackAuth = { requireOrganization: true } as const;
 
@@ -200,8 +215,81 @@ async function exchangeTokenForConnector(args: {
   });
 }
 
-function getRequestedScopes(connectorType: ConnectorType): readonly string[] {
-  return getConnectorOAuthConfig(connectorType)?.scopes ?? [];
+function getRequestedScopes(
+  connectorType: OAuthConnectorType,
+): readonly string[] {
+  return getOAuthConnectorConfig(connectorType).scopes;
+}
+
+function resolveOAuthConnectorType(
+  origin: string,
+  type: string,
+): ResolvedOAuthConnectorType {
+  const typeResult = connectorTypeSchema.safeParse(type);
+  if (!typeResult.success) {
+    return {
+      ok: false,
+      response: redirectWithError(origin, type, "Unknown connector type"),
+    };
+  }
+
+  const connectorType = typeResult.data;
+  if (connectorType === "computer") {
+    return {
+      ok: false,
+      response: redirectWithError(
+        origin,
+        type,
+        "Computer connector does not use OAuth",
+      ),
+    };
+  }
+  if (!isOAuthConnectorType(connectorType)) {
+    return {
+      ok: false,
+      response: redirectWithError(
+        origin,
+        type,
+        `${type} connector does not use OAuth`,
+      ),
+    };
+  }
+
+  return { ok: true, connectorType };
+}
+
+async function claimStoredOAuthStateForCallback(args: {
+  readonly db: Db;
+  readonly state: string;
+  readonly connectorType: OAuthConnectorType;
+  readonly origin: string;
+  readonly type: string;
+  readonly signal: AbortSignal;
+}): Promise<ClaimedCallbackState> {
+  const storedStateResolution = await claimConnectorOAuthState(
+    args.db,
+    { state: args.state, connectorType: args.connectorType },
+    args.signal,
+  );
+  if (storedStateResolution.kind === "invalid") {
+    return {
+      ok: false,
+      response: redirectWithError(
+        args.origin,
+        args.type,
+        "Invalid state - please try again",
+        true,
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    storedState:
+      storedStateResolution.kind === "usable"
+        ? storedStateResolution.state
+        : undefined,
+  };
 }
 
 async function completeConnectorSession(
@@ -238,49 +326,6 @@ async function markConnectorSessionError(
       errorMessage,
     })
     .where(eq(connectorSessions.id, sessionId));
-  signal.throwIfAborted();
-}
-
-async function resolveStoredOAuthState(
-  db: Db,
-  state: string,
-  connectorType: ConnectorType,
-  signal: AbortSignal,
-): Promise<StoredOAuthStateResolution> {
-  const [storedState] = await db
-    .select()
-    .from(connectorOauthStates)
-    .where(eq(connectorOauthStates.state, state))
-    .limit(1);
-  signal.throwIfAborted();
-
-  if (!storedState) {
-    return { kind: "missing" };
-  }
-
-  if (
-    storedState.type !== connectorType ||
-    storedState.consumedAt ||
-    storedState.expiresAt <= nowDate()
-  ) {
-    return { kind: "invalid" };
-  }
-
-  return { kind: "usable", state: storedState };
-}
-
-async function consumeStoredOAuthState(
-  db: Db,
-  storedState: StoredOAuthState | undefined,
-  signal: AbortSignal,
-): Promise<void> {
-  if (!storedState) {
-    return;
-  }
-  await db
-    .update(connectorOauthStates)
-    .set({ consumedAt: nowDate() })
-    .where(eq(connectorOauthStates.id, storedState.id));
   signal.throwIfAborted();
 }
 
@@ -352,7 +397,6 @@ const resolveCallbackState$ = command(
     signal: AbortSignal,
   ): Promise<ResolvedCallbackState> => {
     if (args.storedState) {
-      await consumeStoredOAuthState(set(writeDb$), args.storedState, signal);
       return {
         ok: true,
         identity: {
@@ -427,26 +471,11 @@ const callbackConnectorInner$ = command(
     }
     const origin = getConnectorOAuthOrigin(request);
 
-    const typeResult = connectorTypeSchema.safeParse(params.type);
-    if (!typeResult.success) {
-      return redirectWithError(origin, params.type, "Unknown connector type");
+    const connectorTypeResult = resolveOAuthConnectorType(origin, params.type);
+    if (!connectorTypeResult.ok) {
+      return connectorTypeResult.response;
     }
-    const connectorType = typeResult.data;
-
-    if (connectorType === "computer") {
-      return redirectWithError(
-        origin,
-        params.type,
-        "Computer connector does not use OAuth",
-      );
-    }
-    if (!isOAuthConnectorType(connectorType)) {
-      return redirectWithError(
-        origin,
-        params.type,
-        `${params.type} connector does not use OAuth`,
-      );
-    }
+    const { connectorType } = connectorTypeResult;
 
     const writeDb = set(writeDb$);
     const savedState = getCookie(request, STATE_COOKIE_NAME);
@@ -454,24 +483,21 @@ const callbackConnectorInner$ = command(
     const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
     const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
     const state = query.state;
-    const storedStateResolution = state
-      ? await resolveStoredOAuthState(writeDb, state, connectorType, signal)
-      : { kind: "missing" as const };
-    if (storedStateResolution.kind === "invalid") {
-      return redirectWithError(
-        origin,
-        params.type,
-        "Invalid state - please try again",
-        true,
-      );
-    }
-    const storedState =
-      storedStateResolution.kind === "usable"
-        ? storedStateResolution.state
-        : undefined;
 
     if (query.error) {
-      await consumeStoredOAuthState(writeDb, storedState, signal);
+      if (state) {
+        const claimedState = await claimStoredOAuthStateForCallback({
+          db: writeDb,
+          state,
+          connectorType,
+          origin,
+          type: params.type,
+          signal,
+        });
+        if (!claimedState.ok) {
+          return claimedState.response;
+        }
+      }
       return redirectWithError(
         origin,
         params.type,
@@ -499,6 +525,18 @@ const callbackConnectorInner$ = command(
       );
     }
 
+    const claimedState = await claimStoredOAuthStateForCallback({
+      db: writeDb,
+      state,
+      connectorType,
+      origin,
+      type: params.type,
+      signal,
+    });
+    if (!claimedState.ok) {
+      return claimedState.response;
+    }
+
     const resolvedState = await set(
       resolveCallbackState$,
       {
@@ -509,7 +547,7 @@ const callbackConnectorInner$ = command(
         sessionId,
         codeVerifier,
         oauthContext,
-        storedState,
+        storedState: claimedState.storedState,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+
+import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { createStore } from "ccstate";
+import { inArray } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { writeDb$ } from "../../external/db";
+import { nowDate } from "../../external/time";
+import { claimConnectorOAuthState } from "../connector-oauth-state.service";
+
+const store = createStore();
+
+type SeedOAuthStateInput = {
+  readonly state?: string;
+  readonly type?: OAuthConnectorType;
+  readonly consumedAt?: Date | null;
+  readonly expiresAt?: Date;
+};
+
+describe("connector OAuth state claim", () => {
+  const states = new Set<string>();
+
+  async function seedOAuthState(args: SeedOAuthStateInput = {}) {
+    const db = store.set(writeDb$);
+    const state = args.state ?? `state-${randomUUID()}`;
+    states.add(state);
+
+    const [row] = await db
+      .insert(connectorOauthStates)
+      .values({
+        state,
+        type: args.type ?? "github",
+        userId: `user_${randomUUID()}`,
+        orgId: `org_${randomUUID()}`,
+        redirectUri: "https://app.vm0.test/api/connectors/github/callback",
+        consumedAt: args.consumedAt,
+        expiresAt:
+          args.expiresAt ?? new Date(nowDate().getTime() + 15 * 60 * 1000),
+      })
+      .returning();
+
+    expect(row).toBeDefined();
+    return row!;
+  }
+
+  afterEach(async () => {
+    if (states.size === 0) {
+      return;
+    }
+
+    const db = store.set(writeDb$);
+    await db
+      .delete(connectorOauthStates)
+      .where(inArray(connectorOauthStates.state, [...states]));
+    states.clear();
+  });
+
+  it("claims a valid stored state", async () => {
+    const row = await seedOAuthState();
+    const db = store.set(writeDb$);
+
+    const result = await claimConnectorOAuthState(
+      db,
+      { state: row.state, connectorType: "github" },
+      new AbortController().signal,
+    );
+
+    expect(result).toMatchObject({
+      kind: "usable",
+      state: {
+        id: row.id,
+        state: row.state,
+        type: "github",
+      },
+    });
+    if (result.kind === "usable") {
+      expect(result.state.consumedAt).toBeInstanceOf(Date);
+    }
+  });
+
+  it("rejects a stored state after it has already been claimed", async () => {
+    const row = await seedOAuthState();
+    const db = store.set(writeDb$);
+    const signal = new AbortController().signal;
+
+    await expect(
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        signal,
+      ),
+    ).resolves.toMatchObject({ kind: "usable" });
+    await expect(
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        signal,
+      ),
+    ).resolves.toStrictEqual({ kind: "invalid" });
+  });
+
+  it("allows only one concurrent claim for a stored state", async () => {
+    const row = await seedOAuthState();
+    const db = store.set(writeDb$);
+    const signal = new AbortController().signal;
+
+    const results = await Promise.all([
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        signal,
+      ),
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        signal,
+      ),
+    ]);
+
+    expect(
+      results.filter((result) => {
+        return result.kind === "usable";
+      }),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => {
+        return result.kind === "invalid";
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("rejects an expired stored state", async () => {
+    const row = await seedOAuthState({
+      expiresAt: new Date(nowDate().getTime() - 1000),
+    });
+    const db = store.set(writeDb$);
+
+    await expect(
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        new AbortController().signal,
+      ),
+    ).resolves.toStrictEqual({ kind: "invalid" });
+  });
+
+  it("rejects an already consumed stored state", async () => {
+    const row = await seedOAuthState({ consumedAt: nowDate() });
+    const db = store.set(writeDb$);
+
+    await expect(
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        new AbortController().signal,
+      ),
+    ).resolves.toStrictEqual({ kind: "invalid" });
+  });
+
+  it("rejects a stored state for another connector type", async () => {
+    const row = await seedOAuthState({ type: "slack" });
+    const db = store.set(writeDb$);
+
+    await expect(
+      claimConnectorOAuthState(
+        db,
+        { state: row.state, connectorType: "github" },
+        new AbortController().signal,
+      ),
+    ).resolves.toStrictEqual({ kind: "invalid" });
+  });
+
+  it("returns missing when no stored state exists", async () => {
+    const db = store.set(writeDb$);
+
+    await expect(
+      claimConnectorOAuthState(
+        db,
+        { state: `state-${randomUUID()}`, connectorType: "github" },
+        new AbortController().signal,
+      ),
+    ).resolves.toStrictEqual({ kind: "missing" });
+  });
+});

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -12,6 +12,45 @@ type ConnectorOAuthStateClaimResult =
   | { readonly kind: "invalid" }
   | { readonly kind: "usable"; readonly state: StoredOAuthState };
 
+type ConnectorOAuthStateStatus =
+  | { readonly kind: "missing" }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "usable" };
+
+export async function getConnectorOAuthStateStatus(
+  db: Db,
+  args: {
+    readonly state: string;
+    readonly connectorType: OAuthConnectorType;
+  },
+  signal: AbortSignal,
+): Promise<ConnectorOAuthStateStatus> {
+  const [storedState] = await db
+    .select({
+      type: connectorOauthStates.type,
+      consumedAt: connectorOauthStates.consumedAt,
+      expiresAt: connectorOauthStates.expiresAt,
+    })
+    .from(connectorOauthStates)
+    .where(eq(connectorOauthStates.state, args.state))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!storedState) {
+    return { kind: "missing" };
+  }
+
+  if (
+    storedState.type !== args.connectorType ||
+    storedState.consumedAt ||
+    storedState.expiresAt <= nowDate()
+  ) {
+    return { kind: "invalid" };
+  }
+
+  return { kind: "usable" };
+}
+
 export async function claimConnectorOAuthState(
   db: Db,
   args: {

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,0 +1,50 @@
+import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { and, eq, gt, isNull } from "drizzle-orm";
+
+import { nowDate } from "../../lib/time";
+import type { Db } from "../external/db";
+
+export type StoredOAuthState = typeof connectorOauthStates.$inferSelect;
+
+type ConnectorOAuthStateClaimResult =
+  | { readonly kind: "missing" }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "usable"; readonly state: StoredOAuthState };
+
+export async function claimConnectorOAuthState(
+  db: Db,
+  args: {
+    readonly state: string;
+    readonly connectorType: OAuthConnectorType;
+  },
+  signal: AbortSignal,
+): Promise<ConnectorOAuthStateClaimResult> {
+  const consumedAt = nowDate();
+  const [claimedState] = await db
+    .update(connectorOauthStates)
+    .set({ consumedAt })
+    .where(
+      and(
+        eq(connectorOauthStates.state, args.state),
+        eq(connectorOauthStates.type, args.connectorType),
+        isNull(connectorOauthStates.consumedAt),
+        gt(connectorOauthStates.expiresAt, consumedAt),
+      ),
+    )
+    .returning();
+  signal.throwIfAborted();
+
+  if (claimedState) {
+    return { kind: "usable", state: claimedState };
+  }
+
+  const [existingState] = await db
+    .select({ id: connectorOauthStates.id })
+    .from(connectorOauthStates)
+    .where(eq(connectorOauthStates.state, args.state))
+    .limit(1);
+  signal.throwIfAborted();
+
+  return existingState ? { kind: "invalid" } : { kind: "missing" };
+}


### PR DESCRIPTION
Closes #14383

## Summary

- Add an atomic `UPDATE ... RETURNING` claim helper for connector OAuth handoff state rows.
- Update the callback route to claim stored handoff state only for provider-error and code-present callbacks, preserving cookie-backed direct callbacks and missing-code behavior.
- Add database-boundary and callback route coverage for reuse, already-consumed, expired, wrong-type, missing-code, missing-row, and concurrent claim cases.

## Tests

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/services/__tests__/connector-oauth-state.service.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts`
- `pnpm -F api test`
- `pnpm knip --workspace api`
- pre-commit: prettier, knip, full `pnpm check-types`
