### PR TITLE
refactor: deduplicate connector oauth start helpers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -14,7 +14,7 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { encryptSecretValue } from "../../services/crypto.utils";
@@ -257,6 +257,19 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
         return cookie.startsWith("connector_oauth_state=");
       }),
     ).toBeTruthy();
+  });
+
+  it("sets Secure on OAuth cookies in production", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestAuthorize("github", { authenticated: true });
+
+    const cookies = response.headers.getSetCookie();
+    const stateCookie = cookies.find((cookie) => {
+      return cookie.startsWith("connector_oauth_state=");
+    });
+    expect(stateCookie).toBeDefined();
+    expect(stateCookie).toContain("Secure");
   });
 
   it("uses the web rewrite origin for OAuth callback URLs", async () => {
@@ -733,5 +746,46 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
         code: "UNAUTHORIZED",
       },
     });
+  });
+
+  it("returns 400 when starting OAuth for a non-OAuth connector", async () => {
+    const response = await requestOauthStart("serpapi", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "serpapi connector does not use OAuth",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("does not create server-side handoff state when OAuth is not configured", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", undefined);
+    mocks.clerk.session(userId, orgId);
+
+    const response = await requestOauthStart("github", {
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "github OAuth not configured",
+        code: "INTERNAL_SERVER_ERROR",
+      },
+    });
+
+    const db = store.set(writeDb$);
+    const states = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.userId, userId));
+    expect(states).toHaveLength(0);
   });
 });

