### PR TITLE
fix: target computer-use input dispatch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -354,7 +354,12 @@ describe("desktop computer-use runtime", () => {
         params: { commandId: created.body.commandId },
         body: {
           status: "succeeded",
-          result: { text: "clicked" },
+          result: {
+            text: "clicked",
+            dispatchMode: "accessibility_action",
+            dispatchTarget: "element",
+            inputRisk: "targeted_app_action",
+          },
         },
         headers: { authorization: `Bearer ${hostToken}` },
       }),
@@ -373,5 +378,11 @@ describe("desktop computer-use runtime", () => {
         })
         .sort(),
     ).toStrictEqual(["completed"]);
+    expect(auditEvents[0]?.redactedResult).toStrictEqual({
+      dispatchMode: "accessibility_action",
+      dispatchTarget: "element",
+      inputRisk: "targeted_app_action",
+      textLength: 7,
+    });
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -217,11 +217,40 @@ function redactedResultForAudit(
   if (!result) {
     return null;
   }
+  const redacted: Record<string, unknown> = {};
+  for (const key of [
+    "action",
+    "app",
+    "button",
+    "clickCount",
+    "direction",
+    "dispatchMode",
+    "dispatchTarget",
+    "elementId",
+    "inputRisk",
+    "key",
+    "pages",
+    "role",
+    "x",
+    "y",
+  ]) {
+    const value = result[key];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      redacted[key] = value;
+    }
+  }
   if (typeof result.text === "string") {
-    return { textLength: result.text.length };
+    redacted.textLength = result.text.length;
   }
   if (typeof result.screenshot === "string") {
-    return { screenshot: "[redacted]" };
+    redacted.screenshot = "[redacted]";
+  }
+  if (Object.keys(redacted).length > 0) {
+    return redacted;
   }
   return result;
 }

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -301,4 +301,48 @@ describe("computer-use command visibility", () => {
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain('"text": "clicked"');
   });
