### PR TITLE
chore(mitm-addon): enforce matching import style

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -32,6 +32,7 @@ select = [
     "E",        # pycodestyle errors
     "F",        # pyflakes
     "I",        # isort
+    "ICN003",   # flake8-import-conventions: banned member imports
     "B",        # flake8-bugbear (real correctness bugs)
     "S",        # flake8-bandit (security)
     "ASYNC",    # flake8-async (this addon is async-heavy)
@@ -74,6 +75,9 @@ extend-ignore = [
     "RUF002",
     "RUF003",
 ]
+
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = ["matching"]
 
 [tool.ruff.lint.per-file-ignores]
 # S101: pytest uses `assert` universally; S105: tests hardcode fixture tokens

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -21,15 +21,16 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# Usage/body_utils/registry/response_streaming are imported by module
+# Usage/body_utils/matching/registry/response_streaming are imported by module
 # (not selective `from X import ...`)
 # so that:
 #   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)`` /
-#      ``registry.X(...)`` / ``response_streaming.X(...)``,
+#      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)``,
 #      making the module boundary visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import body_utils
+import matching
 import registry
 import response_streaming
 import usage
@@ -40,7 +41,6 @@ from auth import (
     request_force_refresh,
 )
 from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
-from matching import FirewallAllow, FirewallBlock, match_compiled_firewall_request
 from url_utils import AuthorityValidationError, get_trusted_authority
 
 # HTTP status boundaries used in response-phase classification.
@@ -242,13 +242,13 @@ async def request(flow: http.HTTPFlow) -> None:
         # Match base URL, then check permission rules before injecting auth headers.
         if compiled_firewalls:
             network_policies = vm_info.get("networkPolicies") or {}
-            result = match_compiled_firewall_request(
+            result = matching.match_compiled_firewall_request(
                 original_url,
                 flow.request.method,
                 compiled_firewalls,
                 network_policies,
             )
-            if isinstance(result, FirewallBlock):
+            if isinstance(result, matching.FirewallBlock):
                 proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
                 log_proxy_entry(
                     proxy_log_path,
@@ -280,7 +280,7 @@ async def request(flow: http.HTTPFlow) -> None:
                     {"Content-Type": "application/json"},
                 )
                 return
-            if isinstance(result, FirewallAllow):
+            if isinstance(result, matching.FirewallAllow):
                 _maybe_track_usage_flow(
                     flow,
                     is_billable_firewall(result.match_info, vm_info),

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -5,12 +5,12 @@ from pathlib import Path
 
 from mitmproxy import ctx
 
+import matching
 from auth import evict_stale_cache_keys
-from matching import CompiledFirewallSet, compile_firewalls
 
 # Cache for proxy registry (invalidated by file stat change).
 _registry_cache: dict = {}
-_registry_compiled_cache: dict[str, CompiledFirewallSet] = {}
+_registry_compiled_cache: dict[str, matching.CompiledFirewallSet] = {}
 _registry_cache_key: tuple[int, int] = (0, 0)
 # One-shot guard for stat-path failures: no cache key is available in that
 # branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
@@ -30,11 +30,11 @@ def reset_cache_for_tests() -> None:
     _registry_load_error_logged = False
 
 
-def _compile_registry(new_registry: dict) -> dict[str, CompiledFirewallSet]:
-    compiled: dict[str, CompiledFirewallSet] = {}
+def _compile_registry(new_registry: dict) -> dict[str, matching.CompiledFirewallSet]:
+    compiled: dict[str, matching.CompiledFirewallSet] = {}
     for client_ip, vm in new_registry.items():
         firewalls = vm.get("firewalls") if isinstance(vm, dict) else None
-        compiled_firewalls = compile_firewalls(firewalls)
+        compiled_firewalls = matching.compile_firewalls(firewalls)
         if compiled_firewalls is not None:
             compiled[client_ip] = compiled_firewalls
     return compiled
@@ -104,7 +104,7 @@ def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
 def get_vm_context(
     client_ip: str,
     registry_path: str,
-) -> tuple[dict, CompiledFirewallSet | None] | None:
+) -> tuple[dict, matching.CompiledFirewallSet | None] | None:
     """Look up raw VM info with its compiled firewall matcher sidecar."""
     vm_info = load_registry(registry_path).get(client_ip)
     if vm_info is None:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -53,7 +53,7 @@ sheet for drift.
 import json
 import re
 
-from matching import CompiledPathPattern, compile_path_pattern, match_compiled_path
+import matching
 
 from .x_tlds import IANA_TLDS
 
@@ -203,15 +203,15 @@ _PATH_OVERRIDES: list[tuple[str, str, str, str]] = [
 
 def _build_override_index(
     overrides: list[tuple[str, str, str, str]],
-) -> dict[tuple[str, str], list[tuple[CompiledPathPattern, str]]]:
+) -> dict[tuple[str, str], list[tuple[matching.CompiledPathPattern, str]]]:
     """Group overrides by ``(scope, method)`` so :func:`classify_bucket`
     only walks patterns under the matching scope/method instead of the
     full list.  Insertion order is preserved inside each bucket, which
     keeps first-match-wins semantics from the source list.
     """
-    index: dict[tuple[str, str], list[tuple[CompiledPathPattern, str]]] = {}
+    index: dict[tuple[str, str], list[tuple[matching.CompiledPathPattern, str]]] = {}
     for scope, method, pattern, bucket in overrides:
-        compiled_pattern = compile_path_pattern(pattern)
+        compiled_pattern = matching.compile_path_pattern(pattern)
         if compiled_pattern is None:
             raise ValueError(f"invalid X billing override path pattern: {scope} {method} {pattern}")
         index.setdefault((scope, method), []).append((compiled_pattern, bucket))
@@ -233,7 +233,7 @@ def classify_bucket(permission: str, method: str, path: str) -> str | None:
     case.
     """
     for pattern, bucket in _OVERRIDE_INDEX.get((permission, method.upper()), ()):
-        if match_compiled_path(path, pattern) is not None:
+        if matching.match_compiled_path(path, pattern) is not None:
             return bucket
     return _PERMISSION_TO_BUCKET.get(permission)
 


### PR DESCRIPTION
## Summary

- Enable Ruff ICN003 for the mitm-addon package and ban `from matching import ...`.
- Convert remaining production `matching` imports to module-qualified `matching.*` references.
- Keep the existing module-import rationale in `mitm_addon.py` aligned with the new policy.

Closes #14451

## Tests

- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/ -v` (869 passed)
- `git diff --check`
- `rg -n "^from matching import" crates/runner/mitm-addon || true`
- `cd crates && cargo fmt --all --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `./scripts/check-file-size.sh $(git diff --cached --name-only)`
- `./scripts/block-generated-firewalls.sh`
- `printf '%s\n' 'chore(mitm-addon): enforce matching import style' | ./turbo/node_modules/.bin/commitlint --config commitlint.config.mjs`

Note: the first local `git commit` attempts hit a pre-existing lefthook concurrency issue where `cargo-clippy` and `cargo-doc` run in parallel against the same `crates/target`, producing transient Rust metadata errors. The same cargo commands passed when run sequentially before committing with lefthook disabled.
