### PR TITLE
refactor: centralize vsock-host request lifecycle

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -560,52 +560,73 @@ async fn write_request_frame(
     Ok(())
 }
 
-/// Send a request with a pre-allocated sequence number.
-async fn request_raw_on_shared(
+async fn request_on_shared_with_pending_response<C, W>(
     shared: &Arc<Shared>,
     msg_type: u8,
     seq: u32,
     payload: &[u8],
     timeout: Duration,
-) -> io::Result<RawMessage> {
+    prepare_pending_context: impl FnOnce() -> io::Result<C>,
+    prepare_pending: impl FnOnce(oneshot::Sender<RawMessage>, C) -> io::Result<(PendingResponse, W)>,
+) -> io::Result<RawMessage>
+where
+    W: FnOnce() -> io::Result<()>,
+{
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
-    // Register under the state lock: `Closed` short-circuits to an
-    // immediate error, and insertion into `pending` is serialised with
-    // the `Connected -> Closed` transition in `close()`. There is no
-    // post-write `is_closed` check because close is observed via the
-    // oneshot receiver becoming `Closed` when `close()` drops the map.
-    let (tx, rx) = oneshot::channel();
-    {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Closed => {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ));
-            }
-            ConnectionState::Connected { pending, .. } => {
-                pending.insert(
-                    seq,
-                    PendingResponse {
-                        response_tx: tx,
-                        normal_operation: None,
-                        normal_terminal_msg_types: &[],
-                    },
-                );
-            }
-        }
-    }
+    // Keep request-specific setup after frame encoding, while leaving
+    // `PendingResponse` construction inside the connected-state branch below.
+    // That preserves normal-operation rejection ordering and closed-state
+    // priority for fallible composite handles.
+    let pending_context = prepare_pending_context()?;
+    let (rx, before_write) =
+        register_pending_response(shared, seq, pending_context, prepare_pending)?;
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
     // The pending guard removes the pending entry on write failure, timeout,
     // or cancellation before reader_loop dispatches a response. The write
     // helper separately poisons the connection if cancellation interrupts an
     // in-progress frame write.
-    write_request_frame(shared, &data, || Ok(())).await?;
+    write_request_frame(shared, &data, before_write).await?;
 
+    await_pending_response(rx, timeout).await
+}
+
+fn register_pending_response<C, W>(
+    shared: &Arc<Shared>,
+    seq: u32,
+    pending_context: C,
+    prepare_pending: impl FnOnce(oneshot::Sender<RawMessage>, C) -> io::Result<(PendingResponse, W)>,
+) -> io::Result<(oneshot::Receiver<RawMessage>, W)>
+where
+    W: FnOnce() -> io::Result<()>,
+{
+    // Register under the state lock: `Closed` short-circuits to an
+    // immediate error, and insertion into `pending` is serialised with
+    // the `Connected -> Closed` transition in `close()`. There is no
+    // post-write `is_closed` check because close is observed via the
+    // oneshot receiver becoming `Closed` when `close()` drops the map.
+    let (tx, rx) = oneshot::channel();
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    if let ConnectionState::Connected { pending, .. } = &mut *guard {
+        let (pending_response, before_write) = prepare_pending(tx, pending_context)?;
+        pending.insert(seq, pending_response);
+        Ok((rx, before_write))
+    } else {
+        drop(guard);
+        drop(pending_context);
+        Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        ))
+    }
+}
+
+async fn await_pending_response(
+    rx: oneshot::Receiver<RawMessage>,
+    timeout: Duration,
+) -> io::Result<RawMessage> {
     // `rx` returns `Ok(msg)` when the reader dispatches a response and
     // `Err(RecvError)` when `close()` drops the `Connected` variant. The
     // timeout arm is the only other way out.
@@ -621,6 +642,35 @@ async fn request_raw_on_shared(
             Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
         }
     }
