### PR TITLE
fix(mitm-addon): reject spoofed host authority

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -728,11 +728,13 @@ async def handle_firewall_request(
     flow.metadata["auth_refreshed_secrets"] = token_meta.get("refreshed_secrets", [])
     flow.metadata["auth_cache_hit"] = token_meta.get("cache_hit", False)
 
+    trusted_host = flow.metadata.get("trusted_authority_host") or flow.request.pretty_host
     log_proxy_entry(
         proxy_log_path,
         "info",
-        f"Firewall {firewall_base}: {flow.request.pretty_host}",
+        f"Firewall {firewall_base}: {trusted_host}",
         type="firewall",
         firewall_base=firewall_base,
-        host=flow.request.pretty_host,
+        host=trusted_host,
+        request_host_header=flow.request.host_header,
     )

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -41,7 +41,7 @@ from auth import (
 )
 from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
 from matching import FirewallAllow, FirewallBlock, match_compiled_firewall_request
-from url_utils import get_original_url
+from url_utils import AuthorityValidationError, get_trusted_authority
 
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
@@ -104,6 +104,40 @@ def get_registry_path() -> str:
 _request_start_times: dict = {}
 
 
+def _block_authority_validation_error(flow: http.HTTPFlow, error: AuthorityValidationError) -> None:
+    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    flow.metadata["original_url"] = error.fallback_url
+    flow.metadata["firewall_action"] = "DENY"
+    flow.metadata["firewall_error"] = error.reason
+
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        error.message,
+        type="authority_validation",
+        reason=error.reason,
+        sni=error.sni,
+        request_host=error.request_host,
+        host_header=error.host_header,
+        request_port=error.request_port,
+    )
+
+    flow.response = http.Response.make(
+        403,
+        json.dumps(
+            {
+                "error": error.reason,
+                "message": error.message,
+                "sni": error.sni,
+                "request_host": error.request_host,
+                "host_header": error.host_header,
+                "request_port": error.request_port,
+            }
+        ).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
 # ============================================================================
 # TLS ClientHello Handler
 # ============================================================================
@@ -163,10 +197,7 @@ async def request(flow: http.HTTPFlow) -> None:
     _request_start_times[flow.id] = time.time()
 
     try:
-        original_url = get_original_url(flow)
-
         # Store info for response handler
-        flow.metadata["original_url"] = original_url
         flow.metadata["vm_run_id"] = run_id
         flow.metadata["vm_client_ip"] = client_ip
         flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
@@ -175,8 +206,18 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata["vm_sandbox_token"] = vm_info.get("sandboxToken", "")
         flow.metadata["cli_agent_type"] = vm_info.get("cliAgentType") or "claude-code"
 
-        # Get target hostname
-        hostname = flow.request.pretty_host.lower()
+        try:
+            trusted_authority = get_trusted_authority(flow)
+        except AuthorityValidationError as e:
+            _block_authority_validation_error(flow, e)
+            return
+
+        original_url = trusted_authority.url
+        flow.metadata["original_url"] = original_url
+        flow.metadata["trusted_authority_host"] = trusted_authority.host
+        flow.metadata["trusted_authority_port"] = trusted_authority.port
+
+        hostname = trusted_authority.host.lower()
 
         # --- Step 1: Auto-allow VM0 API requests ---
         # The agent MUST be able to communicate with the platform (heartbeat,

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -57,6 +57,8 @@ def _format_url_host(host: str) -> str:
     candidate = host
     if candidate.startswith("[") and candidate.endswith("]"):
         candidate = candidate[1:-1]
+    if ":" not in candidate:
+        return host
     try:
         parsed = ipaddress.ip_address(candidate)
     except ValueError:

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -4,8 +4,10 @@ Pure functions with no module-level state or I/O.
 """
 
 import urllib.parse
+from dataclasses import dataclass
 
 from mitmproxy import http
+from mitmproxy.net.http import url as mitm_url
 
 # Well-known IANA ports for HTTP and HTTPS.  When the connection uses the
 # default port for its scheme we omit ``:port`` from the reconstructed URL.
@@ -13,30 +15,164 @@ _HTTP_DEFAULT_PORT = 80
 _HTTPS_DEFAULT_PORT = 443
 
 
-def get_original_url(flow: http.HTTPFlow) -> str:
-    """Reconstruct the original target URL from the request.
+@dataclass(frozen=True)
+class TrustedAuthority:
+    host: str
+    port: int
+    url: str
 
-    Uses ``flow.request.scheme`` (populated from the TLS handshake) rather
-    than inferring from the destination port, and anchors the authority
-    on ``pretty_host`` (Host header if present) combined with the actual
-    destination port. ``pretty_url`` is intentionally not used: it takes
-    the port from the Host header, so a request to ``host:8443`` with a
-    plain ``Host: host`` (no port) would lose the ``:8443`` and break
-    firewall rule matching.
-    """
-    scheme = flow.request.scheme
-    host = flow.request.pretty_host
-    port = flow.request.port
 
+class AuthorityValidationError(Exception):
+    def __init__(
+        self,
+        reason: str,
+        *,
+        message: str,
+        sni: str | None,
+        request_host: str,
+        host_header: str | None,
+        request_port: int,
+        fallback_url: str,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+        self.sni = sni
+        self.request_host = request_host
+        self.host_header = host_header
+        self.request_port = request_port
+        self.fallback_url = fallback_url
+
+
+def _normalize_hostname(host: str) -> str:
+    normalized = host.rstrip(".").lower()
+    if not normalized:
+        raise ValueError("empty hostname")
+    return normalized.encode("idna").decode("ascii").lower()
+
+
+def _host_with_port(scheme: str, host: str, port: int) -> str:
     if (scheme == "https" and port != _HTTPS_DEFAULT_PORT) or (
         scheme == "http" and port != _HTTP_DEFAULT_PORT
     ):
-        host_with_port = f"{host}:{port}"
-    else:
-        host_with_port = host
+        return f"{host}:{port}"
+    return host
 
+
+def _build_url(scheme: str, host: str, port: int, path: str) -> str:
+    return f"{scheme}://{_host_with_port(scheme, host, port)}{path}"
+
+
+def _parse_host_authority(authority: str) -> tuple[str, int | None]:
+    host, port = mitm_url.parse_authority(authority, check=True)
+    return host, port
+
+
+def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
+    """Resolve the authority trusted for firewall/auth decisions.
+
+    In transparent HTTPS mode, mitmproxy's request host can be the
+    ``SO_ORIGINAL_DST`` IP. The TLS SNI is the domain authority used for
+    upstream TLS, while Host/``:authority`` is only a client assertion. Require
+    the HTTP authority to agree with SNI before using the URL for firewall
+    matching or credential injection.
+    """
+    scheme = flow.request.scheme
+    port = flow.request.port
     path = flow.request.path
-    return f"{scheme}://{host_with_port}{path}"
+    host_header = flow.request.host_header
+    request_host = flow.request.host
+
+    if scheme != "https":
+        host = flow.request.pretty_host
+        return TrustedAuthority(host=host, port=port, url=_build_url(scheme, host, port, path))
+
+    raw_sni = getattr(flow.client_conn, "sni", None)
+    sni = raw_sni.strip() if isinstance(raw_sni, str) else None
+    if not sni:
+        raise AuthorityValidationError(
+            "missing_sni",
+            message="Request blocked: HTTPS request is missing TLS SNI",
+            sni=sni,
+            request_host=request_host,
+            host_header=host_header,
+            request_port=port,
+            fallback_url=_build_url(scheme, request_host, port, path),
+        )
+
+    try:
+        normalized_sni = _normalize_hostname(sni)
+    except (UnicodeError, ValueError):
+        raise AuthorityValidationError(
+            "invalid_sni",
+            message="Request blocked: HTTPS request has invalid TLS SNI",
+            sni=sni,
+            request_host=request_host,
+            host_header=host_header,
+            request_port=port,
+            fallback_url=_build_url(scheme, request_host, port, path),
+        ) from None
+
+    trusted_url = _build_url(scheme, normalized_sni, port, path)
+    if not host_header:
+        raise AuthorityValidationError(
+            "missing_authority",
+            message="Request blocked: HTTPS request is missing Host authority",
+            sni=sni,
+            request_host=request_host,
+            host_header=host_header,
+            request_port=port,
+            fallback_url=trusted_url,
+        )
+
+    try:
+        header_host, header_port = _parse_host_authority(host_header)
+        normalized_header_host = _normalize_hostname(header_host)
+    except (UnicodeError, ValueError):
+        raise AuthorityValidationError(
+            "invalid_authority",
+            message="Request blocked: HTTPS request has invalid Host authority",
+            sni=sni,
+            request_host=request_host,
+            host_header=host_header,
+            request_port=port,
+            fallback_url=trusted_url,
+        ) from None
+
+    if normalized_header_host != normalized_sni:
+        raise AuthorityValidationError(
+            "authority_mismatch",
+            message="Request blocked: Host authority does not match TLS SNI",
+            sni=sni,
+            request_host=request_host,
+            host_header=host_header,
+            request_port=port,
+            fallback_url=trusted_url,
+        )
+
+    if header_port is not None and header_port != port:
+        raise AuthorityValidationError(
+            "authority_port_mismatch",
+            message="Request blocked: Host authority port does not match destination port",
+            sni=sni,
+            request_host=request_host,
+            host_header=host_header,
+            request_port=port,
+            fallback_url=trusted_url,
+        )
+
+    return TrustedAuthority(host=normalized_sni, port=port, url=trusted_url)
+
+
+def get_original_url(flow: http.HTTPFlow) -> str:
+    """Reconstruct the original target URL from the request.
+
+    Uses the trusted authority for HTTPS firewall/auth decisions. ``pretty_url``
+    is intentionally not used: it takes the port from the Host header, so a
+    request to ``host:8443`` with a plain ``Host: host`` (no port) would lose
+    the ``:8443`` and break firewall rule matching.
+    """
+    return get_trusted_authority(flow).url
 
 
 def build_rewrite_url(resolved_base: str, match_info: dict, orig_query: str) -> str:

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -71,11 +71,12 @@ def _parse_host_authority(authority: str) -> tuple[str, int | None]:
 def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
     """Resolve the authority trusted for firewall/auth decisions.
 
-    In transparent HTTPS mode, mitmproxy's request host can be the
-    ``SO_ORIGINAL_DST`` IP. The TLS SNI is the domain authority used for
+    In transparent mode, mitmproxy's request host is the ``SO_ORIGINAL_DST``
+    destination. For HTTPS, the TLS SNI is the domain authority used for
     upstream TLS, while Host/``:authority`` is only a client assertion. Require
     the HTTP authority to agree with SNI before using the URL for firewall
-    matching or credential injection.
+    matching or credential injection. For non-HTTPS traffic there is no SNI
+    binding, so use the transparent destination host and do not trust Host.
     """
     scheme = flow.request.scheme
     port = flow.request.port
@@ -84,8 +85,11 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
     request_host = flow.request.host
 
     if scheme != "https":
-        host = flow.request.pretty_host
-        return TrustedAuthority(host=host, port=port, url=_build_url(scheme, host, port, path))
+        return TrustedAuthority(
+            host=request_host,
+            port=port,
+            url=_build_url(scheme, request_host, port, path),
+        )
 
     raw_sni = getattr(flow.client_conn, "sni", None)
     sni = raw_sni.strip() if isinstance(raw_sni, str) else None

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -3,6 +3,7 @@
 Pure functions with no module-level state or I/O.
 """
 
+import ipaddress
 import urllib.parse
 from dataclasses import dataclass
 
@@ -13,6 +14,7 @@ from mitmproxy.net.http import url as mitm_url
 # default port for its scheme we omit ``:port`` from the reconstructed URL.
 _HTTP_DEFAULT_PORT = 80
 _HTTPS_DEFAULT_PORT = 443
+_IPV6_VERSION = 6
 
 
 @dataclass(frozen=True)
@@ -51,12 +53,26 @@ def _normalize_hostname(host: str) -> str:
     return normalized.encode("idna").decode("ascii").lower()
 
 
+def _format_url_host(host: str) -> str:
+    candidate = host
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        parsed = ipaddress.ip_address(candidate)
+    except ValueError:
+        return host
+    if parsed.version == _IPV6_VERSION:
+        return f"[{candidate}]"
+    return candidate
+
+
 def _host_with_port(scheme: str, host: str, port: int) -> str:
+    url_host = _format_url_host(host)
     if (scheme == "https" and port != _HTTPS_DEFAULT_PORT) or (
         scheme == "http" and port != _HTTP_DEFAULT_PORT
     ):
-        return f"{host}:{port}"
-    return host
+        return f"{url_host}:{port}"
+    return url_host
 
 
 def _build_url(scheme: str, host: str, port: int, path: str) -> str:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -80,6 +80,7 @@ def real_flow():
         path: str = "/",
         method: str = "GET",
         scheme: str = "https",
+        sni: str | None = None,
         request_body: bytes | None = None,
         request_headers: http.Headers | None = None,
         request_content_type: str | None = None,
@@ -134,6 +135,7 @@ def real_flow():
 
         flow = tflow.tflow(req=req, resp=resp)
         flow.client_conn.peername = (client_ip, 12345)
+        flow.client_conn.sni = sni if sni is not None else (host if scheme == "https" else None)
         return flow
 
     return _build

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -76,6 +76,48 @@ def _assert_pending(path: Path, flows: int, reports: int) -> dict:
     return state
 
 
+def _write_github_firewall_registry(tmp_path: Path, *, client_ip: str = "10.200.0.5") -> Path:
+    registry = {
+        "vms": {
+            client_ip: {
+                "runId": "run-conn-1",
+                "billableFirewalls": [],
+                "sandboxToken": "tok-conn",
+                "networkLogPath": str(tmp_path / "net.jsonl"),
+                "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+                "firewalls": [
+                    {
+                        "name": "github",
+                        "apis": [
+                            {
+                                "base": "https://api.github.com",
+                                "auth": {
+                                    "headers": {
+                                        "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                                    }
+                                },
+                                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                            },
+                        ],
+                    },
+                ],
+                "networkPolicies": {
+                    "github": {
+                        "allow": ["full-access"],
+                        "deny": [],
+                        "ask": [],
+                        "unknownPolicy": "allow",
+                    },
+                },
+                "encryptedSecrets": "iv:tag:data",
+            }
+        }
+    }
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps(registry))
+    return path
+
+
 class TestAddonConfiguration:
     def test_load_registers_usage_state_id_without_pending_write(self):
         loader = MagicMock()
