### PR TITLE
fix(api): handle response-like route results

### DIFF
--- a/turbo/apps/api/src/signals/context/__tests__/route.test.ts
+++ b/turbo/apps/api/src/signals/context/__tests__/route.test.ts
@@ -27,6 +27,15 @@ const routeTestContract = c.router({
       }),
     },
   },
+  responseLike: {
+    method: "GET",
+    path: "/__test/response-like",
+    responses: {
+      200: z.object({
+        ok: z.literal(true),
+      }),
+    },
+  },
   post: {
     method: "POST",
     path: "/__test/post",
@@ -80,6 +89,39 @@ describe("honoSignalHandler", () => {
     const response = await accept(client.command(), [200]);
 
     expect(response.body).toStrictEqual({ aborted: false, sameSignal: true });
+  });
+
+  it("returns response-like objects without ts-rest validation", async () => {
+    const handler$ = computed(() => {
+      const response = Response.json(
+        { ok: true as const },
+        { headers: { "x-test-response": "preserved" } },
+      );
+      return {
+        arrayBuffer: response.arrayBuffer.bind(response),
+        blob: response.blob.bind(response),
+        body: response.body,
+        clone: response.clone.bind(response),
+        formData: response.formData.bind(response),
+        headers: response.headers,
+        json: response.json.bind(response),
+        status: response.status,
+        statusText: response.statusText,
+        text: response.text.bind(response),
+      };
+    });
+    const client = setupApp({
+      context,
+      routes: [
+        ...ROUTES,
+        { route: routeTestContract.responseLike, handler: handler$ },
+      ],
+    })(routeTestContract);
+
+    const response = await accept(client.responseLike(), [200]);
+
+    expect(response.body).toStrictEqual({ ok: true });
+    expect(response.headers.get("x-test-response")).toBe("preserved");
   });
 
   it("registers non-GET handlers", async () => {

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -14,10 +14,61 @@ interface RouteResult {
   readonly body: unknown;
 }
 
+interface HeadersLike {
+  [Symbol.iterator](): IterableIterator<[string, string]>;
+}
+
+interface ResponseLike {
+  readonly status: number;
+  readonly statusText?: string;
+  readonly headers: HeadersLike;
+  readonly body: BodyInit | null;
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isHeadersLike(value: unknown): value is HeadersLike {
+  return isRecord(value) && typeof value[Symbol.iterator] === "function";
+}
+
+function isResponseLike(value: unknown): value is ResponseLike {
+  return (
+    isRecord(value) &&
+    typeof value.status === "number" &&
+    isHeadersLike(value.headers) &&
+    typeof value.arrayBuffer === "function" &&
+    typeof value.blob === "function" &&
+    typeof value.clone === "function" &&
+    typeof value.formData === "function" &&
+    typeof value.json === "function" &&
+    typeof value.text === "function"
+  );
+}
+
+function cloneHeaders(headers: HeadersLike): Headers {
+  const cloned = new Headers();
+  for (const [key, value] of headers) {
+    cloned.append(key, value);
+  }
+  return cloned;
+}
+
+function toResponse(response: ResponseLike): Response {
+  const init: ResponseInit = {
+    headers: cloneHeaders(response.headers),
+    status: response.status,
+  };
+  if (typeof response.statusText === "string") {
+    init.statusText = response.statusText;
+  }
+  return new Response(response.body, init);
+}
+
 function isRouteResult(value: unknown): value is RouteResult {
   return (
-    typeof value === "object" &&
-    value !== null &&
+    isRecord(value) &&
     "status" in value &&
     "body" in value &&
     typeof value.status === "number"
@@ -58,6 +109,10 @@ export function honoSignalHandler(
 
     if (data instanceof Response) {
       return data;
+    }
+
+    if (isResponseLike(data)) {
+      return toResponse(data);
     }
 
     if (!isRouteResult(data)) {


### PR DESCRIPTION
## Summary
- detect response-like route handler returns before ts-rest response validation
- rebuild cross-realm/native Response objects into the current runtime Response
- add regression coverage for response-like signal route results

Fixes #14357

## Tests
- pnpm -F api exec vitest run src/signals/context/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts -t "POST /api/zero/email/inbound"
- pnpm -F api exec vitest run src/signals/routes/__tests__/github-oauth.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts src/signals/routes/__tests__/integrations-github-delete.test.ts src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
- pnpm -F web exec vitest run src/lib/zero/context/__tests__/resolve-model-provider.test.ts (with local dev-seed VM0 key rows temporarily hidden, then restored)
- pnpm format
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip
- pnpm lint
- pnpm check-types
- pnpm test (with local dev-seed VM0 key rows temporarily hidden, then restored)

## Notes
- Ran pnpm -F web db:migrate before the full test run because this checkout was missing recent local DB migrations.