+}
+
+/// Send a request with a pre-allocated sequence number.
+async fn request_raw_on_shared(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    seq: u32,
+    payload: &[u8],
+    timeout: Duration,
+) -> io::Result<RawMessage> {
+    request_on_shared_with_pending_response(
+        shared,
+        msg_type,
+        seq,
+        payload,
+        timeout,
+        || Ok(()),
+        |tx, ()| {
+            Ok((
+                PendingResponse {
+                    response_tx: tx,
+                    normal_operation: None,
+                    normal_terminal_msg_types: &[],
+                },
+                || Ok(()),
+            ))
+        },
+    )
+    .await
 }
 
 async fn normal_request_on_shared_with_write_observer(
@@ -653,52 +703,29 @@ async fn normal_request_on_shared_with_pre_write_observer(
     write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
-    let data = vsock_proto::encode(msg_type, seq, payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-    let normal_operation = shared.reserve_normal_operation()?;
 
-    let (tx, rx) = oneshot::channel();
-    {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Closed => {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ));
-            }
-            ConnectionState::Connected { pending, .. } => {
-                pending.insert(
-                    seq,
-                    PendingResponse {
-                        response_tx: tx,
-                        normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
-                        normal_terminal_msg_types: terminal_msg_types,
-                    },
-                );
-            }
-        }
-    }
-    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-
-    write_request_frame(shared, &data, || {
-        mark_pending_normal_operation_possible_guest_write(shared, seq, pre_write)?;
-        write_observer.record_write_start()
-    })
-    .await?;
-
-    tokio::select! {
-        biased;
-        result = rx => {
-            result.map_err(|_| io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ))
-        }
-        _ = tokio::time::sleep(timeout) => {
-            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
-        }
-    }
+    request_on_shared_with_pending_response(
+        shared,
+        msg_type,
+        seq,
+        payload,
+        timeout,
+        || shared.reserve_normal_operation(),
+        |tx, normal_operation| {
+            Ok((
+                PendingResponse {
+                    response_tx: tx,
+                    normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
+                    normal_terminal_msg_types: terminal_msg_types,
+                },
+                move || {
+                    mark_pending_normal_operation_possible_guest_write(shared, seq, pre_write)?;
+                    write_observer.record_write_start()
+                },
+            ))
+        },
+    )
+    .await
 }
 
 async fn request_on_shared_with_composite_operation_and_observer(
@@ -711,53 +738,31 @@ async fn request_on_shared_with_composite_operation_and_observer(
     write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
-    let data = vsock_proto::encode(msg_type, seq, payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
-    let (tx, rx) = oneshot::channel();
-    {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Closed => {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ));
-            }
-            ConnectionState::Connected { pending, .. } => {
-                pending.insert(
-                    seq,
-                    PendingResponse {
-                        response_tx: tx,
-                        normal_operation: Some(PendingNormalOperation::Composite(
-                            normal_operation.transition_handle()?,
-                        )),
-                        normal_terminal_msg_types: terminal_msg_types,
-                    },
-                );
-            }
-        }
-    }
-    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-
-    write_request_frame(shared, &data, || {
-        normal_operation.mark_possible_guest_write_started()?;
-        write_observer.record_write_start()
-    })
-    .await?;
-
-    tokio::select! {
-        biased;
-        result = rx => {
-            result.map_err(|_| io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                "connection closed",
+    request_on_shared_with_pending_response(
+        shared,
+        msg_type,
+        seq,
+        payload,
+        timeout,
+        || Ok(()),
+        |tx, ()| {
+            Ok((
+                PendingResponse {
+                    response_tx: tx,
+                    normal_operation: Some(PendingNormalOperation::Composite(
+                        normal_operation.transition_handle()?,
+                    )),
+                    normal_terminal_msg_types: terminal_msg_types,
+                },
+                move || {
+                    normal_operation.mark_possible_guest_write_started()?;
+                    write_observer.record_write_start()
+                },
             ))
-        }
-        _ = tokio::time::sleep(timeout) => {
-            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
-        }
-    }
+        },
+    )
+    .await
 }
 
 fn mark_pending_normal_operation_possible_guest_write(

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -560,48 +560,16 @@ async fn write_request_frame(
     Ok(())
 }
 
-async fn request_on_shared_with_pending_response<C, W>(
-    shared: &Arc<Shared>,
-    msg_type: u8,
-    seq: u32,
-    payload: &[u8],
-    timeout: Duration,
-    prepare_pending_context: impl FnOnce() -> io::Result<C>,
-    prepare_pending: impl FnOnce(oneshot::Sender<RawMessage>, C) -> io::Result<(PendingResponse, W)>,
-) -> io::Result<RawMessage>
-where
-    W: FnOnce() -> io::Result<()>,
-{
-    let data = vsock_proto::encode(msg_type, seq, payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-
-    // Keep request-specific setup after frame encoding, while leaving
-    // `PendingResponse` construction inside the connected-state branch below.
-    // That preserves normal-operation rejection ordering and closed-state
-    // priority for fallible composite handles.
-    let pending_context = prepare_pending_context()?;
-    let (rx, before_write) =
-        register_pending_response(shared, seq, pending_context, prepare_pending)?;
-    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-
-    // The pending guard removes the pending entry on write failure, timeout,
-    // or cancellation before reader_loop dispatches a response. The write
-    // helper separately poisons the connection if cancellation interrupts an
-    // in-progress frame write.
-    write_request_frame(shared, &data, before_write).await?;
-
-    await_pending_response(rx, timeout).await
+fn encode_request_frame(msg_type: u8, seq: u32, payload: &[u8]) -> io::Result<Vec<u8>> {
+    vsock_proto::encode(msg_type, seq, payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))
 }
 
-fn register_pending_response<C, W>(
+fn register_pending_response(
     shared: &Arc<Shared>,
     seq: u32,
-    pending_context: C,
-    prepare_pending: impl FnOnce(oneshot::Sender<RawMessage>, C) -> io::Result<(PendingResponse, W)>,
-) -> io::Result<(oneshot::Receiver<RawMessage>, W)>
-where
-    W: FnOnce() -> io::Result<()>,
-{
+    build_pending: impl FnOnce(oneshot::Sender<RawMessage>) -> io::Result<PendingResponse>,
+) -> io::Result<oneshot::Receiver<RawMessage>> {
     // Register under the state lock: `Closed` short-circuits to an
     // immediate error, and insertion into `pending` is serialised with
     // the `Connected -> Closed` transition in `close()`. There is no
@@ -610,17 +578,34 @@ where
     let (tx, rx) = oneshot::channel();
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { pending, .. } = &mut *guard {
-        let (pending_response, before_write) = prepare_pending(tx, pending_context)?;
+        let pending_response = build_pending(tx)?;
         pending.insert(seq, pending_response);
-        Ok((rx, before_write))
+        Ok(rx)
     } else {
-        drop(guard);
-        drop(pending_context);
         Err(io::Error::new(
             io::ErrorKind::ConnectionReset,
             "connection closed",
         ))
     }
+}
+
+async fn write_registered_request_and_wait(
+    shared: &Arc<Shared>,
+    seq: u32,
+    data: &[u8],
+    timeout: Duration,
+    before_write: impl FnOnce() -> io::Result<()>,
+    rx: oneshot::Receiver<RawMessage>,
+) -> io::Result<RawMessage> {
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
+
+    // The pending guard removes the pending entry on write failure, timeout,
+    // or cancellation before reader_loop dispatches a response. The write
+    // helper separately poisons the connection if cancellation interrupts an
+    // in-progress frame write.
+    write_request_frame(shared, data, before_write).await?;
+
+    await_pending_response(rx, timeout).await
 }
 
 async fn await_pending_response(
@@ -652,25 +637,16 @@ async fn request_raw_on_shared(
     payload: &[u8],
     timeout: Duration,
 ) -> io::Result<RawMessage> {
-    request_on_shared_with_pending_response(
-        shared,
-        msg_type,
-        seq,
-        payload,
-        timeout,
-        || Ok(()),
-        |tx, ()| {
-            Ok((
-                PendingResponse {
-                    response_tx: tx,
-                    normal_operation: None,
-                    normal_terminal_msg_types: &[],
-                },
-                || Ok(()),
-            ))
-        },
-    )
-    .await
+    let data = encode_request_frame(msg_type, seq, payload)?;
+    let rx = register_pending_response(shared, seq, |tx| {
+        Ok(PendingResponse {
+            response_tx: tx,
+            normal_operation: None,
+            normal_terminal_msg_types: &[],
+        })
+    })?;
+
+    write_registered_request_and_wait(shared, seq, &data, timeout, || Ok(()), rx).await
 }
 
 async fn normal_request_on_shared_with_write_observer(
@@ -703,27 +679,26 @@ async fn normal_request_on_shared_with_pre_write_observer(
     write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
+    let data = encode_request_frame(msg_type, seq, payload)?;
+    let normal_operation = shared.reserve_normal_operation()?;
+    let rx = register_pending_response(shared, seq, |tx| {
+        Ok(PendingResponse {
+            response_tx: tx,
+            normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
+            normal_terminal_msg_types: terminal_msg_types,
+        })
+    })?;
 
-    request_on_shared_with_pending_response(
+    write_registered_request_and_wait(
         shared,
-        msg_type,
         seq,
-        payload,
+        &data,
         timeout,
-        || shared.reserve_normal_operation(),
-        |tx, normal_operation| {
-            Ok((
-                PendingResponse {
-                    response_tx: tx,
-                    normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
-                    normal_terminal_msg_types: terminal_msg_types,
-                },
-                move || {
-                    mark_pending_normal_operation_possible_guest_write(shared, seq, pre_write)?;
-                    write_observer.record_write_start()
-                },
-            ))
+        || {
+            mark_pending_normal_operation_possible_guest_write(shared, seq, pre_write)?;
+            write_observer.record_write_start()
         },
+        rx,
     )
     .await
 }
@@ -738,29 +713,27 @@ async fn request_on_shared_with_composite_operation_and_observer(
     write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
+    let data = encode_request_frame(msg_type, seq, payload)?;
+    let rx = register_pending_response(shared, seq, |tx| {
+        Ok(PendingResponse {
+            response_tx: tx,
+            normal_operation: Some(PendingNormalOperation::Composite(
+                normal_operation.transition_handle()?,
+            )),
+            normal_terminal_msg_types: terminal_msg_types,
+        })
+    })?;
 
-    request_on_shared_with_pending_response(
+    write_registered_request_and_wait(
         shared,
-        msg_type,
         seq,
-        payload,
+        &data,
         timeout,
-        || Ok(()),
-        |tx, ()| {
-            Ok((
-                PendingResponse {
-                    response_tx: tx,
-                    normal_operation: Some(PendingNormalOperation::Composite(
-                        normal_operation.transition_handle()?,
-                    )),
-                    normal_terminal_msg_types: terminal_msg_types,
-                },
-                move || {
-                    normal_operation.mark_possible_guest_write_started()?;
-                    write_observer.record_write_start()
-                },
-            ))
+        || {
+            normal_operation.mark_possible_guest_write_started()?;
+            write_observer.record_write_start()
         },
+        rx,
     )
     .await
 }

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -411,6 +411,37 @@ async fn test_request_after_close_returns_immediately() {
 }
 
 #[tokio::test]
+async fn lifecycle_request_after_connection_close_returns_immediately() {
+    let (host_stream, mut guest) = make_pair();
+
+    let guest_task = tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        drop(guest);
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(5),
+        host.quiesce_operations(Duration::from_secs(60)),
+    )
+    .await
+    .expect("lifecycle request should return when the connection is already closed")
+    .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+    guest_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn connection_close_marks_normal_operations_closed() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -278,6 +278,37 @@ async fn write_file_connection_close_after_request_marks_tracker_not_parkable() 
 }
 
 #[tokio::test]
+async fn write_file_after_connection_close_returns_immediately_without_not_parkable() {
+    let (host_stream, mut guest) = make_pair();
+
+    let guest_task = tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        drop(guest);
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(5),
+        host.write_file("/tmp/closed.txt", b"hello", false),
+    )
+    .await
+    .expect("write_file should return when the connection is already closed")
+    .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+    guest_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn test_write_file_failure() {
     let (host_stream, mut guest) = make_pair();
 


### PR DESCRIPTION
## Summary

- Extract the shared vsock-host pending-response request lifecycle into private helpers.
- Keep the existing plain, owned-normal-operation, and composite-normal-operation request helpers as thin wrappers.
- Preserve encode, normal-operation setup, state registration, pre-write, and response-timeout ordering.

Closes #14404

## Tests

- `cargo check --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host connection::`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::write`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::write_chunked`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::copy`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy, commitlint