### PR TITLE
refactor: rename mitm usage counter helpers

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -312,13 +312,13 @@ def _maybe_track_usage_flow(flow: http.HTTPFlow, firewall_billable: bool) -> Non
     if flow.metadata.get("_usage_flow_tracked"):
         return
     if firewall_billable:
-        usage.increment_flows()
+        usage.increment_in_flight_flows()
         flow.metadata["_usage_flow_tracked"] = True
 
 
 def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
     if flow.metadata.pop("_usage_flow_tracked", False):
-        usage.decrement_flows()
+        usage.decrement_in_flight_flows()
 
 
 def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
@@ -353,9 +353,9 @@ def websocket_message(flow: http.HTTPFlow) -> None:
 
 
 def _track_usage_flow(fn):
-    """Decorator ensuring decrement_flows runs after response/error handlers.
+    """Decorator ensuring decrement_in_flight_flows runs after response/error handlers.
 
-    Pairs with ``increment_flows()`` in ``request()``.  Uses ``pop`` so
+    Pairs with ``increment_in_flight_flows()`` in ``request()``.  Uses ``pop`` so
     that even if both ``response()`` and ``error()`` fire for the same
     flow, the decrement only happens once.
     """

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -24,7 +24,11 @@ from .anthropic_messages import (
     create_anthropic_messages_sse_usage_extractor,
     extract_anthropic_messages_usage_from_json,
 )
-from .counters import decrement_flows, increment_flows, set_pending_path
+from .counters import (
+    decrement_in_flight_flows,
+    increment_in_flight_flows,
+    set_pending_path,
+)
 from .openai_responses import (
     create_openai_responses_json_usage_extractor,
     create_openai_responses_sse_usage_extractor,
@@ -39,11 +43,11 @@ __all__ = [
     "create_anthropic_messages_sse_usage_extractor",
     "create_openai_responses_json_usage_extractor",
     "create_openai_responses_sse_usage_extractor",
-    "decrement_flows",
+    "decrement_in_flight_flows",
     "extract_anthropic_messages_usage_from_json",
     "extract_openai_responses_usage_from_event_json",
     "extract_openai_responses_usage_from_json",
-    "increment_flows",
+    "increment_in_flight_flows",
     "report_connector_usage",
     "report_model_provider_usage",
     "set_pending_path",

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -79,7 +79,7 @@ def _write_pending() -> None:
             )
 
 
-def increment_flows() -> None:
+def increment_in_flight_flows() -> None:
     """Track a new in-flight billable flow (call from request).
 
     Covers billable model-provider and connector flows — any flow that may
@@ -91,7 +91,7 @@ def increment_flows() -> None:
         _write_pending()
 
 
-def decrement_flows() -> None:
+def decrement_in_flight_flows() -> None:
     """Mark a tracked in-flight flow as complete (call from response/error)."""
     global _in_flight_flows
     with _counter_lock:
@@ -99,14 +99,14 @@ def decrement_flows() -> None:
         _write_pending()
 
 
-def _increment_reports() -> None:
+def increment_pending_reports() -> None:
     global _pending_reports
     with _counter_lock:
         _pending_reports += 1
         _write_pending()
 
 
-def _decrement_reports() -> None:
+def decrement_pending_reports() -> None:
     global _pending_reports
     with _counter_lock:
         _pending_reports = max(0, _pending_reports - 1)

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -16,7 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 from auth import _opener, make_api_request
 from logging_utils import log_proxy_entry
 