@@ -229,6 +271,177 @@ class TestRequestHandler:
         assert flow.response is None
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata.get("original_url") == "https://api.anthropic.com/v1/messages"
+
+    async def test_rejects_spoofed_host_before_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="attacker.example.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "authority_mismatch"
+        assert flow.metadata["firewall_action"] == "DENY"
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+
+    async def test_matching_sni_and_host_allows_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "https://api.github.com"
+        assert flow.metadata["firewall_name"] == "github"
+        assert flow.metadata["firewall_permission"] == "full-access"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+        assert flow.metadata["original_url"] == "https://api.github.com/repos"
+
+    async def test_rejects_spoofed_host_before_vm0_api_auto_allow(
+        self, registry_file, real_flow, mitm_ctx, headers
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="203.0.113.10",
+            sni="attacker.example.com",
+            path="/api/runs/heartbeat",
+            request_headers=headers(("Host", "api.vm0.ai")),
+        )
+
+        with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "authority_mismatch"
+        assert flow.metadata["firewall_action"] == "DENY"
+
+    async def test_accepts_equivalent_host_authority_default_https_port(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com:443")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "https://api.github.com"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+
+    async def test_rejects_host_authority_port_mismatch(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com:444")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "authority_port_mismatch"
+        assert flow.metadata["firewall_action"] == "DENY"
+        auth_fetch.assert_not_called()
+
+    async def test_accepts_authority_host_case_differences(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "API.GITHUB.COM")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "https://api.github.com"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+
+    async def test_rejects_missing_https_sni_before_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+        flow.client_conn.sni = None
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "missing_sni"
+        assert flow.metadata["firewall_action"] == "DENY"
+        auth_fetch.assert_not_called()
 
     async def test_firewall_match_calls_handler(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -76,7 +76,12 @@ def _assert_pending(path: Path, flows: int, reports: int) -> dict:
     return state
 
 
-def _write_github_firewall_registry(tmp_path: Path, *, client_ip: str = "10.200.0.5") -> Path:
+def _write_github_firewall_registry(
+    tmp_path: Path,
+    *,
+    client_ip: str = "10.200.0.5",
+    base: str = "https://api.github.com",
+) -> Path:
     registry = {
         "vms": {
             client_ip: {
@@ -90,7 +95,7 @@ def _write_github_firewall_registry(tmp_path: Path, *, client_ip: str = "10.200.
                         "name": "github",
                         "apis": [
                             {
-                                "base": "https://api.github.com",
+                                "base": base,
                                 "auth": {
                                     "headers": {
                                         "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
@@ -442,6 +447,61 @@ class TestRequestHandler:
         assert body["error"] == "missing_sni"
         assert flow.metadata["firewall_action"] == "DENY"
         auth_fetch.assert_not_called()
+
+    async def test_http_host_spoof_does_not_match_domain_firewall(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path, base="http://api.github.com")
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            scheme="http",
+            host="203.0.113.10",
+            port=80,
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["original_url"] == "http://203.0.113.10/repos"
+        assert "firewall_base" not in flow.metadata
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+
+    async def test_http_host_spoof_does_not_trigger_vm0_api_auto_allow(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(
+            tmp_path,
+            base="http://203.0.113.10/api/runs",
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            scheme="http",
+            host="203.0.113.10",
+            port=80,
+            path="/api/runs/heartbeat",
+            request_headers=headers(("Host", "api.vm0.ai")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "http://203.0.113.10/api/runs"
+        assert flow.metadata["original_url"] == "http://203.0.113.10/api/runs/heartbeat"
+        assert flow.request.headers["Authorization"] == "Bearer x"
 
     async def test_firewall_match_calls_handler(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -373,6 +373,34 @@ class TestRequestHandler:
         assert flow.metadata["firewall_base"] == "https://api.github.com"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    async def test_accepts_matching_non_default_host_authority_port(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(
+            tmp_path,
+            base="https://api.github.com:8443",
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            port=8443,
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com:8443")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "https://api.github.com:8443"
+        assert flow.metadata["original_url"] == "https://api.github.com:8443/repos"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+
     async def test_rejects_host_authority_port_mismatch(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -422,6 +422,46 @@ class TestRequestHandler:
         assert flow.metadata["firewall_base"] == "https://api.github.com"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    @pytest.mark.parametrize(
+        ("host_header", "expected_error"),
+        [
+            ("", "missing_authority"),
+            ("api.github.com:bad", "invalid_authority"),
+        ],
+    )
+    async def test_rejects_invalid_host_authority_before_firewall_auth(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        host_header,
+        expected_error,
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", host_header)),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == expected_error
+        assert flow.metadata["firewall_action"] == "DENY"
+        auth_fetch.assert_not_called()
+
     async def test_rejects_missing_https_sni_before_firewall_auth(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -63,6 +63,16 @@ class TestGetOriginalUrl:
 
         assert exc_info.value.reason == "authority_mismatch"
 
+    def test_http_uses_request_host_not_host_header(self, real_flow, headers):
+        flow = real_flow(
+            scheme="http",
+            host="203.0.113.10",
+            port=80,
+            path="/v1/data",
+            request_headers=headers(("Host", "api.example.com")),
+        )
+        assert get_original_url(flow) == "http://203.0.113.10/v1/data"
+
 
 class TestLogProxyEntry:
     def test_writes_jsonl(self, tmp_path):

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import logging_utils
-from url_utils import get_original_url
+from url_utils import AuthorityValidationError, get_original_url
 
 
 class TestGetOriginalUrl:
@@ -41,6 +41,27 @@ class TestGetOriginalUrl:
     def test_with_path_and_query(self, real_flow):
         flow = real_flow(host="api.example.com", port=443, path="/v1/data?key=val")
         assert get_original_url(flow) == "https://api.example.com/v1/data?key=val"
+
+    def test_https_uses_sni_for_transparent_destination(self, real_flow, headers):
+        flow = real_flow(
+            host="203.0.113.10",
+            sni="api.example.com",
+            path="/v1/data?key=val",
+            request_headers=headers(("Host", "api.example.com")),
+        )
+        assert get_original_url(flow) == "https://api.example.com/v1/data?key=val"
+
+    def test_https_rejects_host_sni_mismatch(self, real_flow, headers):
+        flow = real_flow(
+            host="203.0.113.10",
+            sni="attacker.example.com",
+            path="/v1/data",
+            request_headers=headers(("Host", "api.example.com")),
+        )
+        with pytest.raises(AuthorityValidationError) as exc_info:
+            get_original_url(flow)
+
+        assert exc_info.value.reason == "authority_mismatch"
 
 
 class TestLogProxyEntry:

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -63,6 +63,15 @@ class TestGetOriginalUrl:
 
         assert exc_info.value.reason == "authority_mismatch"
 
+    def test_https_accepts_trailing_dot_authority_equivalence(self, real_flow, headers):
+        flow = real_flow(
+            host="203.0.113.10",
+            sni="api.example.com.",
+            path="/v1/data",
+            request_headers=headers(("Host", "API.EXAMPLE.COM.")),
+        )
+        assert get_original_url(flow) == "https://api.example.com/v1/data"
+
     def test_http_uses_request_host_not_host_header(self, real_flow, headers):
         flow = real_flow(
             scheme="http",
@@ -72,6 +81,16 @@ class TestGetOriginalUrl:
             request_headers=headers(("Host", "api.example.com")),
         )
         assert get_original_url(flow) == "http://203.0.113.10/v1/data"
+
+    def test_http_brackets_ipv6_request_host(self, real_flow, headers):
+        flow = real_flow(
+            scheme="http",
+            host="2001:db8::1",
+            port=8080,
+            path="/v1/data",
+            request_headers=headers(("Host", "api.example.com")),
+        )
+        assert get_original_url(flow) == "http://[2001:db8::1]:8080/v1/data"
 
 
 class TestLogProxyEntry:

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -92,6 +92,16 @@ class TestGetOriginalUrl:
         )
         assert get_original_url(flow) == "http://[2001:db8::1]:8080/v1/data"
 
+    def test_https_brackets_ipv6_sni(self, real_flow, headers):
+        flow = real_flow(
+            host="2001:db8::1",
+            port=8443,
+            sni="2001:db8::1",
+            path="/v1/data",
+            request_headers=headers(("Host", "[2001:db8::1]")),
+        )
+        assert get_original_url(flow) == "https://[2001:db8::1]:8443/v1/data"
+
 
 class TestLogProxyEntry:
     def test_writes_jsonl(self, tmp_path):


### PR DESCRIPTION
## Summary

- Derive HTTPS firewall/auth matching authority from TLS SNI instead of spoofable Host / `pretty_host`.
- Reject Host / `:authority` mismatches, bad Host ports, and missing SNI before firewall auth resolution.
- Keep diagnostic Host details in proxy logs while using trusted authority for `original_url`, VM0 API auto-allow, and firewall matching.
- Add regression coverage for Host/SNI spoofing, VM0 API auto-allow spoofing, default-port equivalence, port mismatch, case-insensitive host matching, and missing SNI.

Closes #14412

## Testing

- `python3 -m pytest tests/test_handlers.py -v`
- `python3 -m pytest tests/test_utils.py -v`
- `python3 -m pytest tests/test_handlers.py::TestRequestHandler tests/test_utils.py -v`
- `python3 -m ruff check src/url_utils.py src/mitm_addon.py src/auth.py tests/conftest.py tests/test_handlers.py tests/test_utils.py`
- `python3 -m ruff format --check src/url_utils.py src/mitm_addon.py src/auth.py tests/conftest.py tests/test_handlers.py tests/test_utils.py`
- `git diff --check`
