### PR TITLE
refactor(vsock-guest): share exec output data helper

### DIFF
--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -1141,6 +1141,31 @@ fn exec_operation_stream_limits_track_exact_over_and_zero_budget() {
     assert!(zero_chunks[0].truncated);
     assert!(zero_chunks[0].chunk.is_empty());
 
+    send_exec_start(
+        &mut host_stream,
+        139,
+        "printf abcde >&2",
+        5000,
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Stream {
+            limit_bytes: 4,
+            chunk_limit_bytes: 2,
+        },
+    );
+    let (stderr_over_chunks, stderr_over) = read_exec_result(&mut host_stream, 139);
+    assert_eq!(
+        stderr_over.termination,
+        ExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(stderr_data(&stderr_over_chunks), b"abcd".to_vec());
+    assert!(
+        stderr_over_chunks
+            .iter()
+            .any(|chunk| chunk.stream == ExecOutputStream::Stderr
+                && chunk.truncated
+                && chunk.chunk.is_empty())
+    );
+
     finish_guest_connection(handle, host_stream);
 }
 

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -1157,6 +1157,8 @@ fn exec_operation_stream_limits_track_exact_over_and_zero_budget() {
         stderr_over.termination,
         ExecTermination::Exited { exit_code: 0 }
     );
+    assert_eq!(stderr_over.stdout, None);
+    assert_eq!(stderr_over.stderr, None);
     assert_eq!(stderr_data(&stderr_over_chunks), b"abcd".to_vec());
     assert!(
         stderr_over_chunks

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -344,20 +344,20 @@ fn captured_truncated(captured: ExecCapturedOutput<'_>) -> bool {
     }
 }
 
-pub(crate) fn stdout_data(chunks: &[ExecOutputChunk]) -> Vec<u8> {
+fn output_data(chunks: &[ExecOutputChunk], stream: ExecOutputStream) -> Vec<u8> {
     chunks
         .iter()
-        .filter(|chunk| chunk.stream == ExecOutputStream::Stdout && !chunk.truncated)
-        .flat_map(|chunk| chunk.chunk.clone())
+        .filter(|chunk| chunk.stream == stream && !chunk.truncated)
+        .flat_map(|chunk| chunk.chunk.iter().copied())
         .collect()
 }
 
+pub(crate) fn stdout_data(chunks: &[ExecOutputChunk]) -> Vec<u8> {
+    output_data(chunks, ExecOutputStream::Stdout)
+}
+
 pub(crate) fn stderr_data(chunks: &[ExecOutputChunk]) -> Vec<u8> {
-    chunks
-        .iter()
-        .filter(|chunk| chunk.stream == ExecOutputStream::Stderr && !chunk.truncated)
-        .flat_map(|chunk| chunk.chunk.clone())
-        .collect()
+    output_data(chunks, ExecOutputStream::Stderr)
 }
 
 pub(crate) fn read_retry_eintr(


### PR DESCRIPTION
## Summary

- Add a private shared helper for aggregating non-truncated exec output chunks by stream.
- Keep `stdout_data` and `stderr_data` as semantic wrappers for readable test assertions.
- Avoid cloning each chunk vector while aggregating test output bytes.

Closes #14477

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection`
- `cargo clippy --all-targets --all-features`
