### PR TITLE
feat(desktop): add native computer use helper

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -118,9 +118,19 @@ jobs:
             find "$app_dir/Contents/Resources" -maxdepth 2 -print || true
             exit 1
           fi
+          if [ ! -x "$app_dir/Contents/Resources/native/computer-use-helper" ]; then
+            echo "No executable native Computer Use helper found"
+            find "$app_dir/Contents/Resources" -maxdepth 3 -print || true
+            exit 1
+          fi
           if [ -e "$app_dir/Contents/Resources/app/src" ]; then
             echo "Packaged app should not contain desktop source files"
             find "$app_dir/Contents/Resources/app/src" -maxdepth 2 -print || true
+            exit 1
+          fi
+          if [ -e "$app_dir/Contents/Resources/app/native" ]; then
+            echo "Packaged app should not contain native helper source files"
+            find "$app_dir/Contents/Resources/app/native" -maxdepth 3 -print || true
             exit 1
           fi
           if [ -e "$app_dir/Contents/Resources/app/desktop-runtime-config.json" ]; then
@@ -140,6 +150,7 @@ jobs:
 
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/MacOS/Zero"
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/native/computer-use-helper"
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/dist/main.js"
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/assets/icon.png"
 
@@ -217,9 +228,19 @@ jobs:
             find "$app_dir/Contents/Resources" -maxdepth 2 -print || true
             exit 1
           fi
+          if [ ! -x "$app_dir/Contents/Resources/native/computer-use-helper" ]; then
+            echo "No executable native Computer Use helper found"
+            find "$app_dir/Contents/Resources" -maxdepth 3 -print || true
+            exit 1
+          fi
           if [ -e "$app_dir/Contents/Resources/app/src" ]; then
             echo "Packaged preview app should not contain desktop source files"
             find "$app_dir/Contents/Resources/app/src" -maxdepth 2 -print || true
+            exit 1
+          fi
+          if [ -e "$app_dir/Contents/Resources/app/native" ]; then
+            echo "Packaged preview app should not contain native helper source files"
+            find "$app_dir/Contents/Resources/app/native" -maxdepth 3 -print || true
             exit 1
           fi
           if [ ! -f "$runtime_config" ]; then
@@ -253,6 +274,7 @@ jobs:
 
           unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/MacOS/Zero Dev"
           unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/native/computer-use-helper"
           unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/dist/main.js"
           unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/assets/icon.png"
           unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/desktop-runtime-config.json"

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -9,8 +9,10 @@ host runtime that page uses.
 
 When the user is signed in and the feature switch is enabled, the main process
 registers a Desktop Computer Use host through the Zero API command queue. It
-uses the Electron session for auth, polls queued commands, executes them with
-macOS Accessibility/JXA, and completes commands back to the API.
+uses the Electron session for auth, polls queued commands, executes them with a
+native macOS `computer-use-helper`, and completes commands back to the API.
+Electron still owns screenshot capture through `desktopCapturer`; the helper
+owns macOS Accessibility and targeted CGEvent input dispatch.
 
 ## Development
 
@@ -19,6 +21,16 @@ By default the app opens production:
 ```bash
 pnpm -F @vm0/desktop dev
 ```
+
+The desktop build compiles both Electron entrypoints and the Swift native helper:
+
+```bash
+pnpm -F @vm0/desktop build
+```
+
+The helper source lives under `apps/desktop/native/computer-use-helper`. Build
+output is copied to `apps/desktop/native/dist/native/computer-use-helper`, which
+is also the path included in packaged macOS artifacts.
 
 Point it at a local or staging platform URL with:
 

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -22,10 +22,22 @@ By default the app opens production:
 pnpm -F @vm0/desktop dev
 ```
 
+From the monorepo root, start the desktop app against the local proxy with:
+
+```bash
+pnpm desktop:dev
+```
+
 The desktop build compiles both Electron entrypoints and the Swift native helper:
 
 ```bash
 pnpm -F @vm0/desktop build
+```
+
+Create a macOS artifact with:
+
+```bash
+pnpm desktop:make
 ```
 
 The helper source lives under `apps/desktop/native/computer-use-helper`. Build
@@ -36,7 +48,7 @@ Point it at a local or staging platform URL with:
 
 ```bash
 VM0_DESKTOP_PLATFORM_URL=https://staging-app.vm6.ai pnpm -F @vm0/desktop dev
