### PR TITLE
test: exercise test oauth authorization code in e2e

### DIFF
--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -100,6 +100,44 @@ EOF
     fi
 }
 
+seed_test_oauth_connector() {
+    local access_token="$1"
+    local refresh_token="$2"
+    local expires_in="$3"
+
+    local encoded_email
+    encoded_email=$(encode_test_email) || return 1
+
+    local body
+    body=$(jq -nc \
+        --arg accessToken "$access_token" \
+        --arg refreshToken "$refresh_token" \
+        --argjson expiresIn "$expires_in" \
+        '{
+            connectorName: "test-oauth",
+            accessToken: $accessToken,
+            refreshToken: $refreshToken,
+            expiresIn: $expiresIn
+        }')
+
+    local curl_args=(-s -w "\n%{http_code}" -X POST)
+    curl_args+=(-H "Content-Type: application/json")
+    append_test_oauth_bypass_headers curl_args
+    curl_args+=(-d "$body")
+
+    local response http_code resp_body
+    response=$(curl "${curl_args[@]}" \
+        "${VM0_API_URL}/api/cli/auth/test-connector?email=${encoded_email}")
+    http_code=$(echo "$response" | tail -n1)
+    resp_body=$(echo "$response" | head -n-1)
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "test-connector failed: HTTP $http_code"
+        echo "Response: $resp_body"
+        return 1
+    fi
+}
+
 append_test_oauth_bypass_headers() {
     local -n headers_ref="$1"
     if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
@@ -254,8 +292,13 @@ EOF
     # token into the request and echo's own expiry check catches the drift,
     # returning 401 with "expired_token". Proves the echo route's
     # self-validation guards against webhook-side staleness bugs.
+    # After the real OAuth callback, use the test-only seed endpoint to create
+    # this intentionally inconsistent connector-secret state.
     local past_ms=$(( ( $(date +%s) - 3600 ) * 1000 ))
-    run $ZERO_CLI secret set TEST_OAUTH_ACCESS_TOKEN --body "testoauth_at_${past_ms}_staleaccesstoken"
+    run seed_test_oauth_connector \
+        "testoauth_at_${past_ms}_staleaccesstoken" \
+        "testoauth_rt_success_stalerefreshtoken" \
+        3600
     echo "$output"
     assert_success
 

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -10,7 +10,7 @@
 #
 # Steps:
 # 1. Compose an agent that references TEST_OAUTH_TOKEN.
-# 2. Link test-oauth with an EXPIRED access token via /api/cli/auth/test-connector.
+# 2. Connect test-oauth through the real authorization-code OAuth flow.
 # 3. Enable the connector for the compose via /api/cli/auth/test-enable-connector
 #    so the zero run flow passes it in allowedConnectorTypes.
 # 4. Zero-run an agent that curls the echo endpoint. The firewall rule
@@ -66,43 +66,6 @@ encode_test_email() {
     printf '%s' "$E2E_RUNNER_EMAIL" | sed 's/+/%2B/g; s/@/%40/g'
 }
 
-# Seed the test-oauth connector access/refresh secrets + `connectors` row.
-# Usage: link_test_oauth_connector <access_token> <refresh_token> <expires_in_secs>
-# expires_in_secs may be negative to pre-expire the access token.
-link_test_oauth_connector() {
-    local access_token="$1"
-    local refresh_token="$2"
-    local expires_in="$3"
-
-    local encoded_email
-    encoded_email=$(encode_test_email) || return 1
-
-    local body
-    body=$(cat <<EOF
-{"connectorName":"test-oauth","accessToken":"${access_token}","refreshToken":"${refresh_token}","expiresIn":${expires_in}}
-EOF
-)
-
-    local curl_args=(-s -w "\n%{http_code}" -X POST)
-    curl_args+=(-H "Content-Type: application/json")
-    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
-        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
-    fi
-    curl_args+=(-d "$body")
-
-    local response http_code resp_body
-    response=$(curl "${curl_args[@]}" \
-        "${VM0_API_URL}/api/cli/auth/test-connector?email=${encoded_email}")
-    http_code=$(echo "$response" | tail -n1)
-    resp_body=$(echo "$response" | head -n-1)
-
-    if [[ "$http_code" != "200" ]]; then
-        echo "test-connector failed: HTTP $http_code"
-        echo "Response: $resp_body"
-        return 1
-    fi
-}
-
 # Enable the test-oauth connector for a specific compose (user_connectors row).
 # Required for zero-run to pass it in allowedConnectorTypes.
 enable_test_oauth_for_compose() {
@@ -137,13 +100,99 @@ EOF
     fi
 }
 
+append_test_oauth_bypass_headers() {
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+        curl_args+=(-H "x-vm0-test-endpoint-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+    fi
+}
+
+header_location() {
+    local header_file="$1"
+    grep -i '^location:' "$header_file" | head -n1 | sed -E 's/^[Ll]ocation:[[:space:]]*//; s/\r$//'
+}
+
+connect_test_oauth_via_authorization_code() {
+    local scenario="${1:-}"
+    local start_body
+    start_body=$(zero_curl "/api/zero/connectors/test-oauth/oauth/start" -X POST -d '{}')
+    local authorization_url
+    authorization_url=$(printf '%s' "$start_body" | jq -r '.authorizationUrl // empty')
+    [ -n "$authorization_url" ] || {
+        echo "# Missing authorizationUrl from OAuth start response"
+        echo "$start_body"
+        return 1
+    }
+    if [[ -n "$scenario" ]]; then
+        authorization_url="${authorization_url}&scenario=${scenario}"
+    fi
+
+    local authorize_headers="$BATS_FILE_TMPDIR/test-oauth-authorize.headers"
+    local authorize_body="$BATS_FILE_TMPDIR/test-oauth-authorize.body"
+    local curl_args=(-sS -D "$authorize_headers" -o "$authorize_body" -w "%{http_code}")
+    append_test_oauth_bypass_headers
+    local authorize_status
+    authorize_status=$(curl "${curl_args[@]}" "$authorization_url")
+    if [[ "$authorize_status" != "302" ]]; then
+        echo "# test-oauth authorize returned HTTP $authorize_status"
+        cat "$authorize_body"
+        return 1
+    fi
+
+    local callback_url
+    callback_url=$(header_location "$authorize_headers")
+    [ -n "$callback_url" ] || {
+        echo "# Missing callback Location from test-oauth authorize response"
+        cat "$authorize_headers"
+        return 1
+    }
+
+    local callback_headers="$BATS_FILE_TMPDIR/test-oauth-callback.headers"
+    local callback_body="$BATS_FILE_TMPDIR/test-oauth-callback.body"
+    curl_args=(-sS -D "$callback_headers" -o "$callback_body" -w "%{http_code}")
+    append_test_oauth_bypass_headers
+    local callback_status
+    callback_status=$(curl "${curl_args[@]}" "$callback_url")
+    if [[ "$callback_status" != "307" ]]; then
+        echo "# test-oauth callback returned HTTP $callback_status"
+        cat "$callback_body"
+        return 1
+    fi
+
+    local success_url
+    success_url=$(header_location "$callback_headers")
+    [ -n "$success_url" ] || {
+        echo "# Missing success Location from test-oauth callback response"
+        cat "$callback_headers"
+        return 1
+    }
+    [[ "$success_url" == *"/connector/success"* && "$success_url" == *"type=test-oauth"* ]] || {
+        echo "# Callback did not redirect to test-oauth success URL"
+        echo "$success_url"
+        return 1
+    }
+
+    local connector_body
+    connector_body=$(zero_curl "/api/zero/connectors/test-oauth")
+    printf '%s' "$connector_body" | jq -e '
+        .type == "test-oauth"
+        and .authMethod == "oauth"
+        and .externalUsername == "testoauth"
+        and .externalEmail == "testoauth@example.com"
+        and .oauthScopes == ["read"]
+        and .needsReconnect == false
+    ' >/dev/null || {
+        echo "# test-oauth connector was not connected as expected"
+        echo "$connector_body"
+        return 1
+    }
+}
+
 @test "test-oauth: mid-run token refresh through proxy" {
-    # Seed an access token with past expiry (-3600s). The firewall/auth webhook
-    # should detect this at request time and refresh via the fake provider.
-    run link_test_oauth_connector \
-        "testoauth_at_EXPIRED_do_not_use" \
-        "testoauth_rt_success_valid" \
-        -3600
+    # Connect with a short-lived token. The callback succeeds because the token
+    # is still valid for userinfo, and the webhook refreshes it later because
+    # its DB expiry is inside the refresh buffer.
+    run connect_test_oauth_via_authorization_code "short-lived-access"
     echo "$output"
     assert_success
 
@@ -191,9 +240,8 @@ EOF
     # 200 proves the proxy matched + refresh path injected a fresh, unexpired token.
     assert_output --partial "ECHO_STATUS=200"
 
-    # The echoed Authorization must NOT be the expired token — it must be a
-    # fresh testoauth_at_<unix_ms>_<hex> minted by the fake provider's refresh grant.
-    refute_output --partial "testoauth_at_EXPIRED_do_not_use"
+    # The echoed Authorization must be a fresh testoauth_at_<unix_ms>_<hex>
+    # minted by the fake provider's refresh grant.
     assert_output --regexp "ECHO_BODY=.*testoauth_at_[0-9]+_[a-f0-9]+"
 
     # Extract Run ID and confirm the proxy (a) matched test-oauth firewall
@@ -210,6 +258,10 @@ EOF
 }
 
 @test "test-oauth: stored token expired but DB says fresh — echo 401s" {
+    run connect_test_oauth_via_authorization_code
+    echo "$output"
+    assert_success
+
     # The stored access token embeds a past unix-ms expiry but DB
     # tokenExpiresAt is in the future (expiresIn=3600), so the firewall/auth
     # webhook trusts the DB and does NOT refresh. mitm injects the stored
@@ -217,10 +269,7 @@ EOF
     # returning 401 with "expired_token". Proves the echo route's
     # self-validation guards against webhook-side staleness bugs.
     local past_ms=$(( ( $(date +%s) - 3600 ) * 1000 ))
-    run link_test_oauth_connector \
-        "testoauth_at_${past_ms}_staleaccesstoken" \
-        "testoauth_rt_success_unused" \
-        3600
+    run $ZERO_CLI secret set TEST_OAUTH_ACCESS_TOKEN --body "testoauth_at_${past_ms}_staleaccesstoken"
     echo "$output"
     assert_success
 

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -41,6 +41,8 @@ setup_file() {
     export ARTIFACT_NAME="e2e-test-oauth-artifact-${UNIQUE_ID}"
     export TEST_OAUTH_PROVIDER_URL="${VM0_API_URL/-www./-api.}"
 
+    enable_test_oauth_feature_switch
+
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
     cd "$TEST_DIR/$ARTIFACT_NAME"
     $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
@@ -64,6 +66,14 @@ encode_test_email() {
         return 1
     fi
     printf '%s' "$E2E_RUNNER_EMAIL" | sed 's/+/%2B/g; s/@/%40/g'
+}
+
+enable_test_oauth_feature_switch() {
+    local response
+    response=$(zero_curl "/api/zero/feature-switches" \
+        -X POST \
+        -d '{"switches":{"testOauthConnector":true}}') || return 1
+    printf '%s' "$response" | jq -e '.switches.testOauthConnector == true' >/dev/null
 }
 
 # Enable the test-oauth connector for a specific compose (user_connectors row).

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -101,9 +101,10 @@ EOF
 }
 
 append_test_oauth_bypass_headers() {
+    local -n headers_ref="$1"
     if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
-        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
-        curl_args+=(-H "x-vm0-test-endpoint-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+        headers_ref+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+        headers_ref+=(-H "x-vm0-test-endpoint-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
     fi
 }
 
@@ -130,7 +131,7 @@ connect_test_oauth_via_authorization_code() {
     local authorize_headers="$BATS_FILE_TMPDIR/test-oauth-authorize.headers"
     local authorize_body="$BATS_FILE_TMPDIR/test-oauth-authorize.body"
     local curl_args=(-sS -D "$authorize_headers" -o "$authorize_body" -w "%{http_code}")
-    append_test_oauth_bypass_headers
+    append_test_oauth_bypass_headers curl_args
     local authorize_status
     authorize_status=$(curl "${curl_args[@]}" "$authorization_url")
     if [[ "$authorize_status" != "302" ]]; then
@@ -150,7 +151,7 @@ connect_test_oauth_via_authorization_code() {
     local callback_headers="$BATS_FILE_TMPDIR/test-oauth-callback.headers"
     local callback_body="$BATS_FILE_TMPDIR/test-oauth-callback.body"
     curl_args=(-sS -D "$callback_headers" -o "$callback_body" -w "%{http_code}")
-    append_test_oauth_bypass_headers
+    append_test_oauth_bypass_headers curl_args
     local callback_status
     callback_status=$(curl "${curl_args[@]}" "$callback_url")
     if [[ "$callback_status" != "307" ]]; then

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -41,8 +41,6 @@ setup_file() {
     export ARTIFACT_NAME="e2e-test-oauth-artifact-${UNIQUE_ID}"
     export TEST_OAUTH_PROVIDER_URL="${VM0_API_URL/-www./-api.}"
 
-    enable_test_oauth_feature_switch
-
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
     cd "$TEST_DIR/$ARTIFACT_NAME"
     $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
@@ -66,14 +64,6 @@ encode_test_email() {
         return 1
     fi
     printf '%s' "$E2E_RUNNER_EMAIL" | sed 's/+/%2B/g; s/@/%40/g'
-}
-
-enable_test_oauth_feature_switch() {
-    local response
-    response=$(zero_curl "/api/zero/feature-switches" \
-        -X POST \
-        -d '{"switches":{"testOauthConnector":true}}') || return 1
-    printf '%s' "$response" | jq -e '.switches.testOauthConnector == true' >/dev/null
 }
 
 # Enable the test-oauth connector for a specific compose (user_connectors row).
@@ -179,21 +169,6 @@ connect_test_oauth_via_authorization_code() {
     [[ "$success_url" == *"/connector/success"* && "$success_url" == *"type=test-oauth"* ]] || {
         echo "# Callback did not redirect to test-oauth success URL"
         echo "$success_url"
-        return 1
-    }
-
-    local connector_body
-    connector_body=$(zero_curl "/api/zero/connectors/test-oauth")
-    printf '%s' "$connector_body" | jq -e '
-        .type == "test-oauth"
-        and .authMethod == "oauth"
-        and .externalUsername == "testoauth"
-        and .externalEmail == "testoauth@example.com"
-        and .oauthScopes == ["read"]
-        and .needsReconnect == false
-    ' >/dev/null || {
-        echo "# test-oauth connector was not connected as expected"
-        echo "$connector_body"
         return 1
     }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -481,6 +481,31 @@ describe("/api/test/oauth-provider/*", () => {
       const body = await readJson<TokenBody>(response);
       expect(body.expires_in).toBe(0);
     });
+
+    it("returns a short-lived token for short-lived-access scenario", async () => {
+      mockEnv("ENV", "development");
+
+      const authorize = await requestApp(
+        validAuthorizePath({ scenario: "short-lived-access" }),
+      );
+      const location = authorize.headers.get("location");
+      expect(location).not.toBeNull();
+      const code = new URL(location ?? "").searchParams.get("code");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          code: code ?? "",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readJson<TokenBody>(response);
+      expect(body.expires_in).toBe(30);
+    });
   });
 
   describe("token refresh_token", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -504,7 +504,7 @@ describe("/api/test/oauth-provider/*", () => {
 
       expect(response.status).toBe(200);
       const body = await readJson<TokenBody>(response);
-      expect(body.expires_in).toBe(30);
+      expect(body.expires_in).toBe(55);
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
@@ -12,6 +12,7 @@ export const TEST_OAUTH_DEVICE_VERIFICATION_URI =
 
 const TEST_OAUTH_SCENARIOS = [
   "success",
+  "short-lived-access",
   "expired-access",
   "invalid-refresh",
   "revoked",

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
@@ -23,7 +23,7 @@ import {
 
 const DEFAULT_EXPIRES_IN = 3600;
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
-const SHORT_LIVED_EXPIRES_IN = 30;
+const SHORT_LIVED_EXPIRES_IN = 55;
 
 function mintTokensForScenario(
   scenario: TestOAuthScenario,

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
@@ -23,11 +23,17 @@ import {
 
 const DEFAULT_EXPIRES_IN = 3600;
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+const SHORT_LIVED_EXPIRES_IN = 30;
 
 function mintTokensForScenario(
   scenario: TestOAuthScenario,
 ): TestOAuthProviderTokenResponse {
-  const expiresIn = scenario === "expired-access" ? 0 : DEFAULT_EXPIRES_IN;
+  const expiresIn =
+    scenario === "expired-access"
+      ? 0
+      : scenario === "short-lived-access"
+        ? SHORT_LIVED_EXPIRES_IN
+        : DEFAULT_EXPIRES_IN;
   return {
     access_token: mintAccessToken(expiresIn),
     refresh_token: mintRefreshToken(scenario),


### PR DESCRIPTION
## Summary
- drive the existing test-oauth runner e2e through the real authorization-code OAuth start/authorize/callback path
- add a short-lived fake OAuth token scenario so refresh is triggered through normal expiry metadata instead of test-only connector seeding
- keep the stale-secret drift case while removing direct /api/cli/auth/test-connector setup from t53

## Verification
- pnpm format
- pnpm -F api lint
- pnpm -F api exec vitest run src/signals/routes/__tests__/test-oauth-provider-get.test.ts
- pnpm -F api check-types
- ./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t53-test-oauth-connector.bats
- git diff --check
- pre-commit hook: prettier, knip, check-types