### PR TITLE
refactor(vsock-proto): compact message type ids

### DIFF
--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -263,15 +263,26 @@ pub(crate) fn handle_basic_message(msg: &RawMessage) -> io::Result<MessageOutcom
         MSG_PING => Ok(MessageOutcome::Response(
             vsock_proto::encode(MSG_PONG, msg.seq, &[]).map_err(to_io_error)?,
         )),
-        MSG_SHUTDOWN => Ok(MessageOutcome::Shutdown(handle_shutdown(msg.seq)?)),
-        _ => {
-            let payload =
-                vsock_proto::encode_error(&format!("Unknown message type: 0x{:02X}", msg.msg_type));
-            Ok(MessageOutcome::Response(
-                vsock_proto::encode(MSG_ERROR, msg.seq, &payload).map_err(to_io_error)?,
-            ))
+        MSG_SHUTDOWN => {
+            if let Err(error) =
+                vsock_proto::decode_empty_payload("shutdown payload must be empty", &msg.payload)
+            {
+                return encode_error_response(msg.seq, &error.to_string());
+            }
+            Ok(MessageOutcome::Shutdown(handle_shutdown(msg.seq)?))
         }
+        _ => encode_error_response(
+            msg.seq,
+            &format!("Unknown message type: 0x{:02X}", msg.msg_type),
+        ),
     }
