### PR TITLE
fix: reject json trailing commas in mitm parser

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -275,11 +275,18 @@ class JsonSelectiveExtractor:
 
     def _consume_object(self, frame: _Frame, chunk: bytes, i: int) -> int:
         b = chunk[i]
-        if frame.state == "key_or_end":
+        if frame.state in ("key_or_end", "key"):
             if b == ord("}"):
-                return self._end_container(i)
+                if frame.state == "key_or_end":
+                    return self._end_container(i)
+                self._error = "expected object key"
+                return i + 1
             if b != ord('"'):
-                self._error = "expected object key or end"
+                self._error = (
+                    "expected object key or end"
+                    if frame.state == "key_or_end"
+                    else "expected object key"
+                )
                 return i + 1
             collect_key = _matches_any_path_pattern(self.key_collection_paths, frame.path)
             self._string = _StringState(
@@ -308,7 +315,7 @@ class JsonSelectiveExtractor:
         if frame.state == "comma_or_end":
             if b == ord(","):
                 frame.pending_key = None
-                frame.state = "key_or_end"
+                frame.state = "key"
             elif b == ord("}"):
                 return self._end_container(i)
             else:
@@ -320,15 +327,21 @@ class JsonSelectiveExtractor:
 
     def _consume_array(self, frame: _Frame, chunk: bytes, i: int) -> int:
         b = chunk[i]
-        if frame.state == "value_or_end":
+        if frame.state in ("value_or_end", "value"):
             if b == ord("]"):
-                return self._end_container(i)
+                if frame.state == "value_or_end":
+                    return self._end_container(i)
+                self._error = "expected json value"
+                return i + 1
+            if not _is_json_value_start(b):
+                self._error = "expected json value"
+                return i + 1
             self._count_array_element(frame)
             return self._start_value((*frame.path, _ARRAY_ELEMENT), chunk, i, from_array=True)
 
         if frame.state == "comma_or_end":
             if b == ord(","):
-                frame.state = "value_or_end"
+                frame.state = "value"
             elif b == ord("]"):
                 return self._end_container(i)
             else:
@@ -492,7 +505,7 @@ class JsonSelectiveExtractor:
             return
         parent = self._stack[-1]
         if (parent.kind == "object" and parent.state == "value") or (
-            parent.kind == "array" and parent.state == "value_or_end"
+            parent.kind == "array" and parent.state in ("value_or_end", "value")
         ):
             parent.state = "comma_or_end"
         else:
@@ -765,6 +778,10 @@ class JsonSelectiveExtractor:
 
 def _is_hex_byte(b: int) -> bool:
     return ord("0") <= b <= ord("9") or ord("a") <= b <= ord("f") or ord("A") <= b <= ord("F")
+
+
+def _is_json_value_start(b: int) -> bool:
+    return b in b'{["tfn-' or ord("0") <= b <= ord("9")
 
 
 def _validate_extractor_config(

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -925,6 +925,8 @@ def test_rejects_missing_separators(payload, error):
     [
         [b"[1,]"],
         [b"[1,2,]"],
+        [b"[{},]"],
+        [b"[[],]"],
         [b"[1, ]"],
         [b"[1,", b"]"],
     ],
@@ -948,12 +950,18 @@ def test_rejects_trailing_commas_in_arrays(chunks):
     [
         [b'{"a":1,}'],
         [b'{"a":1,"b":2,}'],
+        [b'{"a":{},}'],
+        [b'{"a":[],}'],
         [b'{"a":1, }'],
         [b'{"a":1,', b"}"],
     ],
 )
 def test_rejects_trailing_commas_in_objects(chunks):
-    extractor = JsonSelectiveExtractor(scalar_fields={("a",): ScalarField("int")})
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("a",): ScalarField("int")},
+        array_count_paths={("a",)},
+        object_presence_paths={("a",)},
+    )
 
     for chunk in chunks:
         extractor.feed(chunk)
@@ -972,7 +980,9 @@ def test_rejects_trailing_commas_in_objects(chunks):
         b"[]",
         b"{}",
         b"[1, 2]",
