### PR TITLE
test: require secure google oauth endpoints

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -717,9 +717,14 @@ describe("isGoogleOAuthConnector", () => {
       if (!authorizationUrl) {
         throw new Error(`${type}: Google connector must have authorizationUrl`);
       }
+      const parsedAuthorizationUrl = new URL(authorizationUrl);
 
       expect(
-        new URL(authorizationUrl).hostname,
+        parsedAuthorizationUrl.protocol,
+        `${type}: Google connector authorizationUrl must use https`,
+      ).toBe("https:");
+      expect(
+        parsedAuthorizationUrl.hostname,
         `${type}: Google connector authorizationUrl must use accounts.google.com`,
       ).toBe("accounts.google.com");
     }
@@ -731,7 +736,7 @@ describe("isGoogleOAuthConnector", () => {
       if (!oauthConfig?.authorizationUrl) {
         continue;
       }
-      if (!oauthConfig.authorizationUrl.startsWith("https://")) {
+      if (oauthConfig.authorizationUrl.startsWith("/")) {
         continue;
       }
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -736,7 +736,10 @@ describe("isGoogleOAuthConnector", () => {
       if (!oauthConfig?.authorizationUrl) {
         continue;
       }
-      if (oauthConfig.authorizationUrl.startsWith("/")) {
+      if (
+        oauthConfig.authorizationUrl.startsWith("/") &&
+        !oauthConfig.authorizationUrl.startsWith("//")
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- assert Google OAuth connector authorization URLs use https
- keep the drift check from skipping absolute non-https OAuth URLs

## Tests
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types