### PR TITLE
fix(cli): remove computer-use management commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -131,9 +131,9 @@ describe("computer-use command visibility", () => {
     expect(subNames).toContain("press-key");
     expect(subNames).toContain("perform-action");
     expect(subNames).toContain("open-app");
-    expect(subNames).toContain("hosts");
-    expect(subNames).toContain("revoke-host");
-    expect(subNames).toContain("audit");
+    expect(subNames).not.toContain("hosts");
+    expect(subNames).not.toContain("revoke-host");
+    expect(subNames).not.toContain("audit");
   });
 
   it("should write screenshot data URLs to a local file in command result console output", async () => {
@@ -300,49 +300,5 @@ describe("computer-use command visibility", () => {
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain('"text": "clicked"');
-  });
-
-  it("should include dispatch and input risk metadata in audit output", async () => {
-    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-    vi.stubEnv("VM0_TOKEN", "test-token");
-    server.use(
-      http.get(
-        "http://localhost:3000/api/zero/computer-use/audit-events",
-        () => {
-          return HttpResponse.json({
-            auditEvents: [
-              {
-                id: "audit_1",
-                commandId: "cmd_1",
-                runId: null,
-                hostId: "host_1",
-                kind: "keyboard.press_key",
-                app: "Safari",
-                event: "completed",
-                approvalOutcome: null,
-                redactedResult: {
-                  dispatchMode: "targeted_keyboard_event",
-                  inputRisk: "targeted_app_shortcut",
-                },
-                error: null,
-                createdAt: "2026-05-21T10:00:00.000Z",
-              },
-            ],
-          });
-        },
-      ),
-    );
-
-    await zeroComputerUseCommand.parseAsync([
-      "node",
-      "cli",
-      "audit",
-      "--limit",
-      "1",
-    ]);
-
-    const output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("dispatch=targeted_keyboard_event");
-    expect(output).toContain("risk=targeted_app_shortcut");
   });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -2,7 +2,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Command } from "commander";
 import type {
-  ComputerUseAuditEvent,
   ComputerUseCommandResponse,
   ComputerUseReadCommandKind,
   ComputerUseWriteCommandKind,
@@ -10,10 +9,7 @@ import type {
 import {
   createComputerUseReadCommand,
   createComputerUseWriteCommand,
-  deleteComputerUseHost,
   getComputerUseCommand,
-  listComputerUseAuditEvents,
-  listComputerUseHosts,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
@@ -61,13 +57,6 @@ interface ComputerUseTypeTextOptions extends ComputerUseAppOptions {
 
 interface ComputerUsePressKeyOptions extends ComputerUseAppOptions {
   readonly key: string;
-}
-
-interface AuditListOptions {
-  readonly limit?: string;
-  readonly commandId?: string;
-  readonly hostId?: string;
-  readonly runId?: string;
 }
 
 const COMPUTER_USE_SCREENSHOT_DIR = "/tmp/vm0/computer-use";
@@ -133,17 +122,6 @@ function parseMouseButton(
     return value;
   }
   throw new Error("button must be left, right, or middle");
-}
-
-function parseLimit(value: string | undefined): number {
-  if (value === undefined) {
-    return 50;
-  }
-  const parsed = parsePositiveInteger(value, "limit");
-  if (parsed > 200) {
-    throw new Error("limit must be 200 or less");
-  }
-  return parsed;
 }
 
 function sanitizeFilenamePart(value: unknown, fallback: string): string {
@@ -322,32 +300,6 @@ function appOption(command: Command): Command {
   return command.requiredOption("--app <name>", "Target app name or bundle id");
 }
 
-function auditMetadataValue(
-  metadata: Record<string, unknown> | null,
-  key: string,
-): string | null {
-  const value = metadata?.[key];
-  return typeof value === "string" && value.length > 0 ? value : null;
-}
-
-function formatAuditEvent(event: ComputerUseAuditEvent): string {
-  const dispatchMode = auditMetadataValue(event.redactedResult, "dispatchMode");
-  const inputRisk = auditMetadataValue(event.redactedResult, "inputRisk");
-  return [
-    `${event.createdAt} ${event.event} ${event.kind}`,
-    `command=${event.commandId}`,
-    event.hostId ? `host=${event.hostId}` : null,
-    event.app ? `app=${event.app}` : null,
-    event.approvalOutcome ? `approval=${event.approvalOutcome}` : null,
-    dispatchMode ? `dispatch=${dispatchMode}` : null,
-    inputRisk ? `risk=${inputRisk}` : null,
-  ]
-    .filter((part): part is string => {
-      return part !== null;
-    })
-    .join(" ");
-}
-
 const listAppsCommand = addTargetOptions(
   new Command()
     .name("list-apps")
@@ -519,48 +471,6 @@ const openAppCommand = appOption(
   ),
 );
 
-const hostsCommand = new Command()
-  .name("hosts")
-  .description("List linked Desktop Computer Use hosts")
-  .action(
-    withErrorHandler(async () => {
-      const { hosts } = await listComputerUseHosts();
-      console.log(JSON.stringify({ hosts }, null, 2));
-    }),
-  );
-
-const revokeHostCommand = new Command()
-  .name("revoke-host")
-  .description("Revoke a linked Desktop Computer Use host")
-  .argument("<host-id>")
-  .action(
-    withErrorHandler(async (hostId: string) => {
-      await deleteComputerUseHost(hostId);
-      console.log(`Revoked computer-use host ${hostId}`);
-    }),
-  );
-
-const auditCommand = new Command()
-  .name("audit")
-  .description("List Desktop Computer Use write-command audit events")
-  .option("--limit <count>", "Maximum events to return", "50")
-  .option("--command-id <id>", "Filter by command id")
-  .option("--host-id <id>", "Filter by host id")
-  .option("--run-id <id>", "Filter by run id")
-  .action(
-    withErrorHandler(async (options: AuditListOptions) => {
-      const { auditEvents } = await listComputerUseAuditEvents({
-        limit: parseLimit(options.limit),
-        ...(options.commandId ? { commandId: options.commandId } : {}),
-        ...(options.hostId ? { hostId: options.hostId } : {}),
-        ...(options.runId ? { runId: options.runId } : {}),
-      });
-      for (const event of auditEvents) {
-        console.log(formatAuditEvent(event));
-      }
-    }),
-  );
-
 export const zeroComputerUseCommand = new Command()
   .name("computer-use")
   .description("Desktop app computer use through Zero CLI")
@@ -572,7 +482,4 @@ export const zeroComputerUseCommand = new Command()
   .addCommand(typeTextCommand)
   .addCommand(pressKeyCommand)
   .addCommand(performActionCommand)
-  .addCommand(openAppCommand)
-  .addCommand(hostsCommand)
-  .addCommand(revokeHostCommand)
-  .addCommand(auditCommand);
+  .addCommand(openAppCommand);

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -1,17 +1,12 @@
 import { initClient } from "@ts-rest/core";
 import type {
-  ComputerUseAuditEventListResponse,
   ComputerUseCommandCreateResponse,
   ComputerUseCommandResponse,
-  ComputerUseHostDeleteResponse,
-  ComputerUseHostListResponse,
   ComputerUseReadCommandKind,
   ComputerUseWriteCommandKind,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
 import {
-  zeroComputerUseAuditEventsContract,
   zeroComputerUseCommandContract,
-  zeroComputerUseHostsContract,
   zeroComputerUseWriteCommandContract,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
 import {
@@ -151,54 +146,4 @@ export async function getComputerUseCommand(
   }
 
   handleError(result, "Failed to get computer-use command");
-}
-
-export async function listComputerUseHosts(): Promise<ComputerUseHostListResponse> {
-  const config = await getComputerUseClientConfig();
-  const client = initClient(zeroComputerUseHostsContract, config);
-  const result = await client.list({ headers: {} });
-
-  if (result.status === 200) {
-    return result.body;
-  }
-
-  handleError(result, "Failed to list computer-use hosts");
-}
-
-export async function deleteComputerUseHost(
-  hostId: string,
-): Promise<ComputerUseHostDeleteResponse> {
-  const config = await getComputerUseClientConfig();
-  const client = initClient(zeroComputerUseHostsContract, config);
-  const result = await client.delete({ params: { hostId } });
-
-  if (result.status === 200) {
-    return result.body;
-  }
-
-  handleError(result, "Failed to revoke computer-use host");
-}
-
-export async function listComputerUseAuditEvents(params: {
-  readonly limit?: number;
-  readonly commandId?: string;
-  readonly hostId?: string;
-  readonly runId?: string;
-}): Promise<ComputerUseAuditEventListResponse> {
-  const config = await getComputerUseClientConfig();
-  const client = initClient(zeroComputerUseAuditEventsContract, config);
-  const result = await client.list({
-    query: {
-      limit: params.limit ?? 50,
-      ...(params.commandId ? { commandId: params.commandId } : {}),
-      ...(params.hostId ? { hostId: params.hostId } : {}),
-      ...(params.runId ? { runId: params.runId } : {}),
-    },
-  });
-
-  if (result.status === 200) {
-    return result.body;
-  }
-
-  handleError(result, "Failed to list computer-use audit events");
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -194,10 +194,7 @@ export {
 export {
   createComputerUseReadCommand,
   createComputerUseWriteCommand,
-  deleteComputerUseHost,
   getComputerUseCommand,
-  listComputerUseAuditEvents,
-  listComputerUseHosts,
 } from "./domains/zero-computer-use";
 
 // Domain modules - Zero Local Agent


### PR DESCRIPTION
## Summary
- remove zero computer-use hosts, revoke-host, and audit subcommands from the agent-facing CLI
- remove the now-unused CLI computer-use host/audit client helpers
- update command registration tests to assert management commands are not exposed

Fixes #14500

## Tests
- pnpm exec prettier --write apps/cli/src/commands/zero/computer-use/index.ts apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts apps/cli/src/lib/api/domains/zero-computer-use.ts apps/cli/src/lib/api/index.ts
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/cli test -- src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/cli build
- node apps/cli/dist/zero.js computer-use --help