### PR TITLE
fix(runner): log quota failures as info

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -18,6 +18,7 @@ pub struct FailureDiagnostic {
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
     pub failure_detail_source: Option<FailureDetailSource>,
+    pub failure_reason: Option<FailureReason>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
     pub prompt_bytes: u64,
@@ -38,6 +39,7 @@ impl FailureDiagnostic {
             cli_exit_code: None,
             claude_num_turns: None,
             failure_detail_source: None,
+            failure_reason: None,
             session_history_status: SessionHistoryStatus::Unknown,
             prompt_shape: prompt.prompt_shape,
             prompt_bytes: prompt.prompt_bytes,
@@ -63,6 +65,12 @@ impl FailureDiagnostic {
         failure_detail_source: FailureDetailSource,
     ) -> Self {
         self.failure_detail_source = Some(failure_detail_source);
+        self
+    }
+
+    #[must_use]
+    pub fn with_failure_reason(mut self, failure_reason: FailureReason) -> Self {
+        self.failure_reason = Some(failure_reason);
         self
     }
 
@@ -97,6 +105,23 @@ impl FailureClass {
             Self::ClaudeZeroTurnNoHistory => "claude_zero_turn_no_history",
             Self::EventUploadFailed => "event_upload_failed",
             Self::CheckpointFailed => "checkpoint_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureReason {
+    InsufficientCredits,
+    UsageLimit,
+}
+
+impl FailureReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InsufficientCredits => "insufficient_credits",
+            Self::UsageLimit => "usage_limit",
         }
     }
 }
@@ -250,6 +275,7 @@ mod tests {
         assert_eq!(json["cliExitCode"], 0);
         assert_eq!(json["claudeNumTurns"], 0);
         assert_eq!(json["failureDetailSource"], serde_json::Value::Null);
+        assert_eq!(json["failureReason"], serde_json::Value::Null);
         assert_eq!(json["sessionHistoryStatus"], "missing");
         assert_eq!(json["promptShape"], "slash_like");
         assert_eq!(json["promptBytes"], 5);
@@ -260,24 +286,43 @@ mod tests {
     }
 
     #[test]
-    fn failure_diagnostic_serializes_optional_detail_source() {
+    fn failure_diagnostic_serializes_optional_detail_source_and_reason() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
             AgentFramework::ClaudeCode,
             PromptMetadata::from_prompt("debug failure"),
         )
         .with_cli_exit_code(1)
-        .with_failure_detail_source(FailureDetailSource::ClaudeResult);
+        .with_failure_detail_source(FailureDetailSource::ClaudeResult)
+        .with_failure_reason(FailureReason::InsufficientCredits);
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureDetailSource"], "claude_result");
+        assert_eq!(json["failureReason"], "insufficient_credits");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
     }
 
     #[test]
-    fn failure_diagnostic_deserializes_without_optional_detail_source() {
+    fn failure_diagnostic_serializes_usage_limit_reason() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::UsageLimit);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "usage_limit");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_deserializes_without_optional_fields() {
         let json = serde_json::json!({
             "schemaVersion": 1,
             "failureClass": "cli_nonzero",
@@ -293,6 +338,7 @@ mod tests {
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
         assert_eq!(diagnostic.failure_detail_source, None);
+        assert_eq!(diagnostic.failure_reason, None);
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -15,8 +15,8 @@ use guest_agent::paths;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use agent_diagnostics::{
-    AgentFramework, FailureClass, FailureDetailSource, FailureDiagnostic, PromptMetadata,
-    SessionHistoryStatus,
+    AgentFramework, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
+    PromptMetadata, SessionHistoryStatus,
 };
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
@@ -216,6 +216,8 @@ async fn execute(
                     cli_result.claude_result,
                 )
                 .with_failure_detail_source(failure_message.source);
+                let diagnostic =
+                    with_cli_failure_reason(diagnostic, failure_message.message.as_str());
                 (
                     cli_exit_code,
                     cli_exit_code,
@@ -327,6 +329,31 @@ fn diagnostic_framework() -> AgentFramework {
         env::Framework::ClaudeCode => AgentFramework::ClaudeCode,
         env::Framework::Codex => AgentFramework::Codex,
     }
+}
+
+fn with_cli_failure_reason(
+    diagnostic: FailureDiagnostic,
+    failure_message: &str,
+) -> FailureDiagnostic {
+    if let Some(reason) = classify_cli_failure_reason(diagnostic.framework, failure_message) {
+        diagnostic.with_failure_reason(reason)
+    } else {
+        diagnostic
+    }
+}
+
+fn classify_cli_failure_reason(
+    framework: AgentFramework,
+    failure_message: &str,
+) -> Option<FailureReason> {
+    let normalized = failure_message.to_ascii_lowercase();
+    if normalized.contains("402 insufficient credits") {
+        return Some(FailureReason::InsufficientCredits);
+    }
+    if matches!(framework, AgentFramework::Codex) && normalized.contains("usage limit") {
+        return Some(FailureReason::UsageLimit);
+    }
+    None
 }
 
 fn diagnostic_session_history_status() -> SessionHistoryStatus {
@@ -899,6 +926,68 @@ mod tests {
 
         assert_eq!(msg.source, FailureDetailSource::FallbackExitCode);
         assert_eq!(msg.message, "Agent exited with code 7");
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_insufficient_credits() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 402 Insufficient credits. Add credits or configure your own API key to continue.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::InsufficientCredits));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_codex_usage_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::UsageLimit));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_non_codex_usage_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "Claude usage limit reached. Visit https://claude.ai/settings/usage.",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_unrelated_failures() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            "permission denied while running command",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_is_attached_without_changing_failure_class() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::CodexJsonl);
+        let diagnostic = with_cli_failure_reason(
+            diagnostic,
+            "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage.",
+        );
+
+        assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
+        assert_eq!(diagnostic.failure_reason, Some(FailureReason::UsageLimit));
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::CodexJsonl)
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -889,6 +889,38 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_uses_selected_stderr_over_generic_diagnostic() {
+        let _test_state_guard = lock_test_state();
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+        let stderr_lines = vec![
+            "API Error: 402 Insufficient credits. Add credits or configure your own API key to continue."
+                .to_string(),
+        ];
+        let generic_diagnostic = cli_diagnostic("turn failed", FailureDetailSource::CodexJsonl);
+        let msg = cli_failure_message(1, &stderr_lines, Some(&generic_diagnostic));
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic = with_cli_failure_reason(diagnostic, msg.message.as_str());
+
+        assert_eq!(msg.source, FailureDetailSource::Stderr);
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::InsufficientCredits)
+        );
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::Stderr)
+        );
+    }
+
+    #[test]
     fn cli_failure_message_uses_generic_codex_failure_diagnostic_without_stderr() {
         let diagnostic = cli_diagnostic("turn failed", FailureDetailSource::CodexJsonl);
         let msg = cli_failure_message(1, &[], Some(&diagnostic));

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1001,6 +1001,23 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_leaves_unrelated_diagnostic_unchanged() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(2)
+        .with_failure_detail_source(FailureDetailSource::Stderr);
+        let unchanged = with_cli_failure_reason(
+            diagnostic.clone(),
+            "permission denied while running command",
+        );
+
+        assert_eq!(unchanged, diagnostic);
+    }
+
+    #[test]
     fn cli_failure_reason_is_attached_without_changing_failure_class() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
-use agent_diagnostics::{FailureDiagnostic, FailureReason};
+use agent_diagnostics::{FailureClass, FailureDiagnostic, FailureReason};
 use futures_util::FutureExt;
 use sandbox::SandboxId;
 use tokio::task::JoinSet;
@@ -373,10 +373,11 @@ fn log_job_execution_failed(
 }
 
 fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
-    matches!(
-        diagnostic.failure_reason,
-        Some(FailureReason::InsufficientCredits | FailureReason::UsageLimit)
-    )
+    diagnostic.failure_class == FailureClass::CliNonzero
+        && matches!(
+            diagnostic.failure_reason,
+            Some(FailureReason::InsufficientCredits | FailureReason::UsageLimit)
+        )
 }
 
 pub(super) async fn cleanup_panicked_job(
@@ -549,15 +550,12 @@ mod tests {
         events[0].clone()
     }
 
-    fn assert_field_contains(event: &CapturedEvent, field: &str, expected: &str) {
+    fn assert_field_eq(event: &CapturedEvent, field: &str, expected: &str) {
         let value = event
             .fields
             .get(field)
             .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
-        assert!(
-            value.contains(expected),
-            "field {field}={value:?} did not contain {expected:?}"
-        );
+        assert_eq!(value, expected, "field {field} mismatch; event={event:#?}");
     }
 
     #[test]
@@ -580,10 +578,35 @@ mod tests {
                 event.fields.get("message").map(String::as_str),
                 Some("job execution failed")
             );
-            assert_field_contains(&event, "failure_reason", reason.as_str());
-            assert_field_contains(&event, "failure_class", "cli_nonzero");
-            assert_field_contains(&event, "failure_detail_source", "codex_jsonl");
+            assert_field_eq(&event, "failure_reason", reason.as_str());
+            assert_field_eq(&event, "failure_class", "cli_nonzero");
+            assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
         }
+    }
+
+    #[test]
+    fn quota_reason_on_non_cli_failure_logs_job_execution_failed_at_error() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CheckpointFailed,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_failure_reason(FailureReason::UsageLimit);
+        let failure = executor::ExecutionFailure::new(
+            1,
+            "checkpoint upload failed after usage limit event",
+            Some(diagnostic),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+        assert_field_eq(&event, "failure_reason", "usage_limit");
+        assert_field_eq(&event, "failure_class", "checkpoint_failed");
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
+use agent_diagnostics::{FailureDiagnostic, FailureReason};
 use futures_util::FutureExt;
 use sandbox::SandboxId;
 use tokio::task::JoinSet;
@@ -230,28 +231,7 @@ pub(super) fn spawn_job(
             match (cancelled_for_log, failure.as_ref()) {
                 (true, _) => info!(run_id = %run_id, exit_code, reused, "job cancelled"),
                 (false, Some(failure)) => {
-                    if let Some(diagnostic) = failure.diagnostic.as_ref() {
-                        let failure_detail_source =
-                            diagnostic.failure_detail_source.map(|source| source.as_str());
-                        error!(
-                            run_id = %run_id,
-                            exit_code,
-                            reused,
-                            error = %failure.error,
-                            failure_class = diagnostic.failure_class.as_str(),
-                            failure_framework = diagnostic.framework.as_str(),
-                            failure_cli_exit_code = diagnostic.cli_exit_code,
-                            failure_claude_num_turns = diagnostic.claude_num_turns,
-                            failure_detail_source,
-                            session_history_status = diagnostic.session_history_status.as_str(),
-                            prompt_shape = diagnostic.prompt_shape.as_str(),
-                            prompt_bytes = diagnostic.prompt_bytes,
-                            first_line_bytes = diagnostic.first_line_bytes,
-                            "job execution failed"
-                        );
-                    } else {
-                        error!(run_id = %run_id, exit_code, reused, error = %failure.error, "job execution failed");
-                    }
+                    log_job_execution_failed(run_id, exit_code, reused, failure);
                 }
                 (false, None) => info!(run_id = %run_id, exit_code, reused, "job finished"),
             }
@@ -350,6 +330,55 @@ pub(super) fn spawn_job(
     });
 }
 
