### PR TITLE
test: harden heartbeat idle parking assertions

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -231,8 +231,14 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
-        let _ = pool.park(make_synthetic_parked_candidate("sess-1"));
-        let _ = pool.park(make_synthetic_parked_candidate("sess-2"));
+        assert!(matches!(
+            pool.park(make_synthetic_parked_candidate("sess-1")),
+            ParkResult::Parked,
+        ));
+        assert!(matches!(
+            pool.park(make_synthetic_parked_candidate("sess-2")),
+            ParkResult::Parked,
+        ));
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -254,7 +260,11 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
-        let _ = pool.park(make_synthetic_parked_candidate("sess-1"));
+        assert!(matches!(
+            pool.park(make_synthetic_parked_candidate("sess-1")),
+            ParkResult::Parked,
+        ));
+        assert_eq!(pool.len(), 1);
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(


### PR DESCRIPTION
## Summary
- assert heartbeat idle pool test park preconditions return ParkResult::Parked
- verify the saturation test actually creates one idle entry before collecting heartbeat state

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner heartbeat_running_count

Closes #14393