### PR TITLE
fix: harden connector oauth sessions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
@@ -1,13 +1,19 @@
 import { randomUUID } from "node:crypto";
 
-import { describe, expect, it, beforeEach } from "vitest";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
 import { testContext } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
+const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 const BASE_URL = "https://app.vm0.test";
@@ -26,10 +32,18 @@ function sessionHeaders(): HeadersInit {
 
 async function requestAuthorize(
   type: string,
-  options: { readonly session?: string; readonly authenticated?: boolean } = {},
+  options: {
+    readonly session?: string;
+    readonly authenticated?: boolean;
+    readonly userId?: string;
+    readonly orgId?: string;
+  } = {},
 ): Promise<Response> {
   if (options.authenticated) {
-    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    mocks.clerk.session(
+      options.userId ?? `user_${randomUUID()}`,
+      options.orgId ?? `org_${randomUUID()}`,
+    );
   }
   const app = createApp({ signal: context.signal });
   return await app.request(authorizeUrl(type, options.session), {
@@ -38,7 +52,28 @@ async function requestAuthorize(
   });
 }
 
+async function createPendingConnectorSession(args: {
+  readonly userId: string;
+  readonly type?: string;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const [session] = await db
+    .insert(connectorSessions)
+    .values({
+      code: randomUUID().slice(0, 9).toUpperCase(),
+      type: args.type ?? "github",
+      userId: args.userId,
+      status: "pending",
+      expiresAt: new Date(now() + 15 * 60 * 1000),
+    })
+    .returning({ id: connectorSessions.id });
+  expect(session).toBeDefined();
+  return session!.id;
+}
+
 describe("GET /api/connectors/:type/authorize", () => {
+  const sessionIds: string[] = [];
+
   beforeEach(() => {
     mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
     mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "test-client-secret");
@@ -60,6 +95,18 @@ describe("GET /api/connectors/:type/authorize", () => {
     mockOptionalEnv("SLACK_CLIENT_SECRET", "test-slack-client-secret");
     mockOptionalEnv("X_OAUTH_CLIENT_ID", "x-test-client-id");
     mockOptionalEnv("X_OAUTH_CLIENT_SECRET", "x-test-client-secret");
+  });
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    while (sessionIds.length > 0) {
+      const sessionId = sessionIds.pop();
+      if (sessionId) {
+        await db
+          .delete(connectorSessions)
+          .where(eq(connectorSessions.id, sessionId));
+      }
+    }
   });
 
   it("returns 400 for an unknown connector type", async () => {
@@ -117,9 +164,12 @@ describe("GET /api/connectors/:type/authorize", () => {
   });
 
   it("stores the connector session id when provided", async () => {
-    const sessionId = randomUUID();
+    const userId = `user_${randomUUID()}`;
+    const sessionId = await createPendingConnectorSession({ userId });
+    sessionIds.push(sessionId);
     const response = await requestAuthorize("github", {
       authenticated: true,
+      userId,
       session: sessionId,
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
@@ -117,17 +117,30 @@ describe("GET /api/connectors/:type/authorize", () => {
   });
 
   it("stores the connector session id when provided", async () => {
+    const sessionId = randomUUID();
     const response = await requestAuthorize("github", {
       authenticated: true,
-      session: "session-123",
+      session: sessionId,
     });
 
     const cookies = response.headers.getSetCookie();
     expect(
       cookies.some((cookie) => {
-        return cookie.startsWith("connector_oauth_session=session-123");
+        return cookie.startsWith(`connector_oauth_session=${sessionId}`);
       }),
     ).toBeTruthy();
+  });
+
+  it("rejects invalid connector session ids", async () => {
+    const response = await requestAuthorize("github", {
+      authenticated: true,
+      session: "not-a-session-id",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid connector session",
+    });
   });
 
   it("does not set a session cookie when the query parameter is absent", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1974,6 +1974,59 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(storedState?.consumedAt).toBeInstanceOf(Date);
   });
 
+  it("marks server-side connector sessions as error when the provider returns an error", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const sessionId = await seedSession({ userId });
+    sessionIds.push(sessionId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+      sessionId,
+    });
+    oauthStateIds.push(oauthStateId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: {
+        error: "access_denied",
+        error_description: "The user denied access",
+        state,
+      },
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "The user denied access",
+    });
+
+    const db = store.set(writeDb$);
+    const [storedState] = await db
+      .select({ consumedAt: connectorOauthStates.consumedAt })
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.id, oauthStateId));
+    expect(storedState?.consumedAt).toBeInstanceOf(Date);
+
+    const [session] = await db
+      .select({
+        status: connectorSessions.status,
+        errorMessage: connectorSessions.errorMessage,
+      })
+      .from(connectorSessions)
+      .where(eq(connectorSessions.id, sessionId));
+    expect(session).toStrictEqual({
+      status: "error",
+      errorMessage: "The user denied access",
+    });
+  });
+
   it("rejects an invalid server-side OAuth handoff state before provider errors", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -210,6 +210,8 @@ type CapturedOAuthExchange = {
   readonly oauthContext: string | undefined;
 };
 
+type ConnectorSessionStatus = "pending" | "complete" | "expired" | "error";
+
 function useDynamicTestOAuthExchange(): {
   readonly exchanges: readonly CapturedOAuthExchange[];
   readonly restore: () => void;
@@ -914,16 +916,25 @@ function mockProviderOAuth(options: ProviderMockOptions): void {
   mocker(resolvedProviderMockOptions(options));
 }
 
-async function seedSession(userId: string): Promise<string> {
+async function seedSession(args: {
+  readonly userId: string;
+  readonly type?: string;
+  readonly status?: ConnectorSessionStatus;
+  readonly expiresAt?: Date;
+  readonly completedAt?: Date;
+  readonly errorMessage?: string | null;
+}): Promise<string> {
   const db = store.set(writeDb$);
   const [session] = await db
     .insert(connectorSessions)
     .values({
       code: randomUUID().slice(0, 9).toUpperCase(),
-      type: "github",
-      userId,
-      status: "pending",
-      expiresAt: new Date(now() + 15 * 60 * 1000),
+      type: args.type ?? "github",
+      userId: args.userId,
+      status: args.status ?? "pending",
+      expiresAt: args.expiresAt ?? new Date(now() + 15 * 60 * 1000),
+      completedAt: args.completedAt,
+      errorMessage: args.errorMessage,
     })
     .returning({ id: connectorSessions.id });
   expect(session).toBeDefined();
@@ -1434,7 +1445,7 @@ describe("GET /api/connectors/:type/callback", () => {
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
     authenticate({ userId, orgId });
-    const sessionId = await seedSession(userId);
+    const sessionId = await seedSession({ userId });
     sessionIds.push(sessionId);
     mockGitHubOAuth({ accessToken: "github-token", userError: true });
 
@@ -1467,7 +1478,7 @@ describe("GET /api/connectors/:type/callback", () => {
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
     authenticate({ userId, orgId });
-    const sessionId = await seedSession(userId);
+    const sessionId = await seedSession({ userId });
     sessionIds.push(sessionId);
     mockGitHubOAuth({
       accessToken: "github-token",
@@ -1531,6 +1542,129 @@ describe("GET /api/connectors/:type/callback", () => {
       .where(eq(connectorSessions.id, sessionId));
     expect(session?.status).toBe("complete");
     expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects callbacks when the session belongs to another user", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const ownerUserId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const sessionId = await seedSession({ userId: ownerUserId });
+    sessionIds.push(sessionId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123", sessionId }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid session - please try again",
+    );
+    await expect(
+      findConnector({ orgId, userId, type: "github" }),
+    ).resolves.toBeUndefined();
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({ status: connectorSessions.status })
+      .from(connectorSessions)
+      .where(eq(connectorSessions.id, sessionId));
+    expect(session?.status).toBe("pending");
+  });
+
+  it("rejects callbacks when the session belongs to another connector type", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const sessionId = await seedSession({ userId, type: "slack" });
+    sessionIds.push(sessionId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123", sessionId }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid session - please try again",
+    );
+    await expect(
+      findConnector({ orgId, userId, type: "github" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    { status: "complete" as const, completedAt: new Date(now()) },
+    { status: "error" as const, errorMessage: "previous failure" },
+    { status: "expired" as const },
+  ])("rejects callbacks when the session is $status", async (sessionState) => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const sessionId = await seedSession({ userId, ...sessionState });
+    sessionIds.push(sessionId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123", sessionId }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid session - please try again",
+    );
+    await expect(
+      findConnector({ orgId, userId, type: "github" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects callbacks when the session is expired", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const sessionId = await seedSession({
+      userId,
+      expiresAt: new Date(now() - 1000),
+    });
+    sessionIds.push(sessionId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123", sessionId }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid session - please try again",
+    );
+    await expect(
+      findConnector({ orgId, userId, type: "github" }),
+    ).resolves.toBeUndefined();
   });
 
   it("stores a connector from a server-side OAuth handoff without Clerk cookies", async () => {
@@ -2216,7 +2350,7 @@ describe("GET /api/connectors/:type/callback", () => {
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
     authenticate({ userId, orgId });
-    const sessionId = await seedSession(userId);
+    const sessionId = await seedSession({ userId });
     sessionIds.push(sessionId);
     mockGitHubOAuth({ tokenError: "bad code" });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1667,6 +1667,60 @@ describe("GET /api/connectors/:type/callback", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("does not store a connector when the session is completed concurrently", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const sessionId = await seedSession({ userId });
+    sessionIds.push(sessionId);
+    const db = store.set(writeDb$);
+    server.use(
+      http.post(GITHUB_TOKEN_URL, async () => {
+        await db
+          .update(connectorSessions)
+          .set({ status: "expired" })
+          .where(eq(connectorSessions.id, sessionId));
+        return HttpResponse.json({
+          access_token: "github-access-token",
+          scope: "repo",
+          token_type: "bearer",
+        });
+      }),
+      http.get(GITHUB_USER_URL, () => {
+        return HttpResponse.json({
+          id: 98_765,
+          login: "octocat",
+          email: "octocat@example.com",
+        });
+      }),
+    );
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123", sessionId }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid session - please try again",
+    );
+    await expect(
+      findConnector({ orgId, userId, type: "github" }),
+    ).resolves.toBeUndefined();
+
+    const [session] = await db
+      .select({ status: connectorSessions.status })
+      .from(connectorSessions)
+      .where(eq(connectorSessions.id, sessionId));
+    expect(session?.status).toBe("expired");
+  });
+
   it("stores a connector from a server-side OAuth handoff without Clerk cookies", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
@@ -1693,6 +1747,60 @@ describe("GET /api/connectors/:type/callback", () => {
     const response = await requestCallback({
       type: "github",
       query: { code: "code-123", state },
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/success");
+    expect(url.searchParams.get("type")).toBe("github");
+    expect(url.searchParams.get("username")).toBe("octocat");
+
+    const connector = await findConnector({ orgId, userId, type: "github" });
+    expect(connector).toMatchObject({
+      type: "github",
+      authMethod: "oauth",
+      externalId: "98765",
+      externalUsername: "octocat",
+      externalEmail: "octocat@example.com",
+      needsReconnect: false,
+    });
+
+    const db = store.set(writeDb$);
+    const [storedState] = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.id, oauthStateId));
+    expect(storedState?.consumedAt).toBeInstanceOf(Date);
+  });
+
+  it("uses server-side OAuth state when a stale browser state cookie exists", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const state = `state-${randomUUID()}`;
+    orgIds.push(orgId);
+    const oauthStateId = await seedOauthState({
+      type: "github",
+      userId,
+      orgId,
+      state,
+    });
+    oauthStateIds.push(oauthStateId);
+    mockGitHubOAuth({
+      accessToken: "github-token",
+      userId: 98_765,
+      username: "octocat",
+      email: "octocat@example.com",
+    });
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state },
+      headers: callbackHeaders({ stateCookie: "stale-state" }),
     });
 
     expect(response.status).toBe(307);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1606,6 +1606,34 @@ describe("GET /api/connectors/:type/callback", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("rejects callbacks with malformed connector session cookies", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({
+        stateCookie: "state-123",
+        sessionId: "not-a-session-id",
+      }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid session - please try again",
+    );
+    await expect(
+      findConnector({ orgId, userId, type: "github" }),
+    ).resolves.toBeUndefined();
+  });
+
   it.each([
     { status: "complete" as const, completedAt: new Date(now()) },
     { status: "error" as const, errorMessage: "previous failure" },

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1288,6 +1288,43 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
+  it("marks connector sessions as error when the provider returns an error", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const sessionId = await seedSession({ userId });
+    sessionIds.push(sessionId);
+
+    const response = await requestCallback({
+      type: "github",
+      query: {
+        error: "access_denied",
+        error_description: "The user denied access",
+        state: "state-123",
+      },
+      headers: callbackHeaders({ stateCookie: "state-123", sessionId }),
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "github",
+      message: "The user denied access",
+    });
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({
+        status: connectorSessions.status,
+        errorMessage: connectorSessions.errorMessage,
+      })
+      .from(connectorSessions)
+      .where(eq(connectorSessions.id, sessionId));
+    expect(session).toStrictEqual({
+      status: "error",
+      errorMessage: "The user denied access",
+    });
+  });
+
   it("redirects missing authorization codes and clears OAuth cookies", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -13,6 +13,7 @@ import {
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { orgCache } from "@vm0/db/schema/org-cache";
@@ -818,6 +819,12 @@ const deleteClerkFixture$ = command(
     const db = set(writeDb$);
     await db.delete(storages).where(eq(storages.userId, fixture.userId));
     await db.delete(storages).where(eq(storages.orgId, fixture.orgId));
+    await db
+      .delete(connectorOauthStates)
+      .where(eq(connectorOauthStates.userId, fixture.userId));
+    await db
+      .delete(connectorOauthStates)
+      .where(eq(connectorOauthStates.orgId, fixture.orgId));
     await db
       .delete(orgMembersMetadata)
       .where(eq(orgMembersMetadata.userId, fixture.userId));
@@ -2301,6 +2308,20 @@ describe("POST /api/webhooks/clerk", () => {
     const fixture = await trackClerk(
       store.set(seedClerkFixture$, undefined, context.signal),
     );
+    const db = store.set(writeDb$);
+    const [oauthState] = await db
+      .insert(connectorOauthStates)
+      .values({
+        state: `state-${randomUUID()}`,
+        type: "github",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        redirectUri: "https://www.vm0.ai/api/connectors/github/callback",
+        expiresAt: nowDate(),
+      })
+      .returning({ id: connectorOauthStates.id });
+    expect(oauthState).toBeDefined();
+
     context.mocks.clerk.verifyWebhook.mockResolvedValue({
       type: "organization.deleted",
       data: { id: fixture.orgId },
@@ -2316,7 +2337,6 @@ describe("POST /api/webhooks/clerk", () => {
     expect(response.status).toBe(200);
     expect(response.body).toBe("OK");
 
-    const db = store.set(writeDb$);
     const cacheRows = await db
       .select({ orgId: orgCache.orgId })
       .from(orgCache)
@@ -2329,9 +2349,14 @@ describe("POST /api/webhooks/clerk", () => {
       .select({ orgId: orgMembersCache.orgId })
       .from(orgMembersCache)
       .where(eq(orgMembersCache.orgId, fixture.orgId));
+    const oauthStateRows = await db
+      .select({ id: connectorOauthStates.id })
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.id, oauthState!.id));
     expect(cacheRows).toHaveLength(0);
     expect(metadataRows).toHaveLength(0);
     expect(membershipRows).toHaveLength(0);
+    expect(oauthStateRows).toHaveLength(0);
   });
 
   it("does not schedule organization deletion cleanup without an org ID", async () => {
@@ -2394,6 +2419,20 @@ describe("POST /api/webhooks/clerk", () => {
     const fixture = await trackClerk(
       store.set(seedClerkFixture$, undefined, context.signal),
     );
+    const db = store.set(writeDb$);
+    const [oauthState] = await db
+      .insert(connectorOauthStates)
+      .values({
+        state: `state-${randomUUID()}`,
+        type: "github",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        redirectUri: "https://www.vm0.ai/api/connectors/github/callback",
+        expiresAt: nowDate(),
+      })
+      .returning({ id: connectorOauthStates.id });
+    expect(oauthState).toBeDefined();
+
     context.mocks.clerk.verifyWebhook.mockResolvedValue({
       type: "user.deleted",
       data: { id: fixture.userId },
@@ -2409,7 +2448,6 @@ describe("POST /api/webhooks/clerk", () => {
     expect(response.status).toBe(200);
     expect(response.body).toBe("OK");
 
-    const db = store.set(writeDb$);
     const cacheRows = await db
       .select({ userId: userCache.userId })
       .from(userCache)
@@ -2422,9 +2460,14 @@ describe("POST /api/webhooks/clerk", () => {
       .select({ orgId: orgCache.orgId })
       .from(orgCache)
       .where(eq(orgCache.orgId, fixture.orgId));
+    const oauthStateRows = await db
+      .select({ id: connectorOauthStates.id })
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.id, oauthState!.id));
     expect(cacheRows).toHaveLength(0);
     expect(userRows).toHaveLength(0);
     expect(orgRows).toHaveLength(1);
+    expect(oauthStateRows).toHaveLength(0);
   });
 
   it("does not schedule user deletion cleanup without a user ID", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -302,17 +302,30 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
   });
 
   it("stores the connector session id when provided", async () => {
+    const sessionId = randomUUID();
     const response = await requestAuthorize("github", {
       authenticated: true,
-      session: "session-123",
+      session: sessionId,
     });
 
     const cookies = response.headers.getSetCookie();
     expect(
       cookies.some((cookie) => {
-        return cookie.startsWith("connector_oauth_session=session-123");
+        return cookie.startsWith(`connector_oauth_session=${sessionId}`);
       }),
     ).toBeTruthy();
+  });
+
+  it("rejects invalid connector session ids", async () => {
+    const response = await requestAuthorize("github", {
+      authenticated: true,
+      session: "not-a-session-id",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid connector session",
+    });
   });
 
   it("allows dynamic public OAuth authorize without env credentials", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -7,6 +7,7 @@ import {
 import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -120,12 +121,17 @@ async function requestAuthorize(
   options: {
     readonly session?: string;
     readonly authenticated?: boolean;
+    readonly userId?: string;
+    readonly orgId?: string;
     readonly headers?: HeadersInit;
     readonly origin?: string;
   } = {},
 ): Promise<Response> {
   if (options.authenticated) {
-    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    mocks.clerk.session(
+      options.userId ?? `user_${randomUUID()}`,
+      options.orgId ?? `org_${randomUUID()}`,
+    );
   }
   const headers = new Headers(options.headers);
   if (options.authenticated) {
@@ -163,8 +169,28 @@ async function requestOauthStart(
   });
 }
 
+async function createPendingConnectorSession(args: {
+  readonly userId: string;
+  readonly type?: string;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const [session] = await db
+    .insert(connectorSessions)
+    .values({
+      code: randomUUID().slice(0, 9).toUpperCase(),
+      type: args.type ?? "github",
+      userId: args.userId,
+      status: "pending",
+      expiresAt: new Date(now() + 15 * 60 * 1000),
+    })
+    .returning({ id: connectorSessions.id });
+  expect(session).toBeDefined();
+  return session!.id;
+}
+
 describe("GET /api/zero/connectors/:type/authorize", () => {
   const orgIds: string[] = [];
+  const sessionIds: string[] = [];
   let restoreDynamicTestOAuthAuthorize: (() => void) | undefined;
 
   beforeEach(() => {
@@ -176,6 +202,14 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     restoreDynamicTestOAuthAuthorize = undefined;
 
     const db = store.set(writeDb$);
+    while (sessionIds.length > 0) {
+      const sessionId = sessionIds.pop();
+      if (sessionId) {
+        await db
+          .delete(connectorSessions)
+          .where(eq(connectorSessions.id, sessionId));
+      }
+    }
     while (orgIds.length > 0) {
       const orgId = orgIds.pop();
       if (orgId) {
@@ -302,9 +336,15 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
   });
 
   it("stores the connector session id when provided", async () => {
-    const sessionId = randomUUID();
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    const sessionId = await createPendingConnectorSession({ userId });
+    sessionIds.push(sessionId);
     const response = await requestAuthorize("github", {
       authenticated: true,
+      userId,
+      orgId,
       session: sessionId,
     });
 
@@ -314,6 +354,36 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
         return cookie.startsWith(`connector_oauth_session=${sessionId}`);
       }),
     ).toBeTruthy();
+  });
+
+  it("rejects unknown connector session ids before clearing local state", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    const db = store.set(writeDb$);
+    const [connector] = await db
+      .insert(connectors)
+      .values({ orgId, userId, type: "github", authMethod: "oauth" })
+      .returning({ id: connectors.id });
+    expect(connector).toBeDefined();
+
+    const response = await requestAuthorize("github", {
+      authenticated: true,
+      userId,
+      orgId,
+      session: randomUUID(),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid connector session",
+    });
+    const survivors = await db
+      .select()
+      .from(connectors)
+      .where(eq(connectors.id, connector!.id));
+    expect(survivors).toHaveLength(1);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
   });
 
   it("rejects invalid connector session ids", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts
@@ -95,6 +95,31 @@ describe("GET /api/zero/connectors/:type/sessions/:sessionId", () => {
     expect(response.body.status).toBe("complete");
   });
 
+  it("returns errored session status with the error message", async () => {
+    const userId = `user_${randomUUID()}`;
+    const sessionId = await seedSession({
+      userId,
+      status: "error",
+      errorMessage: "OAuth authorization failed",
+    });
+    sessionIds.push(sessionId);
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      errorMessage: "OAuth authorization failed",
+    });
+  });
+
   it("marks expired pending sessions and returns expired status", async () => {
     const userId = `user_${randomUUID()}`;
     const sessionId = await seedSession({
@@ -134,6 +159,24 @@ describe("GET /api/zero/connectors/:type/sessions/:sessionId", () => {
     const response = await accept(
       client.get({
         params: { type: "github", sessionId: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("does not return another connector type's session", async () => {
+    const userId = `user_${randomUUID()}`;
+    const sessionId = await seedSession({ userId, type: "slack" });
+    sessionIds.push(sessionId);
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [404],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
@@ -4,9 +4,10 @@ import { zeroConnectorSessionsContract } from "@vm0/api-contracts/contracts/zero
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -16,6 +17,11 @@ const mocks = createZeroRouteMocks(context);
 
 describe("POST /api/zero/connectors/:type/sessions", () => {
   const sessionIds: string[] = [];
+
+  beforeEach(() => {
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
+    mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "test-client-secret");
+  });
 
   afterEach(async () => {
     const db = store.set(writeDb$);
@@ -72,6 +78,46 @@ describe("POST /api/zero/connectors/:type/sessions", () => {
       userId,
       status: "pending",
     });
+  });
+
+  it("rejects non-OAuth connector sessions", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "computer" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toBe(
+      "Computer connector does not use OAuth",
+    );
+  });
+
+  it("rejects sessions for misconfigured OAuth connectors", async () => {
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", undefined);
+    mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", undefined);
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "github" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [500],
+    );
+
+    expect(response.body.error.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(response.body.error.message).toBe("github OAuth not configured");
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/turbo/apps/api/src/signals/routes/connector-oauth-route-state.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-route-state.ts
@@ -3,6 +3,7 @@ import {
   CONNECTOR_OAUTH_PROVIDERS,
   type AuthUrlResult,
 } from "@vm0/connectors/oauth-providers";
+import { z } from "zod";
 
 import { env } from "../../lib/env";
 
@@ -12,6 +13,7 @@ export const CONNECTOR_OAUTH_PKCE_COOKIE_NAME = "connector_oauth_pkce";
 export const CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 export const CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS = 15 * 60;
 const CONNECTOR_OAUTH_REDIRECT_STATUS = 307;
+const connectorOAuthSessionIdSchema = z.uuid();
 
 export function generateConnectorOAuthState(): string {
   const array = new Uint8Array(32);
@@ -67,6 +69,16 @@ export function redirectResponse(url: string): Response {
     status: CONNECTOR_OAUTH_REDIRECT_STATUS,
     headers: { location: url },
   });
+}
+
+export function parseConnectorOAuthSessionId(
+  value: string | undefined,
+): string | undefined | null {
+  if (!value) {
+    return undefined;
+  }
+  const result = connectorOAuthSessionIdSchema.safeParse(value);
+  return result.success ? result.data : null;
 }
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {

--- a/turbo/apps/api/src/signals/routes/connector-oauth-route-state.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-route-state.ts
@@ -1,0 +1,90 @@
+import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import {
+  CONNECTOR_OAUTH_PROVIDERS,
+  type AuthUrlResult,
+} from "@vm0/connectors/oauth-providers";
+
+import { env } from "../../lib/env";
+
+export const CONNECTOR_OAUTH_STATE_COOKIE_NAME = "connector_oauth_state";
+export const CONNECTOR_OAUTH_SESSION_COOKIE_NAME = "connector_oauth_session";
+export const CONNECTOR_OAUTH_PKCE_COOKIE_NAME = "connector_oauth_pkce";
+export const CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
+export const CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS = 15 * 60;
+const CONNECTOR_OAUTH_REDIRECT_STATUS = 307;
+
+export function generateConnectorOAuthState(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => {
+    return byte.toString(16).padStart(2, "0");
+  }).join("");
+}
+
+export function buildOAuthCookieHeader(
+  name: string,
+  value: string,
+  maxAge: number,
+): string {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    `Max-Age=${maxAge}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (env("ENV") === "production") {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+function buildDeleteOAuthCookieHeader(name: string): string {
+  return `${name}=; Max-Age=0; Path=/`;
+}
+
+export function clearOAuthCookies(response: Response): void {
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteOAuthCookieHeader(CONNECTOR_OAUTH_STATE_COOKIE_NAME),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteOAuthCookieHeader(CONNECTOR_OAUTH_SESSION_COOKIE_NAME),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteOAuthCookieHeader(CONNECTOR_OAUTH_PKCE_COOKIE_NAME),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteOAuthCookieHeader(CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME),
+  );
+}
+
+export function redirectResponse(url: string): Response {
+  return new Response(null, {
+    status: CONNECTOR_OAUTH_REDIRECT_STATUS,
+    headers: { location: url },
+  });
+}
+
+function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
+  return typeof result === "string" ? { url: result } : result;
+}
+
+export async function buildProviderAuthorizeUrl(args: {
+  readonly type: OAuthConnectorType;
+  readonly clientId?: string;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<AuthUrlResult> {
+  const provider = CONNECTOR_OAUTH_PROVIDERS[args.type];
+  return normalizeAuthUrlResult(
+    await provider.buildAuthUrl({
+      clientId: args.clientId,
+      redirectUri: args.redirectUri,
+      state: args.state,
+    }),
+  );
+}

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -130,6 +130,14 @@ type ConnectorSessionTransitionInput = {
   readonly userId: string;
 };
 
+type StoredStateCallbackInput = {
+  readonly db: Db;
+  readonly connectorType: OAuthConnectorType;
+  readonly origin: string;
+  readonly type: string;
+  readonly signal: AbortSignal;
+};
+
 function getCookie(request: Request, name: string): string | undefined {
   const cookieHeader = request.headers.get("cookie");
   if (!cookieHeader) {
@@ -324,6 +332,36 @@ async function rejectInvalidStoredOAuthStateForCallback(args: {
   }
 
   return invalidStateRedirectResponse(args.origin, args.type);
+}
+
+async function claimStoredOAuthStateForCallbackIfPresent(
+  args: StoredStateCallbackInput & { readonly state: string | undefined },
+): Promise<ClaimedCallbackState> {
+  if (!args.state) {
+    return { ok: true, storedState: undefined };
+  }
+
+  const claimedState = await claimStoredOAuthStateForCallback({
+    ...args,
+    state: args.state,
+  });
+  args.signal.throwIfAborted();
+  return claimedState;
+}
+
+async function rejectInvalidStoredOAuthStateForCallbackIfPresent(
+  args: StoredStateCallbackInput & { readonly state: string | undefined },
+): Promise<Response | undefined> {
+  if (!args.state) {
+    return undefined;
+  }
+
+  const invalidStateResponse = await rejectInvalidStoredOAuthStateForCallback({
+    ...args,
+    state: args.state,
+  });
+  args.signal.throwIfAborted();
+  return invalidStateResponse;
 }
 
 async function hasPendingConnectorSession(
@@ -589,18 +627,16 @@ const callbackConnectorInner$ = command(
       origin,
       type: params.type,
       signal,
-    };
+    } satisfies StoredStateCallbackInput;
 
     if (query.error) {
-      if (storedStateValue) {
-        const claimedState = await claimStoredOAuthStateForCallback({
-          ...storedStateCallbackArgs,
-          state: storedStateValue,
-        });
-        signal.throwIfAborted();
-        if (!claimedState.ok) {
-          return claimedState.response;
-        }
+      const claimedState = await claimStoredOAuthStateForCallbackIfPresent({
+        ...storedStateCallbackArgs,
+        state: storedStateValue,
+      });
+      signal.throwIfAborted();
+      if (!claimedState.ok) {
+        return claimedState.response;
       }
       return redirectWithError(
         origin,
@@ -612,16 +648,14 @@ const callbackConnectorInner$ = command(
 
     const code = query.code;
     if (!code) {
-      if (storedStateValue) {
-        const invalidStateResponse =
-          await rejectInvalidStoredOAuthStateForCallback({
-            ...storedStateCallbackArgs,
-            state: storedStateValue,
-          });
-        signal.throwIfAborted();
-        if (invalidStateResponse) {
-          return invalidStateResponse;
-        }
+      const invalidStateResponse =
+        await rejectInvalidStoredOAuthStateForCallbackIfPresent({
+          ...storedStateCallbackArgs,
+          state: storedStateValue,
+        });
+      signal.throwIfAborted();
+      if (invalidStateResponse) {
+        return invalidStateResponse;
       }
       return missingAuthorizationCodeRedirectResponse(origin, params.type);
     }
@@ -630,17 +664,11 @@ const callbackConnectorInner$ = command(
       return missingStateRedirectResponse(origin, params.type);
     }
 
-    let claimedState: ClaimedCallbackState = {
-      ok: true,
-      storedState: undefined,
-    };
-    if (storedStateValue) {
-      claimedState = await claimStoredOAuthStateForCallback({
-        ...storedStateCallbackArgs,
-        state: storedStateValue,
-      });
-      signal.throwIfAborted();
-    }
+    const claimedState = await claimStoredOAuthStateForCallbackIfPresent({
+      ...storedStateCallbackArgs,
+      state: storedStateValue,
+    });
+    signal.throwIfAborted();
     if (!claimedState.ok) {
       return claimedState.response;
     }

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -19,7 +19,7 @@ import {
   type OAuthTokenResult,
 } from "@vm0/connectors/oauth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
-import { eq } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 
 import { requiredAuthContext$ } from "../auth/auth-context";
 import { request$ } from "../context/hono";
@@ -39,12 +39,14 @@ import {
   getConnectorOAuthCanonicalRedirectUrl,
   getConnectorOAuthOrigin,
 } from "./connector-oauth-origin";
-
-const STATE_COOKIE_NAME = "connector_oauth_state";
-const SESSION_COOKIE_NAME = "connector_oauth_session";
-const PKCE_COOKIE_NAME = "connector_oauth_pkce";
-const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
-const REDIRECT_STATUS = 307;
+import {
+  clearOAuthCookies,
+  CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+  CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+  CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+  CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+  redirectResponse,
+} from "./connector-oauth-route-state";
 
 type CallbackIdentity = {
   readonly userId: string;
@@ -62,6 +64,13 @@ type CompleteOAuthCallbackInput = {
   readonly sessionId: string | undefined;
   readonly origin: string;
   readonly type: string;
+};
+
+type CallbackCookies = {
+  readonly savedState: string | undefined;
+  readonly sessionId: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
 };
 
 type ResolveCallbackStateInput = {
@@ -111,6 +120,12 @@ type ResolvedOAuthConnectorType =
 
 const connectorCallbackAuth = { requireOrganization: true } as const;
 
+type ConnectorSessionTransitionInput = {
+  readonly sessionId: string | undefined;
+  readonly connectorType: OAuthConnectorType;
+  readonly userId: string;
+};
+
 function getCookie(request: Request, name: string): string | undefined {
   const cookieHeader = request.headers.get("cookie");
   if (!cookieHeader) {
@@ -126,34 +141,13 @@ function getCookie(request: Request, name: string): string | undefined {
   return undefined;
 }
 
-function buildDeleteCookieHeader(name: string): string {
-  return `${name}=; Max-Age=0; Path=/`;
-}
-
-function redirectResponse(url: string): Response {
-  return new Response(null, {
-    status: REDIRECT_STATUS,
-    headers: { location: url },
-  });
-}
-
-function clearOAuthCookies(response: Response): void {
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(STATE_COOKIE_NAME),
-  );
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(SESSION_COOKIE_NAME),
-  );
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(PKCE_COOKIE_NAME),
-  );
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(OAUTH_CONTEXT_COOKIE_NAME),
-  );
+function getCallbackCookies(request: Request): CallbackCookies {
+  return {
+    savedState: getCookie(request, CONNECTOR_OAUTH_STATE_COOKIE_NAME),
+    sessionId: getCookie(request, CONNECTOR_OAUTH_SESSION_COOKIE_NAME),
+    codeVerifier: getCookie(request, CONNECTOR_OAUTH_PKCE_COOKIE_NAME),
+    oauthContext: getCookie(request, CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME),
+  };
 }
 
 function redirectWithError(
@@ -330,39 +324,87 @@ async function rejectInvalidStoredOAuthStateForCallback(args: {
 
 async function completeConnectorSession(
   db: Db,
-  sessionId: string | undefined,
+  input: ConnectorSessionTransitionInput,
   signal: AbortSignal,
-): Promise<void> {
-  if (!sessionId) {
-    return;
+): Promise<boolean> {
+  if (!input.sessionId) {
+    return true;
   }
-  await db
+  const updatedAt = nowDate();
+  const [updatedSession] = await db
     .update(connectorSessions)
     .set({
       status: "complete",
-      completedAt: nowDate(),
+      completedAt: updatedAt,
     })
-    .where(eq(connectorSessions.id, sessionId));
+    .where(
+      and(
+        eq(connectorSessions.id, input.sessionId),
+        eq(connectorSessions.type, input.connectorType),
+        eq(connectorSessions.userId, input.userId),
+        eq(connectorSessions.status, "pending"),
+        gt(connectorSessions.expiresAt, updatedAt),
+      ),
+    )
+    .returning({ id: connectorSessions.id });
   signal.throwIfAborted();
+  return Boolean(updatedSession);
+}
+
+async function hasPendingConnectorSession(
+  db: Db,
+  input: ConnectorSessionTransitionInput,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (!input.sessionId) {
+    return true;
+  }
+  const currentDate = nowDate();
+  const [session] = await db
+    .select({ id: connectorSessions.id })
+    .from(connectorSessions)
+    .where(
+      and(
+        eq(connectorSessions.id, input.sessionId),
+        eq(connectorSessions.type, input.connectorType),
+        eq(connectorSessions.userId, input.userId),
+        eq(connectorSessions.status, "pending"),
+        gt(connectorSessions.expiresAt, currentDate),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return Boolean(session);
 }
 
 async function markConnectorSessionError(
   db: Db,
-  sessionId: string | undefined,
+  input: ConnectorSessionTransitionInput,
   errorMessage: string,
   signal: AbortSignal,
-): Promise<void> {
-  if (!sessionId) {
-    return;
+): Promise<boolean> {
+  if (!input.sessionId) {
+    return true;
   }
-  await db
+  const updatedAt = nowDate();
+  const [updatedSession] = await db
     .update(connectorSessions)
     .set({
       status: "error",
       errorMessage,
     })
-    .where(eq(connectorSessions.id, sessionId));
+    .where(
+      and(
+        eq(connectorSessions.id, input.sessionId),
+        eq(connectorSessions.type, input.connectorType),
+        eq(connectorSessions.userId, input.userId),
+        eq(connectorSessions.status, "pending"),
+        gt(connectorSessions.expiresAt, updatedAt),
+      ),
+    )
+    .returning({ id: connectorSessions.id });
   signal.throwIfAborted();
+  return Boolean(updatedSession);
 }
 
 function successRedirectResponse(args: {
@@ -389,6 +431,26 @@ const completeOAuthCallback$ = command(
     args: CompleteOAuthCallbackInput,
     signal: AbortSignal,
   ): Promise<Response> => {
+    const writeDb = set(writeDb$);
+    const session = {
+      sessionId: args.sessionId,
+      connectorType: args.connectorType,
+      userId: args.identity.userId,
+    };
+    const hasValidSession = await hasPendingConnectorSession(
+      writeDb,
+      session,
+      signal,
+    );
+    if (!hasValidSession) {
+      return redirectWithError(
+        args.origin,
+        args.type,
+        "Invalid session - please try again",
+        true,
+      );
+    }
+
     const token = await exchangeTokenForConnector({
       connectorType: args.connectorType,
       code: args.code,
@@ -398,6 +460,20 @@ const completeOAuthCallback$ = command(
       oauthContext: args.oauthContext,
     });
     signal.throwIfAborted();
+
+    const sessionStillValid = await hasPendingConnectorSession(
+      writeDb,
+      session,
+      signal,
+    );
+    if (!sessionStillValid) {
+      return redirectWithError(
+        args.origin,
+        args.type,
+        "Invalid session - please try again",
+        true,
+      );
+    }
 
     const provider = CONNECTOR_OAUTH_PROVIDERS[args.connectorType];
     const result = await set(
@@ -417,7 +493,15 @@ const completeOAuthCallback$ = command(
     );
     signal.throwIfAborted();
 
-    await completeConnectorSession(set(writeDb$), args.sessionId, signal);
+    const completed = await completeConnectorSession(writeDb, session, signal);
+    if (!completed) {
+      return redirectWithError(
+        args.origin,
+        args.type,
+        "Invalid session - please try again",
+        true,
+      );
+    }
     return successRedirectResponse({
       origin: args.origin,
       type: args.type,
@@ -514,11 +598,10 @@ const callbackConnectorInner$ = command(
     const { connectorType } = connectorTypeResult;
 
     const writeDb = set(writeDb$);
-    const savedState = getCookie(request, STATE_COOKIE_NAME);
-    const sessionId = getCookie(request, SESSION_COOKIE_NAME);
-    const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
-    const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
+    const callbackCookies = getCallbackCookies(request);
     const state = query.state;
+    const storedStateValue =
+      callbackCookies.savedState === state ? undefined : state;
     const storedStateCallbackArgs = {
       db: writeDb,
       connectorType,
@@ -528,10 +611,10 @@ const callbackConnectorInner$ = command(
     };
 
     if (query.error) {
-      if (state) {
+      if (storedStateValue) {
         const claimedState = await claimStoredOAuthStateForCallback({
           ...storedStateCallbackArgs,
-          state,
+          state: storedStateValue,
         });
         signal.throwIfAborted();
         if (!claimedState.ok) {
@@ -548,11 +631,11 @@ const callbackConnectorInner$ = command(
 
     const code = query.code;
     if (!code) {
-      if (state) {
+      if (storedStateValue) {
         const invalidStateResponse =
           await rejectInvalidStoredOAuthStateForCallback({
             ...storedStateCallbackArgs,
-            state,
+            state: storedStateValue,
           });
         signal.throwIfAborted();
         if (invalidStateResponse) {
@@ -566,11 +649,17 @@ const callbackConnectorInner$ = command(
       return missingStateRedirectResponse(origin, params.type);
     }
 
-    const claimedState = await claimStoredOAuthStateForCallback({
-      ...storedStateCallbackArgs,
-      state,
-    });
-    signal.throwIfAborted();
+    let claimedState: ClaimedCallbackState = {
+      ok: true,
+      storedState: undefined,
+    };
+    if (storedStateValue) {
+      claimedState = await claimStoredOAuthStateForCallback({
+        ...storedStateCallbackArgs,
+        state: storedStateValue,
+      });
+      signal.throwIfAborted();
+    }
     if (!claimedState.ok) {
       return claimedState.response;
     }
@@ -580,11 +669,11 @@ const callbackConnectorInner$ = command(
       {
         origin,
         type: params.type,
-        savedState,
+        savedState: callbackCookies.savedState,
         state,
-        sessionId,
-        codeVerifier,
-        oauthContext,
+        sessionId: callbackCookies.sessionId,
+        codeVerifier: callbackCookies.codeVerifier,
+        oauthContext: callbackCookies.oauthContext,
         storedState: claimedState.storedState,
       },
       signal,
@@ -620,7 +709,11 @@ const callbackConnectorInner$ = command(
 
     await markConnectorSessionError(
       writeDb,
-      resolvedState.sessionId,
+      {
+        sessionId: resolvedState.sessionId,
+        connectorType,
+        userId: resolvedState.identity.userId,
+      },
       errorMessageFromUnknown(callbackResult.error),
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -32,7 +32,10 @@ import {
   getConnectorOAuthStateStatus,
   type StoredOAuthState,
 } from "../services/connector-oauth-state.service";
-import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import {
+  completeOAuthConnectorSession$,
+  upsertOAuthConnector$,
+} from "../services/zero-connector-data.service";
 import { settle } from "../utils";
 import type { RouteEntry } from "../route";
 import {
@@ -322,35 +325,6 @@ async function rejectInvalidStoredOAuthStateForCallback(args: {
   return invalidStateRedirectResponse(args.origin, args.type);
 }
 
-async function completeConnectorSession(
-  db: Db,
-  input: ConnectorSessionTransitionInput,
-  signal: AbortSignal,
-): Promise<boolean> {
-  if (!input.sessionId) {
-    return true;
-  }
-  const updatedAt = nowDate();
-  const [updatedSession] = await db
-    .update(connectorSessions)
-    .set({
-      status: "complete",
-      completedAt: updatedAt,
-    })
-    .where(
-      and(
-        eq(connectorSessions.id, input.sessionId),
-        eq(connectorSessions.type, input.connectorType),
-        eq(connectorSessions.userId, input.userId),
-        eq(connectorSessions.status, "pending"),
-        gt(connectorSessions.expiresAt, updatedAt),
-      ),
-    )
-    .returning({ id: connectorSessions.id });
-  signal.throwIfAborted();
-  return Boolean(updatedSession);
-}
-
 async function hasPendingConnectorSession(
   db: Db,
   input: ConnectorSessionTransitionInput,
@@ -461,40 +435,34 @@ const completeOAuthCallback$ = command(
     });
     signal.throwIfAborted();
 
-    const sessionStillValid = await hasPendingConnectorSession(
-      writeDb,
-      session,
-      signal,
-    );
-    if (!sessionStillValid) {
-      return redirectWithError(
-        args.origin,
-        args.type,
-        "Invalid session - please try again",
-        true,
-      );
-    }
-
     const provider = CONNECTOR_OAUTH_PROVIDERS[args.connectorType];
-    const result = await set(
-      upsertOAuthConnector$,
-      {
-        orgId: args.identity.orgId,
-        userId: args.identity.userId,
-        type: args.connectorType,
-        accessToken: token.accessToken,
-        userInfo: token.userInfo,
-        oauthScopes: getRequestedScopes(args.connectorType),
-        refreshToken: token.refreshToken,
-        refreshSecretName: provider.getRefreshSecretName?.(),
-        expiresIn: token.expiresIn,
-      },
-      signal,
-    );
+    const connectorInput = {
+      orgId: args.identity.orgId,
+      userId: args.identity.userId,
+      type: args.connectorType,
+      accessToken: token.accessToken,
+      userInfo: token.userInfo,
+      oauthScopes: getRequestedScopes(args.connectorType),
+      refreshToken: token.refreshToken,
+      refreshSecretName: provider.getRefreshSecretName?.(),
+      expiresIn: token.expiresIn,
+    };
+    const result = args.sessionId
+      ? await set(
+          completeOAuthConnectorSession$,
+          {
+            ...connectorInput,
+            sessionId: args.sessionId,
+          },
+          signal,
+        )
+      : {
+          status: "complete" as const,
+          ...(await set(upsertOAuthConnector$, connectorInput, signal)),
+        };
     signal.throwIfAborted();
 
-    const completed = await completeConnectorSession(writeDb, session, signal);
-    if (!completed) {
+    if (result.status === "invalid_session") {
       return redirectWithError(
         args.origin,
         args.type,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,6 +1,6 @@
 import { unescape as decodeCookieComponent } from "node:querystring";
 
-import { command } from "ccstate";
+import { command, type Setter } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
   getConnectorOAuthCredentials,
@@ -136,6 +136,14 @@ type StoredStateCallbackInput = {
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
+};
+
+type ProviderErrorCallbackInput = StoredStateCallbackInput & {
+  readonly set: Setter;
+  readonly state: string | undefined;
+  readonly storedStateValue: string | undefined;
+  readonly callbackCookies: CallbackCookies;
+  readonly errorMessage: string;
 };
 
 function getCookie(request: Request, name: string): string | undefined {
@@ -599,6 +607,85 @@ const resolveCallbackState$ = command(
   },
 );
 
+async function markProviderErrorSessionIfPresent(args: {
+  readonly db: Db;
+  readonly set: Setter;
+  readonly connectorType: OAuthConnectorType;
+  readonly origin: string;
+  readonly type: string;
+  readonly state: string | undefined;
+  readonly callbackCookies: CallbackCookies;
+  readonly storedState: StoredOAuthState | undefined;
+  readonly errorMessage: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (!args.state) {
+    return;
+  }
+
+  const resolvedState = await args.set(
+    resolveCallbackState$,
+    {
+      origin: args.origin,
+      type: args.type,
+      savedState: args.callbackCookies.savedState,
+      state: args.state,
+      sessionId: args.callbackCookies.sessionId,
+      codeVerifier: args.callbackCookies.codeVerifier,
+      oauthContext: args.callbackCookies.oauthContext,
+      storedState: args.storedState,
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+  if (!resolvedState.ok || !resolvedState.sessionId) {
+    return;
+  }
+
+  await markConnectorSessionError(
+    args.db,
+    {
+      sessionId: resolvedState.sessionId,
+      connectorType: args.connectorType,
+      userId: resolvedState.identity.userId,
+    },
+    args.errorMessage,
+    args.signal,
+  );
+}
+
+async function handleProviderErrorCallback(
+  args: ProviderErrorCallbackInput,
+): Promise<Response> {
+  const claimedState = await claimStoredOAuthStateForCallbackIfPresent({
+    db: args.db,
+    connectorType: args.connectorType,
+    origin: args.origin,
+    type: args.type,
+    signal: args.signal,
+    state: args.storedStateValue,
+  });
+  args.signal.throwIfAborted();
+  if (!claimedState.ok) {
+    return claimedState.response;
+  }
+
+  await markProviderErrorSessionIfPresent({
+    db: args.db,
+    set: args.set,
+    connectorType: args.connectorType,
+    origin: args.origin,
+    type: args.type,
+    state: args.state,
+    callbackCookies: args.callbackCookies,
+    storedState: claimedState.storedState,
+    errorMessage: args.errorMessage,
+    signal: args.signal,
+  });
+
+  return redirectWithError(args.origin, args.type, args.errorMessage, true);
+}
+
 const callbackConnectorInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const params = get(pathParamsOf(connectorsTypeCallbackContract.callback));
@@ -630,20 +717,17 @@ const callbackConnectorInner$ = command(
     } satisfies StoredStateCallbackInput;
 
     if (query.error) {
-      const claimedState = await claimStoredOAuthStateForCallbackIfPresent({
+      return await handleProviderErrorCallback({
         ...storedStateCallbackArgs,
-        state: storedStateValue,
+        set,
+        state,
+        storedStateValue,
+        callbackCookies,
+        errorMessage:
+          query.error_description ||
+          query.error ||
+          "OAuth authorization failed",
       });
-      signal.throwIfAborted();
-      if (!claimedState.ok) {
-        return claimedState.response;
-      }
-      return redirectWithError(
-        origin,
-        params.type,
-        query.error_description || query.error || "OAuth authorization failed",
-        true,
-      );
     }
 
     const code = query.code;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -34,6 +34,7 @@ import {
 } from "../services/connector-oauth-state.service";
 import {
   completeOAuthConnectorSession$,
+  hasPendingConnectorOAuthSession,
   upsertOAuthConnector$,
 } from "../services/zero-connector-data.service";
 import { settle } from "../utils";
@@ -372,32 +373,6 @@ async function rejectInvalidStoredOAuthStateForCallbackIfPresent(
   return invalidStateResponse;
 }
 
-async function hasPendingConnectorSession(
-  db: Db,
-  input: ConnectorSessionTransitionInput,
-  signal: AbortSignal,
-): Promise<boolean> {
-  if (!input.sessionId) {
-    return true;
-  }
-  const currentDate = nowDate();
-  const [session] = await db
-    .select({ id: connectorSessions.id })
-    .from(connectorSessions)
-    .where(
-      and(
-        eq(connectorSessions.id, input.sessionId),
-        eq(connectorSessions.type, input.connectorType),
-        eq(connectorSessions.userId, input.userId),
-        eq(connectorSessions.status, "pending"),
-        gt(connectorSessions.expiresAt, currentDate),
-      ),
-    )
-    .limit(1);
-  signal.throwIfAborted();
-  return Boolean(session);
-}
-
 async function markConnectorSessionError(
   db: Db,
   input: ConnectorSessionTransitionInput,
@@ -453,16 +428,15 @@ const completeOAuthCallback$ = command(
     signal: AbortSignal,
   ): Promise<Response> => {
     const writeDb = set(writeDb$);
-    const session = {
-      sessionId: args.sessionId,
-      connectorType: args.connectorType,
-      userId: args.identity.userId,
-    };
-    const hasValidSession = await hasPendingConnectorSession(
-      writeDb,
-      session,
-      signal,
-    );
+    const hasValidSession = args.sessionId
+      ? await hasPendingConnectorOAuthSession({
+          db: writeDb,
+          sessionId: args.sessionId,
+          type: args.connectorType,
+          userId: args.identity.userId,
+          signal,
+        })
+      : true;
     if (!hasValidSession) {
       return redirectWithError(
         args.origin,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -48,6 +48,7 @@ import {
   CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
   CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
   CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+  parseConnectorOAuthSessionId,
   redirectResponse,
 } from "./connector-oauth-route-state";
 
@@ -533,6 +534,18 @@ const resolveCallbackState$ = command(
         ),
       };
     }
+    const sessionId = parseConnectorOAuthSessionId(args.sessionId);
+    if (sessionId === null) {
+      return {
+        ok: false,
+        response: redirectWithError(
+          args.origin,
+          args.type,
+          "Invalid session - please try again",
+          true,
+        ),
+      };
+    }
 
     return {
       ok: true,
@@ -540,7 +553,7 @@ const resolveCallbackState$ = command(
         userId: auth.userId,
         orgId: auth.orgId,
       },
-      sessionId: args.sessionId,
+      sessionId,
       codeVerifier: args.codeVerifier,
       oauthContext: args.oauthContext,
       redirectUri: `${args.origin}/api/connectors/${args.type}/callback`,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -49,6 +49,7 @@ import { writeDb$ } from "../external/db";
 import {
   deleteComputerConnector$,
   deleteZeroConnectorLocalState$,
+  hasPendingConnectorOAuthSession,
   zeroConnectorByType,
   zeroConnectorList,
   zeroConnectorScopeDiff,
@@ -104,6 +105,11 @@ type PreparedConnectorOAuthStart =
       readonly oauthContext: string | undefined;
     }
   | { readonly ok: false; readonly reason: "not_configured" };
+
+type SuccessfulConnectorOAuthStart = Extract<
+  PreparedConnectorOAuthStart,
+  { readonly ok: true }
+>;
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -197,6 +203,51 @@ function getAuthorizeClientId(
 
 function invalidConnectorSessionResponse() {
   return jsonResponse({ error: "Invalid connector session" }, 400);
+}
+
+function appendOAuthStartCookies(args: {
+  readonly response: Response;
+  readonly prepared: SuccessfulConnectorOAuthStart;
+  readonly sessionId: string | undefined;
+}): void {
+  args.response.headers.append(
+    "Set-Cookie",
+    buildOAuthCookieHeader(
+      CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+      args.prepared.state,
+      CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+    ),
+  );
+  if (args.prepared.codeVerifier) {
+    args.response.headers.append(
+      "Set-Cookie",
+      buildOAuthCookieHeader(
+        CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+        args.prepared.codeVerifier,
+        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+      ),
+    );
+  }
+  if (args.prepared.oauthContext) {
+    args.response.headers.append(
+      "Set-Cookie",
+      buildOAuthCookieHeader(
+        CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+        args.prepared.oauthContext,
+        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+      ),
+    );
+  }
+  if (args.sessionId) {
+    args.response.headers.append(
+      "Set-Cookie",
+      buildOAuthCookieHeader(
+        CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+        args.sessionId,
+        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+      ),
+    );
+  }
 }
 
 function internalServerError(message: string) {
@@ -516,6 +567,18 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     if (sessionId === null) {
       return invalidConnectorSessionResponse();
     }
+    if (sessionId) {
+      const hasValidSession = await hasPendingConnectorOAuthSession({
+        db: set(writeDb$),
+        sessionId,
+        type: oauthType.type,
+        userId: auth.userId,
+        signal,
+      });
+      if (!hasValidSession) {
+        return invalidConnectorSessionResponse();
+      }
+    }
 
     const prepared = await prepareConnectorOAuthStart({
       request,
@@ -533,44 +596,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     }
 
     const response = redirectResponse(prepared.authorizationUrl);
-    response.headers.append(
-      "Set-Cookie",
-      buildOAuthCookieHeader(
-        CONNECTOR_OAUTH_STATE_COOKIE_NAME,
-        prepared.state,
-        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-      ),
-    );
-    if (prepared.codeVerifier) {
-      response.headers.append(
-        "Set-Cookie",
-        buildOAuthCookieHeader(
-          CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
-          prepared.codeVerifier,
-          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-        ),
-      );
-    }
-    if (prepared.oauthContext) {
-      response.headers.append(
-        "Set-Cookie",
-        buildOAuthCookieHeader(
-          CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
-          prepared.oauthContext,
-          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-        ),
-      );
-    }
-    if (sessionId) {
-      response.headers.append(
-        "Set-Cookie",
-        buildOAuthCookieHeader(
-          CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
-          sessionId,
-          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-        ),
-      );
-    }
+    appendOAuthStartCookies({ response, prepared, sessionId });
     return response;
   });
 }

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -23,14 +23,11 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
+  type ConnectorType,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  isOAuthConnectorType,
-  CONNECTOR_OAUTH_PROVIDERS,
-  type AuthUrlResult,
-} from "@vm0/connectors/oauth-providers";
+import { isOAuthConnectorType } from "@vm0/connectors/oauth-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -46,7 +43,7 @@ import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
-import { env, optionalEnv } from "../../lib/env";
+import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
@@ -66,13 +63,18 @@ import {
   getConnectorOAuthCanonicalRedirectUrl,
   getConnectorOAuthOrigin,
 } from "./connector-oauth-origin";
+import {
+  buildOAuthCookieHeader,
+  buildProviderAuthorizeUrl,
+  CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+  CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+  CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+  CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+  CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+  generateConnectorOAuthState,
+  redirectResponse,
+} from "./connector-oauth-route-state";
 
-const STATE_COOKIE_NAME = "connector_oauth_state";
-const SESSION_COOKIE_NAME = "connector_oauth_session";
-const PKCE_COOKIE_NAME = "connector_oauth_pkce";
-const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
-const COOKIE_MAX_AGE = 15 * 60;
-const REDIRECT_STATUS = 307;
 const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
 const CONNECTOR_SESSION_POLL_INTERVAL_SECONDS = 5;
 const CONNECTOR_SESSION_CODE_LENGTH = 8;
@@ -82,6 +84,25 @@ type ConnectorAuthorizeRoute = AppRoute & {
   readonly pathParams: z.ZodType<{ readonly type: string }>;
   readonly query: z.ZodType<{ readonly session?: string }>;
 };
+
+type OAuthConnectorResolution =
+  | { readonly ok: true; readonly type: OAuthConnectorType }
+  | {
+      readonly ok: false;
+      readonly reason: "computer" | "not_oauth" | "missing_provider";
+    };
+
+type PreparedConnectorOAuthStart =
+  | {
+      readonly ok: true;
+      readonly type: OAuthConnectorType;
+      readonly state: string;
+      readonly redirectUri: string;
+      readonly authorizationUrl: string;
+      readonly codeVerifier: string | undefined;
+      readonly oauthContext: string | undefined;
+    }
+  | { readonly ok: false; readonly reason: "not_configured" };
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -116,14 +137,6 @@ function isLocalBrowserEnabled(params: {
   });
 }
 
-function generateState(): string {
-  const array = new Uint8Array(32);
-  crypto.getRandomValues(array);
-  return Array.from(array, (byte) => {
-    return byte.toString(16).padStart(2, "0");
-  }).join("");
-}
-
 function generateConnectorSessionCode(
   length: number = CONNECTOR_SESSION_CODE_LENGTH,
 ): string {
@@ -140,22 +153,19 @@ function generateConnectorSessionCode(
   return code;
 }
 
-function buildCookieHeader(
-  name: string,
-  value: string,
-  maxAge: number,
-): string {
-  const parts = [
-    `${name}=${encodeURIComponent(value)}`,
-    `Max-Age=${maxAge}`,
-    "Path=/",
-    "HttpOnly",
-    "SameSite=Lax",
-  ];
-  if (env("ENV") === "production") {
-    parts.push("Secure");
+function resolveOAuthConnectorType(
+  type: ConnectorType,
+): OAuthConnectorResolution {
+  if (type === "computer") {
+    return { ok: false, reason: "computer" };
   }
-  return parts.join("; ");
+  if (!getConnectorAuthMethod(type, "oauth")) {
+    return { ok: false, reason: "not_oauth" };
+  }
+  if (!isOAuthConnectorType(type)) {
+    return { ok: false, reason: "missing_provider" };
+  }
+  return { ok: true, type };
 }
 
 function jsonResponse(body: unknown, status: number): Response {
@@ -165,39 +175,12 @@ function jsonResponse(body: unknown, status: number): Response {
   });
 }
 
-function redirectResponse(url: string): Response {
-  return new Response(null, {
-    status: REDIRECT_STATUS,
-    headers: { location: url },
-  });
-}
-
-function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
-  return typeof result === "string" ? { url: result } : result;
-}
-
 function connectorDoesNotUseOAuthResponse(type: string) {
   return jsonResponse({ error: `${type} connector does not use OAuth` }, 400);
 }
 
 function missingOAuthProviderResponse(type: string) {
   return jsonResponse({ error: `${type} OAuth provider not configured` }, 500);
-}
-
-async function buildProviderAuthorizeUrl(args: {
-  readonly type: OAuthConnectorType;
-  readonly clientId?: string;
-  readonly redirectUri: string;
-  readonly state: string;
-}): Promise<AuthUrlResult> {
-  const provider = CONNECTOR_OAUTH_PROVIDERS[args.type];
-  return normalizeAuthUrlResult(
-    await provider.buildAuthUrl({
-      clientId: args.clientId,
-      redirectUri: args.redirectUri,
-      state: args.state,
-    }),
-  );
 }
 
 function getAuthorizeClientId(
@@ -220,6 +203,52 @@ function internalServerError(message: string) {
         code: "INTERNAL_SERVER_ERROR",
       },
     },
+  };
+}
+
+async function prepareConnectorOAuthStart(args: {
+  readonly request: Request;
+  readonly type: OAuthConnectorType;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+  readonly deleteLocalState: (args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: OAuthConnectorType;
+  }) => Promise<void>;
+}): Promise<PreparedConnectorOAuthStart> {
+  const state = generateConnectorOAuthState();
+  const origin = getConnectorOAuthOrigin(args.request);
+  const redirectUri = `${origin}/api/connectors/${args.type}/callback`;
+  const credentials = getConnectorOAuthCredentials(args.type, optionalEnv);
+  if (!credentials?.configured) {
+    return { ok: false, reason: "not_configured" };
+  }
+
+  const authResult = await buildProviderAuthorizeUrl({
+    type: args.type,
+    clientId: getAuthorizeClientId(credentials),
+    redirectUri,
+    state,
+  });
+  args.signal.throwIfAborted();
+
+  await args.deleteLocalState({
+    orgId: args.orgId,
+    userId: args.userId,
+    type: args.type,
+  });
+  args.signal.throwIfAborted();
+
+  return {
+    ok: true,
+    type: args.type,
+    state,
+    redirectUri,
+    authorizationUrl: authResult.url,
+    codeVerifier: authResult.codeVerifier,
+    oauthContext: authResult.oauthContext,
   };
 }
 
@@ -452,17 +481,17 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       return jsonResponse(auth.body, auth.status);
     }
 
-    if (type === "computer") {
-      return jsonResponse(
-        { error: "Computer connector does not use OAuth" },
-        400,
-      );
-    }
-
-    if (!getConnectorAuthMethod(type, "oauth")) {
-      return connectorDoesNotUseOAuthResponse(type);
-    }
-    if (!isOAuthConnectorType(type)) {
+    const oauthType = resolveOAuthConnectorType(type);
+    if (!oauthType.ok) {
+      if (oauthType.reason === "computer") {
+        return jsonResponse(
+          { error: "Computer connector does not use OAuth" },
+          400,
+        );
+      }
+      if (oauthType.reason === "not_oauth") {
+        return connectorDoesNotUseOAuthResponse(type);
+      }
       return missingOAuthProviderResponse(type);
     }
 
@@ -479,57 +508,58 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    const state = generateState();
-    const redirectUri = `${origin}/api/connectors/${type}/callback`;
-    const credentials = getConnectorOAuthCredentials(type, optionalEnv);
-    if (!credentials?.configured) {
+    const prepared = await prepareConnectorOAuthStart({
+      request,
+      type: oauthType.type,
+      orgId: auth.orgId,
+      userId: auth.userId,
+      signal,
+      deleteLocalState: async (args) => {
+        await set(deleteZeroConnectorLocalState$, args, signal);
+      },
+    });
+    signal.throwIfAborted();
+    if (!prepared.ok) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
 
-    const authResult = await buildProviderAuthorizeUrl({
-      type,
-      clientId: getAuthorizeClientId(credentials),
-      redirectUri,
-      state,
-    });
-    signal.throwIfAborted();
-
-    await set(
-      deleteZeroConnectorLocalState$,
-      { orgId: auth.orgId, userId: auth.userId, type },
-      signal,
-    );
-    signal.throwIfAborted();
-
-    const response = redirectResponse(authResult.url);
+    const response = redirectResponse(prepared.authorizationUrl);
     response.headers.append(
       "Set-Cookie",
-      buildCookieHeader(STATE_COOKIE_NAME, state, COOKIE_MAX_AGE),
+      buildOAuthCookieHeader(
+        CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+        prepared.state,
+        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+      ),
     );
-    if (authResult.codeVerifier) {
+    if (prepared.codeVerifier) {
       response.headers.append(
         "Set-Cookie",
-        buildCookieHeader(
-          PKCE_COOKIE_NAME,
-          authResult.codeVerifier,
-          COOKIE_MAX_AGE,
+        buildOAuthCookieHeader(
+          CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+          prepared.codeVerifier,
+          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );
     }
-    if (authResult.oauthContext) {
+    if (prepared.oauthContext) {
       response.headers.append(
         "Set-Cookie",
-        buildCookieHeader(
-          OAUTH_CONTEXT_COOKIE_NAME,
-          authResult.oauthContext,
-          COOKIE_MAX_AGE,
+        buildOAuthCookieHeader(
+          CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+          prepared.oauthContext,
+          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );
     }
     if (query.session) {
       response.headers.append(
         "Set-Cookie",
-        buildCookieHeader(SESSION_COOKIE_NAME, query.session, COOKIE_MAX_AGE),
+        buildOAuthCookieHeader(
+          CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+          query.session,
+          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+        ),
       );
     }
     return response;
@@ -547,14 +577,14 @@ const startConnectorOauthInner$ = command(
     const auth = get(authContext$);
     const type = params.type;
 
-    if (type === "computer") {
-      return badRequestMessage("Computer connector does not use OAuth");
-    }
-
-    if (!getConnectorAuthMethod(type, "oauth")) {
-      return badRequestMessage(`${type} connector does not use OAuth`);
-    }
-    if (!isOAuthConnectorType(type)) {
+    const oauthType = resolveOAuthConnectorType(type);
+    if (!oauthType.ok) {
+      if (oauthType.reason === "computer") {
+        return badRequestMessage("Computer connector does not use OAuth");
+      }
+      if (oauthType.reason === "not_oauth") {
+        return badRequestMessage(`${type} connector does not use OAuth`);
+      }
       return internalServerError(`${type} OAuth provider not configured`);
     }
 
@@ -564,46 +594,40 @@ const startConnectorOauthInner$ = command(
       );
     }
 
-    const state = generateState();
-    const origin = getConnectorOAuthOrigin(request);
-    const redirectUri = `${origin}/api/connectors/${type}/callback`;
-    const credentials = getConnectorOAuthCredentials(type, optionalEnv);
-    if (!credentials?.configured) {
+    const prepared = await prepareConnectorOAuthStart({
+      request,
+      type: oauthType.type,
+      orgId: auth.orgId,
+      userId: auth.userId,
+      signal,
+      deleteLocalState: async (args) => {
+        await set(deleteZeroConnectorLocalState$, args, signal);
+      },
+    });
+    signal.throwIfAborted();
+    if (!prepared.ok) {
       return internalServerError(`${type} OAuth not configured`);
     }
 
-    const authResult = await buildProviderAuthorizeUrl({
-      type,
-      clientId: getAuthorizeClientId(credentials),
-      redirectUri,
-      state,
-    });
-    signal.throwIfAborted();
-
-    await set(
-      deleteZeroConnectorLocalState$,
-      { orgId: auth.orgId, userId: auth.userId, type },
-      signal,
-    );
-    signal.throwIfAborted();
-
     const writeDb = set(writeDb$);
     await writeDb.insert(connectorOauthStates).values({
-      state,
-      type,
+      state: prepared.state,
+      type: prepared.type,
       userId: auth.userId,
       orgId: auth.orgId,
-      redirectUri,
-      codeVerifier: authResult.codeVerifier,
-      oauthContext: authResult.oauthContext,
-      expiresAt: new Date(nowDate().getTime() + COOKIE_MAX_AGE * 1000),
+      redirectUri: prepared.redirectUri,
+      codeVerifier: prepared.codeVerifier,
+      oauthContext: prepared.oauthContext,
+      expiresAt: new Date(
+        nowDate().getTime() + CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS * 1000,
+      ),
     });
     signal.throwIfAborted();
 
     return {
       status: 200 as const,
       body: {
-        authorizationUrl: authResult.url,
+        authorizationUrl: prepared.authorizationUrl,
       },
     };
   },
@@ -613,6 +637,27 @@ const createConnectorSessionInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(authContext$);
     const params = get(pathParamsOf(zeroConnectorSessionsContract.create));
+    const oauthType = resolveOAuthConnectorType(params.type);
+    if (!oauthType.ok) {
+      if (oauthType.reason === "computer") {
+        return badRequestMessage("Computer connector does not use OAuth");
+      }
+      if (oauthType.reason === "not_oauth") {
+        return badRequestMessage(`${params.type} connector does not use OAuth`);
+      }
+      return internalServerError(
+        `${params.type} OAuth provider not configured`,
+      );
+    }
+
+    const credentials = getConnectorOAuthCredentials(
+      oauthType.type,
+      optionalEnv,
+    );
+    if (!credentials?.configured) {
+      return internalServerError(`${params.type} OAuth not configured`);
+    }
+
     const code = generateConnectorSessionCode();
     const expiresAt = new Date(
       nowDate().getTime() + CONNECTOR_SESSION_TTL_SECONDS * 1000,
@@ -677,7 +722,14 @@ const getConnectorSessionByIdInner$ = command(
       await writeDb
         .update(connectorSessions)
         .set({ status: "expired" })
-        .where(eq(connectorSessions.id, session.id));
+        .where(
+          and(
+            eq(connectorSessions.id, session.id),
+            eq(connectorSessions.type, params.type),
+            eq(connectorSessions.userId, auth.userId),
+            eq(connectorSessions.status, "pending"),
+          ),
+        );
       signal.throwIfAborted();
 
       return {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -728,7 +728,7 @@ const getConnectorSessionByIdInner$ = command(
     }
 
     if (session.status === "pending" && nowDate() > session.expiresAt) {
-      await writeDb
+      const [expiredSession] = await writeDb
         .update(connectorSessions)
         .set({ status: "expired" })
         .where(
@@ -738,15 +738,43 @@ const getConnectorSessionByIdInner$ = command(
             eq(connectorSessions.userId, auth.userId),
             eq(connectorSessions.status, "pending"),
           ),
-        );
+        )
+        .returning({ id: connectorSessions.id });
       signal.throwIfAborted();
+
+      if (expiredSession) {
+        return {
+          status: 200 as const,
+          body: {
+            status: "expired" as const,
+            errorMessage: "Session has expired",
+          },
+        };
+      }
+
+      const [currentSession] = await writeDb
+        .select({
+          status: connectorSessions.status,
+          errorMessage: connectorSessions.errorMessage,
+        })
+        .from(connectorSessions)
+        .where(
+          and(
+            eq(connectorSessions.id, params.sessionId),
+            eq(connectorSessions.type, params.type),
+            eq(connectorSessions.userId, auth.userId),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (!currentSession) {
+        return notFound("Connector session not found");
+      }
 
       return {
         status: 200 as const,
-        body: {
-          status: "expired" as const,
-          errorMessage: "Session has expired",
-        },
+        body: currentSession,
       };
     }
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -72,6 +72,7 @@ import {
   CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
   CONNECTOR_OAUTH_STATE_COOKIE_NAME,
   generateConnectorOAuthState,
+  parseConnectorOAuthSessionId,
   redirectResponse,
 } from "./connector-oauth-route-state";
 
@@ -192,6 +193,10 @@ function getAuthorizeClientId(
   return isStaticConnectorOAuthCredentials(credentials)
     ? credentials.clientId
     : undefined;
+}
+
+function invalidConnectorSessionResponse() {
+  return jsonResponse({ error: "Invalid connector session" }, 400);
 }
 
 function internalServerError(message: string) {
@@ -507,6 +512,10 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
         400,
       );
     }
+    const sessionId = parseConnectorOAuthSessionId(query.session);
+    if (sessionId === null) {
+      return invalidConnectorSessionResponse();
+    }
 
     const prepared = await prepareConnectorOAuthStart({
       request,
@@ -552,12 +561,12 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
         ),
       );
     }
-    if (query.session) {
+    if (sessionId) {
       response.headers.append(
         "Set-Cookie",
         buildOAuthCookieHeader(
           CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
-          query.session,
+          sessionId,
           CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -7,6 +7,7 @@ import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { composeJobs } from "@vm0/db/schema/compose-job";
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { connectors } from "@vm0/db/schema/connector";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -480,6 +481,9 @@ async function deleteOrgData(db: Db, orgId: string): Promise<void> {
   await db.delete(modelProviders).where(eq(modelProviders.orgId, orgId));
   await db.delete(secrets).where(eq(secrets.orgId, orgId));
   await db.delete(connectors).where(eq(connectors.orgId, orgId));
+  await db
+    .delete(connectorOauthStates)
+    .where(eq(connectorOauthStates.orgId, orgId));
   await db.delete(variables).where(eq(variables.orgId, orgId));
   await db.delete(usageDaily).where(eq(usageDaily.orgId, orgId));
   await db.delete(exportJobs).where(eq(exportJobs.orgId, orgId));
@@ -536,6 +540,9 @@ async function deleteUserData(db: Db, userId: string): Promise<void> {
   await db
     .delete(connectorSessions)
     .where(eq(connectorSessions.userId, userId));
+  await db
+    .delete(connectorOauthStates)
+    .where(eq(connectorOauthStates.userId, userId));
   await db.delete(deviceCodes).where(eq(deviceCodes.userId, userId));
   await db.delete(orgMembersCache).where(eq(orgMembersCache.userId, userId));
   await db

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -33,9 +33,10 @@ import {
   type FeatureSwitchContext,
 } from "@vm0/core/feature-switch";
 import { connectors } from "@vm0/db/schema/connector";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, gt, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
@@ -71,6 +72,36 @@ type StoredConnectorRow = {
   readonly createdAt: Date;
   readonly updatedAt: Date;
 };
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type ConnectorWriteDb = Db | WriteTx;
+
+interface OAuthConnectorUpsertInput {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: OAuthConnectorType;
+  readonly accessToken: string;
+  readonly userInfo: ExternalUserInfo;
+  readonly oauthScopes: readonly string[];
+  readonly refreshToken?: string | null;
+  readonly refreshSecretName?: string;
+  readonly expiresIn?: number;
+}
+
+interface PreparedConnectorSecret {
+  readonly name: string;
+  readonly encryptedValue: string;
+  readonly description: string;
+}
+
+interface PreparedOAuthConnectorWrite {
+  readonly tokenExpiresAt: Date | null;
+  readonly apiTokenFields: {
+    readonly secrets: readonly string[];
+    readonly variables: readonly string[];
+  } | null;
+  readonly secrets: readonly PreparedConnectorSecret[];
+}
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
@@ -544,7 +575,7 @@ async function revokeExistingConnectorToken(args: {
 }
 
 async function hasApiTokenConnectorLocalState(args: {
-  readonly db: Db;
+  readonly db: ConnectorWriteDb;
   readonly orgId: string;
   readonly userId: string;
   readonly fields: {
@@ -598,7 +629,7 @@ async function hasApiTokenConnectorLocalState(args: {
 }
 
 async function deleteApiTokenConnectorLocalState(args: {
-  readonly db: Db;
+  readonly db: ConnectorWriteDb;
   readonly orgId: string;
   readonly userId: string;
   readonly fields: {
@@ -759,26 +790,21 @@ export const deleteZeroConnectorLocalState$ = command(
 );
 
 async function upsertConnectorSecret(
-  db: Db,
+  db: ConnectorWriteDb,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly name: string;
-    readonly value: string;
+    readonly encryptedValue: string;
     readonly description: string;
-    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(
-    args.value,
-    args.featureSwitchContext,
-  );
   await db
     .insert(secrets)
     .values({
       userId: args.userId,
       name: args.name,
-      encryptedValue,
+      encryptedValue: args.encryptedValue,
       type: "connector",
       description: args.description,
       orgId: args.orgId,
@@ -786,7 +812,7 @@ async function upsertConnectorSecret(
     .onConflictDoUpdate({
       target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
       set: {
-        encryptedValue,
+        encryptedValue: args.encryptedValue,
         description: args.description,
         updatedAt: nowDate(),
       },
@@ -806,32 +832,123 @@ function connectorTokenExpiresAt(args: {
     : new Date(nowDate().getTime() + expiresInSecs * 1000);
 }
 
+async function prepareOAuthConnectorWrite(args: {
+  readonly input: OAuthConnectorUpsertInput;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<PreparedOAuthConnectorWrite> {
+  const provider = CONNECTOR_OAUTH_PROVIDERS[args.input.type];
+  const secretsToWrite: PreparedConnectorSecret[] = [
+    {
+      name: provider.getSecretName(),
+      encryptedValue: await encryptStoredSecretValue(
+        args.input.accessToken,
+        args.featureSwitchContext,
+      ),
+      description: `OAuth token for ${args.input.type} connector`,
+    },
+  ];
+
+  if (args.input.refreshToken && args.input.refreshSecretName) {
+    secretsToWrite.push({
+      name: args.input.refreshSecretName,
+      encryptedValue: await encryptStoredSecretValue(
+        args.input.refreshToken,
+        args.featureSwitchContext,
+      ),
+      description: `OAuth refresh token for ${args.input.type} connector`,
+    });
+  }
+
+  return {
+    tokenExpiresAt: connectorTokenExpiresAt({
+      isRefreshable: isOAuthRefreshProvider(provider),
+      expiresIn: args.input.expiresIn,
+    }),
+    apiTokenFields: getApiTokenFieldsByType(args.input.type),
+    secrets: secretsToWrite,
+  };
+}
+
+async function writeOAuthConnectorLocalState(args: {
+  readonly db: ConnectorWriteDb;
+  readonly input: OAuthConnectorUpsertInput;
+  readonly prepared: PreparedOAuthConnectorWrite;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly connector: ConnectorResponse;
+  readonly created: boolean;
+}> {
+  for (const secret of args.prepared.secrets) {
+    await upsertConnectorSecret(args.db, {
+      orgId: args.input.orgId,
+      userId: args.input.userId,
+      name: secret.name,
+      encryptedValue: secret.encryptedValue,
+      description: secret.description,
+    });
+    args.signal.throwIfAborted();
+  }
+
+  const [connectorRow] = await args.db
+    .insert(connectors)
+    .values({
+      userId: args.input.userId,
+      type: args.input.type,
+      authMethod: "oauth",
+      externalId: args.input.userInfo.id,
+      externalUsername: args.input.userInfo.username,
+      externalEmail: args.input.userInfo.email,
+      oauthScopes: JSON.stringify(args.input.oauthScopes),
+      tokenExpiresAt: args.prepared.tokenExpiresAt,
+      needsReconnect: false,
+      orgId: args.input.orgId,
+    })
+    .onConflictDoUpdate({
+      target: [connectors.orgId, connectors.userId, connectors.type],
+      set: {
+        authMethod: "oauth",
+        externalId: args.input.userInfo.id,
+        externalUsername: args.input.userInfo.username,
+        externalEmail: args.input.userInfo.email,
+        oauthScopes: JSON.stringify(args.input.oauthScopes),
+        tokenExpiresAt: args.prepared.tokenExpiresAt,
+        needsReconnect: false,
+        updatedAt: nowDate(),
+      },
+    })
+    .returning();
+  args.signal.throwIfAborted();
+
+  if (!connectorRow) {
+    throw new Error("Failed to upsert connector");
+  }
+
+  await deleteApiTokenConnectorLocalState({
+    db: args.db,
+    orgId: args.input.orgId,
+    userId: args.input.userId,
+    fields: args.prepared.apiTokenFields,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  return {
+    connector: storedConnectorRowToResponse(connectorRow, args.input.type),
+    created:
+      connectorRow.createdAt.getTime() === connectorRow.updatedAt.getTime(),
+  };
+}
+
 export const upsertOAuthConnector$ = command(
   async (
     { get, set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly type: OAuthConnectorType;
-      readonly accessToken: string;
-      readonly userInfo: ExternalUserInfo;
-      readonly oauthScopes: readonly string[];
-      readonly refreshToken?: string | null;
-      readonly refreshSecretName?: string;
-      readonly expiresIn?: number;
-    },
+    args: OAuthConnectorUpsertInput,
     signal: AbortSignal,
   ): Promise<{
     readonly connector: ConnectorResponse;
     readonly created: boolean;
   }> => {
     const writeDb = set(writeDb$);
-    const provider = CONNECTOR_OAUTH_PROVIDERS[args.type];
-    const tokenExpiresAt = connectorTokenExpiresAt({
-      isRefreshable: isOAuthRefreshProvider(provider),
-      expiresIn: args.expiresIn,
-    });
-    const apiTokenFields = getApiTokenFieldsByType(args.type);
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,
@@ -847,79 +964,110 @@ export const upsertOAuthConnector$ = command(
     );
     signal.throwIfAborted();
 
-    await upsertConnectorSecret(writeDb, {
-      orgId: args.orgId,
-      userId: args.userId,
-      name: provider.getSecretName(),
-      value: args.accessToken,
-      description: `OAuth token for ${args.type} connector`,
+    const prepared = await prepareOAuthConnectorWrite({
+      input: args,
       featureSwitchContext,
     });
     signal.throwIfAborted();
 
-    if (args.refreshToken && args.refreshSecretName) {
-      await upsertConnectorSecret(writeDb, {
-        orgId: args.orgId,
-        userId: args.userId,
-        name: args.refreshSecretName,
-        value: args.refreshToken,
-        description: `OAuth refresh token for ${args.type} connector`,
-        featureSwitchContext,
-      });
-      signal.throwIfAborted();
-    }
-
-    const [connectorRow] = await writeDb
-      .insert(connectors)
-      .values({
-        userId: args.userId,
-        type: args.type,
-        authMethod: "oauth",
-        externalId: args.userInfo.id,
-        externalUsername: args.userInfo.username,
-        externalEmail: args.userInfo.email,
-        oauthScopes: JSON.stringify(args.oauthScopes),
-        tokenExpiresAt,
-        needsReconnect: false,
-        orgId: args.orgId,
-      })
-      .onConflictDoUpdate({
-        target: [connectors.orgId, connectors.userId, connectors.type],
-        set: {
-          authMethod: "oauth",
-          externalId: args.userInfo.id,
-          externalUsername: args.userInfo.username,
-          externalEmail: args.userInfo.email,
-          oauthScopes: JSON.stringify(args.oauthScopes),
-          tokenExpiresAt,
-          needsReconnect: false,
-          updatedAt: nowDate(),
-        },
-      })
-      .returning();
-    signal.throwIfAborted();
-
-    if (!connectorRow) {
-      throw new Error("Failed to upsert connector");
-    }
-
-    await deleteApiTokenConnectorLocalState({
+    const result = await writeOAuthConnectorLocalState({
       db: writeDb,
-      orgId: args.orgId,
-      userId: args.userId,
-      fields: apiTokenFields,
+      input: args,
+      prepared,
       signal,
     });
-    signal.throwIfAborted();
 
     await publishUserSignal([args.userId], "connector:changed");
     signal.throwIfAborted();
 
-    return {
-      connector: storedConnectorRowToResponse(connectorRow, args.type),
-      created:
-        connectorRow.createdAt.getTime() === connectorRow.updatedAt.getTime(),
-    };
+    return result;
+  },
+);
+
+export const completeOAuthConnectorSession$ = command(
+  async (
+    { get, set },
+    args: OAuthConnectorUpsertInput & {
+      readonly sessionId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    | {
+        readonly status: "complete";
+        readonly connector: ConnectorResponse;
+        readonly created: boolean;
+      }
+    | { readonly status: "invalid_session" }
+  > => {
+    const writeDb = set(writeDb$);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
+    const prepared = await prepareOAuthConnectorWrite({
+      input: args,
+      featureSwitchContext,
+    });
+    signal.throwIfAborted();
+
+    const result = await writeDb.transaction(async (tx) => {
+      const completedAt = nowDate();
+      const [updatedSession] = await tx
+        .update(connectorSessions)
+        .set({
+          status: "complete",
+          completedAt,
+        })
+        .where(
+          and(
+            eq(connectorSessions.id, args.sessionId),
+            eq(connectorSessions.type, args.type),
+            eq(connectorSessions.userId, args.userId),
+            eq(connectorSessions.status, "pending"),
+            gt(connectorSessions.expiresAt, completedAt),
+          ),
+        )
+        .returning({ id: connectorSessions.id });
+      if (!updatedSession) {
+        return { status: "invalid_session" as const };
+      }
+
+      const writeResult = await writeOAuthConnectorLocalState({
+        db: tx,
+        input: args,
+        prepared,
+        signal,
+      });
+
+      return {
+        status: "complete" as const,
+        connector: writeResult.connector,
+        created: writeResult.created,
+      };
+    });
+    signal.throwIfAborted();
+
+    if (result.status === "invalid_session") {
+      return result;
+    }
+
+    await bestEffort(
+      invalidateActiveCliAuthSessionsForConnectorType({
+        writeDb,
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorType: args.type,
+        signal,
+      }),
+      signal,
+    );
+    await bestEffort(
+      publishUserSignal([args.userId], "connector:changed"),
+      signal,
+    );
+
+    return result;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -984,6 +984,31 @@ export const upsertOAuthConnector$ = command(
   },
 );
 
+export async function hasPendingConnectorOAuthSession(args: {
+  readonly db: ConnectorWriteDb;
+  readonly sessionId: string;
+  readonly type: OAuthConnectorType;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const currentDate = nowDate();
+  const [session] = await args.db
+    .select({ id: connectorSessions.id })
+    .from(connectorSessions)
+    .where(
+      and(
+        eq(connectorSessions.id, args.sessionId),
+        eq(connectorSessions.type, args.type),
+        eq(connectorSessions.userId, args.userId),
+        eq(connectorSessions.status, "pending"),
+        gt(connectorSessions.expiresAt, currentDate),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+  return Boolean(session);
+}
+
 export const completeOAuthConnectorSession$ = command(
   async (
     { get, set },

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -186,6 +186,7 @@ export const zeroConnectorSessionsContract = c.router({
       200: connectorSessionResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      500: apiErrorSchema,
     },
     summary: "Create connector session for device flow (zero proxy)",
   },


### PR DESCRIPTION
## Summary
- share connector OAuth route-state helpers and start preparation
- restrict connector sessions to configured OAuth connectors
- validate and conditionally transition user-scoped sessions in callbacks
- atomically consume server-side OAuth state rows

Closes #14382

## Tests
- pnpm -F api run lint
- pnpm -F api run check-types
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-authorize.test.ts