### PR TITLE
fix(mitm-addon): preserve rewritten response headers

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from mitmproxy import ctx, http
@@ -317,13 +318,26 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
 _opener = urllib.request.build_opener(_NoRedirect)
 
 
-def _filter_response_headers(raw: dict[str, str]) -> dict[str, str]:
+def _filter_response_headers(raw: Iterable[tuple[str, str]]) -> http.Headers:
     """Strip hop-by-hop headers from an upstream response.
 
     The response body is fully read (not chunked/compressed from our
     perspective), so headers like transfer-encoding must not be forwarded.
     """
-    return {k: v for k, v in raw.items() if k.lower() not in HOP_BY_HOP}
+    pairs = list(raw)
+    hop_by_hop: set[str] = set(HOP_BY_HOP)
+    for name, value in pairs:
+        if name.lower() == "connection":
+            hop_by_hop.update(token.strip().lower() for token in value.split(",") if token.strip())
+
+    return http.Headers(
+        (
+            name.encode("utf-8", "surrogateescape"),
+            value.encode("utf-8", "surrogateescape"),
+        )
+        for name, value in pairs
+        if name.lower() not in hop_by_hop
+    )
 
 
 def _forward_request_sync(
@@ -331,7 +345,7 @@ def _forward_request_sync(
     method: str,
     headers: dict[str, str],
     body: bytes | None,
-) -> tuple[int, bytes, dict[str, str]]:
+) -> tuple[int, bytes, http.Headers]:
     """Forward an HTTP request to the real URL and return (status, body, headers).
 
     Used for auth.base URL rewriting: the addon makes the upstream request
@@ -353,13 +367,13 @@ def _forward_request_sync(
         req.add_header(k, v)
     try:
         with _opener.open(req, timeout=30) as resp:
-            return resp.status, resp.read(), _filter_response_headers(dict(resp.headers))
+            return resp.status, resp.read(), _filter_response_headers(resp.headers.items())
     except urllib.error.HTTPError as e:
         # HTTPError wraps an open socket; context-manage it or the fd leaks
         # (sustained auth.base URL-rewrite traffic would eventually exhaust
         # the mitmproxy process FD limit).
         with e:
-            return e.code, e.read(), _filter_response_headers(dict(e.headers))
+            return e.code, e.read(), _filter_response_headers(e.headers.items())
 
 
 async def forward_request(
@@ -367,7 +381,7 @@ async def forward_request(
     method: str,
     headers: dict[str, str],
     body: bytes | None,
-) -> tuple[int, bytes, dict[str, str]]:
+) -> tuple[int, bytes, http.Headers]:
     """Async wrapper for _forward_request_sync."""
     return await asyncio.to_thread(_forward_request_sync, url, method, headers, body)
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -5,6 +5,7 @@ import io
 import json
 import time
 import urllib.error
+from email.message import Message
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,6 +19,13 @@ from tests.auth_state_helpers import (
     set_cached_headers,
 )
 from tests.firewall_helpers import _cancel_pending_task
+
+
+def _upstream_headers(*pairs: tuple[str, str]) -> Message:
+    headers = Message()
+    for name, value in pairs:
+        headers[name] = value
+    return headers
 
 
 class TestGetFirewallHeaders:
@@ -1019,17 +1027,45 @@ class TestForwardRequestSecurity:
 
     def test_filters_hop_by_hop_from_response(self):
         filtered = auth._filter_response_headers(
-            {
-                "Content-Type": "application/json",
-                "Transfer-Encoding": "chunked",
-                "Connection": "keep-alive",
-                "X-Custom": "value",
-            }
+            [
+                ("Content-Type", "application/json"),
+                ("Transfer-Encoding", "chunked"),
+                ("Connection", "keep-alive"),
+                ("X-Custom", "value"),
+            ]
         )
         assert "Content-Type" in filtered
         assert "X-Custom" in filtered
         assert "Transfer-Encoding" not in filtered
         assert "Connection" not in filtered
+
+    def test_filters_connection_declared_hop_by_hop_from_response(self):
+        filtered = auth._filter_response_headers(
+            [
+                ("Connection", "X-Upstream-Only, x-another-hop"),
+                ("X-Upstream-Only", "drop"),
+                ("x-another-hop", "drop"),
+                ("Set-Cookie", "a=1"),
+                ("Set-Cookie", "b=2"),
+            ]
+        )
+
+        assert "X-Upstream-Only" not in filtered
+        assert "x-another-hop" not in filtered
+        assert filtered.get_all("Set-Cookie") == ["a=1", "b=2"]
+
+    def test_preserves_duplicate_response_headers(self):
+        filtered = auth._filter_response_headers(
+            [
+                ("Set-Cookie", "a=1"),
+                ("Set-Cookie", "b=2"),
+                ("Link", "<next>; rel=next"),
+                ("Link", "<prev>; rel=prev"),
+            ]
+        )
+
+        assert filtered.get_all("Set-Cookie") == ["a=1", "b=2"]
+        assert filtered.get_all("Link") == ["<next>; rel=next", "<prev>; rel=prev"]
 
     def test_no_redirect_following(self):
         """_NoRedirect handler returns None to stop redirect chain."""
@@ -1049,16 +1085,41 @@ class TestForwardRequestResourceCleanup:
         resp.__enter__.return_value = resp
         resp.status = 200
         resp.read.return_value = b"ok"
-        resp.headers = {"Content-Type": "application/json"}
+        resp.headers = _upstream_headers(("Content-Type", "application/json"))
         with patch.object(auth._opener, "open", return_value=resp):
             status, body, _ = auth._forward_request_sync("https://example.com", "GET", {}, None)
         assert status == 200
         assert body == b"ok"
         resp.__exit__.assert_called_once()
 
+    def test_preserves_duplicate_headers_on_success(self):
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.status = 200
+        resp.read.return_value = b"ok"
+        resp.headers = _upstream_headers(
+            ("Set-Cookie", "a=1"),
+            ("Set-Cookie", "b=2"),
+            ("Content-Type", "text/plain"),
+        )
+
+        with patch.object(auth._opener, "open", return_value=resp):
+            status, body, headers = auth._forward_request_sync(
+                "https://example.com", "GET", {}, None
+            )
+
+        assert status == 200
+        assert body == b"ok"
+        assert headers.get_all("Set-Cookie") == ["a=1", "b=2"]
+        assert headers["Content-Type"] == "text/plain"
+
     def test_closes_httperror_on_error(self):
         err = urllib.error.HTTPError(
-            "https://example.com", 500, "Server Error", {}, io.BytesIO(b"oops")
+            "https://example.com",
+            500,
+            "Server Error",
+            _upstream_headers(("Content-Type", "text/plain")),
+            io.BytesIO(b"oops"),
         )
         err.close = MagicMock(wraps=err.close)
         with patch.object(auth._opener, "open", side_effect=err):
@@ -1067,12 +1128,37 @@ class TestForwardRequestResourceCleanup:
         assert body == b"oops"
         err.close.assert_called_once()
 
+    def test_preserves_duplicate_headers_on_httperror(self):
+        err = urllib.error.HTTPError(
+            "https://example.com",
+            429,
+            "Too Many Requests",
+            _upstream_headers(
+                ("WWW-Authenticate", "Bearer realm=one"),
+                ("WWW-Authenticate", "Bearer realm=two"),
+                ("Content-Type", "text/plain"),
+            ),
+            io.BytesIO(b"rate limited"),
+        )
+        err.close = MagicMock(wraps=err.close)
+
+        with patch.object(auth._opener, "open", side_effect=err):
+            status, body, headers = auth._forward_request_sync(
+                "https://example.com", "GET", {}, None
+            )
+
+        assert status == 429
+        assert body == b"rate limited"
+        assert headers.get_all("WWW-Authenticate") == ["Bearer realm=one", "Bearer realm=two"]
+        assert headers["Content-Type"] == "text/plain"
+        err.close.assert_called_once()
+
     def test_closes_response_when_read_raises(self):
         resp = MagicMock()
         resp.__enter__.return_value = resp
         resp.status = 200
         resp.read.side_effect = OSError("socket closed")
-        resp.headers = {}
+        resp.headers = _upstream_headers()
         with (
             patch.object(auth._opener, "open", return_value=resp),
             pytest.raises(OSError, match="socket closed"),

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from urllib.parse import urlparse
 
+from mitmproxy import http
+
 import auth
 import url_utils
 
@@ -53,6 +55,59 @@ class TestAuthBaseUrlRewrite:
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.response.status_code == 200
+
+    async def test_url_rewrite_response_preserves_duplicate_headers(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
+        """Duplicate upstream response headers survive response construction."""
+        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
+            "auth": {"headers": {}, "base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "billableFirewalls": [],
+        }
+        match_info = {
+            "name": "discord-webhook",
+            "permission": "send-message",
+            "rule": "POST /",
+            "params": {},
+            "rel_path": "/",
+        }
+        token_meta = {
+            "headers": {},
+            "base": "https://discord.com/api/webhooks/123/abc",
+            "resolved_secrets": ["DISCORD_WEBHOOK_URL"],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+        response_headers = http.Headers(
+            [
+                (b"Set-Cookie", b"a=1"),
+                (b"Set-Cookie", b"b=2"),
+                (b"Link", b"<next>; rel=next"),
+                (b"Link", b"<prev>; rel=prev"),
+            ]
+        )
+        mock_forward = AsyncMock(return_value=(200, b"ok", response_headers))
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+
+        assert flow.response.status_code == 200
+        assert flow.response.headers.get_all("Set-Cookie") == ["a=1", "b=2"]
+        assert flow.response.headers.get_all("Link") == ["<next>; rel=next", "<prev>; rel=prev"]
 
     async def test_url_rewrite_with_remaining_path(self, real_flow, headers, mitm_ctx, tmp_path):
         """When rel_path has content, it's appended to resolved base in forwarded URL."""


### PR DESCRIPTION
## Summary

- Preserve duplicate upstream response headers in auth.base URL rewrite forwarding by returning mitmproxy Headers instead of collapsing to dict
- Filter fixed and Connection-declared hop-by-hop response headers
- Add regression coverage for duplicate headers on success, HTTPError, and handler response construction

Fixes #14480

## Tests

- ruff check .
- ruff format --check .
- pytest tests/test_firewall_auth.py tests/test_firewall_rewrite.py -v
- pytest tests/ -v