### PR TITLE
refactor: type connector oauth provider credentials

### DIFF
--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -5,15 +5,13 @@ import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/con
 import {
   getConnectorOAuthCredentials,
   getOAuthConnectorConfig,
-  isStaticConfidentialConnectorOAuthCredentials,
-  isStaticConnectorOAuthCredentials,
-  type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  exchangeConnectorOAuthCode,
   isOAuthConnectorType,
   CONNECTOR_OAUTH_PROVIDERS,
   type OAuthTokenResult,
@@ -173,22 +171,6 @@ function redirectWithError(
   return response;
 }
 
-function getProviderCredentialArgs(credentials: ConnectorOAuthCredentials): {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
-} {
-  if (!isStaticConnectorOAuthCredentials(credentials)) {
-    return {};
-  }
-  if (isStaticConfidentialConnectorOAuthCredentials(credentials)) {
-    return {
-      clientId: credentials.clientId,
-      clientSecret: credentials.clientSecret,
-    };
-  }
-  return { clientId: credentials.clientId };
-}
-
 function invalidStateRedirectResponse(origin: string, type: string): Response {
   return redirectWithError(
     origin,
@@ -217,7 +199,6 @@ async function exchangeTokenForConnector(args: {
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  const provider = CONNECTOR_OAUTH_PROVIDERS[args.connectorType];
   const credentials = getConnectorOAuthCredentials(
     args.connectorType,
     optionalEnv,
@@ -226,8 +207,9 @@ async function exchangeTokenForConnector(args: {
     throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
-  return await provider.exchangeCode({
-    ...getProviderCredentialArgs(credentials),
+  return await exchangeConnectorOAuthCode({
+    type: args.connectorType,
+    credentials,
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -18,8 +18,6 @@ import {
 import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
-  isStaticConnectorOAuthCredentials,
-  type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -27,8 +25,8 @@ import {
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
+  buildConnectorOAuthAuthUrl,
   isOAuthConnectorType,
-  CONNECTOR_OAUTH_PROVIDERS,
   type AuthUrlResult,
 } from "@vm0/connectors/oauth-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -186,29 +184,20 @@ function missingOAuthProviderResponse(type: string) {
 
 async function buildProviderAuthorizeUrl(args: {
   readonly type: OAuthConnectorType;
-  readonly clientId?: string;
+  readonly credentials: NonNullable<
+    ReturnType<typeof getConnectorOAuthCredentials>
+  >;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<AuthUrlResult> {
-  const provider = CONNECTOR_OAUTH_PROVIDERS[args.type];
   return normalizeAuthUrlResult(
-    await provider.buildAuthUrl({
-      clientId: args.clientId,
+    await buildConnectorOAuthAuthUrl({
+      type: args.type,
+      credentials: args.credentials,
       redirectUri: args.redirectUri,
       state: args.state,
     }),
   );
-}
-
-function getAuthorizeClientId(
-  credentials: ConnectorOAuthCredentials,
-): string | undefined {
-  if (!credentials.configured) {
-    return undefined;
-  }
-  return isStaticConnectorOAuthCredentials(credentials)
-    ? credentials.clientId
-    : undefined;
 }
 
 function internalServerError(message: string) {
@@ -488,7 +477,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const authResult = await buildProviderAuthorizeUrl({
       type,
-      clientId: getAuthorizeClientId(credentials),
+      credentials,
       redirectUri,
       state,
     });
@@ -574,7 +563,7 @@ const startConnectorOauthInner$ = command(
 
     const authResult = await buildProviderAuthorizeUrl({
       type,
-      clientId: getAuthorizeClientId(credentials),
+      credentials,
       redirectUri,
       state,
     });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3,20 +3,20 @@ import { Buffer } from "node:buffer";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
   getConnectorOAuthCredentials,
-  isStaticConfidentialConnectorOAuthCredentials,
-  isStaticConnectorOAuthCredentials,
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
-import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import type { OAuthConnectorType } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
   getConnectorOAuthProvider,
+  isOAuthConnectorType,
   isOAuthRefreshProvider,
+  refreshConnectorOAuthToken,
   type ProviderEnv,
 } from "@vm0/connectors/oauth-providers";
 import type {
-  OAuthConnectorProvider,
+  OAuthProviderMetadata,
   OAuthRefreshProvider,
 } from "@vm0/connectors/oauth-providers/provider-types";
 import {
@@ -49,7 +49,7 @@ import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 type OAuthSecretSource = "connector" | "model-provider";
 type SecretType = OAuthSecretSource;
 type RegisteredOAuthProvider =
-  | OAuthConnectorProvider
+  | OAuthProviderMetadata
   | ModelProviderOAuthProvider;
 
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
@@ -168,33 +168,24 @@ interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
 interface RefreshTokenContext {
   readonly refreshTokenSecret: string;
   readonly currentRefreshToken: string;
-  readonly clientId: string | undefined;
-  readonly clientSecret: string | undefined;
+  readonly clientId?: string;
+  readonly clientSecret?: string;
   readonly accessTokenSecret: string;
   readonly secretUserId: string;
 }
 
-interface PreparedRefreshTokenContext {
-  readonly sourceType: OAuthSecretSource;
-  readonly provider: OAuthRefreshProvider;
-  readonly context: RefreshTokenContext;
-}
-
-function getRefreshCredentialArgs(credentials: ConnectorOAuthCredentials): {
-  readonly clientId: string | undefined;
-  readonly clientSecret: string | undefined;
-} {
-  if (!isStaticConnectorOAuthCredentials(credentials)) {
-    return { clientId: undefined, clientSecret: undefined };
-  }
-  if (isStaticConfidentialConnectorOAuthCredentials(credentials)) {
-    return {
-      clientId: credentials.clientId,
-      clientSecret: credentials.clientSecret,
+type PreparedRefreshTokenContext =
+  | {
+      readonly sourceType: "connector";
+      readonly connectorType: OAuthConnectorType;
+      readonly credentials: ConnectorOAuthCredentials;
+      readonly context: RefreshTokenContext;
+    }
+  | {
+      readonly sourceType: "model-provider";
+      readonly provider: OAuthRefreshProvider;
+      readonly context: RefreshTokenContext;
     };
-  }
-  return { clientId: credentials.clientId, clientSecret: undefined };
-}
 
 interface SyncRefreshTokensArgs {
   readonly db: Db;
@@ -284,12 +275,6 @@ function resolveRefreshMetadata(
   };
 }
 
-function getConnectorOAuthProviderByKey(
-  connectorType: string,
-): OAuthConnectorProvider | null {
-  return getConnectorOAuthProvider(connectorType) ?? null;
-}
-
 function getOAuthProviderByKey(
   connectorType: string,
   sourceType: OAuthSecretSource,
@@ -298,7 +283,7 @@ function getOAuthProviderByKey(
     return getModelProviderOAuthProvider(connectorType) ?? null;
   }
 
-  return getConnectorOAuthProviderByKey(connectorType);
+  return getConnectorOAuthProvider(connectorType) ?? null;
 }
 
 function currentProviderEnv(): ProviderEnv {
@@ -629,18 +614,20 @@ function prepareRefreshTokenContext(
     };
   }
 
-  const provider = getConnectorOAuthProviderByKey(args.connectorType);
+  if (!isOAuthConnectorType(args.connectorType)) {
+    L.debug(`${args.connectorType} is not an OAuth connector type, skipping`);
+    return null;
+  }
+  const provider = getConnectorOAuthProvider(args.connectorType);
   if (!provider || !isOAuthRefreshProvider(provider)) {
     return null;
   }
-  const typeResult = connectorTypeSchema.safeParse(args.connectorType);
-  if (!typeResult.success) {
-    L.debug(`${args.connectorType} is not a connector type, skipping`);
-    return null;
-  }
-  const credentials = getConnectorOAuthCredentials(typeResult.data, (name) => {
-    return optionalEnv(name);
-  });
+  const credentials = getConnectorOAuthCredentials(
+    args.connectorType,
+    (name) => {
+      return optionalEnv(name);
+    },
+  );
   if (!credentials?.configured) {
     L.debug(
       `${args.connectorType} OAuth credentials not configured, skipping token refresh`,
@@ -655,12 +642,9 @@ function prepareRefreshTokenContext(
     return null;
   }
 
-  const credentialArgs = getRefreshCredentialArgs(credentials);
   const context: RefreshTokenContext = {
     refreshTokenSecret,
     currentRefreshToken,
-    clientId: credentialArgs.clientId,
-    clientSecret: credentialArgs.clientSecret,
     accessTokenSecret: provider.getSecretName(),
     secretUserId: resolveSecretUserId(
       args.sourceType,
@@ -670,8 +654,9 @@ function prepareRefreshTokenContext(
   };
 
   return {
-    sourceType: args.sourceType,
-    provider,
+    sourceType: "connector",
+    connectorType: args.connectorType,
+    credentials,
     context,
   };
 }
@@ -788,11 +773,18 @@ async function refreshConnectorAccessToken(
     return null;
   }
 
-  const refreshPromise = prepared.provider.refreshToken({
-    clientId: prepared.context.clientId,
-    clientSecret: prepared.context.clientSecret,
-    refreshToken: prepared.context.currentRefreshToken,
-  });
+  const refreshPromise =
+    prepared.sourceType === "connector"
+      ? refreshConnectorOAuthToken({
+          type: prepared.connectorType,
+          credentials: prepared.credentials,
+          refreshToken: prepared.context.currentRefreshToken,
+        })
+      : prepared.provider.refreshToken({
+          clientId: prepared.context.clientId,
+          clientSecret: prepared.context.clientSecret,
+          refreshToken: prepared.context.currentRefreshToken,
+        });
   const refreshResult = await settle(refreshPromise);
 
   if (!refreshResult.ok) {

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/google-ads.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/google-ads.test.ts
@@ -5,6 +5,7 @@ import { http } from "../../../../../__tests__/msw";
 import { testContext } from "../../../../../__tests__/test-helpers";
 import { reloadEnv } from "../../../../../env";
 import { injectPlatformEnvSecrets } from "../../../context/resolve-secrets";
+import { getConnectorOAuthCredentials } from "@vm0/connectors/connector-utils";
 import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
 import { googleAdsProvider } from "@vm0/connectors/oauth-providers/providers/google-ads-provider";
 
@@ -49,20 +50,21 @@ describe("connector/providers/google-ads", () => {
       );
     });
 
-    it("getClientId returns GOOGLE_OAUTH_CLIENT_ID from env", () => {
-      const env = {
+    it("resolves OAuth client credentials from Google env keys", () => {
+      const env: Record<string, string> = {
         GOOGLE_OAUTH_CLIENT_ID: "test-client-id",
-      } as Parameters<typeof googleAdsProvider.getClientId>[0];
-
-      expect(googleAdsProvider.getClientId(env)).toBe("test-client-id");
-    });
-
-    it("getClientSecret returns GOOGLE_OAUTH_CLIENT_SECRET from env", () => {
-      const env = {
         GOOGLE_OAUTH_CLIENT_SECRET: "test-client-secret",
-      } as Parameters<typeof googleAdsProvider.getClientSecret>[0];
+      };
 
-      expect(googleAdsProvider.getClientSecret(env)).toBe("test-client-secret");
+      expect(
+        getConnectorOAuthCredentials("google-ads", (name) => {
+          return env[name];
+        }),
+      ).toMatchObject({
+        configured: true,
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+      });
     });
 
     it("getSecretName returns GOOGLE_ADS_ACCESS_TOKEN", () => {

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse } from "msw";
 import { server } from "../../../../../mocks/server";
 import { http } from "../../../../../__tests__/msw";
 import { testContext } from "../../../../../__tests__/test-helpers";
+import { getConnectorOAuthCredentials } from "@vm0/connectors/connector-utils";
 import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
 import {
   buildMetaAdsAuthorizationUrl,
@@ -160,20 +161,21 @@ describe("connector/providers/meta-ads", () => {
       expect(url).toContain("facebook.com/v22.0/dialog/oauth");
     });
 
-    it("getClientId returns META_ADS_OAUTH_CLIENT_ID from env", () => {
-      const env = {
+    it("resolves OAuth client credentials from Meta Ads env keys", () => {
+      const env: Record<string, string> = {
         META_ADS_OAUTH_CLIENT_ID: "test-client-id",
-      } as Parameters<typeof metaAdsProvider.getClientId>[0];
-
-      expect(metaAdsProvider.getClientId(env)).toBe("test-client-id");
-    });
-
-    it("getClientSecret returns META_ADS_OAUTH_CLIENT_SECRET from env", () => {
-      const env = {
         META_ADS_OAUTH_CLIENT_SECRET: "test-client-secret",
-      } as Parameters<typeof metaAdsProvider.getClientSecret>[0];
+      };
 
-      expect(metaAdsProvider.getClientSecret(env)).toBe("test-client-secret");
+      expect(
+        getConnectorOAuthCredentials("meta-ads", (name) => {
+          return env[name];
+        }),
+      ).toMatchObject({
+        configured: true,
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+      });
     });
 
     it("getSecretName returns META_ADS_ACCESS_TOKEN", () => {

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -2,9 +2,15 @@ import type {
   ConnectorType,
   OAuthConnectorType,
 } from "@vm0/connectors/connectors";
-import { getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
+import {
+  getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
+  isStaticConfidentialConnectorOAuthCredentials,
+  isStaticConnectorOAuthCredentials,
+  type ConnectorOAuthCredentials,
+} from "@vm0/connectors/connector-utils";
 import {
   type AuthUrlResult,
+  type ConnectorOAuthProviderFor,
   type OAuthAuthorizeArgs,
   type OAuthExchangeArgs,
   type OAuthRefreshArgs,
@@ -72,6 +78,54 @@ export type {
 export type { ProviderEnv };
 export { providerEnvFromObject, isOAuthRefreshProvider };
 
+type ConnectorOAuthProviderMap = {
+  readonly [Type in OAuthConnectorType]: ConnectorOAuthProviderFor<Type>;
+};
+
+type DispatchAuthorizeProvider = {
+  buildAuthUrl(
+    args: OAuthAuthorizeArgs,
+  ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
+};
+
+type DispatchExchangeProvider = {
+  exchangeCode(args: OAuthExchangeArgs): Promise<OAuthTokenResult>;
+};
+
+type DispatchRefreshProvider = {
+  refreshToken(args: OAuthRefreshArgs): Promise<OAuthRefreshResult>;
+};
+
+function connectorProviderFor<T extends OAuthConnectorType>(
+  type: T,
+): ConnectorOAuthProviderFor<T> {
+  return CONNECTOR_OAUTH_PROVIDERS[type] as ConnectorOAuthProviderFor<T>;
+}
+
+function connectorCredentialArgs(
+  credentials: ConnectorOAuthCredentials,
+): Pick<OAuthExchangeArgs, "clientId" | "clientSecret"> {
+  if (!isStaticConnectorOAuthCredentials(credentials)) {
+    return {};
+  }
+  if (isStaticConfidentialConnectorOAuthCredentials(credentials)) {
+    return {
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
+    };
+  }
+  return { clientId: credentials.clientId };
+}
+
+function assertConfiguredConnectorOAuthCredentials(
+  type: OAuthConnectorType,
+  credentials: ConnectorOAuthCredentials,
+): void {
+  if (!credentials.configured) {
+    throw new Error(`${type} OAuth not configured`);
+  }
+}
+
 export const CONNECTOR_OAUTH_PROVIDERS = {
   ahrefs: ahrefsProvider,
   airtable: airtableProvider,
@@ -118,7 +172,7 @@ export const CONNECTOR_OAUTH_PROVIDERS = {
   xero: xeroProvider,
   zoom: zoomProvider,
   "test-oauth": testOauthProvider,
-} satisfies Record<OAuthConnectorType, OAuthConnectorProvider>;
+} satisfies ConnectorOAuthProviderMap;
 
 export function isOAuthConnectorType(type: string): type is OAuthConnectorType {
   return Object.hasOwn(CONNECTOR_OAUTH_PROVIDERS, type);
@@ -131,6 +185,63 @@ export function getConnectorOAuthProvider(
     return undefined;
   }
   return CONNECTOR_OAUTH_PROVIDERS[type];
+}
+
+export async function buildConnectorOAuthAuthUrl(args: {
+  readonly type: OAuthConnectorType;
+  readonly credentials: ConnectorOAuthCredentials;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<string | AuthUrlResult> {
+  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
+  const provider = connectorProviderFor(
+    args.type,
+  ) as unknown as DispatchAuthorizeProvider;
+  return await provider.buildAuthUrl({
+    ...connectorCredentialArgs(args.credentials),
+    redirectUri: args.redirectUri,
+    state: args.state,
+  });
+}
+
+export async function exchangeConnectorOAuthCode(args: {
+  readonly type: OAuthConnectorType;
+  readonly credentials: ConnectorOAuthCredentials;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
+}): Promise<OAuthTokenResult> {
+  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
+  const provider = connectorProviderFor(
+    args.type,
+  ) as unknown as DispatchExchangeProvider;
+  return await provider.exchangeCode({
+    ...connectorCredentialArgs(args.credentials),
+    code: args.code,
+    redirectUri: args.redirectUri,
+    state: args.state,
+    codeVerifier: args.codeVerifier,
+    oauthContext: args.oauthContext,
+  });
+}
+
+export async function refreshConnectorOAuthToken(args: {
+  readonly type: OAuthConnectorType;
+  readonly credentials: ConnectorOAuthCredentials;
+  readonly refreshToken: string;
+}): Promise<OAuthRefreshResult> {
+  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
+  const provider = connectorProviderFor(args.type);
+  if (!isOAuthRefreshProvider(provider)) {
+    throw new Error(`${args.type} OAuth provider does not support refresh`);
+  }
+  const dispatchProvider = provider as unknown as DispatchRefreshProvider;
+  return await dispatchProvider.refreshToken({
+    ...connectorCredentialArgs(args.credentials),
+    refreshToken: args.refreshToken,
+  });
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -1,3 +1,9 @@
+import type {
+  CONNECTOR_TYPES,
+  ConnectorOAuthClientConfig,
+  OAuthConnectorType,
+} from "@vm0/connectors/connectors";
+
 export interface ProviderEnv {
   readonly [name: string]: string | undefined;
 }
@@ -35,15 +41,12 @@ export interface AuthUrlResult {
   oauthContext?: string;
 }
 
-export interface OAuthAuthorizeArgs {
-  readonly clientId?: string;
+interface OAuthAuthorizeFlowArgs {
   readonly redirectUri: string;
   readonly state: string;
 }
 
-export interface OAuthExchangeArgs {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
+interface OAuthExchangeFlowArgs {
   readonly code: string;
   readonly redirectUri: string;
   readonly state?: string;
@@ -51,11 +54,30 @@ export interface OAuthExchangeArgs {
   readonly oauthContext?: string;
 }
 
-export interface OAuthRefreshArgs {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
+interface OAuthRefreshFlowArgs {
   readonly refreshToken: string;
 }
+
+interface OAuthRevokeFlowArgs {
+  readonly accessToken: string;
+}
+
+type OptionalClientCredentialArgs = {
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+};
+
+export type OAuthAuthorizeArgs = OAuthAuthorizeFlowArgs &
+  OptionalClientCredentialArgs;
+
+export type OAuthExchangeArgs = OAuthExchangeFlowArgs &
+  OptionalClientCredentialArgs;
+
+export type OAuthRefreshArgs = OAuthRefreshFlowArgs &
+  OptionalClientCredentialArgs;
+
+export type OAuthRevokeArgs = OAuthRevokeFlowArgs &
+  OptionalClientCredentialArgs;
 
 export interface OAuthRefreshResult {
   readonly accessToken: string;
@@ -75,37 +97,66 @@ export type RefreshTokenFn = (
   args: OAuthRefreshArgs,
 ) => Promise<OAuthRefreshResult>;
 
-export interface OAuthRevokeArgs {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
-  readonly accessToken: string;
-}
-
 export type RevokeTokenFn = (args: OAuthRevokeArgs) => Promise<void>;
 
-export function requireOAuthClientId(args: {
-  readonly clientId?: string;
-}): string {
-  if (!args.clientId) {
-    throw new Error("OAuth provider requires a client ID");
+type ConnectorOAuthClientFor<T extends OAuthConnectorType> =
+  (typeof CONNECTOR_TYPES)[T]["oauth"]["client"];
+
+type NoClientCredentialArgs = Record<never, never>;
+
+type StaticClientIdArgs<Client extends ConnectorOAuthClientConfig> =
+  Client extends { readonly clientRegistration: "static" }
+    ? { readonly clientId: string }
+    : NoClientCredentialArgs;
+
+type TokenCredentialArgs<Client extends ConnectorOAuthClientConfig> =
+  Client extends {
+    readonly clientRegistration: "static";
+    readonly clientType: "confidential";
   }
-  return args.clientId;
+    ? { readonly clientId: string; readonly clientSecret: string }
+    : Client extends {
+          readonly clientRegistration: "static";
+          readonly clientType: "public";
+        }
+      ? { readonly clientId: string }
+      : NoClientCredentialArgs;
+
+export type ConnectorOAuthAuthorizeArgs<T extends OAuthConnectorType> =
+  OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
+
+export type ConnectorOAuthExchangeArgs<T extends OAuthConnectorType> =
+  OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+
+export type ConnectorOAuthRefreshArgs<T extends OAuthConnectorType> =
+  OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+
+export type ConnectorOAuthRevokeArgs<T extends OAuthConnectorType> =
+  OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+
+type BuildConnectorAuthUrlFn<T extends OAuthConnectorType> = (
+  args: ConnectorOAuthAuthorizeArgs<T>,
+) => string | AuthUrlResult | Promise<string | AuthUrlResult>;
+
+type ExchangeConnectorCodeFn<T extends OAuthConnectorType> = (
+  args: ConnectorOAuthExchangeArgs<T>,
+) => Promise<OAuthTokenResult>;
+
+type RefreshConnectorTokenFn<T extends OAuthConnectorType> = (
+  args: ConnectorOAuthRefreshArgs<T>,
+) => Promise<OAuthRefreshResult>;
+
+type RevokeConnectorTokenFn<T extends OAuthConnectorType> = (
+  args: ConnectorOAuthRevokeArgs<T>,
+) => Promise<void>;
+
+export interface OAuthProviderMetadata {
+  getSecretName(): string;
 }
 
-export function requireOAuthClientCredentials(args: {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
-}): { readonly clientId: string; readonly clientSecret: string } {
-  if (!args.clientId || !args.clientSecret) {
-    throw new Error("OAuth provider requires client credentials");
-  }
-  return { clientId: args.clientId, clientSecret: args.clientSecret };
-}
-
-export interface OAuthProvider {
+export interface OAuthProvider extends OAuthProviderMetadata {
   getClientId(currentEnv: ProviderEnv): string | undefined;
   getClientSecret(currentEnv: ProviderEnv): string | undefined;
-  getSecretName(): string;
 }
 
 export type OAuthAuthorizationCodeProvider = OAuthProvider & {
@@ -131,13 +182,45 @@ type OAuthNoRevocationProvider = {
   revokeToken?: never;
 };
 
-export type OAuthConnectorProvider = OAuthAuthorizationCodeProvider &
-  (OAuthRefreshProvider | OAuthNoRefreshProvider) &
-  (OAuthRevocationProvider | OAuthNoRevocationProvider);
+type ConnectorOAuthAuthorizationCodeProvider<T extends OAuthConnectorType> =
+  OAuthProviderMetadata & {
+    buildAuthUrl: BuildConnectorAuthUrlFn<T>;
+    exchangeCode: ExchangeConnectorCodeFn<T>;
+  };
+
+export type ConnectorOAuthRefreshProvider<T extends OAuthConnectorType> = {
+  getRefreshSecretName(): string;
+  refreshToken: RefreshConnectorTokenFn<T>;
+};
+
+export type ConnectorOAuthRevocationProvider<T extends OAuthConnectorType> = {
+  revokeToken: RevokeConnectorTokenFn<T>;
+};
+
+export type ConnectorOAuthProviderFor<T extends OAuthConnectorType> =
+  ConnectorOAuthAuthorizationCodeProvider<T> &
+    (ConnectorOAuthRefreshProvider<T> | OAuthNoRefreshProvider) &
+    (ConnectorOAuthRevocationProvider<T> | OAuthNoRevocationProvider);
+
+export type AnyConnectorOAuthProvider = {
+  [Type in OAuthConnectorType]: ConnectorOAuthProviderFor<Type>;
+}[OAuthConnectorType];
+
+export type OAuthConnectorProvider = AnyConnectorOAuthProvider;
+
+export function defineConnectorOAuthProvider<T extends OAuthConnectorType>(
+  _type: T,
+  provider: ConnectorOAuthProviderFor<T>,
+): ConnectorOAuthProviderFor<T> {
+  return provider;
+}
 
 export function isOAuthRefreshProvider(
-  provider: OAuthProvider,
-): provider is OAuthRefreshProvider {
+  provider: OAuthProviderMetadata,
+): provider is OAuthProviderMetadata & {
+  getRefreshSecretName(): string;
+  refreshToken: RefreshTokenFn;
+} {
   return (
     "getRefreshSecretName" in provider &&
     typeof provider.getRefreshSecretName === "function" &&

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildAhrefsAuthorizationUrl,
   exchangeAhrefsCode,
   getAhrefsSecretName,
   refreshAhrefsToken,
 } from "./ahrefs";
-export const ahrefsProvider: OAuthConnectorProvider = {
+export const ahrefsProvider = defineConnectorOAuthProvider("ahrefs", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildAhrefsAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeAhrefsCode(
@@ -36,18 +32,12 @@ export const ahrefsProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.AHREFS_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.AHREFS_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getAhrefsSecretName,
   getRefreshSecretName: () => {
     return "AHREFS_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshAhrefsToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable-provider.ts
@@ -1,17 +1,13 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildAirtableAuthorizationUrl,
   exchangeAirtableCode,
   getAirtableSecretName,
   refreshAirtableToken,
 } from "./airtable";
-export const airtableProvider: OAuthConnectorProvider = {
+export const airtableProvider = defineConnectorOAuthProvider("airtable", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildAirtableAuthorizationUrl(
       clientId,
       args.redirectUri,
@@ -19,7 +15,7 @@ export const airtableProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const codeVerifier = args.codeVerifier;
@@ -42,18 +38,12 @@ export const airtableProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.AIRTABLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.AIRTABLE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getAirtableSecretName,
   getRefreshSecretName: () => {
     return "AIRTABLE_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshAirtableToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildAsanaAuthorizationUrl,
   exchangeAsanaCode,
   getAsanaSecretName,
   refreshAsanaToken,
 } from "./asana";
-export const asanaProvider: OAuthConnectorProvider = {
+export const asanaProvider = defineConnectorOAuthProvider("asana", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildAsanaAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeAsanaCode(
@@ -36,18 +32,12 @@ export const asanaProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.ASANA_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.ASANA_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getAsanaSecretName,
   getRefreshSecretName: () => {
     return "ASANA_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshAsanaToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildCanvaAuthorizationUrl,
   exchangeCanvaCode,
   getCanvaSecretName,
   refreshCanvaToken,
 } from "./canva";
-export const canvaProvider: OAuthConnectorProvider = {
+export const canvaProvider = defineConnectorOAuthProvider("canva", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildCanvaAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const state = args.state;
@@ -41,18 +37,12 @@ export const canvaProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.CANVA_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.CANVA_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getCanvaSecretName,
   getRefreshSecretName: () => {
     return "CANVA_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshCanvaToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/close-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildCloseAuthorizationUrl,
   exchangeCloseCode,
   getCloseSecretName,
   refreshCloseToken,
 } from "./close";
-export const closeProvider: OAuthConnectorProvider = {
+export const closeProvider = defineConnectorOAuthProvider("close", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildCloseAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeCloseCode(
@@ -36,18 +32,12 @@ export const closeProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.CLOSE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.CLOSE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getCloseSecretName,
   getRefreshSecretName: () => {
     return "CLOSE_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshCloseToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildDeelAuthorizationUrl,
   exchangeDeelCode,
   getDeelSecretName,
   refreshDeelToken,
 } from "./deel";
-export const deelProvider: OAuthConnectorProvider = {
+export const deelProvider = defineConnectorOAuthProvider("deel", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildDeelAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const state = args.state;
@@ -41,18 +37,12 @@ export const deelProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.DEEL_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.DEEL_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getDeelSecretName,
   getRefreshSecretName: () => {
     return "DEEL_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshDeelToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign-provider.ts
@@ -1,17 +1,13 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildDocuSignAuthorizationUrl,
   exchangeDocuSignCode,
   getDocuSignSecretName,
   refreshDocuSignToken,
 } from "./docusign";
-export const docusignProvider: OAuthConnectorProvider = {
+export const docusignProvider = defineConnectorOAuthProvider("docusign", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildDocuSignAuthorizationUrl(
       clientId,
       args.redirectUri,
@@ -19,7 +15,7 @@ export const docusignProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const state = args.state;
@@ -47,18 +43,12 @@ export const docusignProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.DOCUSIGN_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.DOCUSIGN_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getDocuSignSecretName,
   getRefreshSecretName: () => {
     return "DOCUSIGN_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshDocuSignToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildDropboxAuthorizationUrl,
   exchangeDropboxCode,
   getDropboxSecretName,
   refreshDropboxToken,
 } from "./dropbox";
-export const dropboxProvider: OAuthConnectorProvider = {
+export const dropboxProvider = defineConnectorOAuthProvider("dropbox", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildDropboxAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeDropboxCode(
@@ -36,18 +32,12 @@ export const dropboxProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.DROPBOX_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.DROPBOX_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getDropboxSecretName,
   getRefreshSecretName: () => {
     return "DROPBOX_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshDropboxToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildFigmaAuthorizationUrl,
   exchangeFigmaCode,
   getFigmaSecretName,
   refreshFigmaToken,
 } from "./figma";
-export const figmaProvider: OAuthConnectorProvider = {
+export const figmaProvider = defineConnectorOAuthProvider("figma", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildFigmaAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeFigmaCode(
@@ -36,18 +32,12 @@ export const figmaProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.FIGMA_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.FIGMA_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getFigmaSecretName,
   getRefreshSecretName: () => {
     return "FIGMA_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshFigmaToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect-provider.ts
@@ -1,62 +1,59 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGarminConnectAuthorizationUrl,
   exchangeGarminConnectCode,
   getGarminConnectSecretName,
   refreshGarminConnectToken,
 } from "./garmin-connect";
-export const garminConnectProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    return buildGarminConnectAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
-  },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const state = args.state;
-    if (!state) {
-      throw new Error(
-        "Garmin Connect PKCE requires state for code_verifier derivation",
+export const garminConnectProvider = defineConnectorOAuthProvider(
+  "garmin-connect",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildGarminConnectAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
       );
-    }
-    const result = await exchangeGarminConnectCode(
-      clientId,
-      clientSecret,
-      code,
-      state,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const state = args.state;
+      if (!state) {
+        throw new Error(
+          "Garmin Connect PKCE requires state for code_verifier derivation",
+        );
+      }
+      const result = await exchangeGarminConnectCode(
+        clientId,
+        clientSecret,
+        code,
+        state,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: getGarminConnectSecretName,
+    getRefreshSecretName: () => {
+      return "GARMIN_CONNECT_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshGarminConnectToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+      );
+    },
   },
-  getClientId: (e) => {
-    return e.GARMIN_CONNECT_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GARMIN_CONNECT_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: getGarminConnectSecretName,
-  getRefreshSecretName: () => {
-    return "GARMIN_CONNECT_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    return refreshGarminConnectToken(clientId, clientSecret, args.refreshToken);
-  },
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/github-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github-provider.ts
@@ -1,8 +1,4 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGitHubAuthorizationUrl,
   exchangeGitHubCode,
@@ -10,13 +6,13 @@ import {
   getGitHubSecretName,
   revokeGitHubGrant,
 } from "./github";
-export const githubProvider: OAuthConnectorProvider = {
+export const githubProvider = defineConnectorOAuthProvider("github", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildGitHubAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const { accessToken, scopes } = await exchangeGitHubCode(
@@ -28,15 +24,9 @@ export const githubProvider: OAuthConnectorProvider = {
     const userInfo = await fetchGitHubUserInfo(accessToken);
     return { accessToken, scopes, userInfo };
   },
-  getClientId: (e) => {
-    return e.GH_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GH_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getGitHubSecretName,
   revokeToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return revokeGitHubGrant(clientId, clientSecret, args.accessToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGmailAuthorizationUrl,
   exchangeGmailCode,
   getGmailSecretName,
 } from "./gmail";
 import { refreshGoogleToken } from "./google-oauth";
-export const gmailProvider: OAuthConnectorProvider = {
+export const gmailProvider = defineConnectorOAuthProvider("gmail", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildGmailAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeGmailCode(
@@ -36,19 +32,13 @@ export const gmailProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getGmailSecretName,
   getRefreshSecretName: () => {
     return "GMAIL_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const refreshToken = args.refreshToken;
     return refreshGoogleToken("gmail", clientId, clientSecret, refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-ads-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-ads-provider.ts
@@ -1,16 +1,12 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleAdsProvider: OAuthConnectorProvider = {
+export const googleAdsProvider = defineConnectorOAuthProvider("google-ads", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     const redirectUri = args.redirectUri;
     const state = args.state;
     return buildGoogleAuthorizationUrl(
@@ -21,7 +17,7 @@ export const googleAdsProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeGoogleOAuthCode(
@@ -43,12 +39,6 @@ export const googleAdsProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: () => {
     return "GOOGLE_ADS_ACCESS_TOKEN";
   },
@@ -56,7 +46,7 @@ export const googleAdsProvider: OAuthConnectorProvider = {
     return "GOOGLE_ADS_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const refreshToken = args.refreshToken;
     return refreshGoogleToken(
       "google-ads",
@@ -65,4 +55,4 @@ export const googleAdsProvider: OAuthConnectorProvider = {
       refreshToken,
     );
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-calendar-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-calendar-provider.ts
@@ -1,68 +1,61 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleCalendarProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildGoogleAuthorizationUrl(
-      "google-calendar",
-      clientId,
-      redirectUri,
-      state,
-    );
+export const googleCalendarProvider = defineConnectorOAuthProvider(
+  "google-calendar",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      return buildGoogleAuthorizationUrl(
+        "google-calendar",
+        clientId,
+        redirectUri,
+        state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeGoogleOAuthCode(
+        "google-calendar",
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: () => {
+      return "GOOGLE_CALENDAR_ACCESS_TOKEN";
+    },
+    getRefreshSecretName: () => {
+      return "GOOGLE_CALENDAR_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshGoogleToken(
+        "google-calendar",
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGoogleOAuthCode(
-      "google-calendar",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
-  },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: () => {
-    return "GOOGLE_CALENDAR_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "GOOGLE_CALENDAR_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken(
-      "google-calendar",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-docs-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-docs-provider.ts
@@ -1,16 +1,12 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleDocsProvider: OAuthConnectorProvider = {
+export const googleDocsProvider = defineConnectorOAuthProvider("google-docs", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     const redirectUri = args.redirectUri;
     const state = args.state;
     return buildGoogleAuthorizationUrl(
@@ -21,7 +17,7 @@ export const googleDocsProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeGoogleOAuthCode(
@@ -43,12 +39,6 @@ export const googleDocsProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: () => {
     return "GOOGLE_DOCS_ACCESS_TOKEN";
   },
@@ -56,7 +46,7 @@ export const googleDocsProvider: OAuthConnectorProvider = {
     return "GOOGLE_DOCS_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const refreshToken = args.refreshToken;
     return refreshGoogleToken(
       "google-docs",
@@ -65,4 +55,4 @@ export const googleDocsProvider: OAuthConnectorProvider = {
       refreshToken,
     );
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-drive-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-drive-provider.ts
@@ -1,68 +1,61 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleDriveProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildGoogleAuthorizationUrl(
-      "google-drive",
-      clientId,
-      redirectUri,
-      state,
-    );
+export const googleDriveProvider = defineConnectorOAuthProvider(
+  "google-drive",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      return buildGoogleAuthorizationUrl(
+        "google-drive",
+        clientId,
+        redirectUri,
+        state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeGoogleOAuthCode(
+        "google-drive",
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: () => {
+      return "GOOGLE_DRIVE_ACCESS_TOKEN";
+    },
+    getRefreshSecretName: () => {
+      return "GOOGLE_DRIVE_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshGoogleToken(
+        "google-drive",
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGoogleOAuthCode(
-      "google-drive",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
-  },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: () => {
-    return "GOOGLE_DRIVE_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "GOOGLE_DRIVE_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken(
-      "google-drive",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-meet-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-meet-provider.ts
@@ -1,16 +1,12 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleMeetProvider: OAuthConnectorProvider = {
+export const googleMeetProvider = defineConnectorOAuthProvider("google-meet", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     const redirectUri = args.redirectUri;
     const state = args.state;
     return buildGoogleAuthorizationUrl(
@@ -21,7 +17,7 @@ export const googleMeetProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeGoogleOAuthCode(
@@ -43,12 +39,6 @@ export const googleMeetProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: () => {
     return "GOOGLE_MEET_ACCESS_TOKEN";
   },
@@ -56,7 +46,7 @@ export const googleMeetProvider: OAuthConnectorProvider = {
     return "GOOGLE_MEET_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const refreshToken = args.refreshToken;
     return refreshGoogleToken(
       "google-meet",
@@ -65,4 +55,4 @@ export const googleMeetProvider: OAuthConnectorProvider = {
       refreshToken,
     );
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-sheets-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-sheets-provider.ts
@@ -1,68 +1,61 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleSheetsProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildGoogleAuthorizationUrl(
-      "google-sheets",
-      clientId,
-      redirectUri,
-      state,
-    );
+export const googleSheetsProvider = defineConnectorOAuthProvider(
+  "google-sheets",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      return buildGoogleAuthorizationUrl(
+        "google-sheets",
+        clientId,
+        redirectUri,
+        state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeGoogleOAuthCode(
+        "google-sheets",
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: () => {
+      return "GOOGLE_SHEETS_ACCESS_TOKEN";
+    },
+    getRefreshSecretName: () => {
+      return "GOOGLE_SHEETS_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshGoogleToken(
+        "google-sheets",
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGoogleOAuthCode(
-      "google-sheets",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
-  },
-  getClientId: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GOOGLE_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: () => {
-    return "GOOGLE_SHEETS_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "GOOGLE_SHEETS_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken(
-      "google-sheets",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildGumroadAuthorizationUrl,
   exchangeGumroadCode,
   getGumroadSecretName,
   refreshGumroadToken,
 } from "./gumroad";
-export const gumroadProvider: OAuthConnectorProvider = {
+export const gumroadProvider = defineConnectorOAuthProvider("gumroad", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildGumroadAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeGumroadCode(
@@ -36,18 +32,12 @@ export const gumroadProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.GUMROAD_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.GUMROAD_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getGumroadSecretName,
   getRefreshSecretName: () => {
     return "GUMROAD_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshGumroadToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildHubSpotAuthorizationUrl,
   exchangeHubSpotCode,
   getHubSpotSecretName,
   refreshHubSpotToken,
 } from "./hubspot";
-export const hubspotProvider: OAuthConnectorProvider = {
+export const hubspotProvider = defineConnectorOAuthProvider("hubspot", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildHubSpotAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeHubSpotCode(
@@ -36,18 +32,12 @@ export const hubspotProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.HUBSPOT_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.HUBSPOT_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getHubSpotSecretName,
   getRefreshSecretName: () => {
     return "HUBSPOT_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshHubSpotToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu-provider.ts
@@ -1,42 +1,39 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildIntervalsIcuAuthorizationUrl,
   exchangeIntervalsIcuCode,
   getIntervalsIcuSecretName,
 } from "./intervals-icu";
-export const intervalsIcuProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    return buildIntervalsIcuAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
+export const intervalsIcuProvider = defineConnectorOAuthProvider(
+  "intervals-icu",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildIntervalsIcuAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const result = await exchangeIntervalsIcuCode(
+        clientId,
+        clientSecret,
+        code,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: null,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: getIntervalsIcuSecretName,
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const result = await exchangeIntervalsIcuCode(clientId, clientSecret, code);
-    return {
-      accessToken: result.accessToken,
-      refreshToken: null,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
-  },
-  getClientId: (e) => {
-    return e.INTERVALS_ICU_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.INTERVALS_ICU_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: getIntervalsIcuSecretName,
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear-provider.ts
@@ -1,8 +1,4 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildLinearAuthorizationUrl,
   exchangeLinearCode,
@@ -10,13 +6,13 @@ import {
   refreshLinearToken,
   revokeLinearToken,
 } from "./linear";
-export const linearProvider: OAuthConnectorProvider = {
+export const linearProvider = defineConnectorOAuthProvider("linear", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildLinearAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeLinearCode(
@@ -37,22 +33,16 @@ export const linearProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.LINEAR_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.LINEAR_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getLinearSecretName,
   getRefreshSecretName: () => {
     return "LINEAR_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshLinearToken(clientId, clientSecret, args.refreshToken);
   },
   revokeToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return revokeLinearToken(clientId, clientSecret, args.accessToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-provider.ts
@@ -1,16 +1,12 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildMailchimpAuthorizationUrl,
   exchangeMailchimpCode,
   getMailchimpSecretName,
 } from "./mailchimp";
-export const mailchimpProvider: OAuthConnectorProvider = {
+export const mailchimpProvider = defineConnectorOAuthProvider("mailchimp", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildMailchimpAuthorizationUrl(
       clientId,
       args.redirectUri,
@@ -18,7 +14,7 @@ export const mailchimpProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeMailchimpCode(
@@ -38,11 +34,5 @@ export const mailchimpProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.MAILCHIMP_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.MAILCHIMP_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getMailchimpSecretName,
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildMercuryAuthorizationUrl,
   exchangeMercuryCode,
   getMercurySecretName,
   refreshMercuryToken,
 } from "./mercury";
-export const mercuryProvider: OAuthConnectorProvider = {
+export const mercuryProvider = defineConnectorOAuthProvider("mercury", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildMercuryAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeMercuryCode(
@@ -36,18 +32,12 @@ export const mercuryProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.MERCURY_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.MERCURY_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getMercurySecretName,
   getRefreshSecretName: () => {
     return "MERCURY_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshMercuryToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads-provider.ts
@@ -1,20 +1,16 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
   getMetaAdsSecretName,
 } from "./meta-ads";
-export const metaAdsProvider: OAuthConnectorProvider = {
+export const metaAdsProvider = defineConnectorOAuthProvider("meta-ads", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildMetaAdsAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeMetaAdsCode(
@@ -35,11 +31,5 @@ export const metaAdsProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.META_ADS_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.META_ADS_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getMetaAdsSecretName,
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildMondayAuthorizationUrl,
   exchangeMondayCode,
   getMondaySecretName,
   refreshMondayToken,
 } from "./monday";
-export const mondayProvider: OAuthConnectorProvider = {
+export const mondayProvider = defineConnectorOAuthProvider("monday", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildMondayAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeMondayCode(
@@ -36,18 +32,12 @@ export const mondayProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.MONDAY_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.MONDAY_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getMondaySecretName,
   getRefreshSecretName: () => {
     return "MONDAY_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshMondayToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildNeonAuthorizationUrl,
   exchangeNeonCode,
   getNeonSecretName,
   refreshNeonToken,
 } from "./neon";
-export const neonProvider: OAuthConnectorProvider = {
+export const neonProvider = defineConnectorOAuthProvider("neon", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildNeonAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeNeonCode(
@@ -36,18 +32,12 @@ export const neonProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.NEON_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.NEON_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getNeonSecretName,
   getRefreshSecretName: () => {
     return "NEON_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshNeonToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildNotionAuthorizationUrl,
   exchangeNotionCode,
   getNotionSecretName,
   refreshNotionToken,
 } from "./notion";
-export const notionProvider: OAuthConnectorProvider = {
+export const notionProvider = defineConnectorOAuthProvider("notion", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildNotionAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeNotionCode(
@@ -32,18 +28,12 @@ export const notionProvider: OAuthConnectorProvider = {
       userInfo: result.userInfo,
     };
   },
-  getClientId: (e) => {
-    return e.NOTION_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.NOTION_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getNotionSecretName,
   getRefreshSecretName: () => {
     return "NOTION_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshNotionToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/outlook-calendar-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/outlook-calendar-provider.ts
@@ -1,68 +1,61 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildMicrosoftAuthorizationUrl,
   exchangeMicrosoftOAuthCode,
   refreshMicrosoftToken,
 } from "./microsoft-oauth";
-export const outlookCalendarProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildMicrosoftAuthorizationUrl(
-      "outlook-calendar",
-      clientId,
-      redirectUri,
-      state,
-    );
+export const outlookCalendarProvider = defineConnectorOAuthProvider(
+  "outlook-calendar",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      return buildMicrosoftAuthorizationUrl(
+        "outlook-calendar",
+        clientId,
+        redirectUri,
+        state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeMicrosoftOAuthCode(
+        "outlook-calendar",
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: () => {
+      return "OUTLOOK_CALENDAR_ACCESS_TOKEN";
+    },
+    getRefreshSecretName: () => {
+      return "OUTLOOK_CALENDAR_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshMicrosoftToken(
+        "outlook-calendar",
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeMicrosoftOAuthCode(
-      "outlook-calendar",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
-  },
-  getClientId: (e) => {
-    return e.MICROSOFT_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.MICROSOFT_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: () => {
-    return "OUTLOOK_CALENDAR_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "OUTLOOK_CALENDAR_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const refreshToken = args.refreshToken;
-    return refreshMicrosoftToken(
-      "outlook-calendar",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/outlook-mail-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/outlook-mail-provider.ts
@@ -1,68 +1,61 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildMicrosoftAuthorizationUrl,
   exchangeMicrosoftOAuthCode,
   refreshMicrosoftToken,
 } from "./microsoft-oauth";
-export const outlookMailProvider: OAuthConnectorProvider = {
-  buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildMicrosoftAuthorizationUrl(
-      "outlook-mail",
-      clientId,
-      redirectUri,
-      state,
-    );
+export const outlookMailProvider = defineConnectorOAuthProvider(
+  "outlook-mail",
+  {
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      return buildMicrosoftAuthorizationUrl(
+        "outlook-mail",
+        clientId,
+        redirectUri,
+        state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeMicrosoftOAuthCode(
+        "outlook-mail",
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
+    getSecretName: () => {
+      return "OUTLOOK_MAIL_ACCESS_TOKEN";
+    },
+    getRefreshSecretName: () => {
+      return "OUTLOOK_MAIL_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshMicrosoftToken(
+        "outlook-mail",
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeMicrosoftOAuthCode(
-      "outlook-mail",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
-  },
-  getClientId: (e) => {
-    return e.MICROSOFT_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.MICROSOFT_OAUTH_CLIENT_SECRET;
-  },
-  getSecretName: () => {
-    return "OUTLOOK_MAIL_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "OUTLOOK_MAIL_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    const refreshToken = args.refreshToken;
-    return refreshMicrosoftToken(
-      "outlook-mail",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-};
+);

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildPosthogAuthorizationUrl,
   exchangePosthogCode,
   getPosthogSecretName,
   refreshPosthogToken,
 } from "./posthog";
-export const posthogProvider: OAuthConnectorProvider = {
+export const posthogProvider = defineConnectorOAuthProvider("posthog", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildPosthogAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangePosthogCode(
@@ -36,18 +32,12 @@ export const posthogProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.POSTHOG_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.POSTHOG_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getPosthogSecretName,
   getRefreshSecretName: () => {
     return "POSTHOG_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshPosthogToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildRedditAuthorizationUrl,
   exchangeRedditCode,
   getRedditSecretName,
   refreshRedditToken,
 } from "./reddit";
-export const redditProvider: OAuthConnectorProvider = {
+export const redditProvider = defineConnectorOAuthProvider("reddit", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildRedditAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeRedditCode(
@@ -36,18 +32,12 @@ export const redditProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.REDDIT_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.REDDIT_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getRedditSecretName,
   getRefreshSecretName: () => {
     return "REDDIT_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshRedditToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildSentryAuthorizationUrl,
   exchangeSentryCode,
   getSentrySecretName,
   refreshSentryToken,
 } from "./sentry";
-export const sentryProvider: OAuthConnectorProvider = {
+export const sentryProvider = defineConnectorOAuthProvider("sentry", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildSentryAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeSentryCode(
@@ -36,18 +32,12 @@ export const sentryProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.SENTRY_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.SENTRY_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getSentrySecretName,
   getRefreshSecretName: () => {
     return "SENTRY_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshSentryToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack-provider.ts
@@ -1,8 +1,4 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildSlackAuthorizationUrl,
   exchangeSlackCode,
@@ -10,13 +6,13 @@ import {
   getSlackSecretName,
   revokeSlackToken,
 } from "./slack";
-export const slackProvider: OAuthConnectorProvider = {
+export const slackProvider = defineConnectorOAuthProvider("slack", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildSlackAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const slackResult = await exchangeSlackCode(
@@ -39,15 +35,9 @@ export const slackProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.SLACK_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.SLACK_CLIENT_SECRET;
-  },
   getSecretName: getSlackSecretName,
   revokeToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return revokeSlackToken(clientId, clientSecret, args.accessToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildSpotifyAuthorizationUrl,
   exchangeSpotifyCode,
   getSpotifySecretName,
   refreshSpotifyToken,
 } from "./spotify";
-export const spotifyProvider: OAuthConnectorProvider = {
+export const spotifyProvider = defineConnectorOAuthProvider("spotify", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildSpotifyAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeSpotifyCode(
@@ -36,18 +32,12 @@ export const spotifyProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.SPOTIFY_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.SPOTIFY_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getSpotifySecretName,
   getRefreshSecretName: () => {
     return "SPOTIFY_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshSpotifyToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildStravaAuthorizationUrl,
   exchangeStravaCode,
   getStravaSecretName,
   refreshStravaToken,
 } from "./strava";
-export const stravaProvider: OAuthConnectorProvider = {
+export const stravaProvider = defineConnectorOAuthProvider("strava", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildStravaAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const result = await exchangeStravaCode(clientId, clientSecret, code);
     return {
@@ -30,18 +26,12 @@ export const stravaProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.STRAVA_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.STRAVA_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getStravaSecretName,
   getRefreshSecretName: () => {
     return "STRAVA_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshStravaToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildStripeAuthorizationUrl,
   exchangeStripeCode,
   getStripeSecretName,
   refreshStripeToken,
 } from "./stripe";
-export const stripeProvider: OAuthConnectorProvider = {
+export const stripeProvider = defineConnectorOAuthProvider("stripe", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildStripeAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const result = await exchangeStripeCode(clientId, clientSecret, code);
     return {
@@ -29,18 +25,12 @@ export const stripeProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.STRIPE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.STRIPE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getStripeSecretName,
   getRefreshSecretName: () => {
     return "STRIPE_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshStripeToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase-provider.ts
@@ -1,17 +1,13 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildSupabaseAuthorizationUrl,
   exchangeSupabaseCode,
   getSupabaseSecretName,
   refreshSupabaseToken,
 } from "./supabase";
-export const supabaseProvider: OAuthConnectorProvider = {
+export const supabaseProvider = defineConnectorOAuthProvider("supabase", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildSupabaseAuthorizationUrl(
       clientId,
       args.redirectUri,
@@ -19,7 +15,7 @@ export const supabaseProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const state = args.state;
@@ -47,18 +43,12 @@ export const supabaseProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.SUPABASE_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.SUPABASE_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getSupabaseSecretName,
   getRefreshSecretName: () => {
     return "SUPABASE_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshSupabaseToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-provider.ts
@@ -1,21 +1,15 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildTestOAuthAuthorizationUrl,
   exchangeTestOAuthCode,
   fetchTestOAuthUserInfo,
   refreshTestOAuthToken,
   TEST_OAUTH_ACCESS_SECRET_NAME,
-  TEST_OAUTH_CLIENT_ID,
-  TEST_OAUTH_CLIENT_SECRET,
   TEST_OAUTH_REFRESH_SECRET_NAME,
 } from "./test-oauth";
-export const testOauthProvider: OAuthConnectorProvider = {
+export const testOauthProvider = defineConnectorOAuthProvider("test-oauth", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildTestOAuthAuthorizationUrl(
       clientId,
       args.redirectUri,
@@ -23,7 +17,7 @@ export const testOauthProvider: OAuthConnectorProvider = {
     );
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const token = await exchangeTestOAuthCode(
@@ -41,12 +35,6 @@ export const testOauthProvider: OAuthConnectorProvider = {
       userInfo: user,
     };
   },
-  getClientId: () => {
-    return TEST_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: () => {
-    return TEST_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: () => {
     return TEST_OAUTH_ACCESS_SECRET_NAME;
   },
@@ -54,7 +42,7 @@ export const testOauthProvider: OAuthConnectorProvider = {
     return TEST_OAUTH_REFRESH_SECRET_NAME;
   },
   refreshToken: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const refreshToken = args.refreshToken;
     const result = await refreshTestOAuthToken(
       clientId,
@@ -67,4 +55,4 @@ export const testOauthProvider: OAuthConnectorProvider = {
       expiresIn: result.expiresIn,
     };
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist-provider.ts
@@ -1,20 +1,16 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildTodoistAuthorizationUrl,
   exchangeTodoistCode,
   getTodoistSecretName,
 } from "./todoist";
-export const todoistProvider: OAuthConnectorProvider = {
+export const todoistProvider = defineConnectorOAuthProvider("todoist", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildTodoistAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeTodoistCode(
@@ -34,11 +30,5 @@ export const todoistProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.TODOIST_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.TODOIST_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getTodoistSecretName,
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/vercel-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/vercel-provider.ts
@@ -1,20 +1,16 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildVercelAuthorizationUrl,
   exchangeVercelCode,
   getVercelSecretName,
 } from "./vercel";
-export const vercelProvider: OAuthConnectorProvider = {
+export const vercelProvider = defineConnectorOAuthProvider("vercel", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildVercelAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeVercelCode(
@@ -33,11 +29,5 @@ export const vercelProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.VERCEL_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.VERCEL_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getVercelSecretName,
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow-provider.ts
@@ -1,20 +1,16 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildWebflowAuthorizationUrl,
   exchangeWebflowCode,
   getWebflowSecretName,
 } from "./webflow";
-export const webflowProvider: OAuthConnectorProvider = {
+export const webflowProvider = defineConnectorOAuthProvider("webflow", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildWebflowAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeWebflowCode(
@@ -34,11 +30,5 @@ export const webflowProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.WEBFLOW_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.WEBFLOW_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getWebflowSecretName,
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/x-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildXAuthorizationUrl,
   exchangeXCode,
   getXSecretName,
   refreshXToken,
 } from "./x";
-export const xProvider: OAuthConnectorProvider = {
+export const xProvider = defineConnectorOAuthProvider("x", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildXAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const state = args.state;
@@ -41,18 +37,12 @@ export const xProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.X_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.X_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getXSecretName,
   getRefreshSecretName: () => {
     return "X_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshXToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildXeroAuthorizationUrl,
   exchangeXeroCode,
   getXeroSecretName,
   refreshXeroToken,
 } from "./xero";
-export const xeroProvider: OAuthConnectorProvider = {
+export const xeroProvider = defineConnectorOAuthProvider("xero", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildXeroAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeXeroCode(
@@ -36,18 +32,12 @@ export const xeroProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.XERO_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.XERO_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getXeroSecretName,
   getRefreshSecretName: () => {
     return "XERO_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshXeroToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom-provider.ts
@@ -1,21 +1,17 @@
-import {
-  requireOAuthClientCredentials,
-  requireOAuthClientId,
-  type OAuthConnectorProvider,
-} from "../provider-types";
+import { defineConnectorOAuthProvider } from "../provider-types";
 import {
   buildZoomAuthorizationUrl,
   exchangeZoomCode,
   getZoomSecretName,
   refreshZoomToken,
 } from "./zoom";
-export const zoomProvider: OAuthConnectorProvider = {
+export const zoomProvider = defineConnectorOAuthProvider("zoom", {
   buildAuthUrl: (args) => {
-    const clientId = requireOAuthClientId(args);
+    const { clientId } = args;
     return buildZoomAuthorizationUrl(clientId, args.redirectUri, args.state);
   },
   exchangeCode: async (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     const code = args.code;
     const redirectUri = args.redirectUri;
     const result = await exchangeZoomCode(
@@ -36,18 +32,12 @@ export const zoomProvider: OAuthConnectorProvider = {
       },
     };
   },
-  getClientId: (e) => {
-    return e.ZOOM_OAUTH_CLIENT_ID;
-  },
-  getClientSecret: (e) => {
-    return e.ZOOM_OAUTH_CLIENT_SECRET;
-  },
   getSecretName: getZoomSecretName,
   getRefreshSecretName: () => {
     return "ZOOM_REFRESH_TOKEN";
   },
   refreshToken: (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const { clientId, clientSecret } = args;
     return refreshZoomToken(clientId, clientSecret, args.refreshToken);
   },
-};
+});


### PR DESCRIPTION
## Summary
- derive connector OAuth provider method args from each connector's OAuth client config
- add registry adapter helpers for authorize, exchange, and refresh dispatch with resolved connector credentials
- migrate connector OAuth providers away from runtime client credential assertions while keeping model-provider OAuth separate

Fixes #14386

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm check-types
- pnpm lint
- pnpm knip
- pnpm -F @vm0/connectors test
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F web exec vitest run src/lib/zero/connector/providers/__tests__/google-ads.test.ts src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
- pnpm vitest (fails locally in unrelated tests because local provider secrets/timezone affect existing assertions: zero-chat-messages, zero-slack-events, resolve-model-provider, schedule-dialog)