+}
+
+fn encode_error_response(seq: u32, message: &str) -> io::Result<MessageOutcome> {
+    let payload = vsock_proto::encode_error(message);
+    Ok(MessageOutcome::Response(
+        vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/vsock-guest/tests/connection/shutdown.rs
+++ b/crates/vsock-guest/tests/connection/shutdown.rs
@@ -3,9 +3,12 @@ use std::thread;
 use std::time::Duration;
 
 use vsock_guest::run;
-use vsock_proto::{self, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
+use vsock_proto::{self, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
 
-use super::support::{read_and_discard_message, read_message, unique_socket_path};
+use super::support::{
+    finish_guest_connection, read_and_discard_message, read_error_response, read_message,
+    start_guest_connection, unique_socket_path,
+};
 
 #[test]
 fn run_exits_after_shutdown_even_when_ack_write_fails() {
@@ -77,4 +80,23 @@ fn run_sends_shutdown_ack_and_exits_without_waiting_for_disconnect() {
         result.is_ok(),
         "shutdown should stop run() cleanly: {result:?}"
     );
+}
+
+#[test]
+fn shutdown_rejects_non_empty_payload_without_exiting() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let shutdown = vsock_proto::encode(MSG_SHUTDOWN, 42, b"legacy command payload").unwrap();
+    host_stream.write_all(&shutdown).unwrap();
+
+    let error = read_error_response(&mut host_stream, 42);
+    assert_eq!(error, "invalid payload: shutdown payload must be empty");
+
+    let ping = vsock_proto::encode(MSG_PING, 43, &[]).unwrap();
+    host_stream.write_all(&ping).unwrap();
+    let pong = read_message(&mut host_stream);
+    assert_eq!(pong.msg_type, MSG_PONG);
+    assert_eq!(pong.seq, 43);
+
+    finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,25 +22,19 @@
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x05 |           | retired           | reserved legacy command-start id |
-//! | 0x06 |           | retired           | reserved legacy command-start acknowledgement id |
-//! | 0x07 |           | retired           | reserved legacy command-exit id |
-//! | 0x08 | H→G       | shutdown          | (empty) |
-//! | 0x09 | G→H       | shutdown_ack      | (empty) |
-//! | 0x0A |           | retired           | reserved legacy stdout stream id |
-//! | 0x0B | H→G       | exec_start     | `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
-//! | 0x0C | G→H       | exec_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
-//! | 0x0D | G→H       | exec_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
-//! | 0x0E | H→G       | exec_cancel    | (empty) |
-//! | 0x0F | H→G       | quiesce_operations  | (empty) |
-//! | 0x10 | G→H       | operations_quiesced    | (empty) |
-//! | 0x11 | H→G       | resume_operations | (empty) |
-//! | 0x12 | G→H       | operations_resumed | (empty) |
-//! | 0x13 |           | retired           | reserved legacy control request id |
-//! | 0x14 |           | retired           | reserved legacy control result id |
-//! | 0x15 | G→H       | exec_started | `[4B pid]` |
-//! | 0x16 | H→G       | exec_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
-//! | 0x17 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
+//! | 0x05 | H→G       | shutdown          | (empty) |
+//! | 0x06 | G→H       | shutdown_ack      | (empty) |
+//! | 0x07 | H→G       | exec_start     | `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
+//! | 0x08 | G→H       | exec_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
+//! | 0x09 | G→H       | exec_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
+//! | 0x0A | H→G       | exec_cancel    | (empty) |
+//! | 0x0B | H→G       | quiesce_operations  | (empty) |
+//! | 0x0C | G→H       | operations_quiesced    | (empty) |
+//! | 0x0D | H→G       | resume_operations | (empty) |
+//! | 0x0E | G→H       | operations_resumed | (empty) |
+//! | 0x0F | G→H       | exec_started | `[4B pid]` |
+//! | 0x10 | H→G       | exec_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
+//! | 0x11 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Exec operation messages are request-scoped; host/guest dispatch layers must

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -22,50 +22,44 @@ pub const MSG_WRITE_FILE: u8 = 0x03;
 /// Guest-to-host write-file completion response.
 pub const MSG_WRITE_FILE_RESULT: u8 = 0x04;
 
-// 0x05, 0x06, and 0x07 are retired legacy command lifecycle ids.
-
 /// Host-to-guest shutdown request with an empty payload.
-pub const MSG_SHUTDOWN: u8 = 0x08;
+pub const MSG_SHUTDOWN: u8 = 0x05;
 
 /// Guest-to-host shutdown acknowledgement with an empty payload.
-pub const MSG_SHUTDOWN_ACK: u8 = 0x09;
-
-// 0x0A is a retired legacy stdout stream id.
+pub const MSG_SHUTDOWN_ACK: u8 = 0x06;
 
 /// Host-to-guest exec operation start request.
-pub const MSG_EXEC_START: u8 = 0x0B;
+pub const MSG_EXEC_START: u8 = 0x07;
 
 /// Guest-to-host exec operation output chunk.
-pub const MSG_EXEC_OUTPUT: u8 = 0x0C;
+pub const MSG_EXEC_OUTPUT: u8 = 0x08;
 
 /// Guest-to-host exec operation terminal result.
-pub const MSG_EXEC_RESULT: u8 = 0x0D;
+pub const MSG_EXEC_RESULT: u8 = 0x09;
 
 /// Host-to-guest exec operation cancellation request.
-pub const MSG_EXEC_CANCEL: u8 = 0x0E;
+pub const MSG_EXEC_CANCEL: u8 = 0x0A;
 
 /// Host-to-guest request to fence new guest operations.
-pub const MSG_QUIESCE_OPERATIONS: u8 = 0x0F;
+pub const MSG_QUIESCE_OPERATIONS: u8 = 0x0B;
 
 /// Guest-to-host acknowledgement that operations are quiesced.
-pub const MSG_OPERATIONS_QUIESCED: u8 = 0x10;
+pub const MSG_OPERATIONS_QUIESCED: u8 = 0x0C;
 
 /// Host-to-guest request to resume guest operations.
-pub const MSG_RESUME_OPERATIONS: u8 = 0x11;
+pub const MSG_RESUME_OPERATIONS: u8 = 0x0D;
 
 /// Guest-to-host acknowledgement that operations resumed.
-pub const MSG_OPERATIONS_RESUMED: u8 = 0x12;
-
-// 0x13 and 0x14 are retired legacy control ids.
+pub const MSG_OPERATIONS_RESUMED: u8 = 0x0E;
 
 /// Guest-to-host exec operation start acknowledgement.
-pub const MSG_EXEC_STARTED: u8 = 0x15;
+pub const MSG_EXEC_STARTED: u8 = 0x0F;
 
 /// Host-to-guest control message for an active exec operation.
-pub const MSG_EXEC_CONTROL: u8 = 0x16;
+pub const MSG_EXEC_CONTROL: u8 = 0x10;
 
 /// Guest-to-host exec control delivery result.
-pub const MSG_EXEC_CONTROL_RESULT: u8 = 0x17;
+pub const MSG_EXEC_CONTROL_RESULT: u8 = 0x11;
 
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
@@ -95,13 +89,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn exec_operation_keeps_existing_wire_values() {
-        assert_eq!(MSG_EXEC_START, 0x0B);
-        assert_eq!(MSG_EXEC_OUTPUT, 0x0C);
-        assert_eq!(MSG_EXEC_RESULT, 0x0D);
-        assert_eq!(MSG_EXEC_CANCEL, 0x0E);
-        assert_eq!(MSG_EXEC_STARTED, 0x15);
-        assert_eq!(MSG_EXEC_CONTROL, 0x16);
-        assert_eq!(MSG_EXEC_CONTROL_RESULT, 0x17);
+    fn message_type_wire_values_are_compact() {
+        assert_eq!(MSG_SHUTDOWN, 0x05);
+        assert_eq!(MSG_SHUTDOWN_ACK, 0x06);
+        assert_eq!(MSG_EXEC_START, 0x07);
+        assert_eq!(MSG_EXEC_OUTPUT, 0x08);
+        assert_eq!(MSG_EXEC_RESULT, 0x09);
+        assert_eq!(MSG_EXEC_CANCEL, 0x0A);
+        assert_eq!(MSG_QUIESCE_OPERATIONS, 0x0B);
+        assert_eq!(MSG_OPERATIONS_QUIESCED, 0x0C);
+        assert_eq!(MSG_RESUME_OPERATIONS, 0x0D);
+        assert_eq!(MSG_OPERATIONS_RESUMED, 0x0E);
+        assert_eq!(MSG_EXEC_STARTED, 0x0F);
+        assert_eq!(MSG_EXEC_CONTROL, 0x10);
+        assert_eq!(MSG_EXEC_CONTROL_RESULT, 0x11);
     }
 }


### PR DESCRIPTION
## Summary
- remove retired vsock protocol message type slots from the public message table
- compact subsequent message type constants so protocol ids remain contiguous
- reject malformed non-empty shutdown frames before acknowledging shutdown
- update wire value and shutdown edge-case coverage

## Compatibility
- This intentionally changes vsock wire message ids and requires host and guest to use the same protocol version.
- Malformed `shutdown` frames with non-empty payloads now return `MSG_ERROR` instead of shutting the guest down.

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo test --manifest-path crates/Cargo.toml -p vsock-host -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest shutdown_rejects_non_empty_payload_without_exiting
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc process_control_protocol
- cargo fmt --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-proto -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-guest -p vsock-host --all-targets --all-features
- cargo clippy --all-targets --all-features
- git diff --check
- pre-commit hook: cargo fmt, cargo clippy, cargo doc