### PR TITLE
test: add test oauth device api smoke

### DIFF
--- a/e2e/tests/01-serial/ser-t09-test-oauth-device-api.bats
+++ b/e2e/tests/01-serial/ser-t09-test-oauth-device-api.bats
@@ -97,6 +97,7 @@ assert_response_jq() {
       .userCode == "TEST-DEVICE" and
       .verificationUri == "https://oauth-device.test/device" and
       .verificationUriComplete == "https://oauth-device.test/device?user_code=TEST-DEVICE" and
+      .interval == 0 and
       (.sessionId | type == "string" and length > 0) and
       (.sessionToken | type == "string" and length > 0)
     ' "device authorization start"

--- a/e2e/tests/01-serial/ser-t09-test-oauth-device-api.bats
+++ b/e2e/tests/01-serial/ser-t09-test-oauth-device-api.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+
+# API-only smoke for the synthetic OAuth device authorization connector.
+# This intentionally avoids browser, runner, sandbox, and firewall behavior.
+
+load '../../helpers/setup'
+
+export BATS_TEST_TIMEOUT=30
+
+setup_file() {
+    local token base
+    if ! token=$(zero_auth_token 2>/dev/null) || [[ -z "$token" ]]; then
+        skip "Zero auth token not configured"
+    fi
+    if ! base=$(zero_api_url 2>/dev/null) || [[ -z "$base" ]]; then
+        skip "Zero API URL not configured"
+    fi
+}
+
+zero_api_request() {
+    local method="$1"
+    local path="$2"
+    local body="${3:-}"
+    local token base curl_status
+
+    token=$(zero_auth_token)
+    base=$(zero_api_url)
+    LAST_RESPONSE_BODY="$BATS_TEST_TMPDIR/zero-api-${BATS_TEST_NUMBER}-${RANDOM}.json"
+
+    local -a headers=(
+        -H "Authorization: Bearer $token"
+        -H "Accept: application/json"
+        -H "Content-Type: application/json"
+    )
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        headers+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+    fi
+
+    local -a args=(
+        -sS
+        --max-time 30
+        -o "$LAST_RESPONSE_BODY"
+        -w "%{http_code}"
+        -X "$method"
+        "${headers[@]}"
+    )
+    if [[ -n "$body" ]]; then
+        args+=(-d "$body")
+    fi
+
+    LAST_HTTP_STATUS=$(curl "${args[@]}" "${base%/}${path}")
+    curl_status=$?
+    if [[ "$curl_status" -ne 0 ]]; then
+        echo "# $method $path curl failed with exit $curl_status" >&2
+        if [[ -s "$LAST_RESPONSE_BODY" ]]; then
+            echo "# response body: $(cat "$LAST_RESPONSE_BODY")" >&2
+        fi
+        return 1
+    fi
+}
+
+assert_api_status() {
+    local expected="$1"
+    local label="$2"
+    if [[ "$LAST_HTTP_STATUS" != "$expected" ]]; then
+        echo "# $label returned HTTP $LAST_HTTP_STATUS, expected $expected" >&2
+        echo "# response body: $(cat "$LAST_RESPONSE_BODY")" >&2
+        return 1
+    fi
+}
+
+assert_response_jq() {
+    local filter="$1"
+    local label="$2"
+    if ! jq -e "$filter" "$LAST_RESPONSE_BODY" >/dev/null; then
+        echo "# $label returned unexpected payload" >&2
+        echo "# jq filter: $filter" >&2
+        echo "# response body: $(cat "$LAST_RESPONSE_BODY")" >&2
+        return 1
+    fi
+}
+
+@test "test-oauth-device: API device authorization creates a connector" {
+    zero_api_request POST \
+        "/api/zero/feature-switches" \
+        '{"switches":{"testOauthConnector":true}}'
+    assert_api_status 200 "feature switch update"
+    assert_response_jq '.switches.testOauthConnector == true' "feature switch update"
+
+    zero_api_request POST \
+        "/api/zero/connectors/test-oauth-device/oauth/device/sessions" \
+        '{}'
+    assert_api_status 200 "device authorization start"
+    assert_response_jq '
+      .status == "pending" and
+      .type == "test-oauth-device" and
+      .userCode == "TEST-DEVICE" and
+      .verificationUri == "https://oauth-device.test/device" and
+      .verificationUriComplete == "https://oauth-device.test/device?user_code=TEST-DEVICE" and
+      (.sessionId | type == "string" and length > 0) and
+      (.sessionToken | type == "string" and length > 0)
+    ' "device authorization start"
+
+    local session_id session_token poll_body
+    session_id=$(jq -r '.sessionId' "$LAST_RESPONSE_BODY")
+    session_token=$(jq -r '.sessionToken' "$LAST_RESPONSE_BODY")
+    poll_body=$(jq -nc --arg sessionToken "$session_token" '{sessionToken: $sessionToken}')
+
+    zero_api_request POST \
+        "/api/zero/connectors/test-oauth-device/oauth/device/sessions/${session_id}/poll" \
+        "$poll_body"
+    assert_api_status 200 "device authorization poll"
+    assert_response_jq '
+      .status == "complete" and
+      .connector.type == "test-oauth-device" and
+      .connector.authMethod == "oauth" and
+      .connector.externalUsername == "test-oauth-device-user"
+    ' "device authorization poll"
+
+    zero_api_request GET "/api/zero/connectors"
+    assert_api_status 200 "connector list"
+    assert_response_jq '
+      any(.connectors[]?; .type == "test-oauth-device" and
+        .authMethod == "oauth" and
+        .externalUsername == "test-oauth-device-user")
+    ' "connector list"
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -167,6 +167,7 @@ import { storagesDownloadRoutes } from "./routes/storages-download";
 import { storagesListRoutes } from "./routes/storages-list";
 import { storagesPrepareRoutes } from "./routes/storages-prepare";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
+import { testOAuthProviderDeviceAuthorizationRoutes } from "./routes/test-oauth-provider-device-authorization";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderTokenRoutes } from "./routes/test-oauth-provider-token";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
@@ -353,6 +354,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...modelStatsRoutes,
   ...runnersRoutes,
   ...testOAuthProviderAuthorizeRoutes,
+  ...testOAuthProviderDeviceAuthorizationRoutes,
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderTokenRoutes,
   ...testOAuthProviderUserinfoRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -11,6 +11,7 @@ import {
 
 const context = testContext();
 const AUTHORIZE_ROUTE = "/api/test/oauth-provider/authorize";
+const DEVICE_AUTHORIZATION_ROUTE = "/api/test/oauth-provider/device/code";
 const TOKEN_ROUTE = "/api/test/oauth-provider/token";
 const USERINFO_ROUTE = "/api/test/oauth-provider/userinfo";
 const ECHO_ROUTE = "/api/test/oauth-provider/echo";
@@ -33,10 +34,19 @@ interface UserinfoBody {
 
 interface TokenBody {
   readonly access_token: string;
-  readonly refresh_token: string;
+  readonly refresh_token?: string | null;
   readonly token_type: "Bearer";
   readonly expires_in: number;
   readonly scope: string;
+}
+
+interface DeviceAuthorizationBody {
+  readonly device_code: string;
+  readonly user_code: string;
+  readonly verification_uri: string;
+  readonly verification_uri_complete: string;
+  readonly expires_in: number;
+  readonly interval: number;
 }
 
 function requestApp(path: string, init?: RequestInit): Promise<Response> {
@@ -101,6 +111,21 @@ describe("/api/test/oauth-provider/*", () => {
     const response = await requestApp(
       TOKEN_ROUTE,
       tokenRequest({ grant_type: "authorization_code" }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("returns 404 for the device authorization route in production", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(
+      DEVICE_AUTHORIZATION_ROUTE,
+      tokenRequest({
+        client_id: "test-oauth-device-client",
+        scope: "read",
+      }),
     );
 
     expect(response.status).toBe(404);
@@ -210,6 +235,93 @@ describe("/api/test/oauth-provider/*", () => {
       expect(response.status).toBe(400);
       await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
         error: "invalid_scenario",
+      });
+    });
+  });
+
+  describe("device authorization", () => {
+    it("starts a device authorization session", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        DEVICE_AUTHORIZATION_ROUTE,
+        tokenRequest({
+          client_id: "test-oauth-device-client",
+          scope: "read",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(
+        readJson<DeviceAuthorizationBody>(response),
+      ).resolves.toStrictEqual({
+        device_code: "test-device:test-oauth-device-client:read",
+        user_code: "TEST-DEVICE",
+        verification_uri: "https://oauth-device.test/device",
+        verification_uri_complete:
+          "https://oauth-device.test/device?user_code=TEST-DEVICE",
+        expires_in: 600,
+        interval: 5,
+      });
+    });
+
+    it("requires the preview bypass secret", async () => {
+      mockEnv("ENV", "preview");
+      mockOptionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
+
+      const denied = await requestApp(
+        DEVICE_AUTHORIZATION_ROUTE,
+        tokenRequest({
+          client_id: "test-oauth-device-client",
+          scope: "read",
+        }),
+      );
+      const allowed = await requestApp(DEVICE_AUTHORIZATION_ROUTE, {
+        ...tokenRequest({
+          client_id: "test-oauth-device-client",
+          scope: "read",
+        }),
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-vm0-test-endpoint-bypass": "preview-secret",
+        },
+      });
+
+      expect(denied.status).toBe(404);
+      await expect(denied.text()).resolves.toBe("Not found");
+      expect(allowed.status).toBe(200);
+    });
+
+    it("rejects requests without a form body", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(DEVICE_AUTHORIZATION_ROUTE, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_request",
+        error_description: "expected form body",
+      });
+    });
+
+    it("rejects an invalid client_id", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        DEVICE_AUTHORIZATION_ROUTE,
+        tokenRequest({
+          client_id: "wrong",
+          scope: "read",
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_client",
       });
     });
   });
@@ -389,6 +501,10 @@ describe("/api/test/oauth-provider/*", () => {
         }),
       );
       const first = await readJson<TokenBody>(firstResponse);
+      const refreshToken = first.refresh_token;
+      if (!refreshToken) {
+        throw new Error("Expected refresh token");
+      }
 
       const response = await requestApp(
         TOKEN_ROUTE,
@@ -396,7 +512,7 @@ describe("/api/test/oauth-provider/*", () => {
           grant_type: "refresh_token",
           client_id: "test-oauth-client",
           client_secret: "test-oauth-secret",
-          refresh_token: first.refresh_token,
+          refresh_token: refreshToken,
         }),
       );
 
@@ -517,6 +633,101 @@ describe("/api/test/oauth-provider/*", () => {
       expect(response.status).toBe(400);
       await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
         error: "unsupported_grant_type",
+      });
+    });
+  });
+
+  describe("token device_code", () => {
+    it("exchanges a valid device code for an access token", async () => {
+      mockEnv("ENV", "development");
+
+      const device = await requestApp(
+        DEVICE_AUTHORIZATION_ROUTE,
+        tokenRequest({
+          client_id: "test-oauth-device-client",
+          scope: "read",
+        }),
+      );
+      const deviceBody = await readJson<DeviceAuthorizationBody>(device);
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "test-oauth-device-client",
+          device_code: deviceBody.device_code,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(readJson<TokenBody>(response)).resolves.toStrictEqual({
+        access_token:
+          "test-device-access:test-oauth-device-client:test-device:test-oauth-device-client:read",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read",
+      });
+    });
+
+    it("returns standard pending and terminal device-code errors", async () => {
+      mockEnv("ENV", "development");
+
+      const pending = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "test-oauth-device-client",
+          device_code: "pending",
+        }),
+      );
+      const denied = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "test-oauth-device-client",
+          device_code: "denied",
+        }),
+      );
+
+      expect(pending.status).toBe(400);
+      await expect(readJson<ErrorBody>(pending)).resolves.toStrictEqual({
+        error: "authorization_pending",
+      });
+      expect(denied.status).toBe(400);
+      await expect(readJson<ErrorBody>(denied)).resolves.toStrictEqual({
+        error: "access_denied",
+        error_description: "User denied the device authorization request",
+      });
+    });
+
+    it("rejects invalid device grant requests", async () => {
+      mockEnv("ENV", "development");
+
+      const invalidClient = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "wrong",
+          device_code: "test-device:test-oauth-device-client:read",
+        }),
+      );
+      const missingDeviceCode = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "test-oauth-device-client",
+        }),
+      );
+
+      expect(invalidClient.status).toBe(401);
+      await expect(readJson<ErrorBody>(invalidClient)).resolves.toStrictEqual({
+        error: "invalid_client",
+      });
+      expect(missingDeviceCode.status).toBe(400);
+      await expect(
+        readJson<ErrorBody>(missingDeviceCode),
+      ).resolves.toStrictEqual({
+        error: "invalid_request",
+        error_description: "device_code required",
       });
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -717,6 +717,14 @@ describe("/api/test/oauth-provider/*", () => {
           client_id: "test-oauth-device-client",
         }),
       );