-from .counters import _decrement_reports, _increment_reports
+from .counters import decrement_pending_reports, increment_pending_reports
 
 
 def _log_webhook_entry(
@@ -72,7 +72,7 @@ def _post_webhook_with_retry(
             url, sandbox_token, payload, proxy_log_path, log_type, max_retries
         )
     finally:
-        _decrement_reports()
+        decrement_pending_reports()
 
 
 def _do_post_webhook_attempts(
@@ -164,7 +164,7 @@ def _enqueue_webhook(
         log_type,
         copied,
     )
-    _increment_reports()
+    increment_pending_reports()
     try:
         usage_executor.submit(
             _post_webhook_with_retry, url, sandbox_token, copied, proxy_log_path, log_type
@@ -180,5 +180,5 @@ def _enqueue_webhook(
         )
         _post_webhook_with_retry(url, sandbox_token, copied, proxy_log_path, log_type)
     except Exception:
-        _decrement_reports()
+        decrement_pending_reports()
         raise

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -970,7 +970,7 @@ class TestRequestHandler:
             _assert_pending(pending_path, flows=1, reports=0)
         finally:
             if usage.counters._in_flight_flows:
-                usage.decrement_flows()
+                usage.decrement_in_flight_flows()
             usage.set_pending_path("")
 
     async def test_local_firewall_error_does_not_track_usage_flow(
@@ -1099,7 +1099,7 @@ class TestRequestHandler:
             _assert_pending(pending_path, flows=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
-                usage.decrement_flows()
+                usage.decrement_in_flight_flows()
             usage.set_pending_path("")
 
     async def test_non_billable_model_provider_is_not_tracked_before_responseheaders(
@@ -1244,7 +1244,7 @@ class TestRequestHandler:
             _assert_pending(pending_path, flows=1, reports=0)
         finally:
             if usage.counters._in_flight_flows:
-                usage.decrement_flows()
+                usage.decrement_in_flight_flows()
             usage.set_pending_path("")
 
     async def test_billable_auth_url_rewrite_flow_drains_after_response(
@@ -1343,7 +1343,7 @@ class TestRequestHandler:
             _assert_pending(pending_path, flows=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
-                usage.decrement_flows()
+                usage.decrement_in_flight_flows()
             usage.set_pending_path("")
 
     async def test_billable_auth_url_rewrite_forward_failure_releases_tracking(
@@ -1438,7 +1438,7 @@ class TestRequestHandler:
             _assert_pending(pending_path, flows=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
-                usage.decrement_flows()
+                usage.decrement_in_flight_flows()
             usage.set_pending_path("")
 
     async def test_firewall_no_base_match_passes_through(
@@ -6197,28 +6197,28 @@ class TestUsagePendingCounter:
         usage.counters._usage_state_id = "test-usage-state-id"
         usage.counters._pending_write_error_logged = False
 
-    def test_increment_decrement_flows(self, tmp_path):
+    def test_increment_decrement_in_flight_flows(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
-        usage.increment_flows()
-        usage.increment_flows()
+        usage.increment_in_flight_flows()
+        usage.increment_in_flight_flows()
         assert usage.counters._in_flight_flows == 2
         _assert_pending(pending_path, flows=2, reports=0)
 
-        usage.decrement_flows()
+        usage.decrement_in_flight_flows()
         _assert_pending(pending_path, flows=1, reports=0)
 
-        usage.decrement_flows()
+        usage.decrement_in_flight_flows()
         _assert_pending(pending_path, flows=0, reports=0)
 
-    def test_increment_decrement_reports(self, tmp_path):
+    def test_increment_decrement_pending_reports(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
-        usage.counters._increment_reports()
+        usage.counters.increment_pending_reports()
         assert usage.counters._pending_reports == 1
         _assert_pending(pending_path, flows=0, reports=1)
 
-        usage.counters._decrement_reports()
+        usage.counters.decrement_pending_reports()
         _assert_pending(pending_path, flows=0, reports=0)
 
     def test_enqueue_deep_copies_nested_payload(self):
@@ -6246,7 +6246,7 @@ class TestUsagePendingCounter:
                 "events": [{"category": "tokens.input", "quantity": 1}],
             }
         finally:
-            usage.counters._decrement_reports()
+            usage.counters.decrement_pending_reports()
 
     def test_enqueue_logs_payload_collisions_under_payload(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
@@ -6270,7 +6270,7 @@ class TestUsagePendingCounter:
                 )
             mock_submit.assert_called_once()
         finally:
-            usage.counters._decrement_reports()
+            usage.counters.decrement_pending_reports()
 
         entry = json.loads(proxy_log.read_text())
         assert entry["url"] == "https://api.vm0.ai/api/webhooks/agent/usage-event"
@@ -6307,17 +6307,17 @@ class TestUsagePendingCounter:
 
     def test_decrement_does_not_go_negative(self, tmp_path):
         usage.set_pending_path(str(tmp_path / "usage-pending"))
-        usage.decrement_flows()
-        usage.counters._decrement_reports()
+        usage.decrement_in_flight_flows()
+        usage.counters.decrement_pending_reports()
         assert usage.counters._in_flight_flows == 0
         assert usage.counters._pending_reports == 0
 
     def test_no_op_when_path_not_set(self):
         usage.set_pending_path("")
-        usage.increment_flows()
-        usage.decrement_flows()
-        usage.counters._increment_reports()
-        usage.counters._decrement_reports()
+        usage.increment_in_flight_flows()
+        usage.decrement_in_flight_flows()
+        usage.counters.increment_pending_reports()
+        usage.counters.decrement_pending_reports()
         # Should not raise — just no file written.
         assert usage.counters._in_flight_flows == 0
         assert usage.counters._pending_reports == 0
@@ -6336,7 +6336,7 @@ class TestUsagePendingCounter:
             patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
         ):
             for _ in range(3):
-                usage.increment_flows()
+                usage.increment_in_flight_flows()
 
         assert mock_log.warn.call_count == 1
         assert "Failed to write pending count" in mock_log.warn.call_args[0][0]
@@ -6351,8 +6351,8 @@ class TestUsagePendingCounter:
             patch.object(usage.counters.ctx, "log", MagicMock(), create=True),
             patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
         ):
-            usage.increment_flows()  # should not raise
-            usage.decrement_flows()  # should not raise
+            usage.increment_in_flight_flows()  # should not raise
+            usage.decrement_in_flight_flows()  # should not raise
 
     def test_report_decrements_after_completion(self, tmp_path, real_flow, fresh_usage_executor):
         """Retry exhaustion still runs the decrement finally-block."""
@@ -6407,7 +6407,7 @@ class TestUsagePendingCounter:
     def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
         """If both response() and error() fire for the same flow, decrement only once."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
-        usage.increment_flows()
+        usage.increment_in_flight_flows()
         assert usage.counters._in_flight_flows == 1
 
         flow = real_flow(with_response=False)
@@ -6427,7 +6427,7 @@ class TestUsagePendingCounter:
     def test_untracked_flow_not_decremented(self, tmp_path, real_flow):
         """Flows without _usage_flow_tracked should not touch the counter."""
         usage.set_pending_path(str(tmp_path / "usage-pending"))
-        usage.increment_flows()  # simulate one tracked flow in flight
+        usage.increment_in_flight_flows()  # simulate one tracked flow in flight
 
         flow = real_flow(with_response=False)
         # No _usage_flow_tracked in metadata — this is a regular flow.


### PR DESCRIPTION
## Summary

- Rename mitm usage counter mutators to describe in-flight flows and pending reports explicitly.
- Update the usage facade, webhook imports, mitm addon flow tracking, and pending counter tests.
- Keep counter behavior, pending-count JSON fields, locking, executor retry/fallback paths, and shutdown drain semantics unchanged.

Closes #14479

## Tests

- `python3 -m pytest tests/test_handlers.py::TestUsagePendingCounter`
- `python3 -m ruff check src tests`
- `python3 -m pytest tests/`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
