### PR TITLE
refactor: centralize vsock-host exec dispatch

### DIFF
--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -17,7 +17,8 @@ use crate::{
 use vsock_proto::{
     ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecControlStatus,
     ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy,
-    MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START, RawMessage,
+    MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT,
+    MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, RawMessage,
 };
 
 pub(crate) const DEFAULT_EXEC_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
@@ -1469,6 +1470,19 @@ fn owned_result(
         stderr: owned_captured_output(result.stderr),
         diagnostic: result.diagnostic.to_string(),
         stream_overflowed,
+    }
+}
+
+/// Returns true when exec handling consumed the frame; false lets the normal
+/// pending-response dispatcher handle it.
+pub(crate) fn dispatch_incoming_frame(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
+    match msg.msg_type {
+        MSG_ERROR => dispatch_error(shared, msg),
+        MSG_EXEC_OUTPUT => dispatch_output(shared, msg).map(|_| true),
+        MSG_EXEC_STARTED => dispatch_started(shared, msg).map(|_| true),
+        MSG_EXEC_RESULT => dispatch_result(shared, msg).map(|_| true),
+        MSG_EXEC_CONTROL_RESULT => dispatch_control_result(shared, msg).map(|_| true),
+        _ => Ok(false),
     }
 }
 

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -1486,7 +1486,7 @@ pub(crate) fn dispatch_incoming_frame(shared: &Arc<Shared>, msg: &RawMessage) ->
     }
 }
 
-pub(crate) fn dispatch_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     let mut first_output_slow = None;
     {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -1528,7 +1528,7 @@ pub(crate) fn dispatch_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Res
     Ok(())
 }
 
-pub(crate) fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     let start = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -1576,7 +1576,7 @@ pub(crate) fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Re
     Ok(())
 }
 
-pub(crate) fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     let Some((diagnostic, result_tx, start_tx, stream_overflowed, decoded)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -1632,7 +1632,7 @@ pub(crate) fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Res
     Ok(())
 }
 
-pub(crate) fn dispatch_control_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_control_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     let Some(pending) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -1682,7 +1682,7 @@ pub(crate) fn dispatch_control_result(shared: &Arc<Shared>, msg: &RawMessage) ->
     Ok(())
 }
 
-pub(crate) fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
+fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
     let Some((diagnostic, result_tx, start_tx, err)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -43,8 +43,7 @@ use operation_tracker::{
     NormalOperationTransitionError, NormalOperationTransitionHandle,
 };
 use vsock_proto::{
-    Decoder, MSG_ERROR, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT,
-    MSG_EXEC_STARTED, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG,
+    Decoder, MSG_ERROR, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG,
     MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
     RawMessage,
 };
@@ -455,73 +454,46 @@ async fn reader_loop(
             Err(_) => break,
         };
         for msg in messages {
-            if msg.msg_type == MSG_ERROR {
-                // Intercept active exec-operation errors before the
-                // pending-request dispatch. If no exec operation owns this seq,
-                // the error falls through as a normal request response.
-                match exec_operation::dispatch_error(&shared, &msg) {
-                    Ok(true) => {
-                        continue;
-                    }
-                    Ok(false) => {}
-                    Err(_) => {
-                        shared.poison_connection();
-                        return;
-                    }
+            match exec_operation::dispatch_incoming_frame(&shared, &msg) {
+                Ok(true) => {
+                    continue;
+                }
+                Ok(false) => {}
+                Err(_) => {
+                    shared.poison_connection();
+                    return;
                 }
             }
 
-            if msg.msg_type == MSG_EXEC_OUTPUT {
-                if exec_operation::dispatch_output(&shared, &msg).is_err() {
-                    shared.poison_connection();
-                    return;
-                }
-            } else if msg.msg_type == MSG_EXEC_STARTED {
-                if exec_operation::dispatch_started(&shared, &msg).is_err() {
-                    shared.poison_connection();
-                    return;
-                }
-            } else if msg.msg_type == MSG_EXEC_RESULT {
-                if exec_operation::dispatch_result(&shared, &msg).is_err() {
-                    shared.poison_connection();
-                    return;
-                }
-            } else if msg.msg_type == MSG_EXEC_CONTROL_RESULT {
-                if exec_operation::dispatch_control_result(&shared, &msg).is_err() {
-                    shared.poison_connection();
-                    return;
-                }
-            } else {
-                let mut normal_operation_transition_failed = false;
-                let pending_response = {
-                    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-                    match &mut *guard {
-                        ConnectionState::Connected { pending, .. } => {
-                            if let Some(mut pending_response) = pending.remove(&msg.seq) {
-                                if pending_response
-                                    .normal_terminal_msg_types
-                                    .contains(&msg.msg_type)
-                                    && let Some(normal_operation) =
-                                        pending_response.normal_operation.take()
-                                    && complete_pending_normal_operation(normal_operation).is_err()
-                                {
-                                    normal_operation_transition_failed = true;
-                                }
-                                Some(pending_response)
-                            } else {
-                                None
+            let mut normal_operation_transition_failed = false;
+            let pending_response = {
+                let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                match &mut *guard {
+                    ConnectionState::Connected { pending, .. } => {
+                        if let Some(mut pending_response) = pending.remove(&msg.seq) {
+                            if pending_response
+                                .normal_terminal_msg_types
+                                .contains(&msg.msg_type)
+                                && let Some(normal_operation) =
+                                    pending_response.normal_operation.take()
+                                && complete_pending_normal_operation(normal_operation).is_err()
+                            {
+                                normal_operation_transition_failed = true;
                             }
+                            Some(pending_response)
+                        } else {
+                            None
                         }
-                        ConnectionState::Closed => None,
                     }
-                };
-                if normal_operation_transition_failed {
-                    shared.poison_connection();
-                    return;
+                    ConnectionState::Closed => None,
                 }
-                if let Some(pending_response) = pending_response {
-                    let _ = pending_response.response_tx.send(msg);
-                }
+            };
+            if normal_operation_transition_failed {
+                shared.poison_connection();
+                return;
+            }
+            if let Some(pending_response) = pending_response {
+                let _ = pending_response.response_tx.send(msg);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `exec_operation::dispatch_incoming_frame` to centralize incoming exec frame classification.
- Simplify `reader_loop` so exec dispatch errors share one poison-and-return path.
- Preserve `MSG_ERROR` fall-through behavior for normal pending-response dispatch when no exec operation/control owns the sequence.

Closes #14405

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings` (after cleaning stale local build metadata)
- pre-commit hook