-VM0_DESKTOP_PLATFORM_URL=https://app.vm7.ai pnpm -F @vm0/desktop dev
+VM0_DESKTOP_PLATFORM_URL=https://app.vm7.ai:8443 pnpm -F @vm0/desktop dev
 VM0_DESKTOP_PLATFORM_URL=http://localhost:3002 pnpm -F @vm0/desktop dev
 ```
 

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -32,6 +32,7 @@ module.exports = {
       CFBundleIconFile: "icon.icns",
     },
     asar: false,
+    extraResource: [path.join(__dirname, "native", "dist", "native")],
     osxSign: {
       hardenedRuntime: false,
       identity: "-",
@@ -51,6 +52,8 @@ module.exports = {
     ignore: [
       /^\/node_modules($|\/)/,
       /^\/src($|\/)/,
+      /^\/native($|\/)/,
+      /^\/scripts($|\/)/,
       /^\/\.turbo($|\/)/,
       /^\/\.npmrc$/,
       /^\/README\.md$/,

--- a/turbo/apps/desktop/native/.gitignore
+++ b/turbo/apps/desktop/native/.gitignore
@@ -1,0 +1,2 @@
+dist/
+computer-use-helper/.build/

--- a/turbo/apps/desktop/native/computer-use-helper/Package.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "ComputerUseHelper",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(
+            name: "computer-use-helper",
+            targets: ["ComputerUseHelper"]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "ComputerUseHelper"
+        )
+    ]
+)

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1,0 +1,797 @@
+import AppKit
+import ApplicationServices
+import Darwin
+import Foundation
+
+struct HelperFailure: Error {
+    let code: String
+    let message: String
+}
+
+struct SnapshotLimits {
+    let maxDepth = 32
+    let maxNodes = 2_000
+    let maxChildrenPerSource = 160
+    let maxWindows = 8
+    let maxActions = 12
+}
+
+struct ChildEntry {
+    let element: AXUIElement
+    let segment: String
+}
+
+let limits = SnapshotLimits()
+
+func isRecord(_ value: Any) -> [String: Any]? {
+    return value as? [String: Any]
+}
+
+func requiredString(_ request: [String: Any], _ key: String) throws -> String {
+    guard let value = request[key] as? String else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Missing required payload field: \(key)"
+        )
+    }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Missing required payload field: \(key)"
+        )
+    }
+    return trimmed
+}
+
+func requiredNumber(_ request: [String: Any], _ key: String) throws -> Double {
+    guard let value = request[key] as? NSNumber else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Missing required payload field: \(key)"
+        )
+    }
+    return value.doubleValue
+}
+
+func requiredInt(_ request: [String: Any], _ key: String) throws -> Int {
+    guard let value = request[key] as? NSNumber else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Missing required payload field: \(key)"
+        )
+    }
+    return value.intValue
+}
+
+func optionalString(_ request: [String: Any], _ key: String) -> String? {
+    guard let value = request[key] as? String else {
+        return nil
+    }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+func optionalInt(_ request: [String: Any], _ key: String, default defaultValue: Int) -> Int {
+    return (request[key] as? NSNumber)?.intValue ?? defaultValue
+}
+
+func findRunningApp(named appName: String) -> NSRunningApplication? {
+    let apps = NSWorkspace.shared.runningApplications.filter { app in
+        !app.isTerminated
+    }
+
+    if let exact = apps.first(where: { app in
+        app.localizedName == appName || app.bundleIdentifier == appName
+    }) {
+        return exact
+    }
+
+    let normalized = appName.lowercased()
+    return apps.first { app in
+        app.localizedName?.lowercased() == normalized ||
+            app.bundleIdentifier?.lowercased() == normalized
+    }
+}
+
+func resolveRunningApp(named appName: String) throws -> NSRunningApplication {
+    guard let app = findRunningApp(named: appName) else {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "App is not running: \(appName)"
+        )
+    }
+    return app
+}
+
+func appElement(named appName: String) throws -> AXUIElement {
+    let app = try resolveRunningApp(named: appName)
+    return AXUIElementCreateApplication(app.processIdentifier)
+}
+
+func attribute(_ element: AXUIElement, _ name: CFString) -> Any? {
+    var value: CFTypeRef?
+    let error = AXUIElementCopyAttributeValue(element, name, &value)
+    if error != .success {
+        return nil
+    }
+    return value
+}
+
+func attributeArray(_ element: AXUIElement, _ name: CFString) -> [AXUIElement] {
+    guard let value = attribute(element, name) else {
+        return []
+    }
+    if let elements = value as? [AXUIElement] {
+        return elements
+    }
+    if let elements = value as? [Any] {
+        return elements.compactMap { entry in
+            axElementValue(entry)
+        }
+    }
+    return []
+}
+
+func axElementValue(_ value: Any?) -> AXUIElement? {
+    guard let value else {
+        return nil
+    }
+    let cfValue = value as CFTypeRef
+    if CFGetTypeID(cfValue) != AXUIElementGetTypeID() {
+        return nil
+    }
+    return (value as! AXUIElement)
+}
+
+func axValueValue(_ value: Any?) -> AXValue? {
+    guard let value else {
+        return nil
+    }
+    let cfValue = value as CFTypeRef
+    if CFGetTypeID(cfValue) != AXValueGetTypeID() {
+        return nil
+    }
+    return (value as! AXValue)
+}
+
+func stringValue(_ value: Any?) -> String? {
+    if let string = value as? String {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+    if let number = value as? NSNumber {
+        return number.stringValue
+    }
+    return nil
+}
+
+func boolValue(_ value: Any?) -> Bool? {
+    return (value as? NSNumber)?.boolValue
+}
+
+func numberValue(_ value: Any?) -> Double? {
+    if let number = value as? NSNumber {
+        return number.doubleValue
+    }
+    if let string = value as? String {
+        return Double(string)
+    }
+    return nil
+}
+
+func pointValue(_ value: Any?) -> CGPoint? {
+    guard let axValue = axValueValue(value), AXValueGetType(axValue) == .cgPoint else {
+        return nil
+    }
+    var point = CGPoint.zero
+    AXValueGetValue(axValue, .cgPoint, &point)
+    return point
+}
+
+func sizeValue(_ value: Any?) -> CGSize? {
+    guard let axValue = axValueValue(value), AXValueGetType(axValue) == .cgSize else {
+        return nil
+    }
+    var size = CGSize.zero
+    AXValueGetValue(axValue, .cgSize, &size)
+    return size
+}
+
+func role(_ element: AXUIElement) -> String? {
+    return stringValue(attribute(element, kAXRoleAttribute as CFString))
+}
+
+func bounds(_ element: AXUIElement) -> [String: Double]? {
+    guard let position = pointValue(attribute(element, kAXPositionAttribute as CFString)),
+          let size = sizeValue(attribute(element, kAXSizeAttribute as CFString))
+    else {
+        return nil
+    }
+    return [
+        "x": Double(position.x),
+        "y": Double(position.y),
+        "width": Double(size.width),
+        "height": Double(size.height),
+    ]
+}
+
+func actionNames(_ element: AXUIElement) -> [String] {
+    var names: CFArray?
+    let error = AXUIElementCopyActionNames(element, &names)
+    if error != .success {
+        return []
+    }
+    return ((names as? [String]) ?? []).prefix(limits.maxActions).map { name in
+        name
+    }
+}
+
+func setAttribute(_ element: AXUIElement, _ name: CFString, _ value: CFTypeRef) throws {
+    let error = AXUIElementSetAttributeValue(element, name, value)
+    if error != .success {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "Unable to set accessibility attribute \(name): \(error.rawValue)"
+        )
+    }
+}
+
+func bestEffortSetAttribute(_ element: AXUIElement, _ name: String, _ value: Bool) {
+    _ = AXUIElementSetAttributeValue(element, name as CFString, NSNumber(value: value))
+}
+
+func enableBestEffortAccessibilityModes(_ element: AXUIElement) {
+    bestEffortSetAttribute(element, "AXManualAccessibility", true)
+    bestEffortSetAttribute(element, "AXEnhancedUserInterface", true)
+}
+
+func childFingerprint(_ element: AXUIElement) -> String {
+    guard let bounds = bounds(element) else {
+        return ""
+    }
+    let x = bounds["x"] ?? 0
+    let y = bounds["y"] ?? 0
+    let width = bounds["width"] ?? 0
+    let height = bounds["height"] ?? 0
+    let boundsText = "\(x),\(y),\(width),\(height)"
+    return [
+        role(element) ?? "",
+        stringValue(attribute(element, kAXTitleAttribute as CFString)) ?? "",
+        stringValue(attribute(element, kAXValueAttribute as CFString)) ?? "",
+        boundsText,
+    ].joined(separator: "|")
+}
+
+func prefixedChildren(
+    _ element: AXUIElement,
+    _ attributeName: CFString,
+    _ prefix: String
+) -> [ChildEntry] {
+    return attributeArray(element, attributeName)
+        .prefix(limits.maxChildrenPerSource)
+        .enumerated()
+        .map { index, child in
+            ChildEntry(element: child, segment: "\(prefix)\(index)")
+        }
+}
+
+func collectChildren(_ element: AXUIElement) -> [ChildEntry] {
+    let candidates = prefixedChildren(element, kAXChildrenAttribute as CFString, "e") +
+        prefixedChildren(element, "AXRows" as CFString, "r") +
+        prefixedChildren(element, "AXContents" as CFString, "c") +
+        prefixedChildren(element, "AXVisibleChildren" as CFString, "v")
+
+    var seen = Set<String>()
+    var children: [ChildEntry] = []
+    for candidate in candidates {
+        let fingerprint = childFingerprint(candidate.element)
+        if !fingerprint.isEmpty {
+            if seen.contains(fingerprint) {
+                continue
+            }
+            seen.insert(fingerprint)
+        }
+        children.append(candidate)
+    }
+    return children
+}
+
+func markTruncated(_ reasons: inout [String], _ reason: String) {
+    if !reasons.contains(reason) {
+        reasons.append(reason)
+    }
+}
+
+func describe(
+    _ element: AXUIElement,
+    id: String,
+    depth: Int,
+    nodeCount: inout Int,
+    truncationReasons: inout [String]
+) -> [String: Any]? {
+    if nodeCount >= limits.maxNodes {
+        markTruncated(&truncationReasons, "max_nodes")
+        return nil
+    }
+    if depth > limits.maxDepth {
+        markTruncated(&truncationReasons, "max_depth")
+        return nil
+    }
+    nodeCount += 1
+
+    var node: [String: Any] = ["id": id]
+    if let role = role(element) {
+        node["role"] = role
+    }
+    if let roleDescription = stringValue(attribute(element, kAXRoleDescriptionAttribute as CFString)) {
+        node["roleDescription"] = roleDescription
+    }
+    if let name = stringValue(attribute(element, kAXTitleAttribute as CFString)) {
+        node["name"] = name
+    }
+    if let value = stringValue(attribute(element, kAXValueAttribute as CFString)) {
+        node["value"] = value
+    }
+    if let description = stringValue(attribute(element, kAXDescriptionAttribute as CFString)) {
+        node["description"] = description
+    }
+    if let focused = boolValue(attribute(element, kAXFocusedAttribute as CFString)) {
+        node["focused"] = focused
+    }
+    if let enabled = boolValue(attribute(element, kAXEnabledAttribute as CFString)) {
+        node["enabled"] = enabled
+    }
+    let actions = actionNames(element)
+    if !actions.isEmpty {
+        node["actions"] = actions
+    }
+    if let bounds = bounds(element) {
+        node["bounds"] = bounds
+    }
+
+    if depth >= limits.maxDepth {
+        markTruncated(&truncationReasons, "max_depth")
+        return node
+    }
+
+    let children = collectChildren(element).compactMap { child in
+        describe(
+            child.element,
+            id: "\(id).\(child.segment)",
+            depth: depth + 1,
+            nodeCount: &nodeCount,
+            truncationReasons: &truncationReasons
+        )
+    }
+    if !children.isEmpty {
+        node["children"] = children
+    }
+    return node
+}
+
+func resolveIndex(_ segment: Substring) throws -> Int {
+    guard segment.count > 1,
+          let index = Int(segment.dropFirst()),
+          index >= 0
+    else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Invalid element id segment: \(segment)"
+        )
+    }
+    return index
+}
+
+func childForSegment(_ element: AXUIElement, _ segment: Substring) throws -> AXUIElement {
+    let index = try resolveIndex(segment)
+    let children: [AXUIElement]
+    if segment.hasPrefix("e") {
+        children = attributeArray(element, kAXChildrenAttribute as CFString)
+    } else if segment.hasPrefix("r") {
+        children = attributeArray(element, "AXRows" as CFString)
+    } else if segment.hasPrefix("c") {
+        children = attributeArray(element, "AXContents" as CFString)
+    } else if segment.hasPrefix("v") {
+        children = attributeArray(element, "AXVisibleChildren" as CFString)
+    } else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Invalid element id segment: \(segment)"
+        )
+    }
+
+    guard index < children.count else {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "Element not found: \(segment)"
+        )
+    }
+    return children[index]
+}
+
+func resolveElement(appName: String, elementId: String) throws -> AXUIElement {
+    let root = try appElement(named: appName)
+    let parts = elementId.split(separator: ".")
+    var current: AXUIElement?
+
+    for part in parts {
+        if part.hasPrefix("w") {
+            let index = try resolveIndex(part)
+            let windows = attributeArray(root, kAXWindowsAttribute as CFString)
+            guard index < windows.count else {
+                throw HelperFailure(
+                    code: "accessibility_unavailable",
+                    message: "Element not found: \(elementId)"
+                )
+            }
+            current = windows[index]
+        } else {
+            guard let element = current else {
+                throw HelperFailure(
+                    code: "unsupported_command",
+                    message: "Invalid element id: \(elementId)"
+                )
+            }
+            current = try childForSegment(element, part)
+        }
+    }
+
+    guard let resolved = current else {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "Element not found: \(elementId)"
+        )
+    }
+    return resolved
+}
+
+func handleAppsList() -> [String: Any] {
+    var names = Set<String>()
+    for app in NSWorkspace.shared.runningApplications {
+        if app.activationPolicy == .regular,
+           let name = app.localizedName,
+           !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            names.insert(name)
+        }
+    }
+    return ["apps": Array(names).sorted()]
+}
+
+func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let snapshotId = try requiredString(request, "snapshotId")
+
+    guard let runningApp = findRunningApp(named: appName) else {
+        return [
+            "app": appName,
+            "snapshotId": snapshotId,
+            "elements": [],
+            "nodeCount": 0,
+            "truncated": false,
+            "truncationReasons": [],
+        ]
+    }
+
+    let root = AXUIElementCreateApplication(runningApp.processIdentifier)
+    enableBestEffortAccessibilityModes(root)
+
+    var nodeCount = 0
+    var truncationReasons: [String] = []
+    let windows = attributeArray(root, kAXWindowsAttribute as CFString)
+        .prefix(limits.maxWindows)
+        .enumerated()
+        .compactMap { index, window in
+            describe(
+                window,
+                id: "w\(index)",
+                depth: 0,
+                nodeCount: &nodeCount,
+                truncationReasons: &truncationReasons
+            )
+        }
+
+    return [
+        "app": appName,
+        "snapshotId": snapshotId,
+        "elements": windows,
+        "nodeCount": nodeCount,
+        "truncated": !truncationReasons.isEmpty,
+        "truncationReasons": truncationReasons,
+    ]
+}
+
+func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    process.arguments = ["-a", appName]
+    try process.run()
+    process.waitUntilExit()
+    if process.terminationStatus != 0 {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "Unable to open \(appName)"
+        )
+    }
+    return [:]
+}
+
+func handleElementClick(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let elementId = try requiredString(request, "elementId")
+    let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
+    let element = try resolveElement(appName: appName, elementId: elementId)
+    for index in 0..<clickCount {
+        let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
+        if error != .success {
+            throw HelperFailure(
+                code: "accessibility_unavailable",
+                message: "Unable to press \(elementId): \(error.rawValue)"
+            )
+        }
+        if index + 1 < clickCount {
+            usleep(50_000)
+        }
+    }
+    return [:]
+}
+
+func mouseEventConfig(button: String) throws -> (
+    down: CGEventType,
+    up: CGEventType,
+    button: CGMouseButton
+) {
+    if button == "left" {
+        return (.leftMouseDown, .leftMouseUp, .left)
+    }
+    if button == "right" {
+        return (.rightMouseDown, .rightMouseUp, .right)
+    }
+    if button == "middle" {
+        return (.otherMouseDown, .otherMouseUp, .center)
+    }
+    throw HelperFailure(
+        code: "unsupported_command",
+        message: "Unsupported mouse button: \(button)"
+    )
+}
+
+func handleElementClickPoint(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let app = try resolveRunningApp(named: appName)
+    let x = try requiredNumber(request, "x")
+    let y = try requiredNumber(request, "y")
+    let button = optionalString(request, "button") ?? "left"
+    let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
+    let config = try mouseEventConfig(button: button)
+    let point = CGPoint(x: x, y: y)
+
+    for index in 1...clickCount {
+        for type in [config.down, config.up] {
+            guard let event = CGEvent(
+                mouseEventSource: nil,
+                mouseType: type,
+                mouseCursorPosition: point,
+                mouseButton: config.button
+            ) else {
+                throw HelperFailure(
+                    code: "accessibility_unavailable",
+                    message: "Unable to create mouse event"
+                )
+            }
+            event.setIntegerValueField(.mouseEventClickState, value: Int64(index))
+            event.postToPid(app.processIdentifier)
+        }
+        if index < clickCount {
+            usleep(50_000)
+        }
+    }
+
+    return [:]
+}
+
+func handleElementSetValue(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let elementId = try requiredString(request, "elementId")
+    let value = try requiredString(request, "value")
+    let element = try resolveElement(appName: appName, elementId: elementId)
+    try setAttribute(element, kAXValueAttribute as CFString, value as CFString)
+    return [:]
+}
+
+func handleElementPerformAction(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let elementId = try requiredString(request, "elementId")
+    let action = try requiredString(request, "action")
+    let element = try resolveElement(appName: appName, elementId: elementId)
+    let error = AXUIElementPerformAction(element, action as CFString)
+    if error != .success {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "Unable to perform \(action) on \(elementId): \(error.rawValue)"
+        )
+    }
+    return [:]
+}
+
+func handleTypeText(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let inputText = try requiredString(request, "text")
+    let root = try appElement(named: appName)
+    guard let element = axElementValue(attribute(root, kAXFocusedUIElementAttribute as CFString)) else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "keyboard.type_text requires a focused editable text element in \(appName)"
+        )
+    }
+    let role = role(element)
+    let editableRoles = Set([
+        "AXComboBox",
+        "AXSearchField",
+        "AXTextArea",
+        "AXTextField",
+        "AXTextView",
+    ])
+    guard let role, editableRoles.contains(role) else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "keyboard.type_text requires a focused editable text element in \(appName)"
+        )
+    }
+
+    let currentValue = stringValue(attribute(element, kAXValueAttribute as CFString)) ?? ""
+    try setAttribute(element, kAXValueAttribute as CFString, (currentValue + inputText) as CFString)
+    var result: [String: Any] = ["role": role]
+    if let description = stringValue(attribute(element, kAXDescriptionAttribute as CFString)) {
+        result["description"] = description
+    }
+    return result
+}
+
+func postKey(pid: pid_t, keyCode: Int, keyDown: Bool, flags: Int) throws {
+    guard let event = CGEvent(
+        keyboardEventSource: nil,
+        virtualKey: CGKeyCode(keyCode),
+        keyDown: keyDown
+    ) else {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: "Unable to create keyboard event"
+        )
+    }
+    event.flags = CGEventFlags(rawValue: UInt64(flags))
+    event.postToPid(pid)
+}
+
+func handlePressKey(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let app = try resolveRunningApp(named: appName)
+    let keyCode = try requiredInt(request, "keyCode")
+    let flags = try requiredInt(request, "flags")
+    let modifierRecords = (request["modifiers"] as? [[String: Any]]) ?? []
+    let modifiers = try modifierRecords.map { record -> (keyCode: Int, flag: Int) in
+        guard let keyCode = record["keyCode"] as? NSNumber,
+              let flag = record["flag"] as? NSNumber
+        else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Invalid keyboard modifier payload"
+            )
+        }
+        return (keyCode: keyCode.intValue, flag: flag.intValue)
+    }
+
+    var activeFlags = 0
+    for modifier in modifiers {
+        activeFlags |= modifier.flag
+        try postKey(pid: app.processIdentifier, keyCode: modifier.keyCode, keyDown: true, flags: activeFlags)
+    }
+    try postKey(pid: app.processIdentifier, keyCode: keyCode, keyDown: true, flags: flags)
+    try postKey(pid: app.processIdentifier, keyCode: keyCode, keyDown: false, flags: flags)
+    for modifier in modifiers.reversed() {
+        activeFlags &= ~modifier.flag
+        try postKey(pid: app.processIdentifier, keyCode: modifier.keyCode, keyDown: false, flags: activeFlags)
+    }
+    return [:]
+}
+
+func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let elementId = try requiredString(request, "elementId")
+    let direction = try requiredString(request, "direction")
+    let pages = request["pages"] as? NSNumber
+    let step = pages?.doubleValue ?? 1
+    let axis = direction == "left" || direction == "right"
+        ? "AXHorizontalScrollBar"
+        : "AXVerticalScrollBar"
+    let sign = direction == "up" || direction == "left" ? -1.0 : 1.0
+    let element = try resolveElement(appName: appName, elementId: elementId)
+    guard let scrollBar = attributeArray(element, kAXChildrenAttribute as CFString).first(where: { child in
+        role(child) == axis
+    }) else {
+        return [:]
+    }
+    if let current = numberValue(attribute(scrollBar, kAXValueAttribute as CFString)) {
+        try setAttribute(
+            scrollBar,
+            kAXValueAttribute as CFString,
+            NSNumber(value: current + sign * step)
+        )
+    }
+    return [:]
+}
+
+func handle(_ request: [String: Any]) throws -> [String: Any] {
+    let kind = try requiredString(request, "kind")
+    switch kind {
+    case "apps.list":
+        return handleAppsList()
+    case "app.state":
+        return try handleAppState(request)
+    case "app.open":
+        return try handleAppOpen(request)
+    case "element.click":
+        return try handleElementClick(request)
+    case "element.click_point":
+        return try handleElementClickPoint(request)
+    case "element.set_value":
+        return try handleElementSetValue(request)
+    case "element.perform_action":
+        return try handleElementPerformAction(request)
+    case "keyboard.type_text":
+        return try handleTypeText(request)
+    case "keyboard.press_key":
+        return try handlePressKey(request)
+    case "element.scroll":
+        return try handleScrollElement(request)
+    default:
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Unsupported native Computer Use command: \(kind)"
+        )
+    }
+}
+
+func writeJSONObject(_ object: [String: Any]) throws {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+func run() {
+    do {
+        let input = FileHandle.standardInput.readDataToEndOfFile()
+        let parsed = try JSONSerialization.jsonObject(with: input, options: [])
+        guard let request = isRecord(parsed) else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Native Computer Use helper requires a JSON object request"
+            )
+        }
+        let result = try handle(request)
+        try writeJSONObject([
+            "status": "succeeded",
+            "result": result,
+        ])
+    } catch let failure as HelperFailure {
+        try? writeJSONObject([
+            "status": "failed",
+            "error": [
+                "code": failure.code,
+                "message": failure.message,
+            ],
+        ])
+    } catch {
+        try? writeJSONObject([
+            "status": "failed",
+            "error": [
+                "code": "accessibility_unavailable",
+                "message": String(describing: error),
+            ],
+        ])
+    }
+}
+
+run()

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -6,7 +6,9 @@
   "description": "Zero desktop shell",
   "main": "dist/main.js",
   "scripts": {
-    "build": "tsup src/main.ts src/preload.ts --format cjs --platform node --target node20 --out-dir dist --sourcemap --clean --external electron",
+    "build": "pnpm build:native && pnpm build:electron",
+    "build:electron": "tsup src/main.ts src/preload.ts --format cjs --platform node --target node20 --out-dir dist --sourcemap --clean --external electron",
+    "build:native": "node scripts/build-native-helper.js",
     "check-types": "tsc --noEmit",
     "dev": "pnpm build && electron-forge start",
     "lint": "oxlint src --deny-warnings",

--- a/turbo/apps/desktop/scripts/build-native-helper.js
+++ b/turbo/apps/desktop/scripts/build-native-helper.js
@@ -1,0 +1,26 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const appRoot = path.resolve(__dirname, "..");
+const packageRoot = path.join(appRoot, "native", "computer-use-helper");
+const buildOutput = path.join(
+  packageRoot,
+  ".build",
+  "release",
+  "computer-use-helper",
+);
+const distDir = path.join(appRoot, "native", "dist", "native");
+const distOutput = path.join(distDir, "computer-use-helper");
+
+execFileSync(
+  "swift",
+  ["build", "--package-path", packageRoot, "-c", "release"],
+  {
+    stdio: "inherit",
+  },
+);
+
+fs.mkdirSync(distDir, { recursive: true });
+fs.copyFileSync(buildOutput, distOutput);
+fs.chmodSync(distOutput, 0o755);

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1,8 +1,10 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { ComputerUsePermissionState } from "./computer-use-types";
-
-const execFileAsync = promisify(execFile);
+import {
+  ComputerUseNativeHelperError,
+  createComputerUseNativeBackend,
+  type ComputerUseNativeBackend,
+  type ComputerUseNativePressKeyRequest,
+} from "./computer-use-native";
 
 export const SUPPORTED_COMPUTER_USE_CAPABILITIES = [
   "apps.list",
@@ -25,7 +27,7 @@ export interface ComputerUseCommand {
   readonly payload: Record<string, unknown>;
 }
 
-interface AccessibilityElementSnapshot {
+export interface AccessibilityElementSnapshot {
   readonly id: string;
   readonly role?: string;
   readonly roleDescription?: string;
@@ -39,7 +41,7 @@ interface AccessibilityElementSnapshot {
   readonly children?: readonly AccessibilityElementSnapshot[];
 }
 
-interface AccessibilityAppStateSnapshot {
+export interface AccessibilityAppStateSnapshot {
   readonly app: string;
   readonly snapshotId: string;
   readonly elements: readonly AccessibilityElementSnapshot[];
@@ -53,14 +55,6 @@ interface AccessibilitySnapshotOutputLimits {
   readonly maxNodes: number;
   readonly maxChildrenPerNode: number;
 }
-
-const ACCESSIBILITY_JXA_SNAPSHOT_LIMITS = Object.freeze({
-  maxDepth: 32,
-  maxNodes: 2_000,
-  maxChildrenPerSource: 160,
-  maxWindows: 8,
-  maxActions: 12,
-});
 
 export const ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS =
   Object.freeze<AccessibilitySnapshotOutputLimits>({
@@ -111,8 +105,6 @@ export type ComputerUseCommandExecutionResult =
   | ComputerUseCommandSuccess
   | ComputerUseCommandFailure;
 
-type RunJxa = (script: string) => Promise<string>;
-
 export interface ComputerUseCoordinateBounds {
   readonly x: number;
   readonly y: number;
@@ -135,258 +127,16 @@ interface ComputerUseSnapshotMetadata {
   readonly sourceBounds?: ComputerUseCoordinateBounds;
 }
 
-type ComputerUseMouseButton = "left" | "right" | "middle";
+export type ComputerUseMouseButton = "left" | "right" | "middle";
 
 interface ComputerUseCommandExecutionDependencies {
   readonly captureScreenshot: ComputerUseScreenshotCapture;
   readonly snapshotStore?: ComputerUseSnapshotStore;
   readonly platform?: NodeJS.Platform;
-  readonly runJxa?: RunJxa;
+  readonly nativeBackend?: ComputerUseNativeBackend;
 }
 
 const DEFAULT_SNAPSHOT_STORE_LIMIT = 50;
-
-function appSnapshotKey(app: string): string {
-  return app.trim().toLowerCase();
-}
-
-export class ComputerUseSnapshotStore {
-  private readonly snapshots = new Map<string, ComputerUseSnapshotMetadata>();
-  private readonly latestByApp = new Map<string, string>();
-
-  constructor(private readonly maxEntries = DEFAULT_SNAPSHOT_STORE_LIMIT) {}
-
-  set(metadata: ComputerUseSnapshotMetadata): void {
-    const key = this.key(metadata.app, metadata.snapshotId);
-    if (this.snapshots.has(key)) {
-      this.snapshots.delete(key);
-    }
-    this.snapshots.set(key, metadata);
-    this.latestByApp.set(appSnapshotKey(metadata.app), key);
-
-    while (this.snapshots.size > this.maxEntries) {
-      const oldestKey = this.snapshots.keys().next().value;
-      if (typeof oldestKey !== "string") {
-        return;
-      }
-      this.snapshots.delete(oldestKey);
-      for (const [appKey, snapshotKey] of this.latestByApp) {
-        if (snapshotKey === oldestKey) {
-          this.latestByApp.delete(appKey);
-        }
-      }
-    }
-  }
-
-  get(app: string, snapshotId: string): ComputerUseSnapshotMetadata | null {
-    return this.snapshots.get(this.key(app, snapshotId)) ?? null;
-  }
-
-  getLatestForApp(app: string): ComputerUseSnapshotMetadata | null {
-    const key = this.latestByApp.get(appSnapshotKey(app));
-    return key ? (this.snapshots.get(key) ?? null) : null;
-  }
-
-  private key(app: string, snapshotId: string): string {
-    return `${appSnapshotKey(app)}\0${snapshotId}`;
-  }
-}
-
-function payloadString(
-  payload: Record<string, unknown>,
-  key: string,
-): string | null {
-  const value = payload[key];
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : null;
-}
-
-function snapshotId(): string {
-  return `desktop_${Date.now().toString(36)}`;
-}
-
-function requireAccessibility(
-  permissions: ComputerUsePermissionState,
-  platform: NodeJS.Platform,
-): ComputerUseCommandFailure | null {
-  if (platform !== "darwin") {
-    return {
-      status: "failed",
-      error: {
-        code: "accessibility_unavailable",
-        message: "Desktop Computer Use is currently implemented for macOS",
-      },
-    };
-  }
-  if (!permissions.accessibility) {
-    return {
-      status: "failed",
-      error: {
-        code: "permission_denied",
-        message: "macOS Accessibility permission is required",
-      },
-    };
-  }
-  return null;
-}
-
-function requireScreenRecording(
-  permissions: ComputerUsePermissionState,
-): ComputerUseCommandFailure | null {
-  if (!permissions.screenRecording) {
-    return {
-      status: "failed",
-      error: {
-        code: "screen_recording_unavailable",
-        message: "macOS Screen Recording permission is required",
-      },
-    };
-  }
-  return null;
-}
-
-function jxaString(value: string): string {
-  return JSON.stringify(value);
-}
-
-function stringHasValue(value: string | undefined): boolean {
-  return value !== undefined && value.trim().length > 0;
-}
-
-function elementIsWebArea(element: AccessibilityElementSnapshot): boolean {
-  return (
-    element.role === "AXWebArea" ||
-    element.roleDescription?.toLowerCase().includes("html") === true
-  );
-}
-
-function elementHasMeaningfulContent(
-  element: AccessibilityElementSnapshot,
-): boolean {
-  return (
-    stringHasValue(element.name) ||
-    stringHasValue(element.value) ||
-    stringHasValue(element.description) ||
-    element.focused === true ||
-    element.enabled === false ||
-    (element.actions !== undefined && element.actions.length > 0)
-  );
-}
-
-function shouldElideElement(
-  element: AccessibilityElementSnapshot,
-  childCount: number,
-  inWebArea: boolean,
-): boolean {
-  if (!element.role || !GENERIC_WRAPPER_ROLES.has(element.role)) {
-    return false;
-  }
-  if (elementHasMeaningfulContent(element)) {
-    return false;
-  }
-  if (inWebArea && childCount > 1) {
-    return false;
-  }
-  return true;
-}
-
-function pushUniqueReason(reasons: string[], reason: string): void {
-  if (!reasons.includes(reason)) {
-    reasons.push(reason);
-  }
-}
-
-export function normalizeAccessibilitySnapshot(
-  snapshot: AccessibilityAppStateSnapshot,
-  limits: AccessibilitySnapshotOutputLimits = ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS,
-): AccessibilityAppStateSnapshot {
-  let nodeCount = 0;
-  const truncationReasons: string[] = [];
-
-  const normalizeElement = (
-    element: AccessibilityElementSnapshot,
-    depth: number,
-    inWebArea: boolean,
-  ): AccessibilityElementSnapshot[] => {
-    if (depth > limits.maxDepth) {
-      pushUniqueReason(truncationReasons, "max_depth");
-      return [];
-    }
-
-    const nextInWebArea = inWebArea || elementIsWebArea(element);
-    const rawChildren = element.children ?? [];
-    const childEntries = rawChildren.slice(0, limits.maxChildrenPerNode);
-    if (rawChildren.length > childEntries.length) {
-      pushUniqueReason(truncationReasons, "max_children_per_node");
-    }
-
-    const elide = shouldElideElement(element, rawChildren.length, inWebArea);
-    if (!elide) {
-      if (nodeCount >= limits.maxNodes) {
-        pushUniqueReason(truncationReasons, "max_nodes");
-        return [];
-      }
-      nodeCount += 1;
-    }
-
-    const children: AccessibilityElementSnapshot[] = [];
-    for (const child of childEntries) {
-      if (nodeCount >= limits.maxNodes) {
-        pushUniqueReason(truncationReasons, "max_nodes");
-        break;
-      }
-      children.push(...normalizeElement(child, depth + 1, nextInWebArea));
-    }
-
-    if (elide) {
-      return children;
-    }
-
-    return [
-      {
-        ...element,
-        children: children.length > 0 ? children : undefined,
-      },
-    ];
-  };
-
-  const elements = snapshot.elements.flatMap((element) => {
-    return normalizeElement(element, 0, false);
-  });
-
-  const combinedReasons = [
-    ...(snapshot.truncationReasons ?? []),
-    ...truncationReasons,
-  ];
-
-  return {
-    ...snapshot,
-    elements,
-    nodeCount,
-    truncated:
-      snapshot.truncated === true ||
-      combinedReasons.length > 0 ||
-      snapshot.nodeCount !== undefined
-        ? snapshot.truncated === true || combinedReasons.length > 0
-        : undefined,
-    truncationReasons:
-      combinedReasons.length > 0
-        ? [...new Set(combinedReasons)]
-        : snapshot.truncationReasons,
-  };
-}
-
-async function runJxa(script: string): Promise<string> {
-  const { stdout } = await execFileAsync("osascript", [
-    "-l",
-    "JavaScript",
-    "-e",
-    script,
-  ]);
-  return stdout.trim();
-}
-
 const CG_EVENT_FLAG_SHIFT = 131_072;
 const CG_EVENT_FLAG_CONTROL = 262_144;
 const CG_EVENT_FLAG_OPTION = 524_288;
@@ -565,6 +315,261 @@ class UnsupportedComputerUseCommandError extends Error {
   }
 }
 
+function appSnapshotKey(app: string): string {
+  return app.trim().toLowerCase();
+}
+
+export class ComputerUseSnapshotStore {
+  private readonly snapshots = new Map<string, ComputerUseSnapshotMetadata>();
+  private readonly latestByApp = new Map<string, string>();
+
+  constructor(private readonly maxEntries = DEFAULT_SNAPSHOT_STORE_LIMIT) {}
+
+  set(metadata: ComputerUseSnapshotMetadata): void {
+    const key = this.key(metadata.app, metadata.snapshotId);
+    if (this.snapshots.has(key)) {
+      this.snapshots.delete(key);
+    }
+    this.snapshots.set(key, metadata);
+    this.latestByApp.set(appSnapshotKey(metadata.app), key);
+
+    while (this.snapshots.size > this.maxEntries) {
+      const oldestKey = this.snapshots.keys().next().value;
+      if (typeof oldestKey !== "string") {
+        return;
+      }
+      this.snapshots.delete(oldestKey);
+      for (const [appKey, snapshotKey] of this.latestByApp) {
+        if (snapshotKey === oldestKey) {
+          this.latestByApp.delete(appKey);
+        }
+      }
+    }
+  }
+
+  get(app: string, snapshotId: string): ComputerUseSnapshotMetadata | null {
+    return this.snapshots.get(this.key(app, snapshotId)) ?? null;
+  }
+
+  getLatestForApp(app: string): ComputerUseSnapshotMetadata | null {
+    const key = this.latestByApp.get(appSnapshotKey(app));
+    return key ? (this.snapshots.get(key) ?? null) : null;
+  }
+
+  private key(app: string, snapshotId: string): string {
+    return `${appSnapshotKey(app)}\0${snapshotId}`;
+  }
+}
+
+function payloadString(
+  payload: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function payloadNumber(
+  payload: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function payloadMouseButton(
+  payload: Record<string, unknown>,
+): ComputerUseMouseButton {
+  const value = payload.button;
+  if (value === "right" || value === "middle") {
+    return value;
+  }
+  return "left";
+}
+
+function payloadClickCount(payload: Record<string, unknown>): number {
+  const value = payload.clickCount;
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 3
+    ? value
+    : 1;
+}
+
+function snapshotId(): string {
+  return `desktop_${Date.now().toString(36)}`;
+}
+
+function requireAccessibility(
+  permissions: ComputerUsePermissionState,
+  platform: NodeJS.Platform,
+): ComputerUseCommandFailure | null {
+  if (platform !== "darwin") {
+    return {
+      status: "failed",
+      error: {
+        code: "accessibility_unavailable",
+        message: "Desktop Computer Use is currently implemented for macOS",
+      },
+    };
+  }
+  if (!permissions.accessibility) {
+    return {
+      status: "failed",
+      error: {
+        code: "permission_denied",
+        message: "macOS Accessibility permission is required",
+      },
+    };
+  }
+  return null;
+}
+
+function requireScreenRecording(
+  permissions: ComputerUsePermissionState,
+): ComputerUseCommandFailure | null {
+  if (!permissions.screenRecording) {
+    return {
+      status: "failed",
+      error: {
+        code: "screen_recording_unavailable",
+        message: "macOS Screen Recording permission is required",
+      },
+    };
+  }
+  return null;
+}
+
+function stringHasValue(value: string | undefined): boolean {
+  return value !== undefined && value.trim().length > 0;
+}
+
+function elementIsWebArea(element: AccessibilityElementSnapshot): boolean {
+  return (
+    element.role === "AXWebArea" ||
+    element.roleDescription?.toLowerCase().includes("html") === true
+  );
+}
+
+function elementHasMeaningfulContent(
+  element: AccessibilityElementSnapshot,
+): boolean {
+  return (
+    stringHasValue(element.name) ||
+    stringHasValue(element.value) ||
+    stringHasValue(element.description) ||
+    element.focused === true ||
+    element.enabled === false ||
+    (element.actions !== undefined && element.actions.length > 0)
+  );
+}
+
+function shouldElideElement(
+  element: AccessibilityElementSnapshot,
+  childCount: number,
+  inWebArea: boolean,
+): boolean {
+  if (!element.role || !GENERIC_WRAPPER_ROLES.has(element.role)) {
+    return false;
+  }
+  if (elementHasMeaningfulContent(element)) {
+    return false;
+  }
+  if (inWebArea && childCount > 1) {
+    return false;
+  }
+  return true;
+}
+
+function pushUniqueReason(reasons: string[], reason: string): void {
+  if (!reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+}
+
+export function normalizeAccessibilitySnapshot(
+  snapshot: AccessibilityAppStateSnapshot,
+  limits: AccessibilitySnapshotOutputLimits = ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS,
+): AccessibilityAppStateSnapshot {
+  let nodeCount = 0;
+  const truncationReasons: string[] = [];
+
+  const normalizeElement = (
+    element: AccessibilityElementSnapshot,
+    depth: number,
+    inWebArea: boolean,
+  ): AccessibilityElementSnapshot[] => {
+    if (depth > limits.maxDepth) {
+      pushUniqueReason(truncationReasons, "max_depth");
+      return [];
+    }
+
+    const nextInWebArea = inWebArea || elementIsWebArea(element);
+    const rawChildren = element.children ?? [];
+    const childEntries = rawChildren.slice(0, limits.maxChildrenPerNode);
+    if (rawChildren.length > childEntries.length) {
+      pushUniqueReason(truncationReasons, "max_children_per_node");
+    }
+
+    const elide = shouldElideElement(element, rawChildren.length, inWebArea);
+    if (!elide) {
+      if (nodeCount >= limits.maxNodes) {
+        pushUniqueReason(truncationReasons, "max_nodes");
+        return [];
+      }
+      nodeCount += 1;
+    }
+
+    const children: AccessibilityElementSnapshot[] = [];
+    for (const child of childEntries) {
+      if (nodeCount >= limits.maxNodes) {
+        pushUniqueReason(truncationReasons, "max_nodes");
+        break;
+      }
+      children.push(...normalizeElement(child, depth + 1, nextInWebArea));
+    }
+
+    if (elide) {
+      return children;
+    }
+
+    return [
+      {
+        ...element,
+        children: children.length > 0 ? children : undefined,
+      },
+    ];
+  };
+
+  const elements = snapshot.elements.flatMap((element) => {
+    return normalizeElement(element, 0, false);
+  });
+
+  const combinedReasons = [
+    ...(snapshot.truncationReasons ?? []),
+    ...truncationReasons,
+  ];
+
+  return {
+    ...snapshot,
+    elements,
+    nodeCount,
+    truncated:
+      snapshot.truncated === true ||
+      combinedReasons.length > 0 ||
+      snapshot.nodeCount !== undefined
+        ? snapshot.truncated === true || combinedReasons.length > 0
+        : undefined,
+    truncationReasons:
+      combinedReasons.length > 0
+        ? [...new Set(combinedReasons)]
+        : snapshot.truncationReasons,
+  };
+}
+
 function normalizeKeyToken(value: string): string {
   return value
     .trim()
@@ -591,6 +596,16 @@ function unsupportedCommand(message: string): ComputerUseCommandFailure {
     error: {
       code: "unsupported_command",
       message,
+    },
+  };
+}
+
+function missingField(field: string): ComputerUseCommandFailure {
+  return {
+    status: "failed",
+    error: {
+      code: "unsupported_command",
+      message: `Missing required payload field: ${field}`,
     },
   };
 }
@@ -664,24 +679,6 @@ function parseComputerUseKeyPress(key: string): ParsedComputerUseKeyPress {
       displayKey,
     ].join("+"),
   };
-}
-
-function parseJsonRecord(output: string): Record<string, unknown> {
-  const value = JSON.parse(output) as unknown;
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-  return value as Record<string, unknown>;
-}
-
-function recordString(
-  record: Record<string, unknown>,
-  key: string,
-): string | null {
-  const value = record[key];
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : null;
 }
 
 export function renderAccessibilityTree(
@@ -765,368 +762,22 @@ function buildComputerUseAppStateResult(
   };
 }
 
-function appStateScript(app: string, id: string): string {
-  return `
-const appName = ${jxaString(app)};
-const snapshotId = ${jxaString(id)};
-const limits = ${JSON.stringify(ACCESSIBILITY_JXA_SNAPSHOT_LIMITS)};
-const systemEvents = Application("System Events");
-let nodeCount = 0;
-let truncated = false;
-let truncationReasons = [];
-function markTruncated(reason) {
-  truncated = true;
-  if (!truncationReasons.includes(reason)) {
-    truncationReasons.push(reason);
-  }
-}
-function safeString(read) {
-  try {
-    const value = read();
-    if (value === undefined || value === null) return undefined;
-    const text = String(value).trim();
-    return text.length > 0 ? text : undefined;
-  } catch (_error) {
-    return undefined;
-  }
-}
-function safeAttributeValue(element, name) {
-  try {
-    return element.attributes.byName(name).value();
-  } catch (_error) {
-    return undefined;
-  }
-}
-function safeAttributeString(element, name) {
-  const value = safeAttributeValue(element, name);
-  if (value === undefined || value === null) return undefined;
-  const text = String(value).trim();
-  return text.length > 0 ? text : undefined;
-}
-function safeBool(read) {
-  try {
-    const value = read();
-    return typeof value === "boolean" ? value : undefined;
-  } catch (_error) {
-    return undefined;
-  }
-}
-function safeBounds(element) {
-  try {
-    const position = element.position();
-    const size = element.size();
-    return { x: position[0], y: position[1], width: size[0], height: size[1] };
-  } catch (_error) {
-    return undefined;
-  }
-}
-function safeActions(element) {
-  try {
-    return element.actions().slice(0, limits.maxActions).map((action) => String(action.name()));
-  } catch (_error) {
-    return [];
-  }
-}
-function asArray(value) {
-  if (value === undefined || value === null) return [];
-  if (Array.isArray(value)) return value;
-  try {
-    if (typeof value.length === "number") {
-      return Array.prototype.slice.call(value);
-    }
-  } catch (_error) {
-    return [];
-  }
-  return [value];
-}
-function collectionChildren(read, prefix) {
-  try {
-    return read().slice(0, limits.maxChildrenPerSource).map((child, index) => ({
-      child,
-      segment: prefix + index,
-    }));
-  } catch (_error) {
-    return [];
-  }
-}
-function attributeChildren(element, attributeName, prefix) {
-  return asArray(safeAttributeValue(element, attributeName))
-    .slice(0, limits.maxChildrenPerSource)
-    .map((child, index) => ({
-      child,
-      segment: prefix + index,
-    }));
-}
-function childFingerprint(element) {
-  const bounds = safeBounds(element);
-  if (!bounds) return "";
-  return [
-    safeString(() => element.role()) || "",
-    safeString(() => element.name()) || "",
-    safeString(() => element.value()) || "",
-    [bounds.x, bounds.y, bounds.width, bounds.height].join(","),
-  ].join("|");
-}
-function collectChildren(element) {
-  const candidates = [
-    ...collectionChildren(() => element.uiElements(), "e"),
-    ...collectionChildren(() => element.rows(), "r"),
-    ...attributeChildren(element, "AXContents", "c"),
-    ...attributeChildren(element, "AXVisibleChildren", "v"),
-  ];
-  const seen = {};
-  const children = [];
-  for (const candidate of candidates) {
-    const fingerprint = childFingerprint(candidate.child);
-    if (fingerprint.length > 0 && seen[fingerprint]) {
-      continue;
-    }
-    if (fingerprint.length > 0) {
-      seen[fingerprint] = true;
-    }
-    children.push(candidate);
-  }
-  return children;
-}
-function setAttributeValue(element, name, value) {
-  try {
-    element.attributes.byName(name).value = value;
-  } catch (_error) {
-  }
-}
-function enableBestEffortAccessibilityModes(process) {
-  setAttributeValue(process, "AXManualAccessibility", true);
-  setAttributeValue(process, "AXEnhancedUserInterface", true);
-}
-function describe(element, id, depth) {
-  if (nodeCount >= limits.maxNodes) {
-    markTruncated("max_nodes");
-    return undefined;
-  }
-  if (depth > limits.maxDepth) {
-    markTruncated("max_depth");
-    return undefined;
-  }
-  nodeCount += 1;
-  const node = {
-    id,
-    role: safeString(() => element.role()),
-    roleDescription: safeAttributeString(element, "AXRoleDescription"),
-    name: safeString(() => element.name()),
-    value: safeString(() => element.value()),
-    description: safeString(() => element.description()),
-    focused: safeBool(() => element.focused()),
-    enabled: safeBool(() => element.enabled()),
-    actions: safeActions(element),
-    bounds: safeBounds(element),
-    children: [],
-  };
-  if (depth >= limits.maxDepth) {
-    markTruncated("max_depth");
-    return node;
-  }
-  const childEntries = collectChildren(element);
-  for (const childEntry of childEntries) {
-    const child = describe(childEntry.child, id + "." + childEntry.segment, depth + 1);
-    if (child !== undefined) {
-      node.children.push(child);
-    }
-  }
-  return node;
-}
-const processes = systemEvents.processes.whose({ name: appName })();
-if (processes.length === 0) {
-  JSON.stringify({ app: appName, snapshotId, elements: [] });
-} else {
-  const process = processes[0];
-  enableBestEffortAccessibilityModes(process);
-  const windows = process.windows().slice(0, limits.maxWindows);
-  JSON.stringify({
-    app: appName,
-    snapshotId,
-    elements: windows
-      .map((window, index) => describe(window, "w" + index, 0))
-      .filter((element) => element !== undefined),
-    nodeCount,
-    truncated,
-    truncationReasons,
-  });
-}
-`;
-}
-
-function targetProcessScript(app: string): string {
-  return `
-const appName = ${jxaString(app)};
-const systemEvents = Application("System Events");
-const processes = systemEvents.processes.whose({ name: appName })();
-if (processes.length === 0) throw new Error("App is not running: " + appName);
-const process = processes[0];
-const pid = Number(process.unixId());
-if (!Number.isFinite(pid) || pid <= 0) {
-  throw new Error("Unable to resolve process id for app: " + appName);
-}
-`;
-}
-
-function targetedKeyPressScript(
-  app: string,
-  parsed: ParsedComputerUseKeyPress,
-): string {
-  return `
-ObjC.import("ApplicationServices");
-${targetProcessScript(app)}
-function postKey(keyCode, keyDown, flags) {
-  const event = $.CGEventCreateKeyboardEvent(null, keyCode, keyDown);
-  $.CGEventSetFlags(event, flags);
-  $.CGEventPostToPid(pid, event);
-  $.CFRelease(event);
-}
-const flags = ${parsed.flags};
-const modifiers = ${JSON.stringify(parsed.modifiers)};
-let activeFlags = 0;
-for (const modifier of modifiers) {
-  activeFlags |= modifier.flag;
-  postKey(modifier.keyCode, true, activeFlags);
-}
-postKey(${parsed.keyCode}, true, flags);
-postKey(${parsed.keyCode}, false, flags);
-for (let index = modifiers.length - 1; index >= 0; index -= 1) {
-  activeFlags &= ~modifiers[index].flag;
-  postKey(modifiers[index].keyCode, false, activeFlags);
-}
-JSON.stringify({ pid });
-`;
-}
-
-const MOUSE_BUTTON_EVENT_CONFIG = Object.freeze({
-  left: { button: 0, down: 1, up: 2 },
-  right: { button: 1, down: 3, up: 4 },
-  middle: { button: 2, down: 25, up: 26 },
-} satisfies Record<
-  ComputerUseMouseButton,
-  { readonly button: number; readonly down: number; readonly up: number }
->);
-
-function targetedMouseClickScript(
-  app: string,
-  x: number,
-  y: number,
-  button: ComputerUseMouseButton,
-  clickCount: number,
-): string {
-  const events = MOUSE_BUTTON_EVENT_CONFIG[button];
-  return `
-ObjC.import("ApplicationServices");
-${targetProcessScript(app)}
-const point = $.CGPointMake(${x}, ${y});
-function postMouseEvent(type, clickState) {
-  const event = $.CGEventCreateMouseEvent(null, type, point, ${events.button});
-  $.CGEventSetIntegerValueField(event, $.kCGMouseEventClickState, clickState);
-  $.CGEventPostToPid(pid, event);
-  $.CFRelease(event);
-}
-for (let clickIndex = 1; clickIndex <= ${clickCount}; clickIndex += 1) {
-  postMouseEvent(${events.down}, clickIndex);
-  postMouseEvent(${events.up}, clickIndex);
-  if (clickIndex < ${clickCount}) delay(0.05);
-}
-JSON.stringify({ pid });
-`;
-}
-
-function resolveElementScript(app: string, elementId: string): string {
-  return `
-const appName = ${jxaString(app)};
-const elementId = ${jxaString(elementId)};
-const systemEvents = Application("System Events");
-function asArray(value) {
-  if (value === undefined || value === null) return [];
-  if (Array.isArray(value)) return value;
-  try {
-    if (typeof value.length === "number") {
-      return Array.prototype.slice.call(value);
-    }
-  } catch (_error) {
-    return [];
-  }
-  return [value];
-}
-function attributeChildren(element, attributeName) {
-  try {
-    return asArray(element.attributes.byName(attributeName).value());
-  } catch (_error) {
-    return [];
-  }
-}
-function childForSegment(element, part) {
-  const index = Number(part.slice(1));
-  if (!Number.isInteger(index) || index < 0) {
-    throw new Error("Invalid element id segment: " + part);
-  }
-  if (part.startsWith("e")) {
-    return element.uiElements()[index];
-  }
-  if (part.startsWith("r")) {
-    return element.rows()[index];
-  }
-  if (part.startsWith("c")) {
-    return attributeChildren(element, "AXContents")[index];
-  }
-  if (part.startsWith("v")) {
-    return attributeChildren(element, "AXVisibleChildren")[index];
-  }
-  throw new Error("Invalid element id segment: " + part);
-}
-function resolve(process, id) {
-  const parts = id.split(".");
-  let current = null;
-  for (const part of parts) {
-    const index = Number(part.slice(1));
-    if (part.startsWith("w")) {
-      current = process.windows()[index];
-    } else if (part.startsWith("e") && current) {
-      current = childForSegment(current, part);
-    } else if ((part.startsWith("r") || part.startsWith("c") || part.startsWith("v")) && current) {
-      current = childForSegment(current, part);
-    } else {
-      throw new Error("Invalid element id: " + id);
-    }
-    if (!current) throw new Error("Element not found: " + id);
-  }
-  if (!current) throw new Error("Element not found: " + id);
-  return current;
-}
-const processes = systemEvents.processes.whose({ name: appName })();
-if (processes.length === 0) throw new Error("App is not running: " + appName);
-const element = resolve(processes[0], elementId);
-`;
-}
-
 async function listApps(
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  const output = await runJxaCommand(`
-const systemEvents = Application("System Events");
-const apps = systemEvents.applicationProcesses.whose({ backgroundOnly: false })()
-  .map((app) => String(app.name()))
-  .sort();
-JSON.stringify(apps);
-`);
-  const apps = JSON.parse(output) as string[];
+  const apps = [...(await nativeBackend.listApps())].sort();
   return { status: "succeeded", result: { apps, text: apps.join("\n") } };
 }
 
 async function getAppState(
   app: string,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
   captureScreenshot: ComputerUseScreenshotCapture,
   snapshotStore: ComputerUseSnapshotStore,
 ): Promise<ComputerUseCommandExecutionResult> {
   const id = snapshotId();
-  const output = await runJxaCommand(appStateScript(app, id));
   const snapshot = normalizeAccessibilitySnapshot(
-    JSON.parse(output) as AccessibilityAppStateSnapshot,
+    await nativeBackend.getAppState(app, id),
   );
   const windowBounds = snapshotWindowCaptureCandidates(snapshot);
   let screenshot: ComputerUseScreenshotCaptureResult;
@@ -1164,9 +815,9 @@ async function getAppState(
 
 async function openApp(
   app: string,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await runJxaCommand(`Application(${jxaString(app)}).activate();`);
+  await nativeBackend.openApp(app);
   return {
     status: "succeeded",
     result: {
@@ -1244,7 +895,7 @@ async function clickElement(args: {
   readonly y: number | null;
   readonly button: ComputerUseMouseButton;
   readonly clickCount: number;
-  readonly runJxaCommand: RunJxa;
+  readonly nativeBackend: ComputerUseNativeBackend;
   readonly snapshotStore: ComputerUseSnapshotStore;
 }): Promise<ComputerUseCommandExecutionResult> {
   if (args.elementId) {
@@ -1253,12 +904,12 @@ async function clickElement(args: {
         "element.click with element id only supports the left button; use coordinates for right or middle clicks",
       );
     }
-    await args.runJxaCommand(`
-${resolveElementScript(args.app, args.elementId)}
-for (let clickIndex = 0; clickIndex < ${args.clickCount}; clickIndex += 1) {
-element.click();
-}
-`);
+    await args.nativeBackend.clickElement({
+      app: args.app,
+      elementId: args.elementId,
+      button: args.button,
+      clickCount: args.clickCount,
+    });
     return {
       status: "succeeded",
       result: {
@@ -1286,15 +937,13 @@ element.click();
     if ("status" in screenPoint) {
       return screenPoint;
     }
-    await args.runJxaCommand(
-      targetedMouseClickScript(
-        args.app,
-        screenPoint.screenX,
-        screenPoint.screenY,
-        args.button,
-        args.clickCount,
-      ),
-    );
+    await args.nativeBackend.clickPoint({
+      app: args.app,
+      x: screenPoint.screenX,
+      y: screenPoint.screenY,
+      button: args.button,
+      clickCount: args.clickCount,
+    });
     return {
       status: "succeeded",
       result: {
@@ -1322,12 +971,9 @@ async function setElementValue(
   app: string,
   elementId: string,
   value: string,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await runJxaCommand(`
