### PR TITLE
feat: add OAuth device authorization provider capability

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1353,6 +1353,29 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
+  it("redirects device authorization callbacks to the connector error page", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "test-oauth-device",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("type")).toBe("test-oauth-device");
+    expect(url.searchParams.get("message")).toBe(
+      "test-oauth-device connector does not use authorization-code OAuth",
+    );
+  });
+
   it("rejects state mismatch and clears OAuth cookies", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -775,8 +775,13 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
   });
 
   it("returns 400 when starting browser OAuth for a device authorization connector", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    mocks.clerk.session(userId, orgId);
+
     const response = await requestOauthStart("test-oauth-device", {
-      authenticated: true,
+      headers: { authorization: "Bearer clerk-session" },
     });
 
     expect(response.status).toBe(400);
@@ -787,6 +792,13 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
         code: "BAD_REQUEST",
       },
     });
+
+    const db = store.set(writeDb$);
+    const states = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.userId, userId));
+    expect(states).toHaveLength(0);
   });
 
   it("does not create server-side handoff state when OAuth is not configured", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -259,6 +259,18 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     ).toBeTruthy();
   });
 
+  it("returns 400 when authorizing a device authorization connector", async () => {
+    const response = await requestAuthorize("test-oauth-device", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error:
+        "test-oauth-device connector does not use authorization-code OAuth",
+    });
+  });
+
   it("sets Secure on OAuth cookies in production", async () => {
     mockEnv("ENV", "production");
 
@@ -757,6 +769,21 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     await expect(response.json()).resolves.toStrictEqual({
       error: {
         message: "serpapi connector does not use OAuth",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 400 when starting browser OAuth for a device authorization connector", async () => {
+    const response = await requestOauthStart("test-oauth-device", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message:
+          "test-oauth-device connector does not use authorization-code OAuth",
         code: "BAD_REQUEST",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -218,6 +218,49 @@ describe("GET /api/zero/connectors/search", () => {
     expect(computer).toBeUndefined();
   });
 
+  it("hides the test OAuth device connector when the test OAuth feature is disabled", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: { keyword: "test oauth device" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const connector = response.body.connectors.find((c) => {
+      return c.id === "test-oauth-device";
+    });
+    expect(connector).toBeUndefined();
+  });
+
+  it("shows the test OAuth device connector when the test OAuth feature is enabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFeatureSwitches.push({ orgId, userId });
+    await enableFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: { keyword: "test oauth device" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const connector = response.body.connectors.find((c) => {
+      return c.id === "test-oauth-device";
+    });
+    expect(connector).toBeDefined();
+    expect(connector?.authMethods).toStrictEqual(["oauth"]);
+  });
+
   it("hides local-browser when the feature is disabled", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,12 +1,13 @@
 import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
+  isOAuthAuthorizationCodeConnectorType,
   type ConnectorEnvReader,
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorType,
-  OAuthConnectorType,
+  OAuthAuthorizationCodeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorOAuthAuthUrl,
@@ -36,13 +37,14 @@ type PrepareResolvedConnectorOAuthStartResult =
 type ResolveConnectorOAuthStartTypeResult =
   | {
       readonly ok: true;
-      readonly type: OAuthConnectorType;
+      readonly type: OAuthAuthorizationCodeConnectorType;
     }
   | {
       readonly ok: false;
       readonly reason:
         | "connector_does_not_use_oauth"
-        | "oauth_provider_not_configured";
+        | "oauth_provider_not_configured"
+        | "unsupported_oauth_flow";
     };
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
@@ -58,6 +60,9 @@ export function resolveConnectorOAuthStartType(
   if (!isOAuthConnectorType(type)) {
     return { ok: false, reason: "oauth_provider_not_configured" };
   }
+  if (!isOAuthAuthorizationCodeConnectorType(type)) {
+    return { ok: false, reason: "unsupported_oauth_flow" };
+  }
   return { ok: true, type };
 }
 
@@ -65,7 +70,7 @@ export function resolveConnectorOAuthStartType(
 // ConnectorType first so non-OAuth connectors keep their route-specific errors,
 // then build the provider authorization URL at the normal async commit point.
 export function prepareResolvedConnectorOAuthStart(args: {
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthAuthorizationCodeConnectorType;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareResolvedConnectorOAuthStartResult {
@@ -85,7 +90,7 @@ export function prepareResolvedConnectorOAuthStart(args: {
 }
 
 export async function buildResolvedConnectorOAuthAuthResult(args: {
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthAuthorizationCodeConnectorType;
   readonly credentials: ConfiguredConnectorOAuthCredentials;
   readonly redirectUri: string;
   readonly state: string;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -3,12 +3,13 @@ import { unescape as decodeCookieComponent } from "node:querystring";
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
+  isOAuthAuthorizationCodeConnectorType,
   getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type OAuthConnectorType,
+  type OAuthAuthorizationCodeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorOAuthCode,
@@ -52,7 +53,7 @@ type CallbackIdentity = {
 };
 
 type CompleteOAuthCallbackInput = {
-  readonly connectorType: OAuthConnectorType;
+  readonly connectorType: OAuthAuthorizationCodeConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -102,7 +103,7 @@ type ClaimedCallbackState =
 type ResolvedOAuthConnectorType =
   | {
       readonly ok: true;
-      readonly connectorType: OAuthConnectorType;
+      readonly connectorType: OAuthAuthorizationCodeConnectorType;
     }
   | {
       readonly ok: false;
@@ -164,7 +165,7 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
 }
 
 async function exchangeTokenForConnector(args: {
-  readonly connectorType: OAuthConnectorType;
+  readonly connectorType: OAuthAuthorizationCodeConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -191,7 +192,7 @@ async function exchangeTokenForConnector(args: {
 }
 
 function getRequestedScopes(
-  connectorType: OAuthConnectorType,
+  connectorType: OAuthAuthorizationCodeConnectorType,
 ): readonly string[] {
   return getConnectorOAuthConfig(connectorType).scopes;
 }
@@ -229,6 +230,16 @@ function resolveOAuthConnectorType(
       ),
     };
   }
+  if (!isOAuthAuthorizationCodeConnectorType(connectorType)) {
+    return {
+      ok: false,
+      response: redirectWithError(
+        origin,
+        type,
+        `${type} connector does not use authorization-code OAuth`,
+      ),
+    };
+  }
 
   return { ok: true, connectorType };
 }
@@ -236,7 +247,7 @@ function resolveOAuthConnectorType(
 async function claimStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: OAuthConnectorType;
+  readonly connectorType: OAuthAuthorizationCodeConnectorType;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
@@ -265,7 +276,7 @@ async function claimStoredOAuthStateForCallback(args: {
 async function rejectInvalidStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: OAuthConnectorType;
+  readonly connectorType: OAuthAuthorizationCodeConnectorType;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -137,6 +137,14 @@ function connectorDoesNotUseOAuthResponse(type: string) {
   return jsonResponse({ error: `${type} connector does not use OAuth` }, 400);
 }
 
+function unsupportedOAuthFlowMessage(type: string): string {
+  return `${type} connector does not use authorization-code OAuth`;
+}
+
+function unsupportedOAuthFlowResponse(type: string) {
+  return jsonResponse({ error: unsupportedOAuthFlowMessage(type) }, 400);
+}
+
 function missingOAuthProviderResponse(type: string) {
   return jsonResponse({ error: `${type} OAuth provider not configured` }, 500);
 }
@@ -394,6 +402,9 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       if (startType.reason === "connector_does_not_use_oauth") {
         return connectorDoesNotUseOAuthResponse(type);
       }
+      if (startType.reason === "unsupported_oauth_flow") {
+        return unsupportedOAuthFlowResponse(type);
+      }
       return missingOAuthProviderResponse(type);
     }
 
@@ -495,6 +506,9 @@ const startConnectorOauthInner$ = command(
     if (!startType.ok) {
       if (startType.reason === "connector_does_not_use_oauth") {
         return badRequestMessage(`${type} connector does not use OAuth`);
+      }
+      if (startType.reason === "unsupported_oauth_flow") {
+        return badRequestMessage(unsupportedOAuthFlowMessage(type));
       }
       return internalServerError(`${type} OAuth provider not configured`);
     }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -7,6 +7,7 @@ import { cn } from "@vm0/ui";
 const CONNECTOR_ICON_ALIASES = {
   "slack-webhook": "slack",
   "railway-project": "railway",
+  "test-oauth-device": "test-oauth",
 } as const satisfies Partial<Record<ConnectorType, ConnectorType>>;
 
 export const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> =

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
-  type OAuthConnectorType,
+  type OAuthAuthorizationCodeConnectorType,
 } from "../connectors";
 import {
   getApiTokenFieldStorageType,
@@ -17,11 +17,14 @@ import {
   getConnectorProvidedSecretNames,
   getConnectorAuthMethods,
   getConnectorOAuthClientConfig,
+  getConnectorOAuthDeviceAuthorizationConfig,
   getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
   getConnectorOAuthConfigIfSupported,
   getConnectorOAuthFlow,
   getRuntimeAvailableConnectorTypes,
+  isOAuthAuthorizationCodeConnectorType,
+  isOAuthDeviceAuthorizationConnectorType,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
   isGoogleOAuthConnector,
@@ -32,6 +35,8 @@ import {
   buildConnectorOAuthAuthUrl,
   isOAuthConnectorType,
   CONNECTOR_OAUTH_PROVIDERS,
+  pollConnectorOAuthDeviceAuthorization,
+  startConnectorOAuthDeviceAuthorization,
 } from "../oauth-providers/provider-registry";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../oauth-providers/google-oauth-connectors";
 import { buildGoogleAuthorizationUrl } from "../oauth-providers/providers/google-oauth";
@@ -84,7 +89,7 @@ const EXPECTED_PROVIDER_AUTHORIZATION_BASE_URLS = {
   x: "https://twitter.com/i/oauth2/authorize",
   xero: "https://login.xero.com/identity/connect/authorize",
   zoom: "https://zoom.us/oauth/authorize",
-} as const satisfies Record<keyof typeof CONNECTOR_OAUTH_PROVIDERS, string>;
+} as const satisfies Record<OAuthAuthorizationCodeConnectorType, string>;
 
 function authorizationBaseUrl(url: string): string {
   const parsed = new URL(url);
@@ -216,9 +221,9 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
     process.env.VERCEL_INTEGRATION_SLUG = "test-integration";
 
     try {
-      const providerTypes = Object.keys(
-        CONNECTOR_OAUTH_PROVIDERS,
-      ) as OAuthConnectorType[];
+      const providerTypes = connectorTypeSchema.options.filter(
+        isOAuthAuthorizationCodeConnectorType,
+      );
 
       for (const type of providerTypes) {
         const oauthConfig = getConnectorOAuthConfig(type);
@@ -244,6 +249,102 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
     } finally {
       restoreEnv(previousEnv);
     }
+  });
+
+  it("starts and polls the test OAuth device provider", async () => {
+    const credentials = getConnectorOAuthCredentials(
+      "test-oauth-device",
+      () => {
+        return undefined;
+      },
+    );
+    expect(credentials?.configured).toBe(true);
+
+    if (!credentials?.configured) {
+      throw new Error("Expected test-oauth-device OAuth credentials");
+    }
+
+    const startResult = await startConnectorOAuthDeviceAuthorization({
+      type: "test-oauth-device",
+      credentials,
+    });
+    expect(startResult).toStrictEqual({
+      deviceCode: "test-device:test-oauth-device-client:read",
+      userCode: "TEST-DEVICE",
+      verificationUri: "https://oauth-device.test/device",
+      verificationUriComplete:
+        "https://oauth-device.test/device?user_code=TEST-DEVICE",
+      expiresIn: 600,
+      interval: 5,
+    });
+
+    await expect(
+      pollConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+        deviceCode: "pending",
+      }),
+    ).resolves.toStrictEqual({ status: "pending" });
+    await expect(
+      pollConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+        deviceCode: "slow-down",
+      }),
+    ).resolves.toStrictEqual({ status: "pending", interval: 10 });
+    await expect(
+      pollConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+        deviceCode: "denied",
+      }),
+    ).resolves.toStrictEqual({
+      status: "denied",
+      error: "access_denied",
+      errorDescription: "User denied the device authorization request",
+    });
+    await expect(
+      pollConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+        deviceCode: "expired",
+      }),
+    ).resolves.toStrictEqual({
+      status: "expired",
+      error: "expired_token",
+      errorDescription: "Device authorization expired",
+    });
+    await expect(
+      pollConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+        deviceCode: "error",
+      }),
+    ).resolves.toStrictEqual({
+      status: "error",
+      error: "invalid_request",
+      errorDescription: "Synthetic device authorization error",
+    });
+    await expect(
+      pollConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+        deviceCode: startResult.deviceCode,
+      }),
+    ).resolves.toStrictEqual({
+      status: "complete",
+      token: {
+        accessToken:
+          "test-device-access:test-oauth-device-client:test-device:test-oauth-device-client:read",
+        refreshToken: null,
+        scopes: ["read"],
+        userInfo: {
+          id: "test-oauth-device-user",
+          username: "test-oauth-device-user",
+          email: "test-oauth-device@example.com",
+        },
+      },
+    });
   });
 });
 
@@ -477,6 +578,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(runtimeAvailableTypes).toContain("test-oauth");
+    expect(runtimeAvailableTypes).toContain("test-oauth-device");
   });
 
   it("includes OAuth connectors only when client id and secret are configured", () => {
@@ -766,7 +868,7 @@ describe("getConnectorOAuthConfigIfSupported", () => {
 describe("connector OAuth authorization-code config", () => {
   it("declares the current OAuth connectors as authorization-code flows", () => {
     for (const type of connectorTypeSchema.options) {
-      if (!isOAuthConnectorType(type)) {
+      if (!isOAuthAuthorizationCodeConnectorType(type)) {
         continue;
       }
 
@@ -792,6 +894,31 @@ describe("connector OAuth authorization-code config", () => {
         `${type}: authorization URL should be provider-owned`,
       ).toBe(false);
     }
+  });
+});
+
+describe("connector OAuth device authorization config", () => {
+  it("declares the test OAuth device connector as a device authorization flow", () => {
+    expect(isOAuthDeviceAuthorizationConnectorType("test-oauth-device")).toBe(
+      true,
+    );
+    expect(getConnectorOAuthFlow("test-oauth-device")).toBe(
+      "device-authorization",
+    );
+    expect(
+      getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device"),
+    ).toMatchObject({
+      flow: "device-authorization",
+      deviceAuthorizationUrl: "https://oauth-device.test/device/code",
+      tokenUrl: "https://oauth-device.test/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientId: "test-oauth-device-client",
+      },
+      scopes: ["read"],
+    });
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -15,7 +15,9 @@ import {
   type StaticConfidentialConnectorOAuthClientConfig,
   type StaticPublicConnectorOAuthClientConfig,
   type ConnectorType,
+  type OAuthAuthorizationCodeConnectorType,
   type OAuthConnectorType,
+  type OAuthDeviceAuthorizationConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./oauth-providers/google-oauth-connectors";
@@ -473,6 +475,34 @@ export function getConnectorOAuthFlow(
   type: OAuthConnectorType,
 ): ConnectorOAuthConfig["flow"] {
   return getConnectorOAuthConfig(type).flow;
+}
+
+export function isOAuthAuthorizationCodeConnectorType(
+  type: ConnectorType,
+): type is OAuthAuthorizationCodeConnectorType {
+  return (
+    getConnectorOAuthConfigIfSupported(type)?.flow === "authorization-code"
+  );
+}
+
+export function isOAuthDeviceAuthorizationConnectorType(
+  type: ConnectorType,
+): type is OAuthDeviceAuthorizationConnectorType {
+  return (
+    getConnectorOAuthConfigIfSupported(type)?.flow === "device-authorization"
+  );
+}
+
+export function getConnectorOAuthAuthorizationCodeConfig(
+  type: OAuthAuthorizationCodeConnectorType,
+): Extract<ConnectorOAuthConfig, { readonly flow: "authorization-code" }> {
+  return CONNECTOR_TYPES[type].oauth;
+}
+
+export function getConnectorOAuthDeviceAuthorizationConfig(
+  type: OAuthDeviceAuthorizationConnectorType,
+): Extract<ConnectorOAuthConfig, { readonly flow: "device-authorization" }> {
+  return CONNECTOR_TYPES[type].oauth;
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -493,12 +493,6 @@ export function isOAuthDeviceAuthorizationConnectorType(
   );
 }
 
-export function getConnectorOAuthAuthorizationCodeConfig(
-  type: OAuthAuthorizationCodeConnectorType,
-): Extract<ConnectorOAuthConfig, { readonly flow: "authorization-code" }> {
-  return CONNECTOR_TYPES[type].oauth;
-}
-
 export function getConnectorOAuthDeviceAuthorizationConfig(
   type: OAuthDeviceAuthorizationConnectorType,
 ): Extract<ConnectorOAuthConfig, { readonly flow: "device-authorization" }> {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -201,6 +201,7 @@ import { supadata } from "./connectors/supadata";
 import { supermemory } from "./connectors/supermemory";
 import { tavily } from "./connectors/tavily";
 import { testOauth } from "./connectors/test-oauth";
+import { testOauthDevice } from "./connectors/test-oauth-device";
 import { testrail } from "./connectors/testrail";
 import { tldv } from "./connectors/tldv";
 import { together } from "./connectors/together";
@@ -315,6 +316,8 @@ export type DynamicPublicConnectorOAuthClientConfig = Extract<
   }
 >;
 
+export type ConnectorOAuthFlow = "authorization-code" | "device-authorization";
+
 export interface ConnectorOAuthAuthorizationCodeConfig {
   readonly flow: "authorization-code";
   readonly tokenUrl: string;
@@ -322,7 +325,17 @@ export interface ConnectorOAuthAuthorizationCodeConfig {
   readonly scopes: string[];
 }
 
-export type ConnectorOAuthConfig = ConnectorOAuthAuthorizationCodeConfig;
+export interface ConnectorOAuthDeviceAuthorizationConfig {
+  readonly flow: "device-authorization";
+  readonly deviceAuthorizationUrl: string;
+  readonly tokenUrl: string;
+  readonly client: StaticPublicConnectorOAuthClientConfig;
+  readonly scopes: string[];
+}
+
+export type ConnectorOAuthConfig =
+  | ConnectorOAuthAuthorizationCodeConfig
+  | ConnectorOAuthDeviceAuthorizationConfig;
 
 /**
  * CLI auth configuration for connectors that can import credentials through a
@@ -746,6 +759,7 @@ const CONNECTOR_TYPES_DEF = {
   ...supermemory,
   ...tavily,
   ...testOauth,
+  ...testOauthDevice,
   ...testrail,
   ...tldv,
   ...together,
@@ -776,6 +790,11 @@ export type OAuthConnectorType = {
 }[ConnectorType];
 export type OAuthAuthorizationCodeConnectorType = {
   [Type in OAuthConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["flow"] extends "authorization-code"
+    ? Type
+    : never;
+}[OAuthConnectorType];
+export type OAuthDeviceAuthorizationConnectorType = {
+  [Type in OAuthConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["flow"] extends "device-authorization"
     ? Type
     : never;
 }[OAuthConnectorType];

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -1,0 +1,40 @@
+import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
+
+export const testOauthDevice = {
+  "test-oauth-device": {
+    label: "Test OAuth Device (internal)",
+    category: "data-automation-infrastructure",
+    environmentMapping: {
+      TEST_OAUTH_DEVICE_TOKEN: "$secrets.TEST_OAUTH_DEVICE_ACCESS_TOKEN",
+    },
+    helpText:
+      "Synthetic OAuth 2.0 device authorization connector. For automated tests only.",
+    authMethods: {
+      oauth: {
+        featureFlag: FeatureSwitchKey.TestOauthConnector,
+        label: "OAuth Device Authorization",
+        helpText: "Test-only OAuth device provider.",
+        secrets: {
+          TEST_OAUTH_DEVICE_ACCESS_TOKEN: {
+            label: "Access Token",
+            required: true,
+          },
+        },
+      },
+    },
+    defaultAuthMethod: "oauth",
+    oauth: {
+      flow: "device-authorization",
+      deviceAuthorizationUrl: "https://oauth-device.test/device/code",
+      tokenUrl: "https://oauth-device.test/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientId: "test-oauth-device-client",
+      },
+      scopes: ["read"],
+    },
+  },
+} as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -646,7 +646,8 @@ export type NonFirewallConnectorType =
   // Other
   | "computer" // not an API connector
   | "local-browser" // virtual connector backed by a user-authorized browser host
-  | "local-agent"; // virtual connector backed by vm0's local-agent API
+  | "local-agent" // virtual connector backed by vm0's local-agent API
+  | "test-oauth-device"; // internal provider capability test connector
 
 /**
  * Compile-time exhaustiveness checks.

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -1,8 +1,11 @@
 import type {
   ConnectorType,
+  OAuthAuthorizationCodeConnectorType,
   OAuthConnectorType,
+  OAuthDeviceAuthorizationConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  getConnectorOAuthDeviceAuthorizationConfig,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
@@ -10,8 +13,16 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   type AuthUrlResult,
+  type ConnectorOAuthAuthorizeArgs,
+  type ConnectorOAuthDeviceAuthorizationPollArgs,
+  type ConnectorOAuthDeviceAuthorizationStartArgs,
+  type ConnectorOAuthExchangeArgs,
   type ConnectorOAuthProviderFor,
   type OAuthAuthorizeArgs,
+  type OAuthDeviceAuthorizationPollArgs,
+  type OAuthDeviceAuthorizationPollResult,
+  type OAuthDeviceAuthorizationStartArgs,
+  type OAuthDeviceAuthorizationStartResult,
   type OAuthExchangeArgs,
   type OAuthRefreshArgs,
   type OAuthRefreshResult,
@@ -66,9 +77,14 @@ import { xProvider } from "./providers/x-provider";
 import { xeroProvider } from "./providers/xero-provider";
 import { zoomProvider } from "./providers/zoom-provider";
 import { testOauthProvider } from "./providers/test-oauth-provider";
+import { testOauthDeviceProvider } from "./providers/test-oauth-device-provider";
 
 export type {
   AuthUrlResult,
+  OAuthDeviceAuthorizationPollArgs,
+  OAuthDeviceAuthorizationPollResult,
+  OAuthDeviceAuthorizationStartArgs,
+  OAuthDeviceAuthorizationStartResult,
   OAuthAuthorizeArgs,
   OAuthExchangeArgs,
   OAuthRefreshArgs,
@@ -82,16 +98,6 @@ type ConnectorOAuthProviderMap = {
   readonly [Type in OAuthConnectorType]: ConnectorOAuthProviderFor<Type>;
 };
 
-type DispatchAuthorizeProvider = {
-  buildAuthUrl(
-    args: OAuthAuthorizeArgs,
-  ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
-};
-
-type DispatchExchangeProvider = {
-  exchangeCode(args: OAuthExchangeArgs): Promise<OAuthTokenResult>;
-};
-
 type DispatchRefreshProvider = {
   refreshToken(args: OAuthRefreshArgs): Promise<OAuthRefreshResult>;
 };
@@ -99,7 +105,7 @@ type DispatchRefreshProvider = {
 function connectorProviderFor<T extends OAuthConnectorType>(
   type: T,
 ): ConnectorOAuthProviderFor<T> {
-  return CONNECTOR_OAUTH_PROVIDERS[type] as ConnectorOAuthProviderFor<T>;
+  return CONNECTOR_OAUTH_PROVIDERS[type];
 }
 
 function connectorCredentialArgs(
@@ -126,7 +132,7 @@ function assertConfiguredConnectorOAuthCredentials(
   }
 }
 
-export const CONNECTOR_OAUTH_PROVIDERS = {
+export const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
   ahrefs: ahrefsProvider,
   airtable: airtableProvider,
   asana: asanaProvider,
@@ -172,7 +178,8 @@ export const CONNECTOR_OAUTH_PROVIDERS = {
   xero: xeroProvider,
   zoom: zoomProvider,
   "test-oauth": testOauthProvider,
-} satisfies ConnectorOAuthProviderMap;
+  "test-oauth-device": testOauthDeviceProvider,
+};
 
 export function isOAuthConnectorType(type: string): type is OAuthConnectorType {
   return Object.hasOwn(CONNECTOR_OAUTH_PROVIDERS, type);
@@ -187,25 +194,27 @@ export function getConnectorOAuthProvider(
   return CONNECTOR_OAUTH_PROVIDERS[type];
 }
 
-export async function buildConnectorOAuthAuthUrl(args: {
-  readonly type: OAuthConnectorType;
+export async function buildConnectorOAuthAuthUrl<
+  T extends OAuthAuthorizationCodeConnectorType,
+>(args: {
+  readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(
-    args.type,
-  ) as unknown as DispatchAuthorizeProvider;
+  const provider = connectorProviderFor(args.type);
   return await provider.buildAuthUrl({
     ...connectorCredentialArgs(args.credentials),
     redirectUri: args.redirectUri,
     state: args.state,
-  });
+  } as ConnectorOAuthAuthorizeArgs<T>);
 }
 
-export async function exchangeConnectorOAuthCode(args: {
-  readonly type: OAuthConnectorType;
+export async function exchangeConnectorOAuthCode<
+  T extends OAuthAuthorizationCodeConnectorType,
+>(args: {
+  readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
   readonly code: string;
   readonly redirectUri: string;
@@ -214,9 +223,7 @@ export async function exchangeConnectorOAuthCode(args: {
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(
-    args.type,
-  ) as unknown as DispatchExchangeProvider;
+  const provider = connectorProviderFor(args.type);
   return await provider.exchangeCode({
     ...connectorCredentialArgs(args.credentials),
     code: args.code,
@@ -224,7 +231,37 @@ export async function exchangeConnectorOAuthCode(args: {
     state: args.state,
     codeVerifier: args.codeVerifier,
     oauthContext: args.oauthContext,
-  });
+  } as ConnectorOAuthExchangeArgs<T>);
+}
+
+export async function startConnectorOAuthDeviceAuthorization<
+  T extends OAuthDeviceAuthorizationConnectorType,
+>(args: {
+  readonly type: T;
+  readonly credentials: ConnectorOAuthCredentials;
+}): Promise<OAuthDeviceAuthorizationStartResult> {
+  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
+  const provider = connectorProviderFor(args.type);
+  const oauthConfig = getConnectorOAuthDeviceAuthorizationConfig(args.type);
+  return await provider.startDeviceAuthorization({
+    ...connectorCredentialArgs(args.credentials),
+    scopes: oauthConfig.scopes,
+  } as ConnectorOAuthDeviceAuthorizationStartArgs<T>);
+}
+
+export async function pollConnectorOAuthDeviceAuthorization<
+  T extends OAuthDeviceAuthorizationConnectorType,
+>(args: {
+  readonly type: T;
+  readonly credentials: ConnectorOAuthCredentials;
+  readonly deviceCode: string;
+}): Promise<OAuthDeviceAuthorizationPollResult> {
+  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
+  const provider = connectorProviderFor(args.type);
+  return await provider.pollDeviceAuthorization({
+    ...connectorCredentialArgs(args.credentials),
+    deviceCode: args.deviceCode,
+  } as ConnectorOAuthDeviceAuthorizationPollArgs<T>);
 }
 
 export async function refreshConnectorOAuthToken(args: {

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -338,31 +338,3 @@ export function isOAuthRefreshProvider(
     typeof provider.refreshToken === "function"
   );
 }
-
-export function isOAuthAuthorizationCodeProvider(
-  provider: OAuthProviderMetadata,
-): provider is OAuthProviderMetadata & {
-  buildAuthUrl: BuildAuthUrlFn;
-  exchangeCode: ExchangeCodeFn;
-} {
-  return (
-    "buildAuthUrl" in provider &&
-    typeof provider.buildAuthUrl === "function" &&
-    "exchangeCode" in provider &&
-    typeof provider.exchangeCode === "function"
-  );
-}
-
-export function isOAuthDeviceAuthorizationProvider(
-  provider: OAuthProviderMetadata,
-): provider is OAuthProviderMetadata & {
-  startDeviceAuthorization: StartDeviceAuthorizationFn;
-  pollDeviceAuthorization: PollDeviceAuthorizationFn;
-} {
-  return (
-    "startDeviceAuthorization" in provider &&
-    typeof provider.startDeviceAuthorization === "function" &&
-    "pollDeviceAuthorization" in provider &&
-    typeof provider.pollDeviceAuthorization === "function"
-  );
-}

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -1,7 +1,9 @@
 import type {
   CONNECTOR_TYPES,
   ConnectorOAuthClientConfig,
+  OAuthAuthorizationCodeConnectorType,
   OAuthConnectorType,
+  OAuthDeviceAuthorizationConnectorType,
 } from "@vm0/connectors/connectors";
 
 export interface ProviderEnv {
@@ -62,6 +64,14 @@ interface OAuthRevokeFlowArgs {
   readonly accessToken: string;
 }
 
+interface OAuthDeviceAuthorizationStartFlowArgs {
+  readonly scopes: readonly string[];
+}
+
+interface OAuthDeviceAuthorizationPollFlowArgs {
+  readonly deviceCode: string;
+}
+
 type OptionalClientCredentialArgs = {
   readonly clientId?: string;
   readonly clientSecret?: string;
@@ -79,11 +89,61 @@ export type OAuthRefreshArgs = OAuthRefreshFlowArgs &
 export type OAuthRevokeArgs = OAuthRevokeFlowArgs &
   OptionalClientCredentialArgs;
 
+export type OAuthDeviceAuthorizationStartArgs =
+  OAuthDeviceAuthorizationStartFlowArgs & OptionalClientCredentialArgs;
+
+export type OAuthDeviceAuthorizationPollArgs =
+  OAuthDeviceAuthorizationPollFlowArgs & OptionalClientCredentialArgs;
+
 export interface OAuthRefreshResult {
   readonly accessToken: string;
   readonly refreshToken: string | null;
   readonly expiresIn?: number;
 }
+
+export interface OAuthDeviceAuthorizationStartResult {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string;
+  readonly expiresIn: number;
+  readonly interval?: number;
+}
+
+export interface OAuthDeviceAuthorizationPendingResult {
+  readonly status: "pending";
+  readonly interval?: number;
+}
+
+export interface OAuthDeviceAuthorizationCompleteResult {
+  readonly status: "complete";
+  readonly token: OAuthTokenResult;
+}
+
+export interface OAuthDeviceAuthorizationDeniedResult {
+  readonly status: "denied";
+  readonly error?: string;
+  readonly errorDescription?: string;
+}
+
+export interface OAuthDeviceAuthorizationExpiredResult {
+  readonly status: "expired";
+  readonly error?: string;
+  readonly errorDescription?: string;
+}
+
+export interface OAuthDeviceAuthorizationErrorResult {
+  readonly status: "error";
+  readonly error: string;
+  readonly errorDescription?: string;
+}
+
+export type OAuthDeviceAuthorizationPollResult =
+  | OAuthDeviceAuthorizationPendingResult
+  | OAuthDeviceAuthorizationCompleteResult
+  | OAuthDeviceAuthorizationDeniedResult
+  | OAuthDeviceAuthorizationExpiredResult
+  | OAuthDeviceAuthorizationErrorResult;
 
 export type BuildAuthUrlFn = (
   args: OAuthAuthorizeArgs,
@@ -98,6 +158,14 @@ export type RefreshTokenFn = (
 ) => Promise<OAuthRefreshResult>;
 
 export type RevokeTokenFn = (args: OAuthRevokeArgs) => Promise<void>;
+
+export type StartDeviceAuthorizationFn = (
+  args: OAuthDeviceAuthorizationStartArgs,
+) => Promise<OAuthDeviceAuthorizationStartResult>;
+
+export type PollDeviceAuthorizationFn = (
+  args: OAuthDeviceAuthorizationPollArgs,
+) => Promise<OAuthDeviceAuthorizationPollResult>;
 
 type ConnectorOAuthClientFor<T extends OAuthConnectorType> =
   (typeof CONNECTOR_TYPES)[T]["oauth"]["client"];
@@ -134,11 +202,21 @@ export type ConnectorOAuthRefreshArgs<T extends OAuthConnectorType> =
 export type ConnectorOAuthRevokeArgs<T extends OAuthConnectorType> =
   OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-type BuildConnectorAuthUrlFn<T extends OAuthConnectorType> = (
+export type ConnectorOAuthDeviceAuthorizationStartArgs<
+  T extends OAuthDeviceAuthorizationConnectorType,
+> = OAuthDeviceAuthorizationStartFlowArgs &
+  StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
+
+export type ConnectorOAuthDeviceAuthorizationPollArgs<
+  T extends OAuthDeviceAuthorizationConnectorType,
+> = OAuthDeviceAuthorizationPollFlowArgs &
+  TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+
+type BuildConnectorAuthUrlFn<T extends OAuthAuthorizationCodeConnectorType> = (
   args: ConnectorOAuthAuthorizeArgs<T>,
 ) => string | AuthUrlResult | Promise<string | AuthUrlResult>;
 
-type ExchangeConnectorCodeFn<T extends OAuthConnectorType> = (
+type ExchangeConnectorCodeFn<T extends OAuthAuthorizationCodeConnectorType> = (
   args: ConnectorOAuthExchangeArgs<T>,
 ) => Promise<OAuthTokenResult>;
 
@@ -149,6 +227,18 @@ type RefreshConnectorTokenFn<T extends OAuthConnectorType> = (
 type RevokeConnectorTokenFn<T extends OAuthConnectorType> = (
   args: ConnectorOAuthRevokeArgs<T>,
 ) => Promise<void>;
+
+type StartConnectorDeviceAuthorizationFn<
+  T extends OAuthDeviceAuthorizationConnectorType,
+> = (
+  args: ConnectorOAuthDeviceAuthorizationStartArgs<T>,
+) => Promise<OAuthDeviceAuthorizationStartResult>;
+
+type PollConnectorDeviceAuthorizationFn<
+  T extends OAuthDeviceAuthorizationConnectorType,
+> = (
+  args: ConnectorOAuthDeviceAuthorizationPollArgs<T>,
+) => Promise<OAuthDeviceAuthorizationPollResult>;
 
 export interface OAuthProviderMetadata {
   getSecretName(): string;
@@ -162,6 +252,11 @@ export interface OAuthProvider extends OAuthProviderMetadata {
 export type OAuthAuthorizationCodeProvider = OAuthProvider & {
   buildAuthUrl: BuildAuthUrlFn;
   exchangeCode: ExchangeCodeFn;
+};
+
+export type OAuthDeviceAuthorizationProvider = OAuthProvider & {
+  startDeviceAuthorization: StartDeviceAuthorizationFn;
+  pollDeviceAuthorization: PollDeviceAuthorizationFn;
 };
 
 export type OAuthRefreshProvider = OAuthProvider & {
@@ -182,11 +277,19 @@ type OAuthNoRevocationProvider = {
   revokeToken?: never;
 };
 
-type ConnectorOAuthAuthorizationCodeProvider<T extends OAuthConnectorType> =
-  OAuthProviderMetadata & {
-    buildAuthUrl: BuildConnectorAuthUrlFn<T>;
-    exchangeCode: ExchangeConnectorCodeFn<T>;
-  };
+export type ConnectorOAuthAuthorizationCodeProvider<
+  T extends OAuthAuthorizationCodeConnectorType,
+> = OAuthProviderMetadata & {
+  buildAuthUrl: BuildConnectorAuthUrlFn<T>;
+  exchangeCode: ExchangeConnectorCodeFn<T>;
+};
+
+export type ConnectorOAuthDeviceAuthorizationProvider<
+  T extends OAuthDeviceAuthorizationConnectorType,
+> = OAuthProviderMetadata & {
+  startDeviceAuthorization: StartConnectorDeviceAuthorizationFn<T>;
+  pollDeviceAuthorization: PollConnectorDeviceAuthorizationFn<T>;
+};
 
 export type ConnectorOAuthRefreshProvider<T extends OAuthConnectorType> = {
   getRefreshSecretName(): string;
@@ -197,8 +300,15 @@ export type ConnectorOAuthRevocationProvider<T extends OAuthConnectorType> = {
   revokeToken: RevokeConnectorTokenFn<T>;
 };
 
+type ConnectorOAuthFlowProvider<T extends OAuthConnectorType> =
+  T extends OAuthAuthorizationCodeConnectorType
+    ? ConnectorOAuthAuthorizationCodeProvider<T>
+    : T extends OAuthDeviceAuthorizationConnectorType
+      ? ConnectorOAuthDeviceAuthorizationProvider<T>
+      : never;
+
 export type ConnectorOAuthProviderFor<T extends OAuthConnectorType> =
-  ConnectorOAuthAuthorizationCodeProvider<T> &
+  ConnectorOAuthFlowProvider<T> &
     (ConnectorOAuthRefreshProvider<T> | OAuthNoRefreshProvider) &
     (ConnectorOAuthRevocationProvider<T> | OAuthNoRevocationProvider);
 
@@ -226,5 +336,33 @@ export function isOAuthRefreshProvider(
     typeof provider.getRefreshSecretName === "function" &&
     "refreshToken" in provider &&
     typeof provider.refreshToken === "function"
+  );
+}
+
+export function isOAuthAuthorizationCodeProvider(
+  provider: OAuthProviderMetadata,
+): provider is OAuthProviderMetadata & {
+  buildAuthUrl: BuildAuthUrlFn;
+  exchangeCode: ExchangeCodeFn;
+} {
+  return (
+    "buildAuthUrl" in provider &&
+    typeof provider.buildAuthUrl === "function" &&
+    "exchangeCode" in provider &&
+    typeof provider.exchangeCode === "function"
+  );
+}
+
+export function isOAuthDeviceAuthorizationProvider(
+  provider: OAuthProviderMetadata,
+): provider is OAuthProviderMetadata & {
+  startDeviceAuthorization: StartDeviceAuthorizationFn;
+  pollDeviceAuthorization: PollDeviceAuthorizationFn;
+} {
+  return (
+    "startDeviceAuthorization" in provider &&
+    typeof provider.startDeviceAuthorization === "function" &&
+    "pollDeviceAuthorization" in provider &&
+    typeof provider.pollDeviceAuthorization === "function"
   );
 }

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
@@ -1,0 +1,70 @@
+import { defineConnectorOAuthProvider } from "../provider-types";
+
+export const TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME =
+  "TEST_OAUTH_DEVICE_ACCESS_TOKEN";
+
+export const testOauthDeviceProvider = defineConnectorOAuthProvider(
+  "test-oauth-device",
+  {
+    getSecretName: () => {
+      return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
+    },
+    startDeviceAuthorization: async (args) => {
+      return {
+        deviceCode: `test-device:${args.clientId}:${args.scopes.join(",")}`,
+        userCode: "TEST-DEVICE",
+        verificationUri: "https://oauth-device.test/device",
+        verificationUriComplete:
+          "https://oauth-device.test/device?user_code=TEST-DEVICE",
+        expiresIn: 600,
+        interval: 5,
+      };
+    },
+    pollDeviceAuthorization: async (args) => {
+      switch (args.deviceCode) {
+        case "pending": {
+          return { status: "pending" };
+        }
+        case "slow-down": {
+          return { status: "pending", interval: 10 };
+        }
+        case "denied": {
+          return {
+            status: "denied",
+            error: "access_denied",
+            errorDescription: "User denied the device authorization request",
+          };
+        }
+        case "expired": {
+          return {
+            status: "expired",
+            error: "expired_token",
+            errorDescription: "Device authorization expired",
+          };
+        }
+        case "error": {
+          return {
+            status: "error",
+            error: "invalid_request",
+            errorDescription: "Synthetic device authorization error",
+          };
+        }
+        default: {
+          return {
+            status: "complete",
+            token: {
+              accessToken: `test-device-access:${args.clientId}:${args.deviceCode}`,
+              refreshToken: null,
+              scopes: ["read"],
+              userInfo: {
+                id: "test-oauth-device-user",
+                username: "test-oauth-device-user",
+                email: "test-oauth-device@example.com",
+              },
+            },
+          };
+        }
+      }
+    },
+  },
+);


### PR DESCRIPTION
## Summary
- add flow-specific OAuth connector config/types for authorization-code and device-authorization
- add connector provider capability types and registry helpers for starting and polling device authorization
- add a synthetic test-oauth-device connector/provider plus API guards so browser OAuth routes only handle authorization-code connectors

## Tests
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F api exec vitest src/signals/services/__tests__/zero-connector-data.service.test.ts src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm knip --workspace @vm0/connectors
- pre-commit: pnpm knip --cache, pnpm check-types

Closes #14422
