### PR TITLE
fix(mitm-addon): emit UTC log timestamps

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -6,11 +6,15 @@ log entries, and extracting firewall metadata.
 
 import json
 import os
-import time
+from datetime import datetime, timezone
 
 from mitmproxy import ctx, http
 
 _PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
+
+
+def _utc_log_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
@@ -30,7 +34,10 @@ def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
 
 def log_network_entry(log_path: str, entry: dict) -> None:
     """Write a network log entry to the per-run JSONL file."""
-    _write_jsonl_entry(log_path, entry, "network")
+    if not log_path:
+        return
+    log_entry = {**entry, "timestamp": _utc_log_timestamp()}
+    _write_jsonl_entry(log_path, log_entry, "network")
 
 
 def log_proxy_entry(
@@ -42,7 +49,7 @@ def log_proxy_entry(
 ) -> None:
     """Write a diagnostic log entry to the per-job proxy log file (JSONL)."""
     entry: dict = {
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
+        "timestamp": _utc_log_timestamp(),
         "level": log_level,
         "message": log_message,
     }

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -431,7 +431,6 @@ def response(flow: http.HTTPFlow) -> None:
     proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
     if network_log_path:
         log_entry = {
-            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
             "type": "http",
             "action": firewall_action,
             "host": host,
@@ -549,7 +548,6 @@ def error(flow: http.HTTPFlow) -> None:
 
     # [NETWORK_LOG_FIELDS] — HTTP error fields; api-contracts is the shared schema boundary.
     log_entry: dict = {
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
         "type": "http",
         "action": firewall_action,
         "host": host,
@@ -658,7 +656,6 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
 
     # [NETWORK_LOG_FIELDS] — TCP fields; api-contracts is the shared schema boundary.
     log_entry = {
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
         "type": "tcp",
         "host": host,
         "port": port,

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -29,6 +29,7 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_at,
 )
+from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 from usage import (
     create_anthropic_messages_sse_usage_extractor,
     create_openai_responses_sse_usage_extractor,
@@ -1914,6 +1915,7 @@ class TestResponseHandler:
         assert entry["host"] == "api.anthropic.com"
         assert entry["latency_ms"] > 0
         assert entry["response_size"] == 256
+        assert_utc_millisecond_timestamp(entry["timestamp"])
 
     def test_response_size_from_stream_buffer(
         self, registry_file, tmp_path, real_flow, mitm_ctx, headers
@@ -4196,6 +4198,7 @@ class TestErrorHandler:
         assert entry["response_size"] == 0
         assert entry["error"] == "connection reset by peer"
         assert entry["latency_ms"] > 0
+        assert_utc_millisecond_timestamp(entry["timestamp"])
 
     def test_error_includes_firewall_context(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="slack.com")
@@ -6007,6 +6010,7 @@ class TestTcpLog:
         assert entry["request_size"] == 5  # b"hello"
         assert entry["response_size"] == 14  # b"SSH-2.0-babeld"
         assert "error" not in entry
+        assert_utc_millisecond_timestamp(entry["timestamp"])
 
     def test_logs_tcp_error(self, registry_file, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow(client_ip="10.200.0.1")

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -17,6 +17,7 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_at,
 )
+from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
 def _reset_cache():
@@ -569,6 +570,20 @@ class TestLogNetworkEntry:
         parsed = json.loads(lines[0])
         assert parsed["action"] == "ALLOW"
         assert parsed["host"] == "example.com"
+        assert_utc_millisecond_timestamp(parsed["timestamp"])
+        assert "timestamp" not in entry
+
+    def test_timestamp_is_authoritative(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+        entry = {"timestamp": "caller-timestamp", "action": "ALLOW"}
+
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, entry)
+
+        parsed = json.loads(Path(log_path).read_text().strip())
+        assert_utc_millisecond_timestamp(parsed["timestamp"])
+        assert parsed["timestamp"] != "caller-timestamp"
+        assert entry["timestamp"] == "caller-timestamp"
 
     def test_appends_multiple(self, tmp_path):
         log_path = str(tmp_path / "net.jsonl")

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import logging_utils
+from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 from url_utils import AuthorityValidationError, get_original_url
 
 
@@ -111,7 +112,7 @@ class TestLogProxyEntry:
         assert entry["level"] == "warn"
         assert entry["message"] == "test message"
         assert entry["extra_field"] == "value"
-        assert "timestamp" in entry
+        assert_utc_millisecond_timestamp(entry["timestamp"])
 
     def test_appends_multiple_entries(self, tmp_path):
         proxy_path = str(tmp_path / "proxy-test.jsonl")
@@ -181,6 +182,7 @@ class TestLogProxyEntry:
         logging_utils.log_proxy_entry(str(proxy_path), "warn", "logger-message", **extra)
 
         entry = json.loads(Path(proxy_path).read_text().strip())
+        assert_utc_millisecond_timestamp(entry["timestamp"])
         assert entry["timestamp"] != "caller-timestamp"
         assert entry["level"] == "warn"
         assert entry["message"] == "logger-message"

--- a/crates/runner/mitm-addon/tests/timestamp_helpers.py
+++ b/crates/runner/mitm-addon/tests/timestamp_helpers.py
@@ -1,0 +1,13 @@
+"""Shared timestamp assertions for mitm-addon logging tests."""
+
+import re
+from datetime import datetime, timezone
+
+_UTC_MILLISECOND_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def assert_utc_millisecond_timestamp(value: object) -> None:
+    assert isinstance(value, str)
+    assert _UTC_MILLISECOND_TIMESTAMP_RE.fullmatch(value)
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    assert parsed.utcoffset() == timezone.utc.utcoffset(None)


### PR DESCRIPTION
## Summary

- centralize mitm-addon UTC timestamp generation at the logging boundary
- make `log_network_entry()` inject authoritative millisecond `Z` timestamps without mutating caller entries
- remove duplicated network log timestamp construction from HTTP response, HTTP error, and TCP producers
- add emitted-JSONL coverage for proxy, direct network, HTTP response, HTTP error, and TCP timestamps

Closes #14484

## Tests

- `python3 -m pytest tests/test_utils.py::TestLogProxyEntry tests/test_registry.py::TestLogNetworkEntry tests/test_handlers.py::TestResponseHandler::test_calculates_latency_and_logs tests/test_handlers.py::TestErrorHandler::test_logs_error_to_jsonl tests/test_handlers.py::TestTcpLog -q`
- `ruff check .`
- `ruff format --check .`
- `python3 -m pytest tests/ -v`

## Notes

- `pnpm db:migrate` was attempted after pulling latest `main`, but the command is not available in this workspace (`Command "db:migrate" not found`).
- Downstream API/UI timestamp normalization and stricter webhook validation are intentionally left out of this fix.
