### PR TITLE
fix(cli): save computer-use screenshots locally

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -6,10 +6,19 @@
  * Real (internal): Command registration, capability checking
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFile, rm } from "node:fs/promises";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Command, Help } from "commander";
-import { formatComputerUseResultForConsole } from "../index";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import {
+  formatComputerUseResultForConsole,
+  zeroComputerUseCommand,
+} from "../index";
 import { registerZeroCommands } from "../../../../zero";
+
+const TEST_SCREENSHOT_PATH =
+  "/tmp/vm0/computer-use/Slack-Test-App-desktop_test_snapshot.png";
 
 function buildZeroToken(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
@@ -43,8 +52,16 @@ function hiddenCommandNames(prog: Command): string[] {
 }
 
 describe("computer-use command visibility", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
   beforeEach(() => {
+    mockConsoleLog.mockClear();
     vi.stubEnv("ZERO_TOKEN", "");
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(TEST_SCREENSHOT_PATH, { force: true });
   });
 
   it("should be visible when no ZERO_TOKEN is set", () => {
@@ -119,17 +136,93 @@ describe("computer-use command visibility", () => {
     expect(subNames).toContain("audit");
   });
 
-  it("should omit screenshot data URLs from command result console output", () => {
-    const text = formatComputerUseResultForConsole({
-      app: "Safari",
+  it("should write screenshot data URLs to a local file in command result console output", async () => {
+    const screenshotBytes = Buffer.from("test-png-data");
+    const screenshotBase64 = screenshotBytes.toString("base64");
+    const text = await formatComputerUseResultForConsole({
+      app: "Slack/Test App",
+      snapshotId: "desktop_test_snapshot",
       text: "snapshot_id=snap_1\nw0 AXWindow",
-      screenshot: "data:image/png;base64,abcdefghijklmnopqrstuvwxyz",
+      screenshot: `data:image/png;base64,${screenshotBase64}`,
       screenshotSource: "window",
     });
 
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    expect(parsed.screenshot).toBe(TEST_SCREENSHOT_PATH);
     expect(text).toContain("snapshot_id=snap_1");
     expect(text).toContain("screenshotSource");
-    expect(text).toContain("[omitted 48 character screenshot data URL]");
-    expect(text).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(text).not.toContain(screenshotBase64);
+    await expect(readFile(TEST_SCREENSHOT_PATH)).resolves.toEqual(
+      screenshotBytes,
+    );
+  });
+
+  it("should print a screenshot file path for get-app-state", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    const screenshotBytes = Buffer.from("test-png-data");
+    const screenshotBase64 = screenshotBytes.toString("base64");
+    server.use(
+      http.post(
+        "http://localhost:3000/api/zero/computer-use/commands",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          expect(body.kind).toBe("app.state");
+          expect(body.app).toBe("Slack/Test App");
+          return HttpResponse.json({
+            commandId: "cmd_1",
+            status: "queued",
+          });
+        },
+      ),
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/commands/cmd_1",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_1",
+            kind: "app.state",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: { app: "Slack/Test App" },
+            result: {
+              app: "Slack/Test App",
+              snapshotId: "desktop_test_snapshot",
+              text: "snapshot_id=desktop_test_snapshot\nw0 AXWindow",
+              screenshot: `data:image/png;base64,${screenshotBase64}`,
+              screenshotMimeType: "image/png",
+              screenshotWidth: 1363,
+              screenshotHeight: 1200,
+            },
+            timeoutMs: 10_000,
+            createdAt: "2026-05-21T10:00:00.000Z",
+            claimedAt: "2026-05-21T10:00:01.000Z",
+            completedAt: "2026-05-21T10:00:02.000Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "get-app-state",
+      "--app",
+      "Slack/Test App",
+      "--timeout",
+      "10",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed.screenshot).toBe(TEST_SCREENSHOT_PATH);
+    expect(parsed.text).toBe("snapshot_id=desktop_test_snapshot\nw0 AXWindow");
+    expect(parsed.screenshotWidth).toBe(1363);
+    expect(parsed.screenshotHeight).toBe(1200);
+    expect(output).not.toContain(screenshotBase64);
+    await expect(readFile(TEST_SCREENSHOT_PATH)).resolves.toEqual(
+      screenshotBytes,
+    );
   });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { Command } from "commander";
 import type {
   ComputerUseAuditEvent,
@@ -67,6 +69,9 @@ interface AuditListOptions {
   readonly hostId?: string;
   readonly runId?: string;
 }
+
+const COMPUTER_USE_SCREENSHOT_DIR = "/tmp/vm0/computer-use";
+const DATA_URL_PATTERN = /^data:([^;,]+);base64,(.*)$/s;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -141,25 +146,82 @@ function parseLimit(value: string | undefined): number {
   return parsed;
 }
 
-function summarizeScreenshotValue(value: string): string {
-  return `[omitted ${value.length.toString()} character screenshot data URL]`;
+function sanitizeFilenamePart(value: unknown, fallback: string): string {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const sanitized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return sanitized.length > 0 ? sanitized : fallback;
 }
 
-export function formatComputerUseResultForConsole(
+function extensionForMimeType(mimeType: string): string {
+  if (mimeType === "image/png") {
+    return "png";
+  }
+  if (mimeType === "image/jpeg") {
+    return "jpg";
+  }
+  if (mimeType === "image/webp") {
+    return "webp";
+  }
+  const suffix = mimeType.startsWith("image/") ? mimeType.slice(6) : "bin";
+  return sanitizeFilenamePart(suffix, "bin").toLowerCase();
+}
+
+async function writeScreenshotDataUrl(
   result: Record<string, unknown>,
-): string {
+  dataUrl: string,
+): Promise<string | null> {
+  const match = DATA_URL_PATTERN.exec(dataUrl);
+  if (!match) {
+    return null;
+  }
+
+  const mimeType = match[1] ?? "";
+  if (!mimeType.startsWith("image/")) {
+    throw new Error(`Unsupported screenshot MIME type: ${mimeType}`);
+  }
+
+  const base64Data = match[2] ?? "";
+  const appName = sanitizeFilenamePart(result.app, "app");
+  const snapshotId = sanitizeFilenamePart(result.snapshotId, "snapshot");
+  const outputPath = join(
+    COMPUTER_USE_SCREENSHOT_DIR,
+    `${appName}-${snapshotId}.${extensionForMimeType(mimeType)}`,
+  );
+
+  await mkdir(COMPUTER_USE_SCREENSHOT_DIR, { recursive: true });
+  await writeFile(outputPath, Buffer.from(base64Data, "base64"));
+  return outputPath;
+}
+
+export async function formatComputerUseResultForConsole(
+  result: Record<string, unknown>,
+): Promise<string> {
   const printable: Record<string, unknown> = { ...result };
   if (typeof printable.screenshot === "string") {
-    printable.screenshot = summarizeScreenshotValue(printable.screenshot);
+    const screenshotPath = await writeScreenshotDataUrl(
+      printable,
+      printable.screenshot,
+    );
+    if (screenshotPath) {
+      printable.screenshot = screenshotPath;
+    }
   }
   return JSON.stringify(printable, null, 2);
 }
 
-function resultText(command: ComputerUseCommandResponse): string {
+async function resultText(
+  command: ComputerUseCommandResponse,
+): Promise<string> {
   if (!command.result) {
     return "";
   }
-  return formatComputerUseResultForConsole(command.result);
+  return await formatComputerUseResultForConsole(command.result);
 }
 
 async function waitForCommand(
@@ -193,7 +255,7 @@ async function waitForCommand(
       );
     }
 
-    const text = resultText(command);
+    const text = await resultText(command);
     if (text) {
       console.log(text);
     }


### PR DESCRIPTION
## Summary
- decode computer-use screenshot data URLs into files under `/tmp/vm0/computer-use/`
- keep `get-app-state` stdout as JSON while replacing the `screenshot` field with the local file path
- cover both formatter output and the `get-app-state` command path in CLI tests

Fixes #14457

## Verification
- `pnpm -F @vm0/cli exec vitest src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm knip --workspace @vm0/cli`
- `pnpm format`

## Notes
- Full local pre-commit hook was skipped because `api#check-types` currently fails on unmodified API test files in this devcontainer (`Property 'body' does not exist on type 'never'`). The CLI-scoped checks above passed.