### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,12 +111,12 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.146"
-CODEX_CLI_VERSION="0.132.0"
+CLAUDE_CODE_VERSION="2.1.148"
+CODEX_CLI_VERSION="0.133.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.0"
-PNPM_VERSION="11.1.3"
+PNPM_VERSION="11.2.2"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Updates pinned tool versions in `crates/runner/scripts/build-template.sh` to their latest releases.

| Package | Old | New |
|---|---|---|
| `@anthropic-ai/claude-code` | 2.1.146 | 2.1.148 |
| `@openai/codex` | 0.132.0 | 0.133.0 |
| `pnpm` | 11.1.3 | 11.2.2 |

Already on latest: `go` 1.26.3, `@googleworkspace/cli` 0.22.5, `@xdevplatform/xurl` 1.0.3, `agent-browser` 0.27.0.

## Test plan

- [ ] CI builds the rootfs template successfully with new pinned versions