### PR TITLE
fix(desktop): remove computer use app menu entry

### DIFF
--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -3,9 +3,9 @@
 Electron POC for launching the hosted Zero platform app.
 
 This pass is macOS-only. Windows packaging, native push, tray behavior, and
-auto-update are intentionally out of scope. The application menu links to the
-Platform Computer Use page for the `computerUse` feature switch and macOS
-permission status.
+auto-update are intentionally out of scope. Computer Use setup lives in the
+hosted Platform UI, while this app exposes the Desktop bridge and native macOS
+host runtime that page uses.
 
 When the user is signed in and the feature switch is enabled, the main process
 registers a Desktop Computer Use host through the Zero API command queue. It

--- a/turbo/apps/desktop/src/computer-use-page-url.test.ts
+++ b/turbo/apps/desktop/src/computer-use-page-url.test.ts
@@ -1,26 +1,10 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildDesktopComputerUsePageUrl,
-  isDesktopComputerUsePageUrl,
-} from "./computer-use-page-url";
+import { isDesktopComputerUsePageUrl } from "./computer-use-page-url";
 
 const ALLOWED_ORIGINS = new Set([
   "https://app.vm0.ai",
   "http://localhost:3000",
 ]);
-
-describe("buildDesktopComputerUsePageUrl", () => {
-  it("builds a platform Computer Use page URL", () => {
-    expect(buildDesktopComputerUsePageUrl(new URL("https://app.vm0.ai"))).toBe(
-      "https://app.vm0.ai/computer-use",
-    );
-    expect(
-      buildDesktopComputerUsePageUrl(
-        new URL("http://localhost:3000/settings?tab=computer"),
-      ),
-    ).toBe("http://localhost:3000/computer-use");
-  });
-});
 
 describe("isDesktopComputerUsePageUrl", () => {
   it("allows the desktop Computer Use page from configured app origins", () => {

--- a/turbo/apps/desktop/src/computer-use-page-url.ts
+++ b/turbo/apps/desktop/src/computer-use-page-url.ts
@@ -1,13 +1,5 @@
 const DESKTOP_COMPUTER_USE_PATHS = new Set(["/computer-use", "/computer-use/"]);
 
-export function buildDesktopComputerUsePageUrl(platformUrl: URL): string {
-  const url = new URL(platformUrl.toString());
-  url.pathname = "/computer-use";
-  url.search = "";
-  url.hash = "";
-  return url.toString();
-}
-
 export function isDesktopComputerUsePageUrl(
   rawUrl: string,
   allowedAppOrigins: ReadonlySet<string>,

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -6,7 +6,6 @@ import {
   notifyDesktopComputerUseChanged,
 } from "./computer-use-electron";
 import { ComputerUseHostRuntime } from "./computer-use-host";
-import { buildDesktopComputerUsePageUrl } from "./computer-use-page-url";
 import { captureComputerUseScreenshot } from "./computer-use-screenshot";
 import {
   COMPUTER_USE_FEATURE_SWITCH_KEY,
@@ -114,10 +113,6 @@ function installDesktopLocalAgent(): void {
   });
 }
 
-async function openComputerUsePage(): Promise<void> {
-  await createMainWindow(buildDesktopComputerUsePageUrl(config.platformUrl));
-}
-
 function getComputerUseBridgeState(): DesktopComputerUseState {
   return {
     featureSwitchKey: COMPUTER_USE_FEATURE_SWITCH_KEY,
@@ -187,18 +182,7 @@ function applyApplicationMenu(): void {
   const menu = Menu.buildFromTemplate([
     {
       label: config.identity.displayName,
-      submenu: [
-        { role: "about" },
-        { type: "separator" },
-        {
-          label: "Computer Use",
-          click: () => {
-            void openComputerUsePage();
-          },
-        },
-        { type: "separator" },
-        { role: "quit" },
-      ],
+      submenu: [{ role: "about" }, { type: "separator" }, { role: "quit" }],
     },
     {
       label: "Edit",


### PR DESCRIPTION
## Summary
- remove the macOS app menu shortcut that opened the Computer Use page
- drop the now-unused desktop Computer Use page URL builder
- update the Desktop README to describe the Platform-owned setup page and native bridge/runtime split

## Verification
- pnpm exec prettier --write --ignore-unknown apps/desktop/README.md apps/desktop/src/main.ts apps/desktop/src/computer-use-page-url.ts apps/desktop/src/computer-use-page-url.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm knip --workspace @vm0/desktop

## Notes
- Local full-repo `pnpm check-types` is currently blocked by unrelated `api` / `@vm0/app` ts-rest response typing errors where `body`/`status` resolve to `never`; the changed files are limited to `apps/desktop`.
