### PR TITLE
refactor: make runner completion auth lifecycle explicit

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -92,6 +92,16 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         drop(job_lease);
         return;
     };
+    if claimed.context().run_id != run_id {
+        warn!(
+            run_id = %run_id,
+            context_run_id = %claimed.context().run_id,
+            "claimed job run_id mismatch, skipping"
+        );
+        ctx.cancel_tokens.lock().await.remove(&run_id);
+        drop(job_lease);
+        return;
+    }
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
         ctx.spawn_ctx.device_rate_limits.as_ref(),

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -82,8 +82,8 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     if matches!(*ctx.mode_rx.borrow(), RunnerMode::Stopping) {
         job_cancel.cancel();
     }
-    // claim() runs in the branch handler: non-interruptible, so a successful
-    // claim is always paired with complete().
+    // claim() runs in the branch handler: non-interruptible, so a valid
+    // successful claim is always paired with complete().
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -84,7 +84,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     }
     // claim() runs in the branch handler: non-interruptible, so a successful
     // claim is always paired with complete().
-    let Some(context) = ctx.spawn_ctx.provider.claim(candidate).await else {
+    let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and
         // cancel token so the runner can continue.
@@ -95,14 +95,14 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
         ctx.spawn_ctx.device_rate_limits.as_ref(),
-        &context,
+        claimed.context(),
     );
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot) = try_reuse_from_pool(
         run_id,
         &profile_name,
         &device_rate_limits,
-        &context,
+        claimed.context(),
         job_lease,
         &mut ctx,
     )