-${resolveElementScript(app, elementId)}
-element.value = ${jxaString(value)};
-`);
+  await nativeBackend.setElementValue({ app, elementId, value });
   return {
     status: "succeeded",
     result: {
@@ -1345,12 +991,9 @@ async function performElementAction(
   app: string,
   elementId: string,
   action: string,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await runJxaCommand(`
-${resolveElementScript(app, elementId)}
-element.actions.byName(${jxaString(action)}).perform();
-`);
+  await nativeBackend.performElementAction({ app, elementId, action });
   return {
     status: "succeeded",
     result: {
@@ -1368,70 +1011,9 @@ element.actions.byName(${jxaString(action)}).perform();
 async function typeText(
   app: string,
   text: string,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandExecutionResult> {
-  const output = await runJxaCommand(`
-const inputText = ${jxaString(text)};
-${targetProcessScript(app)}
-function safeString(read) {
-  try {
-    const value = read();
-    if (value === undefined || value === null) return undefined;
-    return String(value);
-  } catch (_error) {
-    return undefined;
-  }
-}
-function focusedElement(process) {
-  try {
-    return process.attributes.byName("AXFocusedUIElement").value();
-  } catch (_error) {
-    return null;
-  }
-}
-const element = focusedElement(process);
-if (!element) {
-  JSON.stringify({
-    status: "failed",
-    message: "keyboard.type_text requires a focused editable text element in " + appName,
-  });
-} else {
-  const role = safeString(() => element.role());
-  const description = safeString(() => element.description());
-  const editableRoles = [
-    "AXComboBox",
-    "AXSearchField",
-    "AXTextArea",
-    "AXTextField",
-    "AXTextView",
-  ];
-  const editable = editableRoles.includes(role);
-  if (!editable) {
-    JSON.stringify({
-      status: "failed",
-      message: "keyboard.type_text requires a focused editable text element in " + appName,
-      role,
-      description,
-    });
-  } else {
-    const currentValue = safeString(() => element.value()) ?? "";
-    element.value = currentValue + inputText;
-    JSON.stringify({
-      status: "succeeded",
-      role,
-      description,
-    });
-  }
-}
-`);
-  const result = parseJsonRecord(output);
-  if (result.status === "failed") {
-    return unsupportedCommand(
-      recordString(result, "message") ??
-        "keyboard.type_text requires a focused editable text element",
-    );
-  }
-
+  const result = await nativeBackend.typeText({ app, text });
   return {
     status: "succeeded",
     result: {
@@ -1439,7 +1021,7 @@ if (!element) {
       dispatchMode: "accessibility_value",
       dispatchTarget: "focused_editable_element",
       inputRisk: "targeted_app_text",
-      role: recordString(result, "role"),
+      role: result.role,
       text: "Typed text",
     },
   };
@@ -1448,10 +1030,17 @@ if (!element) {
 async function pressKey(
   app: string,
   key: string,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
   const parsed = parseComputerUseKeyPress(key);
-  await runJxaCommand(targetedKeyPressScript(app, parsed));
+  const request: ComputerUseNativePressKeyRequest = {
+    app,
+    keyCode: parsed.keyCode,
+    modifiers: parsed.modifiers,
+    flags: parsed.flags,
+    normalizedKey: parsed.normalizedKey,
+  };
+  await nativeBackend.pressKey(request);
   return {
     status: "succeeded",
     result: {
@@ -1470,21 +1059,9 @@ async function scrollElement(
   elementId: string,
   direction: string,
   pages: number,
-  runJxaCommand: RunJxa,
+  nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  const axis =
-    direction === "left" || direction === "right"
-      ? "AXHorizontalScrollBar"
-      : "AXVerticalScrollBar";
-  const sign = direction === "up" || direction === "left" ? -1 : 1;
-  await runJxaCommand(`
-${resolveElementScript(app, elementId)}
-const scrollBars = element.uiElements.whose({ role: ${jxaString(axis)} })();
-if (scrollBars.length > 0) {
-  const scrollBar = scrollBars[0];
-  scrollBar.value = Number(scrollBar.value()) + ${sign * pages};
-}
-`);
+  await nativeBackend.scrollElement({ app, elementId, direction, pages });
   return {
     status: "succeeded",
     result: {
@@ -1498,44 +1075,6 @@ if (scrollBars.length > 0) {
       text: `Scrolled ${elementId}`,
     },
   };
-}
-
-function missingField(field: string): ComputerUseCommandFailure {
-  return {
-    status: "failed",
-    error: {
-      code: "unsupported_command",
-      message: `Missing required payload field: ${field}`,
-    },
-  };
-}
-
-function payloadNumber(
-  payload: Record<string, unknown>,
-  key: string,
-): number | null {
-  const value = payload[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function payloadMouseButton(
-  payload: Record<string, unknown>,
-): ComputerUseMouseButton {
-  const value = payload.button;
-  if (value === "right" || value === "middle") {
-    return value;
-  }
-  return "left";
-}
-
-function payloadClickCount(payload: Record<string, unknown>): number {
-  const value = payload.clickCount;
-  return typeof value === "number" &&
-    Number.isInteger(value) &&
-    value >= 1 &&
-    value <= 3
-    ? value
-    : 1;
 }
 
 export async function executeComputerUseCommand(
@@ -1552,12 +1091,13 @@ export async function executeComputerUseCommand(
   }
 
   try {
-    const runJxaCommand = dependencies.runJxa ?? runJxa;
+    const nativeBackend =
+      dependencies.nativeBackend ?? createComputerUseNativeBackend();
     const snapshotStore =
       dependencies.snapshotStore ?? new ComputerUseSnapshotStore();
     const app = payloadString(command.payload, "app");
     if (command.kind === "apps.list") {
-      return await listApps(runJxaCommand);
+      return await listApps(nativeBackend);
     }
     if (!app) {
       return missingField("app");
@@ -1569,13 +1109,13 @@ export async function executeComputerUseCommand(
       }
       return await getAppState(
         app,
-        runJxaCommand,
+        nativeBackend,
         dependencies.captureScreenshot,
         snapshotStore,
       );
     }
     if (command.kind === "app.open") {
-      return await openApp(app, runJxaCommand);
+      return await openApp(app, nativeBackend);
     }
     if (command.kind === "element.click") {
       const x = payloadNumber(command.payload, "x");
@@ -1594,7 +1134,7 @@ export async function executeComputerUseCommand(
         }
         const snapshotResult = await getAppState(
           app,
-          runJxaCommand,
+          nativeBackend,
           dependencies.captureScreenshot,
           snapshotStore,
         );
@@ -1610,7 +1150,7 @@ export async function executeComputerUseCommand(
         y,
         button: payloadMouseButton(command.payload),
         clickCount: payloadClickCount(command.payload),
-        runJxaCommand,
+        nativeBackend,
         snapshotStore,
       });
     }
@@ -1628,7 +1168,7 @@ export async function executeComputerUseCommand(
         elementId,
         direction,
         payloadNumber(command.payload, "pages") ?? 1,
-        runJxaCommand,
+        nativeBackend,
       );
     }
     if (command.kind === "element.set_value") {
@@ -1640,7 +1180,7 @@ export async function executeComputerUseCommand(
       if (!value) {
         return missingField("value");
       }
-      return await setElementValue(app, elementId, value, runJxaCommand);
+      return await setElementValue(app, elementId, value, nativeBackend);
     }
     if (command.kind === "element.perform_action") {
       const elementId = payloadString(command.payload, "elementId");
@@ -1651,23 +1191,32 @@ export async function executeComputerUseCommand(
       if (!action) {
         return missingField("action");
       }
-      return await performElementAction(app, elementId, action, runJxaCommand);
+      return await performElementAction(app, elementId, action, nativeBackend);
     }
     if (command.kind === "keyboard.type_text") {
       const text = payloadString(command.payload, "text");
       return text
-        ? await typeText(app, text, runJxaCommand)
+        ? await typeText(app, text, nativeBackend)
         : missingField("text");
     }
     if (command.kind === "keyboard.press_key") {
       const key = payloadString(command.payload, "key");
       return key
-        ? await pressKey(app, key, runJxaCommand)
+        ? await pressKey(app, key, nativeBackend)
         : missingField("key");
     }
   } catch (error) {
     if (error instanceof UnsupportedComputerUseCommandError) {
       return unsupportedCommand(error.message);
+    }
+    if (error instanceof ComputerUseNativeHelperError) {
+      return {
+        status: "failed",
+        error: {
+          code: error.code,
+          message: error.message,
+        },
+      };
     }
     return {
       status: "failed",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -1,0 +1,331 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type {
+  AccessibilityAppStateSnapshot,
+  ComputerUseCommandFailure,
+  ComputerUseMouseButton,
+} from "./computer-use-accessibility";
+
+type ComputerUseNativeErrorCode = ComputerUseCommandFailure["error"]["code"];
+
+export interface ComputerUseNativeKeyModifier {
+  readonly keyCode: number;
+  readonly flag: number;
+}
+
+export interface ComputerUseNativePressKeyRequest {
+  readonly app: string;
+  readonly keyCode: number;
+  readonly modifiers: readonly ComputerUseNativeKeyModifier[];
+  readonly flags: number;
+  readonly normalizedKey: string;
+}
+
+export interface ComputerUseNativeBackend {
+  readonly listApps: () => Promise<readonly string[]>;
+  readonly getAppState: (
+    app: string,
+    snapshotId: string,
+  ) => Promise<AccessibilityAppStateSnapshot>;
+  readonly openApp: (app: string) => Promise<void>;
+  readonly clickElement: (args: {
+    readonly app: string;
+    readonly elementId: string;
+    readonly button: ComputerUseMouseButton;
+    readonly clickCount: number;
+  }) => Promise<void>;
+  readonly clickPoint: (args: {
+    readonly app: string;
+    readonly x: number;
+    readonly y: number;
+    readonly button: ComputerUseMouseButton;
+    readonly clickCount: number;
+  }) => Promise<void>;
+  readonly setElementValue: (args: {
+    readonly app: string;
+    readonly elementId: string;
+    readonly value: string;
+  }) => Promise<void>;
+  readonly performElementAction: (args: {
+    readonly app: string;
+    readonly elementId: string;
+    readonly action: string;
+  }) => Promise<void>;
+  readonly typeText: (args: {
+    readonly app: string;
+    readonly text: string;
+  }) => Promise<{ readonly role?: string; readonly description?: string }>;
+  readonly pressKey: (args: ComputerUseNativePressKeyRequest) => Promise<void>;
+  readonly scrollElement: (args: {
+    readonly app: string;
+    readonly elementId: string;
+    readonly direction: string;
+    readonly pages: number;
+  }) => Promise<void>;
+}
+
+type ComputerUseNativeRequest = Record<string, unknown> & {
+  readonly kind: string;
+};
+
+interface ComputerUseNativeSuccessResponse {
+  readonly status: "succeeded";
+  readonly result?: unknown;
+}
+
+interface ComputerUseNativeFailureResponse {
+  readonly status: "failed";
+  readonly error?: {
+    readonly code?: unknown;
+    readonly message?: unknown;
+  };
+}
+
+type ComputerUseNativeResponse =
+  | ComputerUseNativeSuccessResponse
+  | ComputerUseNativeFailureResponse;
+
+interface ResolveComputerUseHelperPathOptions {
+  readonly appRoot?: string;
+  readonly resourcesPath?: string;
+  readonly exists?: (candidate: string) => boolean;
+}
+
+interface RunComputerUseHelperOptions {
+  readonly helperPath?: string;
+}
+
+export class ComputerUseNativeHelperError extends Error {
+  constructor(
+    readonly code: ComputerUseNativeErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ComputerUseNativeHelperError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function responseErrorCode(value: unknown): ComputerUseNativeErrorCode {
+  if (
+    value === "permission_denied" ||
+    value === "accessibility_unavailable" ||
+    value === "screen_recording_unavailable" ||
+    value === "unsupported_command"
+  ) {
+    return value;
+  }
+  return "accessibility_unavailable";
+}
+
+function responseErrorMessage(value: unknown): string {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : "Native Computer Use helper failed";
+}
+
+function parseHelperResponse(output: string): ComputerUseNativeResponse {
+  const parsed = JSON.parse(output) as unknown;
+  if (!isRecord(parsed)) {
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "Native Computer Use helper returned a non-object response",
+    );
+  }
+
+  if (parsed.status === "succeeded") {
+    return { status: "succeeded", result: parsed.result };
+  }
+  if (parsed.status === "failed") {
+    return {
+      status: "failed",
+      error: isRecord(parsed.error) ? parsed.error : undefined,
+    };
+  }
+
+  throw new ComputerUseNativeHelperError(
+    "accessibility_unavailable",
+    "Native Computer Use helper returned an invalid response status",
+  );
+}
+
+function resultRecord(result: unknown, kind: string): Record<string, unknown> {
+  if (isRecord(result)) {
+    return result;
+  }
+  throw new ComputerUseNativeHelperError(
+    "accessibility_unavailable",
+    `Native Computer Use helper returned invalid result for ${kind}`,
+  );
+}
+
+function resultStringArray(
+  result: Record<string, unknown>,
+  key: string,
+): readonly string[] {
+  const value = result[key];
+  if (
+    Array.isArray(value) &&
+    value.every((entry): entry is string => {
+      return typeof entry === "string";
+    })
+  ) {
+    return value;
+  }
+  throw new ComputerUseNativeHelperError(
+    "accessibility_unavailable",
+    `Native Computer Use helper returned invalid ${key}`,
+  );
+}
+
+function resultOptionalString(
+  result: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = result[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function helperPathCandidates(
+  options: ResolveComputerUseHelperPathOptions,
+): readonly [string, string, string] {
+  const appRoot = options.appRoot ?? path.resolve(__dirname, "..");
+  const resourcesPath =
+    options.resourcesPath ?? process.resourcesPath ?? appRoot;
+  return [
+    path.join(resourcesPath, "native", "computer-use-helper"),
+    path.join(appRoot, "native", "dist", "native", "computer-use-helper"),
+    path.join(
+      appRoot,
+      "native",
+      "computer-use-helper",
+      ".build",
+      "release",
+      "computer-use-helper",
+    ),
+  ];
+}
+
+export function resolveComputerUseHelperPath(
+  options: ResolveComputerUseHelperPathOptions = {},
+): string {
+  const exists = options.exists ?? existsSync;
+  const candidates = helperPathCandidates(options);
+  const existing = candidates.find((candidate) => {
+    return exists(candidate);
+  });
+  return existing ?? candidates[1];
+}
+
+async function runComputerUseHelper(
+  request: ComputerUseNativeRequest,
+  options: RunComputerUseHelperOptions = {},
+): Promise<Record<string, unknown>> {
+  const helperPath = options.helperPath ?? resolveComputerUseHelperPath();
+  return await new Promise((resolve, reject) => {
+    const child = spawn(helperPath, [], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      reject(
+        new ComputerUseNativeHelperError(
+          "accessibility_unavailable",
+          `Unable to start native Computer Use helper: ${error.message}`,
+        ),
+      );
+    });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new ComputerUseNativeHelperError(
+            "accessibility_unavailable",
+            stderr.trim() ||
+              `Native Computer Use helper exited with status ${code ?? "null"}`,
+          ),
+        );
+        return;
+      }
+
+      try {
+        const response = parseHelperResponse(stdout.trim());
+        if (response.status === "failed") {
+          throw new ComputerUseNativeHelperError(
+            responseErrorCode(response.error?.code),
+            responseErrorMessage(response.error?.message),
+          );
+        }
+        resolve(resultRecord(response.result ?? {}, request.kind));
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    child.stdin.end(`${JSON.stringify(request)}\n`);
+  });
+}
+
+export function createComputerUseNativeBackend(
+  options: RunComputerUseHelperOptions = {},
+): ComputerUseNativeBackend {
+  const run = async (
+    request: ComputerUseNativeRequest,
+  ): Promise<Record<string, unknown>> => {
+    return await runComputerUseHelper(request, options);
+  };
+
+  return {
+    listApps: async () => {
+      const result = await run({ kind: "apps.list" });
+      return resultStringArray(result, "apps");
+    },
+    getAppState: async (app, snapshotId) => {
+      const result = await run({ kind: "app.state", app, snapshotId });
+      return result as unknown as AccessibilityAppStateSnapshot;
+    },
+    openApp: async (app) => {
+      await run({ kind: "app.open", app });
+    },
+    clickElement: async (args) => {
+      await run({ kind: "element.click", ...args });
+    },
+    clickPoint: async (args) => {
+      await run({ kind: "element.click_point", ...args });
+    },
+    setElementValue: async (args) => {
+      await run({ kind: "element.set_value", ...args });
+    },
+    performElementAction: async (args) => {
+      await run({ kind: "element.perform_action", ...args });
+    },
+    typeText: async (args) => {
+      const result = await run({ kind: "keyboard.type_text", ...args });
+      return {
+        role: resultOptionalString(result, "role"),
+        description: resultOptionalString(result, "description"),
+      };
+    },
+    pressKey: async (args) => {
+      await run({ kind: "keyboard.press_key", ...args });
+    },
+    scrollElement: async (args) => {
+      await run({ kind: "element.scroll", ...args });
+    },
+  };
+}

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -7,6 +7,12 @@ import {
   renderAccessibilityTree,
 } from "./computer-use-accessibility";
 import {
+  ComputerUseNativeHelperError,
+  resolveComputerUseHelperPath,
+  type ComputerUseNativeBackend,
+  type ComputerUseNativePressKeyRequest,
+} from "./computer-use-native";
+import {
   buildComputerUseRuntimeBody,
   resolveComputerUseApiBaseUrl,
 } from "./computer-use-host";
@@ -22,6 +28,28 @@ import {
 } from "./desktop-auth";
 import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
+
+function createNativeBackend(
+  overrides: Partial<ComputerUseNativeBackend> = {},
+): ComputerUseNativeBackend {
+  const defaults: ComputerUseNativeBackend = {
+    listApps: async () => [],
+    getAppState: async (app, snapshotId) => {
+      return { app, snapshotId, elements: [] };
+    },
+    openApp: async () => {},
+    clickElement: async () => {},
+    clickPoint: async () => {},
+    setElementValue: async () => {},
+    performElementAction: async () => {},
+    typeText: async () => {
+      return {};
+    },
+    pressKey: async () => {},
+    scrollElement: async () => {},
+  };
+  return { ...defaults, ...overrides };
+}
 
 describe("resolveDesktopConfig", () => {
   it("defaults to production", () => {
@@ -168,6 +196,36 @@ describe("window policy", () => {
     expect(
       decideWindowOpen("javascript:alert('nope')", allowedOrigins),
     ).toStrictEqual({ action: "deny" });
+  });
+});
+
+describe("computer use native helper", () => {
+  it("prefers the packaged helper path when it exists", () => {
+    const packagedPath = "/resources/native/computer-use-helper";
+    const localPath = "/app/native/dist/native/computer-use-helper";
+    const existing = new Set([packagedPath, localPath]);
+
+    expect(
+      resolveComputerUseHelperPath({
+        appRoot: "/app",
+        resourcesPath: "/resources",
+        exists: (candidate) => {
+          return existing.has(candidate);
+        },
+      }),
+    ).toBe(packagedPath);
+  });
+
+  it("falls back to the local dist helper path", () => {
+    expect(
+      resolveComputerUseHelperPath({
+        appRoot: "/app",
+        resourcesPath: "/resources",
+        exists: () => {
+          return false;
+        },
+      }),
+    ).toBe("/app/native/dist/native/computer-use-helper");
   });
 });
 
@@ -521,19 +579,21 @@ describe("computer use desktop runtime", () => {
       { accessibility: true, screenRecording: true },
       {
         platform: "darwin",
-        runJxa: async () => {
-          return JSON.stringify({
-            app: "Safari",
-            snapshotId: "snap_1",
-            elements: [
-              {
-                id: "w0",
-                role: "AXWindow",
-                name: "Example",
-              },
-            ],
-          });
-        },
+        nativeBackend: createNativeBackend({
+          getAppState: async (app, snapshotId) => {
+            return {
+              app,
+              snapshotId,
+              elements: [
+                {
+                  id: "w0",
+                  role: "AXWindow",
+                  name: "Example",
+                },
+              ],
+            };
+          },
+        }),
         captureScreenshot: async (request) => {
           expect(request).toStrictEqual({
             app: "Safari",
@@ -558,7 +618,7 @@ describe("computer use desktop runtime", () => {
     expect(result).toMatchObject({
       result: {
         app: "Safari",
-        snapshotId: "snap_1",
+        snapshotId: expect.stringMatching(/^desktop_/),
         screenshot: "data:image/png;base64,abc123",
         screenshotMimeType: "image/png",
         screenshotSource: "window",
@@ -570,62 +630,67 @@ describe("computer use desktop runtime", () => {
     expect(result.result.text).toContain('w0 AXWindow "Example"');
   });
 
-  it("requests bounded deep accessibility state from JXA", async () => {
-    let capturedScript = "";
+  it("normalizes deep accessibility state from the native helper", async () => {
+    const nativeRequests: {
+      readonly app: string;
+      readonly snapshotId: string;
+    }[] = [];
     const result = await executeComputerUseCommand(
       { id: "cmd_1", kind: "app.state", payload: { app: "Slack" } },
       { accessibility: true, screenRecording: true },
       {
         platform: "darwin",
-        runJxa: async (script) => {
-          capturedScript = script;
-          return JSON.stringify({
-            app: "Slack",
-            snapshotId: "snap_1",
-            nodeCount: 7,
-            truncated: false,
-            truncationReasons: [],
-            elements: [
-              {
-                id: "w0",
-                role: "AXWindow",
-                name: "release-notify (Channel) - VM0 - Slack",
-                children: [
-                  {
-                    id: "w0.e0",
-                    role: "AXGroup",
-                    children: [
-                      {
-                        id: "w0.e0.e0",
-                        role: "AXGroup",
-                        children: [
-                          {
-                            id: "w0.e0.e0.c0",
-                            role: "AXWebArea",
-                            roleDescription: "HTML content",
-                            children: [
-                              {
-                                id: "w0.e0.e0.c0.v0",
-                                role: "AXStaticText",
-                                value: "Release notes posted",
-                              },
-                              {
-                                id: "w0.e0.e0.c0.v1",
-                                role: "AXTextArea",
-                                name: "Message composer",
-                                actions: ["AXConfirm"],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          });
-        },
+        nativeBackend: createNativeBackend({
+          getAppState: async (app, snapshotId) => {
+            nativeRequests.push({ app, snapshotId });
+            return {
+              app,
+              snapshotId,
+              nodeCount: 7,
+              truncated: false,
+              truncationReasons: [],
+              elements: [
+                {
+                  id: "w0",
+                  role: "AXWindow",
+                  name: "release-notify (Channel) - VM0 - Slack",
+                  children: [
+                    {
+                      id: "w0.e0",
+                      role: "AXGroup",
+                      children: [
+                        {
+                          id: "w0.e0.e0",
+                          role: "AXGroup",
+                          children: [
+                            {
+                              id: "w0.e0.e0.c0",
+                              role: "AXWebArea",
+                              roleDescription: "HTML content",
+                              children: [
+                                {
+                                  id: "w0.e0.e0.c0.v0",
+                                  role: "AXStaticText",
+                                  value: "Release notes posted",
+                                },
+                                {
+                                  id: "w0.e0.e0.c0.v1",
+                                  role: "AXTextArea",
+                                  name: "Message composer",
+                                  actions: ["AXConfirm"],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            };
+          },
+        }),
         captureScreenshot: async () => {
           return {
             dataUrl: "data:image/png;base64,abc123",
@@ -642,11 +707,11 @@ describe("computer use desktop runtime", () => {
     if (result.status !== "succeeded") {
       throw new Error("expected app.state to succeed");
     }
-    expect(capturedScript).toContain('"maxDepth":32');
-    expect(capturedScript).toContain("AXManualAccessibility");
-    expect(capturedScript).toContain("AXEnhancedUserInterface");
-    expect(capturedScript).toContain("AXContents");
-    expect(capturedScript).toContain("AXVisibleChildren");
+    expect(nativeRequests).toHaveLength(1);
+    expect(nativeRequests[0]).toMatchObject({
+      app: "Slack",
+      snapshotId: expect.stringMatching(/^desktop_/),
+    });
     expect(result.result.text).toContain("Release notes posted");
     expect(result.result.text).toContain(
       'w0.e0.e0.c0.v1 AXTextArea "Message composer"',
@@ -655,7 +720,7 @@ describe("computer use desktop runtime", () => {
   });
 
   it("resolves action element ids from non-uiElement child sources", async () => {
-    let capturedScript = "";
+    const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -665,10 +730,7 @@ describe("computer use desktop runtime", () => {
       { accessibility: true, screenRecording: false },
       {
         platform: "darwin",
-        runJxa: async (script) => {
-          capturedScript = script;
-          return "";
-        },
+        nativeBackend: createNativeBackend({ clickElement }),
         captureScreenshot: async () => {
           throw new Error("unexpected screenshot capture");
         },
@@ -676,18 +738,34 @@ describe("computer use desktop runtime", () => {
     );
 
     expect(result.status).toBe("succeeded");
-    expect(capturedScript).toContain(
-      'attributeChildren(element, "AXContents")',
-    );
-    expect(capturedScript).toContain(
-      'attributeChildren(element, "AXVisibleChildren")',
-    );
-    expect(capturedScript).toContain("element.click()");
+    expect(clickElement).toHaveBeenCalledWith({
+      app: "Slack",
+      elementId: "w0.c0.v2",
+      button: "left",
+      clickCount: 1,
+    });
   });
 
   it("maps screenshot coordinate clicks through cached snapshot bounds", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
-    const scripts: string[] = [];
+    const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
+    const nativeBackend = createNativeBackend({
+      clickPoint,
+      getAppState: async (app) => {
+        return {
+          app,
+          snapshotId: "snap_1",
+          elements: [
+            {
+              id: "w0",
+              role: "AXWindow",
+              name: "Example",
+              bounds: { x: 100, y: 200, width: 1600, height: 1200 },
+            },
+          ],
+        };
+      },
+    });
 
     const state = await executeComputerUseCommand(
       { id: "cmd_1", kind: "app.state", payload: { app: "Safari" } },
@@ -695,21 +773,7 @@ describe("computer use desktop runtime", () => {
       {
         platform: "darwin",
         snapshotStore,
-        runJxa: async (script) => {
-          scripts.push(script);
-          return JSON.stringify({
-            app: "Safari",
-            snapshotId: "snap_1",
-            elements: [
-              {
-                id: "w0",
-                role: "AXWindow",
-                name: "Example",
-                bounds: { x: 100, y: 200, width: 1600, height: 1200 },
-              },
-            ],
-          });
-        },
+        nativeBackend,
         captureScreenshot: async (request) => {
           expect(request).toStrictEqual({
             app: "Safari",
@@ -751,10 +815,7 @@ describe("computer use desktop runtime", () => {
       {
         platform: "darwin",
         snapshotStore,
-        runJxa: async (script) => {
-          scripts.push(script);
-          return "";
-        },
+        nativeBackend,
         captureScreenshot: async () => {
           throw new Error("unexpected screenshot capture");
         },
@@ -777,19 +838,19 @@ describe("computer use desktop runtime", () => {
         inputRisk: "targeted_app_pointer",
       },
     });
-    const clickScript = scripts.at(-1);
-    expect(clickScript).toContain("$.CGPointMake(900, 800)");
-    expect(clickScript).toContain("$.CGEventCreateMouseEvent");
-    expect(clickScript).toContain("$.CGEventPostToPid(pid, event)");
-    expect(clickScript).toContain("postMouseEvent(3, clickIndex)");
-    expect(clickScript).not.toContain("$.CGEventPost($.kCGHIDEventTap");
-    expect(clickScript).not.toContain("systemEvents.click");
+    expect(clickPoint).toHaveBeenCalledWith({
+      app: "Safari",
+      x: 900,
+      y: 800,
+      button: "right",
+      clickCount: 2,
+    });
   });
 
   it("captures fresh app state for coordinate clicks without a cached snapshot", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
-    const scripts: string[] = [];
     let captureCount = 0;
+    const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
 
     const result = await executeComputerUseCommand(
       {
@@ -801,10 +862,10 @@ describe("computer use desktop runtime", () => {
       {
         platform: "darwin",
         snapshotStore,
-        runJxa: async (script) => {
-          scripts.push(script);
-          if (script.includes("snapshotId")) {
-            return JSON.stringify({
+        nativeBackend: createNativeBackend({
+          clickPoint,
+          getAppState: async () => {
+            return {
               app: "Safari",
               snapshotId: "snap_fresh",
               elements: [
@@ -815,10 +876,9 @@ describe("computer use desktop runtime", () => {
                   bounds: { x: 40, y: 80, width: 800, height: 600 },
                 },
               ],
-            });
-          }
-          return "";
-        },
+            };
+          },
+        }),
         captureScreenshot: async () => {
           captureCount += 1;
           return {
@@ -850,9 +910,13 @@ describe("computer use desktop runtime", () => {
       },
     });
     expect(captureCount).toBe(1);
-    expect(scripts).toHaveLength(2);
-    expect(scripts[1]).toContain("$.CGPointMake(440, 380)");
-    expect(scripts[1]).toContain("$.CGEventPostToPid(pid, event)");
+    expect(clickPoint).toHaveBeenCalledWith({
+      app: "Safari",
+      x: 440,
+      y: 380,
+      button: "left",
+      clickCount: 1,
+    });
   });
 
   it("requires screen recording permission for app state screenshots", async () => {
@@ -881,25 +945,31 @@ describe("computer use desktop runtime", () => {
       {
         key: "Command+K",
         normalizedKey: "Command+K",
-        keyCodeSnippet: "postKey(40, true, flags)",
-        flagsSnippet: "const flags = 1048576;",
+        keyCode: 40,
+        flags: 1_048_576,
+        modifiers: [{ keyCode: 55, flag: 1_048_576 }],
       },
       {
         key: "Control+K",
         normalizedKey: "Control+K",
-        keyCodeSnippet: "postKey(40, true, flags)",
-        flagsSnippet: "const flags = 262144;",
+        keyCode: 40,
+        flags: 262_144,
+        modifiers: [{ keyCode: 59, flag: 262_144 }],
       },
       {
         key: "Command+Shift+S",
         normalizedKey: "Command+Shift+S",
-        keyCodeSnippet: "postKey(1, true, flags)",
-        flagsSnippet: "const flags = 1179648;",
+        keyCode: 1,
+        flags: 1_179_648,
+        modifiers: [
+          { keyCode: 55, flag: 1_048_576 },
+          { keyCode: 56, flag: 131_072 },
+        ],
       },
     ];
 
     for (const testCase of cases) {
-      const scripts: string[] = [];
+      const pressRequests: ComputerUseNativePressKeyRequest[] = [];
       const result = await executeComputerUseCommand(
         {
           id: "cmd_1",
@@ -909,10 +979,11 @@ describe("computer use desktop runtime", () => {
         { accessibility: true, screenRecording: true },
         {
           platform: "darwin",
-          runJxa: async (script) => {
-            scripts.push(script);
-            return JSON.stringify({ pid: 123 });
-          },
+          nativeBackend: createNativeBackend({
+            pressKey: async (request) => {
+              pressRequests.push(request);
+            },
+          }),
           captureScreenshot: async () => {
             throw new Error("unexpected screenshot capture");
           },
@@ -923,13 +994,21 @@ describe("computer use desktop runtime", () => {
         status: "succeeded",
         result: { key: testCase.normalizedKey },
       });
-      expect(scripts[0]).toContain(testCase.keyCodeSnippet);
-      expect(scripts[0]).toContain(testCase.flagsSnippet);
+      expect(pressRequests).toStrictEqual([
+        {
+          app: "Safari",
+          keyCode: testCase.keyCode,
+          flags: testCase.flags,
+          modifiers: testCase.modifiers,
+          normalizedKey: testCase.normalizedKey,
+        },
+      ]);
     }
   });
 
   it("posts press-key combinations to the target process without app activation", async () => {
-    const scripts: string[] = [];
+    const openApp = vi.fn<ComputerUseNativeBackend["openApp"]>();
+    const pressKey = vi.fn<ComputerUseNativeBackend["pressKey"]>();
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -939,10 +1018,7 @@ describe("computer use desktop runtime", () => {
       { accessibility: true, screenRecording: true },
       {
         platform: "darwin",
-        runJxa: async (script) => {
-          scripts.push(script);
-          return JSON.stringify({ pid: 123 });
-        },
+        nativeBackend: createNativeBackend({ openApp, pressKey }),
         captureScreenshot: async () => {
           throw new Error("unexpected screenshot capture");
         },
@@ -958,15 +1034,18 @@ describe("computer use desktop runtime", () => {
         inputRisk: "targeted_app_shortcut",
       },
     });
-    expect(scripts).toHaveLength(1);
-    expect(scripts[0]).toContain("$.CGEventPostToPid(pid, event)");
-    expect(scripts[0]).toContain("postKey(40, true, flags)");
-    expect(scripts[0]).not.toContain("activate()");
-    expect(scripts[0]).not.toContain("keystroke");
+    expect(pressKey).toHaveBeenCalledWith({
+      app: "Safari",
+      keyCode: 40,
+      modifiers: [{ keyCode: 55, flag: 1_048_576 }],
+      flags: 1_048_576,
+      normalizedKey: "Command+K",
+    });
+    expect(openApp).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported press-key syntax before dispatching input", async () => {
-    const runJxa = vi.fn<(script: string) => Promise<string>>();
+    const pressKey = vi.fn<ComputerUseNativeBackend["pressKey"]>();
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -976,7 +1055,7 @@ describe("computer use desktop runtime", () => {
       { accessibility: true, screenRecording: true },
       {
         platform: "darwin",
-        runJxa,
+        nativeBackend: createNativeBackend({ pressKey }),
         captureScreenshot: async () => {
           throw new Error("unexpected screenshot capture");
         },
@@ -990,7 +1069,7 @@ describe("computer use desktop runtime", () => {
         message: "Unsupported key specification: Launchpad",
       },
     });
-    expect(runJxa).not.toHaveBeenCalled();
+    expect(pressKey).not.toHaveBeenCalled();
   });
 
   it("rejects type-text when the target app has no focused editable element", async () => {
@@ -1003,13 +1082,14 @@ describe("computer use desktop runtime", () => {
       { accessibility: true, screenRecording: true },
       {
         platform: "darwin",
-        runJxa: async () => {
-          return JSON.stringify({
-            status: "failed",
-            message:
+        nativeBackend: createNativeBackend({
+          typeText: async () => {
+            throw new ComputerUseNativeHelperError(
+              "unsupported_command",
               "keyboard.type_text requires a focused editable text element in Safari",
-          });
-        },
+            );
+          },
+        }),
         captureScreenshot: async () => {
           throw new Error("unexpected screenshot capture");
         },

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -6,6 +6,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "dev:auth": "bash ../scripts/dev-auth.sh",
+    "desktop:dev": "VM0_DESKTOP_PLATFORM_URL=https://app.vm7.ai:8443 pnpm -F @vm0/desktop dev",
+    "desktop:make": "pnpm -F @vm0/desktop make",
     "lint": "turbo run lint --concurrency=1",
     "format": "prettier --write --ignore-unknown .",
     "check-types": "turbo run check-types --concurrency=1",


### PR DESCRIPTION
## Summary

- replace Desktop Computer Use osascript/JXA execution with a Swift `computer-use-helper` invoked through a JSON stdin/stdout bridge
- wire `pnpm -F @vm0/desktop build` and Electron Forge packaging to build and include the native helper under `Contents/Resources/native`
- update desktop tests, docs, and artifact verification for the native helper path

Closes #14494

## Validation

- `pnpm format`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `pnpm -F @vm0/desktop package`
- packaged helper checks: executable helper exists under `Zero.app/Contents/Resources/native/computer-use-helper`; native source tree is absent from `Contents/Resources/app`
- native helper smoke test: `apps.list` returns JSON successfully
- `pnpm check-types` after clearing stale `apps/web/.next`
- `pnpm lint`
- `pnpm knip` exits 0 with existing configuration hints

## Local test note

Full `pnpm vitest --run` is blocked in this local checkout before tests start because web global setup cannot connect to PostgreSQL on `localhost:5432`. `scripts/prepare.sh` also fails because `DATABASE_URL` is unset and 1Password CLI (`op`) is not installed for env sync. The scoped desktop test suite passes.