### PR TITLE
perf(mitm-addon): adapt brotli decompression chunk size

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -36,9 +36,10 @@ _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 # calls while still bounding decompression bombs.
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
-# Python's brotli binding has no max-output API. Keep small compressed inputs on
-# tiny chunks to preserve the high-compression guard, but scale up for larger
-# inputs to avoid thousands of Python-to-C calls.
+# Python's brotli binding has no max-output API, and one process() call can
+# still transiently emit multi-MB output. Keep small compressed inputs on tiny
+# chunks to preserve the best-effort high-compression guard, but scale up for
+# larger inputs to avoid thousands of Python-to-C calls.
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -36,10 +36,12 @@ _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 # calls while still bounding decompression bombs.
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
-# Python's brotli binding has no max-output API. Feed compressed data in small
-# chunks and stop once the caller's cap is accumulated; process() can still
-# transiently emit a multi-MB chunk from a tiny input.
-_BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE = 16
+# Python's brotli binding has no max-output API. Keep small compressed inputs on
+# tiny chunks to preserve the high-compression guard, but scale up for larger
+# inputs to avoid thousands of Python-to-C calls.
+_BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
+_BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
+_BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
 
 
 # ---------------------------------------------------------------------------
@@ -181,10 +183,19 @@ def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
     if max_output <= 0:
         return b""
 
+    chunk_size = min(
+        _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE,
+        max(
+            _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE,
+            (len(data) + _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS - 1)
+            // _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS,
+        ),
+    )
+
     dec = brotli.Decompressor()
     out = bytearray()
-    for offset in range(0, len(data), _BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE):
-        chunk = data[offset : offset + _BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE]
+    for offset in range(0, len(data), chunk_size):
+        chunk = data[offset : offset + chunk_size]
         decoded = dec.process(chunk)
         if not decoded:
             continue

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -26,6 +26,34 @@ from usage import (
 )
 
 
+def _track_brotli_decompressor(monkeypatch):
+    real_decompressor = brotli.Decompressor
+    stats = {"calls": 0, "max_input": 0, "max_output": 0}
+
+    class CountingDecompressor:
+        def __init__(self):
+            self._inner = real_decompressor()
+
+        def process(self, chunk: bytes) -> bytes:
+            out = self._inner.process(chunk)
+            stats["calls"] += 1
+            stats["max_input"] = max(stats["max_input"], len(chunk))
+            stats["max_output"] = max(stats["max_output"], len(out))
+            return out
+
+    monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
+    return stats
+
+
+def _pseudo_random_ascii(size: int) -> bytes:
+    state = 0x12345678
+    body = bytearray()
+    for _ in range(size):
+        state = (1103515245 * state + 12345) & 0x7FFFFFFF
+        body.append(32 + (state % 95))
+    return bytes(body)
+
+
 class TestIsTextContent:
     def test_json(self):
         assert _is_text_content("application/json") is True
@@ -602,32 +630,6 @@ class TestDecompression:
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         return flow
 
-    def _track_brotli_decompressor(self, monkeypatch):
-        real_decompressor = brotli.Decompressor
-        stats = {"calls": 0, "max_input": 0, "max_output": 0}
-
-        class CountingDecompressor:
-            def __init__(self):
-                self._inner = real_decompressor()
-
-            def process(self, chunk: bytes) -> bytes:
-                out = self._inner.process(chunk)
-                stats["calls"] += 1
-                stats["max_input"] = max(stats["max_input"], len(chunk))
-                stats["max_output"] = max(stats["max_output"], len(out))
-                return out
-
-        monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
-        return stats
-
-    def _pseudo_random_ascii(self, size: int) -> bytes:
-        state = 0x12345678
-        body = bytearray()
-        for _ in range(size):
-            state = (1103515245 * state + 12345) & 0x7FFFFFFF
-            body.append(32 + (state % 95))
-        return bytes(body)
-
     def test_no_encoding_captures_plain_text(self, real_flow):
         flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "")
         entry = {}
@@ -684,13 +686,13 @@ class TestDecompression:
         assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
     def test_brotli_large_text_uses_adaptive_chunks(self, real_flow, monkeypatch):