+      const unknownDeviceCode = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "test-oauth-device-client",
+          device_code: "not-issued",
+        }),
+      );
 
       expect(invalidClient.status).toBe(401);
       await expect(readJson<ErrorBody>(invalidClient)).resolves.toStrictEqual({
@@ -728,6 +736,13 @@ describe("/api/test/oauth-provider/*", () => {
       ).resolves.toStrictEqual({
         error: "invalid_request",
         error_description: "device_code required",
+      });
+      expect(unknownDeviceCode.status).toBe(400);
+      await expect(
+        readJson<ErrorBody>(unknownDeviceCode),
+      ).resolves.toStrictEqual({
+        error: "invalid_grant",
+        error_description: "unknown device_code",
       });
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -261,7 +261,7 @@ describe("/api/test/oauth-provider/*", () => {
         verification_uri_complete:
           "https://oauth-device.test/device?user_code=TEST-DEVICE",
         expires_in: 600,
-        interval: 5,
+        interval: 0,
       });
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
@@ -148,6 +148,15 @@ function mockTestOAuthDeviceProvider(): void {
           { status: 400 },
         );
       }
+      if (!deviceCode?.startsWith("test-device:test-oauth-device-client:")) {
+        return HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "Unknown device authorization code",
+          },
+          { status: 400 },
+        );
+      }
 
       return HttpResponse.json({
         access_token: `test-device-access:${body.get("client_id")}:${deviceCode}`,
@@ -593,6 +602,14 @@ describe("OAuth device authorization connector routes", () => {
           status: "error",
           errorCode: "invalid_request",
           errorMessage: "Synthetic device authorization error",
+        },
+      },
+      {
+        deviceCode: "not-issued",
+        expected: {
+          status: "error",
+          errorCode: "invalid_grant",
+          errorMessage: "Unknown device authorization code",
         },
       },
     ] as const;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
@@ -99,7 +99,7 @@ function mockTestOAuthDeviceProvider(): void {
         verification_uri_complete:
           "https://oauth-device.test/device?user_code=TEST-DEVICE",
         expires_in: 600,
-        interval: 5,
+        interval: 0,
       });
     }),
     http.post(TEST_OAUTH_TOKEN_URL, async ({ request }) => {
@@ -279,7 +279,7 @@ describe("OAuth device authorization connector routes", () => {
       verificationUriComplete:
         "https://oauth-device.test/device?user_code=TEST-DEVICE",
       expiresIn: 600,
-      interval: 5,
+      interval: 0,
     });
     expect(JSON.stringify(response.body)).not.toContain("test-device:");
 
@@ -522,7 +522,6 @@ describe("OAuth device authorization connector routes", () => {
       }),
       [200],
     );
-    await makeSessionPollable(start.body.sessionId);
     testOauthDeviceProvider.pollDeviceAuthorization = async (args) => {
       const result = await originalPollDeviceAuthorization(args);
       if (result.status !== "complete") {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
@@ -9,10 +9,12 @@ import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { nowDate } from "../../../lib/time";
+import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import {
   decryptSecretValue,
@@ -26,6 +28,11 @@ const mocks = createZeroRouteMocks(context);
 const testOauthDeviceProvider = CONNECTOR_OAUTH_PROVIDERS["test-oauth-device"];
 const originalPollDeviceAuthorization =
   testOauthDeviceProvider.pollDeviceAuthorization;
+const TEST_OAUTH_DEVICE_CODE_URL =
+  "http://localhost:3000/api/test/oauth-provider/device/code";
+const TEST_OAUTH_TOKEN_URL =
+  "http://localhost:3000/api/test/oauth-provider/token";
+const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 function sessionTokenHash(sessionToken: string): string {
   return createHash("sha256").update(sessionToken).digest("hex");
@@ -77,6 +84,77 @@ function encryptedProviderState(deviceCode: string): string {
     JSON.stringify({
       connectorType: "test-oauth-device",
       deviceCode,
+    }),
+  );
+}
+
+function mockTestOAuthDeviceProvider(): void {
+  server.use(
+    http.post(TEST_OAUTH_DEVICE_CODE_URL, async ({ request }) => {
+      const body = new URLSearchParams(await request.text());
+      return HttpResponse.json({
+        device_code: `test-device:${body.get("client_id")}:${body.get("scope")}`,
+        user_code: "TEST-DEVICE",
+        verification_uri: "https://oauth-device.test/device",
+        verification_uri_complete:
+          "https://oauth-device.test/device?user_code=TEST-DEVICE",
+        expires_in: 600,
+        interval: 5,
+      });
+    }),
+    http.post(TEST_OAUTH_TOKEN_URL, async ({ request }) => {
+      const body = new URLSearchParams(await request.text());
+      if (body.get("grant_type") !== DEVICE_CODE_GRANT_TYPE) {
+        return HttpResponse.json(
+          { error: "unsupported_grant_type" },
+          { status: 400 },
+        );
+      }
+
+      const deviceCode = body.get("device_code");
+      if (deviceCode === "pending") {
+        return HttpResponse.json(
+          { error: "authorization_pending" },
+          { status: 400 },
+        );
+      }
+      if (deviceCode === "slow-down") {
+        return HttpResponse.json({ error: "slow_down" }, { status: 400 });
+      }
+      if (deviceCode === "denied") {
+        return HttpResponse.json(
+          {
+            error: "access_denied",
+            error_description: "User denied the device authorization request",
+          },
+          { status: 400 },
+        );
+      }
+      if (deviceCode === "expired") {
+        return HttpResponse.json(
+          {
+            error: "expired_token",
+            error_description: "Device authorization expired",
+          },
+          { status: 400 },
+        );
+      }
+      if (deviceCode === "error") {
+        return HttpResponse.json(
+          {
+            error: "invalid_request",
+            error_description: "Synthetic device authorization error",
+          },
+          { status: 400 },
+        );
+      }
+
+      return HttpResponse.json({
+        access_token: `test-device-access:${body.get("client_id")}:${deviceCode}`,
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read",
+      });
     }),
   );
 }
@@ -169,6 +247,7 @@ describe("OAuth device authorization connector routes", () => {
   });
 
   async function setupUser() {
+    mockTestOAuthDeviceProvider();
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     users.push({ userId, orgId });

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
@@ -1,0 +1,74 @@
+import { command } from "ccstate";
+import { testOAuthProviderDeviceAuthorizationContract } from "@vm0/api-contracts/contracts/test-oauth-provider-device-authorization";
+
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route";
+import {
+  isTestEndpointAllowed,
+  TEST_OAUTH_DEVICE_CLIENT_ID,
+  TEST_OAUTH_DEVICE_USER_CODE,
+  TEST_OAUTH_DEVICE_VERIFICATION_URI,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const DEFAULT_EXPIRES_IN = 600;
+const DEFAULT_INTERVAL = 5;
+
+function errorResponse(
+  status: 400 | 401,
+  error: string,
+  errorDescription?: string,
+) {
+  return {
+    status,
+    body: errorDescription
+      ? { error, error_description: errorDescription }
+      : { error },
+  };
+}
+
+const deviceAuthorization$ = command(async ({ get }, signal: AbortSignal) => {
+  const request = get(request$);
+  const contentType = request.header("content-type") ?? "";
+  if (!contentType.includes("application/x-www-form-urlencoded")) {
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+    return errorResponse(400, "invalid_request", "expected form body");
+  }
+
+  const text = await request.text();
+  signal.throwIfAborted();
+
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const body = new URLSearchParams(text);
+  const clientId = body.get("client_id");
+  if (clientId !== TEST_OAUTH_DEVICE_CLIENT_ID) {
+    return errorResponse(401, "invalid_client");
+  }
+
+  const scope = body.get("scope") ?? "";
+  const deviceCode = `test-device:${clientId}:${scope}`;
+  return {
+    status: 200 as const,
+    body: {
+      device_code: deviceCode,
+      user_code: TEST_OAUTH_DEVICE_USER_CODE,
+      verification_uri: TEST_OAUTH_DEVICE_VERIFICATION_URI,
+      verification_uri_complete: `${TEST_OAUTH_DEVICE_VERIFICATION_URI}?user_code=${TEST_OAUTH_DEVICE_USER_CODE}`,
+      expires_in: DEFAULT_EXPIRES_IN,
+      interval: DEFAULT_INTERVAL,
+    },
+  };
+});
+
+export const testOAuthProviderDeviceAuthorizationRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: testOAuthProviderDeviceAuthorizationContract.deviceAuthorization,
+      handler: deviceAuthorization$,
+    },
+  ];

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
@@ -29,20 +29,17 @@ function errorResponse(
 
 const deviceAuthorization$ = command(async ({ get }, signal: AbortSignal) => {
   const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
   const contentType = request.header("content-type") ?? "";
   if (!contentType.includes("application/x-www-form-urlencoded")) {
-    if (!isTestEndpointAllowed(request)) {
-      return testEndpointNotFoundResponse();
-    }
     return errorResponse(400, "invalid_request", "expected form body");
   }
 
   const text = await request.text();
   signal.throwIfAborted();
-
-  if (!isTestEndpointAllowed(request)) {
-    return testEndpointNotFoundResponse();
-  }
 
   const body = new URLSearchParams(text);
   const clientId = body.get("client_id");

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
@@ -12,7 +12,7 @@ import {
 } from "./test-oauth-provider-helpers";
 
 const DEFAULT_EXPIRES_IN = 600;
-const DEFAULT_INTERVAL = 5;
+const DEFAULT_INTERVAL = 0;
 
 function errorResponse(
   status: 400 | 401,

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
@@ -5,6 +5,10 @@ import { now } from "../../lib/time";
 
 export const TEST_OAUTH_CLIENT_ID = "test-oauth-client";
 export const TEST_OAUTH_CLIENT_SECRET = "test-oauth-secret";
+export const TEST_OAUTH_DEVICE_CLIENT_ID = "test-oauth-device-client";
+export const TEST_OAUTH_DEVICE_USER_CODE = "TEST-DEVICE";
+export const TEST_OAUTH_DEVICE_VERIFICATION_URI =
+  "https://oauth-device.test/device";
 
 const TEST_OAUTH_SCENARIOS = [
   "success",

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
@@ -133,6 +133,9 @@ function handleDeviceCode(body: URLSearchParams) {
   if (error) {
     return error;
   }
+  if (!deviceCode.startsWith(`test-device:${clientId}:`)) {
+    return errorResponse(400, "invalid_grant", "unknown device_code");
+  }
 
   return {
     status: 200 as const,
@@ -159,9 +162,14 @@ function isPreviewSyntheticRefreshRequest(body: URLSearchParams): boolean {
 
 const token$ = command(async ({ get }, signal: AbortSignal) => {
   const request = get(request$);
+  const testEndpointAllowed = isTestEndpointAllowed(request);
+  if (!testEndpointAllowed && env("ENV") !== "preview") {
+    return testEndpointNotFoundResponse();
+  }
+
   const contentType = request.header("content-type") ?? "";
   if (!contentType.includes("application/x-www-form-urlencoded")) {
-    if (!isTestEndpointAllowed(request)) {
+    if (!testEndpointAllowed) {
       return testEndpointNotFoundResponse();
     }
     return errorResponse(400, "invalid_request", "expected form body");
@@ -171,10 +179,7 @@ const token$ = command(async ({ get }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
   const body = new URLSearchParams(text);
-  if (
-    !isTestEndpointAllowed(request) &&
-    !isPreviewSyntheticRefreshRequest(body)
-  ) {
+  if (!testEndpointAllowed && !isPreviewSyntheticRefreshRequest(body)) {
     return testEndpointNotFoundResponse();
   }
 

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
@@ -16,11 +16,13 @@ import {
   parseScenarioFromRefreshToken,
   TEST_OAUTH_CLIENT_ID,
   TEST_OAUTH_CLIENT_SECRET,
+  TEST_OAUTH_DEVICE_CLIENT_ID,
   testEndpointNotFoundResponse,
   type TestOAuthScenario,
 } from "./test-oauth-provider-helpers";
 
 const DEFAULT_EXPIRES_IN = 3600;
+const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 function mintTokensForScenario(
   scenario: TestOAuthScenario,
@@ -87,6 +89,62 @@ function handleRefreshToken(refreshToken: string | null) {
   return { status: 200 as const, body: mintTokensForScenario(resolved) };
 }
 
+function deviceGrantErrorForDeviceCode(
+  deviceCode: string,
+): ReturnType<typeof errorResponse> | null {
+  if (deviceCode === "pending") {
+    return errorResponse(400, "authorization_pending");
+  }
+  if (deviceCode === "slow-down") {
+    return errorResponse(400, "slow_down");
+  }
+  if (deviceCode === "denied") {
+    return errorResponse(
+      400,
+      "access_denied",
+      "User denied the device authorization request",
+    );
+  }
+  if (deviceCode === "expired") {
+    return errorResponse(400, "expired_token", "Device authorization expired");
+  }
+  if (deviceCode === "error") {
+    return errorResponse(
+      400,
+      "invalid_request",
+      "Synthetic device authorization error",
+    );
+  }
+  return null;
+}
+
+function handleDeviceCode(body: URLSearchParams) {
+  const clientId = body.get("client_id");
+  if (clientId !== TEST_OAUTH_DEVICE_CLIENT_ID) {
+    return errorResponse(401, "invalid_client");
+  }
+
+  const deviceCode = body.get("device_code");
+  if (!deviceCode) {
+    return errorResponse(400, "invalid_request", "device_code required");
+  }
+
+  const error = deviceGrantErrorForDeviceCode(deviceCode);
+  if (error) {
+    return error;
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      access_token: `test-device-access:${clientId}:${deviceCode}`,
+      token_type: "Bearer" as const,
+      expires_in: DEFAULT_EXPIRES_IN,
+      scope: "read",
+    },
+  };
+}
+
 function isPreviewSyntheticRefreshRequest(body: URLSearchParams): boolean {
   if (env("ENV") !== "preview") {
     return false;
@@ -121,6 +179,10 @@ const token$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const grantType = body.get("grant_type");
+  if (grantType === DEVICE_CODE_GRANT_TYPE) {
+    return handleDeviceCode(body);
+  }
+
   const clientId = body.get("client_id");
   const clientSecret = body.get("client_secret");
 

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-authorization.service.ts
@@ -740,6 +740,8 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
           verificationUri: startResult.verificationUri,
           verificationUriComplete: startResult.verificationUriComplete,
           intervalSeconds,
+          createdAt: now,
+          updatedAt: now,
           expiresAt,
         })
         .returning({

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -254,6 +254,23 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
+  it("matches the test OAuth provider device code rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath("/api/test/oauth-provider/device/code"),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/oauth-provider/device/code/extra",
+      ),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath("/api/test/oauth-provider/device"),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/test/oauth-provider")).toBe(
+      false,
+    );
+  });
+
   it("matches the test OAuth provider echo rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/test/oauth-provider/echo")).toBe(
       true,

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -334,6 +334,15 @@ const TEST_OAUTH_PROVIDER_AUTHORIZE_PROXY_NEGATIVE_PATHS = [
   "/api/test/oauth-provider",
   "/api/test/oauth-provider/profile",
 ] as const;
+const TEST_OAUTH_PROVIDER_DEVICE_CODE_REWRITE_SOURCE =
+  "/api/test/oauth-provider/device/code";
+const TEST_OAUTH_PROVIDER_DEVICE_CODE_PATH =
+  "/api/test/oauth-provider/device/code";
+const TEST_OAUTH_PROVIDER_DEVICE_CODE_PROXY_NEGATIVE_PATHS = [
+  "/api/test/oauth-provider/device/code/extra",
+  "/api/test/oauth-provider/device",
+  "/api/test/oauth-provider",
+] as const;
 const TEST_OAUTH_PROVIDER_ECHO_REWRITE_SOURCE = "/api/test/oauth-provider/echo";
 const TEST_OAUTH_PROVIDER_ECHO_PATH = "/api/test/oauth-provider/echo";
 const TEST_OAUTH_PROVIDER_ECHO_PROXY_NEGATIVE_PATHS = [
@@ -2042,6 +2051,11 @@ describe("API backend rewrites", () => {
           source: TEST_OAUTH_PROVIDER_AUTHORIZE_REWRITE_SOURCE,
           destination:
             "https://api.example.test/api/test/oauth-provider/authorize",
+        },
+        {
+          source: TEST_OAUTH_PROVIDER_DEVICE_CODE_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/test/oauth-provider/device/code",
         },
         {
           source: TEST_OAUTH_PROVIDER_ECHO_REWRITE_SOURCE,
@@ -8018,6 +8032,15 @@ describe("API backend rewrites", () => {
       matchesApiBackendRewritePath(TEST_OAUTH_PROVIDER_AUTHORIZE_PATH),
     ).toBe(true);
     for (const pathname of TEST_OAUTH_PROVIDER_AUTHORIZE_PROXY_NEGATIVE_PATHS) {
+      expect(matchesApiBackendRewritePath(pathname)).toBe(false);
+    }
+  });
+
+  it("should bypass web middleware only for the exact test OAuth provider device code path", () => {
+    expect(
+      matchesApiBackendRewritePath(TEST_OAUTH_PROVIDER_DEVICE_CODE_PATH),
+    ).toBe(true);
+    for (const pathname of TEST_OAUTH_PROVIDER_DEVICE_CODE_PROXY_NEGATIVE_PATHS) {
       expect(matchesApiBackendRewritePath(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -575,6 +575,10 @@ export const API_BACKEND_REWRITES = [
   ],
   ["/api/internal/vercel-sandbox/smoke", "/api/internal/vercel-sandbox/smoke"],
   ["/api/test/oauth-provider/authorize", "/api/test/oauth-provider/authorize"],
+  [
+    "/api/test/oauth-provider/device/code",
+    "/api/test/oauth-provider/device/code",
+  ],
   ["/api/test/oauth-provider/echo", "/api/test/oauth-provider/echo"],
   ["/api/test/oauth-provider/token", "/api/test/oauth-provider/token"],
   ["/api/test/oauth-provider/userinfo", "/api/test/oauth-provider/userinfo"],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -320,6 +320,13 @@ export {
   type TestOAuthProviderTokenResponse,
 } from "./test-oauth-provider-token";
 export {
+  testOAuthProviderDeviceAuthorizationContract,
+  testOAuthProviderDeviceAuthorizationErrorSchema,
+  testOAuthProviderDeviceAuthorizationResponseSchema,
+  type TestOAuthProviderDeviceAuthorizationContract,
+  type TestOAuthProviderDeviceAuthorizationResponse,
+} from "./test-oauth-provider-device-authorization";
+export {
   testOAuthProviderUserinfoContract,
   testOAuthProviderUserinfoErrorSchema,
   testOAuthProviderUserinfoResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-device-authorization.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-device-authorization.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testOAuthProviderDeviceAuthorizationErrorSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+});
+
+export const testOAuthProviderDeviceAuthorizationResponseSchema = z.object({
+  device_code: z.string(),
+  user_code: z.string(),
+  verification_uri: z.string(),
+  verification_uri_complete: z.string(),
+  expires_in: z.number(),
+  interval: z.number(),
+});
+
+export const testOAuthProviderDeviceAuthorizationContract = c.router({
+  deviceAuthorization: {
+    method: "POST",
+    path: "/api/test/oauth-provider/device/code",
+    body: c.type<string>(),
+    responses: {
+      200: testOAuthProviderDeviceAuthorizationResponseSchema,
+      400: testOAuthProviderDeviceAuthorizationErrorSchema,
+      401: testOAuthProviderDeviceAuthorizationErrorSchema,
+      404: z.string(),
+    },
+    summary:
+      "Synthetic OAuth device authorization endpoint for test connector flows",
+  },
+});
+
+export type TestOAuthProviderDeviceAuthorizationContract =
+  typeof testOAuthProviderDeviceAuthorizationContract;
+export type TestOAuthProviderDeviceAuthorizationResponse = z.infer<
+  typeof testOAuthProviderDeviceAuthorizationResponseSchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-token.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-token.ts
@@ -11,7 +11,7 @@ export const testOAuthProviderTokenErrorSchema = z.object({
 
 export const testOAuthProviderTokenResponseSchema = z.object({
   access_token: z.string(),
-  refresh_token: z.string(),
+  refresh_token: z.string().nullable().optional(),
   token_type: z.literal("Bearer"),
   expires_in: z.number(),
   scope: z.string(),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -265,7 +265,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
             verification_uri_complete:
               "https://oauth-device.test/device?user_code=TEST-DEVICE",
             expires_in: 600,
-            interval: 5,
+            interval: 0,
           });
         }
 
@@ -346,7 +346,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         verificationUriComplete:
           "https://oauth-device.test/device?user_code=TEST-DEVICE",
         expiresIn: 600,
-        interval: 5,
+        interval: 0,
       });
 
       await expect(

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -308,6 +308,17 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
               { status: 400 },
             );
           }
+          if (
+            !deviceCode?.startsWith(`test-device:${body.get("client_id")}:`)
+          ) {
+            return Response.json(
+              {
+                error: "invalid_grant",
+                error_description: "Unknown device authorization code",
+              },
+              { status: 400 },
+            );
+          }
 
           return Response.json({
             access_token: `test-device-access:${body.get("client_id")}:${deviceCode}`,
@@ -395,6 +406,17 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         status: "error",
         error: "invalid_request",
         errorDescription: "Synthetic device authorization error",
+      });
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: "invalid-grant",
+        }),
+      ).resolves.toStrictEqual({
+        status: "error",
+        error: "invalid_grant",
+        errorDescription: "Unknown device authorization code",
       });
       await expect(
         pollConnectorOAuthDeviceAuthorization({

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
@@ -252,99 +252,174 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
   });
 
   it("starts and polls the test OAuth device provider", async () => {
-    const credentials = getConnectorOAuthCredentials(
-      "test-oauth-device",
-      () => {
-        return undefined;
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init: RequestInit | undefined) => {
+        const url = input.toString();
+        const body = new URLSearchParams(String(init?.body ?? ""));
+
+        if (url.endsWith("/api/test/oauth-provider/device/code")) {
+          return Response.json({
+            device_code: `test-device:${body.get("client_id")}:${body.get("scope")}`,
+            user_code: "TEST-DEVICE",
+            verification_uri: "https://oauth-device.test/device",
+            verification_uri_complete:
+              "https://oauth-device.test/device?user_code=TEST-DEVICE",
+            expires_in: 600,
+            interval: 5,
+          });
+        }
+
+        if (url.endsWith("/api/test/oauth-provider/token")) {
+          const deviceCode = body.get("device_code");
+          if (deviceCode === "pending") {
+            return Response.json(
+              { error: "authorization_pending" },
+              { status: 400 },
+            );
+          }
+          if (deviceCode === "slow-down") {
+            return Response.json({ error: "slow_down" }, { status: 400 });
+          }
+          if (deviceCode === "denied") {
+            return Response.json(
+              {
+                error: "access_denied",
+                error_description:
+                  "User denied the device authorization request",
+              },
+              { status: 400 },
+            );
+          }
+          if (deviceCode === "expired") {
+            return Response.json(
+              {
+                error: "expired_token",
+                error_description: "Device authorization expired",
+              },
+              { status: 400 },
+            );
+          }
+          if (deviceCode === "error") {
+            return Response.json(
+              {
+                error: "invalid_request",
+                error_description: "Synthetic device authorization error",
+              },
+              { status: 400 },
+            );
+          }
+
+          return Response.json({
+            access_token: `test-device-access:${body.get("client_id")}:${deviceCode}`,
+            token_type: "Bearer",
+            expires_in: 3600,
+            scope: "read",
+          });
+        }
+
+        throw new Error(`Unexpected test OAuth device request: ${url}`);
       },
     );
-    expect(credentials?.configured).toBe(true);
+    vi.stubGlobal("fetch", fetchMock);
 
-    if (!credentials?.configured) {
-      throw new Error("Expected test-oauth-device OAuth credentials");
-    }
-
-    const startResult = await startConnectorOAuthDeviceAuthorization({
-      type: "test-oauth-device",
-      credentials,
-    });
-    expect(startResult).toStrictEqual({
-      deviceCode: "test-device:test-oauth-device-client:read",
-      userCode: "TEST-DEVICE",
-      verificationUri: "https://oauth-device.test/device",
-      verificationUriComplete:
-        "https://oauth-device.test/device?user_code=TEST-DEVICE",
-      expiresIn: 600,
-      interval: 5,
-    });
-
-    await expect(
-      pollConnectorOAuthDeviceAuthorization({
-        type: "test-oauth-device",
-        credentials,
-        deviceCode: "pending",
-      }),
-    ).resolves.toStrictEqual({ status: "pending" });
-    await expect(
-      pollConnectorOAuthDeviceAuthorization({
-        type: "test-oauth-device",
-        credentials,
-        deviceCode: "slow-down",
-      }),
-    ).resolves.toStrictEqual({ status: "slow_down" });
-    await expect(
-      pollConnectorOAuthDeviceAuthorization({
-        type: "test-oauth-device",
-        credentials,
-        deviceCode: "denied",
-      }),
-    ).resolves.toStrictEqual({
-      status: "denied",
-      error: "access_denied",
-      errorDescription: "User denied the device authorization request",
-    });
-    await expect(
-      pollConnectorOAuthDeviceAuthorization({
-        type: "test-oauth-device",
-        credentials,
-        deviceCode: "expired",
-      }),
-    ).resolves.toStrictEqual({
-      status: "expired",
-      error: "expired_token",
-      errorDescription: "Device authorization expired",
-    });
-    await expect(
-      pollConnectorOAuthDeviceAuthorization({
-        type: "test-oauth-device",
-        credentials,
-        deviceCode: "error",
-      }),
-    ).resolves.toStrictEqual({
-      status: "error",
-      error: "invalid_request",
-      errorDescription: "Synthetic device authorization error",
-    });
-    await expect(
-      pollConnectorOAuthDeviceAuthorization({
-        type: "test-oauth-device",
-        credentials,
-        deviceCode: startResult.deviceCode,
-      }),
-    ).resolves.toStrictEqual({
-      status: "complete",
-      token: {
-        accessToken:
-          "test-device-access:test-oauth-device-client:test-device:test-oauth-device-client:read",
-        refreshToken: null,
-        scopes: ["read"],
-        userInfo: {
-          id: "test-oauth-device-user",
-          username: "test-oauth-device-user",
-          email: "test-oauth-device@example.com",
+    try {
+      const credentials = getConnectorOAuthCredentials(
+        "test-oauth-device",
+        () => {
+          return undefined;
         },
-      },
-    });
+      );
+      expect(credentials?.configured).toBe(true);
+
+      if (!credentials?.configured) {
+        throw new Error("Expected test-oauth-device OAuth credentials");
+      }
+
+      const startResult = await startConnectorOAuthDeviceAuthorization({
+        type: "test-oauth-device",
+        credentials,
+      });
+      expect(startResult).toStrictEqual({
+        deviceCode: "test-device:test-oauth-device-client:read",
+        userCode: "TEST-DEVICE",
+        verificationUri: "https://oauth-device.test/device",
+        verificationUriComplete:
+          "https://oauth-device.test/device?user_code=TEST-DEVICE",
+        expiresIn: 600,
+        interval: 5,
+      });
+
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: "pending",
+        }),
+      ).resolves.toStrictEqual({ status: "pending" });
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: "slow-down",
+        }),
+      ).resolves.toStrictEqual({ status: "slow_down" });
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: "denied",
+        }),
+      ).resolves.toStrictEqual({
+        status: "denied",
+        error: "access_denied",
+        errorDescription: "User denied the device authorization request",
+      });
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: "expired",
+        }),
+      ).resolves.toStrictEqual({
+        status: "expired",
+        error: "expired_token",
+        errorDescription: "Device authorization expired",
+      });
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: "error",
+        }),
+      ).resolves.toStrictEqual({
+        status: "error",
+        error: "invalid_request",
+        errorDescription: "Synthetic device authorization error",
+      });
+      await expect(
+        pollConnectorOAuthDeviceAuthorization({
+          type: "test-oauth-device",
+          credentials,
+          deviceCode: startResult.deviceCode,
+        }),
+      ).resolves.toStrictEqual({
+        status: "complete",
+        token: {
+          accessToken:
+            "test-device-access:test-oauth-device-client:test-device:test-oauth-device-client:read",
+          expiresIn: 3600,
+          refreshToken: null,
+          scopes: ["read"],
+          userInfo: {
+            id: "test-oauth-device-user",
+            username: "test-oauth-device-user",
+            email: "test-oauth-device@example.com",
+          },
+        },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 
@@ -909,8 +984,8 @@ describe("connector OAuth device authorization config", () => {
       getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device"),
     ).toMatchObject({
       flow: "device-authorization",
-      deviceAuthorizationUrl: "https://oauth-device.test/device/code",
-      tokenUrl: "https://oauth-device.test/token",
+      deviceAuthorizationUrl: "/api/test/oauth-provider/device/code",
+      tokenUrl: "/api/test/oauth-provider/token",
       client: {
         clientRegistration: "static",
         clientType: "public",

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -26,8 +26,11 @@ export const testOauthDevice = {
     defaultAuthMethod: "oauth",
     oauth: {
       flow: "device-authorization",
-      deviceAuthorizationUrl: "https://oauth-device.test/device/code",
-      tokenUrl: "https://oauth-device.test/token",
+      // Relative paths — the provider resolves them against the concrete
+      // app/API URL because the fake provider lives inside this same app and
+      // the preview URL host changes per deploy.
+      deviceAuthorizationUrl: "/api/test/oauth-provider/device/code",
+      tokenUrl: "/api/test/oauth-provider/token",
       client: {
         clientRegistration: "static",
         clientType: "public",

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
@@ -1,7 +1,9 @@
 import { defineConnectorOAuthProvider } from "../provider-types";
-
-export const TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME =
-  "TEST_OAUTH_DEVICE_ACCESS_TOKEN";
+import {
+  pollTestOAuthDeviceAuthorization,
+  startTestOAuthDeviceAuthorization,
+  TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
+} from "./test-oauth-device";
 
 export const testOauthDeviceProvider = defineConnectorOAuthProvider(
   "test-oauth-device",
@@ -10,61 +12,18 @@ export const testOauthDeviceProvider = defineConnectorOAuthProvider(
       return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
     },
     startDeviceAuthorization: async (args) => {
-      return {
-        deviceCode: `test-device:${args.clientId}:${args.scopes.join(",")}`,
-        userCode: "TEST-DEVICE",
-        verificationUri: "https://oauth-device.test/device",
-        verificationUriComplete:
-          "https://oauth-device.test/device?user_code=TEST-DEVICE",
-        expiresIn: 600,
-        interval: 5,
-      };
+      const { clientId } = args;
+      return await startTestOAuthDeviceAuthorization({
+        clientId,
+        scopes: args.scopes,
+      });
     },
     pollDeviceAuthorization: async (args) => {
-      switch (args.deviceCode) {
-        case "pending": {
-          return { status: "pending" };
-        }
-        case "slow-down": {
-          return { status: "slow_down" };
-        }
-        case "denied": {
-          return {
-            status: "denied",
-            error: "access_denied",
-            errorDescription: "User denied the device authorization request",
-          };
-        }
-        case "expired": {
-          return {
-            status: "expired",
-            error: "expired_token",
-            errorDescription: "Device authorization expired",
-          };
-        }
-        case "error": {
-          return {
-            status: "error",
-            error: "invalid_request",
-            errorDescription: "Synthetic device authorization error",
-          };
-        }
-        default: {
-          return {
-            status: "complete",
-            token: {
-              accessToken: `test-device-access:${args.clientId}:${args.deviceCode}`,
-              refreshToken: null,
-              scopes: ["read"],
-              userInfo: {
-                id: "test-oauth-device-user",
-                username: "test-oauth-device-user",
-                email: "test-oauth-device@example.com",
-              },
-            },
-          };
-        }
-      }
+      const { clientId } = args;
+      return await pollTestOAuthDeviceAuthorization({
+        clientId,
+        deviceCode: args.deviceCode,
+      });
     },
   },
 );

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device.ts
@@ -1,0 +1,182 @@
+import { getConnectorOAuthDeviceAuthorizationConfig } from "@vm0/connectors/connector-utils";
+import { z } from "zod";
+
+import type {
+  OAuthDeviceAuthorizationPollResult,
+  OAuthDeviceAuthorizationStartResult,
+} from "../provider-types";
+import { throwOAuthError } from "./oauth-error";
+import {
+  resolveTestOAuthProviderUrl,
+  testOAuthPreviewBypassHeaders,
+} from "./test-oauth";
+
+export const TEST_OAUTH_DEVICE_CLIENT_ID = "test-oauth-device-client";
+export const TEST_OAUTH_DEVICE_USER_CODE = "TEST-DEVICE";
+export const TEST_OAUTH_DEVICE_VERIFICATION_URI =
+  "https://oauth-device.test/device";
+export const TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME =
+  "TEST_OAUTH_DEVICE_ACCESS_TOKEN";
+
+const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+const deviceAuthorizationResponseSchema = z.object({
+  device_code: z.string(),
+  user_code: z.string(),
+  verification_uri: z.string(),
+  verification_uri_complete: z.string().optional(),
+  expires_in: z.number(),
+  interval: z.number().optional(),
+});
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().nullable().optional(),
+  expires_in: z.number().optional(),
+  token_type: z.string().optional(),
+  scope: z.string().optional(),
+});
+
+const tokenErrorResponseSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+});
+
+function getDeviceAuthorizationUrl(): string {
+  return resolveTestOAuthProviderUrl(
+    "deviceAuthorizationUrl",
+    getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device")
+      .deviceAuthorizationUrl,
+  );
+}
+
+function getDeviceTokenUrl(): string {
+  return resolveTestOAuthProviderUrl(
+    "tokenUrl",
+    getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device").tokenUrl,
+  );
+}
+
+export async function startTestOAuthDeviceAuthorization(args: {
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+}): Promise<OAuthDeviceAuthorizationStartResult> {
+  const response = await fetch(getDeviceAuthorizationUrl(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...testOAuthPreviewBypassHeaders(),
+    },
+    body: new URLSearchParams({
+      client_id: args.clientId,
+      scope: args.scopes.join(" "),
+    }),
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("TestOAuthDevice", "start", response);
+  }
+
+  const data = deviceAuthorizationResponseSchema.parse(await response.json());
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    verificationUriComplete: data.verification_uri_complete,
+    expiresIn: data.expires_in,
+    interval: data.interval,
+  };
+}
+
+function devicePollErrorResult(args: {
+  readonly error: string;
+  readonly errorDescription: string | undefined;
+}): OAuthDeviceAuthorizationPollResult | null {
+  if (args.error === "authorization_pending") {
+    return { status: "pending" };
+  }
+  if (args.error === "slow_down") {
+    return { status: "slow_down" };
+  }
+  if (args.error === "access_denied") {
+    return {
+      status: "denied",
+      error: args.error,
+      errorDescription: args.errorDescription,
+    };
+  }
+  if (args.error === "expired_token") {
+    return {
+      status: "expired",
+      error: args.error,
+      errorDescription: args.errorDescription,
+    };
+  }
+  if (args.error === "invalid_request") {
+    return {
+      status: "error",
+      error: args.error,
+      errorDescription: args.errorDescription,
+    };
+  }
+  return null;
+}
+
+export async function pollTestOAuthDeviceAuthorization(args: {
+  readonly clientId: string;
+  readonly deviceCode: string;
+}): Promise<OAuthDeviceAuthorizationPollResult> {
+  const response = await fetch(getDeviceTokenUrl(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...testOAuthPreviewBypassHeaders(),
+    },
+    body: new URLSearchParams({
+      grant_type: DEVICE_CODE_GRANT_TYPE,
+      client_id: args.clientId,
+      device_code: args.deviceCode,
+    }),
+  });
+
+  if (!response.ok) {
+    const diagnosticResponse = response.clone();
+    const errorParse = tokenErrorResponseSchema.safeParse(
+      await response.json().catch(() => {
+        return null;
+      }),
+    );
+    if (!errorParse.success) {
+      return await throwOAuthError(
+        "TestOAuthDevice",
+        "poll",
+        diagnosticResponse,
+      );
+    }
+    const errorData = errorParse.data;
+    const result = devicePollErrorResult({
+      error: errorData.error,
+      errorDescription: errorData.error_description,
+    });
+    if (result) {
+      return result;
+    }
+    await throwOAuthError("TestOAuthDevice", "poll", diagnosticResponse);
+  }
+
+  const data = tokenResponseSchema.parse(await response.json());
+  return {
+    status: "complete",
+    token: {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token ?? null,
+      expiresIn: data.expires_in,
+      scopes: data.scope?.split(" ") ?? [],
+      userInfo: {
+        id: "test-oauth-device-user",
+        username: "test-oauth-device-user",
+        email: "test-oauth-device@example.com",
+      },
+    },
+  };
+}

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device.ts
@@ -112,7 +112,7 @@ function devicePollErrorResult(args: {
       errorDescription: args.errorDescription,
     };
   }
-  if (args.error === "invalid_request") {
+  if (args.error === "invalid_request" || args.error === "invalid_grant") {
     return {
       status: "error",
       error: args.error,

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
@@ -34,7 +34,10 @@ interface UserInfo {
   email: string | null;
 }
 
-function resolveUrl(field: string, path: string): string {
+export function resolveTestOAuthProviderUrl(
+  field: string,
+  path: string,
+): string {
   if (!path) {
     throw new Error(`Test OAuth URL missing: ${field} is not set`);
   }
@@ -115,7 +118,7 @@ function runtimeBaseUrl(): string {
   return "http://localhost:3000";
 }
 
-function previewBypassHeaders(): Record<string, string> {
+export function testOAuthPreviewBypassHeaders(): Record<string, string> {
   return process.env.VERCEL_AUTOMATION_BYPASS_SECRET
     ? {
         "x-vercel-protection-bypass":
@@ -127,11 +130,17 @@ function previewBypassHeaders(): Record<string, string> {
 }
 
 function getAuthorizationUrl(): string {
-  return resolveUrl("authorizationUrl", TEST_OAUTH_AUTHORIZATION_URL);
+  return resolveTestOAuthProviderUrl(
+    "authorizationUrl",
+    TEST_OAUTH_AUTHORIZATION_URL,
+  );
 }
 
-function getTokenUrl(): string {
-  return resolveUrl("tokenUrl", getConnectorOAuthConfig("test-oauth").tokenUrl);
+function getTestOAuthTokenUrl(): string {
+  return resolveTestOAuthProviderUrl(
+    "tokenUrl",
+    getConnectorOAuthConfig("test-oauth").tokenUrl,
+  );
 }
 
 export function buildTestOAuthAuthorizationUrl(
@@ -161,11 +170,11 @@ async function postToken(
   body: URLSearchParams,
   operation: "exchange" | "refresh",
 ): Promise<TokenResponse> {
-  const response = await fetch(getTokenUrl(), {
+  const response = await fetch(getTestOAuthTokenUrl(), {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...previewBypassHeaders(),
+      ...testOAuthPreviewBypassHeaders(),
     },
     body,
   });
@@ -228,7 +237,7 @@ export async function fetchTestOAuthUserInfo(
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        ...previewBypassHeaders(),
+        ...testOAuthPreviewBypassHeaders(),
       },
     },
   );


### PR DESCRIPTION
## Summary

- add a test-only OAuth device authorization provider endpoint and wire `test-oauth-device` through it
- add API integration coverage for device authorization start, poll completion, and pending/error token responses
- add an API-only serial Bats smoke for starting, polling, and listing the connected `test-oauth-device` connector

Fixes #14475

## Tests

- `git diff --check`
- `pnpm -C turbo --filter @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -C turbo --filter api exec vitest src/signals/routes/__tests__/test-oauth-provider-get.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts`
- `./e2e/test/libs/bats/bin/bats --tap e2e/tests/01-serial/ser-t09-test-oauth-device-api.bats` (skips locally when Zero auth token is not configured)
- `pnpm -C turbo --filter api lint`
- `pnpm -C turbo --filter @vm0/connectors lint`
- `pnpm -C turbo --filter @vm0/api-contracts lint`
- `pnpm -C turbo check-types`

## Notes

- The Bats smoke covers the happy path only; pending remains covered by provider/API integration tests to avoid serverless state or sleep-based E2E behavior.