--- a/turbo/apps/api/src/signals/routes/connector-oauth-route-state.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-route-state.ts
@@ -1,0 +1,65 @@
+import { env } from "../../lib/env";
+
+export const CONNECTOR_OAUTH_STATE_COOKIE_NAME = "connector_oauth_state";
+export const CONNECTOR_OAUTH_SESSION_COOKIE_NAME = "connector_oauth_session";
+export const CONNECTOR_OAUTH_PKCE_COOKIE_NAME = "connector_oauth_pkce";
+export const CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
+export const CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS = 15 * 60;
+
+const CONNECTOR_OAUTH_REDIRECT_STATUS = 307;
+
+export function generateConnectorOAuthState(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => {
+    return byte.toString(16).padStart(2, "0");
+  }).join("");
+}
+
+export function buildConnectorOAuthCookieHeader(
+  name: string,
+  value: string,
+  maxAge: number,
+): string {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    `Max-Age=${maxAge}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (env("ENV") === "production") {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+function buildDeleteConnectorOAuthCookieHeader(name: string): string {
+  return `${name}=; Max-Age=0; Path=/`;
+}
+
+export function connectorOAuthRedirectResponse(url: string): Response {
+  return new Response(null, {
+    status: CONNECTOR_OAUTH_REDIRECT_STATUS,
+    headers: { location: url },
+  });
+}
+
+export function clearConnectorOAuthCookies(response: Response): void {
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteConnectorOAuthCookieHeader(CONNECTOR_OAUTH_STATE_COOKIE_NAME),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteConnectorOAuthCookieHeader(CONNECTOR_OAUTH_SESSION_COOKIE_NAME),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteConnectorOAuthCookieHeader(CONNECTOR_OAUTH_PKCE_COOKIE_NAME),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteConnectorOAuthCookieHeader(CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME),
+  );
+}

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,0 +1,85 @@
+import {
+  getConnectorAuthMethod,
+  getConnectorOAuthCredentials,
+  type ConnectorEnvReader,
+} from "@vm0/connectors/connector-utils";
+import type {
+  ConnectorType,
+  OAuthConnectorType,
+} from "@vm0/connectors/connectors";
+import {
+  buildConnectorOAuthAuthUrl,
+  isOAuthConnectorType,
+  type AuthUrlResult,
+} from "@vm0/connectors/oauth-providers";
+
+import { generateConnectorOAuthState } from "./connector-oauth-route-state";
+
+type PrepareConnectorOAuthStartResult =
+  | {
+      readonly ok: true;
+      readonly state: string;
+      readonly redirectUri: string;
+      readonly authResult: AuthUrlResult;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "oauth_not_configured";
+    };
+
+type ResolveConnectorOAuthStartTypeResult =
+  | {
+      readonly ok: true;
+      readonly type: OAuthConnectorType;
+    }
+  | {
+      readonly ok: false;
+      readonly reason:
+        | "connector_does_not_use_oauth"
+        | "oauth_provider_not_configured";
+    };
+
+function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
+  return typeof result === "string" ? { url: result } : result;
+}
+
+export function resolveConnectorOAuthStartType(
+  type: ConnectorType,
+): ResolveConnectorOAuthStartTypeResult {
+  if (!getConnectorAuthMethod(type, "oauth")) {
+    return { ok: false, reason: "connector_does_not_use_oauth" };
+  }
+  if (!isOAuthConnectorType(type)) {
+    return { ok: false, reason: "oauth_provider_not_configured" };
+  }
+  return { ok: true, type };
+}
+
+export async function prepareConnectorOAuthStart(args: {
+  readonly type: OAuthConnectorType;
+  readonly origin: string;
+  readonly readEnv: ConnectorEnvReader;
+}): Promise<PrepareConnectorOAuthStartResult> {
+  const state = generateConnectorOAuthState();
+  const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
+  const credentials = getConnectorOAuthCredentials(args.type, args.readEnv);
+  if (!credentials?.configured) {
+    return { ok: false, reason: "oauth_not_configured" };
+  }
+
+  const authResult = normalizeAuthUrlResult(
+    await buildConnectorOAuthAuthUrl({
+      type: args.type,
+      credentials,
+      redirectUri,
+      state,
+    }),
+  );
+
+  return {
+    ok: true,
+    state,
+    redirectUri,
+    authResult,
+  };
+}

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -61,9 +61,9 @@ export function resolveConnectorOAuthStartType(
   return { ok: true, type };
 }
 
-// This helper intentionally prepares only provider-specific data. Callers must
-// resolve the route's ConnectorType first so non-OAuth connectors keep their
-// existing route-specific error responses.
+// Prepare only synchronous OAuth start data. Callers must resolve the route's
+// ConnectorType first so non-OAuth connectors keep their route-specific errors,
+// then build the provider authorization URL at the normal async commit point.
 export function prepareResolvedConnectorOAuthStart(args: {
   readonly type: OAuthConnectorType;
   readonly origin: string;

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -15,7 +15,7 @@ import {
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
 
-type PrepareConnectorOAuthStartResult =
+type PrepareResolvedConnectorOAuthStartResult =
   | {
       readonly ok: true;
       readonly state: string;
@@ -55,11 +55,14 @@ export function resolveConnectorOAuthStartType(
   return { ok: true, type };
 }
 
-export async function prepareConnectorOAuthStart(args: {
+// This helper intentionally prepares only provider-specific data. Callers must
+// resolve the route's ConnectorType first so non-OAuth connectors keep their
+// existing route-specific error responses.
+export async function prepareResolvedConnectorOAuthStart(args: {
   readonly type: OAuthConnectorType;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
-}): Promise<PrepareConnectorOAuthStartResult> {
+}): Promise<PrepareResolvedConnectorOAuthStartResult> {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
   const credentials = getConnectorOAuthCredentials(args.type, args.readEnv);

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -2,6 +2,7 @@ import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
   type ConnectorEnvReader,
+  type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorType,
@@ -15,12 +16,17 @@ import {
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
 
+type ConfiguredConnectorOAuthCredentials = Extract<
+  ConnectorOAuthCredentials,
+  { readonly configured: true }
+>;
+
 type PrepareResolvedConnectorOAuthStartResult =
   | {
       readonly ok: true;
       readonly state: string;
       readonly redirectUri: string;
-      readonly authResult: AuthUrlResult;
+      readonly credentials: ConfiguredConnectorOAuthCredentials;
     }
   | {
       readonly ok: false;
@@ -58,11 +64,11 @@ export function resolveConnectorOAuthStartType(
 // This helper intentionally prepares only provider-specific data. Callers must
 // resolve the route's ConnectorType first so non-OAuth connectors keep their
 // existing route-specific error responses.
-export async function prepareResolvedConnectorOAuthStart(args: {
+export function prepareResolvedConnectorOAuthStart(args: {
   readonly type: OAuthConnectorType;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
-}): Promise<PrepareResolvedConnectorOAuthStartResult> {
+}): PrepareResolvedConnectorOAuthStartResult {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
   const credentials = getConnectorOAuthCredentials(args.type, args.readEnv);
@@ -70,19 +76,26 @@ export async function prepareResolvedConnectorOAuthStart(args: {
     return { ok: false, reason: "oauth_not_configured" };
   }
 
-  const authResult = normalizeAuthUrlResult(
-    await buildConnectorOAuthAuthUrl({
-      type: args.type,
-      credentials,
-      redirectUri,
-      state,
-    }),
-  );
-
   return {
     ok: true,
     state,
     redirectUri,
-    authResult,
+    credentials,
   };
+}
+
+export async function buildResolvedConnectorOAuthAuthResult(args: {
+  readonly type: OAuthConnectorType;
+  readonly credentials: ConfiguredConnectorOAuthCredentials;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<AuthUrlResult> {
+  return normalizeAuthUrlResult(
+    await buildConnectorOAuthAuthUrl({
+      type: args.type,
+      credentials: args.credentials,
+      redirectUri: args.redirectUri,
+      state: args.state,
+    }),
+  );
 }

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -37,12 +37,14 @@ import {
   getConnectorOAuthCanonicalRedirectUrl,
   getConnectorOAuthOrigin,
 } from "./connector-oauth-origin";
-
-const STATE_COOKIE_NAME = "connector_oauth_state";
-const SESSION_COOKIE_NAME = "connector_oauth_session";
-const PKCE_COOKIE_NAME = "connector_oauth_pkce";
-const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
-const REDIRECT_STATUS = 307;
+import {
+  clearConnectorOAuthCookies,
+  CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+  CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+  CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+  CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+  connectorOAuthRedirectResponse,
+} from "./connector-oauth-route-state";
 
 type CallbackIdentity = {
   readonly userId: string;
@@ -124,36 +126,6 @@ function getCookie(request: Request, name: string): string | undefined {
   return undefined;
 }
 
-function buildDeleteCookieHeader(name: string): string {
-  return `${name}=; Max-Age=0; Path=/`;
-}
-
-function redirectResponse(url: string): Response {
-  return new Response(null, {
-    status: REDIRECT_STATUS,
-    headers: { location: url },
-  });
-}
-
-function clearOAuthCookies(response: Response): void {
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(STATE_COOKIE_NAME),
-  );
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(SESSION_COOKIE_NAME),
-  );
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(PKCE_COOKIE_NAME),
-  );
-  response.headers.append(
-    "Set-Cookie",
-    buildDeleteCookieHeader(OAUTH_CONTEXT_COOKIE_NAME),
-  );
-}
-
 function redirectWithError(
   origin: string,
   type: string,
@@ -164,9 +136,9 @@ function redirectWithError(
   errorUrl.searchParams.set("type", type);
   errorUrl.searchParams.set("message", message);
 
-  const response = redirectResponse(errorUrl.toString());
+  const response = connectorOAuthRedirectResponse(errorUrl.toString());
   if (clearCookies) {
-    clearOAuthCookies(response);
+    clearConnectorOAuthCookies(response);
   }
   return response;
 }
@@ -356,8 +328,8 @@ function successRedirectResponse(args: {
   successUrl.searchParams.set("type", args.type);
   successUrl.searchParams.set("username", args.username ?? "");
 
-  const response = redirectResponse(successUrl.toString());
-  clearOAuthCookies(response);
+  const response = connectorOAuthRedirectResponse(successUrl.toString());
+  clearConnectorOAuthCookies(response);
   return response;
 }
 
@@ -485,7 +457,7 @@ const callbackConnectorInner$ = command(
     const request = get(request$).raw;
     const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrl(request);
     if (canonicalRedirectUrl) {
-      return redirectResponse(canonicalRedirectUrl);
+      return connectorOAuthRedirectResponse(canonicalRedirectUrl);
     }
     const origin = getConnectorOAuthOrigin(request);
 
@@ -496,10 +468,13 @@ const callbackConnectorInner$ = command(
     const { connectorType } = connectorTypeResult;
 
     const writeDb = set(writeDb$);
-    const savedState = getCookie(request, STATE_COOKIE_NAME);
-    const sessionId = getCookie(request, SESSION_COOKIE_NAME);
-    const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
-    const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
+    const savedState = getCookie(request, CONNECTOR_OAUTH_STATE_COOKIE_NAME);
+    const sessionId = getCookie(request, CONNECTOR_OAUTH_SESSION_COOKIE_NAME);
+    const codeVerifier = getCookie(request, CONNECTOR_OAUTH_PKCE_COOKIE_NAME);
+    const oauthContext = getCookie(
+      request,
+      CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+    );
     const state = query.state;
     const storedStateCallbackArgs = {
       db: writeDb,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -62,7 +62,7 @@ import {
   connectorOAuthRedirectResponse,
 } from "./connector-oauth-route-state";
 import {
-  prepareConnectorOAuthStart,
+  prepareResolvedConnectorOAuthStart,
   resolveConnectorOAuthStartType,
 } from "./connector-oauth-start";
 
@@ -409,7 +409,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    const prepared = await prepareConnectorOAuthStart({
+    const prepared = await prepareResolvedConnectorOAuthStart({
       type: startType.type,
       origin,
       readEnv: optionalEnv,
@@ -499,7 +499,7 @@ const startConnectorOauthInner$ = command(
     }
 
     const origin = getConnectorOAuthOrigin(request);
-    const prepared = await prepareConnectorOAuthStart({
+    const prepared = await prepareResolvedConnectorOAuthStart({
       type: startType.type,
       origin,
       readEnv: optionalEnv,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -62,6 +62,7 @@ import {
   connectorOAuthRedirectResponse,
 } from "./connector-oauth-route-state";
 import {
+  buildResolvedConnectorOAuthAuthResult,
   prepareResolvedConnectorOAuthStart,
   resolveConnectorOAuthStartType,
 } from "./connector-oauth-start";
@@ -409,15 +410,21 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    const prepared = await prepareResolvedConnectorOAuthStart({
+    const prepared = prepareResolvedConnectorOAuthStart({
       type: startType.type,
       origin,
       readEnv: optionalEnv,
     });
-    signal.throwIfAborted();
     if (!prepared.ok) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
+    const authResult = await buildResolvedConnectorOAuthAuthResult({
+      type: startType.type,
+      credentials: prepared.credentials,
+      redirectUri: prepared.redirectUri,
+      state: prepared.state,
+    });
+    signal.throwIfAborted();
 
     await set(
       deleteZeroConnectorLocalState$,
@@ -426,7 +433,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     );
     signal.throwIfAborted();
 
-    const response = connectorOAuthRedirectResponse(prepared.authResult.url);
+    const response = connectorOAuthRedirectResponse(authResult.url);
     response.headers.append(
       "Set-Cookie",
       buildConnectorOAuthCookieHeader(
@@ -435,22 +442,22 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
         CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
       ),
     );
-    if (prepared.authResult.codeVerifier) {
+    if (authResult.codeVerifier) {
       response.headers.append(
         "Set-Cookie",
         buildConnectorOAuthCookieHeader(
           CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
-          prepared.authResult.codeVerifier,
+          authResult.codeVerifier,
           CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );
     }
-    if (prepared.authResult.oauthContext) {
+    if (authResult.oauthContext) {
       response.headers.append(
         "Set-Cookie",
         buildConnectorOAuthCookieHeader(
           CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
-          prepared.authResult.oauthContext,
+          authResult.oauthContext,
           CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );
@@ -499,15 +506,21 @@ const startConnectorOauthInner$ = command(
     }
 
     const origin = getConnectorOAuthOrigin(request);
-    const prepared = await prepareResolvedConnectorOAuthStart({
+    const prepared = prepareResolvedConnectorOAuthStart({
       type: startType.type,
       origin,
       readEnv: optionalEnv,
     });
-    signal.throwIfAborted();
     if (!prepared.ok) {
       return internalServerError(`${type} OAuth not configured`);
     }
+    const authResult = await buildResolvedConnectorOAuthAuthResult({
+      type: startType.type,
+      credentials: prepared.credentials,
+      redirectUri: prepared.redirectUri,
+      state: prepared.state,
+    });
+    signal.throwIfAborted();
 
     await set(
       deleteZeroConnectorLocalState$,
@@ -523,8 +536,8 @@ const startConnectorOauthInner$ = command(
       userId: auth.userId,
       orgId: auth.orgId,
       redirectUri: prepared.redirectUri,
-      codeVerifier: prepared.authResult.codeVerifier,
-      oauthContext: prepared.authResult.oauthContext,
+      codeVerifier: authResult.codeVerifier,
+      oauthContext: authResult.oauthContext,
       expiresAt: new Date(
         nowDate().getTime() + CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS * 1000,
       ),
@@ -534,7 +547,7 @@ const startConnectorOauthInner$ = command(
     return {
       status: 200 as const,
       body: {
-        authorizationUrl: prepared.authResult.url,
+        authorizationUrl: authResult.url,
       },
     };
   },

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -15,20 +15,8 @@ import {
   zeroLocalBrowserConnectorContract,
   zeroLocalAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
-import {
-  getConnectorAuthMethod,
-  getConnectorOAuthCredentials,
-} from "@vm0/connectors/connector-utils";
-import {
-  connectorTypeSchema,
-  type OAuthConnectorType,
-} from "@vm0/connectors/connectors";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  buildConnectorOAuthAuthUrl,
-  isOAuthConnectorType,
-  type AuthUrlResult,
-} from "@vm0/connectors/oauth-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -44,7 +32,7 @@ import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
-import { env, optionalEnv } from "../../lib/env";
+import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
@@ -64,13 +52,20 @@ import {
   getConnectorOAuthCanonicalRedirectUrl,
   getConnectorOAuthOrigin,
 } from "./connector-oauth-origin";
+import {
+  buildConnectorOAuthCookieHeader,
+  CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+  CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+  CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+  CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+  CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+  connectorOAuthRedirectResponse,
+} from "./connector-oauth-route-state";
+import {
+  prepareConnectorOAuthStart,
+  resolveConnectorOAuthStartType,
+} from "./connector-oauth-start";
 
-const STATE_COOKIE_NAME = "connector_oauth_state";
-const SESSION_COOKIE_NAME = "connector_oauth_session";
-const PKCE_COOKIE_NAME = "connector_oauth_pkce";
-const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
-const COOKIE_MAX_AGE = 15 * 60;
-const REDIRECT_STATUS = 307;
 const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
 const CONNECTOR_SESSION_POLL_INTERVAL_SECONDS = 5;
 const CONNECTOR_SESSION_CODE_LENGTH = 8;
@@ -114,14 +109,6 @@ function isLocalBrowserEnabled(params: {
   });
 }
 
-function generateState(): string {
-  const array = new Uint8Array(32);
-  crypto.getRandomValues(array);
-  return Array.from(array, (byte) => {
-    return byte.toString(16).padStart(2, "0");
-  }).join("");
-}
-
 function generateConnectorSessionCode(
   length: number = CONNECTOR_SESSION_CODE_LENGTH,
 ): string {
@@ -138,40 +125,11 @@ function generateConnectorSessionCode(
   return code;
 }
 
-function buildCookieHeader(
-  name: string,
-  value: string,
-  maxAge: number,
-): string {
-  const parts = [
-    `${name}=${encodeURIComponent(value)}`,
-    `Max-Age=${maxAge}`,
-    "Path=/",
-    "HttpOnly",
-    "SameSite=Lax",
-  ];
-  if (env("ENV") === "production") {
-    parts.push("Secure");
-  }
-  return parts.join("; ");
-}
-
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
   });
-}
-
-function redirectResponse(url: string): Response {
-  return new Response(null, {
-    status: REDIRECT_STATUS,
-    headers: { location: url },
-  });
-}
-
-function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
-  return typeof result === "string" ? { url: result } : result;
 }
 
 function connectorDoesNotUseOAuthResponse(type: string) {
@@ -180,24 +138,6 @@ function connectorDoesNotUseOAuthResponse(type: string) {
 
 function missingOAuthProviderResponse(type: string) {
   return jsonResponse({ error: `${type} OAuth provider not configured` }, 500);
-}
-
-async function buildProviderAuthorizeUrl(args: {
-  readonly type: OAuthConnectorType;
-  readonly credentials: NonNullable<
-    ReturnType<typeof getConnectorOAuthCredentials>
-  >;
-  readonly redirectUri: string;
-  readonly state: string;
-}): Promise<AuthUrlResult> {
-  return normalizeAuthUrlResult(
-    await buildConnectorOAuthAuthUrl({
-      type: args.type,
-      credentials: args.credentials,
-      redirectUri: args.redirectUri,
-      state: args.state,
-    }),
-  );
 }
 
 function internalServerError(message: string) {
@@ -408,7 +348,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     const request = get(request$).raw;
     const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrl(request);
     if (canonicalRedirectUrl) {
-      return redirectResponse(canonicalRedirectUrl);
+      return connectorOAuthRedirectResponse(canonicalRedirectUrl);
     }
     const origin = getConnectorOAuthOrigin(request);
     const requestUrl = new URL(request.url);
@@ -436,7 +376,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
           origin,
         );
         loginUrl.searchParams.set("redirect_url", authorizeUrl.toString());
-        return redirectResponse(loginUrl.toString());
+        return connectorOAuthRedirectResponse(loginUrl.toString());
       }
       return jsonResponse(auth.body, auth.status);
     }
@@ -448,10 +388,11 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    if (!getConnectorAuthMethod(type, "oauth")) {
-      return connectorDoesNotUseOAuthResponse(type);
-    }
-    if (!isOAuthConnectorType(type)) {
+    const startType = resolveConnectorOAuthStartType(type);
+    if (!startType.ok) {
+      if (startType.reason === "connector_does_not_use_oauth") {
+        return connectorDoesNotUseOAuthResponse(type);
+      }
       return missingOAuthProviderResponse(type);
     }
 
@@ -468,20 +409,15 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    const state = generateState();
-    const redirectUri = `${origin}/api/connectors/${type}/callback`;
-    const credentials = getConnectorOAuthCredentials(type, optionalEnv);
-    if (!credentials?.configured) {
-      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
-    }
-
-    const authResult = await buildProviderAuthorizeUrl({
-      type,
-      credentials,
-      redirectUri,
-      state,
+    const prepared = await prepareConnectorOAuthStart({
+      type: startType.type,
+      origin,
+      readEnv: optionalEnv,
     });
     signal.throwIfAborted();
+    if (!prepared.ok) {
+      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
+    }
 
     await set(
       deleteZeroConnectorLocalState$,
@@ -490,35 +426,43 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     );
     signal.throwIfAborted();
 
-    const response = redirectResponse(authResult.url);
+    const response = connectorOAuthRedirectResponse(prepared.authResult.url);
     response.headers.append(
       "Set-Cookie",
-      buildCookieHeader(STATE_COOKIE_NAME, state, COOKIE_MAX_AGE),
+      buildConnectorOAuthCookieHeader(
+        CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+        prepared.state,
+        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+      ),
     );
-    if (authResult.codeVerifier) {
+    if (prepared.authResult.codeVerifier) {
       response.headers.append(
         "Set-Cookie",
-        buildCookieHeader(
-          PKCE_COOKIE_NAME,
-          authResult.codeVerifier,
-          COOKIE_MAX_AGE,
+        buildConnectorOAuthCookieHeader(
+          CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+          prepared.authResult.codeVerifier,
+          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );
     }
-    if (authResult.oauthContext) {
+    if (prepared.authResult.oauthContext) {
       response.headers.append(
         "Set-Cookie",
-        buildCookieHeader(
-          OAUTH_CONTEXT_COOKIE_NAME,
-          authResult.oauthContext,
-          COOKIE_MAX_AGE,
+        buildConnectorOAuthCookieHeader(
+          CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+          prepared.authResult.oauthContext,
+          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
         ),
       );
     }
     if (query.session) {
       response.headers.append(
         "Set-Cookie",
-        buildCookieHeader(SESSION_COOKIE_NAME, query.session, COOKIE_MAX_AGE),
+        buildConnectorOAuthCookieHeader(
+          CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+          query.session,
+          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+        ),
       );
     }
     return response;
@@ -540,10 +484,11 @@ const startConnectorOauthInner$ = command(
       return badRequestMessage("Computer connector does not use OAuth");
     }
 
-    if (!getConnectorAuthMethod(type, "oauth")) {
-      return badRequestMessage(`${type} connector does not use OAuth`);
-    }
-    if (!isOAuthConnectorType(type)) {
+    const startType = resolveConnectorOAuthStartType(type);
+    if (!startType.ok) {
+      if (startType.reason === "connector_does_not_use_oauth") {
+        return badRequestMessage(`${type} connector does not use OAuth`);
+      }
       return internalServerError(`${type} OAuth provider not configured`);
     }
 
@@ -553,21 +498,16 @@ const startConnectorOauthInner$ = command(
       );
     }
 
-    const state = generateState();
     const origin = getConnectorOAuthOrigin(request);
-    const redirectUri = `${origin}/api/connectors/${type}/callback`;
-    const credentials = getConnectorOAuthCredentials(type, optionalEnv);
-    if (!credentials?.configured) {
-      return internalServerError(`${type} OAuth not configured`);
-    }
-
-    const authResult = await buildProviderAuthorizeUrl({
-      type,
-      credentials,
-      redirectUri,
-      state,
+    const prepared = await prepareConnectorOAuthStart({
+      type: startType.type,
+      origin,
+      readEnv: optionalEnv,
     });
     signal.throwIfAborted();
+    if (!prepared.ok) {
+      return internalServerError(`${type} OAuth not configured`);
+    }
 
     await set(
       deleteZeroConnectorLocalState$,
@@ -578,21 +518,23 @@ const startConnectorOauthInner$ = command(
 
     const writeDb = set(writeDb$);
     await writeDb.insert(connectorOauthStates).values({
-      state,
-      type,
+      state: prepared.state,
+      type: startType.type,
       userId: auth.userId,
       orgId: auth.orgId,
-      redirectUri,
-      codeVerifier: authResult.codeVerifier,
-      oauthContext: authResult.oauthContext,
-      expiresAt: new Date(nowDate().getTime() + COOKIE_MAX_AGE * 1000),
+      redirectUri: prepared.redirectUri,
+      codeVerifier: prepared.authResult.codeVerifier,
+      oauthContext: prepared.authResult.oauthContext,
+      expiresAt: new Date(
+        nowDate().getTime() + CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS * 1000,
+      ),
     });
     signal.throwIfAborted();
 
     return {
       status: 200 as const,
       body: {
-        authorizationUrl: authResult.url,
+        authorizationUrl: prepared.authResult.url,
       },
     };
   },


### PR DESCRIPTION
## Summary

- Add shared connector OAuth route-state helpers for cookies, redirect responses, and state generation.
- Add focused connector OAuth start helpers for OAuth capability/provider resolution and provider authorization URL preparation.
- Refactor browser authorize, Zero OAuth start, and callback routes to use the shared helpers without changing route-specific side effects.

Closes #14438

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit hook: full `turbo run check-types --concurrency=1`
