### PR TITLE
fix(api): validate checkout redirect origin against APP_URL

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -14,7 +14,7 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
-const APP_ORIGIN = "http://localhost:3001";
+const APP_ORIGIN = "http://localhost:3002";
 const TEST_PRICE_PRO = "price_test_pro";
 const TEST_PRICE_TEAM = "price_test_team";
 
@@ -196,7 +196,7 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
-  it("returns 400 when successUrl origin does not match VM0_WEB_URL", async () => {
+  it("returns 400 when successUrl origin does not match APP_URL", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 

--- a/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
@@ -38,7 +38,7 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const { tier, successUrl, cancelUrl } = bodyResult.data;
 
-  const appOrigin = new URL(env("VM0_WEB_URL")).origin;
+  const appOrigin = new URL(env("APP_URL")).origin;
   if (
     new URL(successUrl).origin !== appOrigin ||
     new URL(cancelUrl).origin !== appOrigin


### PR DESCRIPTION
## Summary

The zero billing checkout route (`turbo/apps/api/src/signals/routes/zero-billing-checkout.ts`) pinned `successUrl`/`cancelUrl` to `VM0_WEB_URL`, but the **"Upgrade plan"** button lives in the **platform** app (`apps/platform`). `startCheckout$` builds those URLs from `window.location.href`, so their origin is always the platform app origin — i.e. `APP_URL`, not `VM0_WEB_URL`.

`APP_URL` never equals `VM0_WEB_URL` in any environment (test stub `:3002` vs `:3001`, local dev `app.vm7.ai` vs `www.vm7.ai`, prod `app.vm0.ai` vs `www.vm0.ai`), so the origin check rejected every request with `400 successUrl and cancelUrl must match the platform origin`.

The wrong variable was written when the API checkout route was created (#12596/#12606, 2026-05-11) but stayed dormant — the platform still hit the old `apps/web` checkout route. PR #14136 (2026-05-20) deleted that web route and proxied checkout traffic to this API route, activating the latent bug and breaking "Upgrade plan" everywhere.

## Changes

- `zero-billing-checkout.ts`: validate against `env("APP_URL")` instead of `env("VM0_WEB_URL")`, matching the sibling `zero-billing-redeem.ts` and `zero-billing-portal.ts` routes which already use `APP_URL`.
- `zero-billing-checkout.test.ts`: the test masked the bug — its `APP_ORIGIN` constant was set to `http://localhost:3001` (the env-stub's `VM0_WEB_URL`, not `APP_URL` which is `:3002`). Corrected the constant and the test title.

No workflow or Vercel env changes needed: the shared `.github/actions/web-api-env` action already injects `APP_URL` unconditionally for the API project in both preview and production deploys.

## Test plan

- [x] `vitest run zero-billing-checkout.test.ts` — 8/8 passing
- [ ] CI green