### PR TITLE
[codex] preserve admin role for workspace settings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
@@ -11,6 +11,7 @@ import { and, eq } from "drizzle-orm";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { storages } from "@vm0/db/schema/storage";
@@ -96,6 +97,10 @@ const deleteOnboardingSetupFixture$ = command(
       .where(eq(userConnectors.orgId, fixture.orgId));
     signal.throwIfAborted();
     await db
+      .delete(orgMembersCache)
+      .where(eq(orgMembersCache.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await db
       .delete(orgMembersMetadata)
       .where(eq(orgMembersMetadata.orgId, fixture.orgId));
     signal.throwIfAborted();
@@ -168,6 +173,19 @@ async function readMemberMetadata(orgId: string, userId: string) {
         eq(orgMembersMetadata.orgId, orgId),
         eq(orgMembersMetadata.userId, userId),
       ),
+    );
+  return row;
+}
+
+async function readMemberRole(orgId: string, userId: string) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      role: orgMembersCache.role,
+    })
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
     );
   return row;
 }
@@ -335,6 +353,11 @@ describe("POST /api/zero/onboarding/setup", () => {
       readMemberMetadata(fixture.orgId, fixture.userId),
     ).resolves.toStrictEqual({
       timezone: "America/Los_Angeles",
+    });
+    await expect(
+      readMemberRole(fixture.orgId, fixture.userId),
+    ).resolves.toStrictEqual({
+      role: "admin",
     });
     await expect(readVm0Provider(fixture.orgId)).resolves.toMatchObject({
       userId: "__org__",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
@@ -908,7 +908,7 @@ describe("GET /api/zero/org — org resolution", () => {
       slug,
       name: "Clerk Fresh Org",
       tier: "free",
-      role: "member",
+      role: "admin",
       createdBy: userId,
     });
     expect(

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -39,7 +39,7 @@ const getOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const org = await set(
     zeroOrgDetail$,
-    { orgId: auth.orgId, userId: auth.userId },
+    { orgId: auth.orgId, userId: auth.userId, orgRole: auth.orgRole },
     signal,
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -5,6 +5,7 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import { SEED_INSTRUCTIONS } from "@vm0/core/zero-seed-instructions";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -295,6 +296,27 @@ async function upsertSetupMemberMetadata(
     });
 }
 
+async function upsertSetupMemberRole(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<void> {
+  await db
+    .insert(orgMembersCache)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      role: "admin",
+      cachedAt: nowDate(),
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
+      set: { role: "admin", cachedAt: nowDate() },
+    });
+}
+
 async function replaceSelectedConnectors(
   db: Db,
   args: {
@@ -522,6 +544,12 @@ export const setupOnboarding$ = command(
       orgId: args.orgId,
       userId: args.userId,
       timezone: args.timezone,
+    });
+    signal.throwIfAborted();
+
+    await upsertSetupMemberRole(writeDb, {
+      orgId: args.orgId,
+      userId: args.userId,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -299,6 +299,7 @@ async function getOrgIdentityForDelete(args: {
 interface ZeroOrgDetailArgs {
   readonly orgId: string;
   readonly userId: string;
+  readonly orgRole?: OrgRole;
 }
 
 export const zeroOrgDetail$ = command(
@@ -394,7 +395,7 @@ export const zeroOrgDetail$ = command(
       slug: identity.slug,
       name: identity.name,
       tier: meta[0]?.tier ?? "free",
-      role: (membership[0]?.role as OrgRole) ?? "member",
+      role: args.orgRole ?? (membership[0]?.role as OrgRole) ?? "member",
       createdBy: identity.createdBy ?? undefined,
     };
   },


### PR DESCRIPTION
## Summary
- Pass the Clerk session org role through `/api/zero/org` resolution so newly created admins are not downgraded to member when the local membership cache is empty.
- Seed the onboarding user's `org_members_cache` role as admin when workspace setup completes.
- Update API tests to cover fresh Clerk-only org resolution and onboarding membership cache seeding.

## Root Cause
New local workspaces could resolve org identity from Clerk before `org_members_cache` had a membership row. `zeroOrgDetail$` defaulted missing cache rows to `member`, so the platform hid admin-only Workspace Settings tabs such as Models.

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org.test.ts src/signals/routes/__tests__/zero-onboarding-setup.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- commit hook: `pnpm knip --cache`
- commit hook: `turbo run check-types --concurrency=1`