### PR TITLE
refactor(connectors): keep oauth authorization urls in providers

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { CONNECTOR_TYPES, connectorTypeSchema } from "../connectors";
+import {
+  CONNECTOR_TYPES,
+  connectorTypeSchema,
+  type OAuthConnectorType,
+} from "../connectors";
 import {
   getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
@@ -25,11 +29,77 @@ import {
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
+  buildConnectorOAuthAuthUrl,
   isOAuthConnectorType,
   CONNECTOR_OAUTH_PROVIDERS,
 } from "../oauth-providers/provider-registry";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../oauth-providers/google-oauth-connectors";
 import { buildGoogleAuthorizationUrl } from "../oauth-providers/providers/google-oauth";
+
+const EXPECTED_PROVIDER_AUTHORIZATION_BASE_URLS = {
+  ahrefs: "https://app.ahrefs.com/api/auth",
+  airtable: "https://airtable.com/oauth2/v1/authorize",
+  asana: "https://app.asana.com/-/oauth_authorize",
+  canva: "https://www.canva.com/api/oauth/authorize",
+  close: "https://app.close.com/oauth2/authorize/",
+  deel: "https://app.deel.com/oauth2/authorize",
+  docusign: "https://account-d.docusign.com/oauth/auth",
+  dropbox: "https://www.dropbox.com/oauth2/authorize",
+  figma: "https://www.figma.com/oauth",
+  "garmin-connect": "https://connect.garmin.com/oauth2Confirm",
+  github: "https://github.com/login/oauth/authorize",
+  gmail: "https://accounts.google.com/o/oauth2/v2/auth",
+  "google-ads": "https://accounts.google.com/o/oauth2/v2/auth",
+  "google-calendar": "https://accounts.google.com/o/oauth2/v2/auth",
+  "google-docs": "https://accounts.google.com/o/oauth2/v2/auth",
+  "google-drive": "https://accounts.google.com/o/oauth2/v2/auth",
+  "google-meet": "https://accounts.google.com/o/oauth2/v2/auth",
+  "google-sheets": "https://accounts.google.com/o/oauth2/v2/auth",
+  gumroad: "https://gumroad.com/oauth/authorize",
+  hubspot: "https://app.hubspot.com/oauth/authorize",
+  "intervals-icu": "https://intervals.icu/oauth/authorize",
+  linear: "https://linear.app/oauth/authorize",
+  mailchimp: "https://login.mailchimp.com/oauth2/authorize",
+  mercury: "https://oauth2.mercury.com/oauth2/auth",
+  "meta-ads": "https://www.facebook.com/v22.0/dialog/oauth",
+  monday: "https://auth.monday.com/oauth2/authorize",
+  neon: "https://oauth2.neon.tech/oauth2/auth",
+  notion: "https://api.notion.com/v1/oauth/authorize",
+  "outlook-calendar":
+    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  "outlook-mail":
+    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  posthog: "https://us.posthog.com/oauth/authorize",
+  reddit: "https://www.reddit.com/api/v1/authorize",
+  sentry: "https://sentry.io/oauth/authorize/",
+  slack: "https://slack.com/oauth/v2/authorize",
+  spotify: "https://accounts.spotify.com/authorize",
+  strava: "https://www.strava.com/oauth/authorize",
+  stripe: "https://connect.stripe.com/oauth/authorize",
+  supabase: "https://api.supabase.com/v1/oauth/authorize",
+  "test-oauth": "https://api.test/api/test/oauth-provider/authorize",
+  todoist: "https://todoist.com/oauth/authorize",
+  vercel: "https://vercel.com/integrations/test-integration/new",
+  webflow: "https://webflow.com/oauth/authorize",
+  x: "https://twitter.com/i/oauth2/authorize",
+  xero: "https://login.xero.com/identity/connect/authorize",
+  zoom: "https://zoom.us/oauth/authorize",
+} as const satisfies Record<keyof typeof CONNECTOR_OAUTH_PROVIDERS, string>;
+
+function authorizationBaseUrl(url: string): string {
+  const parsed = new URL(url);
+  return `${parsed.origin}${parsed.pathname}`;
+}
+
+function restoreEnv(values: Record<string, string | undefined>): void {
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -133,6 +203,46 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
       expect(isOAuthConnectorType(type)).toBe(
         oauthConnectorTypes.includes(type),
       );
+    }
+  });
+
+  it("builds the expected authorization URL base for every OAuth provider", async () => {
+    const previousEnv = {
+      VM0_API_URL: process.env.VM0_API_URL,
+      VERCEL_INTEGRATION_SLUG: process.env.VERCEL_INTEGRATION_SLUG,
+    };
+
+    process.env.VM0_API_URL = "https://api.test";
+    process.env.VERCEL_INTEGRATION_SLUG = "test-integration";
+
+    try {
+      const providerTypes = Object.keys(
+        CONNECTOR_OAUTH_PROVIDERS,
+      ) as OAuthConnectorType[];
+
+      for (const type of providerTypes) {
+        const oauthConfig = getConnectorOAuthConfig(type);
+        const credentials = resolveConnectorOAuthClientCredentials(
+          oauthConfig.client,
+          () => {
+            return "test-client-credential";
+          },
+        );
+        const authResult = await buildConnectorOAuthAuthUrl({
+          type,
+          credentials,
+          redirectUri: "https://app.test/callback",
+          state: "state-123",
+        });
+        const authorizationUrl =
+          typeof authResult === "string" ? authResult : authResult.url;
+
+        expect(authorizationBaseUrl(authorizationUrl), `${type}`).toBe(
+          EXPECTED_PROVIDER_AUTHORIZATION_BASE_URLS[type],
+        );
+      }
+    } finally {
+      restoreEnv(previousEnv);
     }
   });
 });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -14,7 +14,6 @@ import {
   getConnectorAuthMethods,
   getConnectorOAuthClientConfig,
   getConnectorOAuthCredentials,
-  getConnectorOAuthAuthorizationEndpoint,
   getConnectorOAuthConfig,
   getConnectorOAuthConfigIfSupported,
   getConnectorOAuthFlow,
@@ -30,6 +29,7 @@ import {
   CONNECTOR_OAUTH_PROVIDERS,
 } from "../oauth-providers/provider-registry";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../oauth-providers/google-oauth-connectors";
+import { buildGoogleAuthorizationUrl } from "../oauth-providers/providers/google-oauth";
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -666,38 +666,22 @@ describe("connector OAuth authorization-code config", () => {
     }
   });
 
-  it("marks Vercel authorization endpoint construction as provider-managed", () => {
-    expect(
-      getConnectorOAuthConfig("vercel").authorizationEndpoint,
-    ).toStrictEqual({
-      type: "provider",
-    });
-  });
-
-  it("keeps all non-Vercel OAuth authorization endpoints in connector config", () => {
+  it("keeps provider authorization URLs out of connector OAuth config", () => {
     for (const type of connectorTypeSchema.options) {
       const oauthConfig = getConnectorOAuthConfigIfSupported(type);
-      if (!oauthConfig || type === "vercel") {
+      if (!oauthConfig) {
         continue;
       }
 
       expect(
-        oauthConfig.authorizationEndpoint.type,
-        `${type}: authorization endpoint source`,
-      ).toBe("config");
-      if (oauthConfig.authorizationEndpoint.type === "config") {
-        expect(
-          oauthConfig.authorizationEndpoint.url,
-          `${type}: authorization endpoint URL`,
-        ).toBeTruthy();
-      }
+        "authorizationEndpoint" in oauthConfig,
+        `${type}: authorization endpoint should be provider-owned`,
+      ).toBe(false);
+      expect(
+        "authorizationUrl" in oauthConfig,
+        `${type}: authorization URL should be provider-owned`,
+      ).toBe(false);
     }
-  });
-
-  it("keeps the synthetic test OAuth connector on a relative configured endpoint", () => {
-    expect(getConnectorOAuthAuthorizationEndpoint("test-oauth")).toBe(
-      "/api/test/oauth-provider/authorize",
-    );
   });
 });
 
@@ -760,34 +744,25 @@ describe("isGoogleOAuthConnector", () => {
     );
   });
 
-  it("keeps Google OAuth connector configs on the Google authorization endpoint", () => {
+  it("builds Google OAuth authorization URLs at the provider boundary", () => {
     for (const type of GOOGLE_OAUTH_CONNECTOR_TYPES) {
+      const authorizationUrl = new URL(
+        buildGoogleAuthorizationUrl(
+          type,
+          "client-id",
+          "https://app.test/callback",
+          "state-123",
+        ),
+      );
+
       expect(
-        new URL(getConnectorOAuthAuthorizationEndpoint(type)).hostname,
+        authorizationUrl.hostname,
         `${type}: Google connector authorization endpoint must use accounts.google.com`,
       ).toBe("accounts.google.com");
-    }
-  });
-
-  it("includes every connector configured with the Google authorization endpoint", () => {
-    for (const type of connectorTypeSchema.options) {
-      const oauthConfig = getConnectorOAuthConfigIfSupported(type);
-      if (oauthConfig?.authorizationEndpoint.type !== "config") {
-        continue;
-      }
-      if (!oauthConfig.authorizationEndpoint.url.startsWith("https://")) {
-        continue;
-      }
-
-      const hostname = new URL(oauthConfig.authorizationEndpoint.url).hostname;
-      if (hostname !== "accounts.google.com") {
-        continue;
-      }
-
-      expect(
-        GOOGLE_OAUTH_CONNECTOR_TYPES,
-        `${type} uses Google OAuth and must be listed in GOOGLE_OAUTH_CONNECTOR_TYPES`,
-      ).toContain(type);
+      expect(authorizationUrl.searchParams.get("client_id")).toBe("client-id");
+      expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+        "https://app.test/callback",
+      );
     }
   });
 });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -14,8 +14,10 @@ import {
   getConnectorAuthMethods,
   getConnectorOAuthClientConfig,
   getConnectorOAuthCredentials,
+  getConnectorOAuthAuthorizationEndpoint,
   getConnectorOAuthConfig,
   getConnectorOAuthConfigIfSupported,
+  getConnectorOAuthFlow,
   getRuntimeAvailableConnectorTypes,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
@@ -651,6 +653,54 @@ describe("getConnectorOAuthConfigIfSupported", () => {
   });
 });
 
