### PR TITLE
refactor: clarify connector oauth config getters

### DIFF
--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -4,7 +4,7 @@ import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
   getConnectorOAuthCredentials,
-  getOAuthConnectorConfig,
+  getConnectorOAuthConfig,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -221,7 +221,7 @@ async function exchangeTokenForConnector(args: {
 function getRequestedScopes(
   connectorType: OAuthConnectorType,
 ): readonly string[] {
-  return getOAuthConnectorConfig(connectorType).scopes;
+  return getConnectorOAuthConfig(connectorType).scopes;
 }
 
 function resolveOAuthConnectorType(

--- a/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
@@ -2,7 +2,7 @@ import type {
   ConnectorType,
   OAuthConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfigIfSupported } from "@vm0/connectors/connector-utils";
 import { createTestOAuthConnectorRecord } from "../db-test-seeders/connectors";
 import { createTestSecret } from "./secrets";
 import { getTestAuthContext } from "./core";
@@ -74,7 +74,9 @@ async function createTestOAuthConnector(options?: {
     externalUsername: options?.externalUsername ?? "testuser",
     externalEmail: options?.externalEmail ?? "test@example.com",
     oauthScopes:
-      options?.oauthScopes ?? getConnectorOAuthConfig(type)?.scopes ?? [],
+      options?.oauthScopes ??
+      getConnectorOAuthConfigIfSupported(type)?.scopes ??
+      [],
   });
 }
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
@@ -2,7 +2,7 @@ import type {
   ConnectorType,
   OAuthConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfigIfSupported } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { createTestOAuthConnectorRecord } from "../db-test-seeders/connectors";
 import { createTestSecret } from "./secrets";
 import { getTestAuthContext } from "./core";
@@ -73,10 +73,7 @@ async function createTestOAuthConnector(options?: {
     externalId: options?.externalId ?? `test-${type}-external-id`,
     externalUsername: options?.externalUsername ?? "testuser",
     externalEmail: options?.externalEmail ?? "test@example.com",
-    oauthScopes:
-      options?.oauthScopes ??
-      getConnectorOAuthConfigIfSupported(type)?.scopes ??
-      [],
+    oauthScopes: options?.oauthScopes ?? getConnectorOAuthConfig(type).scopes,
   });
 }
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -700,6 +700,7 @@ export {
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorType,
+  type OAuthConnectorType,
   type ConnectorConfig,
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -718,6 +718,7 @@ export {
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorOAuthConfig,
+  getConnectorOAuthConfigIfSupported,
   isGoogleOAuthConnector,
   hasRequiredScopes,
   getScopeDiff,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -639,6 +639,18 @@ describe("getConnectorOAuthConfig - google-meet scopes", () => {
   });
 });
 
+describe("getConnectorOAuthConfigIfSupported", () => {
+  it("returns OAuth config for OAuth connectors", () => {
+    expect(getConnectorOAuthConfigIfSupported("github")).toEqual(
+      getConnectorOAuthConfig("github"),
+    );
+  });
+
+  it("returns undefined for connectors without OAuth", () => {
+    expect(getConnectorOAuthConfigIfSupported("axiom")).toBeUndefined();
+  });
+});
+
 describe("getConnectorTypeForSecretName", () => {
   it("finds connector type for OAuth env mapping key", () => {
     expect(getConnectorTypeForSecretName("GH_TOKEN")).toBe("github");
@@ -690,12 +702,12 @@ describe("isGoogleOAuthConnector", () => {
     }
   });
 
-  it("returns false for api-token-only connectors", () => {
-    const apiTokenOnly = ["axiom", "atlassian", "ahrefs"] as const;
-    for (const type of apiTokenOnly) {
+  it("returns false for connectors without Google OAuth", () => {
+    const nonGoogleOAuth = ["axiom", "atlassian", "ahrefs"] as const;
+    for (const type of nonGoogleOAuth) {
       expect(
         isGoogleOAuthConnector(type),
-        `${type} has no OAuth config and should return false`,
+        `${type} should not be classified as Google OAuth`,
       ).toBe(false);
     }
   });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -15,6 +15,7 @@ import {
   getConnectorOAuthClientConfig,
   getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
+  getConnectorOAuthConfigIfSupported,
   getRuntimeAvailableConnectorTypes,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
@@ -257,7 +258,7 @@ describe("getConnectorEnvironmentMapping", () => {
     //   environmentMapping: all values -> $secrets.XXX_ACCESS_TOKEN
     //   api-token secrets:  XXX_TOKEN (if api-token auth method exists)
     for (const type of connectorTypeSchema.options) {
-      if (!getConnectorOAuthConfig(type)) continue;
+      if (!getConnectorOAuthConfigIfSupported(type)) continue;
       const authMethods = getConnectorAuthMethods(type);
       if (!authMethods["oauth"]) continue;
 
@@ -311,7 +312,7 @@ describe("getConnectorEnvironmentMapping", () => {
     for (const type of connectorTypeSchema.options) {
       const authMethods = getConnectorAuthMethods(type);
       if (authMethods["oauth"] || !authMethods["api-token"]) continue;
-      if (getConnectorOAuthConfig(type)) continue;
+      if (getConnectorOAuthConfigIfSupported(type)) continue;
 
       const secrets = Object.keys(authMethods["api-token"].secrets);
       const mapping = getConnectorEnvironmentMapping(type);
@@ -556,7 +557,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
 
   it("includes active OAuth connectors when their runtime env is configured", () => {
     const activeOAuthTypes = connectorTypeSchema.options.filter((type) => {
-      return getConnectorOAuthConfig(type);
+      return getConnectorOAuthConfigIfSupported(type);
     });
 
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(() => {
@@ -702,7 +703,7 @@ describe("isGoogleOAuthConnector", () => {
   it("returns true only for connectors whose OAuth authorizationUrl hostname is accounts.google.com", () => {
     for (const type of connectorTypeSchema.options) {
       const result = isGoogleOAuthConnector(type);
-      const oauthConfig = getConnectorOAuthConfig(type);
+      const oauthConfig = getConnectorOAuthConfigIfSupported(type);
 
       if (result) {
         // If classified as Google, the OAuth URL must point to accounts.google.com

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -628,8 +628,7 @@ describe("getConnectorProvidedSecretNames", () => {
 describe("getConnectorOAuthConfig - google-meet scopes", () => {
   it("uses meetings.space.readonly for google meet oauth scopes", () => {
     const config = getConnectorOAuthConfig("google-meet");
-    expect(config).not.toBeNull();
-    const scopes = config!.scopes;
+    const scopes = config.scopes;
     expect(scopes).toContain(
       "https://www.googleapis.com/auth/meetings.space.readonly",
     );

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -231,7 +231,7 @@ function hasEnvValue(readEnv: ConnectorEnvReader, name: string): boolean {
 export function getConnectorOAuthClientConfig(
   type: ConnectorType,
 ): ConnectorOAuthClientConfig | undefined {
-  return getConnectorOAuthConfig(type)?.client;
+  return getConnectorOAuthConfigIfSupported(type)?.client;
 }
 
 export function resolveConnectorOAuthClientCredentials(
@@ -450,16 +450,19 @@ export function getConnectorProvidedSecretNames(
 }
 
 /**
- * Get OAuth configuration for a connector type
+ * Get OAuth configuration for a connector type if it supports OAuth.
  */
-export function getConnectorOAuthConfig(
+export function getConnectorOAuthConfigIfSupported(
   type: ConnectorType,
 ): ConnectorOAuthConfig | undefined {
   const config = CONNECTOR_TYPES[type];
   return "oauth" in config ? config.oauth : undefined;
 }
 
-export function getOAuthConnectorConfig(
+/**
+ * Get OAuth configuration for a connector type known to support OAuth.
+ */
+export function getConnectorOAuthConfig(
   type: OAuthConnectorType,
 ): ConnectorOAuthConfig {
   return CONNECTOR_TYPES[type].oauth;
@@ -469,7 +472,7 @@ export function getOAuthConnectorConfig(
  * Check if a connector type uses Google OAuth (accounts.google.com).
  */
 export function isGoogleOAuthConnector(type: ConnectorType): boolean {
-  const oauthConfig = getConnectorOAuthConfig(type);
+  const oauthConfig = getConnectorOAuthConfigIfSupported(type);
   if (!oauthConfig?.authorizationUrl) return false;
   try {
     return (
@@ -489,7 +492,7 @@ export function hasRequiredScopes(
   connectorType: ConnectorType,
   storedScopes: string[] | null,
 ): boolean {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfigIfSupported(connectorType);
   if (!oauthConfig) return true;
   if (oauthConfig.scopes.length === 0) return true;
   if (!storedScopes) return false;
@@ -513,7 +516,7 @@ export function getScopeDiff(
   connectorType: ConnectorType,
   storedScopes: string[] | null,
 ): ScopeDiff {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfigIfSupported(connectorType);
   const currentScopes = oauthConfig?.scopes ?? [];
   const stored = storedScopes ?? [];
   const storedSet = new Set(stored);

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,7 +33,7 @@ export function buildAhrefsAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("ahrefs");
+  const oauthConfig = getConnectorOAuthConfig("ahrefs");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,7 +54,7 @@ export async function exchangeAhrefsCode(
   code: string,
   redirectUri: string,
 ): Promise<AhrefsTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("ahrefs");
+  const oauthConfig = getConnectorOAuthConfig("ahrefs");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -113,7 +113,7 @@ export async function refreshAhrefsToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AhrefsRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("ahrefs");
+  const oauthConfig = getConnectorOAuthConfig("ahrefs");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -58,7 +58,7 @@ export async function buildAirtableAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<{ url: string; codeVerifier: string }> {
-  const oauthConfig = getOAuthConnectorConfig("airtable");
+  const oauthConfig = getConnectorOAuthConfig("airtable");
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -89,7 +89,7 @@ export async function exchangeAirtableCode(
   redirectUri: string,
   codeVerifier?: string,
 ): Promise<AirtableTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("airtable");
+  const oauthConfig = getConnectorOAuthConfig("airtable");
   if (!codeVerifier) {
     throw new Error("Airtable requires PKCE code_verifier for token exchange");
   }
@@ -154,7 +154,7 @@ export async function refreshAirtableToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AirtableRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("airtable");
+  const oauthConfig = getConnectorOAuthConfig("airtable");
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
   const response = await fetch(oauthConfig.tokenUrl, {

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,7 +30,7 @@ export function buildAsanaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("asana");
+  const oauthConfig = getConnectorOAuthConfig("asana");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -51,7 +51,7 @@ export async function exchangeAsanaCode(
   code: string,
   redirectUri: string,
 ): Promise<AsanaTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("asana");
+  const oauthConfig = getConnectorOAuthConfig("asana");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -158,7 +158,7 @@ export async function refreshAsanaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AsanaRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("asana");
+  const oauthConfig = getConnectorOAuthConfig("asana");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -66,7 +66,7 @@ export async function buildCanvaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getOAuthConnectorConfig("canva");
+  const oauthConfig = getConnectorOAuthConfig("canva");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -93,7 +93,7 @@ export async function refreshCanvaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<CanvaRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("canva");
+  const oauthConfig = getConnectorOAuthConfig("canva");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -149,7 +149,7 @@ export async function exchangeCanvaCode(
   redirectUri: string,
   state: string,
 ): Promise<CanvaTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("canva");
+  const oauthConfig = getConnectorOAuthConfig("canva");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/close.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,7 +30,7 @@ export function buildCloseAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("close");
+  const oauthConfig = getConnectorOAuthConfig("close");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -50,7 +50,7 @@ export async function exchangeCloseCode(
   code: string,
   redirectUri: string,
 ): Promise<CloseTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("close");
+  const oauthConfig = getConnectorOAuthConfig("close");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -114,7 +114,7 @@ export async function refreshCloseToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<CloseRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("close");
+  const oauthConfig = getConnectorOAuthConfig("close");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -65,7 +65,7 @@ export async function buildDeelAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getOAuthConnectorConfig("deel");
+  const oauthConfig = getConnectorOAuthConfig("deel");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -93,7 +93,7 @@ export async function refreshDeelToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DeelRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("deel");
+  const oauthConfig = getConnectorOAuthConfig("deel");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -149,7 +149,7 @@ export async function exchangeDeelCode(
   redirectUri: string,
   state: string,
 ): Promise<DeelTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("deel");
+  const oauthConfig = getConnectorOAuthConfig("deel");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -65,7 +65,7 @@ export async function buildDocuSignAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getOAuthConnectorConfig("docusign");
+  const oauthConfig = getConnectorOAuthConfig("docusign");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -93,7 +93,7 @@ export async function exchangeDocuSignCode(
   redirectUri: string,
   state: string,
 ): Promise<DocuSignTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("docusign");
+  const oauthConfig = getConnectorOAuthConfig("docusign");
   const codeVerifier = await deriveCodeVerifier(state);
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
@@ -158,7 +158,7 @@ export async function refreshDocuSignToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DocuSignRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("docusign");
+  const oauthConfig = getConnectorOAuthConfig("docusign");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -34,7 +34,7 @@ export function buildDropboxAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("dropbox");
+  const oauthConfig = getConnectorOAuthConfig("dropbox");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -57,7 +57,7 @@ export async function exchangeDropboxCode(
   code: string,
   redirectUri: string,
 ): Promise<DropboxTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("dropbox");
+  const oauthConfig = getConnectorOAuthConfig("dropbox");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -116,7 +116,7 @@ export async function refreshDropboxToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DropboxRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("dropbox");
+  const oauthConfig = getConnectorOAuthConfig("dropbox");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildFigmaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("figma");
+  const oauthConfig = getConnectorOAuthConfig("figma");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,7 +54,7 @@ export async function exchangeFigmaCode(
   code: string,
   redirectUri: string,
 ): Promise<FigmaTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("figma");
+  const oauthConfig = getConnectorOAuthConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -116,7 +116,7 @@ export async function refreshFigmaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<FigmaRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("figma");
+  const oauthConfig = getConnectorOAuthConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -67,7 +67,7 @@ export async function buildGarminConnectAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getOAuthConnectorConfig("garmin-connect");
+  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -92,7 +92,7 @@ export async function exchangeGarminConnectCode(
   code: string,
   state: string,
 ): Promise<GarminConnectTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("garmin-connect");
+  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
   const codeVerifier = await deriveCodeVerifier(state);
 
   const response = await fetch(oauthConfig.tokenUrl, {
@@ -154,7 +154,7 @@ export async function refreshGarminConnectToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GarminConnectRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("garmin-connect");
+  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/github.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -18,7 +18,7 @@ export function buildGitHubAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("github");
+  const oauthConfig = getConnectorOAuthConfig("github");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -38,7 +38,7 @@ export async function exchangeGitHubCode(
   code: string,
   redirectUri: string,
 ): Promise<{ accessToken: string; scopes: string[] }> {
-  const oauthConfig = getOAuthConnectorConfig("github");
+  const oauthConfig = getConnectorOAuthConfig("github");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -28,7 +28,7 @@ export function buildGmailAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("gmail");
+  const oauthConfig = getConnectorOAuthConfig("gmail");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -52,7 +52,7 @@ export async function exchangeGmailCode(
   code: string,
   redirectUri: string,
 ): Promise<GmailTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("gmail");
+  const oauthConfig = getConnectorOAuthConfig("gmail");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
@@ -1,5 +1,5 @@
 import type { OAuthConnectorType } from "@vm0/connectors/connectors";
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -46,7 +46,7 @@ export function buildGoogleAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -71,7 +71,7 @@ export async function exchangeGoogleOAuthCode(
   code: string,
   redirectUri: string,
 ): Promise<GoogleTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -132,7 +132,7 @@ export async function refreshGoogleToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GoogleRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -29,7 +29,7 @@ export function buildGumroadAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("gumroad");
+  const oauthConfig = getConnectorOAuthConfig("gumroad");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -47,7 +47,7 @@ export async function exchangeGumroadCode(
   code: string,
   redirectUri: string,
 ): Promise<GumroadTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("gumroad");
+  const oauthConfig = getConnectorOAuthConfig("gumroad");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -101,7 +101,7 @@ export async function refreshGumroadToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GumroadRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("gumroad");
+  const oauthConfig = getConnectorOAuthConfig("gumroad");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildHubSpotAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("hubspot");
+  const oauthConfig = getConnectorOAuthConfig("hubspot");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -52,7 +52,7 @@ export async function exchangeHubSpotCode(
   code: string,
   redirectUri: string,
 ): Promise<HubSpotTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("hubspot");
+  const oauthConfig = getConnectorOAuthConfig("hubspot");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -109,7 +109,7 @@ export async function refreshHubSpotToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<HubSpotRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("hubspot");
+  const oauthConfig = getConnectorOAuthConfig("hubspot");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -21,7 +21,7 @@ export function buildIntervalsIcuAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("intervals-icu");
+  const oauthConfig = getConnectorOAuthConfig("intervals-icu");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -43,7 +43,7 @@ export async function exchangeIntervalsIcuCode(
   clientSecret: string,
   code: string,
 ): Promise<IntervalsIcuTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("intervals-icu");
+  const oauthConfig = getConnectorOAuthConfig("intervals-icu");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -34,7 +34,7 @@ export function buildLinearAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("linear");
+  const oauthConfig = getConnectorOAuthConfig("linear");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,7 +58,7 @@ export async function exchangeLinearCode(
   code: string,
   redirectUri: string,
 ): Promise<LinearTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("linear");
+  const oauthConfig = getConnectorOAuthConfig("linear");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -117,7 +117,7 @@ export async function refreshLinearToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<LinearRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("linear");
+  const oauthConfig = getConnectorOAuthConfig("linear");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -24,7 +24,7 @@ export function buildMailchimpAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("mailchimp");
+  const oauthConfig = getConnectorOAuthConfig("mailchimp");
   const params = new URLSearchParams({
     response_type: "code",
     client_id: clientId,
@@ -45,7 +45,7 @@ export async function exchangeMailchimpCode(
   code: string,
   redirectUri: string,
 ): Promise<MailchimpTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("mailchimp");
+  const oauthConfig = getConnectorOAuthConfig("mailchimp");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,7 +33,7 @@ export function buildMercuryAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("mercury");
+  const oauthConfig = getConnectorOAuthConfig("mercury");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,7 +54,7 @@ export async function exchangeMercuryCode(
   code: string,
   redirectUri: string,
 ): Promise<MercuryTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("mercury");
+  const oauthConfig = getConnectorOAuthConfig("mercury");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -113,7 +113,7 @@ export async function refreshMercuryToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MercuryRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("mercury");
+  const oauthConfig = getConnectorOAuthConfig("mercury");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -27,7 +27,7 @@ export function buildMetaAdsAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("meta-ads");
+  const oauthConfig = getConnectorOAuthConfig("meta-ads");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -49,7 +49,7 @@ export async function exchangeMetaAdsCode(
   code: string,
   redirectUri: string,
 ): Promise<MetaAdsTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("meta-ads");
+  const oauthConfig = getConnectorOAuthConfig("meta-ads");
   // Step 1: Exchange code for short-lived token
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",

--- a/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
@@ -1,5 +1,5 @@
 import type { OAuthConnectorType } from "@vm0/connectors/connectors";
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -40,7 +40,7 @@ export function buildMicrosoftAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -64,7 +64,7 @@ export async function exchangeMicrosoftOAuthCode(
   code: string,
   redirectUri: string,
 ): Promise<MicrosoftTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -125,7 +125,7 @@ export async function refreshMicrosoftToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MicrosoftRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig(connectorType);
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildMondayAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("monday");
+  const oauthConfig = getConnectorOAuthConfig("monday");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,7 +54,7 @@ export async function exchangeMondayCode(
   code: string,
   redirectUri: string,
 ): Promise<MondayTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("monday");
+  const oauthConfig = getConnectorOAuthConfig("monday");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -112,7 +112,7 @@ export async function refreshMondayToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MondayRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("monday");
+  const oauthConfig = getConnectorOAuthConfig("monday");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,7 +33,7 @@ export function buildNeonAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("neon");
+  const oauthConfig = getConnectorOAuthConfig("neon");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
@@ -55,7 +55,7 @@ export async function exchangeNeonCode(
   code: string,
   redirectUri: string,
 ): Promise<NeonTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("neon");
+  const oauthConfig = getConnectorOAuthConfig("neon");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -114,7 +114,7 @@ export async function refreshNeonToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<NeonRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("neon");
+  const oauthConfig = getConnectorOAuthConfig("neon");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -37,7 +37,7 @@ export function buildNotionAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("notion");
+  const oauthConfig = getConnectorOAuthConfig("notion");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -60,7 +60,7 @@ export async function exchangeNotionCode(
   code: string,
   redirectUri: string,
 ): Promise<NotionTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("notion");
+  const oauthConfig = getConnectorOAuthConfig("notion");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -130,7 +130,7 @@ export async function refreshNotionToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<NotionRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("notion");
+  const oauthConfig = getConnectorOAuthConfig("notion");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildPosthogAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("posthog");
+  const oauthConfig = getConnectorOAuthConfig("posthog");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -53,7 +53,7 @@ export async function exchangePosthogCode(
   code: string,
   redirectUri: string,
 ): Promise<PosthogTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("posthog");
+  const oauthConfig = getConnectorOAuthConfig("posthog");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -111,7 +111,7 @@ export async function refreshPosthogToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<PosthogRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("posthog");
+  const oauthConfig = getConnectorOAuthConfig("posthog");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -36,7 +36,7 @@ export function buildRedditAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("reddit");
+  const oauthConfig = getConnectorOAuthConfig("reddit");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
@@ -59,7 +59,7 @@ export async function exchangeRedditCode(
   code: string,
   redirectUri: string,
 ): Promise<RedditTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("reddit");
+  const oauthConfig = getConnectorOAuthConfig("reddit");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -158,7 +158,7 @@ export async function refreshRedditToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<RedditRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("reddit");
+  const oauthConfig = getConnectorOAuthConfig("reddit");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,7 +30,7 @@ export function buildSentryAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("sentry");
+  const oauthConfig = getConnectorOAuthConfig("sentry");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -52,7 +52,7 @@ export async function exchangeSentryCode(
   code: string,
   redirectUri: string,
 ): Promise<SentryTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("sentry");
+  const oauthConfig = getConnectorOAuthConfig("sentry");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -124,7 +124,7 @@ export async function refreshSentryToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SentryRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("sentry");
+  const oauthConfig = getConnectorOAuthConfig("sentry");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -23,7 +23,7 @@ export function buildSlackAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("slack");
+  const oauthConfig = getConnectorOAuthConfig("slack");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -44,7 +44,7 @@ export async function exchangeSlackCode(
   code: string,
   redirectUri: string,
 ): Promise<SlackTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("slack");
+  const oauthConfig = getConnectorOAuthConfig("slack");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildSpotifyAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("spotify");
+  const oauthConfig = getConnectorOAuthConfig("spotify");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,7 +54,7 @@ export async function exchangeSpotifyCode(
   code: string,
   redirectUri: string,
 ): Promise<SpotifyTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("spotify");
+  const oauthConfig = getConnectorOAuthConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -115,7 +115,7 @@ export async function refreshSpotifyToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SpotifyRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("spotify");
+  const oauthConfig = getConnectorOAuthConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,7 +33,7 @@ export function buildStravaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("strava");
+  const oauthConfig = getConnectorOAuthConfig("strava");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -55,7 +55,7 @@ export async function exchangeStravaCode(
   clientSecret: string,
   code: string,
 ): Promise<StravaTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("strava");
+  const oauthConfig = getConnectorOAuthConfig("strava");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -131,7 +131,7 @@ export async function refreshStravaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<StravaRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("strava");
+  const oauthConfig = getConnectorOAuthConfig("strava");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildStripeAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("stripe");
+  const oauthConfig = getConnectorOAuthConfig("stripe");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -53,7 +53,7 @@ export async function exchangeStripeCode(
   clientSecret: string,
   code: string,
 ): Promise<StripeTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("stripe");
+  const oauthConfig = getConnectorOAuthConfig("stripe");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -114,7 +114,7 @@ export async function refreshStripeToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<StripeRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("stripe");
+  const oauthConfig = getConnectorOAuthConfig("stripe");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -65,7 +65,7 @@ export async function buildSupabaseAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getOAuthConnectorConfig("supabase");
+  const oauthConfig = getConnectorOAuthConfig("supabase");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -92,7 +92,7 @@ export async function refreshSupabaseToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SupabaseRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("supabase");
+  const oauthConfig = getConnectorOAuthConfig("supabase");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -149,7 +149,7 @@ export async function exchangeSupabaseCode(
   redirectUri: string,
   state: string,
 ): Promise<SupabaseTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("supabase");
+  const oauthConfig = getConnectorOAuthConfig("supabase");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
@@ -9,7 +9,7 @@
  * the provider routes themselves 404 in production via isTestEndpointAllowed().
  */
 
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 export {
@@ -129,12 +129,12 @@ function previewBypassHeaders(): Record<string, string> {
 function getAuthorizationUrl(): string {
   return resolveUrl(
     "authorizationUrl",
-    getOAuthConnectorConfig("test-oauth").authorizationUrl,
+    getConnectorOAuthConfig("test-oauth").authorizationUrl,
   );
 }
 
 function getTokenUrl(): string {
-  return resolveUrl("tokenUrl", getOAuthConnectorConfig("test-oauth").tokenUrl);
+  return resolveUrl("tokenUrl", getConnectorOAuthConfig("test-oauth").tokenUrl);
 }
 
 export function buildTestOAuthAuthorizationUrl(

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -23,7 +23,7 @@ export function buildTodoistAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("todoist");
+  const oauthConfig = getConnectorOAuthConfig("todoist");
   const params = new URLSearchParams({
     client_id: clientId,
     scope: oauthConfig.scopes.join(","),
@@ -45,7 +45,7 @@ export async function exchangeTodoistCode(
   code: string,
   redirectUri: string,
 ): Promise<TodoistTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("todoist");
+  const oauthConfig = getConnectorOAuthConfig("todoist");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/vercel.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/vercel.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -42,7 +42,7 @@ export async function exchangeVercelCode(
   code: string,
   redirectUri: string,
 ): Promise<VercelTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("vercel");
+  const oauthConfig = getConnectorOAuthConfig("vercel");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -20,7 +20,7 @@ export function buildWebflowAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("webflow");
+  const oauthConfig = getConnectorOAuthConfig("webflow");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
@@ -42,7 +42,7 @@ export async function exchangeWebflowCode(
   code: string,
   redirectUri: string,
 ): Promise<WebflowTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("webflow");
+  const oauthConfig = getConnectorOAuthConfig("webflow");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/x.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -66,7 +66,7 @@ export async function buildXAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getOAuthConnectorConfig("x");
+  const oauthConfig = getConnectorOAuthConfig("x");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -93,7 +93,7 @@ export async function refreshXToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<XRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("x");
+  const oauthConfig = getConnectorOAuthConfig("x");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -149,7 +149,7 @@ export async function exchangeXCode(
   redirectUri: string,
   state: string,
 ): Promise<XTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("x");
+  const oauthConfig = getConnectorOAuthConfig("x");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildXeroAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("xero");
+  const oauthConfig = getConnectorOAuthConfig("xero");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,7 +54,7 @@ export async function exchangeXeroCode(
   code: string,
   redirectUri: string,
 ): Promise<XeroTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("xero");
+  const oauthConfig = getConnectorOAuthConfig("xero");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -114,7 +114,7 @@ export async function refreshXeroToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<XeroRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("xero");
+  const oauthConfig = getConnectorOAuthConfig("xero");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
@@ -1,4 +1,4 @@
-import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,7 +32,7 @@ export function buildZoomAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getOAuthConnectorConfig("zoom");
+  const oauthConfig = getConnectorOAuthConfig("zoom");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -56,7 +56,7 @@ export async function exchangeZoomCode(
   code: string,
   redirectUri: string,
 ): Promise<ZoomTokenResult> {
-  const oauthConfig = getOAuthConnectorConfig("zoom");
+  const oauthConfig = getConnectorOAuthConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -118,7 +118,7 @@ export async function refreshZoomToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<ZoomRefreshResult> {
-  const oauthConfig = getOAuthConnectorConfig("zoom");
+  const oauthConfig = getConnectorOAuthConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -232,6 +232,7 @@ export {
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorOAuthConfig,
+  getConnectorOAuthConfigIfSupported,
   isGoogleOAuthConnector,
   hasRequiredScopes,
   getScopeDiff,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -590,6 +590,7 @@ export {
   type TriggerSource,
   type LogsFilters,
   type ConnectorType,
+  type OAuthConnectorType,
   type ConnectorConfig,
   type ConnectorSecretConfig,
   type ConnectorAuthMethodConfig,


### PR DESCRIPTION
## Summary
- Rename the strict OAuth connector config getter to `getConnectorOAuthConfig` for known OAuth connector types.
- Add `getConnectorOAuthConfigIfSupported` for generic connector paths that need an optional result.
- Update provider implementations and tests to use the strict or optional helper based on their type guarantees.

## Tests
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts src/oauth-providers/providers/__tests__/test-oauth.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-authorize.test.ts`
- `pnpm check-types`
- pre-commit: prettier, knip, check-types

Closes #14428