### PR TITLE
refactor: share google oauth connector classification

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -27,6 +27,7 @@ import {
   isOAuthConnectorType,
   CONNECTOR_OAUTH_PROVIDERS,
 } from "../oauth-providers/provider-registry";
+import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../oauth-providers/google-oauth-connectors";
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -672,18 +673,8 @@ describe("getConnectorTypeForSecretName", () => {
 });
 
 describe("isGoogleOAuthConnector", () => {
-  const GOOGLE_CONNECTORS = [
-    "gmail",
-    "google-ads",
-    "google-sheets",
-    "google-docs",
-    "google-drive",
-    "google-calendar",
-    "google-meet",
-  ] as const;
-
   it("returns true for all known Google OAuth connectors", () => {
-    for (const type of GOOGLE_CONNECTORS) {
+    for (const type of GOOGLE_OAUTH_CONNECTOR_TYPES) {
       expect(
         isGoogleOAuthConnector(type),
         `${type} should be identified as a Google OAuth connector`,
@@ -711,51 +702,26 @@ describe("isGoogleOAuthConnector", () => {
     }
   });
 
-  it("returns true only for connectors whose OAuth authorizationUrl hostname is accounts.google.com", () => {
-    for (const type of connectorTypeSchema.options) {
-      const result = isGoogleOAuthConnector(type);
-      const oauthConfig = getConnectorOAuthConfigIfSupported(type);
+  it("returns true only for the shared Google OAuth provider connector set", () => {
+    const detected = connectorTypeSchema.options.filter(isGoogleOAuthConnector);
 
-      if (result) {
-        // If classified as Google, the OAuth URL must point to accounts.google.com
-        const authorizationUrl = oauthConfig?.authorizationUrl;
-        expect(
-          authorizationUrl,
-          `${type}: Google connector must have an authorizationUrl`,
-        ).toBeDefined();
-        expect(
-          new URL(authorizationUrl as string).hostname,
-          `${type}: Google connector authorizationUrl must use accounts.google.com`,
-        ).toBe("accounts.google.com");
-      } else if (oauthConfig?.authorizationUrl) {
-        // If not classified as Google but has an OAuth URL, it must NOT be accounts.google.com
-        let hostname: string | null = null;
-        try {
-          hostname = new URL(oauthConfig.authorizationUrl).hostname;
-        } catch {
-          // invalid URL — isGoogleOAuthConnector correctly returns false
-        }
-        if (hostname) {
-          expect(
-            hostname,
-            `${type}: non-Google connector must not use accounts.google.com`,
-          ).not.toBe("accounts.google.com");
-        }
-      }
-    }
+    expect([...detected].sort()).toStrictEqual(
+      [...GOOGLE_OAUTH_CONNECTOR_TYPES].sort(),
+    );
   });
 
-  it("covers exactly the same set as the legacy hardcoded type list", () => {
-    // Ensures isGoogleOAuthConnector detects at least the 6 connectors
-    // previously handled by the hardcoded isGoogleConnector function.
-    const detected = connectorTypeSchema.options.filter(isGoogleOAuthConnector);
-    for (const type of GOOGLE_CONNECTORS) {
+  it("keeps Google OAuth connector configs on the Google authorization endpoint", () => {
+    for (const type of GOOGLE_OAUTH_CONNECTOR_TYPES) {
+      const oauthConfig = getConnectorOAuthConfig(type);
+      const authorizationUrl = oauthConfig.authorizationUrl;
+      if (!authorizationUrl) {
+        throw new Error(`${type}: Google connector must have authorizationUrl`);
+      }
+
       expect(
-        detected,
-        `${type} must be detected by isGoogleOAuthConnector`,
-      ).toContain(type);
+        new URL(authorizationUrl).hostname,
+        `${type}: Google connector authorizationUrl must use accounts.google.com`,
+      ).toBe("accounts.google.com");
     }
-    // No non-Google connector should slip through
-    expect(detected.length).toBe(GOOGLE_CONNECTORS.length);
   });
 });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -724,4 +724,26 @@ describe("isGoogleOAuthConnector", () => {
       ).toBe("accounts.google.com");
     }
   });
+
+  it("includes every connector configured with the Google authorization endpoint", () => {
+    for (const type of connectorTypeSchema.options) {
+      const oauthConfig = getConnectorOAuthConfigIfSupported(type);
+      if (!oauthConfig?.authorizationUrl) {
+        continue;
+      }
+      if (!oauthConfig.authorizationUrl.startsWith("https://")) {
+        continue;
+      }
+
+      const hostname = new URL(oauthConfig.authorizationUrl).hostname;
+      if (hostname !== "accounts.google.com") {
+        continue;
+      }
+
+      expect(
+        GOOGLE_OAUTH_CONNECTOR_TYPES,
+        `${type} uses Google OAuth and must be listed in GOOGLE_OAUTH_CONNECTOR_TYPES`,
+      ).toContain(type);
+    }
+  });
 });

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -18,6 +18,7 @@ import {
   type OAuthConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
+import { isGoogleOAuthConnectorType } from "./oauth-providers/google-oauth-connectors";
 
 /**
  * Connector utility vocabulary:
@@ -469,18 +470,10 @@ export function getConnectorOAuthConfig(
 }
 
 /**
- * Check if a connector type uses Google OAuth (accounts.google.com).
+ * Check if a connector type uses the shared Google OAuth provider.
  */
 export function isGoogleOAuthConnector(type: ConnectorType): boolean {
-  const oauthConfig = getConnectorOAuthConfigIfSupported(type);
-  if (!oauthConfig?.authorizationUrl) return false;
-  try {
-    return (
-      new URL(oauthConfig.authorizationUrl).hostname === "accounts.google.com"
-    );
-  } catch {
-    return false;
-  }
+  return isGoogleOAuthConnectorType(type);
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -18,7 +18,7 @@ import {
   type OAuthConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
-import { isGoogleOAuthConnectorType } from "./oauth-providers/google-oauth-connectors";
+export { isGoogleOAuthConnector } from "./oauth-providers/google-oauth-connectors";
 
 /**
  * Connector utility vocabulary:
@@ -467,13 +467,6 @@ export function getConnectorOAuthConfig(
   type: OAuthConnectorType,
 ): ConnectorOAuthConfig {
   return CONNECTOR_TYPES[type].oauth;
-}
-
-/**
- * Check if a connector type uses the shared Google OAuth provider.
- */
-export function isGoogleOAuthConnector(type: ConnectorType): boolean {
-  return isGoogleOAuthConnectorType(type);
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
+++ b/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
@@ -1,0 +1,23 @@
+import type { ConnectorType, OAuthConnectorType } from "../connectors";
+
+export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
+  "gmail",
+  "google-ads",
+  "google-calendar",
+  "google-docs",
+  "google-drive",
+  "google-meet",
+  "google-sheets",
+] as const satisfies readonly OAuthConnectorType[];
+
+export type GoogleOAuthConnectorType =
+  (typeof GOOGLE_OAUTH_CONNECTOR_TYPES)[number];
+
+const GOOGLE_OAUTH_CONNECTOR_TYPE_SET: ReadonlySet<ConnectorType> =
+  new Set<ConnectorType>(GOOGLE_OAUTH_CONNECTOR_TYPES);
+
+export function isGoogleOAuthConnectorType(
+  type: ConnectorType,
+): type is GoogleOAuthConnectorType {
+  return GOOGLE_OAUTH_CONNECTOR_TYPE_SET.has(type);
+}

--- a/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
+++ b/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
@@ -16,7 +16,10 @@ export type GoogleOAuthConnectorType =
 const GOOGLE_OAUTH_CONNECTOR_TYPE_SET: ReadonlySet<ConnectorType> =
   new Set<ConnectorType>(GOOGLE_OAUTH_CONNECTOR_TYPES);
 
-export function isGoogleOAuthConnectorType(
+/**
+ * Check if a connector type uses the shared Google OAuth provider.
+ */
+export function isGoogleOAuthConnector(
   type: ConnectorType,
 ): type is GoogleOAuthConnectorType {
   return GOOGLE_OAUTH_CONNECTOR_TYPE_SET.has(type);

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
@@ -1,20 +1,9 @@
-import type { OAuthConnectorType } from "@vm0/connectors/connectors";
 import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+import type { GoogleOAuthConnectorType } from "../google-oauth-connectors";
 import { throwOAuthError } from "./oauth-error";
 
 const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
-
-type GoogleOAuthConnectorType = Extract<
-  OAuthConnectorType,
-  | "gmail"
-  | "google-ads"
-  | "google-calendar"
-  | "google-docs"
-  | "google-drive"
-  | "google-meet"
-  | "google-sheets"
->;
 
 interface GoogleUserInfo {
   id: string;


### PR DESCRIPTION
## Summary
- move the Google OAuth connector set into a shared module
- make isGoogleOAuthConnector use the shared provider set instead of parsing authorizationUrl hostnames
- update connector tests to assert the shared set and keep the Google authorization endpoint coverage

## Tests
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pre-commit hook: prettier, knip, turbo run check-types