### PR TITLE
fix: run computer use writes without approval prompts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -2,7 +2,6 @@ import { createHash, randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import {
-  zeroComputerUseCommandApprovalContract,
   zeroComputerUseCommandContract,
   zeroComputerUseHostCommandsContract,
   zeroComputerUseHostsContract,
@@ -286,18 +285,19 @@ describe("desktop computer-use runtime", () => {
     });
   });
 
-  it("requires approval for write commands and audits the decision", async () => {
+  it("queues write commands without approval and audits completion", async () => {
     const fixture = await createOrgFixture();
-    await seedComputerUseHost({
+    const hostToken = "host-token";
+    const hostId = await seedComputerUseHost({
       orgId: fixture.orgId,
       userId: fixture.userId,
-      hostToken: "host-token",
+      hostToken,
     });
     const writeClient = setupApp({ context })(
       zeroComputerUseWriteCommandContract,
     );
-    const approvalClient = setupApp({ context })(
-      zeroComputerUseCommandApprovalContract,
+    const hostClient = setupApp({ context })(
+      zeroComputerUseHostCommandsContract,
     );
     const token = mintZeroToken({
       orgId: fixture.orgId,
@@ -317,29 +317,38 @@ describe("desktop computer-use runtime", () => {
       }),
       [200],
     );
-    expect(created.body.status).toBe("pending_approval");
+    expect(created.body.status).toBe("queued");
 
-    const agentApproval = await accept(
-      approvalClient.decide({
-        params: { commandId: created.body.commandId },
-        body: { decision: "approve" },
-        headers: { authorization: `Bearer ${token}` },
-      }),
-      [403],
-    );
-    expect(agentApproval.body.error.message).toBe(
-      "This endpoint is not available for sandbox tokens",
-    );
-
-    const approved = await accept(
-      approvalClient.decide({
-        params: { commandId: created.body.commandId },
-        body: { decision: "approve" },
-        headers: { authorization: "Bearer clerk-session" },
+    const next = await accept(
+      hostClient.next({
+        body: { supportedCapabilities: [...supportedCapabilities] },
+        headers: { authorization: `Bearer ${hostToken}` },
       }),
       [200],
     );
-    expect(approved.body.status).toBe("queued");
+    expect(next.body.status).toBe("command");
+    if (next.body.status !== "command") {
+      throw new Error("expected command");
+    }
+    expect(next.body.command).toMatchObject({
+      id: created.body.commandId,
+      hostId,
+      kind: "element.click",
+      status: "running",
+      payload: { app: "Safari", elementId: "42" },
+    });
+
+    await accept(
+      hostClient.complete({
+        params: { commandId: created.body.commandId },
+        body: {
+          status: "succeeded",
+          result: { text: "clicked" },
+        },
+        headers: { authorization: `Bearer ${hostToken}` },
+      }),
+      [200],
+    );
 
     const writeDb = store.set(writeDb$);
     const auditEvents = await writeDb
@@ -352,6 +361,6 @@ describe("desktop computer-use runtime", () => {
           return event.event;
         })
         .sort(),
-    ).toStrictEqual(["approved", "created"]);
+    ).toStrictEqual(["completed"]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -273,7 +273,7 @@ const writeCommandCreateInner$ = command(
         kind: bodyResult.data.kind,
         payload: bodyResult.data,
         timeoutMs: bodyResult.data.timeoutMs,
-        requiresApproval: true,
+        requiresApproval: false,
         ...(auth.tokenType === "zero" ? { runId: auth.runId } : {}),
         ...(bodyResult.data.hostId ? { hostId: bodyResult.data.hostId } : {}),
         ...(bodyResult.data.hostName

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -9,7 +9,7 @@ permission status.
 
 When the user is signed in and the feature switch is enabled, the main process
 registers a Desktop Computer Use host through the Zero API command queue. It
-uses the Electron session for auth, polls approved commands, executes them with
+uses the Electron session for auth, polls queued commands, executes them with
 macOS Accessibility/JXA, and completes commands back to the API.
 
 ## Development

--- a/turbo/apps/platform/src/signals/desktop-computer-use-page/desktop-computer-use-signals.ts
+++ b/turbo/apps/platform/src/signals/desktop-computer-use-page/desktop-computer-use-signals.ts
@@ -4,9 +4,6 @@ type DesktopComputerUseApi = NonNullable<Window["vm0DesktopComputerUse"]>;
 export type DesktopComputerUseState = Awaited<
   ReturnType<DesktopComputerUseApi["getState"]>
 >;
-type DesktopComputerUseApprovalAction = Parameters<
-  DesktopComputerUseApi["decideCommand"]
->[0];
 
 const internalReload$ = state(0);
 
@@ -78,20 +75,6 @@ export const openDesktopComputerUseAccessibilitySettings$ = command(
 export const openDesktopComputerUseScreenRecordingSettings$ = command(
   async ({ set }, signal: AbortSignal) => {
     await desktopComputerUseApi().openScreenRecordingSettings();
-    signal.throwIfAborted();
-    set(internalReload$, (previous) => {
-      return previous + 1;
-    });
-  },
-);
-
-export const decideDesktopComputerUseCommand$ = command(
-  async (
-    { set },
-    action: DesktopComputerUseApprovalAction,
-    signal: AbortSignal,
-  ) => {
-    await desktopComputerUseApi().decideCommand(action);
     signal.throwIfAborted();
     set(internalReload$, (previous) => {
       return previous + 1;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
@@ -88,12 +88,8 @@ afterEach(() => {
 });
 
 describe("zero desktop Computer Use page", () => {
-  it("renders desktop permissions, runtime state, and approval actions", async () => {
-    const user = userEvent.setup();
+  it("renders desktop permissions, runtime state, and command history", async () => {
     const state = computerUseState();
-    const decideCommand = vi.fn(() => {
-      return Promise.resolve(state);
-    });
     installDesktopComputerUseApi({
       getState() {
         return Promise.resolve(state);
@@ -110,7 +106,9 @@ describe("zero desktop Computer Use page", () => {
       openScreenRecordingSettings() {
         return Promise.resolve();
       },
-      decideCommand,
+      decideCommand() {
+        return Promise.resolve(state);
+      },
       subscribe() {
         return () => {};
       },
@@ -134,17 +132,8 @@ describe("zero desktop Computer Use page", () => {
     expect(screen.getByText("host-1")).toBeInTheDocument();
     expect(screen.getAllByText("element.click")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Safari")[0]).toBeInTheDocument();
-
-    const approveButton = screen.getByText("Approve").closest("button");
-    expect(approveButton).toBeInstanceOf(HTMLButtonElement);
-    await user.click(approveButton as HTMLButtonElement);
-
-    await waitFor(() => {
-      expect(decideCommand).toHaveBeenCalledWith({
-        commandId: "command-1",
-        decision: "approve",
-      });
-    });
+    expect(screen.queryByText("Pending approvals")).not.toBeInTheDocument();
+    expect(screen.queryByText("Approve")).not.toBeInTheDocument();
   });
 
   it("runs native permission onboarding actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
@@ -22,7 +22,6 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
-  decideDesktopComputerUseCommand$,
   desktopComputerUseData$,
   openDesktopComputerUseAccessibilitySettings$,
   openDesktopComputerUseScreenRecordingSettings$,
@@ -105,7 +104,7 @@ function PermissionPanel({
 
   return (
     <section className="zero-border bg-card rounded-xl px-5 py-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-4">
         <div className="flex min-w-0 items-start gap-3">
           <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
             {granted ? (
@@ -119,12 +118,12 @@ function PermissionPanel({
               <h2 className="text-sm font-semibold text-foreground">{title}</h2>
               <StatusBadge status={granted ? "granted" : "missing"} />
             </div>
-            <p className="mt-1 max-w-[620px] text-sm text-muted-foreground">
+            <p className="mt-1 max-w-[680px] text-sm text-muted-foreground">
               {body}
             </p>
           </div>
         </div>
-        <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 pl-12">
           {kind === "accessibility" ? (
             <Button
               variant={granted ? "outline" : "default"}
@@ -250,103 +249,6 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   );
 }
 
-function ApprovalsPanel({
-  state,
-}: {
-  readonly state: DesktopComputerUseState;
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const [decisionLoadable, decideCommand] = useLoadableSet(
-    decideDesktopComputerUseCommand$,
-  );
-  const pending = decisionLoadable.state === "loading";
-  return (
-    <section className="zero-border bg-card rounded-xl overflow-hidden">
-      <div className="flex items-center justify-between gap-4 border-b px-5 py-4">
-        <div>
-          <h2 className="text-sm font-semibold text-foreground">
-            Pending approvals
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Write commands wait for a local decision before execution.
-          </p>
-        </div>
-        <StatusBadge
-          status={`${state.host.pendingApprovals.length.toString()} pending`}
-        />
-      </div>
-      {state.host.pendingApprovals.length === 0 ? (
-        <div className="px-5 py-8 text-center text-sm text-muted-foreground">
-          No pending approvals.
-        </div>
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Command</TableHead>
-              <TableHead>App</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead className="w-[170px]" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {state.host.pendingApprovals.map((approval) => {
-              return (
-                <TableRow key={approval.commandId}>
-                  <TableCell className="font-medium">{approval.kind}</TableCell>
-                  <TableCell>{approval.app ?? "-"}</TableCell>
-                  <TableCell>{formatDateTime(approval.createdAt)}</TableCell>
-                  <TableCell>
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={pending}
-                        onClick={() => {
-                          detach(
-                            decideCommand(
-                              {
-                                commandId: approval.commandId,
-                                decision: "deny",
-                              },
-                              pageSignal,
-                            ),
-                            Reason.DomCallback,
-                          );
-                        }}
-                      >
-                        Deny
-                      </Button>
-                      <Button
-                        size="sm"
-                        disabled={pending}
-                        onClick={() => {
-                          detach(
-                            decideCommand(
-                              {
-                                commandId: approval.commandId,
-                                decision: "approve",
-                              },
-                              pageSignal,
-                            ),
-                            Reason.DomCallback,
-                          );
-                        }}
-                      >
-                        Approve
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      )}
-    </section>
-  );
-}
-
 function HistoryPanel({ state }: { readonly state: DesktopComputerUseState }) {
   return (
     <section className="zero-border bg-card rounded-xl overflow-hidden">
@@ -416,7 +318,7 @@ function DesktopComputerUseHeader() {
             Computer Use
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Desktop host setup, permissions, and command approvals
+            Desktop host setup, permissions, and command execution
           </p>
         </div>
         <Button
@@ -462,7 +364,6 @@ function DesktopComputerUsePageBody() {
               />
             </div>
             <RuntimePanel state={dataLoadable.data} />
-            <ApprovalsPanel state={dataLoadable.data} />
             <HistoryPanel state={dataLoadable.data} />
           </>
         )}

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -474,7 +474,7 @@ export const zeroComputerUseWriteCommandContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Create an approved-write desktop computer-use command",
+    summary: "Create a desktop computer-use write command",
   },
 });
 


### PR DESCRIPTION
## Summary
- queue Desktop Computer Use write commands immediately instead of holding them for per-command approval
- remove the Pending approvals panel from the Computer Use page
- stack permission card actions below their descriptions to avoid cramped horizontal layout
- update Computer Use route/page tests and related contract/docs text

## Tests
- `pnpm prettier --write apps/api/src/signals/routes/zero-computer-use.ts apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts apps/platform/src/views/zero-page/desktop-computer-use-page.tsx apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx packages/api-contracts/src/contracts/zero-computer-use.ts apps/desktop/README.md`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts lint`

Note: API test used a temporary local Docker PostgreSQL with migrated schema because the host did not have PostgreSQL running.