### PR TITLE
refactor: centralize runner log filename patterns

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -788,8 +788,9 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
 
 /// Delete stale log files (older than [`JOB_LOG_MAX_AGE`]).
 ///
-/// Covers per-job logs (`network-*.jsonl`, `system-*.log`, `metrics-*.jsonl`,
-/// `sandbox-ops-*.jsonl`) and runner instance logs (`runner-*.log`).
+/// Covers per-job logs (`network-*.jsonl`, `proxy-*.jsonl`, `system-*.log`,
+/// `metrics-*.jsonl`, `sandbox-ops-*.jsonl`) and runner instance logs
+/// (`runner-*.log`).
 /// Returns `(files_removed, bytes_freed)`.
 async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)> {
     let logs_dir = home.logs_dir();

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -673,6 +673,29 @@ mod tests {
     }
 
     #[test]
+    fn is_gc_eligible_log_temp_matching() {
+        let lp = LogPaths::new(PathBuf::from("/test/logs"));
+        let id = RunId::nil();
+        let paths = [
+            lp.network_log(id),
+            lp.system_log(id),
+            lp.metrics_log(id),
+            lp.sandbox_ops_log(id),
+            lp.proxy_log(id),
+        ];
+
+        for path in paths {
+            let file_name = path.file_name().and_then(|name| name.to_str()).unwrap();
+            let temp_name = format!(".{file_name}.vm0tmp-101-7-1");
+            assert!(LogPaths::is_gc_eligible_log(&temp_name));
+        }
+
+        assert!(LogPaths::is_gc_eligible_log(
+            ".runner-default.2026-04-01.log.vm0tmp-101-7-6"
+        ));
+    }
+
+    #[test]
     fn is_gc_eligible_log_non_matching() {
         assert!(!LogPaths::is_gc_eligible_log("config.yaml"));
         assert!(!LogPaths::is_gc_eligible_log("status.json"));

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -341,6 +341,56 @@ pub struct LogPaths {
     dir: PathBuf,
 }
 
+#[derive(Clone, Copy)]
+struct LogFilenamePattern {
+    prefix: &'static str,
+    suffix: &'static str,
+}
+
+impl LogFilenamePattern {
+    fn path(self, dir: &Path, run_id: RunId) -> PathBuf {
+        dir.join(format!("{}{run_id}{}", self.prefix, self.suffix))
+    }
+
+    fn matches(self, name: &str) -> bool {
+        name.starts_with(self.prefix) && name.ends_with(self.suffix)
+    }
+}
+
+const NETWORK_LOG_PATTERN: LogFilenamePattern = LogFilenamePattern {
+    prefix: "network-",
+    suffix: ".jsonl",
+};
+const PROXY_LOG_PATTERN: LogFilenamePattern = LogFilenamePattern {
+    prefix: "proxy-",
+    suffix: ".jsonl",
+};
+const SYSTEM_LOG_PATTERN: LogFilenamePattern = LogFilenamePattern {
+    prefix: "system-",
+    suffix: ".log",
+};
+const METRICS_LOG_PATTERN: LogFilenamePattern = LogFilenamePattern {
+    prefix: "metrics-",
+    suffix: ".jsonl",
+};
+const SANDBOX_OPS_LOG_PATTERN: LogFilenamePattern = LogFilenamePattern {
+    prefix: "sandbox-ops-",
+    suffix: ".jsonl",
+};
+
+const PER_RUN_LOG_PATTERNS: &[LogFilenamePattern] = &[
+    NETWORK_LOG_PATTERN,
+    PROXY_LOG_PATTERN,
+    SYSTEM_LOG_PATTERN,
+    METRICS_LOG_PATTERN,
+    SANDBOX_OPS_LOG_PATTERN,
+];
+
+const RUNNER_INSTANCE_LOG_PATTERN: LogFilenamePattern = LogFilenamePattern {
+    prefix: "runner-",
+    suffix: ".log",
+};
+
 impl LogPaths {
     pub fn new(dir: PathBuf) -> Self {
         Self { dir }
@@ -351,23 +401,23 @@ impl LogPaths {
     }
 
     pub fn network_log(&self, run_id: RunId) -> PathBuf {
-        self.dir.join(format!("network-{run_id}.jsonl"))
+        NETWORK_LOG_PATTERN.path(&self.dir, run_id)
     }
 
     pub fn proxy_log(&self, run_id: RunId) -> PathBuf {
-        self.dir.join(format!("proxy-{run_id}.jsonl"))
+        PROXY_LOG_PATTERN.path(&self.dir, run_id)
     }
 
     pub fn system_log(&self, run_id: RunId) -> PathBuf {
-        self.dir.join(format!("system-{run_id}.log"))
+        SYSTEM_LOG_PATTERN.path(&self.dir, run_id)
     }
 
     pub fn metrics_log(&self, run_id: RunId) -> PathBuf {
-        self.dir.join(format!("metrics-{run_id}.jsonl"))
+        METRICS_LOG_PATTERN.path(&self.dir, run_id)
     }
 
     pub fn sandbox_ops_log(&self, run_id: RunId) -> PathBuf {
-        self.dir.join(format!("sandbox-ops-{run_id}.jsonl"))
+        SANDBOX_OPS_LOG_PATTERN.path(&self.dir, run_id)
     }
 
     /// Whether `name` matches any GC-eligible log file pattern.
@@ -380,12 +430,10 @@ impl LogPaths {
     }
 
     fn is_final_gc_eligible_log(name: &str) -> bool {
-        (name.starts_with("network-") && name.ends_with(".jsonl"))
-            || (name.starts_with("system-") && name.ends_with(".log"))
-            || (name.starts_with("metrics-") && name.ends_with(".jsonl"))
-            || (name.starts_with("sandbox-ops-") && name.ends_with(".jsonl"))
-            || (name.starts_with("proxy-") && name.ends_with(".jsonl"))
-            || (name.starts_with("runner-") && name.ends_with(".log"))
+        PER_RUN_LOG_PATTERNS
+            .iter()
+            .any(|pattern| pattern.matches(name))
+            || RUNNER_INSTANCE_LOG_PATTERN.matches(name)
     }
 
     fn is_gc_eligible_log_temp(name: &str) -> bool {
@@ -564,15 +612,34 @@ mod tests {
     fn log_paths_structure() {
         let lp = LogPaths::new(PathBuf::from("/test/logs"));
         let id = RunId::nil();
-        assert!(lp.network_log(id).to_string_lossy().contains("network-"));
-        assert!(lp.system_log(id).to_string_lossy().contains("system-"));
-        assert!(lp.metrics_log(id).to_string_lossy().contains("metrics-"));
-        assert!(
-            lp.sandbox_ops_log(id)
-                .to_string_lossy()
-                .contains("sandbox-ops-")
-        );
-        assert!(lp.proxy_log(id).to_string_lossy().contains("proxy-"));
+        let paths = [
+            (
+                lp.network_log(id),
+                PathBuf::from(format!("/test/logs/network-{id}.jsonl")),
+            ),
+            (
+                lp.system_log(id),
+                PathBuf::from(format!("/test/logs/system-{id}.log")),
+            ),
+            (
+                lp.metrics_log(id),
+                PathBuf::from(format!("/test/logs/metrics-{id}.jsonl")),
+            ),
+            (
+                lp.sandbox_ops_log(id),
+                PathBuf::from(format!("/test/logs/sandbox-ops-{id}.jsonl")),
+            ),
+            (
+                lp.proxy_log(id),
+                PathBuf::from(format!("/test/logs/proxy-{id}.jsonl")),
+            ),
+        ];
+
+        for (actual, expected) in paths {
+            assert_eq!(actual, expected);
+            let file_name = actual.file_name().and_then(|name| name.to_str()).unwrap();
+            assert!(LogPaths::is_gc_eligible_log(file_name));
+        }
     }
 
     #[test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -422,9 +422,10 @@ impl LogPaths {
 
     /// Whether `name` matches any GC-eligible log file pattern.
     ///
-    /// Includes per-job logs (`network-*`, `system-*`, `metrics-*`,
-    /// `sandbox-ops-*`, `proxy-*`) runner instance logs (`runner-*.log`), and
-    /// stale `.vm0tmp-*` copies of those files left behind by a killed runner.
+    /// Includes per-job logs (`network-*`, `proxy-*`, `system-*`,
+    /// `metrics-*`, `sandbox-ops-*`), runner instance logs (`runner-*.log`),
+    /// and stale `.vm0tmp-*` copies of those files left behind by a killed
+    /// runner.
     pub fn is_gc_eligible_log(name: &str) -> bool {
         Self::is_final_gc_eligible_log(name) || Self::is_gc_eligible_log_temp(name)
     }


### PR DESCRIPTION
## Summary

- Centralize runner log filename prefix/suffix patterns in `LogPaths`
- Keep existing named per-run log path methods while deriving them from shared patterns
- Keep runner instance log matching separate from per-run log matching
- Strengthen path tests so generated per-run log filenames must be GC-eligible

Closes #14392

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner paths::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::tests::gc_job_logs_deletes_stale`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy
