### PR TITLE
refactor(vsock-proto): group message type ids

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -15,9 +15,9 @@
 //!
 //! ## Message Types
 //!
-//! Message types are continuous and grouped by protocol domain: connection
-//! lifecycle, operation gates, file operations, exec operations, and the generic
-//! protocol error sentinel at `0xFF`.
+//! Non-error message types are continuous and grouped by protocol domain:
+//! connection lifecycle, operation gates, file operations, exec operations, and
+//! the generic protocol error sentinel at `0xFF`.
 //!
 //! | Type | Direction | Name              | Payload |
 //! |------|-----------|-------------------|---------|

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -15,24 +15,28 @@
 //!
 //! ## Message Types
 //!
+//! Message types are continuous and grouped by protocol domain: connection
+//! lifecycle, operation gates, file operations, exec operations, and the generic
+//! protocol error sentinel at `0xFF`.
+//!
 //! | Type | Direction | Name              | Payload |
 //! |------|-----------|-------------------|---------|
 //! | 0x00 | G→H       | ready             | (empty) |
 //! | 0x01 | H→G       | ping              | (empty) |
 //! | 0x02 | G→H       | pong              | (empty) |
-//! | 0x03 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
-//! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x05 | H→G       | shutdown          | (empty) |
-//! | 0x06 | G→H       | shutdown_ack      | (empty) |
-//! | 0x07 | H→G       | exec_start     | `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
-//! | 0x08 | G→H       | exec_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
-//! | 0x09 | G→H       | exec_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
-//! | 0x0A | H→G       | exec_cancel    | (empty) |
-//! | 0x0B | H→G       | quiesce_operations  | (empty) |
-//! | 0x0C | G→H       | operations_quiesced    | (empty) |
-//! | 0x0D | H→G       | resume_operations | (empty) |
-//! | 0x0E | G→H       | operations_resumed | (empty) |
-//! | 0x0F | G→H       | exec_started | `[4B pid]` |
+//! | 0x03 | H→G       | shutdown          | (empty) |
+//! | 0x04 | G→H       | shutdown_ack      | (empty) |
+//! | 0x05 | H→G       | quiesce_operations  | (empty) |
+//! | 0x06 | G→H       | operations_quiesced    | (empty) |
+//! | 0x07 | H→G       | resume_operations | (empty) |
+//! | 0x08 | G→H       | operations_resumed | (empty) |
+//! | 0x09 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
+//! | 0x0A | G→H       | write_file_result | `[1B success][2B error_len][error]` |
+//! | 0x0B | H→G       | exec_start     | `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
+//! | 0x0C | G→H       | exec_started | `[4B pid]` |
+//! | 0x0D | G→H       | exec_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
+//! | 0x0E | G→H       | exec_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
+//! | 0x0F | H→G       | exec_cancel    | (empty) |
 //! | 0x10 | H→G       | exec_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
 //! | 0x11 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -7,6 +7,8 @@ pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 /// Minimum body size: type (1) + seq (4).
 pub const MIN_BODY_SIZE: usize = 5;
 
+// Message types are ordered by protocol domain.
+
 /// Guest-to-host ready notification with an empty payload.
 pub const MSG_READY: u8 = 0x00;
 
@@ -16,44 +18,44 @@ pub const MSG_PING: u8 = 0x01;
 /// Guest-to-host pong response with an empty payload.
 pub const MSG_PONG: u8 = 0x02;
 
-/// Host-to-guest write-file request.
-pub const MSG_WRITE_FILE: u8 = 0x03;
-
-/// Guest-to-host write-file completion response.
-pub const MSG_WRITE_FILE_RESULT: u8 = 0x04;
-
 /// Host-to-guest shutdown request with an empty payload.
-pub const MSG_SHUTDOWN: u8 = 0x05;
+pub const MSG_SHUTDOWN: u8 = 0x03;
 
 /// Guest-to-host shutdown acknowledgement with an empty payload.
-pub const MSG_SHUTDOWN_ACK: u8 = 0x06;
-
-/// Host-to-guest exec operation start request.
-pub const MSG_EXEC_START: u8 = 0x07;
-
-/// Guest-to-host exec operation output chunk.
-pub const MSG_EXEC_OUTPUT: u8 = 0x08;
-
-/// Guest-to-host exec operation terminal result.
-pub const MSG_EXEC_RESULT: u8 = 0x09;
-
-/// Host-to-guest exec operation cancellation request.
-pub const MSG_EXEC_CANCEL: u8 = 0x0A;
+pub const MSG_SHUTDOWN_ACK: u8 = 0x04;
 
 /// Host-to-guest request to fence new guest operations.
-pub const MSG_QUIESCE_OPERATIONS: u8 = 0x0B;
+pub const MSG_QUIESCE_OPERATIONS: u8 = 0x05;
 
 /// Guest-to-host acknowledgement that operations are quiesced.
-pub const MSG_OPERATIONS_QUIESCED: u8 = 0x0C;
+pub const MSG_OPERATIONS_QUIESCED: u8 = 0x06;
 
 /// Host-to-guest request to resume guest operations.
-pub const MSG_RESUME_OPERATIONS: u8 = 0x0D;
+pub const MSG_RESUME_OPERATIONS: u8 = 0x07;
 
 /// Guest-to-host acknowledgement that operations resumed.
-pub const MSG_OPERATIONS_RESUMED: u8 = 0x0E;
+pub const MSG_OPERATIONS_RESUMED: u8 = 0x08;
+
+/// Host-to-guest write-file request.
+pub const MSG_WRITE_FILE: u8 = 0x09;
+
+/// Guest-to-host write-file completion response.
+pub const MSG_WRITE_FILE_RESULT: u8 = 0x0A;
+
+/// Host-to-guest exec operation start request.
+pub const MSG_EXEC_START: u8 = 0x0B;
 
 /// Guest-to-host exec operation start acknowledgement.
-pub const MSG_EXEC_STARTED: u8 = 0x0F;
+pub const MSG_EXEC_STARTED: u8 = 0x0C;
+
+/// Guest-to-host exec operation output chunk.
+pub const MSG_EXEC_OUTPUT: u8 = 0x0D;
+
+/// Guest-to-host exec operation terminal result.
+pub const MSG_EXEC_RESULT: u8 = 0x0E;
+
+/// Host-to-guest exec operation cancellation request.
+pub const MSG_EXEC_CANCEL: u8 = 0x0F;
 
 /// Host-to-guest control message for an active exec operation.
 pub const MSG_EXEC_CONTROL: u8 = 0x10;
@@ -89,19 +91,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn message_type_wire_values_are_compact() {
-        assert_eq!(MSG_SHUTDOWN, 0x05);
-        assert_eq!(MSG_SHUTDOWN_ACK, 0x06);
-        assert_eq!(MSG_EXEC_START, 0x07);
-        assert_eq!(MSG_EXEC_OUTPUT, 0x08);
-        assert_eq!(MSG_EXEC_RESULT, 0x09);
-        assert_eq!(MSG_EXEC_CANCEL, 0x0A);
-        assert_eq!(MSG_QUIESCE_OPERATIONS, 0x0B);
-        assert_eq!(MSG_OPERATIONS_QUIESCED, 0x0C);
-        assert_eq!(MSG_RESUME_OPERATIONS, 0x0D);
-        assert_eq!(MSG_OPERATIONS_RESUMED, 0x0E);
-        assert_eq!(MSG_EXEC_STARTED, 0x0F);
+    fn message_type_wire_values_are_grouped_by_domain() {
+        assert_eq!(MSG_READY, 0x00);
+        assert_eq!(MSG_PING, 0x01);
+        assert_eq!(MSG_PONG, 0x02);
+        assert_eq!(MSG_SHUTDOWN, 0x03);
+        assert_eq!(MSG_SHUTDOWN_ACK, 0x04);
+        assert_eq!(MSG_QUIESCE_OPERATIONS, 0x05);
+        assert_eq!(MSG_OPERATIONS_QUIESCED, 0x06);
+        assert_eq!(MSG_RESUME_OPERATIONS, 0x07);
+        assert_eq!(MSG_OPERATIONS_RESUMED, 0x08);
+        assert_eq!(MSG_WRITE_FILE, 0x09);
+        assert_eq!(MSG_WRITE_FILE_RESULT, 0x0A);
+        assert_eq!(MSG_EXEC_START, 0x0B);
+        assert_eq!(MSG_EXEC_STARTED, 0x0C);
+        assert_eq!(MSG_EXEC_OUTPUT, 0x0D);
+        assert_eq!(MSG_EXEC_RESULT, 0x0E);
+        assert_eq!(MSG_EXEC_CANCEL, 0x0F);
         assert_eq!(MSG_EXEC_CONTROL, 0x10);
         assert_eq!(MSG_EXEC_CONTROL_RESULT, 0x11);
+        assert_eq!(MSG_ERROR, 0xFF);
     }
 }

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -7,7 +7,7 @@ pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 /// Minimum body size: type (1) + seq (4).
 pub const MIN_BODY_SIZE: usize = 5;
 
-// Message types are ordered by protocol domain.
+// Connection lifecycle.
 
 /// Guest-to-host ready notification with an empty payload.
 pub const MSG_READY: u8 = 0x00;
@@ -24,6 +24,8 @@ pub const MSG_SHUTDOWN: u8 = 0x03;
 /// Guest-to-host shutdown acknowledgement with an empty payload.
 pub const MSG_SHUTDOWN_ACK: u8 = 0x04;
 
+// Operation gates.
+
 /// Host-to-guest request to fence new guest operations.
 pub const MSG_QUIESCE_OPERATIONS: u8 = 0x05;
 
@@ -36,11 +38,15 @@ pub const MSG_RESUME_OPERATIONS: u8 = 0x07;
 /// Guest-to-host acknowledgement that operations resumed.
 pub const MSG_OPERATIONS_RESUMED: u8 = 0x08;
 
+// File operations.
+
 /// Host-to-guest write-file request.
 pub const MSG_WRITE_FILE: u8 = 0x09;
 
 /// Guest-to-host write-file completion response.
 pub const MSG_WRITE_FILE_RESULT: u8 = 0x0A;
+
+// Exec operations.
 
 /// Host-to-guest exec operation start request.
 pub const MSG_EXEC_START: u8 = 0x0B;

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -92,24 +92,31 @@ mod tests {
 
     #[test]
     fn message_type_wire_values_are_grouped_by_domain() {
-        assert_eq!(MSG_READY, 0x00);
-        assert_eq!(MSG_PING, 0x01);
-        assert_eq!(MSG_PONG, 0x02);
-        assert_eq!(MSG_SHUTDOWN, 0x03);
-        assert_eq!(MSG_SHUTDOWN_ACK, 0x04);
-        assert_eq!(MSG_QUIESCE_OPERATIONS, 0x05);
-        assert_eq!(MSG_OPERATIONS_QUIESCED, 0x06);
-        assert_eq!(MSG_RESUME_OPERATIONS, 0x07);
-        assert_eq!(MSG_OPERATIONS_RESUMED, 0x08);
-        assert_eq!(MSG_WRITE_FILE, 0x09);
-        assert_eq!(MSG_WRITE_FILE_RESULT, 0x0A);
-        assert_eq!(MSG_EXEC_START, 0x0B);
-        assert_eq!(MSG_EXEC_STARTED, 0x0C);
-        assert_eq!(MSG_EXEC_OUTPUT, 0x0D);
-        assert_eq!(MSG_EXEC_RESULT, 0x0E);
-        assert_eq!(MSG_EXEC_CANCEL, 0x0F);
-        assert_eq!(MSG_EXEC_CONTROL, 0x10);
-        assert_eq!(MSG_EXEC_CONTROL_RESULT, 0x11);
+        let non_error_types = [
+            MSG_READY,
+            MSG_PING,
+            MSG_PONG,
+            MSG_SHUTDOWN,
+            MSG_SHUTDOWN_ACK,
+            MSG_QUIESCE_OPERATIONS,
+            MSG_OPERATIONS_QUIESCED,
+            MSG_RESUME_OPERATIONS,
+            MSG_OPERATIONS_RESUMED,
+            MSG_WRITE_FILE,
+            MSG_WRITE_FILE_RESULT,
+            MSG_EXEC_START,
+            MSG_EXEC_STARTED,
+            MSG_EXEC_OUTPUT,
+            MSG_EXEC_RESULT,
+            MSG_EXEC_CANCEL,
+            MSG_EXEC_CONTROL,
+            MSG_EXEC_CONTROL_RESULT,
+        ];
+
+        for (expected, actual) in (0_u8..).zip(non_error_types) {
+            assert_eq!(actual, expected);
+        }
+
         assert_eq!(MSG_ERROR, 0xFF);
     }
 }


### PR DESCRIPTION
## Summary
- reorder vsock protocol message type ids by protocol domain while keeping them continuous
- update the protocol docs table to match the new ordering
- adjust the wire-value test to lock in the grouped layout

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto