### PR TITLE
fix: surface storage download diagnostics

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -46,6 +46,10 @@ impl DownloadTask {
     pub(crate) fn mount_path(&self) -> &str {
         &self.mount_path
     }
+
+    fn failure_detail(&self, error: &DownloadError) -> String {
+        format!("{} download failed: {}", self.label, error)
+    }
 }
 
 struct ActiveDownload {
@@ -238,8 +242,9 @@ fn run_download_task(task: DownloadTask) -> bool {
             true
         }
         Err(e) => {
-            record_sandbox_op(task.op_name, start.elapsed(), false, Some(&e.message));
-            log_error!(LOG_TAG, "{} download failed: {}", task.label, e);
+            let failure_detail = task.failure_detail(&e);
+            record_sandbox_op(task.op_name, start.elapsed(), false, Some(&failure_detail));
+            log_error!(LOG_TAG, "{failure_detail}");
             false
         }
     }
@@ -355,5 +360,27 @@ mod tests {
         });
 
         assert!(matches!(result, Ok(false)));
+    }
+
+    #[test]
+    fn download_task_failure_detail_includes_entry_metadata() {
+        let task = DownloadTask::new(
+            "storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false"
+                .into(),
+            "storage_download",
+            "file:///tmp/archive.tar.gz".into(),
+            "/workspace".into(),
+            false,
+        );
+        let error = DownloadError::fatal("Failed to read archive entries: invalid gzip header");
+
+        let detail = task.failure_detail(&error);
+
+        assert!(detail.contains("storage 1"));
+        assert!(detail.contains("mountPath=/workspace"));
+        assert!(detail.contains("vasStorageName=repo"));
+        assert!(detail.contains("vasVersionId=v1"));
+        assert!(detail.contains("urlScheme=file"));
+        assert!(detail.contains("Failed to read archive entries"));
     }
 }

--- a/crates/guest-download/src/manifest.rs
+++ b/crates/guest-download/src/manifest.rs
@@ -36,6 +36,10 @@ pub(crate) struct ManifestEntry {
     pub(crate) instructions_target_filename: Option<String>,
     #[serde(default)]
     pub(crate) cached: bool,
+    #[serde(default)]
+    pub(crate) vas_storage_name: Option<String>,
+    #[serde(default)]
+    pub(crate) vas_version_id: Option<String>,
 }
 
 #[cfg(test)]
@@ -87,7 +91,7 @@ mod tests {
     }
 
     #[test]
-    fn manifest_ignores_runner_entry_metadata() {
+    fn manifest_preserves_runner_entry_metadata() {
         let json = r#"{
             "storages": [{
                 "mountPath": "/data",
@@ -105,6 +109,16 @@ mod tests {
         }"#;
         let manifest: Manifest = serde_json::from_str(json).unwrap();
         assert_eq!(manifest.storages[0].mount_path, "/data");
+        assert_eq!(
+            manifest.storages[0].vas_storage_name.as_deref(),
+            Some("storage")
+        );
+        assert_eq!(manifest.storages[0].vas_version_id.as_deref(), Some("v1"));
         assert_eq!(manifest.artifacts[0].mount_path, "/workspace");
+        assert_eq!(
+            manifest.artifacts[0].vas_storage_name.as_deref(),
+            Some("artifact")
+        );
+        assert_eq!(manifest.artifacts[0].vas_version_id.as_deref(), Some("v2"));
     }
 }

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -91,7 +91,7 @@ fn append_download_tasks(
             && let Some(url) = entry.archive_url.clone()
         {
             tasks.push(DownloadTask::new(
-                format!("{} {}", label_prefix, idx + 1),
+                format_entry_label(entry, label_prefix, idx + 1, &url),
                 op_name,
                 url,
                 entry.mount_path.clone(),
@@ -99,6 +99,25 @@ fn append_download_tasks(
             ));
         }
     }
+}
+
+fn format_entry_label(
+    entry: &ManifestEntry,
+    label_prefix: &str,
+    index: usize,
+    archive_url: &str,
+) -> String {
+    let storage_name = entry.vas_storage_name.as_deref().unwrap_or("unknown");
+    let version_id = entry.vas_version_id.as_deref().unwrap_or("unknown");
+    let url_scheme = archive_url
+        .split_once("://")
+        .map(|(scheme, _)| scheme)
+        .unwrap_or("unknown");
+
+    format!(
+        "{} {} mountPath={} vasStorageName={} vasVersionId={} urlScheme={} cached={}",
+        label_prefix, index, entry.mount_path, storage_name, version_id, url_scheme, entry.cached
+    )
 }
 
 #[cfg(test)]
@@ -133,11 +152,26 @@ mod tests {
     fn manifest_entries_yield_storage_and_artifact_tasks() {
         let json = r#"{
             "storages": [
-                {"mountPath": "/data", "archiveUrl": "https://s3/storage.tar.gz"}
+                {
+                    "mountPath": "/data",
+                    "archiveUrl": "https://s3/storage.tar.gz",
+                    "vasStorageName": "data",
+                    "vasVersionId": "storage-v1"
+                }
             ],
             "artifacts": [
-                {"mountPath": "/workspace/a", "archiveUrl": "https://s3/a.tar.gz"},
-                {"mountPath": "/workspace/b", "archiveUrl": "https://s3/b.tar.gz"}
+                {
+                    "mountPath": "/workspace/a",
+                    "archiveUrl": "https://s3/a.tar.gz",
+                    "vasStorageName": "workspace-a",
+                    "vasVersionId": "artifact-v1"
+                },
+                {
+                    "mountPath": "/workspace/b",
+                    "archiveUrl": "file:///tmp/vm0-storage-cache/b.tar.gz",
+                    "vasStorageName": "workspace-b",
+                    "vasVersionId": "artifact-v2"
+                }
             ]
         }"#;
         let manifest: Manifest = serde_json::from_str(json).unwrap();
@@ -150,7 +184,7 @@ mod tests {
         assert_eq!(
             plan.download_tasks[0],
             DownloadTask::new(
-                "storage 1".into(),
+                "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
                 "storage_download",
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
@@ -160,7 +194,7 @@ mod tests {
         assert_eq!(
             plan.download_tasks[1],
             DownloadTask::new(
-                "artifact 1".into(),
+                "artifact 1 mountPath=/workspace/a vasStorageName=workspace-a vasVersionId=artifact-v1 urlScheme=https cached=false".into(),
                 "artifact_download",
                 "https://s3/a.tar.gz".into(),
                 "/workspace/a".into(),
@@ -170,9 +204,9 @@ mod tests {
         assert_eq!(
             plan.download_tasks[2],
             DownloadTask::new(
-                "artifact 2".into(),
+                "artifact 2 mountPath=/workspace/b vasStorageName=workspace-b vasVersionId=artifact-v2 urlScheme=file cached=false".into(),
                 "artifact_download",
-                "https://s3/b.tar.gz".into(),
+                "file:///tmp/vm0-storage-cache/b.tar.gz".into(),
                 "/workspace/b".into(),
                 true,
             )

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -575,7 +575,11 @@ fn binary_does_not_log_http_archive_url_on_fatal_status() {
         ops.iter()
             .any(|entry| entry["action_type"] == "storage_download"
                 && entry["success"] == false
-                && entry["error"] == "HTTP status 404"),
+                && entry["error"]
+                    .as_str()
+                    .is_some_and(|error| error.contains("HTTP status 404")
+                        && error.contains("mountPath=")
+                        && error.contains("urlScheme=http"))),
         "missing failed storage_download entry: {ops_log_content}"
     );
     assert!(

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -46,6 +46,7 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
 const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES: usize = 8 * 1024;
 const STDOUT_STREAM_LIMIT_MARKER: &[u8] =
     b"[vm0] stdout stream reached the guest stream limit; later output was omitted\n";
 const STDOUT_STREAM_OVERFLOW_MARKER: &[u8] =
@@ -1483,12 +1484,85 @@ async fn download_storages(
         .await?;
 
     if result.exit_code != 0 {
-        return Err(RunnerError::Internal(format!(
-            "storage download failed (exit code {})",
-            result.exit_code
+        return Err(RunnerError::Internal(format_guest_download_failure(
+            &result,
         )));
     }
     Ok(())
+}
+
+fn format_guest_download_failure(result: &sandbox::ExecResult) -> String {
+    let mut message = format!("storage download failed (exit code {})", result.exit_code);
+
+    if let Some(stderr) =
+        format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated)
+    {
+        message.push_str("; ");
+        message.push_str(&stderr);
+    }
+    if let Some(stdout) =
+        format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated)
+    {
+        message.push_str("; ");
+        message.push_str(&stdout);
+    }
+
+    message
+}
+
+fn format_command_output_excerpt(
+    label: &str,
+    bytes: &[u8],
+    sandbox_truncated: bool,
+) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let omitted_prefix = bytes.len() > GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
+    let excerpt_start = if omitted_prefix {
+        bytes.len() - GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES
+    } else {
+        0
+    };
+    let excerpt_bytes = bytes.get(excerpt_start..)?;
+    let excerpt = String::from_utf8_lossy(excerpt_bytes);
+    let excerpt = redact_url_query_strings(excerpt.trim());
+    if excerpt.is_empty() {
+        return None;
+    }
+
+    let mut qualifiers = Vec::new();
+    if omitted_prefix {
+        qualifiers.push("last 8192 bytes");
+    } else {
+        qualifiers.push("captured");
+    }
+    if sandbox_truncated {
+        qualifiers.push("sandbox-truncated");
+    }
+
+    Some(format!("{label} ({}): {excerpt}", qualifiers.join(", ")))
+}
+
+fn redact_url_query_strings(input: &str) -> String {
+    input
+        .split_whitespace()
+        .map(redact_url_query_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn redact_url_query_token(token: &str) -> String {
+    for scheme in ["https://", "http://"] {
+        if let Some((prefix, candidate)) = token.split_once(scheme)
+            && let Some((base_url, _)) = candidate.split_once('?')
+        {
+            return format!("{prefix}{scheme}{base_url}?<redacted>");
+        }
+    }
+
+    token.to_owned()
 }
 
 /// Write CLI agent session history into the guest filesystem.
@@ -3102,8 +3176,8 @@ mod tests {
         // write_file succeeds, but exec returns non-zero.
         sandbox.push_exec_result(Ok(ExecResult::new(
             1,
-            Vec::new(),
-            b"download failed".to_vec(),
+            b"stdout clue".to_vec(),
+            b"[2026-05-20T18:03:00Z] [ERROR] [sandbox:guest-download] storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false download failed: Failed to read archive entries: invalid gzip header".to_vec(),
         )));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
@@ -3114,7 +3188,31 @@ mod tests {
         let err = download_storages(&sandbox, &ctx, &manifest)
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("storage download failed"));
+        let msg = err.to_string();
+        assert!(msg.contains("storage download failed (exit code 1)"));
+        assert!(msg.contains("stderr (captured)"));
+        assert!(msg.contains("mountPath=/workspace"));
+        assert!(msg.contains("vasStorageName=repo"));
+        assert!(msg.contains("Failed to read archive entries"));
+        assert!(msg.contains("stdout (captured): stdout clue"));
+    }
+
+    #[test]
+    fn guest_download_failure_output_redacts_url_queries() {
+        let result = ExecResult {
+            exit_code: 1,
+            stdout: Vec::new(),
+            stderr: b"HTTP transport error for archiveUrl=https://storage.example/archive.tar.gz?X-Amz-Signature=secret"
+                .to_vec(),
+            stdout_truncated: false,
+            stderr_truncated: true,
+        };
+
+        let msg = format_guest_download_failure(&result);
+
+        assert!(msg.contains("stderr (captured, sandbox-truncated)"));
+        assert!(msg.contains("archiveUrl=https://storage.example/archive.tar.gz?<redacted>"));
+        assert!(!msg.contains("secret"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- include captured guest-download stderr/stdout excerpts when runner storage hydration exits non-zero
- parse runner storage metadata in guest-download and include mount path, storage name, version, URL scheme, and cached state in failure details
- keep archive URLs out of guest logs while preserving failure class/status for debugging

Fixes #14356

## Tests

- cargo test --manifest-path crates/Cargo.toml -p guest-download
- cargo test --manifest-path crates/Cargo.toml -p runner download_storages_nonzero_exit_code
- cargo test --manifest-path crates/Cargo.toml -p runner guest_download_failure_output_redacts_url_queries
- cargo clippy --manifest-path crates/Cargo.toml -p guest-download -p runner --all-targets -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