+describe("connector OAuth authorization-code config", () => {
+  it("declares the current OAuth connectors as authorization-code flows", () => {
+    for (const type of connectorTypeSchema.options) {
+      if (!isOAuthConnectorType(type)) {
+        continue;
+      }
+
+      expect(getConnectorOAuthFlow(type), `${type}: OAuth flow`).toBe(
+        "authorization-code",
+      );
+    }
+  });
+
+  it("marks Vercel authorization endpoint construction as provider-managed", () => {
+    expect(
+      getConnectorOAuthConfig("vercel").authorizationEndpoint,
+    ).toStrictEqual({
+      type: "provider",
+    });
+  });
+
+  it("keeps all non-Vercel OAuth authorization endpoints in connector config", () => {
+    for (const type of connectorTypeSchema.options) {
+      const oauthConfig = getConnectorOAuthConfigIfSupported(type);
+      if (!oauthConfig || type === "vercel") {
+        continue;
+      }
+
+      expect(
+        oauthConfig.authorizationEndpoint.type,
+        `${type}: authorization endpoint source`,
+      ).toBe("config");
+      if (oauthConfig.authorizationEndpoint.type === "config") {
+        expect(
+          oauthConfig.authorizationEndpoint.url,
+          `${type}: authorization endpoint URL`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  it("keeps the synthetic test OAuth connector on a relative configured endpoint", () => {
+    expect(getConnectorOAuthAuthorizationEndpoint("test-oauth")).toBe(
+      "/api/test/oauth-provider/authorize",
+    );
+  });
+});
+
 describe("getConnectorTypeForSecretName", () => {
   it("finds connector type for OAuth env mapping key", () => {
     expect(getConnectorTypeForSecretName("GH_TOKEN")).toBe("github");
@@ -712,20 +762,9 @@ describe("isGoogleOAuthConnector", () => {
 
   it("keeps Google OAuth connector configs on the Google authorization endpoint", () => {
     for (const type of GOOGLE_OAUTH_CONNECTOR_TYPES) {
-      const oauthConfig = getConnectorOAuthConfig(type);
-      const authorizationUrl = oauthConfig.authorizationUrl;
-      if (!authorizationUrl) {
-        throw new Error(`${type}: Google connector must have authorizationUrl`);
-      }
-      const parsedAuthorizationUrl = new URL(authorizationUrl);
-
       expect(
-        parsedAuthorizationUrl.protocol,
-        `${type}: Google connector authorizationUrl must use https`,
-      ).toBe("https:");
-      expect(
-        parsedAuthorizationUrl.hostname,
-        `${type}: Google connector authorizationUrl must use accounts.google.com`,
+        new URL(getConnectorOAuthAuthorizationEndpoint(type)).hostname,
+        `${type}: Google connector authorization endpoint must use accounts.google.com`,
       ).toBe("accounts.google.com");
     }
   });
@@ -733,17 +772,14 @@ describe("isGoogleOAuthConnector", () => {
   it("includes every connector configured with the Google authorization endpoint", () => {
     for (const type of connectorTypeSchema.options) {
       const oauthConfig = getConnectorOAuthConfigIfSupported(type);
-      if (!oauthConfig?.authorizationUrl) {
+      if (oauthConfig?.authorizationEndpoint.type !== "config") {
         continue;
       }
-      if (
-        oauthConfig.authorizationUrl.startsWith("/") &&
-        !oauthConfig.authorizationUrl.startsWith("//")
-      ) {
+      if (!oauthConfig.authorizationEndpoint.url.startsWith("https://")) {
         continue;
       }
 
-      const hostname = new URL(oauthConfig.authorizationUrl).hostname;
+      const hostname = new URL(oauthConfig.authorizationEndpoint.url).hostname;
       if (hostname !== "accounts.google.com") {
         continue;
       }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -15,6 +15,7 @@ import {
   type StaticConfidentialConnectorOAuthClientConfig,
   type StaticPublicConnectorOAuthClientConfig,
   type ConnectorType,
+  type OAuthConfigManagedAuthorizationCodeConnectorType,
   type OAuthConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
@@ -467,6 +468,18 @@ export function getConnectorOAuthConfig(
   type: OAuthConnectorType,
 ): ConnectorOAuthConfig {
   return CONNECTOR_TYPES[type].oauth;
+}
+
+export function getConnectorOAuthFlow(
+  type: OAuthConnectorType,
+): ConnectorOAuthConfig["flow"] {
+  return getConnectorOAuthConfig(type).flow;
+}
+
+export function getConnectorOAuthAuthorizationEndpoint<
+  T extends OAuthConfigManagedAuthorizationCodeConnectorType,
+>(type: T): string {
+  return CONNECTOR_TYPES[type].oauth.authorizationEndpoint.url;
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -15,7 +15,6 @@ import {
   type StaticConfidentialConnectorOAuthClientConfig,
   type StaticPublicConnectorOAuthClientConfig,
   type ConnectorType,
-  type OAuthConfigManagedAuthorizationCodeConnectorType,
   type OAuthConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
@@ -474,12 +473,6 @@ export function getConnectorOAuthFlow(
   type: OAuthConnectorType,
 ): ConnectorOAuthConfig["flow"] {
   return getConnectorOAuthConfig(type).flow;
-}
-
-export function getConnectorOAuthAuthorizationEndpoint<
-  T extends OAuthConfigManagedAuthorizationCodeConnectorType,
->(type: T): string {
-  return CONNECTOR_TYPES[type].oauth.authorizationEndpoint.url;
 }
 
 /**

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -315,18 +315,8 @@ export type DynamicPublicConnectorOAuthClientConfig = Extract<
   }
 >;
 
-export type ConnectorOAuthAuthorizationEndpointConfig =
-  | {
-      readonly type: "config";
-      readonly url: string;
-    }
-  | {
-      readonly type: "provider";
-    };
-
 export interface ConnectorOAuthAuthorizationCodeConfig {
   readonly flow: "authorization-code";
-  readonly authorizationEndpoint: ConnectorOAuthAuthorizationEndpointConfig;
   readonly tokenUrl: string;
   readonly client: ConnectorOAuthClientConfig;
   readonly scopes: string[];
@@ -789,16 +779,6 @@ export type OAuthAuthorizationCodeConnectorType = {
     ? Type
     : never;
 }[OAuthConnectorType];
-export type OAuthConfigManagedAuthorizationCodeConnectorType = {
-  [Type in OAuthAuthorizationCodeConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["authorizationEndpoint"]["type"] extends "config"
-    ? Type
-    : never;
-}[OAuthAuthorizationCodeConnectorType];
-export type OAuthProviderManagedAuthorizationCodeConnectorType = {
-  [Type in OAuthAuthorizationCodeConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["authorizationEndpoint"]["type"] extends "provider"
-    ? Type
-    : never;
-}[OAuthAuthorizationCodeConnectorType];
 export type ConnectorCliAuthConnectorType = {
   [Type in ConnectorType]: "cli-auth" extends keyof (typeof CONNECTOR_TYPES_DEF)[Type]["authMethods"]
     ? Type

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -315,12 +315,24 @@ export type DynamicPublicConnectorOAuthClientConfig = Extract<
   }
 >;
 
-export interface ConnectorOAuthConfig {
-  authorizationUrl?: string;
-  tokenUrl: string;
-  client: ConnectorOAuthClientConfig;
-  scopes: string[];
+export type ConnectorOAuthAuthorizationEndpointConfig =
+  | {
+      readonly type: "config";
+      readonly url: string;
+    }
+  | {
+      readonly type: "provider";
+    };
+
+export interface ConnectorOAuthAuthorizationCodeConfig {
+  readonly flow: "authorization-code";
+  readonly authorizationEndpoint: ConnectorOAuthAuthorizationEndpointConfig;
+  readonly tokenUrl: string;
+  readonly client: ConnectorOAuthClientConfig;
+  readonly scopes: string[];
 }
+
+export type ConnectorOAuthConfig = ConnectorOAuthAuthorizationCodeConfig;
 
 /**
  * CLI auth configuration for connectors that can import credentials through a
@@ -772,6 +784,21 @@ export type OAuthConnectorType = {
     ? Type
     : never;
 }[ConnectorType];
+export type OAuthAuthorizationCodeConnectorType = {
+  [Type in OAuthConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["flow"] extends "authorization-code"
+    ? Type
+    : never;
+}[OAuthConnectorType];
+export type OAuthConfigManagedAuthorizationCodeConnectorType = {
+  [Type in OAuthAuthorizationCodeConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["authorizationEndpoint"]["type"] extends "config"
+    ? Type
+    : never;
+}[OAuthAuthorizationCodeConnectorType];
+export type OAuthProviderManagedAuthorizationCodeConnectorType = {
+  [Type in OAuthAuthorizationCodeConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["authorizationEndpoint"]["type"] extends "provider"
+    ? Type
+    : never;
+}[OAuthAuthorizationCodeConnectorType];
 export type ConnectorCliAuthConnectorType = {
   [Type in ConnectorType]: "cli-auth" extends keyof (typeof CONNECTOR_TYPES_DEF)[Type]["authMethods"]
     ? Type

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -41,7 +41,11 @@ export const ahrefs = {
     },
     defaultAuthMethod: "api-token",
     oauth: {
-      authorizationUrl: "https://app.ahrefs.com/api/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://app.ahrefs.com/api/auth",
+      },
       tokenUrl: "https://app.ahrefs.com/api/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -42,10 +42,6 @@ export const ahrefs = {
     defaultAuthMethod: "api-token",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://app.ahrefs.com/api/auth",
-      },
       tokenUrl: "https://app.ahrefs.com/api/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -28,10 +28,6 @@ export const airtable = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://airtable.com/oauth2/v1/authorize",
-      },
       tokenUrl: "https://airtable.com/oauth2/v1/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -27,7 +27,11 @@ export const airtable = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://airtable.com/oauth2/v1/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://airtable.com/oauth2/v1/authorize",
+      },
       tokenUrl: "https://airtable.com/oauth2/v1/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -27,7 +27,11 @@ export const asana = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://app.asana.com/-/oauth_authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://app.asana.com/-/oauth_authorize",
+      },
       tokenUrl: "https://app.asana.com/-/oauth_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -28,10 +28,6 @@ export const asana = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://app.asana.com/-/oauth_authorize",
-      },
       tokenUrl: "https://app.asana.com/-/oauth_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -30,10 +30,6 @@ export const canva = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://www.canva.com/api/oauth/authorize",
-      },
       tokenUrl: "https://api.canva.com/rest/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -29,7 +29,11 @@ export const canva = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://www.canva.com/api/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://www.canva.com/api/oauth/authorize",
+      },
       tokenUrl: "https://api.canva.com/rest/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -30,10 +30,6 @@ export const close = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://app.close.com/oauth2/authorize/",
-      },
       tokenUrl: "https://api.close.com/oauth2/token/",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -29,7 +29,11 @@ export const close = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://app.close.com/oauth2/authorize/",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://app.close.com/oauth2/authorize/",
+      },
       tokenUrl: "https://api.close.com/oauth2/token/",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -41,10 +41,6 @@ export const deel = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://app.deel.com/oauth2/authorize",
-      },
       tokenUrl: "https://app.deel.com/oauth2/tokens",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -40,7 +40,11 @@ export const deel = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://app.deel.com/oauth2/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://app.deel.com/oauth2/authorize",
+      },
       tokenUrl: "https://app.deel.com/oauth2/tokens",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -29,7 +29,11 @@ export const docusign = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://account-d.docusign.com/oauth/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://account-d.docusign.com/oauth/auth",
+      },
       tokenUrl: "https://account-d.docusign.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -30,10 +30,6 @@ export const docusign = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://account-d.docusign.com/oauth/auth",
-      },
       tokenUrl: "https://account-d.docusign.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -40,7 +40,11 @@ export const dropbox = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://www.dropbox.com/oauth2/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://www.dropbox.com/oauth2/authorize",
+      },
       tokenUrl: "https://api.dropboxapi.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -41,10 +41,6 @@ export const dropbox = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://www.dropbox.com/oauth2/authorize",
-      },
       tokenUrl: "https://api.dropboxapi.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -40,7 +40,11 @@ export const figma = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://www.figma.com/oauth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://www.figma.com/oauth",
+      },
       tokenUrl: "https://api.figma.com/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -41,10 +41,6 @@ export const figma = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://www.figma.com/oauth",
-      },
       tokenUrl: "https://api.figma.com/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -29,7 +29,11 @@ export const garminConnect = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://connect.garmin.com/oauth2Confirm",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://connect.garmin.com/oauth2Confirm",
+      },
       tokenUrl: "https://diauth.garmin.com/di-oauth2-service/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -30,10 +30,6 @@ export const garminConnect = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://connect.garmin.com/oauth2Confirm",
-      },
       tokenUrl: "https://diauth.garmin.com/di-oauth2-service/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -25,7 +25,11 @@ export const github = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://github.com/login/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://github.com/login/oauth/authorize",
+      },
       tokenUrl: "https://github.com/login/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -26,10 +26,6 @@ export const github = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://github.com/login/oauth/authorize",
-      },
       tokenUrl: "https://github.com/login/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -28,10 +28,6 @@ export const gmail = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -27,7 +27,11 @@ export const gmail = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -32,10 +32,6 @@ export const googleAds = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -31,7 +31,11 @@ export const googleAds = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -29,10 +29,6 @@ export const googleCalendar = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -28,7 +28,11 @@ export const googleCalendar = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -26,7 +26,11 @@ export const googleDocs = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -27,10 +27,6 @@ export const googleDocs = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -26,7 +26,11 @@ export const googleDrive = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -27,10 +27,6 @@ export const googleDrive = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -28,10 +28,6 @@ export const googleMeet = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -27,7 +27,11 @@ export const googleMeet = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -26,7 +26,11 @@ export const googleSheets = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -27,10 +27,6 @@ export const googleSheets = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.google.com/o/oauth2/v2/auth",
-      },
       tokenUrl: "https://oauth2.googleapis.com/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -37,10 +37,6 @@ export const gumroad = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://gumroad.com/oauth/authorize",
-      },
       tokenUrl: "https://gumroad.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -36,7 +36,11 @@ export const gumroad = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://gumroad.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://gumroad.com/oauth/authorize",
+      },
       tokenUrl: "https://gumroad.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -28,10 +28,6 @@ export const hubspot = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://app.hubspot.com/oauth/authorize",
-      },
       tokenUrl: "https://api.hubapi.com/oauth/v1/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -27,7 +27,11 @@ export const hubspot = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://app.hubspot.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://app.hubspot.com/oauth/authorize",
+      },
       tokenUrl: "https://api.hubapi.com/oauth/v1/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -23,7 +23,11 @@ export const intervalsIcu = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://intervals.icu/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://intervals.icu/oauth/authorize",
+      },
       tokenUrl: "https://intervals.icu/api/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -24,10 +24,6 @@ export const intervalsIcu = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://intervals.icu/oauth/authorize",
-      },
       tokenUrl: "https://intervals.icu/api/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -27,7 +27,11 @@ export const linear = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://linear.app/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://linear.app/oauth/authorize",
+      },
       tokenUrl: "https://api.linear.app/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -28,10 +28,6 @@ export const linear = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://linear.app/oauth/authorize",
-      },
       tokenUrl: "https://api.linear.app/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -37,7 +37,11 @@ export const mailchimp = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://login.mailchimp.com/oauth2/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://login.mailchimp.com/oauth2/authorize",
+      },
       tokenUrl: "https://login.mailchimp.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -38,10 +38,6 @@ export const mailchimp = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://login.mailchimp.com/oauth2/authorize",
-      },
       tokenUrl: "https://login.mailchimp.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -42,10 +42,6 @@ export const mercury = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://oauth2.mercury.com/oauth2/auth",
-      },
       tokenUrl: "https://oauth2.mercury.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -41,7 +41,11 @@ export const mercury = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://oauth2.mercury.com/oauth2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://oauth2.mercury.com/oauth2/auth",
+      },
       tokenUrl: "https://oauth2.mercury.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -25,7 +25,11 @@ export const metaAds = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://www.facebook.com/v22.0/dialog/oauth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://www.facebook.com/v22.0/dialog/oauth",
+      },
       tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -26,10 +26,6 @@ export const metaAds = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://www.facebook.com/v22.0/dialog/oauth",
-      },
       tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -28,10 +28,6 @@ export const monday = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://auth.monday.com/oauth2/authorize",
-      },
       tokenUrl: "https://auth.monday.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -27,7 +27,11 @@ export const monday = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://auth.monday.com/oauth2/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://auth.monday.com/oauth2/authorize",
+      },
       tokenUrl: "https://auth.monday.com/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -41,7 +41,11 @@ export const neon = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://oauth2.neon.tech/oauth2/auth",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://oauth2.neon.tech/oauth2/auth",
+      },
       tokenUrl: "https://oauth2.neon.tech/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -42,10 +42,6 @@ export const neon = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://oauth2.neon.tech/oauth2/auth",
-      },
       tokenUrl: "https://oauth2.neon.tech/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -28,10 +28,6 @@ export const notion = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://api.notion.com/v1/oauth/authorize",
-      },
       tokenUrl: "https://api.notion.com/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -27,7 +27,11 @@ export const notion = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://api.notion.com/v1/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://api.notion.com/v1/oauth/authorize",
+      },
       tokenUrl: "https://api.notion.com/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -30,10 +30,6 @@ export const outlookCalendar = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      },
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -29,8 +29,11 @@ export const outlookCalendar = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl:
-        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      },
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -29,10 +29,6 @@ export const outlookMail = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      },
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -28,8 +28,11 @@ export const outlookMail = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl:
-        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      },
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -41,7 +41,11 @@ export const posthog = {
     },
     defaultAuthMethod: "api-token",
     oauth: {
-      authorizationUrl: "https://us.posthog.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://us.posthog.com/oauth/authorize",
+      },
       tokenUrl: "https://us.posthog.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -42,10 +42,6 @@ export const posthog = {
     defaultAuthMethod: "api-token",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://us.posthog.com/oauth/authorize",
-      },
       tokenUrl: "https://us.posthog.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -29,7 +29,11 @@ export const reddit = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://www.reddit.com/api/v1/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://www.reddit.com/api/v1/authorize",
+      },
       tokenUrl: "https://www.reddit.com/api/v1/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -30,10 +30,6 @@ export const reddit = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://www.reddit.com/api/v1/authorize",
-      },
       tokenUrl: "https://www.reddit.com/api/v1/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -28,10 +28,6 @@ export const sentry = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://sentry.io/oauth/authorize/",
-      },
       tokenUrl: "https://sentry.io/oauth/token/",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -27,7 +27,11 @@ export const sentry = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://sentry.io/oauth/authorize/",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://sentry.io/oauth/authorize/",
+      },
       tokenUrl: "https://sentry.io/oauth/token/",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -23,7 +23,11 @@ export const slack = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://slack.com/oauth/v2/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://slack.com/oauth/v2/authorize",
+      },
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -24,10 +24,6 @@ export const slack = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://slack.com/oauth/v2/authorize",
-      },
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -30,10 +30,6 @@ export const spotify = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://accounts.spotify.com/authorize",
-      },
       tokenUrl: "https://accounts.spotify.com/api/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -29,7 +29,11 @@ export const spotify = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://accounts.spotify.com/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://accounts.spotify.com/authorize",
+      },
       tokenUrl: "https://accounts.spotify.com/api/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -28,10 +28,6 @@ export const strava = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://www.strava.com/oauth/authorize",
-      },
       tokenUrl: "https://www.strava.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -27,7 +27,11 @@ export const strava = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://www.strava.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://www.strava.com/oauth/authorize",
+      },
       tokenUrl: "https://www.strava.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -64,10 +64,6 @@ export const stripe = {
     },
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://connect.stripe.com/oauth/authorize",
-      },
       tokenUrl: "https://connect.stripe.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -63,7 +63,11 @@ export const stripe = {
       ],
     },
     oauth: {
-      authorizationUrl: "https://connect.stripe.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://connect.stripe.com/oauth/authorize",
+      },
       tokenUrl: "https://connect.stripe.com/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -42,10 +42,6 @@ export const supabase = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://api.supabase.com/v1/oauth/authorize",
-      },
       tokenUrl: "https://api.supabase.com/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -41,7 +41,11 @@ export const supabase = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://api.supabase.com/v1/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://api.supabase.com/v1/oauth/authorize",
+      },
       tokenUrl: "https://api.supabase.com/v1/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -29,10 +29,14 @@ export const testOauth = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
+      flow: "authorization-code",
       // Relative paths — the handler resolves them against NEXT_PUBLIC_APP_URL
       // at call time because the fake provider lives inside this same app and
       // the preview-URL host changes per deploy.
-      authorizationUrl: "/api/test/oauth-provider/authorize",
+      authorizationEndpoint: {
+        type: "config",
+        url: "/api/test/oauth-provider/authorize",
+      },
       tokenUrl: "/api/test/oauth-provider/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -30,13 +30,9 @@ export const testOauth = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      // Relative paths — the handler resolves them against NEXT_PUBLIC_APP_URL
-      // at call time because the fake provider lives inside this same app and
-      // the preview-URL host changes per deploy.
-      authorizationEndpoint: {
-        type: "config",
-        url: "/api/test/oauth-provider/authorize",
-      },
+      // Relative path — the provider resolves it against the concrete app/API
+      // URL at call time because the fake provider lives inside this same app
+      // and the preview-URL host changes per deploy.
       tokenUrl: "/api/test/oauth-provider/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -24,10 +24,6 @@ export const todoist = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://todoist.com/oauth/authorize",
-      },
       tokenUrl: "https://todoist.com/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -23,7 +23,11 @@ export const todoist = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://todoist.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://todoist.com/oauth/authorize",
+      },
       tokenUrl: "https://todoist.com/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -24,7 +24,6 @@ export const vercel = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: { type: "provider" },
       tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -23,6 +23,8 @@ export const vercel = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
+      flow: "authorization-code",
+      authorizationEndpoint: { type: "provider" },
       tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -36,7 +36,11 @@ export const webflow = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://webflow.com/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://webflow.com/oauth/authorize",
+      },
       tokenUrl: "https://api.webflow.com/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -37,10 +37,6 @@ export const webflow = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://webflow.com/oauth/authorize",
-      },
       tokenUrl: "https://api.webflow.com/oauth/access_token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -28,10 +28,6 @@ export const x = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://twitter.com/i/oauth2/authorize",
-      },
       tokenUrl: "https://api.twitter.com/2/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -27,7 +27,11 @@ export const x = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://twitter.com/i/oauth2/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://twitter.com/i/oauth2/authorize",
+      },
       tokenUrl: "https://api.twitter.com/2/oauth2/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -27,7 +27,11 @@ export const xero = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://login.xero.com/identity/connect/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://login.xero.com/identity/connect/authorize",
+      },
       tokenUrl: "https://identity.xero.com/connect/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -28,10 +28,6 @@ export const xero = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://login.xero.com/identity/connect/authorize",
-      },
       tokenUrl: "https://identity.xero.com/connect/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -30,10 +30,6 @@ export const zoom = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "authorization-code",
-      authorizationEndpoint: {
-        type: "config",
-        url: "https://zoom.us/oauth/authorize",
-      },
       tokenUrl: "https://zoom.us/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -29,7 +29,11 @@ export const zoom = {
     },
     defaultAuthMethod: "oauth",
     oauth: {
-      authorizationUrl: "https://zoom.us/oauth/authorize",
+      flow: "authorization-code",
+      authorizationEndpoint: {
+        type: "config",
+        url: "https://zoom.us/oauth/authorize",
+      },
       tokenUrl: "https://zoom.us/oauth/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
+++ b/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectorType,
-  OAuthConfigManagedAuthorizationCodeConnectorType,
+  OAuthAuthorizationCodeConnectorType,
 } from "../connectors";
 
 export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
@@ -11,7 +11,7 @@ export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
   "google-drive",
   "google-meet",
   "google-sheets",
-] as const satisfies readonly OAuthConfigManagedAuthorizationCodeConnectorType[];
+] as const satisfies readonly OAuthAuthorizationCodeConnectorType[];
 
 export type GoogleOAuthConnectorType =
   (typeof GOOGLE_OAUTH_CONNECTOR_TYPES)[number];

--- a/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
+++ b/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
@@ -1,4 +1,7 @@
-import type { ConnectorType, OAuthConnectorType } from "../connectors";
+import type {
+  ConnectorType,
+  OAuthConfigManagedAuthorizationCodeConnectorType,
+} from "../connectors";
 
 export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
   "gmail",
@@ -8,7 +11,7 @@ export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
   "google-drive",
   "google-meet",
   "google-sheets",
-] as const satisfies readonly OAuthConnectorType[];
+] as const satisfies readonly OAuthConfigManagedAuthorizationCodeConnectorType[];
 
 export type GoogleOAuthConnectorType =
   (typeof GOOGLE_OAUTH_CONNECTOR_TYPES)[number];

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const AHREFS_AUTHORIZATION_URL = "https://app.ahrefs.com/api/auth";
 
 const AHREFS_SUBSCRIPTION_URL =
   "https://api.ahrefs.com/v3/subscription-info/limits-and-usage";
@@ -45,7 +44,7 @@ export function buildAhrefsAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("ahrefs")}?${params.toString()}`;
+  return `${AHREFS_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -42,7 +45,7 @@ export function buildAhrefsAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("ahrefs")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -73,7 +76,7 @@ export async function buildAirtableAuthorizationUrl(
   });
 
   return {
-    url: `${oauthConfig.authorizationUrl}?${params.toString()}`,
+    url: `${getConnectorOAuthAuthorizationEndpoint("airtable")}?${params.toString()}`,
     codeVerifier,
   };
 }

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const AIRTABLE_AUTHORIZATION_URL = "https://airtable.com/oauth2/v1/authorize";
 
 const AIRTABLE_WHOAMI_URL = "https://api.airtable.com/v0/meta/whoami";
 
@@ -76,7 +75,7 @@ export async function buildAirtableAuthorizationUrl(
   });
 
   return {
-    url: `${getConnectorOAuthAuthorizationEndpoint("airtable")}?${params.toString()}`,
+    url: `${AIRTABLE_AUTHORIZATION_URL}?${params.toString()}`,
     codeVerifier,
   };
 }

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const ASANA_AUTHORIZATION_URL = "https://app.asana.com/-/oauth_authorize";
 
 const ASANA_USER_URL = "https://app.asana.com/api/1.0/users/me";
 
@@ -40,7 +39,7 @@ export function buildAsanaAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("asana")}?${params.toString()}`;
+  return `${ASANA_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,7 +33,6 @@ export function buildAsanaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("asana");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -38,7 +40,7 @@ export function buildAsanaAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("asana")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -80,7 +83,7 @@ export async function buildCanvaAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("canva")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const CANVA_AUTHORIZATION_URL = "https://www.canva.com/api/oauth/authorize";
 
 const CANVA_ME_URL = "https://api.canva.com/rest/v1/users/me";
 const CANVA_PROFILE_URL = "https://api.canva.com/rest/v1/users/me/profile";
@@ -83,7 +82,7 @@ export async function buildCanvaAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("canva")}?${params.toString()}`;
+  return `${CANVA_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/close.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const CLOSE_AUTHORIZATION_URL = "https://app.close.com/oauth2/authorize/";
 
 interface CloseUserInfo {
   id: string;
@@ -40,7 +39,7 @@ export function buildCloseAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("close")}?${params.toString()}`;
+  return `${CLOSE_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/close.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,7 +33,6 @@ export function buildCloseAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("close");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -38,7 +40,7 @@ export function buildCloseAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("close")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -79,7 +82,7 @@ export async function buildDeelAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("deel")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const DEEL_AUTHORIZATION_URL = "https://app.deel.com/oauth2/authorize";
 
 const DEEL_PEOPLE_ME_URL = "https://api.letsdeel.com/rest/v2/people/me";
 
@@ -82,7 +81,7 @@ export async function buildDeelAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("deel")}?${params.toString()}`;
+  return `${DEEL_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -79,7 +82,7 @@ export async function buildDocuSignAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("docusign")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const DOCUSIGN_AUTHORIZATION_URL = "https://account-d.docusign.com/oauth/auth";
 
 const DOCUSIGN_USERINFO_URL = "https://account-d.docusign.com/oauth/userinfo";
 
@@ -82,7 +81,7 @@ export async function buildDocuSignAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("docusign")}?${params.toString()}`;
+  return `${DOCUSIGN_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -45,7 +48,7 @@ export function buildDropboxAuthorizationUrl(
     force_reapprove: "true",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("dropbox")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const DROPBOX_AUTHORIZATION_URL = "https://www.dropbox.com/oauth2/authorize";
 
 const DROPBOX_CURRENT_ACCOUNT_URL =
   "https://api.dropboxapi.com/2/users/get_current_account";
@@ -48,7 +47,7 @@ export function buildDropboxAuthorizationUrl(
     force_reapprove: "true",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("dropbox")}?${params.toString()}`;
+  return `${DROPBOX_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const FIGMA_AUTHORIZATION_URL = "https://www.figma.com/oauth";
 
 const FIGMA_ME_URL = "https://api.figma.com/v1/me";
 
@@ -44,7 +43,7 @@ export function buildFigmaAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("figma")}?${params.toString()}`;
+  return `${FIGMA_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildFigmaAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("figma")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -67,7 +70,6 @@ export async function buildGarminConnectAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -80,7 +82,7 @@ export async function buildGarminConnectAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("garmin-connect")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
@@ -1,9 +1,9 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const GARMIN_CONNECT_AUTHORIZATION_URL =
+  "https://connect.garmin.com/oauth2Confirm";
 
 const GARMIN_USER_ID_URL = "https://apis.garmin.com/wellness-api/rest/user/id";
 
@@ -82,7 +82,7 @@ export async function buildGarminConnectAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("garmin-connect")}?${params.toString()}`;
+  return `${GARMIN_CONNECT_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/github.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -26,7 +29,7 @@ export function buildGitHubAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("github")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/github.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const GITHUB_AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
 
 const GITHUB_API_BASE = "https://api.github.com";
 
@@ -29,7 +28,7 @@ export function buildGitHubAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("github")}?${params.toString()}`;
+  return `${GITHUB_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
@@ -1,8 +1,7 @@
 import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+import { buildGoogleAuthorizationUrl } from "./google-oauth";
 import { throwOAuthError } from "./oauth-error";
-
-const GMAIL_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 
 const GMAIL_PROFILE_URL =
   "https://www.googleapis.com/gmail/v1/users/me/profile";
@@ -30,18 +29,7 @@ export function buildGmailAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("gmail");
-  const params = new URLSearchParams({
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
-    state,
-    access_type: "offline",
-    prompt: "consent",
-  });
-
-  return `${GMAIL_AUTHORIZATION_URL}?${params.toString()}`;
+  return buildGoogleAuthorizationUrl("gmail", clientId, redirectUri, state);
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const GMAIL_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 
 const GMAIL_PROFILE_URL =
   "https://www.googleapis.com/gmail/v1/users/me/profile";
@@ -42,7 +41,7 @@ export function buildGmailAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("gmail")}?${params.toString()}`;
+  return `${GMAIL_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -39,7 +42,7 @@ export function buildGmailAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("gmail")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
@@ -1,10 +1,10 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import type { GoogleOAuthConnectorType } from "../google-oauth-connectors";
 import { throwOAuthError } from "./oauth-error";
+
+const GOOGLE_OAUTH_AUTHORIZATION_URL =
+  "https://accounts.google.com/o/oauth2/v2/auth";
 
 const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
 
@@ -49,7 +49,7 @@ export function buildGoogleAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint(connectorType)}?${params.toString()}`;
+  return `${GOOGLE_OAUTH_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import type { GoogleOAuthConnectorType } from "../google-oauth-connectors";
 import { throwOAuthError } from "./oauth-error";
@@ -46,7 +49,7 @@ export function buildGoogleAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint(connectorType)}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -38,7 +41,7 @@ export function buildGumroadAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("gumroad")}?${params.toString()}`;
 }
 
 export async function exchangeGumroadCode(

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const GUMROAD_AUTHORIZATION_URL = "https://gumroad.com/oauth/authorize";
 
 const GUMROAD_USER_URL = "https://api.gumroad.com/v2/user";
 
@@ -41,7 +40,7 @@ export function buildGumroadAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("gumroad")}?${params.toString()}`;
+  return `${GUMROAD_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 export async function exchangeGumroadCode(

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const HUBSPOT_AUTHORIZATION_URL = "https://app.hubspot.com/oauth/authorize";
 
 const HUBSPOT_TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens";
 
@@ -43,7 +42,7 @@ export function buildHubSpotAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("hubspot")}?${params.toString()}`;
+  return `${HUBSPOT_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -40,7 +43,7 @@ export function buildHubSpotAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("hubspot")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,7 +33,7 @@ export function buildIntervalsIcuAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("intervals-icu")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const INTERVALS_ICU_AUTHORIZATION_URL = "https://intervals.icu/oauth/authorize";
 
 interface IntervalsIcuTokenResult {
   accessToken: string;
@@ -33,7 +32,7 @@ export function buildIntervalsIcuAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("intervals-icu")}?${params.toString()}`;
+  return `${INTERVALS_ICU_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -45,7 +48,7 @@ export function buildLinearAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("linear")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const LINEAR_AUTHORIZATION_URL = "https://linear.app/oauth/authorize";
 
 // User info URL is not part of ConnectorOAuthConfig since it uses GraphQL (POST), not a standard
 // REST GET endpoint. Same pattern as GMAIL_PROFILE_URL in gmail.ts.
@@ -48,7 +47,7 @@ export function buildLinearAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("linear")}?${params.toString()}`;
+  return `${LINEAR_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
@@ -1,9 +1,9 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const MAILCHIMP_AUTHORIZATION_URL =
+  "https://login.mailchimp.com/oauth2/authorize";
 
 const MAILCHIMP_METADATA_URL = "https://login.mailchimp.com/oauth2/metadata";
 
@@ -34,7 +34,7 @@ export function buildMailchimpAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("mailchimp")}?${params.toString()}`;
+  return `${MAILCHIMP_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -24,7 +27,6 @@ export function buildMailchimpAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("mailchimp");
   const params = new URLSearchParams({
     response_type: "code",
     client_id: clientId,
@@ -32,7 +34,7 @@ export function buildMailchimpAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("mailchimp")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -42,7 +45,7 @@ export function buildMercuryAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("mercury")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const MERCURY_AUTHORIZATION_URL = "https://oauth2.mercury.com/oauth2/auth";
 
 const MERCURY_ACCOUNTS_URL = "https://api.mercury.com/api/v1/accounts";
 
@@ -45,7 +44,7 @@ export function buildMercuryAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("mercury")}?${params.toString()}`;
+  return `${MERCURY_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
@@ -1,9 +1,9 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const META_ADS_AUTHORIZATION_URL =
+  "https://www.facebook.com/v22.0/dialog/oauth";
 
 const META_USER_URL = "https://graph.facebook.com/v22.0/me";
 
@@ -39,7 +39,7 @@ export function buildMetaAdsAuthorizationUrl(
     scope: oauthConfig.scopes.join(","),
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("meta-ads")}?${params.toString()}`;
+  return `${META_ADS_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -36,7 +39,7 @@ export function buildMetaAdsAuthorizationUrl(
     scope: oauthConfig.scopes.join(","),
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("meta-ads")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
@@ -1,15 +1,15 @@
-import type { OAuthConfigManagedAuthorizationCodeConnectorType } from "@vm0/connectors/connectors";
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import type { OAuthAuthorizationCodeConnectorType } from "@vm0/connectors/connectors";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const MICROSOFT_AUTHORIZATION_URL =
+  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 
 const MICROSOFT_USERINFO_URL = "https://graph.microsoft.com/v1.0/me";
 
 type MicrosoftOAuthConnectorType = Extract<
-  OAuthConfigManagedAuthorizationCodeConnectorType,
+  OAuthAuthorizationCodeConnectorType,
   "outlook-calendar" | "outlook-mail"
 >;
 
@@ -53,7 +53,7 @@ export function buildMicrosoftAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint(connectorType)}?${params.toString()}`;
+  return `${MICROSOFT_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
@@ -1,12 +1,15 @@
-import type { OAuthConnectorType } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import type { OAuthConfigManagedAuthorizationCodeConnectorType } from "@vm0/connectors/connectors";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
 const MICROSOFT_USERINFO_URL = "https://graph.microsoft.com/v1.0/me";
 
 type MicrosoftOAuthConnectorType = Extract<
-  OAuthConnectorType,
+  OAuthConfigManagedAuthorizationCodeConnectorType,
   "outlook-calendar" | "outlook-mail"
 >;
 
@@ -50,7 +53,7 @@ export function buildMicrosoftAuthorizationUrl(
     prompt: "consent",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint(connectorType)}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const MONDAY_AUTHORIZATION_URL = "https://auth.monday.com/oauth2/authorize";
 
 interface MondayUserInfo {
   id: string;
@@ -44,7 +43,7 @@ export function buildMondayAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("monday")}?${params.toString()}`;
+  return `${MONDAY_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildMondayAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("monday")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const NEON_AUTHORIZATION_URL = "https://oauth2.neon.tech/oauth2/auth";
 
 const NEON_USER_INFO_URL = "https://console.neon.tech/api/v2/users/me";
 
@@ -45,7 +44,7 @@ export function buildNeonAuthorizationUrl(
     scope: oauthConfig.scopes.join(" "),
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("neon")}?${params.toString()}`;
+  return `${NEON_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -42,7 +45,7 @@ export function buildNeonAuthorizationUrl(
     scope: oauthConfig.scopes.join(" "),
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("neon")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -37,7 +40,6 @@ export function buildNotionAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("notion");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -46,7 +48,7 @@ export function buildNotionAuthorizationUrl(
     owner: "user",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("notion")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const NOTION_AUTHORIZATION_URL = "https://api.notion.com/v1/oauth/authorize";
 
 interface NotionUserInfo {
   id: string;
@@ -48,7 +47,7 @@ export function buildNotionAuthorizationUrl(
     owner: "user",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("notion")}?${params.toString()}`;
+  return `${NOTION_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildPosthogAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("posthog")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const POSTHOG_AUTHORIZATION_URL = "https://us.posthog.com/oauth/authorize";
 
 const POSTHOG_USER_INFO_URL = "https://us.posthog.com/api/users/@me/";
 
@@ -44,7 +43,7 @@ export function buildPosthogAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("posthog")}?${params.toString()}`;
+  return `${POSTHOG_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const REDDIT_AUTHORIZATION_URL = "https://www.reddit.com/api/v1/authorize";
 
 const REDDIT_USER_INFO_URL = "https://oauth.reddit.com/api/v1/me";
 const REDDIT_USER_AGENT = "web:vm0-reddit-connector:v1.0";
@@ -49,7 +48,7 @@ export function buildRedditAuthorizationUrl(
     scope: oauthConfig.scopes.join(" "),
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("reddit")}?${params.toString()}`;
+  return `${REDDIT_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -46,7 +49,7 @@ export function buildRedditAuthorizationUrl(
     scope: oauthConfig.scopes.join(" "),
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("reddit")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const SENTRY_AUTHORIZATION_URL = "https://sentry.io/oauth/authorize/";
 
 interface SentryUserInfo {
   id: string;
@@ -42,7 +41,7 @@ export function buildSentryAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("sentry")}?${params.toString()}`;
+  return `${SENTRY_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -39,7 +42,7 @@ export function buildSentryAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("sentry")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -31,7 +34,7 @@ export function buildSlackAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("slack")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const SLACK_AUTHORIZATION_URL = "https://slack.com/oauth/v2/authorize";
 
 interface SlackTokenResult {
   accessToken: string;
@@ -34,7 +33,7 @@ export function buildSlackAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("slack")}?${params.toString()}`;
+  return `${SLACK_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildSpotifyAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("spotify")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const SPOTIFY_AUTHORIZATION_URL = "https://accounts.spotify.com/authorize";
 
 const SPOTIFY_ME_URL = "https://api.spotify.com/v1/me";
 
@@ -44,7 +43,7 @@ export function buildSpotifyAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("spotify")}?${params.toString()}`;
+  return `${SPOTIFY_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const STRAVA_AUTHORIZATION_URL = "https://www.strava.com/oauth/authorize";
 
 const STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete";
 
@@ -46,7 +45,7 @@ export function buildStravaAuthorizationUrl(
     approval_prompt: "force",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("strava")}?${params.toString()}`;
+  return `${STRAVA_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -43,7 +46,7 @@ export function buildStravaAuthorizationUrl(
     approval_prompt: "force",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("strava")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const STRIPE_AUTHORIZATION_URL = "https://connect.stripe.com/oauth/authorize";
 
 const STRIPE_ACCOUNT_URL = "https://api.stripe.com/v1/account";
 
@@ -44,7 +43,7 @@ export function buildStripeAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("stripe")}?${params.toString()}`;
+  return `${STRIPE_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildStripeAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("stripe")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -79,7 +82,7 @@ export async function buildSupabaseAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("supabase")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
@@ -1,9 +1,9 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const SUPABASE_AUTHORIZATION_URL =
+  "https://api.supabase.com/v1/oauth/authorize";
 
 const SUPABASE_ORGANIZATIONS_URL = "https://api.supabase.com/v1/organizations";
 
@@ -82,7 +82,7 @@ export async function buildSupabaseAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("supabase")}?${params.toString()}`;
+  return `${SUPABASE_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
@@ -9,7 +9,10 @@
  * the provider routes themselves 404 in production via isTestEndpointAllowed().
  */
 
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 export {
@@ -128,8 +131,8 @@ function previewBypassHeaders(): Record<string, string> {
 
 function getAuthorizationUrl(): string {
   return resolveUrl(
-    "authorizationUrl",
-    getConnectorOAuthConfig("test-oauth").authorizationUrl,
+    "authorizationEndpoint",
+    getConnectorOAuthAuthorizationEndpoint("test-oauth"),
   );
 }
 
@@ -224,8 +227,8 @@ export async function refreshTestOAuthToken(
 export async function fetchTestOAuthUserInfo(
   accessToken: string,
 ): Promise<UserInfo> {
-  // userinfo is not part of the OAuth 2 spec's tokenUrl/authorizationUrl
-  // pair so ConnectorOAuthConfig doesn't carry it. Derive from the same app.
+  // userinfo is not part of the OAuth 2 spec's token and authorization
+  // endpoints, so ConnectorOAuthConfig doesn't carry it. Derive from the same app.
   const response = await fetch(
     `${runtimeBaseUrl()}/api/test/oauth-provider/userinfo`,
     {

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
@@ -9,10 +9,7 @@
  * the provider routes themselves 404 in production via isTestEndpointAllowed().
  */
 
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 export {
@@ -21,6 +18,8 @@ export {
   TEST_OAUTH_ACCESS_SECRET_NAME,
   TEST_OAUTH_REFRESH_SECRET_NAME,
 } from "./test-oauth-constants";
+
+const TEST_OAUTH_AUTHORIZATION_URL = "/api/test/oauth-provider/authorize";
 
 interface TokenResponse {
   accessToken: string;
@@ -35,11 +34,9 @@ interface UserInfo {
   email: string | null;
 }
 
-function resolveUrl(field: string, path: string | undefined): string {
+function resolveUrl(field: string, path: string): string {
   if (!path) {
-    throw new Error(
-      `Test OAuth URL missing: CONNECTOR_TYPES_DEF["test-oauth"].oauth.${field} is not set`,
-    );
+    throw new Error(`Test OAuth URL missing: ${field} is not set`);
   }
   if (URL.canParse(path)) {
     return path;
@@ -130,10 +127,7 @@ function previewBypassHeaders(): Record<string, string> {
 }
 
 function getAuthorizationUrl(): string {
-  return resolveUrl(
-    "authorizationEndpoint",
-    getConnectorOAuthAuthorizationEndpoint("test-oauth"),
-  );
+  return resolveUrl("authorizationUrl", TEST_OAUTH_AUTHORIZATION_URL);
 }
 
 function getTokenUrl(): string {

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const TODOIST_AUTHORIZATION_URL = "https://todoist.com/oauth/authorize";
 
 const TODOIST_USER_URL = "https://api.todoist.com/api/v1/user";
 
@@ -34,7 +33,7 @@ export function buildTodoistAuthorizationUrl(
     redirect_uri: redirectUri,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("todoist")}?${params.toString()}`;
+  return `${TODOIST_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -31,7 +34,7 @@ export function buildTodoistAuthorizationUrl(
     redirect_uri: redirectUri,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("todoist")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const WEBFLOW_AUTHORIZATION_URL = "https://webflow.com/oauth/authorize";
 
 interface WebflowTokenResult {
   accessToken: string;
@@ -32,7 +31,7 @@ export function buildWebflowAuthorizationUrl(
     redirect_uri: redirectUri,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("webflow")}?${params.toString()}`;
+  return `${WEBFLOW_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -29,7 +32,7 @@ export function buildWebflowAuthorizationUrl(
     redirect_uri: redirectUri,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("webflow")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/x.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -80,7 +83,7 @@ export async function buildXAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("x")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/x.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const X_AUTHORIZATION_URL = "https://twitter.com/i/oauth2/authorize";
 
 const X_USERS_ME_URL =
   "https://api.twitter.com/2/users/me?user.fields=id,username,name";
@@ -83,7 +82,7 @@ export async function buildXAuthorizationUrl(
     code_challenge_method: "S256",
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("x")}?${params.toString()}`;
+  return `${X_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildXeroAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("xero")}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
@@ -1,9 +1,9 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const XERO_AUTHORIZATION_URL =
+  "https://login.xero.com/identity/connect/authorize";
 
 const XERO_USERINFO_URL = "https://identity.xero.com/connect/userinfo";
 
@@ -44,7 +44,7 @@ export function buildXeroAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("xero")}?${params.toString()}`;
+  return `${XERO_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
@@ -1,9 +1,8 @@
-import {
-  getConnectorOAuthAuthorizationEndpoint,
-  getConnectorOAuthConfig,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
+
+const ZOOM_AUTHORIZATION_URL = "https://zoom.us/oauth/authorize";
 
 const ZOOM_ME_URL = "https://api.zoom.us/v2/users/me";
 
@@ -44,7 +43,7 @@ export function buildZoomAuthorizationUrl(
     state,
   });
 
-  return `${getConnectorOAuthAuthorizationEndpoint("zoom")}?${params.toString()}`;
+  return `${ZOOM_AUTHORIZATION_URL}?${params.toString()}`;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
@@ -1,4 +1,7 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthAuthorizationEndpoint,
+  getConnectorOAuthConfig,
+} from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -41,7 +44,7 @@ export function buildZoomAuthorizationUrl(
     state,
   });
 
-  return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+  return `${getConnectorOAuthAuthorizationEndpoint("zoom")}?${params.toString()}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add the OAuth `flow` discriminator while keeping `ConnectorOAuthConfig` limited to runtime token/client/scope data
- move static authorization URLs out of connector configs and into OAuth provider modules
- remove the public configured-authorization-endpoint helper and the config/provider endpoint union
- preserve the final `authorizationUrl` API behavior; tests now assert provider-built authorization URLs and that connector OAuth config does not expose authorization URL fields

Closes #14426

## Tests
- `pnpm --dir turbo -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts src/oauth-providers/providers/__tests__/test-oauth.test.ts`
- `pnpm --dir turbo -F @vm0/connectors exec vitest src/oauth-providers/providers/__tests__/test-oauth.test.ts`
- `pnpm --dir turbo -F @vm0/connectors check-types`
- `pnpm --dir turbo -F @vm0/connectors lint`
- `pnpm --dir turbo -F @vm0/connectors test`
- `git diff --check`
- pre-commit hook: prettier, knip, check-types