-        original = self._pseudo_random_ascii(STREAM_BUFFER_LIMIT // 2)
+        original = _pseudo_random_ascii(STREAM_BUFFER_LIMIT // 2)
         compressed = brotli.compress(original)
         old_call_count = (len(compressed) + 15) // 16
         assert len(compressed) < STREAM_BUFFER_LIMIT
         assert old_call_count > 1000
 
-        stats = self._track_brotli_decompressor(monkeypatch)
+        stats = _track_brotli_decompressor(monkeypatch)
 
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
         entry = {}
@@ -702,27 +704,12 @@ class TestDecompression:
         assert stats["calls"] < old_call_count // 8
         assert stats["max_input"] <= 1024
 
-    def test_brotli_very_large_input_caps_adaptive_chunk_size(self, real_flow, monkeypatch):
-        original = self._pseudo_random_ascii(STREAM_BUFFER_LIMIT * 3)
-        compressed = brotli.compress(original)
-        assert len(compressed) > 64 * 1024
-
-        stats = self._track_brotli_decompressor(monkeypatch)
-
-        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
-        entry = {}
-        add_capture_fields(flow, entry)
-
-        assert entry["response_body_truncated"] is True
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
-        assert stats["max_input"] == 1024
-
     def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
         original = b"\x00" * (10 * 1024 * 1024)
         compressed = brotli.compress(original)
         assert len(compressed) < STREAM_BUFFER_LIMIT
 
-        stats = self._track_brotli_decompressor(monkeypatch)
+        stats = _track_brotli_decompressor(monkeypatch)
 
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
         entry = {}
@@ -1181,6 +1168,19 @@ class TestDecompressBody:
         hdrs = headers(("Content-Encoding", "zstd"))
         result = decompress_body(compressed, hdrs, max_output=64 * 1024)
         assert result == plaintext
+
+    def test_brotli_large_input_caps_adaptive_chunk_size(self, headers, monkeypatch):
+        plaintext = _pseudo_random_ascii(STREAM_BUFFER_LIMIT * 3)
+        compressed = brotli.compress(plaintext)
+        assert len(compressed) > 64 * 1024
+
+        stats = _track_brotli_decompressor(monkeypatch)
+
+        hdrs = headers(("Content-Encoding", "br"))
+        result = decompress_body(compressed, hdrs, max_output=STREAM_BUFFER_LIMIT)
+
+        assert result == plaintext[:STREAM_BUFFER_LIMIT]
+        assert stats["max_input"] == 1024
 
     def test_zstd_corrupted_returns_original_data(self, headers, mitm_ctx):
         # Malformed payload should fall through to the outer

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -602,6 +602,24 @@ class TestDecompression:
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         return flow
 
+    def _track_brotli_decompressor(self, monkeypatch):
+        real_decompressor = brotli.Decompressor
+        stats = {"calls": 0, "max_input": 0, "max_output": 0}
+
+        class CountingDecompressor:
+            def __init__(self):
+                self._inner = real_decompressor()
+
+            def process(self, chunk: bytes) -> bytes:
+                out = self._inner.process(chunk)
+                stats["calls"] += 1
+                stats["max_input"] = max(stats["max_input"], len(chunk))
+                stats["max_output"] = max(stats["max_output"], len(out))
+                return out
+
+        monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
+        return stats
+
     def test_no_encoding_captures_plain_text(self, real_flow):
         flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "")
         entry = {}
@@ -657,26 +675,36 @@ class TestDecompression:
         assert entry["response_body_encoding"] == "utf-8"
         assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
+    def test_brotli_large_text_uses_adaptive_chunks(self, real_flow, monkeypatch):
+        state = 0x12345678
+        body = bytearray()
+        for _ in range(STREAM_BUFFER_LIMIT // 2):
+            state = (1103515245 * state + 12345) & 0x7FFFFFFF
+            body.append(32 + (state % 95))
+        original = bytes(body)
+        compressed = brotli.compress(original)
+        old_call_count = (len(compressed) + 15) // 16
+        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert old_call_count > 1000
+
+        stats = self._track_brotli_decompressor(monkeypatch)
+
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body"] == original.decode("ascii")
+        assert "response_body_truncated" not in entry
+        assert stats["calls"] <= 80
+        assert stats["calls"] < old_call_count // 8
+        assert stats["max_input"] <= 1024
+
     def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
         original = b"\x00" * (10 * 1024 * 1024)
         compressed = brotli.compress(original)
         assert len(compressed) < STREAM_BUFFER_LIMIT
 
-        real_decompressor = brotli.Decompressor
-        stats = {"calls": 0, "max_input": 0, "max_output": 0}
-
-        class CountingDecompressor:
-            def __init__(self):
-                self._inner = real_decompressor()
-
-            def process(self, chunk: bytes) -> bytes:
-                out = self._inner.process(chunk)
-                stats["calls"] += 1
-                stats["max_input"] = max(stats["max_input"], len(chunk))
-                stats["max_output"] = max(stats["max_output"], len(out))
-                return out
-
-        monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
+        stats = self._track_brotli_decompressor(monkeypatch)
 
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
         entry = {}
@@ -685,6 +713,7 @@ class TestDecompression:
         assert entry["response_body_truncated"] is True
         assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
         assert stats["max_input"] < len(compressed)
+        assert stats["max_input"] <= 16
         assert stats["max_output"] < len(original)
 
     def test_zstd_decompressed(self, real_flow):

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -620,6 +620,14 @@ class TestDecompression:
         monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
         return stats
 
+    def _pseudo_random_ascii(self, size: int) -> bytes:
+        state = 0x12345678
+        body = bytearray()
+        for _ in range(size):
+            state = (1103515245 * state + 12345) & 0x7FFFFFFF
+            body.append(32 + (state % 95))
+        return bytes(body)
+
     def test_no_encoding_captures_plain_text(self, real_flow):
         flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "")
         entry = {}
@@ -676,12 +684,7 @@ class TestDecompression:
         assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
     def test_brotli_large_text_uses_adaptive_chunks(self, real_flow, monkeypatch):
-        state = 0x12345678
-        body = bytearray()
-        for _ in range(STREAM_BUFFER_LIMIT // 2):
-            state = (1103515245 * state + 12345) & 0x7FFFFFFF
-            body.append(32 + (state % 95))
-        original = bytes(body)
+        original = self._pseudo_random_ascii(STREAM_BUFFER_LIMIT // 2)
         compressed = brotli.compress(original)
         old_call_count = (len(compressed) + 15) // 16
         assert len(compressed) < STREAM_BUFFER_LIMIT
@@ -698,6 +701,21 @@ class TestDecompression:
         assert stats["calls"] <= 80
         assert stats["calls"] < old_call_count // 8
         assert stats["max_input"] <= 1024
+
+    def test_brotli_very_large_input_caps_adaptive_chunk_size(self, real_flow, monkeypatch):
+        original = self._pseudo_random_ascii(STREAM_BUFFER_LIMIT * 3)
+        compressed = brotli.compress(original)
+        assert len(compressed) > 64 * 1024
+
+        stats = self._track_brotli_decompressor(monkeypatch)
+
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body_truncated"] is True
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert stats["max_input"] == 1024
 
     def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
         original = b"\x00" * (10 * 1024 * 1024)


### PR DESCRIPTION
## Summary
- Replace the fixed 16-byte brotli decompression input chunk with adaptive sizing bounded between 16 bytes and 1024 bytes.
- Keep small compressed payloads on tiny chunks to preserve the high-compression guard from #11799.
- Add capture-path regression coverage proving larger brotli payloads no longer require thousands of decoder calls.

Closes #14402

## Tests
- `python3 -m pytest tests/test_body_capture.py::TestDecompression -v`
- `python3 -m pytest tests/test_body_capture.py::TestDecompressBody -v`
- `python3 -m pytest tests/test_body_capture.py -v`
- `python3 -m ruff check src/body_utils.py tests/test_body_capture.py`
- `python3 -m ruff format --check src/body_utils.py tests/test_body_capture.py`
- `git diff --check`