+fn log_job_execution_failed(
+    run_id: RunId,
+    exit_code: i32,
+    reused: bool,
+    failure: &executor::ExecutionFailure,
+) {
+    if let Some(diagnostic) = failure.diagnostic.as_ref() {
+        let failure_detail_source = diagnostic
+            .failure_detail_source
+            .map(|source| source.as_str());
+        let failure_reason = diagnostic.failure_reason.map(|reason| reason.as_str());
+        macro_rules! log_with_diagnostic {
+            ($level:ident) => {
+                $level!(
+                    run_id = %run_id,
+                    exit_code,
+                    reused,
+                    error = %failure.error,
+                    failure_class = diagnostic.failure_class.as_str(),
+                    failure_framework = diagnostic.framework.as_str(),
+                    failure_cli_exit_code = diagnostic.cli_exit_code,
+                    failure_claude_num_turns = diagnostic.claude_num_turns,
+                    failure_detail_source,
+                    failure_reason,
+                    session_history_status = diagnostic.session_history_status.as_str(),
+                    prompt_shape = diagnostic.prompt_shape.as_str(),
+                    prompt_bytes = diagnostic.prompt_bytes,
+                    first_line_bytes = diagnostic.first_line_bytes,
+                    "job execution failed"
+                )
+            };
+        }
+        if is_info_level_job_failure(diagnostic) {
+            log_with_diagnostic!(info);
+        } else {
+            log_with_diagnostic!(error);
+        }
+    } else {
+        error!(run_id = %run_id, exit_code, reused, error = %failure.error, "job execution failed");
+    }
+}
+
+fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
+    matches!(
+        diagnostic.failure_reason,
+        Some(FailureReason::InsufficientCredits | FailureReason::UsageLimit)
+    )
+}
+
 pub(super) async fn cleanup_panicked_job(
     run_id: RunId,
     sandbox_id: SandboxId,
@@ -404,13 +433,21 @@ pub(super) async fn handle_job_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
+    use std::fmt;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use agent_diagnostics::{
+        AgentFramework, FailureClass, FailureDetailSource, PromptMetadata, SessionHistoryStatus,
+    };
     use sandbox::{SandboxFactory, SandboxId};
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
     use tokio_util::sync::CancellationToken;
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Level, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::prelude::*;
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::RunCleanupState;
@@ -422,6 +459,160 @@ mod tests {
     use crate::ids::RunId;
     use crate::resource_budget::ResourceBudget;
     use crate::status::StatusTracker;
+
+    #[derive(Clone, Debug)]
+    struct CapturedEvent {
+        level: Level,
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedEvents {
+        events: Arc<std::sync::Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl CapturedEvents {
+        fn entries(&self) -> Vec<CapturedEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl<S> Layer<S> for CapturedEvents
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = CapturedFields::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                level: *event.metadata().level(),
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturedFields {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for CapturedFields {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    fn job_failure_diagnostic(failure_reason: Option<FailureReason>) -> FailureDiagnostic {
+        let mut diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::CodexJsonl)
+        .with_session_history_status(SessionHistoryStatus::NotApplicable);
+        if let Some(reason) = failure_reason {
+            diagnostic = diagnostic.with_failure_reason(reason);
+        }
+        diagnostic
+    }
+
+    fn capture_job_failure_log(failure: &executor::ExecutionFailure) -> CapturedEvent {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            log_job_execution_failed(RunId::nil(), failure.exit_code, false, failure);
+        });
+        let events = captured.entries();
+        assert_eq!(events.len(), 1, "captured events: {events:#?}");
+        events[0].clone()
+    }
+
+    fn assert_field_contains(event: &CapturedEvent, field: &str, expected: &str) {
+        let value = event
+            .fields
+            .get(field)
+            .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
+        assert!(
+            value.contains(expected),
+            "field {field}={value:?} did not contain {expected:?}"
+        );
+    }
+
+    #[test]
+    fn quota_failure_reasons_log_job_execution_failed_at_info() {
+        for reason in [
+            FailureReason::InsufficientCredits,
+            FailureReason::UsageLimit,
+        ] {
+            let diagnostic = job_failure_diagnostic(Some(reason));
+            let failure = executor::ExecutionFailure::new(
+                1,
+                format!("quota failure: {}", reason.as_str()),
+                Some(diagnostic),
+            );
+
+            let event = capture_job_failure_log(&failure);
+
+            assert_eq!(event.level, Level::INFO);
+            assert_eq!(
+                event.fields.get("message").map(String::as_str),
+                Some("job execution failed")
+            );
+            assert_field_contains(&event, "failure_reason", reason.as_str());
+            assert_field_contains(&event, "failure_class", "cli_nonzero");
+            assert_field_contains(&event, "failure_detail_source", "codex_jsonl");
+        }
+    }
+
+    #[test]
+    fn unclassified_diagnostic_failure_logs_job_execution_failed_at_error() {
+        let diagnostic = job_failure_diagnostic(None);
+        let failure = executor::ExecutionFailure::new(1, "permission denied", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+    }
+
+    #[test]
+    fn failure_without_diagnostic_logs_job_execution_failed_at_error() {
+        let failure = executor::ExecutionFailure::new(1, "executor task panicked", None);
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+        assert!(!event.fields.contains_key("failure_reason"));
+    }
 
     async fn status_idle_sessions_and_active_runs(
         status_path: &std::path::Path,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -621,6 +621,7 @@ mod tests {
             event.fields.get("message").map(String::as_str),
             Some("job execution failed")
         );
+        assert!(!event.fields.contains_key("failure_reason"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add optional structured failure reasons to guest-agent failure diagnostics
- classify insufficient-credits and Codex usage-limit CLI failures in guest-agent
- log runner terminal quota failures at info level while keeping unclassified failures at error

Closes #14509

## Tests
- cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib
- cargo test --manifest-path crates/Cargo.toml -p runner job_execution_failed
- cargo test --manifest-path crates/Cargo.toml -p runner job_spawn
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo fmt --all --check
- cargo clippy --all-targets --all-features
- cargo doc --workspace --all-features --no-deps
- git diff --check