### PR TITLE
feat: add claude code device auth login

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -77,6 +77,7 @@ import { zeroBillingRedeemRoutes } from "./routes/zero-billing-redeem";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
 import { zeroChatMessagesRoutes } from "./routes/zero-chat-messages";
+import { zeroClaudeCodeDeviceAuthRoutes } from "./routes/zero-claude-code-device-auth";
 import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
@@ -258,6 +259,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBillingStatusRoutes,
   ...zeroChatThreadRoutes,
   ...zeroChatMessagesRoutes,
+  ...zeroClaudeCodeDeviceAuthRoutes,
   ...zeroComposesRoutes,
   ...zeroComputerUseRoutes,
   ...zeroCodexDeviceAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
+import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { secrets } from "@vm0/db/schema/secret";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import { decryptSecretValue } from "../../services/crypto.utils";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const ORG_SENTINEL_USER_ID = "__org__";
+
+function client() {
+  return setupApp({ context })(zeroClaudeCodeDeviceAuthContract);
+}
+
+function mockClaudeCodeDeviceAuthHttp() {
+  const calls = {
+    token: [] as unknown[],
+  };
+
+  server.use(
+    http.post(
+      "https://platform.claude.com/v1/oauth/token",
+      async ({ request }) => {
+        calls.token.push(await request.json());
+        return HttpResponse.json({
+          access_token: "claude-code-access-token",
+          expires_in: 31_536_000,
+          scope: "user:inference",
+        });
+      },
+    ),
+  );
+
+  return calls;
+}
+
+async function cleanupUser(userId: string, orgId: string) {
+  const db = store.set(writeDb$);
+  await db
+    .delete(connectorCliAuthSessions)
+    .where(
+      and(
+        eq(connectorCliAuthSessions.userId, userId),
+        eq(connectorCliAuthSessions.orgId, orgId),
+      ),
+    );
+  await db
+    .delete(modelProviders)
+    .where(
+      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
+    );
+  await db
+    .delete(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+      ),
+    );
+  await db
+    .delete(secrets)
+    .where(and(eq(secrets.userId, userId), eq(secrets.orgId, orgId)));
+  await db
+    .delete(secrets)
+    .where(
+      and(eq(secrets.userId, ORG_SENTINEL_USER_ID), eq(secrets.orgId, orgId)),
+    );
+}
+
+function claudeCodeDeviceAuthSessions(userId: string, orgId: string) {
+  return store
+    .set(writeDb$)
+    .select()
+    .from(connectorCliAuthSessions)
+    .where(
+      and(
+        eq(connectorCliAuthSessions.userId, userId),
+        eq(connectorCliAuthSessions.orgId, orgId),
+        eq(connectorCliAuthSessions.connectorType, "claude-code-oauth-token"),
+        eq(connectorCliAuthSessions.source, "claude-code-device-auth"),
+      ),
+    );
+}
+
+async function claudeCodeSecret(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  const [secret] = await store
+    .set(writeDb$)
+    .select({ encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, args.orgId),
+        eq(secrets.userId, args.userId),
+        eq(secrets.name, "CLAUDE_CODE_OAUTH_TOKEN"),
+        eq(secrets.type, "model-provider"),
+      ),
+    )
+    .limit(1);
+  return secret ? decryptSecretValue(secret.encryptedValue) : null;
+}
+
+function stateFromBrowserUrl(browserUrl: string): string {
+  const state = new URL(browserUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Missing state in Claude Code browser URL");
+  }
+  return state;
+}
+
+describe("Claude Code device auth routes", () => {
+  const fixtures: { readonly userId: string; readonly orgId: string }[] = [];
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await cleanupUser(fixture.userId, fixture.orgId);
+      }
+    }
+  });
+
+  function setupUser(role: "org:admin" | "org:member" = "org:admin") {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    fixtures.push({ userId, orgId });
+    mocks.clerk.session(userId, orgId, role);
+    return { userId, orgId };
+  }
+
+  it("starts Claude Code device auth and returns setup-token OAuth details", async () => {
+    const { userId, orgId } = setupUser();
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { scope: "org" },
+      }),
+      [200],
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.type).toBe("claude-code");
+    expect(response.body.scope).toBe("org");
+    const browserUrl = new URL(response.body.browserUrl);
+    expect(browserUrl.origin + browserUrl.pathname).toBe(
+      "https://claude.com/cai/oauth/authorize",
+    );
+    expect(browserUrl.searchParams.get("code")).toBe("true");
+    expect(browserUrl.searchParams.get("client_id")).toBe(
+      "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    );
+    expect(browserUrl.searchParams.get("redirect_uri")).toBe(
+      "https://platform.claude.com/oauth/code/callback",
+    );
+    expect(browserUrl.searchParams.get("scope")).toBe("user:inference");
+    await expect(
+      claudeCodeDeviceAuthSessions(userId, orgId),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("cancels pending Claude Code device auth", async () => {
+    const { userId, orgId } = setupUser();
+    const started = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { scope: "org" },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      client().cancel({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: started.body.sessionToken },
+      }),
+      [200],
+    );
+
+    expect(response.status).toBe(200);
+    const [session] = await claudeCodeDeviceAuthSessions(userId, orgId);
+    expect(session?.status).toBe("cancelled");
+    expect(session?.errorMessage).toBe(
+      "Claude Code device auth session was cancelled",
+    );
+  });
+
+  it("completes org-scope Claude Code device auth and imports the OAuth token", async () => {
+    const { orgId } = setupUser();
+    const calls = mockClaudeCodeDeviceAuthHttp();
+    const started = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { scope: "org" },
+      }),
+      [200],
+    );
+    const state = stateFromBrowserUrl(started.body.browserUrl);
+
+    const response = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          sessionToken: started.body.sessionToken,
+          authorizationCode: `auth_code_test#${state}`,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe("complete");
+    expect(response.body.provider.type).toBe("claude-code-oauth-token");
+    expect(response.body.provider.secretName).toBe("CLAUDE_CODE_OAUTH_TOKEN");
+    await expect(
+      claudeCodeSecret({ orgId, userId: ORG_SENTINEL_USER_ID }),
+    ).resolves.toBe("claude-code-access-token");
+    expect(calls.token).toMatchObject([
+      {
+        grant_type: "authorization_code",
+        code: "auth_code_test",
+        redirect_uri: "https://platform.claude.com/oauth/code/callback",
+        client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+        state,
+        expires_in: 31_536_000,
+      },
+    ]);
+  });
+
+  it("completes personal-scope Claude Code device auth for non-admin members", async () => {
+    const { userId, orgId } = setupUser("org:member");
+    mockClaudeCodeDeviceAuthHttp();
+    const started = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { scope: "personal" },
+      }),
+      [200],
+    );
+    const state = stateFromBrowserUrl(started.body.browserUrl);
+
+    const response = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          sessionToken: started.body.sessionToken,
+          authorizationCode: `https://platform.claude.com/oauth/code/callback?code=member_code&state=${state}`,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.provider.type).toBe("claude-code-oauth-token");
+    await expect(claudeCodeSecret({ orgId, userId })).resolves.toBe(
+      "claude-code-access-token",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-claude-code-device-auth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-claude-code-device-auth.ts
@@ -1,0 +1,183 @@
+import { command } from "ccstate";
+import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
+
+import { badRequestMessage, notFound } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import {
+  cancelClaudeCodeDeviceAuth$,
+  claudeCodeDeviceAuthUnavailable,
+  completeClaudeCodeDeviceAuth$,
+  startClaudeCodeDeviceAuth,
+} from "../services/claude-code-device-auth.service";
+import type { RouteEntry } from "../route";
+
+const modelProviderWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only admins can manage org model providers",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const startClaudeCodeDeviceAuthBody$ = bodyResultOf(
+  zeroClaudeCodeDeviceAuthContract.start,
+);
+const completeClaudeCodeDeviceAuthBody$ = bodyResultOf(
+  zeroClaudeCodeDeviceAuthContract.complete,
+);
+const cancelClaudeCodeDeviceAuthBody$ = bodyResultOf(
+  zeroClaudeCodeDeviceAuthContract.cancel,
+);
+
+const startClaudeCodeDeviceAuthInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(startClaudeCodeDeviceAuthBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+    if (body.data.scope === "org" && auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+
+    const result = await startClaudeCodeDeviceAuth({
+      writeDb: set(writeDb$),
+      orgId: auth.orgId,
+      userId: auth.userId,
+      scope: body.data.scope,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (!result.ok) {
+      return claudeCodeDeviceAuthUnavailable(result.message);
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        sessionToken: result.sessionToken,
+        type: "claude-code" as const,
+        status: "pending" as const,
+        scope: result.scope,
+        browserUrl: result.browserUrl,
+        expiresIn: result.expiresIn,
+      },
+    };
+  },
+);
+
+const completeClaudeCodeDeviceAuthInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(completeClaudeCodeDeviceAuthBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await set(
+      completeClaudeCodeDeviceAuth$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        orgRole: auth.orgRole,
+        sessionToken: body.data.sessionToken,
+        authorizationCode: body.data.authorizationCode,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    switch (result.status) {
+      case "complete": {
+        return {
+          status: 200 as const,
+          body: {
+            status: "complete" as const,
+            provider: result.body.provider,
+            created: result.body.created,
+          },
+        };
+      }
+      case "invalid_token": {
+        return badRequestMessage(result.message);
+      }
+      case "forbidden": {
+        return notFound(result.message);
+      }
+      case "error": {
+        return claudeCodeDeviceAuthUnavailable(result.message);
+      }
+    }
+  },
+);
+
+const cancelClaudeCodeDeviceAuthInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(cancelClaudeCodeDeviceAuthBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await set(
+      cancelClaudeCodeDeviceAuth$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        sessionToken: body.data.sessionToken,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    switch (result.status) {
+      case "cancelled": {
+        return {
+          status: 200 as const,
+          body: { status: "cancelled" as const },
+        };
+      }
+      case "invalid_token": {
+        return badRequestMessage(result.message);
+      }
+      case "forbidden": {
+        return notFound(result.message);
+      }
+    }
+  },
+);
+
+export const zeroClaudeCodeDeviceAuthRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroClaudeCodeDeviceAuthContract.start,
+    handler: authRoute(modelProviderWriteAuth, startClaudeCodeDeviceAuthInner$),
+  },
+  {
+    route: zeroClaudeCodeDeviceAuthContract.complete,
+    handler: authRoute(
+      modelProviderWriteAuth,
+      completeClaudeCodeDeviceAuthInner$,
+    ),
+  },
+  {
+    route: zeroClaudeCodeDeviceAuthContract.cancel,
+    handler: authRoute(
+      modelProviderWriteAuth,
+      cancelClaudeCodeDeviceAuthInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
@@ -1,0 +1,972 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import { command, type Setter } from "ccstate";
+import type { ClaudeCodeDeviceAuthScope } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
+import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
+import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+
+import { nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import {
+  detach,
+  Mechanism,
+  onRejection,
+  safeJsonParse,
+  safeSync,
+  settle,
+} from "../utils";
+import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
+import {
+  upsertOrgModelProvider$,
+  upsertUserModelProvider$,
+  type ModelProviderInfo,
+} from "./zero-model-provider.service";
+
+const CLAUDE_CODE_DEVICE_AUTH_AUTHORIZE_URL =
+  "https://claude.com/cai/oauth/authorize";
+const CLAUDE_CODE_DEVICE_AUTH_TOKEN_URL =
+  "https://platform.claude.com/v1/oauth/token";
+const CLAUDE_CODE_DEVICE_AUTH_REDIRECT_URI =
+  "https://platform.claude.com/oauth/code/callback";
+const CLAUDE_CODE_DEVICE_AUTH_CLIENT_ID =
+  "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const CLAUDE_CODE_DEVICE_AUTH_SCOPE = "user:inference";
+const CLAUDE_CODE_DEVICE_AUTH_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
+const CLAUDE_CODE_DEVICE_AUTH_SESSION_TTL_SECONDS = 15 * 60;
+const CLAUDE_CODE_DEVICE_AUTH_CONNECTOR_TYPE = "claude-code-oauth-token";
+const CLAUDE_CODE_DEVICE_AUTH_SOURCE = "claude-code-device-auth";
+
+const claudeCodeDeviceAuthSessionTokenSchema = z.object({
+  version: z.literal(1),
+  sessionId: z.string().uuid(),
+});
+
+const claudeCodeDeviceAuthProviderStateSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("claude-code"),
+  scope: z.enum(["org", "personal"]),
+  state: z.string().min(1),
+  codeVerifier: z.string().min(1),
+});
+
+const claudeCodeOAuthTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+});
+
+type ClaudeCodeDeviceAuthSessionToken = z.infer<
+  typeof claudeCodeDeviceAuthSessionTokenSchema
+>;
+type ClaudeCodeDeviceAuthProviderState = z.infer<
+  typeof claudeCodeDeviceAuthProviderStateSchema
+>;
+type ConnectorCliAuthSession = typeof connectorCliAuthSessions.$inferSelect;
+type ConnectorCliAuthSessionStatus = ConnectorCliAuthSession["status"];
+const CLAUDE_CODE_DEVICE_AUTH_ACTIVE_STATUSES = [
+  "initializing",
+  "awaiting_user_approval",
+  "completing",
+] as const satisfies readonly ConnectorCliAuthSessionStatus[];
+
+type ClaudeCodeDeviceAuthFailureCode =
+  | "CLAUDE_CODE_DEVICE_AUTH_UNAVAILABLE"
+  | "CLAUDE_CODE_DEVICE_AUTH_FAILED"
+  | "CLAUDE_CODE_DEVICE_AUTH_EXPIRED";
+
+type ClaudeCodeDeviceAuthStartResult =
+  | {
+      readonly ok: true;
+      readonly sessionToken: string;
+      readonly scope: ClaudeCodeDeviceAuthScope;
+      readonly browserUrl: string;
+      readonly expiresIn: number;
+    }
+  | {
+      readonly ok: false;
+      readonly code: ClaudeCodeDeviceAuthFailureCode;
+      readonly message: string;
+    };
+
+type ClaudeCodeDeviceAuthCompleteResult =
+  | {
+      readonly status: "complete";
+      readonly body: {
+        readonly provider: ModelProviderResponse;
+        readonly created: boolean;
+      };
+    }
+  | {
+      readonly status: "invalid_token";
+      readonly message: string;
+    }
+  | {
+      readonly status: "forbidden";
+      readonly message: string;
+    }
+  | {
+      readonly status: "error";
+      readonly code: ClaudeCodeDeviceAuthFailureCode;
+      readonly message: string;
+    };
+
+type ClaudeCodeDeviceAuthCancelResult =
+  | { readonly status: "cancelled" }
+  | { readonly status: "invalid_token"; readonly message: string }
+  | { readonly status: "forbidden"; readonly message: string };
+
+type ClaudeCodeOAuthTokens = {
+  readonly accessToken: string;
+};
+
+function base64Url(input: Buffer): string {
+  return input
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function randomBase64Url(): string {
+  return base64Url(randomBytes(32));
+}
+
+function codeChallenge(verifier: string): string {
+  return base64Url(createHash("sha256").update(verifier).digest());
+}
+
+function encodeSession(payload: ClaudeCodeDeviceAuthSessionToken): string {
+  return encryptSecretValue(JSON.stringify(payload));
+}
+
+function encodeProviderState(
+  payload: ClaudeCodeDeviceAuthProviderState,
+): string {
+  return encryptSecretValue(JSON.stringify(payload));
+}
+
+function decodeSession(token: string): ClaudeCodeDeviceAuthSessionToken | null {
+  const decoded = safeSync(() => {
+    const parsed = claudeCodeDeviceAuthSessionTokenSchema.safeParse(
+      safeJsonParse(decryptSecretValue(token)),
+    );
+    return parsed.success ? parsed.data : null;
+  });
+  if ("error" in decoded) {
+    return null;
+  }
+  return decoded.ok;
+}
+
+function decodeProviderState(
+  encryptedProviderState: string | null,
+): ClaudeCodeDeviceAuthProviderState | null {
+  if (!encryptedProviderState) {
+    return null;
+  }
+  const decoded = safeSync(() => {
+    const parsed = claudeCodeDeviceAuthProviderStateSchema.safeParse(
+      safeJsonParse(decryptSecretValue(encryptedProviderState)),
+    );
+    return parsed.success ? parsed.data : null;
+  });
+  if ("error" in decoded) {
+    return null;
+  }
+  return decoded.ok;
+}
+
+function expiresAt(now: Date): Date {
+  return new Date(
+    now.getTime() + CLAUDE_CODE_DEVICE_AUTH_SESSION_TTL_SECONDS * 1000,
+  );
+}
+
+function remainingTtlSeconds(expiresAtValue: Date, now: Date): number {
+  return Math.max(
+    1,
+    Math.ceil((expiresAtValue.getTime() - now.getTime()) / 1000),
+  );
+}
+
+function sanitizeSessionError(message: string): string {
+  return message.slice(0, 500);
+}
+
+function unknownErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function terminalSessionSet(args: {
+  readonly status: Extract<
+    ConnectorCliAuthSessionStatus,
+    "cancelled" | "error" | "expired" | "imported"
+  >;
+  readonly now: Date;
+  readonly message?: string | null;
+}) {
+  return {
+    status: args.status,
+    approvalUrl: null,
+    verificationCode: null,
+    encryptedProviderState: null,
+    errorMessage: args.message ? sanitizeSessionError(args.message) : null,
+    completedAt: args.status === "imported" ? args.now : null,
+    cancelledAt: args.status === "cancelled" ? args.now : null,
+    updatedAt: args.now,
+  };
+}
+
+function ownerWhere(args: { readonly orgId: string; readonly userId: string }) {
+  return and(
+    eq(connectorCliAuthSessions.orgId, args.orgId),
+    eq(connectorCliAuthSessions.userId, args.userId),
+    eq(
+      connectorCliAuthSessions.connectorType,
+      CLAUDE_CODE_DEVICE_AUTH_CONNECTOR_TYPE,
+    ),
+    eq(connectorCliAuthSessions.source, CLAUDE_CODE_DEVICE_AUTH_SOURCE),
+  );
+}
+
+function sessionWhere(args: {
+  readonly sessionId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  return and(eq(connectorCliAuthSessions.id, args.sessionId), ownerWhere(args));
+}
+
+async function cancelActiveSessions(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly now: Date;
+}): Promise<void> {
+  await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalSessionSet({
+        status: "cancelled",
+        now: args.now,
+        message: "Claude Code device auth session was superseded",
+      }),
+    )
+    .where(
+      and(
+        ownerWhere(args),
+        inArray(connectorCliAuthSessions.status, [
+          ...CLAUDE_CODE_DEVICE_AUTH_ACTIVE_STATUSES,
+        ]),
+      ),
+    );
+}
+
+async function cancelSession(args: {
+  readonly writeDb: Db;
+  readonly sessionId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly message: string;
+}): Promise<void> {
+  await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalSessionSet({
+        status: "cancelled",
+        now: nowDate(),
+        message: args.message,
+      }),
+    )
+    .where(
+      and(
+        sessionWhere({
+          sessionId: args.sessionId,
+          orgId: args.orgId,
+          userId: args.userId,
+        }),
+        inArray(connectorCliAuthSessions.status, [
+          ...CLAUDE_CODE_DEVICE_AUTH_ACTIVE_STATUSES,
+        ]),
+      ),
+    );
+}
+
+async function createSession(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly expiresAt: Date;
+}): Promise<ConnectorCliAuthSession> {
+  const [session] = await args.writeDb
+    .insert(connectorCliAuthSessions)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorType: CLAUDE_CODE_DEVICE_AUTH_CONNECTOR_TYPE,
+      source: CLAUDE_CODE_DEVICE_AUTH_SOURCE,
+      status: "initializing",
+      expiresAt: args.expiresAt,
+    })
+    .returning();
+  if (!session) {
+    throw new Error("Failed to create Claude Code device auth session");
+  }
+  return session;
+}
+
+function registerStartAbortCancellation(args: {
+  readonly signal: AbortSignal;
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+  readonly orgId: string;
+  readonly userId: string;
+}): () => void {
+  const cleanupOnAbort = () => {
+    detach(
+      cancelSession({
+        writeDb: args.writeDb,
+        sessionId: args.session.id,
+        orgId: args.orgId,
+        userId: args.userId,
+        message: "Claude Code device auth session was cancelled",
+      }),
+      Mechanism.WaitUntil,
+      "cancel aborted Claude Code device auth session",
+    );
+  };
+  args.signal.addEventListener("abort", cleanupOnAbort, { once: true });
+  return () => {
+    args.signal.removeEventListener("abort", cleanupOnAbort);
+  };
+}
+
+async function markSessionError(args: {
+  readonly writeDb: Db;
+  readonly sessionId: string;
+  readonly message: string;
+}) {
+  await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalSessionSet({
+        status: "error",
+        now: nowDate(),
+        message: args.message,
+      }),
+    )
+    .where(eq(connectorCliAuthSessions.id, args.sessionId));
+}
+
+async function markSessionExpired(args: {
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+}) {
+  await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalSessionSet({
+        status: "expired",
+        now: nowDate(),
+      }),
+    )
+    .where(eq(connectorCliAuthSessions.id, args.session.id));
+}
+
+async function moveSessionToAwaitingApproval(args: {
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+  readonly scope: ClaudeCodeDeviceAuthScope;
+  readonly state: string;
+  readonly codeVerifier: string;
+  readonly approvalUrl: string;
+}): Promise<ConnectorCliAuthSession> {
+  const [updated] = await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set({
+      status: "awaiting_user_approval",
+      approvalUrl: args.approvalUrl,
+      verificationCode: null,
+      encryptedProviderState: encodeProviderState({
+        version: 1,
+        type: "claude-code",
+        scope: args.scope,
+        state: args.state,
+        codeVerifier: args.codeVerifier,
+      }),
+      updatedAt: nowDate(),
+    })
+    .where(eq(connectorCliAuthSessions.id, args.session.id))
+    .returning();
+  if (!updated) {
+    throw new Error("Failed to update Claude Code device auth session");
+  }
+  return updated;
+}
+
+function buildApprovalUrl(args: {
+  readonly state: string;
+  readonly codeVerifier: string;
+}): string {
+  const url = new URL(CLAUDE_CODE_DEVICE_AUTH_AUTHORIZE_URL);
+  url.searchParams.set("code", "true");
+  url.searchParams.set("client_id", CLAUDE_CODE_DEVICE_AUTH_CLIENT_ID);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("redirect_uri", CLAUDE_CODE_DEVICE_AUTH_REDIRECT_URI);
+  url.searchParams.set("scope", CLAUDE_CODE_DEVICE_AUTH_SCOPE);
+  url.searchParams.set("code_challenge", codeChallenge(args.codeVerifier));
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", args.state);
+  return url.toString();
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  const parsed = safeJsonParse(text);
+  if (parsed === undefined) {
+    throw new Error("Claude Code OAuth returned invalid JSON");
+  }
+  return parsed;
+}
+
+async function readErrorMessage(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  const text = await response.text();
+  const trimmed = text.trim();
+  return trimmed
+    ? `${fallback}: ${trimmed.slice(0, 500)}`
+    : `${fallback} with status ${response.status}`;
+}
+
+function parseAuthorizationCodeInput(args: {
+  readonly raw: string;
+  readonly expectedState: string;
+}): string {
+  const trimmed = args.raw.trim();
+  if (!trimmed) {
+    throw new Error("Paste the Claude Code authorization code to continue");
+  }
+
+  const fromUrl = safeSync(() => {
+    const url = new URL(trimmed);
+    return {
+      code: url.searchParams.get("code"),
+      state: url.searchParams.get("state"),
+    };
+  });
+  if (!("error" in fromUrl) && fromUrl.ok.code) {
+    assertStateMatches(fromUrl.ok.state, args.expectedState);
+    return fromUrl.ok.code;
+  }
+
+  const [code, state] = trimmed.split("#", 2);
+  if (!code) {
+    throw new Error("Claude Code authorization code is missing");
+  }
+  assertStateMatches(state ?? null, args.expectedState);
+  return code;
+}
+
+function assertStateMatches(
+  providedState: string | null,
+  expectedState: string,
+): void {
+  if (providedState && providedState !== expectedState) {
+    throw new Error(
+      "Claude Code authorization code belongs to another session",
+    );
+  }
+}
+
+async function exchangeClaudeCodeAuthorizationCode(args: {
+  readonly authorizationCode: string;
+  readonly state: string;
+  readonly codeVerifier: string;
+  readonly signal: AbortSignal;
+}): Promise<ClaudeCodeOAuthTokens> {
+  const response = await fetch(CLAUDE_CODE_DEVICE_AUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code: args.authorizationCode,
+      redirect_uri: CLAUDE_CODE_DEVICE_AUTH_REDIRECT_URI,
+      client_id: CLAUDE_CODE_DEVICE_AUTH_CLIENT_ID,
+      code_verifier: args.codeVerifier,
+      state: args.state,
+      expires_in: CLAUDE_CODE_DEVICE_AUTH_TOKEN_TTL_SECONDS,
+    }),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      await readErrorMessage(response, "Claude Code token exchange failed"),
+    );
+  }
+
+  const parsed = claudeCodeOAuthTokenResponseSchema.safeParse(
+    await readJsonResponse(response),
+  );
+  if (!parsed.success) {
+    throw new Error(
+      "Claude Code OAuth returned an unrecognized token response",
+    );
+  }
+  return { accessToken: parsed.data.access_token };
+}
+
+export async function startClaudeCodeDeviceAuth(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly scope: ClaudeCodeDeviceAuthScope;
+  readonly signal: AbortSignal;
+}): Promise<ClaudeCodeDeviceAuthStartResult> {
+  const startedAt = nowDate();
+  await cancelActiveSessions({
+    writeDb: args.writeDb,
+    orgId: args.orgId,
+    userId: args.userId,
+    now: startedAt,
+  });
+
+  const session = await createSession({
+    writeDb: args.writeDb,
+    orgId: args.orgId,
+    userId: args.userId,
+    expiresAt: expiresAt(startedAt),
+  });
+  const unregisterAbortCancellation = registerStartAbortCancellation({
+    signal: args.signal,
+    writeDb: args.writeDb,
+    session,
+    orgId: args.orgId,
+    userId: args.userId,
+  });
+
+  const codeVerifier = randomBase64Url();
+  const state = randomBase64Url();
+  const approvalUrl = buildApprovalUrl({ state, codeVerifier });
+  const updatedResult = await onRejection(
+    settle(
+      moveSessionToAwaitingApproval({
+        writeDb: args.writeDb,
+        session,
+        scope: args.scope,
+        state,
+        codeVerifier,
+        approvalUrl,
+      }),
+      args.signal,
+    ),
+    unregisterAbortCancellation,
+  );
+  unregisterAbortCancellation();
+  args.signal.throwIfAborted();
+
+  if (!updatedResult.ok) {
+    const message = unknownErrorMessage(
+      updatedResult.error,
+      "Claude Code device auth session failed",
+    );
+    await markSessionError({
+      writeDb: args.writeDb,
+      sessionId: session.id,
+      message,
+    });
+    return {
+      ok: false,
+      code: "CLAUDE_CODE_DEVICE_AUTH_UNAVAILABLE",
+      message,
+    };
+  }
+
+  return {
+    ok: true,
+    sessionToken: encodeSession({ version: 1, sessionId: session.id }),
+    scope: args.scope,
+    browserUrl: approvalUrl,
+    expiresIn: remainingTtlSeconds(updatedResult.value.expiresAt, nowDate()),
+  };
+}
+
+async function loadSession(args: {
+  readonly writeDb: Db;
+  readonly sessionId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<ConnectorCliAuthSession | null> {
+  const [session] = await args.writeDb
+    .select()
+    .from(connectorCliAuthSessions)
+    .where(sessionWhere(args))
+    .limit(1);
+  return session ?? null;
+}
+
+async function claimCompleting(args: {
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+}): Promise<boolean> {
+  const [updated] = await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set({ status: "completing", updatedAt: nowDate() })
+    .where(
+      and(
+        eq(connectorCliAuthSessions.id, args.session.id),
+        eq(connectorCliAuthSessions.status, "awaiting_user_approval"),
+      ),
+    )
+    .returning({ id: connectorCliAuthSessions.id });
+  return Boolean(updated);
+}
+
+async function markSessionImported(args: {
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+}) {
+  await args.writeDb
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalSessionSet({
+        status: "imported",
+        now: nowDate(),
+      }),
+    )
+    .where(eq(connectorCliAuthSessions.id, args.session.id));
+}
+
+function isSessionExpired(session: ConnectorCliAuthSession): boolean {
+  return session.expiresAt.getTime() <= nowDate().getTime();
+}
+
+function toModelProviderResponse(
+  provider: ModelProviderInfo,
+): ModelProviderResponse {
+  return {
+    id: provider.id,
+    type: provider.type,
+    framework: provider.framework,
+    secretName: provider.secretName,
+    authMethod: provider.authMethod,
+    secretNames: provider.secretNames,
+    isDefault: provider.isDefault,
+    selectedModel: provider.selectedModel,
+    workspaceName: provider.workspaceName,
+    planType: provider.planType,
+    needsReconnect: provider.needsReconnect,
+    lastRefreshErrorCode: provider.lastRefreshErrorCode,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  };
+}
+
+async function importClaudeCodeOAuthToken(args: {
+  readonly stateSet: Setter;
+  readonly scope: ClaudeCodeDeviceAuthScope;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly accessToken: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly provider: ModelProviderResponse;
+  readonly created: boolean;
+}> {
+  const result =
+    args.scope === "org"
+      ? await args.stateSet(
+          upsertOrgModelProvider$,
+          {
+            orgId: args.orgId,
+            type: CLAUDE_CODE_DEVICE_AUTH_CONNECTOR_TYPE,
+            secret: args.accessToken,
+          },
+          args.signal,
+        )
+      : await args.stateSet(
+          upsertUserModelProvider$,
+          {
+            orgId: args.orgId,
+            userId: args.userId,
+            type: CLAUDE_CODE_DEVICE_AUTH_CONNECTOR_TYPE,
+            secret: args.accessToken,
+          },
+          args.signal,
+        );
+  if ("status" in result) {
+    throw new Error(
+      "Claude Code OAuth token import returned an unexpected response",
+    );
+  }
+  return {
+    provider: toModelProviderResponse(result.provider),
+    created: result.created,
+  };
+}
+
+async function completeLoadedClaudeCodeDeviceAuth(args: {
+  readonly stateSet: Setter;
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly orgRole: "admin" | "member" | undefined;
+  readonly authorizationCode: string;
+  readonly signal: AbortSignal;
+}): Promise<ClaudeCodeDeviceAuthCompleteResult> {
+  const { writeDb, session, signal } = args;
+  if (isSessionExpired(session)) {
+    await markSessionExpired({ writeDb, session });
+    return {
+      status: "invalid_token",
+      message: "Claude Code device auth session expired",
+    };
+  }
+  if (session.status !== "awaiting_user_approval") {
+    return {
+      status: "invalid_token",
+      message: "Claude Code device auth session is not ready",
+    };
+  }
+
+  const providerState = decodeProviderState(session.encryptedProviderState);
+  if (!providerState) {
+    return {
+      status: "error",
+      code: "CLAUDE_CODE_DEVICE_AUTH_FAILED",
+      message: "Claude Code device auth session state is invalid",
+    };
+  }
+  if (providerState.scope === "org" && args.orgRole !== "admin") {
+    return {
+      status: "forbidden",
+      message: "Only admins can manage org model providers",
+    };
+  }
+
+  const parsedAuthorizationCode = safeSync(() => {
+    return parseAuthorizationCodeInput({
+      raw: args.authorizationCode,
+      expectedState: providerState.state,
+    });
+  });
+  if ("error" in parsedAuthorizationCode) {
+    return {
+      status: "invalid_token",
+      message: unknownErrorMessage(
+        parsedAuthorizationCode.error,
+        "Invalid Claude Code authorization code",
+      ),
+    };
+  }
+  const authorizationCode = parsedAuthorizationCode.ok;
+
+  const claimed = await claimCompleting({ writeDb, session });
+  signal.throwIfAborted();
+  if (!claimed) {
+    return {
+      status: "invalid_token",
+      message: "Claude Code device auth session is already completing",
+    };
+  }
+
+  return await importClaimedClaudeCodeDeviceAuth({
+    stateSet: args.stateSet,
+    writeDb,
+    session,
+    scope: providerState.scope,
+    orgId: args.orgId,
+    userId: args.userId,
+    authorizationCode,
+    state: providerState.state,
+    codeVerifier: providerState.codeVerifier,
+    signal,
+  });
+}
+
+async function importClaimedClaudeCodeDeviceAuth(args: {
+  readonly stateSet: Setter;
+  readonly writeDb: Db;
+  readonly session: ConnectorCliAuthSession;
+  readonly scope: ClaudeCodeDeviceAuthScope;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly authorizationCode: string;
+  readonly state: string;
+  readonly codeVerifier: string;
+  readonly signal: AbortSignal;
+}): Promise<ClaudeCodeDeviceAuthCompleteResult> {
+  const tokens = await settle(
+    exchangeClaudeCodeAuthorizationCode({
+      authorizationCode: args.authorizationCode,
+      state: args.state,
+      codeVerifier: args.codeVerifier,
+      signal: args.signal,
+    }),
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  if (!tokens.ok) {
+    const message = unknownErrorMessage(
+      tokens.error,
+      "Claude Code device auth token exchange failed",
+    );
+    await markSessionError({
+      writeDb: args.writeDb,
+      sessionId: args.session.id,
+      message,
+    });
+    return {
+      status: "error",
+      code: "CLAUDE_CODE_DEVICE_AUTH_FAILED",
+      message,
+    };
+  }
+
+  const imported = await settle(
+    importClaudeCodeOAuthToken({
+      stateSet: args.stateSet,
+      scope: args.scope,
+      orgId: args.orgId,
+      userId: args.userId,
+      accessToken: tokens.value.accessToken,
+      signal: args.signal,
+    }),
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  if (!imported.ok) {
+    const message = unknownErrorMessage(
+      imported.error,
+      "Claude Code device auth import failed",
+    );
+    await markSessionError({
+      writeDb: args.writeDb,
+      sessionId: args.session.id,
+      message,
+    });
+    return {
+      status: "error",
+      code: "CLAUDE_CODE_DEVICE_AUTH_FAILED",
+      message,
+    };
+  }
+
+  await markSessionImported({ writeDb: args.writeDb, session: args.session });
+  return {
+    status: "complete",
+    body: imported.value,
+  };
+}
+
+export const completeClaudeCodeDeviceAuth$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly orgRole: "admin" | "member" | undefined;
+      readonly sessionToken: string;
+      readonly authorizationCode: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ClaudeCodeDeviceAuthCompleteResult> => {
+    const decoded = decodeSession(args.sessionToken);
+    if (!decoded) {
+      return {
+        status: "invalid_token",
+        message: "Invalid Claude Code device auth session token",
+      };
+    }
+
+    const writeDb = set(writeDb$);
+    const session = await loadSession({
+      writeDb,
+      sessionId: decoded.sessionId,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+
+    if (!session) {
+      return {
+        status: "forbidden",
+        message: "Claude Code device auth session not found",
+      };
+    }
+    return await completeLoadedClaudeCodeDeviceAuth({
+      stateSet: set,
+      writeDb,
+      session,
+      orgId: args.orgId,
+      userId: args.userId,
+      orgRole: args.orgRole,
+      authorizationCode: args.authorizationCode,
+      signal,
+    });
+  },
+);
+
+export const cancelClaudeCodeDeviceAuth$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly sessionToken: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ClaudeCodeDeviceAuthCancelResult> => {
+    const decoded = decodeSession(args.sessionToken);
+    if (!decoded) {
+      return {
+        status: "invalid_token",
+        message: "Invalid Claude Code device auth session token",
+      };
+    }
+
+    const writeDb = set(writeDb$);
+    const session = await loadSession({
+      writeDb,
+      sessionId: decoded.sessionId,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+
+    if (!session) {
+      return {
+        status: "forbidden",
+        message: "Claude Code device auth session not found",
+      };
+    }
+
+    await cancelSession({
+      writeDb,
+      sessionId: session.id,
+      orgId: args.orgId,
+      userId: args.userId,
+      message: "Claude Code device auth session was cancelled",
+    });
+    signal.throwIfAborted();
+
+    return { status: "cancelled" };
+  },
+);
+
+export function claudeCodeDeviceAuthUnavailable(message: string) {
+  return {
+    status: 503 as const,
+    body: {
+      error: {
+        message,
+        code: "CLAUDE_CODE_DEVICE_AUTH_UNAVAILABLE",
+      },
+    },
+  };
+}

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -9,7 +9,7 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
-import { resetSignal, settle } from "../../utils.ts";
+import { onRef, resetSignal, settle } from "../../utils.ts";
 
 type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
 
@@ -573,6 +573,81 @@ export const runClaudeCodeDeviceAuthPersonal$ = command(
       signal: flowSignal,
     });
   },
+);
+
+const startClaudeCodeDeviceAuthOnRef$ = command(
+  async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
+    if (get(internalClaudeCodeDeviceAuthFlowState$).status !== "idle") {
+      return;
+    }
+    const flowSignal = set(resetClaudeCodeDeviceAuthFlowSignal$, signal);
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (get(internalClaudeCodeDeviceAuthFlowState$).status === "starting") {
+          set(internalClaudeCodeDeviceAuthFlowState$, createIdleFlowState());
+        }
+      },
+      { once: true },
+    );
+    await runClaudeCodeDeviceAuthFlow({
+      scope: "org",
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowState$, next);
+      },
+      signal: flowSignal,
+    });
+  },
+);
+
+const startClaudeCodeDeviceAuthPersonalOnRef$ = command(
+  async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
+    if (get(internalClaudeCodeDeviceAuthFlowStatePersonal$).status !== "idle") {
+      return;
+    }
+    const flowSignal = set(
+      resetClaudeCodeDeviceAuthFlowSignalPersonal$,
+      signal,
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (
+          get(internalClaudeCodeDeviceAuthFlowStatePersonal$).status ===
+          "starting"
+        ) {
+          set(
+            internalClaudeCodeDeviceAuthFlowStatePersonal$,
+            createIdleFlowState(),
+          );
+        }
+      },
+      { once: true },
+    );
+    await runClaudeCodeDeviceAuthFlow({
+      scope: "personal",
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowStatePersonal$, next);
+      },
+      signal: flowSignal,
+    });
+  },
+);
+
+export const claudeCodeDeviceAuthAutoStartRef$ = onRef(
+  startClaudeCodeDeviceAuthOnRef$,
+);
+
+export const claudeCodeDeviceAuthAutoStartRefPersonal$ = onRef(
+  startClaudeCodeDeviceAuthPersonalOnRef$,
 );
 
 export type { ClaudeCodeDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -1,0 +1,578 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import {
+  zeroClaudeCodeDeviceAuthContract,
+  type ClaudeCodeDeviceAuthScope,
+} from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
+
+import { ApiError, accept } from "../../../lib/accept.ts";
+import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
+import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
+import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
+import { resetSignal, settle } from "../../utils.ts";
+
+type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
+
+interface ClaudeCodeDeviceAuthDialogState {
+  open: boolean;
+  mode: ClaudeCodeDeviceAuthDialogMode;
+}
+
+type ActiveClaudeCodeDeviceAuthFlowState = {
+  readonly status: "pending" | "submitting";
+  readonly requestId: string;
+  readonly sessionToken: string;
+  readonly browserUrl: string;
+  readonly expiresAtMs: number;
+  readonly authorizationCode: string;
+  readonly approvalOpened: boolean;
+  readonly errorMessage: string | null;
+};
+
+type ClaudeCodeDeviceAuthFlowState =
+  | { readonly status: "idle" }
+  | { readonly status: "starting"; readonly requestId: string }
+  | ActiveClaudeCodeDeviceAuthFlowState
+  | { readonly status: "expired"; readonly message: string }
+  | { readonly status: "error"; readonly message: string };
+
+type FlowSetter = (next: ClaudeCodeDeviceAuthFlowState) => void;
+type FlowGetter = () => ClaudeCodeDeviceAuthFlowState;
+
+function createInitialDialogState(): ClaudeCodeDeviceAuthDialogState {
+  return {
+    open: false,
+    mode: "connect",
+  };
+}
+
+function createIdleFlowState(): ClaudeCodeDeviceAuthFlowState {
+  return { status: "idle" };
+}
+
+const internalClaudeCodeDeviceAuthDialogState$ =
+  state<ClaudeCodeDeviceAuthDialogState>(createInitialDialogState());
+const internalClaudeCodeDeviceAuthFlowState$ =
+  state<ClaudeCodeDeviceAuthFlowState>(createIdleFlowState());
+const internalClaudeCodeDeviceAuthDialogStatePersonal$ =
+  state<ClaudeCodeDeviceAuthDialogState>(createInitialDialogState());
+const internalClaudeCodeDeviceAuthFlowStatePersonal$ =
+  state<ClaudeCodeDeviceAuthFlowState>(createIdleFlowState());
+const resetClaudeCodeDeviceAuthFlowSignal$ = resetSignal();
+const resetClaudeCodeDeviceAuthFlowSignalPersonal$ = resetSignal();
+
+export const claudeCodeDeviceAuthDialogState$ = computed((get) => {
+  return get(internalClaudeCodeDeviceAuthDialogState$);
+});
+
+export const claudeCodeDeviceAuthFlowState$ = computed((get) => {
+  return get(internalClaudeCodeDeviceAuthFlowState$);
+});
+
+export const claudeCodeDeviceAuthDialogStatePersonal$ = computed((get) => {
+  return get(internalClaudeCodeDeviceAuthDialogStatePersonal$);
+});
+
+export const claudeCodeDeviceAuthFlowStatePersonal$ = computed((get) => {
+  return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+});
+
+export const setClaudeCodeDeviceAuthDialogState$ = command(
+  ({ set }, next: ClaudeCodeDeviceAuthDialogState) => {
+    set(internalClaudeCodeDeviceAuthDialogState$, next);
+    if (!next.open) {
+      set(resetClaudeCodeDeviceAuthFlowSignal$);
+      set(internalClaudeCodeDeviceAuthFlowState$, createIdleFlowState());
+    }
+  },
+);
+
+export const setClaudeCodeDeviceAuthDialogStatePersonal$ = command(
+  ({ set }, next: ClaudeCodeDeviceAuthDialogState) => {
+    set(internalClaudeCodeDeviceAuthDialogStatePersonal$, next);
+    if (!next.open) {
+      set(resetClaudeCodeDeviceAuthFlowSignalPersonal$);
+      set(
+        internalClaudeCodeDeviceAuthFlowStatePersonal$,
+        createIdleFlowState(),
+      );
+    }
+  },
+);
+
+function createRequestId(scope: ClaudeCodeDeviceAuthScope): string {
+  return `${scope}-claude-code-device-auth-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function secondsToMilliseconds(seconds: number): number {
+  return seconds * 1000;
+}
+
+function claudeCodeDeviceAuthErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+  return error instanceof Error
+    ? error.message
+    : "Claude Code connection failed";
+}
+
+function openApprovalPage(browserUrl: string): boolean {
+  const approvalWindow = window.open(browserUrl, "_blank");
+  if (!approvalWindow) {
+    return false;
+  }
+  approvalWindow.opener = null;
+  return true;
+}
+
+function isCurrentStarting(
+  stateValue: ClaudeCodeDeviceAuthFlowState,
+  requestId: string,
+): boolean {
+  return stateValue.status === "starting" && stateValue.requestId === requestId;
+}
+
+function isCurrentActive(
+  stateValue: ClaudeCodeDeviceAuthFlowState,
+  requestId: string,
+): stateValue is ActiveClaudeCodeDeviceAuthFlowState {
+  return (
+    (stateValue.status === "pending" || stateValue.status === "submitting") &&
+    stateValue.requestId === requestId
+  );
+}
+
+function isActive(
+  stateValue: ClaudeCodeDeviceAuthFlowState,
+): stateValue is ActiveClaudeCodeDeviceAuthFlowState {
+  return stateValue.status === "pending" || stateValue.status === "submitting";
+}
+
+async function startClaudeCodeDeviceAuth(args: {
+  readonly createClient: ZeroClientFactory;
+  readonly scope: ClaudeCodeDeviceAuthScope;
+  readonly signal: AbortSignal;
+}) {
+  const client = args.createClient(zeroClaudeCodeDeviceAuthContract);
+  const result = await accept(
+    client.start({
+      body: { scope: args.scope },
+      fetchOptions: { signal: args.signal },
+    }),
+    [200],
+    { toast: false },
+  );
+  return result.body;
+}
+
+async function completeClaudeCodeDeviceAuth(args: {
+  readonly createClient: ZeroClientFactory;
+  readonly sessionToken: string;
+  readonly authorizationCode: string;
+  readonly signal: AbortSignal;
+}) {
+  const client = args.createClient(zeroClaudeCodeDeviceAuthContract);
+  const result = await accept(
+    client.complete({
+      body: {
+        sessionToken: args.sessionToken,
+        authorizationCode: args.authorizationCode,
+      },
+      fetchOptions: { signal: args.signal },
+    }),
+    [200],
+    { toast: false },
+  );
+  return result.body;
+}
+
+async function cancelClaudeCodeDeviceAuth(args: {
+  readonly createClient: ZeroClientFactory;
+  readonly sessionToken: string;
+  readonly signal: AbortSignal;
+}) {
+  const client = args.createClient(zeroClaudeCodeDeviceAuthContract);
+  const result = await accept(
+    client.cancel({
+      body: { sessionToken: args.sessionToken },
+      fetchOptions: { signal: args.signal },
+    }),
+    [200],
+    { toast: false },
+  );
+  return result.body;
+}
+
+async function runClaudeCodeDeviceAuthFlow(args: {
+  readonly scope: ClaudeCodeDeviceAuthScope;
+  readonly createClient: ZeroClientFactory;
+  readonly getFlow: FlowGetter;
+  readonly setFlow: FlowSetter;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const requestId = createRequestId(args.scope);
+  args.setFlow({ status: "starting", requestId });
+
+  const started = await settle(
+    startClaudeCodeDeviceAuth({
+      createClient: args.createClient,
+      scope: args.scope,
+      signal: args.signal,
+    }),
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  if (!isCurrentStarting(args.getFlow(), requestId)) {
+    return false;
+  }
+  if (!started.ok) {
+    args.setFlow({
+      status: "error",
+      message: claudeCodeDeviceAuthErrorMessage(started.error),
+    });
+    return false;
+  }
+
+  args.setFlow({
+    status: "pending",
+    requestId,
+    sessionToken: started.value.sessionToken,
+    browserUrl: started.value.browserUrl,
+    expiresAtMs: Date.now() + secondsToMilliseconds(started.value.expiresIn),
+    authorizationCode: "",
+    approvalOpened: false,
+    errorMessage: null,
+  });
+  return true;
+}
+
+function openClaudeCodeDeviceAuthApprovalPage(args: {
+  readonly getFlow: FlowGetter;
+  readonly setFlow: FlowSetter;
+  readonly signal: AbortSignal;
+}): boolean {
+  const current = args.getFlow();
+  if (!isActive(current)) {
+    return false;
+  }
+  const opened = openApprovalPage(current.browserUrl);
+  args.signal.throwIfAborted();
+  const latest = args.getFlow();
+  if (!isCurrentActive(latest, current.requestId)) {
+    return opened;
+  }
+  args.setFlow({
+    ...latest,
+    approvalOpened: opened || latest.approvalOpened,
+    errorMessage: opened
+      ? null
+      : "The approval page could not be opened. Use the link manually and paste the code here.",
+  });
+  return opened;
+}
+
+function setAuthorizationCode(args: {
+  readonly getFlow: FlowGetter;
+  readonly setFlow: FlowSetter;
+  readonly authorizationCode: string;
+}): void {
+  const current = args.getFlow();
+  if (!isActive(current)) {
+    return;
+  }
+  args.setFlow({
+    ...current,
+    authorizationCode: args.authorizationCode,
+    errorMessage: null,
+  });
+}
+
+async function submitClaudeCodeDeviceAuth(args: {
+  readonly createClient: ZeroClientFactory;
+  readonly getFlow: FlowGetter;
+  readonly setFlow: FlowSetter;
+  readonly reloadProviders: () => void;
+  readonly closeDialog: () => void;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const current = args.getFlow();
+  if (!isActive(current)) {
+    return false;
+  }
+  if (current.expiresAtMs <= Date.now()) {
+    args.setFlow({
+      status: "expired",
+      message: "Claude Code connection session expired. Start again to retry.",
+    });
+    return false;
+  }
+  if (!current.authorizationCode.trim()) {
+    args.setFlow({
+      ...current,
+      errorMessage: "Paste the Claude Code authorization code to continue.",
+    });
+    return false;
+  }
+
+  args.setFlow({ ...current, status: "submitting", errorMessage: null });
+  const completed = await settle(
+    completeClaudeCodeDeviceAuth({
+      createClient: args.createClient,
+      sessionToken: current.sessionToken,
+      authorizationCode: current.authorizationCode,
+      signal: args.signal,
+    }),
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  const latest = args.getFlow();
+  if (!isCurrentActive(latest, current.requestId)) {
+    return false;
+  }
+  if (!completed.ok) {
+    const message = claudeCodeDeviceAuthErrorMessage(completed.error);
+    if (completed.error instanceof ApiError && completed.error.status === 400) {
+      args.setFlow({
+        ...latest,
+        status: "pending",
+        errorMessage: message,
+      });
+      return false;
+    }
+    args.setFlow({ status: "error", message });
+    return false;
+  }
+
+  args.reloadProviders();
+  toast.success("Claude Code connected");
+  args.closeDialog();
+  return true;
+}
+
+async function closeClaudeCodeDeviceAuthDialog(args: {
+  readonly createClient: ZeroClientFactory;
+  readonly getFlow: FlowGetter;
+  readonly setFlow: FlowSetter;
+  readonly closeDialog: () => void;
+  readonly resetFlow: () => void;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const current = args.getFlow();
+  const sessionToken = isActive(current) ? current.sessionToken : null;
+  args.resetFlow();
+  args.closeDialog();
+  args.setFlow(createIdleFlowState());
+
+  if (!sessionToken) {
+    return;
+  }
+
+  await settle(
+    cancelClaudeCodeDeviceAuth({
+      createClient: args.createClient,
+      sessionToken,
+      signal: args.signal,
+    }),
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+}
+
+export const openClaudeCodeDeviceAuthApprovalPage$ = command(
+  ({ get, set }, signal: AbortSignal) => {
+    return openClaudeCodeDeviceAuthApprovalPage({
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowState$, next);
+      },
+      signal,
+    });
+  },
+);
+
+export const openClaudeCodeDeviceAuthApprovalPagePersonal$ = command(
+  ({ get, set }, signal: AbortSignal) => {
+    return openClaudeCodeDeviceAuthApprovalPage({
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowStatePersonal$, next);
+      },
+      signal,
+    });
+  },
+);
+
+export const setClaudeCodeDeviceAuthAuthorizationCode$ = command(
+  ({ get, set }, authorizationCode: string) => {
+    setAuthorizationCode({
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowState$, next);
+      },
+      authorizationCode,
+    });
+  },
+);
+
+export const setClaudeCodeDeviceAuthAuthorizationCodePersonal$ = command(
+  ({ get, set }, authorizationCode: string) => {
+    setAuthorizationCode({
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowStatePersonal$, next);
+      },
+      authorizationCode,
+    });
+  },
+);
+
+export const submitClaudeCodeDeviceAuth$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    return await submitClaudeCodeDeviceAuth({
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowState$, next);
+      },
+      reloadProviders: () => {
+        set(reloadOrgModelProviders$);
+      },
+      closeDialog: () => {
+        set(
+          internalClaudeCodeDeviceAuthDialogState$,
+          createInitialDialogState(),
+        );
+        set(internalClaudeCodeDeviceAuthFlowState$, createIdleFlowState());
+      },
+      signal,
+    });
+  },
+);
+
+export const submitClaudeCodeDeviceAuthPersonal$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    return await submitClaudeCodeDeviceAuth({
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowStatePersonal$, next);
+      },
+      reloadProviders: () => {
+        set(reloadPersonalModelProviders$);
+      },
+      closeDialog: () => {
+        set(
+          internalClaudeCodeDeviceAuthDialogStatePersonal$,
+          createInitialDialogState(),
+        );
+        set(
+          internalClaudeCodeDeviceAuthFlowStatePersonal$,
+          createIdleFlowState(),
+        );
+      },
+      signal,
+    });
+  },
+);
+
+export const closeClaudeCodeDeviceAuthDialog$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    await closeClaudeCodeDeviceAuthDialog({
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowState$, next);
+      },
+      closeDialog: () => {
+        set(
+          internalClaudeCodeDeviceAuthDialogState$,
+          createInitialDialogState(),
+        );
+      },
+      resetFlow: () => {
+        set(resetClaudeCodeDeviceAuthFlowSignal$);
+      },
+      signal,
+    });
+  },
+);
+
+export const closeClaudeCodeDeviceAuthDialogPersonal$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    await closeClaudeCodeDeviceAuthDialog({
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowStatePersonal$, next);
+      },
+      closeDialog: () => {
+        set(
+          internalClaudeCodeDeviceAuthDialogStatePersonal$,
+          createInitialDialogState(),
+        );
+      },
+      resetFlow: () => {
+        set(resetClaudeCodeDeviceAuthFlowSignalPersonal$);
+      },
+      signal,
+    });
+  },
+);
+
+export const runClaudeCodeDeviceAuth$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    const flowSignal = set(resetClaudeCodeDeviceAuthFlowSignal$, signal);
+    return await runClaudeCodeDeviceAuthFlow({
+      scope: "org",
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowState$, next);
+      },
+      signal: flowSignal,
+    });
+  },
+);
+
+export const runClaudeCodeDeviceAuthPersonal$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    const flowSignal = set(
+      resetClaudeCodeDeviceAuthFlowSignalPersonal$,
+      signal,
+    );
+    return await runClaudeCodeDeviceAuthFlow({
+      scope: "personal",
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalClaudeCodeDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalClaudeCodeDeviceAuthFlowStatePersonal$, next);
+      },
+      signal: flowSignal,
+    });
+  },
+);
+
+export type { ClaudeCodeDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -10,7 +10,7 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
-import { resetSignal, settle } from "../../utils.ts";
+import { onRef, resetSignal, settle } from "../../utils.ts";
 import { writeToClipboard } from "../clipboard.ts";
 
 type CodexDeviceAuthDialogMode = "connect" | "reconnect";
@@ -552,6 +552,89 @@ export const runCodexDeviceAuthPersonal$ = command(
       signal: flowSignal,
     });
   },
+);
+
+const startCodexDeviceAuthOnRef$ = command(
+  async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
+    if (get(internalCodexDeviceAuthFlowState$).status !== "idle") {
+      return;
+    }
+    const flowSignal = set(resetCodexDeviceAuthFlowSignal$, signal);
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (get(internalCodexDeviceAuthFlowState$).status === "starting") {
+          set(internalCodexDeviceAuthFlowState$, createIdleFlowState());
+        }
+      },
+      { once: true },
+    );
+    await runCodexDeviceAuthFlow({
+      scope: "org",
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalCodexDeviceAuthFlowState$);
+      },
+      setFlow: (next) => {
+        set(internalCodexDeviceAuthFlowState$, next);
+      },
+      reloadProviders: () => {
+        set(reloadOrgModelProviders$);
+      },
+      closeDialog: () => {
+        set(internalCodexDeviceAuthDialogState$, createInitialDialogState());
+        set(internalCodexDeviceAuthFlowState$, createIdleFlowState());
+      },
+      signal: flowSignal,
+    });
+  },
+);
+
+const startCodexDeviceAuthPersonalOnRef$ = command(
+  async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
+    if (get(internalCodexDeviceAuthFlowStatePersonal$).status !== "idle") {
+      return;
+    }
+    const flowSignal = set(resetCodexDeviceAuthFlowSignalPersonal$, signal);
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (
+          get(internalCodexDeviceAuthFlowStatePersonal$).status === "starting"
+        ) {
+          set(internalCodexDeviceAuthFlowStatePersonal$, createIdleFlowState());
+        }
+      },
+      { once: true },
+    );
+    await runCodexDeviceAuthFlow({
+      scope: "personal",
+      createClient: get(zeroClient$),
+      getFlow: () => {
+        return get(internalCodexDeviceAuthFlowStatePersonal$);
+      },
+      setFlow: (next) => {
+        set(internalCodexDeviceAuthFlowStatePersonal$, next);
+      },
+      reloadProviders: () => {
+        set(reloadPersonalModelProviders$);
+      },
+      closeDialog: () => {
+        set(
+          internalCodexDeviceAuthDialogStatePersonal$,
+          createInitialDialogState(),
+        );
+        set(internalCodexDeviceAuthFlowStatePersonal$, createIdleFlowState());
+      },
+      signal: flowSignal,
+    });
+  },
+);
+
+export const codexDeviceAuthAutoStartRef$ = onRef(startCodexDeviceAuthOnRef$);
+
+export const codexDeviceAuthAutoStartRefPersonal$ = onRef(
+  startCodexDeviceAuthPersonalOnRef$,
 );
 
 export type { CodexDeviceAuthFlowState };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -376,8 +376,11 @@ describe("chat composer — default model resolution", () => {
     await expectComposerShowsModel("Claude Opus 4.7");
   });
 
-  it("blocks agent chat submit and opens Claude Code OAuth token input from the model warning", async () => {
+  it("blocks agent chat submit and opens Claude Code device login from the model warning", async () => {
     const user = userEvent.setup();
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ closed: true } as Window);
     let sendRequests = 0;
     setMockFeatureSwitches({});
     setMockOrgModelPolicies([buildMemberOauthPolicy()]);
@@ -424,14 +427,10 @@ describe("chat composer — default model resolution", () => {
 
     await user.click(warning);
     await expect(
-      screen.findByText("Configure Claude Code OAuth"),
+      screen.findByTestId("claude-code-device-auth-start"),
     ).resolves.toBeInTheDocument();
-    await fill(screen.getByPlaceholderText("sk-ant-XXXXXXX"), "oauth-token");
-    await user.click(screen.getByText("Save"));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Send")).not.toBeDisabled();
-    });
+    expect(screen.getByText("Connect Claude Code")).toBeInTheDocument();
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it("blocks agent chat submit and opens ChatGPT device login from the model warning", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -33,6 +33,8 @@ import {
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
+import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 import type {
   ModelProviderResponse,
   OrgModelPolicy,
@@ -396,6 +398,16 @@ describe("chat composer — default model resolution", () => {
           createdAt: "2026-03-10T00:00:00Z",
         });
       }),
+      mockApi(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-claude-code-device-session",
+          type: "claude-code",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://claude.com/cai/oauth/authorize?code=true",
+          expiresIn: 30,
+        });
+      }),
     );
 
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
@@ -427,7 +439,7 @@ describe("chat composer — default model resolution", () => {
 
     await user.click(warning);
     await expect(
-      screen.findByTestId("claude-code-device-auth-start"),
+      screen.findByTestId("claude-code-device-auth-code"),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("Connect Claude Code")).toBeInTheDocument();
     expect(openSpy).not.toHaveBeenCalled();
@@ -459,6 +471,21 @@ describe("chat composer — default model resolution", () => {
           createdAt: "2026-03-10T00:00:00Z",
         });
       }),
+      mockApi(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-codex-device-session",
+          type: "codex",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://auth.openai.com/codex/device",
+          verificationCode: "ABCD-EFGH",
+          expiresIn: 30,
+          interval: 1,
+        });
+      }),
+      mockApi(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+        return respond(200, { status: "pending", errorMessage: null });
+      }),
     );
 
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
@@ -481,8 +508,8 @@ describe("chat composer — default model resolution", () => {
     await user.click(warning);
 
     await expect(
-      screen.findByTestId("codex-device-auth-start"),
-    ).resolves.toBeInTheDocument();
+      screen.findByTestId("codex-device-auth-code"),
+    ).resolves.toHaveTextContent("ABCD-EFGH");
     expect(screen.getByText("Connect Codex")).toBeInTheDocument();
     expect(openSpy).not.toHaveBeenCalled();
   });
@@ -535,6 +562,21 @@ describe("chat composer — default model resolution", () => {
           createdAt: "2026-03-10T00:00:00Z",
         });
       }),
+      mockApi(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-codex-device-session",
+          type: "codex",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://auth.openai.com/codex/device",
+          verificationCode: "ABCD-EFGH",
+          expiresIn: 30,
+          interval: 1,
+        });
+      }),
+      mockApi(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+        return respond(200, { status: "pending", errorMessage: null });
+      }),
     );
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
@@ -556,8 +598,8 @@ describe("chat composer — default model resolution", () => {
     await user.click(warning);
 
     await expect(
-      screen.findByTestId("codex-device-auth-start"),
-    ).resolves.toBeInTheDocument();
+      screen.findByTestId("codex-device-auth-code"),
+    ).resolves.toHaveTextContent("ABCD-EFGH");
     expect(screen.getByText("Connect Codex")).toBeInTheDocument();
     expect(openSpy).not.toHaveBeenCalled();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
@@ -4,7 +4,7 @@
  * Covers:
  * - Card visible by default
  * - Click on the card opens the Codex device login dialog
- * - Device auth starts on the dialog Connect click, shows the device code, and
+ * - Device auth starts when the dialog opens, shows the device code, and
  *   waits for an explicit click before copying the code and opening OpenAI
  */
 
@@ -61,6 +61,18 @@ describe("connect Claude Code card — click handler", () => {
   });
 
   it("opens the Claude Code device login dialog when the card is clicked", async () => {
+    server.use(
+      mockApi(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-claude-code-device-session",
+          type: "claude-code",
+          status: "pending",
+          scope: "org",
+          browserUrl: "https://claude.com/cai/oauth/authorize?code=true",
+          expiresIn: 30,
+        });
+      }),
+    );
     await openProvidersPage();
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
@@ -73,10 +85,14 @@ describe("connect Claude Code card — click handler", () => {
         screen.getByRole("dialog", { name: /Connect Claude Code/i }),
       ).toBeInTheDocument();
     });
+    await expect(
+      screen.findByTestId("claude-code-device-auth-code"),
+    ).resolves.toBeInTheDocument();
     expect(
-      screen.getByTestId("claude-code-device-auth-start"),
+      screen.getByText(/First click Open Claude approval page/),
     ).toBeInTheDocument();
-    expect(screen.getByText("Sign in with Claude")).toBeInTheDocument();
+    expect(screen.getByText("Open Claude approval page")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in with Claude")).not.toBeInTheDocument();
   });
 
   it("starts Claude Code auth, opens approval, and submits the callback code", async () => {
@@ -128,7 +144,6 @@ describe("connect Claude Code card — click handler", () => {
     click(
       await screen.findByTestId("org-provider-card-claude-code-oauth-token"),
     );
-    click(await screen.findByTestId("claude-code-device-auth-start"));
     await expect(
       screen.findByTestId("claude-code-device-auth-code"),
     ).resolves.toBeInTheDocument();
@@ -171,6 +186,23 @@ describe("connect Codex card — click handler", () => {
   });
 
   it("opens the device login dialog when the codex card is clicked", async () => {
+    server.use(
+      mockApi(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-codex-device-session",
+          type: "codex",
+          status: "pending",
+          scope: "org",
+          browserUrl: "https://auth.openai.com/codex/device",
+          verificationCode: "ABCD-EFGH",
+          expiresIn: 30,
+          interval: 1,
+        });
+      }),
+      mockApi(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+        return respond(200, { status: "pending", errorMessage: null });
+      }),
+    );
     await openProvidersPage();
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
@@ -184,11 +216,21 @@ describe("connect Codex card — click handler", () => {
         screen.getByRole("dialog", { name: /Connect Codex/i }),
       ).toBeInTheDocument();
     });
-    expect(screen.getByTestId("codex-device-auth-start")).toBeInTheDocument();
-    expect(screen.getByText("Sign in with ChatGPT")).toBeInTheDocument();
+    await expect(
+      screen.findByTestId("codex-device-auth-code"),
+    ).resolves.toHaveTextContent("ABCD-EFGH");
+    expect(screen.getByLabelText("Copy to clipboard")).toBeInTheDocument();
+    expect(
+      screen.getByText(/First click Copy code and open approval page/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Copy code and open approval page"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Sign in with ChatGPT")).not.toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
-  it("keeps the connect button visible and loading while preparing", async () => {
+  it("shows only loading while preparing", async () => {
     server.use(
       mockApi(zeroCodexDeviceAuthContract.start, async ({ never }) => {
         return await never();
@@ -199,13 +241,15 @@ describe("connect Codex card — click handler", () => {
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
     click(await screen.findByTestId("org-provider-card-codex-oauth-token"));
-    click(await screen.findByTestId("codex-device-auth-start"));
 
     await waitFor(() => {
-      const startButton = screen.getByTestId("codex-device-auth-start");
-      expect(startButton).toBeDisabled();
-      expect(startButton).toHaveTextContent("Preparing...");
+      expect(screen.getByTestId("codex-device-auth-loading")).toHaveTextContent(
+        "Preparing...",
+      );
     });
+    expect(
+      screen.queryByTestId("codex-device-auth-start"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Preparing Codex login…"),
     ).not.toBeInTheDocument();
@@ -278,13 +322,13 @@ describe("connect Codex card — click handler", () => {
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
     click(await screen.findByTestId("org-provider-card-codex-oauth-token"));
-    click(await screen.findByTestId("codex-device-auth-start"));
 
     await expect(
       screen.findByTestId("codex-device-auth-code"),
     ).resolves.toHaveTextContent("ABCD-EFGH");
     expect(open).not.toHaveBeenCalled();
     expect(writeText).not.toHaveBeenCalled();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
     click(screen.getByTestId("codex-device-auth-open"));
 
@@ -295,6 +339,9 @@ describe("connect Codex card — click handler", () => {
         "_blank",
       );
     });
+    await expect(screen.findByRole("status")).resolves.toHaveTextContent(
+      "Device code copied. Waiting for approval...",
+    );
     expect(resolveComplete).toBeDefined();
     resolveComplete?.();
 
@@ -336,7 +383,6 @@ describe("connect Codex card — click handler", () => {
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
     click(await screen.findByTestId("org-provider-card-codex-oauth-token"));
-    click(await screen.findByTestId("codex-device-auth-start"));
 
     await expect(
       screen.findByTestId("codex-device-auth-code"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
@@ -10,9 +10,14 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
+import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
 import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  fill,
+} from "../../../__tests__/page-helper.ts";
 import { setOrgAddProviderDialogOpen$ } from "../../../signals/zero-page/settings/org-model-providers.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
 import { resetMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-providers.ts";
@@ -45,6 +50,116 @@ describe("connect ChatGPT card", () => {
       expect(
         screen.getByTestId("org-provider-card-codex-oauth-token"),
       ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("connect Claude Code card — click handler", () => {
+  beforeEach(() => {
+    setMockFeatureSwitches({});
+    resetMockOrgModelProviders();
+  });
+
+  it("opens the Claude Code device login dialog when the card is clicked", async () => {
+    await openProvidersPage();
+    context.store.set(setOrgAddProviderDialogOpen$, true);
+
+    click(
+      await screen.findByTestId("org-provider-card-claude-code-oauth-token"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /Connect Claude Code/i }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("claude-code-device-auth-start"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sign in with Claude")).toBeInTheDocument();
+  });
+
+  it("starts Claude Code auth, opens approval, and submits the callback code", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue({} as Window);
+    const completeBodies: unknown[] = [];
+    server.use(
+      mockApi(zeroClaudeCodeDeviceAuthContract.start, ({ body, respond }) => {
+        expect(body).toStrictEqual({ scope: "org" });
+        return respond(200, {
+          sessionToken: "mock-claude-code-device-session",
+          type: "claude-code",
+          status: "pending",
+          scope: "org",
+          browserUrl: "https://claude.com/cai/oauth/authorize?code=true",
+          expiresIn: 30,
+        });
+      }),
+      mockApi(
+        zeroClaudeCodeDeviceAuthContract.complete,
+        ({ body, respond }) => {
+          completeBodies.push(body);
+          return respond(200, {
+            status: "complete",
+            created: true,
+            provider: {
+              id: "00000000-0000-4000-a000-000000000140",
+              type: "claude-code-oauth-token",
+              framework: "claude-code",
+              secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+              authMethod: null,
+              secretNames: null,
+              isDefault: false,
+              selectedModel: null,
+              workspaceName: null,
+              planType: null,
+              needsReconnect: false,
+              lastRefreshErrorCode: null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          });
+        },
+      ),
+    );
+
+    await openProvidersPage();
+    context.store.set(setOrgAddProviderDialogOpen$, true);
+
+    click(
+      await screen.findByTestId("org-provider-card-claude-code-oauth-token"),
+    );
+    click(await screen.findByTestId("claude-code-device-auth-start"));
+    await expect(
+      screen.findByTestId("claude-code-device-auth-code"),
+    ).resolves.toBeInTheDocument();
+    expect(open).not.toHaveBeenCalled();
+
+    click(screen.getByTestId("claude-code-device-auth-open"));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        "https://claude.com/cai/oauth/authorize?code=true",
+        "_blank",
+      );
+    });
+    await fill(
+      screen.getByTestId("claude-code-device-auth-code"),
+      "auth_code#state",
+    );
+    click(screen.getByTestId("claude-code-device-auth-submit"));
+
+    await waitFor(() => {
+      expect(completeBodies).toStrictEqual([
+        {
+          sessionToken: "mock-claude-code-device-session",
+          authorizationCode: "auth_code#state",
+        },
+      ]);
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: /Connect Claude Code/i }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -84,6 +84,7 @@ import {
   usePersonalOauthConfigurationAction,
 } from "./model-first-oauth-submit-blocker.ts";
 import { PersonalProviderDialog } from "./components/settings/personal-provider-dialog.tsx";
+import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
 
 function getTagline(
@@ -626,6 +627,7 @@ export function AgentChatPage() {
         </div>
       </main>
       <PersonalProviderDialog />
+      <PersonalClaudeCodeDeviceAuthDialog />
       <PersonalCodexDeviceAuthDialog />
       {lightboxUrl && <AttachmentLightbox />}
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -407,6 +407,23 @@ describe("org-providers-tab — stale banner reconnect", () => {
   it("opens the device login dialog in reconnect mode when Reconnect is clicked", async () => {
     setMockFeatureSwitches({});
     setMockOrgModelProviders([makeStaleProvider()]);
+    server.use(
+      mockApi(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-codex-device-session",
+          type: "codex",
+          status: "pending",
+          scope: "org",
+          browserUrl: "https://auth.openai.com/codex/device",
+          verificationCode: "ABCD-EFGH",
+          expiresIn: 30,
+          interval: 1,
+        });
+      }),
+      mockApi(zeroCodexDeviceAuthContract.complete, async ({ never }) => {
+        return await never();
+      }),
+    );
     await openProvidersPage();
 
     click(await findReconnectButton());
@@ -414,8 +431,15 @@ describe("org-providers-tab — stale banner reconnect", () => {
     await waitFor(() => {
       expect(findReconnectDialogTitle()).toBeInTheDocument();
     });
-    expect(screen.getByTestId("codex-device-auth-start")).toBeInTheDocument();
-    expect(screen.getByText("Reconnect ChatGPT")).toBeInTheDocument();
+    await expect(
+      screen.findByTestId("codex-device-auth-code"),
+    ).resolves.toHaveTextContent("ABCD-EFGH");
+    expect(
+      screen.getByText("Copy code and open approval page"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("codex-device-auth-start"),
+    ).not.toBeInTheDocument();
   });
 
   it("clears the stale banner after a successful reconnect", async () => {
@@ -454,7 +478,6 @@ describe("org-providers-tab — stale banner reconnect", () => {
     });
 
     click(await findReconnectButton());
-    click(await screen.findByTestId("codex-device-auth-start"));
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -7,11 +7,16 @@ import {
   setOrgAddProviderDialogOpen$,
   orgConfiguredProviders$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
+import { setClaudeCodeDeviceAuthDialogState$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogState$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import { OrgAddProviderDialog } from "../settings/org-add-provider-dialog.tsx";
 import { OrgProviderDialog } from "../settings/org-provider-dialog.tsx";
 import { OrgDeleteProviderDialog } from "../settings/org-delete-provider-dialog.tsx";
+import {
+  ClaudeCodeDeviceAuthDialog,
+  PersonalClaudeCodeDeviceAuthDialog,
+} from "../settings/claude-code-device-auth-dialog.tsx";
 import {
   CodexDeviceAuthDialog,
   PersonalCodexDeviceAuthDialog,
@@ -38,10 +43,12 @@ export function OrgProvidersTab() {
       )}
       <OrgDeleteProviderDialog />
       <OrgProviderDialog />
+      <ClaudeCodeDeviceAuthDialog />
       <CodexDeviceAuthDialog />
       {isAdmin && (
         <>
           <PersonalProviderDialog />
+          <PersonalClaudeCodeDeviceAuthDialog />
           <PersonalCodexDeviceAuthDialog />
         </>
       )}
@@ -68,13 +75,19 @@ function StaleProviderBanner({
 }: {
   providers: ModelProviderResponse[];
 }) {
+  const setClaudeCodeDeviceDialog = useSet(setClaudeCodeDeviceAuthDialogState$);
   const setDeviceDialog = useSet(setCodexDeviceAuthDialogState$);
   const stale = providers.find((p) => {
-    return p.type === "codex-oauth-token" && p.needsReconnect;
+    return (
+      (p.type === "claude-code-oauth-token" ||
+        p.type === "codex-oauth-token") &&
+      p.needsReconnect
+    );
   });
   if (!stale) {
     return null;
   }
+  const isClaudeCode = stale.type === "claude-code-oauth-token";
   return (
     <section
       className="flex items-center gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4"
@@ -82,15 +95,20 @@ function StaleProviderBanner({
     >
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium text-foreground">
-          ChatGPT session needs reconnection
+          {isClaudeCode
+            ? "Claude Code session needs reconnection"
+            : "ChatGPT session needs reconnection"}
         </p>
         <p className="mt-0.5 text-xs text-muted-foreground">
-          {staleMessage(stale.lastRefreshErrorCode)}
+          {staleMessage(stale)}
         </p>
       </div>
       <button
         type="button"
         onClick={() => {
+          if (isClaudeCode) {
+            return setClaudeCodeDeviceDialog({ open: true, mode: "reconnect" });
+          }
           return setDeviceDialog({ open: true, mode: "reconnect" });
         }}
         className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
@@ -101,10 +119,12 @@ function StaleProviderBanner({
   );
 }
 
-function staleMessage(code: string | null): string {
-  switch (code) {
+function staleMessage(provider: ModelProviderResponse): string {
+  switch (provider.lastRefreshErrorCode) {
     case "refresh_token_expired": {
-      return "Your ChatGPT session expired. Re-connect to continue.";
+      return provider.type === "claude-code-oauth-token"
+        ? "Your Claude Code session expired. Re-connect to continue."
+        : "Your ChatGPT session expired. Re-connect to continue.";
     }
     case "refresh_token_reused": {
       return "Your ChatGPT session was used elsewhere. Re-connect.";
@@ -113,7 +133,9 @@ function staleMessage(code: string | null): string {
       return "Your ChatGPT session was revoked. Re-connect.";
     }
     default: {
-      return "ChatGPT refresh failed. Re-connect to retry.";
+      return provider.type === "claude-code-oauth-token"
+        ? "Claude Code refresh failed. Re-connect to retry."
+        : "ChatGPT refresh failed. Re-connect to retry.";
     }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -4,6 +4,8 @@ import {
   zeroPersonalModelProvidersByTypeContract,
   zeroPersonalModelProvidersMainContract,
 } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
+import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 import type {
   ModelProviderResponse,
   ModelProviderType,
@@ -152,6 +154,18 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
   });
 
   it("opens the Claude Code device login dialog", async () => {
+    server.use(
+      mockApi(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-claude-code-device-session",
+          type: "claude-code",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://claude.com/cai/oauth/authorize?code=true",
+          expiresIn: 30,
+        });
+      }),
+    );
     setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
@@ -161,10 +175,14 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     click(await screen.findByLabelText("Connect Claude Code OAuth"));
 
     await expect(
-      screen.findByTestId("claude-code-device-auth-start"),
+      screen.findByTestId("claude-code-device-auth-code"),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("Connect Claude Code")).toBeInTheDocument();
-    expect(screen.getByText("Sign in with Claude")).toBeInTheDocument();
+    expect(
+      screen.getByText(/First click Open Claude approval page/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Open Claude approval page")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in with Claude")).not.toBeInTheDocument();
     expect(screen.queryByText("Select model")).not.toBeInTheDocument();
   });
 
@@ -281,6 +299,23 @@ describe("personal-providers-tab — ChatGPT (Codex) device login flow", () => {
     const openSpy = vi
       .spyOn(window, "open")
       .mockReturnValue({ closed: true } as Window);
+    server.use(
+      mockApi(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-codex-device-session",
+          type: "codex",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://auth.openai.com/codex/device",
+          verificationCode: "ABCD-EFGH",
+          expiresIn: 30,
+          interval: 1,
+        });
+      }),
+      mockApi(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+        return respond(200, { status: "pending", errorMessage: null });
+      }),
+    );
     setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
@@ -290,14 +325,37 @@ describe("personal-providers-tab — ChatGPT (Codex) device login flow", () => {
     click(await screen.findByLabelText("Connect ChatGPT (Codex)"));
 
     await expect(
-      screen.findByTestId("codex-device-auth-start"),
-    ).resolves.toBeInTheDocument();
+      screen.findByTestId("codex-device-auth-code"),
+    ).resolves.toHaveTextContent("ABCD-EFGH");
     expect(openSpy).not.toHaveBeenCalled();
     expect(screen.getByText("Connect Codex")).toBeInTheDocument();
-    expect(screen.getByText("Sign in with ChatGPT")).toBeInTheDocument();
+    expect(
+      screen.getByText(/First click Copy code and open approval page/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Copy code and open approval page"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Sign in with ChatGPT")).not.toBeInTheDocument();
   });
 
   it("opens the device reconnect dialog for stale ChatGPT (Codex)", async () => {
+    server.use(
+      mockApi(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+        return respond(200, {
+          sessionToken: "mock-codex-device-session",
+          type: "codex",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://auth.openai.com/codex/device",
+          verificationCode: "ABCD-EFGH",
+          expiresIn: 30,
+          interval: 1,
+        });
+      }),
+      mockApi(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+        return respond(200, { status: "pending", errorMessage: null });
+      }),
+    );
     setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([
@@ -323,8 +381,10 @@ describe("personal-providers-tab — ChatGPT (Codex) device login flow", () => {
     await expect(
       screen.findByText("Re-connect Codex"),
     ).resolves.toBeInTheDocument();
-    expect(screen.getByTestId("codex-device-auth-start")).toBeInTheDocument();
-    expect(screen.getByText("Reconnect ChatGPT")).toBeInTheDocument();
+    await expect(
+      screen.findByTestId("codex-device-auth-code"),
+    ).resolves.toHaveTextContent("ABCD-EFGH");
+    expect(screen.queryByText("Reconnect ChatGPT")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Your ChatGPT session expired."),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -135,6 +135,11 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     expect(screen.getByText("ChatGPT (Codex)")).toBeInTheDocument();
     expect(
       screen.getByText(
+        "Connect with Claude Code login for Claude-backed model routes.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
         "Connect with Codex device login for Codex-backed model routes.",
       ),
     ).toBeInTheDocument();
@@ -146,7 +151,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("opens the Claude Code OAuth write dialog without a model selector", async () => {
+  it("opens the Claude Code device login dialog", async () => {
     setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
@@ -155,12 +160,11 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await openModelConfiguration();
     click(await screen.findByLabelText("Connect Claude Code OAuth"));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("Configure Claude Code OAuth"),
-      ).toBeInTheDocument();
-    });
-    expect(screen.getByText("Claude OAuth token")).toBeInTheDocument();
+    await expect(
+      screen.findByTestId("claude-code-device-auth-start"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Connect Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Sign in with Claude")).toBeInTheDocument();
     expect(screen.queryByText("Select model")).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -15,13 +15,14 @@ import {
   disconnectPersonalOAuthCredential$,
   personalActionPromise$,
   personalConfiguredProviders$,
-  personalOpenOAuthCredentialDialog$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
+import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ProviderIcon } from "../settings/provider-icons.tsx";
 import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx";
+import { PersonalClaudeCodeDeviceAuthDialog } from "../settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "../settings/codex-device-auth-dialog.tsx";
 
 type OAuthStatus = "connected" | "stale" | "missing";
@@ -31,6 +32,7 @@ export function PersonalProvidersTab() {
     <div className="flex flex-col gap-8">
       <OAuthCredentialsSection />
       <PersonalProviderDialog />
+      <PersonalClaudeCodeDeviceAuthDialog />
       <PersonalCodexDeviceAuthDialog />
     </div>
   );
@@ -38,7 +40,9 @@ export function PersonalProvidersTab() {
 
 function OAuthCredentialsSection() {
   const providersLoadable = useLastLoadable(personalConfiguredProviders$);
-  const openCredentialDialog = useSet(personalOpenOAuthCredentialDialog$);
+  const openClaudeCodeDeviceAuthDialog = useSet(
+    setClaudeCodeDeviceAuthDialogStatePersonal$,
+  );
   const openCodexDeviceAuthDialog = useSet(
     setCodexDeviceAuthDialogStatePersonal$,
   );
@@ -53,6 +57,13 @@ function OAuthCredentialsSection() {
   const openAI = findProvider(providers, "codex-oauth-token");
   const openAIStatus = getOpenAIStatus(openAI);
   const disconnecting = actionLoadable.state === "loading";
+  const connectClaudeCode = () => {
+    const next = {
+      open: true,
+      mode: claudeCode?.needsReconnect ? "reconnect" : "connect",
+    } as const;
+    openClaudeCodeDeviceAuthDialog(next);
+  };
   const connectOpenAI = () => {
     const next = {
       open: true,
@@ -84,16 +95,14 @@ function OAuthCredentialsSection() {
             <OAuthCredentialCard
               type="claude-code-oauth-token"
               title="Claude Code OAuth"
-              description="Paste the Claude Code OAuth token used by workspace model routes."
-              status={claudeCode ? "connected" : "missing"}
+              description="Connect with Claude Code login for Claude-backed model routes."
+              status={getOpenAIStatus(claudeCode)}
               menuItems={
                 claudeCode
                   ? [
                       {
                         label: "Replace",
-                        onSelect: () => {
-                          openCredentialDialog("claude-code-oauth-token");
-                        },
+                        onSelect: connectClaudeCode,
                       },
                       {
                         label: "Disconnect",
@@ -111,9 +120,7 @@ function OAuthCredentialsSection() {
                     ]
                   : []
               }
-              onAction={() => {
-                openCredentialDialog("claude-code-oauth-token");
-              }}
+              onAction={connectClaudeCode}
               testId="oauth-card-claude-code-oauth-token"
             />
             <OAuthCredentialCard

--- a/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
@@ -1,0 +1,336 @@
+import { useGet, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { Button } from "@vm0/ui/components/ui/button";
+import { Input } from "@vm0/ui/components/ui/input";
+import { IconLoader2 } from "@tabler/icons-react";
+
+import {
+  claudeCodeDeviceAuthDialogState$,
+  claudeCodeDeviceAuthDialogStatePersonal$,
+  claudeCodeDeviceAuthFlowState$,
+  claudeCodeDeviceAuthFlowStatePersonal$,
+  closeClaudeCodeDeviceAuthDialog$,
+  closeClaudeCodeDeviceAuthDialogPersonal$,
+  openClaudeCodeDeviceAuthApprovalPage$,
+  openClaudeCodeDeviceAuthApprovalPagePersonal$,
+  runClaudeCodeDeviceAuth$,
+  runClaudeCodeDeviceAuthPersonal$,
+  setClaudeCodeDeviceAuthAuthorizationCode$,
+  setClaudeCodeDeviceAuthAuthorizationCodePersonal$,
+  setClaudeCodeDeviceAuthDialogState$,
+  setClaudeCodeDeviceAuthDialogStatePersonal$,
+  submitClaudeCodeDeviceAuth$,
+  submitClaudeCodeDeviceAuthPersonal$,
+  type ClaudeCodeDeviceAuthFlowState,
+} from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { ConnectorHelpText } from "./connector-help-text.tsx";
+import { ProviderIcon } from "./provider-icons.tsx";
+
+type ClaudeCodeDeviceAuthDialogState = {
+  open: boolean;
+  mode: "connect" | "reconnect";
+};
+
+interface ClaudeCodeDeviceAuthScopeBundle {
+  dialog: ClaudeCodeDeviceAuthDialogState;
+  flow: ClaudeCodeDeviceAuthFlowState;
+  setDialog: (next: ClaudeCodeDeviceAuthDialogState) => void;
+  close: (signal: AbortSignal) => Promise<void>;
+  openApprovalPage: (signal: AbortSignal) => boolean | Promise<boolean>;
+  run: (signal: AbortSignal) => Promise<boolean>;
+  submit: (signal: AbortSignal) => Promise<boolean>;
+  setAuthorizationCode: (value: string) => void;
+}
+
+export function ClaudeCodeDeviceAuthDialog() {
+  const bundle = useOrgClaudeCodeDeviceAuthBundle();
+  return <ClaudeCodeDeviceAuthDialogView bundle={bundle} />;
+}
+
+export function PersonalClaudeCodeDeviceAuthDialog() {
+  const bundle = usePersonalClaudeCodeDeviceAuthBundle();
+  return <ClaudeCodeDeviceAuthDialogView bundle={bundle} />;
+}
+
+function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
+  const dialog = useGet(claudeCodeDeviceAuthDialogState$);
+  const flow = useGet(claudeCodeDeviceAuthFlowState$);
+  const setDialog = useSet(setClaudeCodeDeviceAuthDialogState$);
+  const close = useSet(closeClaudeCodeDeviceAuthDialog$);
+  const openApprovalPage = useSet(openClaudeCodeDeviceAuthApprovalPage$);
+  const [, run] = useLoadableSet(runClaudeCodeDeviceAuth$);
+  const [, submit] = useLoadableSet(submitClaudeCodeDeviceAuth$);
+  const setAuthorizationCode = useSet(
+    setClaudeCodeDeviceAuthAuthorizationCode$,
+  );
+  return {
+    dialog,
+    flow,
+    setDialog,
+    close,
+    openApprovalPage,
+    run,
+    submit,
+    setAuthorizationCode,
+  };
+}
+
+function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
+  const dialog = useGet(claudeCodeDeviceAuthDialogStatePersonal$);
+  const flow = useGet(claudeCodeDeviceAuthFlowStatePersonal$);
+  const setDialog = useSet(setClaudeCodeDeviceAuthDialogStatePersonal$);
+  const close = useSet(closeClaudeCodeDeviceAuthDialogPersonal$);
+  const openApprovalPage = useSet(
+    openClaudeCodeDeviceAuthApprovalPagePersonal$,
+  );
+  const [, run] = useLoadableSet(runClaudeCodeDeviceAuthPersonal$);
+  const [, submit] = useLoadableSet(submitClaudeCodeDeviceAuthPersonal$);
+  const setAuthorizationCode = useSet(
+    setClaudeCodeDeviceAuthAuthorizationCodePersonal$,
+  );
+  return {
+    dialog,
+    flow,
+    setDialog,
+    close,
+    openApprovalPage,
+    run,
+    submit,
+    setAuthorizationCode,
+  };
+}
+
+function ClaudeCodeDeviceAuthDialogView({
+  bundle,
+}: {
+  bundle: ClaudeCodeDeviceAuthScopeBundle;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const {
+    dialog,
+    flow,
+    setDialog,
+    close,
+    openApprovalPage,
+    run,
+    submit,
+    setAuthorizationCode,
+  } = bundle;
+  const title =
+    dialog.mode === "reconnect"
+      ? "Re-connect Claude Code"
+      : "Connect Claude Code";
+
+  function handleOpenChange(nextOpen: boolean): void {
+    if (nextOpen) {
+      setDialog({ ...dialog, open: true });
+      return;
+    }
+    detach(close(pageSignal), Reason.DomCallback);
+  }
+
+  function handleStart(): void {
+    detach(run(pageSignal), Reason.DomCallback);
+  }
+
+  function handleSubmit(): void {
+    detach(submit(pageSignal), Reason.DomCallback);
+  }
+
+  return (
+    <Dialog open={dialog.open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md" aria-describedby={undefined}>
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+              <ProviderIcon type="claude-code-oauth-token" size={20} />
+            </div>
+            <DialogTitle>{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+
+        <ClaudeCodeDeviceAuthBody
+          flow={flow}
+          mode={dialog.mode}
+          onStart={handleStart}
+          onSubmit={handleSubmit}
+          openApprovalPage={openApprovalPage}
+          pageSignal={pageSignal}
+          setAuthorizationCode={setAuthorizationCode}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ClaudeCodeDeviceAuthBody({
+  flow,
+  mode,
+  onStart,
+  onSubmit,
+  openApprovalPage,
+  pageSignal,
+  setAuthorizationCode,
+}: {
+  flow: ClaudeCodeDeviceAuthFlowState;
+  mode: "connect" | "reconnect";
+  onStart: () => void;
+  onSubmit: () => void;
+  openApprovalPage: (signal: AbortSignal) => boolean | Promise<boolean>;
+  pageSignal: AbortSignal;
+  setAuthorizationCode: (value: string) => void;
+}) {
+  switch (flow.status) {
+    case "idle": {
+      return <ClaudeCodeDeviceAuthStartContent mode={mode} onStart={onStart} />;
+    }
+    case "starting": {
+      return (
+        <ClaudeCodeDeviceAuthStartContent
+          mode={mode}
+          onStart={onStart}
+          loading
+        />
+      );
+    }
+    case "pending":
+    case "submitting": {
+      return (
+        <div className="space-y-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              detach(openApprovalPage(pageSignal), Reason.DomCallback);
+            }}
+            data-testid="claude-code-device-auth-open"
+          >
+            Open Claude approval page
+          </Button>
+          <div className="flex flex-col gap-2">
+            <label
+              className="text-sm font-medium text-foreground"
+              htmlFor="claude-code-device-auth-code"
+            >
+              Authorization code
+            </label>
+            <Input
+              id="claude-code-device-auth-code"
+              value={flow.authorizationCode}
+              placeholder="Paste code from Claude"
+              readOnly={flow.status === "submitting"}
+              onChange={(event) => {
+                setAuthorizationCode(event.target.value);
+              }}
+              data-testid="claude-code-device-auth-code"
+            />
+          </div>
+          {flow.errorMessage && (
+            <p className="text-xs text-destructive" role="alert">
+              {flow.errorMessage}
+            </p>
+          )}
+          <Button
+            type="button"
+            className="w-full gap-2"
+            onClick={onSubmit}
+            disabled={flow.status === "submitting"}
+            data-testid="claude-code-device-auth-submit"
+          >
+            {flow.status === "submitting" && (
+              <IconLoader2 size={14} className="animate-spin" />
+            )}
+            {flow.status === "submitting" ? "Connecting..." : "Connect"}
+          </Button>
+          <p className="text-xs text-muted-foreground" role="status">
+            {claudeCodeDeviceAuthStatusText(flow)}
+          </p>
+        </div>
+      );
+    }
+    case "expired":
+    case "error": {
+      return (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-destructive" role="alert">
+            {flow.message}
+          </p>
+          <ClaudeCodeDeviceAuthStartButton mode={mode} onStart={onStart} />
+        </div>
+      );
+    }
+  }
+}
+
+function ClaudeCodeDeviceAuthStartContent({
+  mode,
+  onStart,
+  loading = false,
+}: {
+  mode: "connect" | "reconnect";
+  onStart: () => void;
+  loading?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <ConnectorHelpText text="vm0 will start a short-lived Claude Code login session. After approval, paste the one-time code shown by Claude." />
+      <ClaudeCodeDeviceAuthStartButton
+        mode={mode}
+        onStart={onStart}
+        loading={loading}
+      />
+    </div>
+  );
+}
+
+function ClaudeCodeDeviceAuthStartButton({
+  mode,
+  onStart,
+  loading = false,
+}: {
+  mode: "connect" | "reconnect";
+  onStart: () => void;
+  loading?: boolean;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={onStart}
+      disabled={loading}
+      className="w-full gap-2"
+      data-testid="claude-code-device-auth-start"
+    >
+      {loading && <IconLoader2 size={14} className="animate-spin" />}
+      {loading
+        ? "Preparing..."
+        : mode === "reconnect"
+          ? "Reconnect Claude Code"
+          : "Sign in with Claude"}
+    </Button>
+  );
+}
+
+function claudeCodeDeviceAuthStatusText(
+  flow: Extract<
+    ClaudeCodeDeviceAuthFlowState,
+    { status: "pending" | "submitting" }
+  >,
+): string {
+  if (flow.status === "submitting") {
+    return "Checking connection...";
+  }
+  if (!flow.approvalOpened) {
+    return "Open the approval page to continue.";
+  }
+  return "Paste the code shown after approval.";
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
@@ -13,6 +13,8 @@ import { IconLoader2 } from "@tabler/icons-react";
 import {
   claudeCodeDeviceAuthDialogState$,
   claudeCodeDeviceAuthDialogStatePersonal$,
+  claudeCodeDeviceAuthAutoStartRef$,
+  claudeCodeDeviceAuthAutoStartRefPersonal$,
   claudeCodeDeviceAuthFlowState$,
   claudeCodeDeviceAuthFlowStatePersonal$,
   closeClaudeCodeDeviceAuthDialog$,
@@ -31,7 +33,6 @@ import {
 } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { ConnectorHelpText } from "./connector-help-text.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 
 type ClaudeCodeDeviceAuthDialogState = {
@@ -39,9 +40,12 @@ type ClaudeCodeDeviceAuthDialogState = {
   mode: "connect" | "reconnect";
 };
 
+type AutoStartRef = (element: HTMLDivElement | null) => void;
+
 interface ClaudeCodeDeviceAuthScopeBundle {
   dialog: ClaudeCodeDeviceAuthDialogState;
   flow: ClaudeCodeDeviceAuthFlowState;
+  autoStartRef: AutoStartRef;
   setDialog: (next: ClaudeCodeDeviceAuthDialogState) => void;
   close: (signal: AbortSignal) => Promise<void>;
   openApprovalPage: (signal: AbortSignal) => boolean | Promise<boolean>;
@@ -63,6 +67,7 @@ export function PersonalClaudeCodeDeviceAuthDialog() {
 function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   const dialog = useGet(claudeCodeDeviceAuthDialogState$);
   const flow = useGet(claudeCodeDeviceAuthFlowState$);
+  const autoStartRef = useSet(claudeCodeDeviceAuthAutoStartRef$);
   const setDialog = useSet(setClaudeCodeDeviceAuthDialogState$);
   const close = useSet(closeClaudeCodeDeviceAuthDialog$);
   const openApprovalPage = useSet(openClaudeCodeDeviceAuthApprovalPage$);
@@ -74,6 +79,7 @@ function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   return {
     dialog,
     flow,
+    autoStartRef,
     setDialog,
     close,
     openApprovalPage,
@@ -86,6 +92,7 @@ function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
 function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   const dialog = useGet(claudeCodeDeviceAuthDialogStatePersonal$);
   const flow = useGet(claudeCodeDeviceAuthFlowStatePersonal$);
+  const autoStartRef = useSet(claudeCodeDeviceAuthAutoStartRefPersonal$);
   const setDialog = useSet(setClaudeCodeDeviceAuthDialogStatePersonal$);
   const close = useSet(closeClaudeCodeDeviceAuthDialogPersonal$);
   const openApprovalPage = useSet(
@@ -99,6 +106,7 @@ function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundl
   return {
     dialog,
     flow,
+    autoStartRef,
     setDialog,
     close,
     openApprovalPage,
@@ -117,6 +125,7 @@ function ClaudeCodeDeviceAuthDialogView({
   const {
     dialog,
     flow,
+    autoStartRef,
     setDialog,
     close,
     openApprovalPage,
@@ -148,24 +157,26 @@ function ClaudeCodeDeviceAuthDialogView({
   return (
     <Dialog open={dialog.open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md" aria-describedby={undefined}>
-        <DialogHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-              <ProviderIcon type="claude-code-oauth-token" size={20} />
+        <div ref={autoStartRef} className="contents">
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+                <ProviderIcon type="claude-code-oauth-token" size={20} />
+              </div>
+              <DialogTitle>{title}</DialogTitle>
             </div>
-            <DialogTitle>{title}</DialogTitle>
-          </div>
-        </DialogHeader>
+          </DialogHeader>
 
-        <ClaudeCodeDeviceAuthBody
-          flow={flow}
-          mode={dialog.mode}
-          onStart={handleStart}
-          onSubmit={handleSubmit}
-          openApprovalPage={openApprovalPage}
-          pageSignal={pageSignal}
-          setAuthorizationCode={setAuthorizationCode}
-        />
+          <ClaudeCodeDeviceAuthBody
+            flow={flow}
+            mode={dialog.mode}
+            onStart={handleStart}
+            onSubmit={handleSubmit}
+            openApprovalPage={openApprovalPage}
+            pageSignal={pageSignal}
+            setAuthorizationCode={setAuthorizationCode}
+          />
+        </div>
       </DialogContent>
     </Dialog>
   );
@@ -190,21 +201,22 @@ function ClaudeCodeDeviceAuthBody({
 }) {
   switch (flow.status) {
     case "idle": {
-      return <ClaudeCodeDeviceAuthStartContent mode={mode} onStart={onStart} />;
+      return <ClaudeCodeDeviceAuthLoadingContent />;
     }
     case "starting": {
-      return (
-        <ClaudeCodeDeviceAuthStartContent
-          mode={mode}
-          onStart={onStart}
-          loading
-        />
-      );
+      return <ClaudeCodeDeviceAuthLoadingContent />;
     }
     case "pending":
     case "submitting": {
       return (
         <div className="space-y-3">
+          <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs leading-5 text-muted-foreground">
+            <p>
+              First click Open Claude approval page. Then approve vm0 in Claude
+              and copy the authorization code shown after approval. Finally
+              paste that code here and click Connect.
+            </p>
+          </div>
           <Button
             type="button"
             variant="outline"
@@ -251,9 +263,6 @@ function ClaudeCodeDeviceAuthBody({
             )}
             {flow.status === "submitting" ? "Connecting..." : "Connect"}
           </Button>
-          <p className="text-xs text-muted-foreground" role="status">
-            {claudeCodeDeviceAuthStatusText(flow)}
-          </p>
         </div>
       );
     }
@@ -271,23 +280,15 @@ function ClaudeCodeDeviceAuthBody({
   }
 }
 
-function ClaudeCodeDeviceAuthStartContent({
-  mode,
-  onStart,
-  loading = false,
-}: {
-  mode: "connect" | "reconnect";
-  onStart: () => void;
-  loading?: boolean;
-}) {
+function ClaudeCodeDeviceAuthLoadingContent() {
   return (
-    <div className="flex flex-col gap-4">
-      <ConnectorHelpText text="vm0 will start a short-lived Claude Code login session. After approval, paste the one-time code shown by Claude." />
-      <ClaudeCodeDeviceAuthStartButton
-        mode={mode}
-        onStart={onStart}
-        loading={loading}
-      />
+    <div
+      className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground"
+      role="status"
+      data-testid="claude-code-device-auth-loading"
+    >
+      <IconLoader2 size={16} className="animate-spin" />
+      <span>Preparing...</span>
     </div>
   );
 }
@@ -295,42 +296,19 @@ function ClaudeCodeDeviceAuthStartContent({
 function ClaudeCodeDeviceAuthStartButton({
   mode,
   onStart,
-  loading = false,
 }: {
   mode: "connect" | "reconnect";
   onStart: () => void;
-  loading?: boolean;
 }) {
   return (
     <Button
       type="button"
       variant="outline"
       onClick={onStart}
-      disabled={loading}
       className="w-full gap-2"
       data-testid="claude-code-device-auth-start"
     >
-      {loading && <IconLoader2 size={14} className="animate-spin" />}
-      {loading
-        ? "Preparing..."
-        : mode === "reconnect"
-          ? "Reconnect Claude Code"
-          : "Sign in with Claude"}
+      {mode === "reconnect" ? "Reconnect Claude Code" : "Sign in with Claude"}
     </Button>
   );
-}
-
-function claudeCodeDeviceAuthStatusText(
-  flow: Extract<
-    ClaudeCodeDeviceAuthFlowState,
-    { status: "pending" | "submitting" }
-  >,
-): string {
-  if (flow.status === "submitting") {
-    return "Checking connection...";
-  }
-  if (!flow.approvalOpened) {
-    return "Open the approval page to continue.";
-  }
-  return "Paste the code shown after approval.";
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
@@ -7,11 +7,14 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import { Button } from "@vm0/ui/components/ui/button";
+import { CopyButton } from "@vm0/ui/components/ui/copy-button";
 import { IconLoader2 } from "@tabler/icons-react";
 
 import {
   closeCodexDeviceAuthDialog$,
   closeCodexDeviceAuthDialogPersonal$,
+  codexDeviceAuthAutoStartRef$,
+  codexDeviceAuthAutoStartRefPersonal$,
   codexDeviceAuthDialogState$,
   codexDeviceAuthDialogStatePersonal$,
   codexDeviceAuthFlowState$,
@@ -26,7 +29,6 @@ import {
 } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { ConnectorHelpText } from "./connector-help-text.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 
 type CodexDeviceAuthDialogState = {
@@ -34,9 +36,12 @@ type CodexDeviceAuthDialogState = {
   mode: "connect" | "reconnect";
 };
 
+type AutoStartRef = (element: HTMLDivElement | null) => void;
+
 interface CodexDeviceAuthScopeBundle {
   dialog: CodexDeviceAuthDialogState;
   flow: CodexDeviceAuthFlowState;
+  autoStartRef: AutoStartRef;
   setDialog: (next: CodexDeviceAuthDialogState) => void;
   close: (signal: AbortSignal) => Promise<void>;
   openApprovalPage: (signal: AbortSignal) => Promise<boolean>;
@@ -56,6 +61,7 @@ export function PersonalCodexDeviceAuthDialog() {
 function useOrgCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
   const dialog = useGet(codexDeviceAuthDialogState$);
   const flow = useGet(codexDeviceAuthFlowState$);
+  const autoStartRef = useSet(codexDeviceAuthAutoStartRef$);
   const setDialog = useSet(setCodexDeviceAuthDialogState$);
   const close = useSet(closeCodexDeviceAuthDialog$);
   const openApprovalPage = useSet(openCodexDeviceAuthApprovalPage$);
@@ -63,6 +69,7 @@ function useOrgCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
   return {
     dialog,
     flow,
+    autoStartRef,
     setDialog,
     close,
     openApprovalPage,
@@ -73,6 +80,7 @@ function useOrgCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
 function usePersonalCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
   const dialog = useGet(codexDeviceAuthDialogStatePersonal$);
   const flow = useGet(codexDeviceAuthFlowStatePersonal$);
+  const autoStartRef = useSet(codexDeviceAuthAutoStartRefPersonal$);
   const setDialog = useSet(setCodexDeviceAuthDialogStatePersonal$);
   const close = useSet(closeCodexDeviceAuthDialogPersonal$);
   const openApprovalPage = useSet(openCodexDeviceAuthApprovalPagePersonal$);
@@ -80,6 +88,7 @@ function usePersonalCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
   return {
     dialog,
     flow,
+    autoStartRef,
     setDialog,
     close,
     openApprovalPage,
@@ -93,7 +102,15 @@ function CodexDeviceAuthDialogView({
   bundle: CodexDeviceAuthScopeBundle;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const { dialog, flow, setDialog, close, openApprovalPage, run } = bundle;
+  const {
+    dialog,
+    flow,
+    autoStartRef,
+    setDialog,
+    close,
+    openApprovalPage,
+    run,
+  } = bundle;
   const title =
     dialog.mode === "reconnect" ? "Re-connect Codex" : "Connect Codex";
 
@@ -112,22 +129,24 @@ function CodexDeviceAuthDialogView({
   return (
     <Dialog open={dialog.open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md" aria-describedby={undefined}>
-        <DialogHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-              <ProviderIcon type="codex-oauth-token" size={20} />
+        <div ref={autoStartRef} className="contents">
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+                <ProviderIcon type="codex-oauth-token" size={20} />
+              </div>
+              <DialogTitle>{title}</DialogTitle>
             </div>
-            <DialogTitle>{title}</DialogTitle>
-          </div>
-        </DialogHeader>
+          </DialogHeader>
 
-        <CodexDeviceAuthBody
-          flow={flow}
-          mode={dialog.mode}
-          onStart={handleStart}
-          openApprovalPage={openApprovalPage}
-          pageSignal={pageSignal}
-        />
+          <CodexDeviceAuthBody
+            flow={flow}
+            mode={dialog.mode}
+            onStart={handleStart}
+            openApprovalPage={openApprovalPage}
+            pageSignal={pageSignal}
+          />
+        </div>
       </DialogContent>
     </Dialog>
   );
@@ -148,27 +167,40 @@ function CodexDeviceAuthBody({
 }) {
   switch (flow.status) {
     case "idle": {
-      return <CodexDeviceAuthStartContent mode={mode} onStart={onStart} />;
+      return <CodexDeviceAuthLoadingContent />;
     }
     case "starting": {
-      return (
-        <CodexDeviceAuthStartContent mode={mode} onStart={onStart} loading />
-      );
+      return <CodexDeviceAuthLoadingContent />;
     }
     case "pending":
     case "polling": {
+      const statusText = codexDeviceAuthStatusText(flow);
       return (
         <div className="space-y-3">
+          <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs leading-5 text-muted-foreground">
+            <p>
+              First click Copy code and open approval page. Then paste the
+              device code into OpenAI when prompted. Finally approve access and
+              keep this dialog open while vm0 finishes the connection.
+            </p>
+          </div>
           <div className="rounded-lg border border-border bg-muted/30 p-3">
-            <p className="text-xs text-muted-foreground">
-              Copy this device code before approving
-            </p>
-            <p
-              className="mt-1 font-mono text-2xl font-semibold tracking-normal"
-              data-testid="codex-device-auth-code"
-            >
-              {flow.verificationCode}
-            </p>
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-xs text-muted-foreground">Device code</p>
+                <p
+                  className="mt-1 font-mono text-2xl font-semibold tracking-normal"
+                  data-testid="codex-device-auth-code"
+                >
+                  {flow.verificationCode}
+                </p>
+              </div>
+              <CopyButton
+                type="button"
+                text={flow.verificationCode}
+                className="-m-1 p-1.5 hover:bg-accent"
+              />
+            </div>
           </div>
           {flow.errorMessage && (
             <p className="text-xs text-destructive" role="alert">
@@ -186,9 +218,11 @@ function CodexDeviceAuthBody({
           >
             Copy code and open approval page
           </Button>
-          <p className="text-xs text-muted-foreground" role="status">
-            {codexDeviceAuthStatusText(flow)}
-          </p>
+          {statusText && (
+            <p className="text-xs text-muted-foreground" role="status">
+              {statusText}
+            </p>
+          )}
         </div>
       );
     }
@@ -206,23 +240,15 @@ function CodexDeviceAuthBody({
   }
 }
 
-function CodexDeviceAuthStartContent({
-  mode,
-  onStart,
-  loading = false,
-}: {
-  mode: "connect" | "reconnect";
-  onStart: () => void;
-  loading?: boolean;
-}) {
+function CodexDeviceAuthLoadingContent() {
   return (
-    <div className="flex flex-col gap-4">
-      <ConnectorHelpText text="vm0 will start a short-lived Codex login session and show a device code. Open the approval page after the code appears." />
-      <CodexDeviceAuthStartButton
-        mode={mode}
-        onStart={onStart}
-        loading={loading}
-      />
+    <div
+      className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground"
+      role="status"
+      data-testid="codex-device-auth-loading"
+    >
+      <IconLoader2 size={16} className="animate-spin" />
+      <span>Preparing...</span>
     </div>
   );
 }
@@ -230,36 +256,28 @@ function CodexDeviceAuthStartContent({
 function CodexDeviceAuthStartButton({
   mode,
   onStart,
-  loading = false,
 }: {
   mode: "connect" | "reconnect";
   onStart: () => void;
-  loading?: boolean;
 }) {
   return (
     <Button
       type="button"
       variant="outline"
       onClick={onStart}
-      disabled={loading}
       className="w-full gap-2"
       data-testid="codex-device-auth-start"
     >
-      {loading && <IconLoader2 size={14} className="animate-spin" />}
-      {loading
-        ? "Preparing..."
-        : mode === "reconnect"
-          ? "Reconnect ChatGPT"
-          : "Sign in with ChatGPT"}
+      {mode === "reconnect" ? "Reconnect ChatGPT" : "Sign in with ChatGPT"}
     </Button>
   );
 }
 
 function codexDeviceAuthStatusText(
   flow: Extract<CodexDeviceAuthFlowState, { status: "pending" | "polling" }>,
-): string {
+): string | null {
   if (!flow.approvalOpened && !flow.codeCopied) {
-    return "Open the approval page to continue.";
+    return null;
   }
   if (flow.codeCopied && !flow.approvalOpened) {
     return "Device code copied. Try opening the approval page again.";
@@ -267,7 +285,5 @@ function codexDeviceAuthStatusText(
   if (!flow.codeCopied) {
     return "Approval page opened. Copy the device code before approving.";
   }
-  return flow.status === "polling"
-    ? "Checking connection..."
-    : "Device code copied. Waiting for approval...";
+  return "Device code copied. Waiting for approval...";
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -15,6 +15,7 @@ import {
   orgConfiguredProviders$,
   orgOpenAddDialog$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
+import { setClaudeCodeDeviceAuthDialogState$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogState$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { getUILabel, getUIDescription } from "./provider-ui-config.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
@@ -72,6 +73,7 @@ export function OrgAddProviderDialog({
 }) {
   const configuredProviders = useLastResolved(orgConfiguredProviders$);
   const openAdd = useSet(orgOpenAddDialog$);
+  const openClaudeCodeDeviceAuth = useSet(setClaudeCodeDeviceAuthDialogState$);
   const openCodexDeviceAuth = useSet(setCodexDeviceAuthDialogState$);
   const configuredSet = new Set(
     configuredProviders?.map((p) => {
@@ -80,6 +82,11 @@ export function OrgAddProviderDialog({
   );
 
   const handleAdd = (type: ModelProviderType) => {
+    if (type === "claude-code-oauth-token") {
+      openClaudeCodeDeviceAuth({ open: true, mode: "connect" });
+      onOpenChange(false);
+      return;
+    }
     if (type === "codex-oauth-token") {
       openCodexDeviceAuth({ open: true, mode: "connect" });
       onOpenChange(false);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -50,7 +50,7 @@ const PROVIDER_UI_OVERRIDES = Object.freeze<
   "claude-code-oauth-token": {
     label: "Claude Code (OAuth token)",
     description:
-      "Leverage Claude Code's exceptional intelligence to build and run agents.",
+      "Sign in with your Claude subscription for Claude Code-backed agents.",
   },
   "codex-oauth-token": {
     description:

--- a/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
+++ b/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
@@ -4,7 +4,7 @@ import type {
   OrgModelPoliciesResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { useSet } from "ccstate-react";
-import { personalOpenOAuthCredentialDialog$ } from "../../signals/zero-page/settings/personal-model-providers.ts";
+import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../../signals/zero-page/settings/codex-device-auth.ts";
 import type { ModelFirstPersonalOauthState } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
@@ -126,18 +126,26 @@ export function resolveChatComposerSubmitBlocker(params: {
 }
 
 export function usePersonalOauthConfigurationAction() {
+  const openClaudeCodeDeviceAuthDialog = useSet(
+    setClaudeCodeDeviceAuthDialogStatePersonal$,
+  );
   const openCodexDeviceAuthDialog = useSet(
     setCodexDeviceAuthDialogStatePersonal$,
   );
-  const openCredentialDialog = useSet(personalOpenOAuthCredentialDialog$);
   return (
     providerType: MemberOauthProviderType,
     codexDeviceAuthMode: CodexDeviceAuthDialogMode,
   ) => {
+    if (providerType === "claude-code-oauth-token") {
+      openClaudeCodeDeviceAuthDialog({
+        open: true,
+        mode: codexDeviceAuthMode,
+      });
+      return;
+    }
     if (providerType === "codex-oauth-token") {
       openCodexDeviceAuthDialog({ open: true, mode: codexDeviceAuthMode });
       return;
     }
-    openCredentialDialog(providerType);
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -159,6 +159,7 @@ import {
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { createZipBlob } from "../../lib/zip.ts";
 import { PersonalProviderDialog } from "./components/settings/personal-provider-dialog.tsx";
+import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
 
 const CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP =
@@ -2091,6 +2092,7 @@ function ChatThreadComposer({
             onRemoveQueuedItem={onRemoveQueuedItem}
           />
           <PersonalProviderDialog />
+          <PersonalClaudeCodeDeviceAuthDialog />
           <PersonalCodexDeviceAuthDialog />
         </div>
       </div>

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -713,6 +713,18 @@ export const API_BACKEND_REWRITES = [
   ],
   ["/api/zero/model-providers", "/api/zero/model-providers"],
   [
+    "/api/zero/model-providers/claude-code/device-auth/sessions",
+    "/api/zero/model-providers/claude-code/device-auth/sessions",
+  ],
+  [
+    "/api/zero/model-providers/claude-code/device-auth/sessions/complete",
+    "/api/zero/model-providers/claude-code/device-auth/sessions/complete",
+  ],
+  [
+    "/api/zero/model-providers/claude-code/device-auth/sessions/cancel",
+    "/api/zero/model-providers/claude-code/device-auth/sessions/cancel",
+  ],
+  [
     "/api/zero/model-providers/codex/device-auth/sessions",
     "/api/zero/model-providers/codex/device-auth/sessions",
   ],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -939,6 +939,12 @@ export {
   type ZeroCodexDeviceAuthContract,
 } from "./zero-codex-device-auth";
 export {
+  claudeCodeDeviceAuthScopeSchema,
+  zeroClaudeCodeDeviceAuthContract,
+  type ClaudeCodeDeviceAuthScope,
+  type ZeroClaudeCodeDeviceAuthContract,
+} from "./zero-claude-code-device-auth";
+export {
   zeroOrgContract,
   zeroOrgLeaveContract,
   zeroOrgDeleteContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-claude-code-device-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-claude-code-device-auth.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { modelProviderResponseSchema } from "./model-providers";
+
+const c = initContract();
+
+export const claudeCodeDeviceAuthScopeSchema = z.enum(["org", "personal"]);
+
+const claudeCodeDeviceAuthStartResponseSchema = z.object({
+  sessionToken: z.string(),
+  type: z.literal("claude-code"),
+  status: z.literal("pending"),
+  scope: claudeCodeDeviceAuthScopeSchema,
+  browserUrl: z.url(),
+  expiresIn: z.number().int().positive(),
+});
+
+const claudeCodeDeviceAuthCompleteResponseSchema = z.object({
+  status: z.literal("complete"),
+  provider: modelProviderResponseSchema,
+  created: z.boolean(),
+});
+
+const claudeCodeDeviceAuthCancelResponseSchema = z.object({
+  status: z.literal("cancelled"),
+});
+
+/**
+ * Zero contract for Claude Code device-style OAuth.
+ * Runs the same PKCE OAuth path as `claude setup-token` and imports the
+ * resulting long-lived Claude Code token.
+ */
+export const zeroClaudeCodeDeviceAuthContract = c.router({
+  start: {
+    method: "POST",
+    path: "/api/zero/model-providers/claude-code/device-auth/sessions",
+    headers: authHeadersSchema,
+    body: z.object({ scope: claudeCodeDeviceAuthScopeSchema }),
+    responses: {
+      200: claudeCodeDeviceAuthStartResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Start Claude Code device auth",
+  },
+  complete: {
+    method: "POST",
+    path: "/api/zero/model-providers/claude-code/device-auth/sessions/complete",
+    headers: authHeadersSchema,
+    body: z.object({
+      sessionToken: z.string().min(1),
+      authorizationCode: z.string().min(1),
+    }),
+    responses: {
+      200: claudeCodeDeviceAuthCompleteResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Complete Claude Code device auth and import OAuth token",
+  },
+  cancel: {
+    method: "POST",
+    path: "/api/zero/model-providers/claude-code/device-auth/sessions/cancel",
+    headers: authHeadersSchema,
+    body: z.object({ sessionToken: z.string().min(1) }),
+    responses: {
+      200: claudeCodeDeviceAuthCancelResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Cancel Claude Code device auth",
+  },
+});
+
+export type ClaudeCodeDeviceAuthScope = z.infer<
+  typeof claudeCodeDeviceAuthScopeSchema
+>;
+export type ZeroClaudeCodeDeviceAuthContract =
+  typeof zeroClaudeCodeDeviceAuthContract;


### PR DESCRIPTION
## Summary
- add Claude Code device auth API contract, routes, and backend token import flow
- switch org and personal Claude Code connection UI to a browser approval plus callback-code flow
- add rewrites and tests for backend compatibility, provider dialogs, and model warning entry points

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm vitest
- pnpm knip