### PR TITLE
[codex] fix computer-use running app activation

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -109,6 +109,34 @@ func appElement(named appName: String) throws -> AXUIElement {
     return AXUIElementCreateApplication(app.processIdentifier)
 }
 
+func trimmedPipeOutput(_ pipe: Pipe) -> String {
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+}
+
+func appOpenFailureCode(_ stderr: String) -> String {
+    let normalized = stderr.lowercased()
+    if normalized.contains("unable to find application") ||
+        normalized.contains("does not exist")
+    {
+        return "app_not_found"
+    }
+    return "app_open_failed"
+}
+
+func activateRunningApp(_ app: NSRunningApplication, named appName: String) throws {
+    if app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps]) {
+        return
+    }
+
+    let targetName = app.localizedName ?? app.bundleIdentifier ?? appName
+    throw HelperFailure(
+        code: "app_open_failed",
+        message: "Unable to activate \(targetName)"
+    )
+}
+
 func attribute(_ element: AXUIElement, _ name: CFString) -> Any? {
     var value: CFTypeRef?
     let error = AXUIElementCopyAttributeValue(element, name, &value)
@@ -504,15 +532,34 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
 
 func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
+    if let runningApp = findRunningApp(named: appName) {
+        try activateRunningApp(runningApp, named: appName)
+        return [:]
+    }
+
     let process = Process()
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
     process.arguments = ["-a", appName]
-    try process.run()
-    process.waitUntilExit()
-    if process.terminationStatus != 0 {
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    do {
+        try process.run()
+    } catch {
         throw HelperFailure(
-            code: "accessibility_unavailable",
-            message: "Unable to open \(appName)"
+            code: "app_open_failed",
+            message: "Unable to request opening \(appName): \(error)"
+        )
+    }
+    process.waitUntilExit()
+    _ = trimmedPipeOutput(stdoutPipe)
+    if process.terminationStatus != 0 {
+        let stderr = trimmedPipeOutput(stderrPipe)
+        let detail = stderr.isEmpty ? "" : ": \(stderr)"
+        throw HelperFailure(
+            code: appOpenFailureCode(stderr),
+            message: "Unable to open \(appName)\(detail)"
         )
     }
     return [:]

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -96,6 +96,8 @@ export interface ComputerUseCommandFailure {
       | "permission_denied"
       | "accessibility_unavailable"
       | "screen_recording_unavailable"
+      | "app_not_found"
+      | "app_open_failed"
       | "unsupported_command";
     readonly message: string;
   };

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -1,0 +1,49 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createComputerUseNativeBackend } from "./computer-use-native";
+
+async function createHelper(
+  response: unknown,
+): Promise<{ readonly dir: string; readonly helperPath: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "computer-use-helper-"));
+  const helperPath = path.join(dir, "helper");
+  await writeFile(
+    helperPath,
+    `#!/usr/bin/env node
+process.stdin.resume();
+process.stdin.on("data", () => {});
+process.stdin.on("end", () => {
+  process.stdout.write(${JSON.stringify(`${JSON.stringify(response)}\n`)});
+});
+`,
+  );
+  await chmod(helperPath, 0o755);
+  return { dir, helperPath };
+}
+
+describe("computer use native backend", () => {
+  it.each([
+    ["app_not_found", "Unable to open Things: Unable to find application"],
+    ["app_open_failed", "Unable to activate Things"],
+  ])("preserves %s helper failures", async (code, message) => {
+    const helper = await createHelper({
+      status: "failed",
+      error: { code, message },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+      });
+
+      await expect(backend.openApp("Things")).rejects.toMatchObject({
+        code,
+        message,
+      });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -115,6 +115,8 @@ function responseErrorCode(value: unknown): ComputerUseNativeErrorCode {
     value === "permission_denied" ||
     value === "accessibility_unavailable" ||
     value === "screen_recording_unavailable" ||
+    value === "app_not_found" ||
+    value === "app_open_failed" ||
     value === "unsupported_command"
   ) {
     return value;

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  computerUseCommandErrorCodeSchema,
+  computerUseHostCommandCompleteBodySchema,
+} from "../zero-computer-use";
+
+describe("computer-use contract", () => {
+  it.each(["app_not_found", "app_open_failed"])(
+    "accepts %s command failures",
+    (code) => {
+      expect(computerUseCommandErrorCodeSchema.parse(code)).toBe(code);
+      expect(
+        computerUseHostCommandCompleteBodySchema.parse({
+          status: "failed",
+          error: {
+            code,
+            message: "Unable to open Things",
+          },
+        }),
+      ).toStrictEqual({
+        status: "failed",
+        error: {
+          code,
+          message: "Unable to open Things",
+        },
+      });
+    },
+  );
+});

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -39,6 +39,8 @@ export const computerUseCommandErrorCodeSchema = z.enum([
   "permission_denied",
   "accessibility_unavailable",
   "screen_recording_unavailable",
+  "app_not_found",
+  "app_open_failed",
   "unsupported_command",
   "timeout",
 ]);


### PR DESCRIPTION
## Summary

- Activate an already-running macOS app directly before falling back to `/usr/bin/open -a`.
- Return `app_not_found` / `app_open_failed` instead of mislabeling launch failures as `accessibility_unavailable`.
- Preserve the new error codes through the Desktop native backend and API contract schemas.

## Root cause

`app.open` always shelled out to `open -a` and mapped non-zero exits to `accessibility_unavailable`, even when the target app was already running and AX inspection could work.

## Validation

- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --cache`
- `git diff --check`

Not fully green locally:

- `pnpm check-types` fails in `@vm0/app` on this checkout even with this branch's issue changes stashed; first error: `src/lib/ably-auth.ts(55,30): Property 'body' does not exist on type 'never'`.
- Native Swift helper build was not run because `swift` is not installed in the devcontainer.

Closes #14501