+        b'["x", true, false, null, -1, {}, []]',
         b'{"a":1, "b":2}',
+        b'{"a":{}, "b":[]}',
     ],
 )
 def test_accepts_valid_empty_containers_and_commas(payload):

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -920,6 +920,70 @@ def test_rejects_missing_separators(payload, error):
     assert result.error == error
 
 
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        [b"[1,]"],
+        [b"[1,2,]"],
+        [b"[1, ]"],
+        [b"[1,", b"]"],
+    ],
+)
+def test_rejects_trailing_commas_in_arrays(chunks):
+    extractor = JsonSelectiveExtractor(array_count_paths={()})
+
+    for chunk in chunks:
+        extractor.feed(chunk)
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.values == {}
+    assert result.array_counts == {}
+    assert result.wildcard_array_counts == {}
+    assert result.object_present == set()
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        [b'{"a":1,}'],
+        [b'{"a":1,"b":2,}'],
+        [b'{"a":1, }'],
+        [b'{"a":1,', b"}"],
+    ],
+)
+def test_rejects_trailing_commas_in_objects(chunks):
+    extractor = JsonSelectiveExtractor(scalar_fields={("a",): ScalarField("int")})
+
+    for chunk in chunks:
+        extractor.feed(chunk)
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.values == {}
+    assert result.array_counts == {}
+    assert result.wildcard_array_counts == {}
+    assert result.object_present == set()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"[]",
+        b"{}",
+        b"[1, 2]",
+        b'{"a":1, "b":2}',
+    ],
+)
+def test_accepts_valid_empty_containers_and_commas(payload):
+    extractor = JsonSelectiveExtractor(scalar_fields={("a",): ScalarField("int")})
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is True
+
+
 def test_rejects_trailing_data():
     extractor = JsonSelectiveExtractor()
 

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -925,6 +925,10 @@ def test_rejects_missing_separators(payload, error):
     [
         [b"[1,]"],
         [b"[1,2,]"],
+        [b'["x",]'],
+        [b"[true,]"],
+        [b"[false,]"],
+        [b"[null,]"],
         [b"[{},]"],
         [b"[[],]"],
         [b"[1, ]"],
@@ -950,6 +954,10 @@ def test_rejects_trailing_commas_in_arrays(chunks):
     [
         [b'{"a":1,}'],
         [b'{"a":1,"b":2,}'],
+        [b'{"s":"x",}'],
+        [b'{"a":true,}'],
+        [b'{"a":false,}'],
+        [b'{"a":null,}'],
         [b'{"a":{},}'],
         [b'{"a":[],}'],
         [b'{"a":1, }'],
@@ -958,7 +966,7 @@ def test_rejects_trailing_commas_in_arrays(chunks):
 )
 def test_rejects_trailing_commas_in_objects(chunks):
     extractor = JsonSelectiveExtractor(
-        scalar_fields={("a",): ScalarField("int")},
+        scalar_fields={("a",): ScalarField("int"), ("s",): ScalarField("string")},
         array_count_paths={("a",)},
         object_presence_paths={("a",)},
     )


### PR DESCRIPTION
## Summary

- split JsonSelectiveExtractor's initial container states from post-comma states
- reject object and array trailing commas while preserving valid empty containers
- add regression coverage for single-chunk, split-chunk, and whitespace trailing-comma cases

## Tests

- `cd crates/runner/mitm-addon && pytest tests/test_json_selective.py::test_rejects_trailing_commas_in_arrays tests/test_json_selective.py::test_rejects_trailing_commas_in_objects tests/test_json_selective.py::test_accepts_valid_empty_containers_and_commas`
- `cd crates/runner/mitm-addon && pytest tests/test_json_selective.py`
- `cd crates/runner/mitm-addon && pytest tests/`
- `cd crates/runner/mitm-addon && ruff check src tests`
- `cd crates/runner/mitm-addon && ruff format --check src tests`
- `git diff --check`

Closes #14372