+
+  it("should include dispatch and input risk metadata in audit output", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/audit-events",
+        () => {
+          return HttpResponse.json({
+            auditEvents: [
+              {
+                id: "audit_1",
+                commandId: "cmd_1",
+                runId: null,
+                hostId: "host_1",
+                kind: "keyboard.press_key",
+                app: "Safari",
+                event: "completed",
+                approvalOutcome: null,
+                redactedResult: {
+                  dispatchMode: "targeted_keyboard_event",
+                  inputRisk: "targeted_app_shortcut",
+                },
+                error: null,
+                createdAt: "2026-05-21T10:00:00.000Z",
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "audit",
+      "--limit",
+      "1",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("dispatch=targeted_keyboard_event");
+    expect(output).toContain("risk=targeted_app_shortcut");
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -322,13 +322,25 @@ function appOption(command: Command): Command {
   return command.requiredOption("--app <name>", "Target app name or bundle id");
 }
 
+function auditMetadataValue(
+  metadata: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 function formatAuditEvent(event: ComputerUseAuditEvent): string {
+  const dispatchMode = auditMetadataValue(event.redactedResult, "dispatchMode");
+  const inputRisk = auditMetadataValue(event.redactedResult, "inputRisk");
   return [
     `${event.createdAt} ${event.event} ${event.kind}`,
     `command=${event.commandId}`,
     event.hostId ? `host=${event.hostId}` : null,
     event.app ? `app=${event.app}` : null,
     event.approvalOutcome ? `approval=${event.approvalOutcome}` : null,
+    dispatchMode ? `dispatch=${dispatchMode}` : null,
+    inputRisk ? `risk=${inputRisk}` : null,
   ]
     .filter((part): part is string => {
       return part !== null;
@@ -458,7 +470,10 @@ const pressKeyCommand = appOption(
     new Command()
       .name("press-key")
       .description("Press a key or key combination in the target app")
-      .requiredOption("--key <key>", "Key or key combination to press")
+      .requiredOption(
+        "--key <key>",
+        "Key or key combination to press, for example Command+K or Control+K",
+      )
       .action(
         withErrorHandler(async (options: ComputerUsePressKeyOptions) => {
           await runWriteCommand("keyboard.press_key", options, {

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -387,6 +387,303 @@ async function runJxa(script: string): Promise<string> {
   return stdout.trim();
 }
 
+const CG_EVENT_FLAG_SHIFT = 131_072;
+const CG_EVENT_FLAG_CONTROL = 262_144;
+const CG_EVENT_FLAG_OPTION = 524_288;
+const CG_EVENT_FLAG_COMMAND = 1_048_576;
+
+type ComputerUseKeyModifier = "command" | "control" | "option" | "shift";
+
+interface ComputerUseModifierDefinition {
+  readonly name: ComputerUseKeyModifier;
+  readonly displayName: string;
+  readonly keyCode: number;
+  readonly flag: number;
+}
+
+interface ParsedComputerUseKeyPress {
+  readonly keyCode: number;
+  readonly modifiers: readonly {
+    readonly keyCode: number;
+    readonly flag: number;
+  }[];
+  readonly flags: number;
+  readonly normalizedKey: string;
+}
+
+const MODIFIER_DEFINITIONS: readonly ComputerUseModifierDefinition[] = [
+  {
+    name: "command",
+    displayName: "Command",
+    keyCode: 55,
+    flag: CG_EVENT_FLAG_COMMAND,
+  },
+  {
+    name: "control",
+    displayName: "Control",
+    keyCode: 59,
+    flag: CG_EVENT_FLAG_CONTROL,
+  },
+  {
+    name: "option",
+    displayName: "Option",
+    keyCode: 58,
+    flag: CG_EVENT_FLAG_OPTION,
+  },
+  {
+    name: "shift",
+    displayName: "Shift",
+    keyCode: 56,
+    flag: CG_EVENT_FLAG_SHIFT,
+  },
+] as const;
+
+const MODIFIER_ALIASES: Readonly<Record<string, ComputerUseKeyModifier>> =
+  Object.freeze({
+    alt: "option",
+    cmd: "command",
+    command: "command",
+    control: "control",
+    ctrl: "control",
+    meta: "command",
+    option: "option",
+    shift: "shift",
+    super: "command",
+  });
+
+const KEY_CODES: Readonly<Record<string, number>> = Object.freeze({
+  "'": 39,
+  ",": 43,
+  "-": 27,
+  ".": 47,
+  "/": 44,
+  "0": 29,
+  "1": 18,
+  "2": 19,
+  "3": 20,
+  "4": 21,
+  "5": 23,
+  "6": 22,
+  "7": 26,
+  "8": 28,
+  "9": 25,
+  ";": 41,
+  "=": 24,
+  "[": 33,
+  "\\": 42,
+  "]": 30,
+  "`": 50,
+  a: 0,
+  b: 11,
+  backspace: 51,
+  c: 8,
+  d: 2,
+  delete: 51,
+  down: 125,
+  downarrow: 125,
+  e: 14,
+  end: 119,
+  enter: 36,
+  esc: 53,
+  escape: 53,
+  f: 3,
+  f1: 122,
+  f2: 120,
+  f3: 99,
+  f4: 118,
+  f5: 96,
+  f6: 97,
+  f7: 98,
+  f8: 100,
+  f9: 101,
+  f10: 109,
+  f11: 103,
+  f12: 111,
+  forwarddelete: 117,
+  g: 5,
+  h: 4,
+  home: 115,
+  i: 34,
+  j: 38,
+  k: 40,
+  l: 37,
+  left: 123,
+  leftarrow: 123,
+  m: 46,
+  n: 45,
+  o: 31,
+  p: 35,
+  pagedown: 121,
+  pageup: 116,
+  q: 12,
+  r: 15,
+  return: 36,
+  right: 124,
+  rightarrow: 124,
+  s: 1,
+  space: 49,
+  spacebar: 49,
+  t: 17,
+  tab: 48,
+  u: 32,
+  up: 126,
+  uparrow: 126,
+  v: 9,
+  w: 13,
+  x: 7,
+  y: 16,
+  z: 6,
+});
+
+const KEY_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.freeze({
+  backspace: "Backspace",
+  delete: "Backspace",
+  down: "Down",
+  downarrow: "Down",
+  enter: "Return",
+  esc: "Escape",
+  escape: "Escape",
+  forwarddelete: "ForwardDelete",
+  left: "Left",
+  leftarrow: "Left",
+  pagedown: "PageDown",
+  pageup: "PageUp",
+  return: "Return",
+  right: "Right",
+  rightarrow: "Right",
+  space: "Space",
+  spacebar: "Space",
+  tab: "Tab",
+  up: "Up",
+  uparrow: "Up",
+});
+
+class UnsupportedComputerUseCommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedComputerUseCommandError";
+  }
+}
+
+function normalizeKeyToken(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[\s_-]+/g, "");
+}
+
+function displayKeyToken(token: string): string {
+  if (KEY_DISPLAY_NAMES[token]) {
+    return KEY_DISPLAY_NAMES[token];
+  }
+  if (/^f\d{1,2}$/.test(token)) {
+    return token.toUpperCase();
+  }
+  if (token.length === 1) {
+    return token.toUpperCase();
+  }
+  return token;
+}
+
+function unsupportedCommand(message: string): ComputerUseCommandFailure {
+  return {
+    status: "failed",
+    error: {
+      code: "unsupported_command",
+      message,
+    },
+  };
+}
+
+function parseComputerUseKeyPress(key: string): ParsedComputerUseKeyPress {
+  const rawParts = key.split("+").map((part) => {
+    return part.trim();
+  });
+  if (
+    rawParts.length === 0 ||
+    rawParts.some((part) => {
+      return part.length === 0;
+    })
+  ) {
+    throw new UnsupportedComputerUseCommandError(
+      "keyboard.press_key requires a non-empty key or key combination",
+    );
+  }
+
+  const modifiers = new Set<ComputerUseKeyModifier>();
+  let keyCode: number | null = null;
+  let displayKey: string | null = null;
+
+  for (const rawPart of rawParts) {
+    const token = normalizeKeyToken(rawPart);
+    const modifier = MODIFIER_ALIASES[token];
+    if (modifier) {
+      modifiers.add(modifier);
+      continue;
+    }
+
+    const code = KEY_CODES[token];
+    if (code === undefined) {
+      throw new UnsupportedComputerUseCommandError(
+        `Unsupported key specification: ${rawPart}`,
+      );
+    }
+    if (keyCode !== null) {
+      throw new UnsupportedComputerUseCommandError(
+        "keyboard.press_key supports exactly one non-modifier key",
+      );
+    }
+    keyCode = code;
+    displayKey = displayKeyToken(token);
+  }
+
+  if (keyCode === null || displayKey === null) {
+    throw new UnsupportedComputerUseCommandError(
+      "keyboard.press_key requires a non-modifier key",
+    );
+  }
+
+  const activeModifiers = MODIFIER_DEFINITIONS.filter((modifier) => {
+    return modifiers.has(modifier.name);
+  });
+  return {
+    keyCode,
+    modifiers: activeModifiers.map((modifier) => {
+      return {
+        keyCode: modifier.keyCode,
+        flag: modifier.flag,
+      };
+    }),
+    flags: activeModifiers.reduce((flags, modifier) => {
+      return flags | modifier.flag;
+    }, 0),
+    normalizedKey: [
+      ...activeModifiers.map((modifier) => {
+        return modifier.displayName;
+      }),
+      displayKey,
+    ].join("+"),
+  };
+}
+
+function parseJsonRecord(output: string): Record<string, unknown> {
+  const value = JSON.parse(output) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function recordString(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
 export function renderAccessibilityTree(
   snapshot: AccessibilityAppStateSnapshot,
 ): string {
@@ -642,7 +939,6 @@ if (processes.length === 0) {
   JSON.stringify({ app: appName, snapshotId, elements: [] });
 } else {
   const process = processes[0];
-  process.frontmost = true;
   enableBestEffortAccessibilityModes(process);
   const windows = process.windows().slice(0, limits.maxWindows);
   JSON.stringify({
@@ -656,6 +952,86 @@ if (processes.length === 0) {
     truncationReasons,
   });
 }
+`;
+}
+
+function targetProcessScript(app: string): string {
+  return `
+const appName = ${jxaString(app)};
+const systemEvents = Application("System Events");
+const processes = systemEvents.processes.whose({ name: appName })();
+if (processes.length === 0) throw new Error("App is not running: " + appName);
+const process = processes[0];
+const pid = Number(process.unixId());
+if (!Number.isFinite(pid) || pid <= 0) {
+  throw new Error("Unable to resolve process id for app: " + appName);
+}
+`;
+}
+
+function targetedKeyPressScript(
+  app: string,
+  parsed: ParsedComputerUseKeyPress,
+): string {
+  return `
+ObjC.import("ApplicationServices");
+${targetProcessScript(app)}
+function postKey(keyCode, keyDown, flags) {
+  const event = $.CGEventCreateKeyboardEvent(null, keyCode, keyDown);
+  $.CGEventSetFlags(event, flags);
+  $.CGEventPostToPid(pid, event);
+  $.CFRelease(event);
+}
+const flags = ${parsed.flags};
+const modifiers = ${JSON.stringify(parsed.modifiers)};
+let activeFlags = 0;
+for (const modifier of modifiers) {
+  activeFlags |= modifier.flag;
+  postKey(modifier.keyCode, true, activeFlags);
+}
+postKey(${parsed.keyCode}, true, flags);
+postKey(${parsed.keyCode}, false, flags);
+for (let index = modifiers.length - 1; index >= 0; index -= 1) {
+  activeFlags &= ~modifiers[index].flag;
+  postKey(modifiers[index].keyCode, false, activeFlags);
+}
+JSON.stringify({ pid });
+`;
+}
+
+const MOUSE_BUTTON_EVENT_CONFIG = Object.freeze({
+  left: { button: 0, down: 1, up: 2 },
+  right: { button: 1, down: 3, up: 4 },
+  middle: { button: 2, down: 25, up: 26 },
+} satisfies Record<
+  ComputerUseMouseButton,
+  { readonly button: number; readonly down: number; readonly up: number }
+>);
+
+function targetedMouseClickScript(
+  app: string,
+  x: number,
+  y: number,
+  button: ComputerUseMouseButton,
+  clickCount: number,
+): string {
+  const events = MOUSE_BUTTON_EVENT_CONFIG[button];
+  return `
+ObjC.import("ApplicationServices");
+${targetProcessScript(app)}
+const point = $.CGPointMake(${x}, ${y});
+function postMouseEvent(type, clickState) {
+  const event = $.CGEventCreateMouseEvent(null, type, point, ${events.button});
+  $.CGEventSetIntegerValueField(event, $.kCGMouseEventClickState, clickState);
+  $.CGEventPostToPid(pid, event);
+  $.CFRelease(event);
+}
+for (let clickIndex = 1; clickIndex <= ${clickCount}; clickIndex += 1) {
+  postMouseEvent(${events.down}, clickIndex);
+  postMouseEvent(${events.up}, clickIndex);
+  if (clickIndex < ${clickCount}) delay(0.05);
+}
+JSON.stringify({ pid });
 `;
 }
 
@@ -791,48 +1167,14 @@ async function openApp(
   runJxaCommand: RunJxa,
 ): Promise<ComputerUseCommandSuccess> {
   await runJxaCommand(`Application(${jxaString(app)}).activate();`);
-  return { status: "succeeded", result: { app, text: `Opened ${app}` } };
-}
-
-const MOUSE_BUTTON_EVENT_CONFIG = Object.freeze({
-  left: { button: 0, down: 1, up: 2 },
-  right: { button: 1, down: 3, up: 4 },
-  middle: { button: 2, down: 25, up: 26 },
-} satisfies Record<
-  ComputerUseMouseButton,
-  { readonly button: number; readonly down: number; readonly up: number }
->);
-
-function quartzMouseClickScript(args: {
-  readonly x: number;
-  readonly y: number;
-  readonly button: ComputerUseMouseButton;
-  readonly clickCount: number;
-}): string {
-  const events = MOUSE_BUTTON_EVENT_CONFIG[args.button];
-  return `
-ObjC.import("ApplicationServices");
-const point = $.CGPointMake(${args.x}, ${args.y});
-function postMouseEvent(type, clickState) {
-  const event = $.CGEventCreateMouseEvent(null, type, point, ${events.button});
-  $.CGEventSetIntegerValueField(event, $.kCGMouseEventClickState, clickState);
-  $.CGEventPost($.kCGHIDEventTap, event);
-  $.CFRelease(event);
-}
-for (let clickIndex = 1; clickIndex <= ${args.clickCount}; clickIndex += 1) {
-  postMouseEvent(${events.down}, clickIndex);
-  postMouseEvent(${events.up}, clickIndex);
-  if (clickIndex < ${args.clickCount}) delay(0.05);
-}
-`;
-}
-
-function unsupportedCommand(message: string): ComputerUseCommandFailure {
   return {
-    status: "failed",
-    error: {
-      code: "unsupported_command",
-      message,
+    status: "succeeded",
+    result: {
+      app,
+      dispatchMode: "app_activation",
+      dispatchTarget: "target_app",
+      inputRisk: "activates_app",
+      text: `Opened ${app}`,
     },
   };
 }
@@ -924,6 +1266,9 @@ element.click();
         elementId: args.elementId,
         button: args.button,
         clickCount: args.clickCount,
+        dispatchMode: "accessibility_action",
+        dispatchTarget: "element",
+        inputRisk: "targeted_app_action",
         text: `Clicked ${args.elementId}`,
       },
     };
@@ -942,12 +1287,13 @@ element.click();
       return screenPoint;
     }
     await args.runJxaCommand(
-      quartzMouseClickScript({
-        x: screenPoint.screenX,
-        y: screenPoint.screenY,
-        button: args.button,
-        clickCount: args.clickCount,
-      }),
+      targetedMouseClickScript(
+        args.app,
+        screenPoint.screenX,
+        screenPoint.screenY,
+        args.button,
+        args.clickCount,
+      ),
     );
     return {
       status: "succeeded",
@@ -960,6 +1306,9 @@ element.click();
         screenY: screenPoint.screenY,
         button: args.button,
         clickCount: args.clickCount,
+        dispatchMode: "targeted_mouse_event",
+        dispatchTarget: "app_process",
+        inputRisk: "targeted_app_pointer",
         text: `Clicked ${args.x},${args.y}`,
       },
     };
@@ -981,7 +1330,14 @@ element.value = ${jxaString(value)};
 `);
   return {
     status: "succeeded",
-    result: { app, elementId, text: `Set ${elementId}` },
+    result: {
+      app,
+      elementId,
+      dispatchMode: "accessibility_value",
+      dispatchTarget: "element",
+      inputRisk: "targeted_app_text",
+      text: `Set ${elementId}`,
+    },
   };
 }
 
@@ -997,7 +1353,15 @@ element.actions.byName(${jxaString(action)}).perform();
 `);
   return {
     status: "succeeded",
-    result: { app, elementId, action, text: `Performed ${action}` },
+    result: {
+      app,
+      elementId,
+      action,
+      dispatchMode: "accessibility_action",
+      dispatchTarget: "element",
+      inputRisk: "targeted_app_action",
+      text: `Performed ${action}`,
+    },
   };
 }
 
@@ -1005,12 +1369,80 @@ async function typeText(
   app: string,
   text: string,
   runJxaCommand: RunJxa,
-): Promise<ComputerUseCommandSuccess> {
-  await runJxaCommand(`
-Application(${jxaString(app)}).activate();
-Application("System Events").keystroke(${jxaString(text)});
+): Promise<ComputerUseCommandExecutionResult> {
+  const output = await runJxaCommand(`
+const inputText = ${jxaString(text)};
+${targetProcessScript(app)}
+function safeString(read) {
+  try {
+    const value = read();
+    if (value === undefined || value === null) return undefined;
+    return String(value);
+  } catch (_error) {
+    return undefined;
+  }
+}
+function focusedElement(process) {
+  try {
+    return process.attributes.byName("AXFocusedUIElement").value();
+  } catch (_error) {
+    return null;
+  }
+}
+const element = focusedElement(process);
+if (!element) {
+  JSON.stringify({
+    status: "failed",
+    message: "keyboard.type_text requires a focused editable text element in " + appName,
+  });
+} else {
+  const role = safeString(() => element.role());
+  const description = safeString(() => element.description());
+  const editableRoles = [
+    "AXComboBox",
+    "AXSearchField",
+    "AXTextArea",
+    "AXTextField",
+    "AXTextView",
+  ];
+  const editable = editableRoles.includes(role);
+  if (!editable) {
+    JSON.stringify({
+      status: "failed",
+      message: "keyboard.type_text requires a focused editable text element in " + appName,
+      role,
+      description,
+    });
+  } else {
+    const currentValue = safeString(() => element.value()) ?? "";
+    element.value = currentValue + inputText;
+    JSON.stringify({
+      status: "succeeded",
+      role,
+      description,
+    });
+  }
+}
 `);
-  return { status: "succeeded", result: { app, text: "Typed text" } };
+  const result = parseJsonRecord(output);
+  if (result.status === "failed") {
+    return unsupportedCommand(
+      recordString(result, "message") ??
+        "keyboard.type_text requires a focused editable text element",
+    );
+  }
+
+  return {
+    status: "succeeded",
+    result: {
+      app,
+      dispatchMode: "accessibility_value",
+      dispatchTarget: "focused_editable_element",
+      inputRisk: "targeted_app_text",
+      role: recordString(result, "role"),
+      text: "Typed text",
+    },
+  };
 }
 
 async function pressKey(
@@ -1018,11 +1450,19 @@ async function pressKey(
   key: string,
   runJxaCommand: RunJxa,
 ): Promise<ComputerUseCommandSuccess> {
-  await runJxaCommand(`
-Application(${jxaString(app)}).activate();
-Application("System Events").keystroke(${jxaString(key)});
-`);
-  return { status: "succeeded", result: { app, key, text: `Pressed ${key}` } };
+  const parsed = parseComputerUseKeyPress(key);
+  await runJxaCommand(targetedKeyPressScript(app, parsed));
+  return {
+    status: "succeeded",
+    result: {
+      app,
+      key: parsed.normalizedKey,
+      dispatchMode: "targeted_keyboard_event",
+      dispatchTarget: "app_process",
+      inputRisk: "targeted_app_shortcut",
+      text: `Pressed ${parsed.normalizedKey}`,
+    },
+  };
 }
 
 async function scrollElement(
@@ -1047,7 +1487,16 @@ if (scrollBars.length > 0) {
 `);
   return {
     status: "succeeded",
-    result: { app, elementId, direction, pages, text: `Scrolled ${elementId}` },
+    result: {
+      app,
+      elementId,
+      direction,
+      pages,
+      dispatchMode: "accessibility_action",
+      dispatchTarget: "element",
+      inputRisk: "targeted_app_action",
+      text: `Scrolled ${elementId}`,
+    },
   };
 }
 
@@ -1217,6 +1666,9 @@ export async function executeComputerUseCommand(
         : missingField("key");
     }
   } catch (error) {
+    if (error instanceof UnsupportedComputerUseCommandError) {
+      return unsupportedCommand(error.message);
+    }
     return {
       status: "failed",
       error: {

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -26,6 +26,7 @@ export interface ComputerUseRuntimeAuditEvent {
   readonly app: string | null;
   readonly event: "created" | "approved" | "denied" | "completed";
   readonly approvalOutcome: "approved" | "denied" | null;
+  readonly redactedResult?: Record<string, unknown> | null;
   readonly createdAt: string;
 }
 

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS,
   ComputerUseSnapshotStore,
@@ -772,13 +772,18 @@ describe("computer use desktop runtime", () => {
         screenY: 800,
         button: "right",
         clickCount: 2,
+        dispatchMode: "targeted_mouse_event",
+        dispatchTarget: "app_process",
+        inputRisk: "targeted_app_pointer",
       },
     });
     const clickScript = scripts.at(-1);
     expect(clickScript).toContain("$.CGPointMake(900, 800)");
     expect(clickScript).toContain("$.CGEventCreateMouseEvent");
+    expect(clickScript).toContain("$.CGEventPostToPid(pid, event)");
     expect(clickScript).toContain("postMouseEvent(3, clickIndex)");
-    expect(clickScript).not.toContain("System Events");
+    expect(clickScript).not.toContain("$.CGEventPost($.kCGHIDEventTap");
+    expect(clickScript).not.toContain("systemEvents.click");
   });
 
   it("captures fresh app state for coordinate clicks without a cached snapshot", async () => {
@@ -839,11 +844,15 @@ describe("computer use desktop runtime", () => {
         screenY: 380,
         button: "left",
         clickCount: 1,
+        dispatchMode: "targeted_mouse_event",
+        dispatchTarget: "app_process",
+        inputRisk: "targeted_app_pointer",
       },
     });
     expect(captureCount).toBe(1);
     expect(scripts).toHaveLength(2);
     expect(scripts[1]).toContain("$.CGPointMake(440, 380)");
+    expect(scripts[1]).toContain("$.CGEventPostToPid(pid, event)");
   });
 
   it("requires screen recording permission for app state screenshots", async () => {
@@ -863,6 +872,156 @@ describe("computer use desktop runtime", () => {
       error: {
         code: "screen_recording_unavailable",
         message: "macOS Screen Recording permission is required",
+      },
+    });
+  });
+
+  it("parses press-key combinations before posting targeted input", async () => {
+    const cases = [
+      {
+        key: "Command+K",
+        normalizedKey: "Command+K",
+        keyCodeSnippet: "postKey(40, true, flags)",
+        flagsSnippet: "const flags = 1048576;",
+      },
+      {
+        key: "Control+K",
+        normalizedKey: "Control+K",
+        keyCodeSnippet: "postKey(40, true, flags)",
+        flagsSnippet: "const flags = 262144;",
+      },
+      {
+        key: "Command+Shift+S",
+        normalizedKey: "Command+Shift+S",
+        keyCodeSnippet: "postKey(1, true, flags)",
+        flagsSnippet: "const flags = 1179648;",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const scripts: string[] = [];
+      const result = await executeComputerUseCommand(
+        {
+          id: "cmd_1",
+          kind: "keyboard.press_key",
+          payload: { app: "Safari", key: testCase.key },
+        },
+        { accessibility: true, screenRecording: true },
+        {
+          platform: "darwin",
+          runJxa: async (script) => {
+            scripts.push(script);
+            return JSON.stringify({ pid: 123 });
+          },
+          captureScreenshot: async () => {
+            throw new Error("unexpected screenshot capture");
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        status: "succeeded",
+        result: { key: testCase.normalizedKey },
+      });
+      expect(scripts[0]).toContain(testCase.keyCodeSnippet);
+      expect(scripts[0]).toContain(testCase.flagsSnippet);
+    }
+  });
+
+  it("posts press-key combinations to the target process without app activation", async () => {
+    const scripts: string[] = [];
+    const result = await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "keyboard.press_key",
+        payload: { app: "Safari", key: "Command+K" },
+      },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        runJxa: async (script) => {
+          scripts.push(script);
+          return JSON.stringify({ pid: 123 });
+        },
+        captureScreenshot: async () => {
+          throw new Error("unexpected screenshot capture");
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "succeeded",
+      result: {
+        key: "Command+K",
+        dispatchMode: "targeted_keyboard_event",
+        dispatchTarget: "app_process",
+        inputRisk: "targeted_app_shortcut",
+      },
+    });
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0]).toContain("$.CGEventPostToPid(pid, event)");
+    expect(scripts[0]).toContain("postKey(40, true, flags)");
+    expect(scripts[0]).not.toContain("activate()");
+    expect(scripts[0]).not.toContain("keystroke");
+  });
+
+  it("rejects unsupported press-key syntax before dispatching input", async () => {
+    const runJxa = vi.fn<(script: string) => Promise<string>>();
+    const result = await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "keyboard.press_key",
+        payload: { app: "Safari", key: "Command+Launchpad" },
+      },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        runJxa,
+        captureScreenshot: async () => {
+          throw new Error("unexpected screenshot capture");
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      status: "failed",
+      error: {
+        code: "unsupported_command",
+        message: "Unsupported key specification: Launchpad",
+      },
+    });
+    expect(runJxa).not.toHaveBeenCalled();
+  });
+
+  it("rejects type-text when the target app has no focused editable element", async () => {
+    const result = await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "keyboard.type_text",
+        payload: { app: "Safari", text: "hello" },
+      },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        runJxa: async () => {
+          return JSON.stringify({
+            status: "failed",
+            message:
+              "keyboard.type_text requires a focused editable text element in Safari",
+          });
+        },
+        captureScreenshot: async () => {
+          throw new Error("unexpected screenshot capture");
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      status: "failed",
+      error: {
+        code: "unsupported_command",
+        message:
+          "keyboard.type_text requires a focused editable text element in Safari",
       },
     });
   });

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -78,6 +78,7 @@ interface DesktopComputerUseAuditEvent {
   readonly app: string | null;
   readonly event: "created" | "approved" | "denied" | "completed";
   readonly approvalOutcome: "approved" | "denied" | null;
+  readonly redactedResult?: Record<string, unknown> | null;
   readonly createdAt: string;
 }
 

--- a/turbo/apps/platform/src/signals/desktop-computer-use-page/desktop-computer-use-signals.ts
+++ b/turbo/apps/platform/src/signals/desktop-computer-use-page/desktop-computer-use-signals.ts
@@ -1,6 +1,9 @@
 import { command, computed, state } from "ccstate";
 
 type DesktopComputerUseApi = NonNullable<Window["vm0DesktopComputerUse"]>;
+type DesktopComputerUseApprovalAction = Parameters<
+  DesktopComputerUseApi["decideCommand"]
+>[0];
 export type DesktopComputerUseState = Awaited<
   ReturnType<DesktopComputerUseApi["getState"]>
 >;
@@ -45,6 +48,20 @@ export const refreshDesktopComputerUse$ = command(({ set }) => {
 export const startDesktopComputerUse$ = command(
   async ({ set }, signal: AbortSignal) => {
     await desktopComputerUseApi().start();
+    signal.throwIfAborted();
+    set(internalReload$, (previous) => {
+      return previous + 1;
+    });
+  },
+);
+
+export const decideDesktopComputerUseCommand$ = command(
+  async (
+    { set },
+    action: DesktopComputerUseApprovalAction,
+    signal: AbortSignal,
+  ) => {
+    await desktopComputerUseApi().decideCommand(action);
     signal.throwIfAborted();
     set(internalReload$, (previous) => {
       return previous + 1;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
@@ -51,6 +51,10 @@ function computerUseState(): TestDesktopComputerUseState {
           app: "Safari",
           event: "created",
           approvalOutcome: null,
+          redactedResult: {
+            dispatchMode: "targeted_mouse_event",
+            inputRisk: "targeted_app_pointer",
+          },
           createdAt: "2026-05-20T00:02:00.000Z",
         },
       ],
@@ -132,8 +136,58 @@ describe("zero desktop Computer Use page", () => {
     expect(screen.getByText("host-1")).toBeInTheDocument();
     expect(screen.getAllByText("element.click")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Safari")[0]).toBeInTheDocument();
-    expect(screen.queryByText("Pending approvals")).not.toBeInTheDocument();
-    expect(screen.queryByText("Approve")).not.toBeInTheDocument();
+    expect(screen.getByText("Pending approvals")).toBeInTheDocument();
+    expect(screen.getByText("targeted pointer")).toBeInTheDocument();
+    expect(screen.getByText("targeted_mouse_event")).toBeInTheDocument();
+    expect(screen.getByText("targeted_app_pointer")).toBeInTheDocument();
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+  });
+
+  it("submits pending approval decisions through the native bridge", async () => {
+    const user = userEvent.setup();
+    const state = computerUseState();
+    const decideCommand = vi.fn(() => {
+      return Promise.resolve(state);
+    });
+    installDesktopComputerUseApi({
+      getState() {
+        return Promise.resolve(state);
+      },
+      start() {
+        return Promise.resolve(state);
+      },
+      requestAccessibilityPermission() {
+        return Promise.resolve(state);
+      },
+      openAccessibilitySettings() {
+        return Promise.resolve();
+      },
+      openScreenRecordingSettings() {
+        return Promise.resolve();
+      },
+      decideCommand,
+      subscribe() {
+        return () => {};
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/computer-use",
+      featureSwitches: {
+        [FeatureSwitchKey.ComputerUse]: true,
+      },
+    });
+
+    await screen.findByRole("heading", { name: "Computer Use" });
+    await user.click(buttonByText("Approve"));
+
+    await waitFor(() => {
+      expect(decideCommand).toHaveBeenCalledWith({
+        commandId: "command-1",
+        decision: "approve",
+      });
+    });
   });
 
   it("runs native permission onboarding actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
@@ -3,6 +3,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconAlertCircle,
   IconCircleCheck,
+  IconCircleX,
   IconDeviceDesktop,
   IconExternalLink,
   IconLoader2,
@@ -22,6 +23,7 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
+  decideDesktopComputerUseCommand$,
   desktopComputerUseData$,
   openDesktopComputerUseAccessibilitySettings$,
   openDesktopComputerUseScreenRecordingSettings$,
@@ -55,6 +57,46 @@ function statusClassName(status: string): string {
     return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
   }
   return "bg-muted text-muted-foreground";
+}
+
+function auditMetadataValue(
+  metadata: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function inputRiskLabel(kind: string): string {
+  if (kind === "keyboard.press_key") {
+    return "targeted shortcut";
+  }
+  if (kind === "keyboard.type_text" || kind === "element.set_value") {
+    return "focused text edit";
+  }
+  if (kind === "element.click") {
+    return "targeted pointer";
+  }
+  if (kind === "app.open") {
+    return "app activation";
+  }
+  return "targeted app action";
+}
+
+function inputRiskDescription(kind: string): string {
+  if (kind === "keyboard.press_key") {
+    return "Shortcut events are posted to the target app process.";
+  }
+  if (kind === "keyboard.type_text") {
+    return "Text is written only through the focused editable element.";
+  }
+  if (kind === "element.click") {
+    return "Pointer input targets an accessibility element or target app process.";
+  }
+  if (kind === "app.open") {
+    return "This command can bring the target app forward.";
+  }
+  return "This command mutates the target app through Accessibility.";
 }
 
 function StatusBadge({
@@ -249,6 +291,105 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   );
 }
 
+function PendingApprovalsPanel({
+  state,
+}: {
+  readonly state: DesktopComputerUseState;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [decisionLoadable, decideCommand] = useLoadableSet(
+    decideDesktopComputerUseCommand$,
+  );
+  const pending = decisionLoadable.state === "loading";
+
+  if (state.host.pendingApprovals.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="zero-border bg-card rounded-xl overflow-hidden">
+      <div className="border-b px-5 py-4">
+        <h2 className="text-sm font-semibold text-foreground">
+          Pending approvals
+        </h2>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Command</TableHead>
+            <TableHead>App</TableHead>
+            <TableHead>Input risk</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead className="text-right">Decision</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {state.host.pendingApprovals.map((event) => {
+            return (
+              <TableRow key={event.commandId}>
+                <TableCell className="font-medium">{event.kind}</TableCell>
+                <TableCell>{event.app ?? "-"}</TableCell>
+                <TableCell>
+                  <div className="font-medium">
+                    {inputRiskLabel(event.kind)}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {inputRiskDescription(event.kind)}
+                  </div>
+                </TableCell>
+                <TableCell>{formatDateTime(event.createdAt)}</TableCell>
+                <TableCell>
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      size="sm"
+                      disabled={pending}
+                      onClick={() => {
+                        detach(
+                          decideCommand(
+                            {
+                              commandId: event.commandId,
+                              decision: "approve",
+                            },
+                            pageSignal,
+                          ),
+                          Reason.DomCallback,
+                        );
+                      }}
+                    >
+                      <IconCircleCheck size={15} />
+                      Approve
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={pending}
+                      onClick={() => {
+                        detach(
+                          decideCommand(
+                            {
+                              commandId: event.commandId,
+                              decision: "deny",
+                            },
+                            pageSignal,
+                          ),
+                          Reason.DomCallback,
+                        );
+                      }}
+                    >
+                      <IconCircleX size={15} />
+                      Deny
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </section>
+  );
+}
+
 function HistoryPanel({ state }: { readonly state: DesktopComputerUseState }) {
   return (
     <section className="zero-border bg-card rounded-xl overflow-hidden">
@@ -267,6 +408,8 @@ function HistoryPanel({ state }: { readonly state: DesktopComputerUseState }) {
             <TableRow>
               <TableHead>Command</TableHead>
               <TableHead>App</TableHead>
+              <TableHead>Dispatch</TableHead>
+              <TableHead>Input risk</TableHead>
               <TableHead>Event</TableHead>
               <TableHead>Created</TableHead>
             </TableRow>
@@ -277,6 +420,14 @@ function HistoryPanel({ state }: { readonly state: DesktopComputerUseState }) {
                 <TableRow key={`${event.commandId}-${event.event}`}>
                   <TableCell className="font-medium">{event.kind}</TableCell>
                   <TableCell>{event.app ?? "-"}</TableCell>
+                  <TableCell>
+                    {auditMetadataValue(event.redactedResult, "dispatchMode") ??
+                      "-"}
+                  </TableCell>
+                  <TableCell>
+                    {auditMetadataValue(event.redactedResult, "inputRisk") ??
+                      inputRiskLabel(event.kind)}
+                  </TableCell>
                   <TableCell>
                     {event.event}
                     {event.approvalOutcome ? ` / ${event.approvalOutcome}` : ""}
@@ -364,6 +515,7 @@ function DesktopComputerUsePageBody() {
               />
             </div>
             <RuntimePanel state={dataLoadable.data} />
+            <PendingApprovalsPanel state={dataLoadable.data} />
             <HistoryPanel state={dataLoadable.data} />
           </>
         )}


### PR DESCRIPTION
## Summary
- parse Desktop computer-use key combinations and post keyboard/mouse events to the target app process instead of activating the app and typing literal keys
- guard type-text behind a focused editable Accessibility element and reject unsupported input before dispatch
- preserve dispatch/risk metadata in audit events and show it in Desktop Platform and CLI surfaces

Closes #14467
Fixes #14454

## Tests
- pnpm --dir turbo -F @vm0/desktop exec vitest run src/window-policy.test.ts
- pnpm --dir turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
- pnpm --dir turbo -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts
- pnpm --dir turbo -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm --dir turbo --filter @vm0/desktop --filter @vm0/app --filter api --filter @vm0/cli run check-types
- pnpm --dir turbo --filter @vm0/desktop --filter @vm0/app --filter api --filter @vm0/cli run lint
- pnpm --dir turbo knip --workspace @vm0/desktop --workspace @vm0/app --workspace api --workspace @vm0/cli

Pre-commit also ran prettier, full knip, and full turbo check-types.