@@ -132,7 +132,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         cancel: job_cancel,
     };
     spawn_job(
-        context,
+        claimed,
         sandbox_id,
         job_profile,
         reuse_entry,

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -191,7 +191,7 @@ impl CompletionReady {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use async_trait::async_trait;
     use sandbox::SandboxId;
@@ -249,6 +249,10 @@ mod tests {
         status_path: std::path::PathBuf,
     }
 
+    struct CompletionAuthProvider {
+        auth_matches: Arc<AtomicBool>,
+    }
+
     #[async_trait]
     impl JobProvider for CompletionOrderProvider {
         async fn discover(&self) -> Option<JobCandidate> {
@@ -272,6 +276,36 @@ mod tests {
                 .store(self.budget.allocated().2, Ordering::SeqCst);
             self.active_runs_at_complete.store(
                 status_active_run_count(&self.status_path).await,
+                Ordering::SeqCst,
+            );
+        }
+
+        async fn heartbeat(&self, _state: &HeartbeatState) {}
+
+        async fn shutdown(&self) {}
+    }
+
+    #[async_trait]
+    impl JobProvider for CompletionAuthProvider {
+        async fn discover(&self) -> Option<JobCandidate> {
+            None
+        }
+
+        async fn claim(&self, _candidate: JobCandidate) -> Option<ClaimedJob> {
+            None
+        }
+
+        async fn complete(
+            &self,
+            run_id: RunId,
+            _exit_code: i32,
+            _error: Option<&str>,
+            _sandbox_id: Option<SandboxId>,
+            _reuse_result: Option<SandboxReuseResult>,
+            completion_auth: CompletionAuth,
+        ) {
+            self.auth_matches.store(
+                completion_auth.matches_sandbox_token_for_test(run_id, "completion-token"),
                 Ordering::SeqCst,
             );
         }
@@ -328,6 +362,41 @@ mod tests {
             RunCleanupDisposition::StatusRemoved,
         );
         assert_eq!(budget.allocated().2, 0);
+    }
+
+    #[tokio::test]
+    async fn completion_ready_forwards_completion_auth() {
+        let (_budget, lease) = test_budget_lease();
+        let auth_matches = Arc::new(AtomicBool::new(false));
+        let dir = tempfile::tempdir().unwrap();
+        let status = StatusTracker::new(dir.path().join("status.json"), 4, None, None);
+        let ownership = OwnershipTransitions::new(&status);
+        let provider = CompletionAuthProvider {
+            auth_matches: Arc::clone(&auth_matches),
+        };
+        let cleanup_state = RunCleanupState::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+
+        CompletionReady::new(
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::sandbox_token(run_id, "completion-token".to_string()),
+            ),
+            BudgetOwnership::active(ActiveBudgetLease::new(lease)),
+        )
+        .complete_and_release(&provider, &ownership, &cleanup_state)
+        .await;
+
+        assert!(
+            auth_matches.load(Ordering::SeqCst),
+            "completion payload auth must be forwarded to provider.complete"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use crate::ids::RunId;
-use crate::provider::JobProvider;
+use crate::provider::{CompletionAuth, JobProvider};
 use crate::resource_budget::BudgetLease;
 use crate::types::SandboxReuseResult;
 
@@ -118,6 +118,7 @@ pub(super) struct CompletionPayload {
     error: Option<String>,
     sandbox_id: SandboxId,
     reuse_result: SandboxReuseResult,
+    completion_auth: CompletionAuth,
 }
 
 impl CompletionPayload {
@@ -127,6 +128,7 @@ impl CompletionPayload {
         error: Option<String>,
         sandbox_id: SandboxId,
         reuse_result: SandboxReuseResult,
+        completion_auth: CompletionAuth,
     ) -> Self {
         Self {
             run_id,
@@ -134,6 +136,7 @@ impl CompletionPayload {
             error,
             sandbox_id,
             reuse_result,
+            completion_auth,
         }
     }
 }
@@ -163,6 +166,7 @@ impl CompletionReady {
             error,
             sandbox_id,
             reuse_result,
+            completion_auth,
         } = payload;
 
         provider
@@ -172,6 +176,7 @@ impl CompletionReady {
                 error.as_deref(),
                 Some(sandbox_id),
                 Some(reuse_result),
+                completion_auth,
             )
             .await;
         ownership
@@ -192,10 +197,10 @@ mod tests {
     use sandbox::SandboxId;
 
     use crate::ids::RunId;
-    use crate::provider::{JobCandidate, JobProvider};
+    use crate::provider::{ClaimedJob, JobCandidate, JobProvider};
     use crate::resource_budget::{BudgetLease, ResourceBudget};
     use crate::status::StatusTracker;
-    use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+    use crate::types::{HeartbeatState, SandboxReuseResult};
 
     use super::super::ownership::OwnershipTransitions;
 
@@ -205,7 +210,14 @@ mod tests {
         (budget, lease)
     }
     fn test_completion_payload(run_id: RunId, sandbox_id: SandboxId) -> CompletionPayload {
-        CompletionPayload::new(run_id, 0, None, sandbox_id, SandboxReuseResult::PoolMiss)
+        CompletionPayload::new(
+            run_id,
+            0,
+            None,
+            sandbox_id,
+            SandboxReuseResult::PoolMiss,
+            CompletionAuth::local(),
+        )
     }
 
     async fn status_active_run_count(path: &std::path::Path) -> usize {
@@ -243,7 +255,7 @@ mod tests {
             None
         }
 
-        async fn claim(&self, _candidate: JobCandidate) -> Option<ExecutionContext> {
+        async fn claim(&self, _candidate: JobCandidate) -> Option<ClaimedJob> {
             None
         }
 
@@ -254,6 +266,7 @@ mod tests {
             _error: Option<&str>,
             _sandbox_id: Option<SandboxId>,
             _reuse_result: Option<SandboxReuseResult>,
+            _completion_auth: CompletionAuth,
         ) {
             self.budget_count_at_complete
                 .store(self.budget.allocated().2, Ordering::SeqCst);

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -28,11 +28,11 @@ use crate::executor::{self, ExecutorConfig};
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_logs;
-use crate::provider::JobProvider;
+use crate::provider::{ClaimedJob, JobProvider};
 use crate::resource_budget::BudgetLease;
 use crate::status::StatusTracker;
 use crate::telemetry::JobTelemetry;
-use crate::types::{ExecutionContext, SandboxReuseResult};
+use crate::types::SandboxReuseResult;
 
 /// Per-job profile parameters resolved from the profile config.
 pub(super) struct JobProfile {
@@ -81,7 +81,7 @@ pub(super) struct SpawnContext {
 /// After a successful execution with a session ID available, the sandbox
 /// is parked in the idle pool instead of being destroyed.
 pub(super) fn spawn_job(
-    context: ExecutionContext,
+    claimed: ClaimedJob,
     sandbox_id: SandboxId,
     job_profile: JobProfile,
     reuse_entry: Option<ReusableIdleSandbox>,
@@ -89,6 +89,7 @@ pub(super) fn spawn_job(
     ctx: &SpawnContext,
     jobs: &mut JoinSet<Option<RunId>>,
 ) {
+    let (context, completion_auth) = claimed.into_parts();
     let run_id = context.run_id;
     let session_id = context.session_id().map(String::from);
     let vcpu = job_profile.vcpu;
@@ -257,7 +258,14 @@ pub(super) fn spawn_job(
             }
 
             let completion_payload =
-                CompletionPayload::new(run_id, exit_code, err, sandbox_id, reuse_result);
+                CompletionPayload::new(
+                    run_id,
+                    exit_code,
+                    err,
+                    sandbox_id,
+                    reuse_result,
+                    completion_auth,
+                );
             // Cancellation can arrive after terminal logging or while
             // `sandbox.park()` is in flight. Pass the live token so finalization
             // can re-check immediately before idle-pool ownership transfer.

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -257,15 +257,14 @@ pub(super) fn spawn_job(
                 (false, None) => info!(run_id = %run_id, exit_code, reused, "job finished"),
             }
 
-            let completion_payload =
-                CompletionPayload::new(
-                    run_id,
-                    exit_code,
-                    err,
-                    sandbox_id,
-                    reuse_result,
-                    completion_auth,
-                );
+            let completion_payload = CompletionPayload::new(
+                run_id,
+                exit_code,
+                err,
+                sandbox_id,
+                reuse_result,
+                completion_auth,
+            );
             // Cancellation can arrive after terminal logging or while
             // `sandbox.park()` is in flight. Pass the live token so finalization
             // can re-check immediately before idle-pool ownership transfer.

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -28,6 +28,8 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogSession;
+#[cfg(test)]
+use crate::provider::CompletionAuth;
 use crate::status::StatusTracker;
 
 pub(super) struct FinalizeContext {
@@ -565,7 +567,14 @@ mod tests {
         let _completion_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("network-log-park"))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(run_id, 0, None, sandbox_id, SandboxReuseResult::PoolMiss),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
             fixture.finalize_context(
                 run_id,
                 sandbox_id,
@@ -602,7 +611,14 @@ mod tests {
         let _completion_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("network-log-cancel"))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(run_id, 0, None, sandbox_id, SandboxReuseResult::PoolMiss),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
             fixture.finalize_context(
                 run_id,
                 sandbox_id,

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -1065,6 +1065,58 @@ async fn claim_failure_rolls_back_budget() {
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test]
+async fn claim_run_id_mismatch_rolls_back_local_state() {
+    // Budget for exactly 1 job, so a leaked lease would block the follow-up job.
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let candidate_run_id = RunId::new_v4();
+    let context_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        candidate_run_id,
+        "vm0/default",
+        Some(minimal_context(context_run_id)),
+    );
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, candidate_run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    {
+        let completions = env.handle.completions.lock().unwrap();
+        assert!(
+            !completions
+                .iter()
+                .any(|completion| completion.run_id == candidate_run_id
+                    || completion.run_id == context_run_id),
+            "mismatched claim should not produce a completion for either run id"
+        );
+    }
+
+    let followup_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        followup_run_id,
+        "vm0/default",
+        Some(minimal_context(followup_run_id)),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(followup_run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        completion.is_some(),
+        "follow-up job should complete after mismatched claim is rejected"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
 // -----------------------------------------------------------------------
 // Test 5: Shutdown drains running jobs before exiting
 // -----------------------------------------------------------------------

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -1045,7 +1045,7 @@ async fn claim_failure_rolls_back_budget() {
 
     // Returning to discovery proves the failed claim was processed.
     wait_discover_entered(&env, Duration::from_secs(5)).await;
-    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 0);
 
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();
@@ -1088,7 +1088,7 @@ async fn claim_run_id_mismatch_rolls_back_local_state() {
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, candidate_run_id, Duration::from_secs(5)).await;
-    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 0);
     {
         let completions = env.handle.completions.lock().unwrap();
         assert!(

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -1068,7 +1068,7 @@ async fn claim_failure_rolls_back_budget() {
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn claim_run_id_mismatch_rolls_back_local_state() {
     // Budget for exactly 1 job, so a leaked lease would block the follow-up job.
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -1034,15 +1034,18 @@ async fn draining_auto_stop_preserves_concurrent_resume() {
 async fn claim_failure_rolls_back_budget() {
     // Budget for exactly 1 job (2 vcpu, 4096 MB matches the test profile).
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.budget);
     let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     // First job: claim returns None (409 conflict)
     let run_id_1 = RunId::new_v4();
     push_job(&env, run_id_1, "vm0/default", None);
 
-    // Give main loop time to process the failed claim and release budget.
-    tokio::time::advance(Duration::from_millis(100)).await;
-    tokio::task::yield_now().await;
+    // Returning to discovery proves the failed claim was processed.
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -785,6 +785,99 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn api_provider_claimed_jobs_complete_out_of_order_with_their_own_tokens() {
+        let server = MockServer::start_async().await;
+        let run_id_a: RunId = "00000000-0000-0000-0000-000000000101".parse().unwrap();
+        let run_id_b: RunId = "00000000-0000-0000-0000-000000000102".parse().unwrap();
+        let claim_path_a = format!("/api/runners/jobs/{run_id_a}/claim");
+        let claim_path_b = format!("/api/runners/jobs/{run_id_b}/claim");
+        let claim_mock_a = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path_a.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id_a,
+                    "prompt": "first",
+                    "sandboxToken": "sandbox-token-a",
+                    "workingDir": "/home/user",
+                    "cliAgentType": "claude_code",
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let claim_mock_b = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path_b.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id_b,
+                    "prompt": "second",
+                    "sandboxToken": "sandbox-token-b",
+                    "workingDir": "/home/user",
+                    "cliAgentType": "claude_code",
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let complete_mock_a = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::webhooks::agent::complete::COMPLETE.path)
+                    .header("authorization", "Bearer sandbox-token-a")
+                    .json_body(serde_json::json!({
+                        "runId": run_id_a,
+                        "exitCode": 0
+                    }));
+                then.status(200);
+            })
+            .await;
+        let complete_mock_b = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::webhooks::agent::complete::COMPLETE.path)
+                    .header("authorization", "Bearer sandbox-token-b")
+                    .json_body(serde_json::json!({
+                        "runId": run_id_b,
+                        "exitCode": 0
+                    }));
+                then.status(200);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let claimed_a = provider
+            .claim(JobCandidate::new(
+                run_id_a,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("first claim should succeed");
+        let claimed_b = provider
+            .claim(JobCandidate::new(
+                run_id_b,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("second claim should succeed");
+        let (context_a, completion_auth_a) = claimed_a.into_parts();
+        let (context_b, completion_auth_b) = claimed_b.into_parts();
+
+        provider
+            .complete(context_b.run_id, 0, None, None, None, completion_auth_b)
+            .await;
+        provider
+            .complete(context_a.run_id, 0, None, None, None, completion_auth_a)
+            .await;
+
+        claim_mock_a.assert_calls_async(1).await;
+        claim_mock_b.assert_calls_async(1).await;
+        complete_mock_a.assert_calls_async(1).await;
+        complete_mock_b.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
     async fn api_provider_complete_uses_sandbox_token_from_completion_auth() {
         let server = MockServer::start_async().await;
         let run_id = RunId::nil();

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1068,7 +1068,8 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn api_provider_complete_stops_after_two_failures() {
-        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 500]).await;
+        let (api_url, mut requests, server_task) =
+            complete_sequence_server(vec![500, 500, 200]).await;
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
             api_url,
@@ -1096,10 +1097,10 @@ mod tests {
         assert_complete_authorization(&second_request, "sandbox-token");
 
         complete_task.await.unwrap();
-        server_task.await.unwrap();
         assert!(
             requests.try_recv().is_err(),
             "completion should stop after the retry"
         );
+        server_task.abort();
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -12,7 +12,7 @@ use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::de::DeserializeOwned;
 
 use super::api_ably_supervisor::{AblySupervisor, PollOutcome, PollWakeups};
-use super::{JobCandidate, JobProvider};
+use super::{ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobProvider};
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::ids::RunId;
@@ -54,8 +54,6 @@ pub struct ApiProvider {
     poll_wakeups: Arc<PollWakeups>,
     /// Background Ably control-plane task.
     ably_supervisor: AblySupervisor,
-    /// Per-job sandbox tokens for completion auth.
-    tokens: tokio::sync::Mutex<HashMap<RunId, String>>,
     /// Session IDs held in the idle pool, sent in poll requests for affinity ordering.
     held_sessions: tokio::sync::Mutex<Vec<String>>,
     /// Shutdown signal.
@@ -90,7 +88,6 @@ impl ApiProvider {
             profiles,
             poll_wakeups,
             ably_supervisor,
-            tokens: tokio::sync::Mutex::new(HashMap::new()),
             held_sessions: tokio::sync::Mutex::new(Vec::new()),
             cancel,
         })
@@ -156,16 +153,12 @@ impl JobProvider for ApiProvider {
         }
     }
 
-    async fn claim(&self, candidate: JobCandidate) -> Option<ExecutionContext> {
+    async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
         match self.api.claim(run_id).await {
             Ok(ctx) => {
                 info!(run_id = %run_id, "job claimed");
-                self.tokens
-                    .lock()
-                    .await
-                    .insert(run_id, ctx.sandbox_token.clone());
-                Some(ctx)
+                Some(ClaimedJob::api(ctx))
             }
             Err(RunnerError::AlreadyClaimed) => {
                 info!(run_id = %run_id, "already claimed, skipping");
@@ -199,16 +192,21 @@ impl JobProvider for ApiProvider {
         error: Option<&str>,
         sandbox_id: Option<SandboxId>,
         reuse_result: Option<SandboxReuseResult>,
+        completion_auth: CompletionAuth,
     ) {
-        let token = self.tokens.lock().await.remove(&run_id);
-        let token = match token {
-            Some(t) => t,
-            None => {
+        let token = match completion_auth.into_sandbox_token(run_id) {
+            Ok(token) => token,
+            Err(CompletionAuthError::NotSandbox) => {
+                error!(run_id = %run_id, "completion auth missing sandbox token");
+                return;
+            }
+            Err(CompletionAuthError::RunIdMismatch { auth_run_id }) => {
                 error!(
                     run_id = %run_id,
-                    "no sandbox token for completion, falling back to runner token"
+                    auth_run_id = %auth_run_id,
+                    "completion auth run_id mismatch"
                 );
-                self.api.token.clone()
+                return;
             }
         };
 
@@ -417,6 +415,8 @@ mod tests {
     use httpmock::MockServer;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio::task::JoinHandle;
 
     fn api_client_for_server(server: &MockServer) -> ApiClient {
         ApiClient::new(
@@ -446,15 +446,68 @@ mod tests {
             profiles: Vec::new(),
             poll_wakeups,
             ably_supervisor: AblySupervisor::disabled(),
-            tokens: tokio::sync::Mutex::new(HashMap::new()),
             held_sessions: tokio::sync::Mutex::new(Vec::new()),
             cancel,
         })
     }
 
     async fn read_http_request(socket: &mut tokio::net::TcpStream) {
+        let _ = read_http_request_text(socket).await;
+    }
+
+    async fn read_http_request_text(socket: &mut tokio::net::TcpStream) -> String {
         let mut buf = [0_u8; 4096];
-        let _ = socket.read(&mut buf).await.unwrap();
+        let n = socket.read(&mut buf).await.unwrap();
+        String::from_utf8_lossy(&buf[..n]).into_owned()
+    }
+
+    async fn write_http_status_response(socket: &mut tokio::net::TcpStream, status: u16) {
+        let reason = match status {
+            200 => "OK",
+            500 => "Internal Server Error",
+            _ => "Unknown",
+        };
+        let body = if status == 200 { "ok" } else { "failed" };
+        let response = format!(
+            "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    }
+
+    async fn complete_sequence_server(
+        statuses: Vec<u16>,
+    ) -> (String, mpsc::UnboundedReceiver<String>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
+        let server_task = tokio::spawn(async move {
+            for status in statuses {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let request = read_http_request_text(&mut socket).await;
+                request_tx.send(request).unwrap();
+                write_http_status_response(&mut socket, status).await;
+            }
+        });
+        (api_url, request_rx, server_task)
+    }
+
+    async fn next_request(requests: &mut mpsc::UnboundedReceiver<String>) -> String {
+        requests
+            .recv()
+            .await
+            .expect("complete request should reach the server")
+    }
+
+    fn assert_complete_authorization(request: &str, token: &str) {
+        let expected = format!("authorization: Bearer {token}");
+        assert!(
+            request
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case(&expected)),
+            "completion request should use sandbox auth; request was:\n{request}",
+        );
     }
 
     async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {
@@ -669,5 +722,210 @@ mod tests {
 
         assert_api_error(err, "complete 500 Internal Server Error: complete failed");
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_provider_claim_carries_sandbox_token_to_completion() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id,
+                    "prompt": "hello",
+                    "sandboxToken": "claim-sandbox-token",
+                    "workingDir": "/home/user",
+                    "cliAgentType": "claude_code",
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let complete_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::webhooks::agent::complete::COMPLETE.path)
+                    .header("authorization", "Bearer claim-sandbox-token");
+                then.status(200);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("claim should succeed");
+        let (context, completion_auth) = claimed.into_parts();
+        assert_eq!(context.sandbox_token, "claim-sandbox-token");
+
+        provider
+            .complete(run_id, 0, None, None, None, completion_auth)
+            .await;
+
+        claim_mock.assert_calls_async(1).await;
+        complete_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn api_provider_complete_uses_sandbox_token_from_completion_auth() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::webhooks::agent::complete::COMPLETE.path)
+                    .header("authorization", "Bearer sandbox-token");
+                then.status(200);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        provider
+            .complete(
+                run_id,
+                0,
+                None,
+                None,
+                None,
+                CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+            )
+            .await;
+
+        mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn api_provider_complete_with_local_auth_does_not_send_request() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::webhooks::agent::complete::COMPLETE.path);
+                then.status(200);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        provider
+            .complete(RunId::nil(), 0, None, None, None, CompletionAuth::local())
+            .await;
+
+        mock.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn api_provider_complete_with_mismatched_auth_does_not_send_request() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::webhooks::agent::complete::COMPLETE.path);
+                then.status(200);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        provider
+            .complete(
+                RunId::nil(),
+                0,
+                None,
+                None,
+                None,
+                CompletionAuth::sandbox_token(RunId::new_v4(), "sandbox-token".to_string()),
+            )
+            .await;
+
+        mock.assert_calls_async(0).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_provider_complete_retries_once_after_failure_and_succeeds() {
+        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 200]).await;
+        let run_id = RunId::nil();
+        let provider = api_provider_for_test(
+            api_url,
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let complete_task = tokio::spawn(async move {
+            provider
+                .complete(
+                    run_id,
+                    0,
+                    None,
+                    None,
+                    None,
+                    CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+                )
+                .await;
+        });
+
+        let first_request = next_request(&mut requests).await;
+        assert_complete_authorization(&first_request, "sandbox-token");
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let second_request = next_request(&mut requests).await;
+        assert_complete_authorization(&second_request, "sandbox-token");
+
+        complete_task.await.unwrap();
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_provider_complete_stops_after_two_failures() {
+        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 500]).await;
+        let run_id = RunId::nil();
+        let provider = api_provider_for_test(
+            api_url,
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let complete_task = tokio::spawn(async move {
+            provider
+                .complete(
+                    run_id,
+                    1,
+                    Some("boom"),
+                    None,
+                    None,
+                    CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+                )
+                .await;
+        });
+
+        let first_request = next_request(&mut requests).await;
+        assert_complete_authorization(&first_request, "sandbox-token");
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let second_request = next_request(&mut requests).await;
+        assert_complete_authorization(&second_request, "sandbox-token");
+
+        complete_task.await.unwrap();
+        server_task.await.unwrap();
+        assert!(
+            requests.try_recv().is_err(),
+            "completion should stop after the retry"
+        );
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -466,15 +466,42 @@ mod tests {
     async fn read_http_request_text(socket: &mut tokio::net::TcpStream) -> String {
         let mut request = Vec::new();
         let mut buf = [0_u8; 1024];
+        let header_end = loop {
+            let n = socket.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break request.len();
+            }
+            request.extend_from_slice(&buf[..n]);
+            if let Some(header_end) = request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .map(|position| position + 4)
+            {
+                break header_end;
+            }
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.eq_ignore_ascii_case("content-length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+        let request_len = header_end + content_length;
         loop {
+            if request.len() >= request_len {
+                break;
+            }
             let n = socket.read(&mut buf).await.unwrap();
             if n == 0 {
                 break;
             }
             request.extend_from_slice(&buf[..n]);
-            if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                break;
-            }
         }
         String::from_utf8_lossy(&request).into_owned()
     }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -157,6 +157,14 @@ impl JobProvider for ApiProvider {
         let run_id = candidate.run_id();
         match self.api.claim(run_id).await {
             Ok(ctx) => {
+                if ctx.run_id != run_id {
+                    error!(
+                        run_id = %run_id,
+                        context_run_id = %ctx.run_id,
+                        "claim response run_id mismatch"
+                    );
+                    return None;
+                }
                 info!(run_id = %run_id, "job claimed");
                 Some(ClaimedJob::api(ctx))
             }
@@ -732,6 +740,42 @@ mod tests {
 
         assert_api_error(err, "complete 500 Internal Server Error: complete failed");
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_provider_claim_rejects_run_id_mismatch() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let context_run_id = RunId::new_v4();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": context_run_id,
+                    "prompt": "hello",
+                    "sandboxToken": "claim-sandbox-token",
+                    "workingDir": "/home/user",
+                    "cliAgentType": "claude_code",
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await;
+
+        assert!(claimed.is_none());
+        claim_mock.assert_calls_async(1).await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1102,5 +1102,6 @@ mod tests {
             "completion should stop after the retry"
         );
         server_task.abort();
+        let _ = server_task.await;
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -456,9 +456,19 @@ mod tests {
     }
 
     async fn read_http_request_text(socket: &mut tokio::net::TcpStream) -> String {
-        let mut buf = [0_u8; 4096];
-        let n = socket.read(&mut buf).await.unwrap();
-        String::from_utf8_lossy(&buf[..n]).into_owned()
+        let mut request = Vec::new();
+        let mut buf = [0_u8; 1024];
+        loop {
+            let n = socket.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            request.extend_from_slice(&buf[..n]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        String::from_utf8_lossy(&request).into_owned()
     }
 
     async fn write_http_status_response(socket: &mut tokio::net::TcpStream, status: u16) {

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use super::{JobCandidate, JobProvider, local_queue};
+use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider, local_queue};
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 use sandbox::SandboxId;
@@ -568,7 +568,7 @@ impl JobProvider for LocalProvider {
         }
     }
 
-    async fn claim(&self, candidate: JobCandidate) -> Option<ExecutionContext> {
+    async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
         let partition_profile = candidate.profile_name().to_owned();
         let Some(job_file) = candidate.local_job_path().map(std::path::Path::to_path_buf) else {
@@ -673,7 +673,7 @@ impl JobProvider for LocalProvider {
 
         self.cancel_scanner.mark_owned_claim(run_id).await;
         info!(run_id = %run_id, "local: job claimed");
-        Some(ExecutionContext {
+        Some(ClaimedJob::local(ExecutionContext {
             run_id,
             prompt: req.prompt,
             append_system_prompt: None,
@@ -707,7 +707,7 @@ impl JobProvider for LocalProvider {
             feature_flags: req.feature_flags,
             billable_firewalls: vec![],
             model_usage_provider: None,
-        })
+        }))
     }
 
     async fn complete(
@@ -717,6 +717,7 @@ impl JobProvider for LocalProvider {
         error: Option<&str>,
         _sandbox_id: Option<SandboxId>,
         _reuse_result: Option<SandboxReuseResult>,
+        _completion_auth: CompletionAuth,
     ) {
         self.cancel_scanner.remove_owned_claim(run_id).await;
         if !self.write_result(run_id, exit_code, error) {
@@ -867,11 +868,14 @@ mod tests {
         assert_eq!(candidate.run_id(), job_id);
         assert_eq!(candidate.profile_name(), crate::profile::DEFAULT_PROFILE);
 
-        let ctx = provider.claim(candidate).await.unwrap();
+        let claimed = provider.claim(candidate).await.unwrap();
+        let ctx = claimed.context();
         assert_eq!(ctx.run_id, job_id);
         assert_eq!(ctx.prompt, "hello world");
 
-        provider.complete(job_id, 0, None, None, None).await;
+        provider
+            .complete(job_id, 0, None, None, None, CompletionAuth::local())
+            .await;
 
         let resp = read_result(dir.path(), job_id);
         assert_eq!(resp.exit_code, 0);
@@ -958,10 +962,13 @@ mod tests {
 
         let candidate = provider.discover().await.unwrap();
         assert_eq!(candidate.run_id(), job_id);
-        let ctx = provider.claim(candidate).await.unwrap();
+        let claimed = provider.claim(candidate).await.unwrap();
+        let ctx = claimed.context();
         assert_eq!(ctx.prompt, "retry me");
 
-        provider.complete(job_id, 0, None, None, None).await;
+        provider
+            .complete(job_id, 0, None, None, None, CompletionAuth::local())
+            .await;
         let resp = read_result(dir.path(), job_id);
         assert_eq!(resp.exit_code, 0);
     }
@@ -1000,20 +1007,31 @@ mod tests {
 
         let candidate1 = provider.discover().await.unwrap();
         let run_id1 = candidate1.run_id();
-        let ctx1 = provider.claim(candidate1).await.unwrap();
+        let claimed1 = provider.claim(candidate1).await.unwrap();
+        let ctx1 = claimed1.context();
         assert_eq!(ctx1.prompt, "job1");
 
         write_job(dir.path(), job2, "job2");
 
         let candidate2 = provider.discover().await.unwrap();
         let run_id2 = candidate2.run_id();
-        let ctx2 = provider.claim(candidate2).await.unwrap();
+        let claimed2 = provider.claim(candidate2).await.unwrap();
+        let ctx2 = claimed2.context();
         assert_eq!(ctx2.prompt, "job2");
         assert_ne!(run_id1, run_id2);
 
-        provider.complete(run_id1, 0, None, None, None).await;
         provider
-            .complete(run_id2, 1, Some("test error"), None, None)
+            .complete(run_id1, 0, None, None, None, CompletionAuth::local())
+            .await;
+        provider
+            .complete(
+                run_id2,
+                1,
+                Some("test error"),
+                None,
+                None,
+                CompletionAuth::local(),
+            )
             .await;
 
         let resp1 = read_result(dir.path(), job1);
@@ -1064,7 +1082,8 @@ mod tests {
         assert_eq!(candidate.run_id(), job_id);
         assert_eq!(candidate.profile_name(), "vm0/default");
 
-        let ctx = provider.claim(candidate).await.unwrap();
+        let claimed = provider.claim(candidate).await.unwrap();
+        let ctx = claimed.context();
         assert_eq!(ctx.experimental_profile.as_deref(), Some("vm0/default"));
     }
 
@@ -1086,7 +1105,8 @@ mod tests {
         let candidate = provider.discover().await.unwrap();
         assert_eq!(candidate.run_id(), job_id);
         assert_eq!(candidate.profile_name(), crate::profile::DEFAULT_PROFILE);
-        let ctx = provider.claim(candidate).await.unwrap();
+        let claimed = provider.claim(candidate).await.unwrap();
+        let ctx = claimed.context();
         assert_eq!(
             ctx.experimental_profile.as_deref(),
             Some(crate::profile::DEFAULT_PROFILE)
@@ -1542,7 +1562,9 @@ mod tests {
         std::fs::write(&cancel_path, b"").unwrap();
         std::fs::write(&claim_path, b"").unwrap();
 
-        provider.complete(run_id, 0, None, None, None).await;
+        provider
+            .complete(run_id, 0, None, None, None, CompletionAuth::local())
+            .await;
 
         assert!(
             !cancel_path.exists(),
@@ -1575,7 +1597,9 @@ mod tests {
         std::fs::write(&cancel_path, b"").unwrap();
         std::fs::write(&result_dir, b"not a directory").unwrap();
 
-        provider.complete(run_id, 0, None, None, None).await;
+        provider
+            .complete(run_id, 0, None, None, None, CompletionAuth::local())
+            .await;
 
         assert!(
             !job_path.exists(),

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use tokio::sync::{Mutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use super::{JobCandidate, JobProvider};
+use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 use sandbox::SandboxId;
@@ -268,13 +268,14 @@ impl JobProvider for MockJobProvider {
         }
     }
 
-    async fn claim(&self, candidate: JobCandidate) -> Option<ExecutionContext> {
+    async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
         self.claim_results
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(&run_id)
             .flatten()
+            .map(ClaimedJob::local)
     }
 
     async fn complete(
@@ -284,6 +285,7 @@ impl JobProvider for MockJobProvider {
         error: Option<&str>,
         sandbox_id: Option<SandboxId>,
         reuse_result: Option<SandboxReuseResult>,
+        _completion_auth: CompletionAuth,
     ) {
         self.completions
             .lock()

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -66,7 +66,7 @@ pub struct ClaimedJob {
 }
 
 impl ClaimedJob {
-    pub(crate) fn new(context: ExecutionContext, completion_auth: CompletionAuth) -> Self {
+    fn new(context: ExecutionContext, completion_auth: CompletionAuth) -> Self {
         Self {
             context,
             completion_auth,
@@ -102,8 +102,8 @@ enum CompletionAuthKind {
     Local,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum CompletionAuthError {
+#[derive(Debug)]
+enum CompletionAuthError {
     NotSandbox,
     RunIdMismatch { auth_run_id: RunId },
 }
@@ -121,10 +121,7 @@ impl CompletionAuth {
         }
     }
 
-    pub(crate) fn into_sandbox_token(
-        self,
-        expected_run_id: RunId,
-    ) -> Result<String, CompletionAuthError> {
+    fn into_sandbox_token(self, expected_run_id: RunId) -> Result<String, CompletionAuthError> {
         match self.kind {
             CompletionAuthKind::Sandbox { run_id, token } if run_id == expected_run_id => Ok(token),
             CompletionAuthKind::Sandbox { run_id, .. } => Err(CompletionAuthError::RunIdMismatch {

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -59,6 +59,82 @@ impl JobCandidate {
     }
 }
 
+/// Job claim result with the context and auth required for terminal completion.
+pub struct ClaimedJob {
+    context: ExecutionContext,
+    completion_auth: CompletionAuth,
+}
+
+impl ClaimedJob {
+    pub(crate) fn new(context: ExecutionContext, completion_auth: CompletionAuth) -> Self {
+        Self {
+            context,
+            completion_auth,
+        }
+    }
+
+    pub(crate) fn api(context: ExecutionContext) -> Self {
+        let completion_auth =
+            CompletionAuth::sandbox_token(context.run_id, context.sandbox_token.clone());
+        Self::new(context, completion_auth)
+    }
+
+    pub(crate) fn local(context: ExecutionContext) -> Self {
+        Self::new(context, CompletionAuth::local())
+    }
+
+    pub(crate) fn into_parts(self) -> (ExecutionContext, CompletionAuth) {
+        (self.context, self.completion_auth)
+    }
+
+    pub(crate) fn context(&self) -> &ExecutionContext {
+        &self.context
+    }
+}
+
+/// Auth material needed by a provider to report terminal completion.
+pub struct CompletionAuth {
+    kind: CompletionAuthKind,
+}
+
+enum CompletionAuthKind {
+    Sandbox { run_id: RunId, token: String },
+    Local,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CompletionAuthError {
+    NotSandbox,
+    RunIdMismatch { auth_run_id: RunId },
+}
+
+impl CompletionAuth {
+    pub(crate) fn sandbox_token(run_id: RunId, token: String) -> Self {
+        Self {
+            kind: CompletionAuthKind::Sandbox { run_id, token },
+        }
+    }
+
+    pub(crate) fn local() -> Self {
+        Self {
+            kind: CompletionAuthKind::Local,
+        }
+    }
+
+    pub(crate) fn into_sandbox_token(
+        self,
+        expected_run_id: RunId,
+    ) -> Result<String, CompletionAuthError> {
+        match self.kind {
+            CompletionAuthKind::Sandbox { run_id, token } if run_id == expected_run_id => Ok(token),
+            CompletionAuthKind::Sandbox { run_id, .. } => Err(CompletionAuthError::RunIdMismatch {
+                auth_run_id: run_id,
+            }),
+            CompletionAuthKind::Local => Err(CompletionAuthError::NotSandbox),
+        }
+    }
+}
+
 /// Abstraction over job lifecycle — discovery, claiming, and completion reporting.
 ///
 /// The runner main loop calls [`discover()`](JobProvider::discover) to find work,
@@ -89,7 +165,7 @@ pub trait JobProvider: Send + Sync {
     /// Callers **must** invoke this from a non-cancellable context (e.g.
     /// inside a `select!` branch handler) to guarantee that a successful
     /// claim is always paired with a later [`complete()`](JobProvider::complete).
-    async fn claim(&self, candidate: JobCandidate) -> Option<ExecutionContext>;
+    async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob>;
 
     /// Report job completion. Called concurrently from spawned executor tasks.
     ///
@@ -98,7 +174,8 @@ pub trait JobProvider: Send + Sync {
     /// before the run started. Both are `Option` so non-runner callers
     /// (tests, future transports) can omit them.
     ///
-    /// Implementations manage auth tokens and retry logic internally.
+    /// `completion_auth` is returned by [`claim()`](JobProvider::claim) and
+    /// carried by the claimed job lifecycle until completion.
     async fn complete(
         &self,
         run_id: RunId,
@@ -106,6 +183,7 @@ pub trait JobProvider: Send + Sync {
         error: Option<&str>,
         sandbox_id: Option<SandboxId>,
         reuse_result: Option<SandboxReuseResult>,
+        completion_auth: CompletionAuth,
     );
 
     /// Report runner state to the server. Fire-and-forget — failures are

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -157,7 +157,8 @@ pub trait JobProvider: Send + Sync {
     async fn discover(&self) -> Option<JobCandidate>;
 
     /// Claim a discovered job. Returns `None` if the job was already claimed
-    /// by another runner or an error occurred.
+    /// by another runner or an error occurred. A returned claim must carry an
+    /// execution context whose `run_id` matches the discovered candidate.
     ///
     /// Callers **must** invoke this from a non-cancellable context (e.g.
     /// inside a `select!` branch handler) to guarantee that a successful

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -130,6 +130,19 @@ impl CompletionAuth {
             CompletionAuthKind::Local => Err(CompletionAuthError::NotSandbox),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn matches_sandbox_token_for_test(
+        &self,
+        expected_run_id: RunId,
+        expected_token: &str,
+    ) -> bool {
+        matches!(
+            &self.kind,
+            CompletionAuthKind::Sandbox { run_id, token }
+                if *run_id == expected_run_id && token == expected_token
+        )
+    }
 }
 
 /// Abstraction over job lifecycle — discovery, claiming, and completion reporting.


### PR DESCRIPTION
## Summary
- Carry completion auth in `ClaimedJob` from provider claim through runner completion.
- Remove `ApiProvider`'s per-run sandbox-token side table and runner-token fallback.
- Add API provider coverage for claim-to-complete auth, missing/mismatched auth, and completion retry behavior.

## Tests
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`

Closes #14506
