### PR TITLE
docs: document local cargo enomem handling

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -52,6 +52,22 @@ Summary: [Ready to commit / Issues need attention]
 
 ## Troubleshooting
 
+If local Rust checks fail with `Cannot allocate memory`, `os error 12`, or `ENOMEM`
+during `cargo test`, `cargo clippy`, `cargo doc`, `rustc`, or linker output:
+
+1. Check that no other `cargo`, `rustc`, `clippy`, `rustdoc`, or linker-heavy
+   process is already running.
+2. Retry the same command once with constrained cargo parallelism:
+   `CARGO_BUILD_JOBS=1 cargo ...`.
+3. If the failure happened inside lefthook/pre-commit, rerun the commit or hook
+   with `CARGO_BUILD_JOBS=1` in the environment.
+4. Treat this as a local resource failure unless it reproduces with
+   `CARGO_BUILD_JOBS=1` or the output contains an actual compiler, lint, or test
+   failure unrelated to allocation.
+
+Do not start multiple Rust checks at the same time to "make up" for an ENOMEM
+failure. That usually makes the next run less reliable.
+
 If hooks are slow or lint times out:
 
 ```bash

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -88,15 +88,20 @@ jobs:
       - name: Detect changed crates
         id: detect
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
-          else
-            BASE_REF="HEAD^"
-          fi
           # In CI containers, the repo may be owned by a different user (host vs container).
           # Git 2.35.2+ rejects such repos unless marked as safe.
           git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
+            echo "PR mode: comparing against merge base $BASE_REF"
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            BASE_REF="${{ github.event.merge_group.base_sha }}"
+            echo "Merge queue mode: comparing against base $BASE_REF"
+          else
+            BASE_REF="HEAD^"
+            echo "Main push mode: comparing against HEAD^"
+          fi
           # Check if the workflow file or ansible playbooks changed
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
             echo "ci-changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- document how to handle local Rust `Cannot allocate memory` / `ENOMEM` failures in the commit skill
- recommend checking for concurrent Rust processes and retrying once with `CARGO_BUILD_JOBS=1`
- fix the crates workflow pull request base ref detection so stale `origin/main` updates do not make doc-only PRs look like Rust changes

## Tests
- `git diff --check`
- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh && for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`
- `actionlint -color=false .github/workflows/crates.yml`
- pre-commit hooks via `git commit`