### PR TITLE
fix(mitm-addon): skip empty decoded request body capture

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -344,5 +344,5 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             "response",
             body,
             res_ct,
-            already_truncated=bool(stream_state and stream_state["truncated"]),
+            already_truncated=bool(body and stream_state and stream_state["truncated"]),
         )

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -335,8 +335,6 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 # ZlibError (decompression failure) or ValueError from mitmproxy
                 log_entry["response_body_encoding"] = "binary"
                 return
-        if not body:
-            return
         stream_state = flow.metadata.get("stream_buffer_state")
         res_ct = flow.response.headers.get("content-type", "")
         # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -14,6 +14,7 @@ import base64
 import contextlib
 import zlib
 from collections.abc import Callable
+from typing import Literal
 
 import brotli  # type: ignore[import-untyped]
 import zstandard
@@ -266,6 +267,30 @@ def _redact_headers(headers) -> dict:
     return result
 
 
+def _set_body_fields(
+    log_entry: dict,
+    side: Literal["request", "response"],
+    body: bytes,
+    content_type: str,
+    *,
+    already_truncated: bool = False,
+) -> None:
+    if not body:
+        return
+
+    truncated = already_truncated or len(body) > STREAM_BUFFER_LIMIT
+    if truncated:
+        body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
+    encoded, encoding = _encode_body(body, content_type)
+    if encoded is not None:
+        log_entry[f"{side}_body"] = encoded
+        log_entry[f"{side}_body_encoding"] = encoding
+        if truncated:
+            log_entry[f"{side}_body_truncated"] = True
+    else:
+        log_entry[f"{side}_body_encoding"] = "binary"
+
+
 def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     """Add request/response headers and bodies to a log entry.
 
@@ -287,17 +312,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             # when Content-Encoding doesn't match the body bytes.
             log_entry["request_body_encoding"] = "binary"
         else:
-            truncated = len(body) > STREAM_BUFFER_LIMIT
-            if truncated:
-                body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
-            encoded, encoding = _encode_body(body, req_ct)
-            if encoded is not None:
-                log_entry["request_body"] = encoded
-                log_entry["request_body_encoding"] = encoding
-                if truncated:
-                    log_entry["request_body_truncated"] = True
-            else:
-                log_entry["request_body_encoding"] = "binary"
+            _set_body_fields(log_entry, "request", body, req_ct)
 
     # Response headers
     if flow.response:
@@ -326,14 +341,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         res_ct = flow.response.headers.get("content-type", "")
         # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
-        truncated = (stream_state and stream_state["truncated"]) or len(body) > STREAM_BUFFER_LIMIT
-        if truncated:
-            body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
-        encoded, encoding = _encode_body(body, res_ct)
-        if encoded is not None:
-            log_entry["response_body"] = encoded
-            log_entry["response_body_encoding"] = encoding
-            if truncated:
-                log_entry["response_body_truncated"] = True
-        else:
-            log_entry["response_body_encoding"] = "binary"
+        _set_body_fields(
+            log_entry,
+            "response",
+            body,
+            res_ct,
+            already_truncated=bool(stream_state and stream_state["truncated"]),
+        )

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -323,6 +323,26 @@ class TestAddCaptureFields:
         assert "request_headers" in entry  # headers always captured
         assert "response_headers" in entry  # headers captured despite empty body
 
+    def test_request_body_gzip_empty_skips_body_and_captures_response(self, real_flow):
+        compressed = gzip.compress(b"")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=compressed,
+            request_encoding="gzip",
+            response_body=b'{"ok": true}',
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert "request_headers" in entry
+        assert entry["response_body"] == '{"ok": true}'
+        assert entry["response_body_encoding"] == "utf-8"
+
     def test_response_decompression_error_skips_body(self, real_flow, headers):
         # Content-Encoding: gzip + non-gzip bytes makes flow.response.content
         # raise ValueError, which add_capture_fields is expected to catch.

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -513,6 +513,25 @@ class TestAddCaptureFields:
         assert entry["response_body"] == '{"a": "result"}'
         assert entry["request_headers"]["Host"] == "api.example.com"
 
+    def test_non_utf8_text_bodies_capture_base64(self, real_flow):
+        request_body = b"\xff\xfe request"
+        response_body = b"\xff\xfe response"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_body=request_body,
+            request_content_type="text/plain",
+            response_body=response_body,
+            response_content_type="text/plain",
+            include_request_id=True,
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == request_body
+        assert entry["response_body_encoding"] == "base64"
+        assert base64.b64decode(entry["response_body"]) == response_body
+
     def test_captures_response_body_from_stream_buffer(self, real_flow):
         """When stream_buffer is present, response body should be read from it."""
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -549,6 +549,22 @@ class TestAddCaptureFields:
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry  # headers still captured
 
+    def test_empty_stream_buffer_does_not_require_truncated_state(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray()
+        flow.metadata["stream_buffer_state"] = {"total_bytes": 0}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert "response_body_encoding" not in entry
+        assert "response_headers" in entry
+
     def test_stream_buffer_truncated_marks_truncation(self, real_flow):
         """When stream_buffer was truncated, response_body_truncated should be set."""
         body = b"x" * STREAM_BUFFER_LIMIT


### PR DESCRIPTION
## Summary

- Extract the shared decoded-body capture write path into `_set_body_fields`.
- Treat decoded empty request bodies the same as decoded empty response bodies: omit body fields.
- Add regression coverage for a gzip-compressed empty request body while confirming response capture still runs.

Closes #14413
Related #14408

## Tests

- `pytest tests/test_body_capture.py::TestAddCaptureFields::test_request_body_gzip_empty_skips_body_and_captures_response` (failed before the fix, passed after)
- `pytest tests/test_body_capture.py`
- `pytest tests/`
- `ruff check src tests`
- `ruff format --check src tests`
