### PR TITLE
feat: align computer use state output with CUA

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -311,10 +311,9 @@ describe("desktop computer-use runtime", () => {
           kind: "element.click",
           app: "Safari",
           snapshotId: "snap_1",
-          x: 680,
-          y: 600,
-          button: "right",
-          clickCount: 2,
+          elementIndex: 7,
+          button: "left",
+          clickCount: 1,
           timeoutMs: 15_000,
         },
         headers: { authorization: `Bearer ${token}` },
@@ -342,10 +341,9 @@ describe("desktop computer-use runtime", () => {
       payload: {
         app: "Safari",
         snapshotId: "snap_1",
-        x: 680,
-        y: 600,
-        button: "right",
-        clickCount: 2,
+        elementIndex: 7,
+        button: "left",
+        clickCount: 1,
       },
     });
 
@@ -356,6 +354,7 @@ describe("desktop computer-use runtime", () => {
           status: "succeeded",
           result: {
             text: "clicked",
+            elementIndex: 7,
             dispatchMode: "accessibility_action",
             dispatchTarget: "element",
             inputRisk: "targeted_app_action",
@@ -381,6 +380,7 @@ describe("desktop computer-use runtime", () => {
     expect(auditEvents[0]?.redactedResult).toStrictEqual({
       dispatchMode: "accessibility_action",
       dispatchTarget: "element",
+      elementIndex: 7,
       inputRisk: "targeted_app_action",
       textLength: 7,
     });

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -49,6 +49,7 @@ interface ComputerUseCommandPayload {
   readonly app?: string;
   readonly snapshotId?: string;
   readonly elementId?: string;
+  readonly elementIndex?: number;
   readonly x?: number;
   readonly y?: number;
   readonly button?: "left" | "right" | "middle";
@@ -178,6 +179,9 @@ function commandPayload(
   if (params.elementId) {
     payload.elementId = params.elementId.trim();
   }
+  if (params.elementIndex !== undefined) {
+    payload.elementIndex = params.elementIndex;
+  }
   if (params.x !== undefined) {
     payload.x = params.x;
   }
@@ -227,6 +231,7 @@ function redactedResultForAudit(
     "dispatchMode",
     "dispatchTarget",
     "elementId",
+    "elementIndex",
     "inputRisk",
     "key",
     "pages",

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -301,4 +301,70 @@ describe("computer-use command visibility", () => {
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain('"text": "clicked"');
   });
+
+  it("should send click element indexes", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    server.use(
+      http.post(
+        "http://localhost:3000/api/zero/computer-use/write-commands",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          expect(body).toMatchObject({
+            kind: "element.click",
+            app: "Slack",
+            snapshotId: "snap_1",
+            elementIndex: 7,
+            button: "left",
+            clickCount: 1,
+            timeoutMs: 30_000,
+          });
+          return HttpResponse.json({
+            commandId: "cmd_click_index",
+            status: "queued",
+          });
+        },
+      ),
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/commands/cmd_click_index",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_click_index",
+            kind: "element.click",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: {
+              app: "Slack",
+              snapshotId: "snap_1",
+              elementIndex: 7,
+              button: "left",
+              clickCount: 1,
+            },
+            result: { text: "clicked" },
+            timeoutMs: 30_000,
+            createdAt: "2026-05-21T10:00:00.000Z",
+            claimedAt: "2026-05-21T10:00:01.000Z",
+            completedAt: "2026-05-21T10:00:02.000Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "click",
+      "--app",
+      "Slack",
+      "--snapshot-id",
+      "snap_1",
+      "--element-index",
+      "7",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain('"text": "clicked"');
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -26,6 +26,7 @@ interface ComputerUseAppOptions extends ComputerUseCommandOptions {
 interface ComputerUseClickOptions extends ComputerUseAppOptions {
   readonly snapshotId?: string;
   readonly element?: string;
+  readonly elementIndex?: string;
   readonly x?: string;
   readonly y?: string;
   readonly button?: "left" | "right" | "middle";
@@ -34,20 +35,23 @@ interface ComputerUseClickOptions extends ComputerUseAppOptions {
 
 interface ComputerUseScrollOptions extends ComputerUseAppOptions {
   readonly snapshotId?: string;
-  readonly element: string;
+  readonly element?: string;
+  readonly elementIndex?: string;
   readonly direction: "up" | "down" | "left" | "right";
   readonly pages?: string;
 }
 
 interface ComputerUseSetValueOptions extends ComputerUseAppOptions {
   readonly snapshotId?: string;
-  readonly element: string;
+  readonly element?: string;
+  readonly elementIndex?: string;
   readonly value: string;
 }
 
 interface ComputerUsePerformActionOptions extends ComputerUseAppOptions {
   readonly snapshotId?: string;
-  readonly element: string;
+  readonly element?: string;
+  readonly elementIndex?: string;
   readonly action: string;
 }
 
@@ -122,6 +126,23 @@ function parseMouseButton(
     return value;
   }
   throw new Error("button must be left, right, or middle");
+}
+
+function elementTargetPayload(options: {
+  readonly element?: string;
+  readonly elementIndex?: string;
+}): { readonly elementId?: string; readonly elementIndex?: number } {
+  const elementIndex = parseOptionalNonNegativeInteger(
+    options.elementIndex,
+    "element-index",
+  );
+  if (!options.element && elementIndex === undefined) {
+    throw new Error("element or element-index is required");
+  }
+  return {
+    ...(options.element ? { elementId: options.element } : {}),
+    ...(elementIndex !== undefined ? { elementIndex } : {}),
+  };
 }
 
 function sanitizeFilenamePart(value: unknown, fallback: string): string {
@@ -266,6 +287,7 @@ async function runWriteCommand(
     readonly app: string;
     readonly snapshotId?: string;
     readonly elementId?: string;
+    readonly elementIndex?: number;
     readonly x?: number;
     readonly y?: number;
     readonly button?: "left" | "right" | "middle";
@@ -331,6 +353,7 @@ const clickCommand = appOption(
       .description("Click an accessibility element or screenshot coordinate")
       .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
       .option("--element <id>", "Element id from get-app-state")
+      .option("--element-index <index>", "Element index from get-app-state")
       .option("--x <points>", "Screenshot x coordinate fallback")
       .option("--y <points>", "Screenshot y coordinate fallback")
       .option("--button <button>", "Mouse button", "left")
@@ -339,10 +362,15 @@ const clickCommand = appOption(
         withErrorHandler(async (options: ComputerUseClickOptions) => {
           const x = parseOptionalNonNegativeInteger(options.x, "x");
           const y = parseOptionalNonNegativeInteger(options.y, "y");
+          const elementIndex = parseOptionalNonNegativeInteger(
+            options.elementIndex,
+            "element-index",
+          );
           await runWriteCommand("element.click", options, {
             app: options.app,
             ...(options.snapshotId ? { snapshotId: options.snapshotId } : {}),
             ...(options.element ? { elementId: options.element } : {}),
+            ...(elementIndex !== undefined ? { elementIndex } : {}),
             ...(x !== undefined ? { x } : {}),
             ...(y !== undefined ? { y } : {}),
             button: parseMouseButton(options.button),
@@ -359,7 +387,8 @@ const scrollCommand = appOption(
       .name("scroll")
       .description("Scroll an accessibility element")
       .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
-      .requiredOption("--element <id>", "Element id from get-app-state")
+      .option("--element <id>", "Element id from get-app-state")
+      .option("--element-index <index>", "Element index from get-app-state")
       .requiredOption(
         "--direction <direction>",
         "Scroll direction: up, down, left, or right",
@@ -370,7 +399,7 @@ const scrollCommand = appOption(
           await runWriteCommand("element.scroll", options, {
             app: options.app,
             ...(options.snapshotId ? { snapshotId: options.snapshotId } : {}),
-            elementId: options.element,
+            ...elementTargetPayload(options),
             direction: options.direction,
             pages: parsePositiveNumber(options.pages, "pages"),
           });
@@ -385,14 +414,15 @@ const setValueCommand = appOption(
       .name("set-value")
       .description("Set the value of a settable accessibility element")
       .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
-      .requiredOption("--element <id>", "Element id from get-app-state")
+      .option("--element <id>", "Element id from get-app-state")
+      .option("--element-index <index>", "Element index from get-app-state")
       .requiredOption("--value <text>", "Value to assign")
       .action(
         withErrorHandler(async (options: ComputerUseSetValueOptions) => {
           await runWriteCommand("element.set_value", options, {
             app: options.app,
             ...(options.snapshotId ? { snapshotId: options.snapshotId } : {}),
-            elementId: options.element,
+            ...elementTargetPayload(options),
             value: options.value,
           });
         }),
@@ -443,14 +473,15 @@ const performActionCommand = appOption(
       .name("perform-action")
       .description("Invoke a secondary accessibility action")
       .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
-      .requiredOption("--element <id>", "Element id from get-app-state")
+      .option("--element <id>", "Element id from get-app-state")
+      .option("--element-index <index>", "Element index from get-app-state")
       .requiredOption("--action <name>", "Accessibility action name")
       .action(
         withErrorHandler(async (options: ComputerUsePerformActionOptions) => {
           await runWriteCommand("element.perform_action", options, {
             app: options.app,
             ...(options.snapshotId ? { snapshotId: options.snapshotId } : {}),
-            elementId: options.element,
+            ...elementTargetPayload(options),
             action: options.action,
           });
         }),

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -67,6 +67,7 @@ interface ComputerUseCommandParams<
   readonly app?: string;
   readonly snapshotId?: string;
   readonly elementId?: string;
+  readonly elementIndex?: number;
   readonly x?: number;
   readonly y?: number;
   readonly button?: "left" | "right" | "middle";
@@ -91,6 +92,9 @@ function commandBody<
     ...(params.app ? { app: params.app } : {}),
     ...(params.snapshotId ? { snapshotId: params.snapshotId } : {}),
     ...(params.elementId ? { elementId: params.elementId } : {}),
+    ...(params.elementIndex !== undefined
+      ? { elementIndex: params.elementIndex }
+      : {}),
     ...(params.x !== undefined ? { x: params.x } : {}),
     ...(params.y !== undefined ? { y: params.y } : {}),
     ...(params.button ? { button: params.button } : {}),

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -194,6 +194,16 @@ func stringValue(_ value: Any?) -> String? {
     return nil
 }
 
+func urlStringValue(_ value: Any?) -> String? {
+    if let url = value as? URL {
+        return stringValue(url.absoluteString)
+    }
+    if let url = value as? NSURL {
+        return stringValue(url.absoluteString)
+    }
+    return stringValue(value)
+}
+
 func boolValue(_ value: Any?) -> Bool? {
     return (value as? NSNumber)?.boolValue
 }
@@ -253,6 +263,54 @@ func actionNames(_ element: AXUIElement) -> [String] {
     return ((names as? [String]) ?? []).prefix(limits.maxActions).map { name in
         name
     }
+}
+
+func attributeIsSettable(_ element: AXUIElement, _ name: CFString) -> Bool? {
+    var settable = DarwinBoolean(false)
+    let error = AXUIElementIsAttributeSettable(element, name, &settable)
+    if error != .success {
+        return nil
+    }
+    return settable.boolValue
+}
+
+func valueTypeDescription(_ value: Any?) -> String? {
+    guard let value else {
+        return nil
+    }
+    if value is String {
+        return "string"
+    }
+    if value is URL || value is NSURL {
+        return "url"
+    }
+    if let number = value as? NSNumber {
+        if CFGetTypeID(number as CFTypeRef) == CFBooleanGetTypeID() {
+            return "boolean"
+        }
+        return "number"
+    }
+    if let axValue = axValueValue(value) {
+        switch AXValueGetType(axValue) {
+        case .cgPoint:
+            return "point"
+        case .cgSize:
+            return "size"
+        case .cgRect:
+            return "rect"
+        case .cfRange:
+            return "range"
+        default:
+            return "value"
+        }
+    }
+    if axElementValue(value) != nil {
+        return "element"
+    }
+    if value is [Any] {
+        return "array"
+    }
+    return nil
 }
 
 func setAttribute(_ element: AXUIElement, _ name: CFString, _ value: CFTypeRef) throws {
@@ -355,20 +413,45 @@ func describe(
     if let roleDescription = stringValue(attribute(element, kAXRoleDescriptionAttribute as CFString)) {
         node["roleDescription"] = roleDescription
     }
+    if let subrole = stringValue(attribute(element, kAXSubroleAttribute as CFString)) {
+        node["subrole"] = subrole
+    }
     if let name = stringValue(attribute(element, kAXTitleAttribute as CFString)) {
         node["name"] = name
     }
-    if let value = stringValue(attribute(element, kAXValueAttribute as CFString)) {
+    let rawValue = attribute(element, kAXValueAttribute as CFString)
+    if let value = stringValue(rawValue) {
         node["value"] = value
+    }
+    if let valueType = valueTypeDescription(rawValue) {
+        node["valueType"] = valueType
+    }
+    if let valueSettable = attributeIsSettable(element, kAXValueAttribute as CFString), valueSettable {
+        node["valueSettable"] = valueSettable
     }
     if let description = stringValue(attribute(element, kAXDescriptionAttribute as CFString)) {
         node["description"] = description
+    }
+    if let help = stringValue(attribute(element, kAXHelpAttribute as CFString)) {
+        node["help"] = help
+    }
+    if let identifier = stringValue(attribute(element, kAXIdentifierAttribute as CFString)) {
+        node["identifier"] = identifier
+    }
+    if let url = urlStringValue(attribute(element, kAXURLAttribute as CFString)) {
+        node["url"] = url
     }
     if let focused = boolValue(attribute(element, kAXFocusedAttribute as CFString)) {
         node["focused"] = focused
     }
     if let enabled = boolValue(attribute(element, kAXEnabledAttribute as CFString)) {
         node["enabled"] = enabled
+    }
+    if let selected = boolValue(attribute(element, kAXSelectedAttribute as CFString)) {
+        node["selected"] = selected
+    }
+    if let expanded = boolValue(attribute(element, kAXExpandedAttribute as CFString)) {
+        node["expanded"] = expanded
     }
     let actions = actionNames(element)
     if !actions.isEmpty {
@@ -454,6 +537,17 @@ func resolveElement(appName: String, elementId: String) throws -> AXUIElement {
                 )
             }
             current = windows[index]
+        } else if part.hasPrefix("m") {
+            let index = try resolveIndex(part)
+            guard index == 0,
+                  let menuBar = axElementValue(attribute(root, kAXMenuBarAttribute as CFString))
+            else {
+                throw HelperFailure(
+                    code: "accessibility_unavailable",
+                    message: "Element not found: \(elementId)"
+                )
+            }
+            current = menuBar
         } else {
             guard let element = current else {
                 throw HelperFailure(
@@ -520,14 +614,39 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
             )
         }
 
-    return [
+    var elements = Array(windows)
+    if let menuBar = axElementValue(attribute(root, kAXMenuBarAttribute as CFString)),
+       let menuBarSnapshot = describe(
+           menuBar,
+           id: "m0",
+           depth: 0,
+           nodeCount: &nodeCount,
+           truncationReasons: &truncationReasons
+       )
+    {
+        elements.append(menuBarSnapshot)
+    }
+
+    var response: [String: Any] = [
         "app": appName,
+        "appDisplayName": runningApp.localizedName ?? appName,
+        "pid": Int(runningApp.processIdentifier),
         "snapshotId": snapshotId,
-        "elements": windows,
+        "elements": elements,
         "nodeCount": nodeCount,
         "truncated": !truncationReasons.isEmpty,
         "truncationReasons": truncationReasons,
     ]
+    if let bundleId = runningApp.bundleIdentifier {
+        response["bundleId"] = bundleId
+    }
+    if let appPath = runningApp.bundleURL?.path {
+        response["appPath"] = appPath
+    }
+    if let windowTitle = elements.first?["name"] as? String {
+        response["windowTitle"] = windowTitle
+    }
+    return response
 }
 
 func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -29,13 +29,22 @@ export interface ComputerUseCommand {
 
 export interface AccessibilityElementSnapshot {
   readonly id: string;
+  readonly index?: number;
   readonly role?: string;
   readonly roleDescription?: string;
+  readonly subrole?: string;
   readonly name?: string;
   readonly value?: string;
+  readonly valueType?: string;
+  readonly valueSettable?: boolean;
   readonly description?: string;
+  readonly help?: string;
+  readonly identifier?: string;
+  readonly url?: string;
   readonly focused?: boolean;
   readonly enabled?: boolean;
+  readonly selected?: boolean;
+  readonly expanded?: boolean;
   readonly actions?: readonly string[];
   readonly bounds?: ComputerUseCoordinateBounds;
   readonly children?: readonly AccessibilityElementSnapshot[];
@@ -43,8 +52,14 @@ export interface AccessibilityElementSnapshot {
 
 export interface AccessibilityAppStateSnapshot {
   readonly app: string;
+  readonly appDisplayName?: string;
+  readonly bundleId?: string;
+  readonly pid?: number;
+  readonly appPath?: string;
+  readonly windowTitle?: string;
   readonly snapshotId: string;
   readonly elements: readonly AccessibilityElementSnapshot[];
+  readonly focusedElementIndex?: number;
   readonly nodeCount?: number;
   readonly truncated?: boolean;
   readonly truncationReasons?: readonly string[];
@@ -122,11 +137,25 @@ export interface ComputerUseWindowCaptureCandidate {
 interface ComputerUseSnapshotMetadata {
   readonly app: string;
   readonly snapshotId: string;
+  readonly elementIdsByIndex?: readonly string[];
+  readonly focusedElementIndex?: number;
   readonly screenshotWidth: number;
   readonly screenshotHeight: number;
   readonly screenshotSource: "window" | "screen";
   readonly screenshotSourceName: string;
   readonly sourceBounds?: ComputerUseCoordinateBounds;
+}
+
+interface IndexedAccessibilitySnapshot {
+  readonly snapshot: AccessibilityAppStateSnapshot;
+  readonly elementIdsByIndex: readonly string[];
+  readonly focusedElementIndex?: number;
+}
+
+interface ComputerUseElementTarget {
+  readonly elementId: string;
+  readonly elementIndex?: number;
+  readonly snapshotId?: string;
 }
 
 export type ComputerUseMouseButton = "left" | "right" | "middle";
@@ -379,6 +408,19 @@ function payloadNumber(
 ): number | null {
   const value = payload[key];
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function payloadElementIndex(payload: Record<string, unknown>): number | null {
+  const value = payload.elementIndex;
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+  throw new UnsupportedComputerUseCommandError(
+    "elementIndex must be a non-negative integer",
+  );
 }
 
 function payloadMouseButton(
@@ -683,38 +725,311 @@ function parseComputerUseKeyPress(key: string): ParsedComputerUseKeyPress {
   };
 }
 
+function indexAccessibilitySnapshot(
+  snapshot: AccessibilityAppStateSnapshot,
+): IndexedAccessibilitySnapshot {
+  let nextIndex = 0;
+  const elementIdsByIndex: string[] = [];
+  let focusedElementIndex = snapshot.focusedElementIndex;
+
+  const indexElement = (
+    element: AccessibilityElementSnapshot,
+  ): AccessibilityElementSnapshot => {
+    const index = nextIndex;
+    nextIndex += 1;
+    elementIdsByIndex[index] = element.id;
+    if (focusedElementIndex === undefined && element.focused === true) {
+      focusedElementIndex = index;
+    }
+
+    const children = element.children?.map((child) => {
+      return indexElement(child);
+    });
+    return {
+      ...element,
+      index,
+      ...(children && children.length > 0 ? { children } : {}),
+    };
+  };
+
+  const elements = snapshot.elements.map((element) => {
+    return indexElement(element);
+  });
+
+  return {
+    snapshot: {
+      ...snapshot,
+      elements,
+      ...(focusedElementIndex !== undefined ? { focusedElementIndex } : {}),
+    },
+    elementIdsByIndex,
+    ...(focusedElementIndex !== undefined ? { focusedElementIndex } : {}),
+  };
+}
+
+const ROLE_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  AXButton: "button",
+  AXCheckBox: "checkbox",
+  AXComboBox: "combo box",
+  AXDisclosureTriangle: "disclosure triangle",
+  AXGroup: "container",
+  AXHeading: "heading",
+  AXImage: "image",
+  AXLink: "link",
+  AXList: "list",
+  AXMenu: "menu",
+  AXMenuBar: "menu bar",
+  AXMenuBarItem: "menu bar item",
+  AXMenuItem: "menu item",
+  AXOutline: "outline",
+  AXPopUpButton: "pop up button",
+  AXRadioButton: "radio button",
+  AXScrollArea: "scroll area",
+  AXSlider: "slider",
+  AXStaticText: "text",
+  AXTabGroup: "tab group",
+  AXTable: "table",
+  AXTextArea: "text entry area",
+  AXTextField: "text field",
+  AXToolbar: "toolbar",
+  AXUnknown: "container",
+});
+
+const DEFAULT_ACTION_NAMES = new Set(["AXPress"]);
+
+const ACTION_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  AXCancel: "Cancel",
+  AXConfirm: "Confirm",
+  AXDecrement: "Decrement",
+  AXDelete: "Delete",
+  AXIncrement: "Increment",
+  AXPick: "Pick",
+  AXRaise: "Raise",
+  AXShowMenu: "Show Menu",
+});
+
+function normalizeText(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  const normalized = value.replaceAll(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function truncateText(value: string, maxLength = 180): string {
+  return value.length <= maxLength
+    ? value
+    : `${value.slice(0, maxLength - 3)}...`;
+}
+
+function formatText(
+  value: string | undefined,
+  maxLength?: number,
+): string | null {
+  const normalized = normalizeText(value);
+  return normalized ? truncateText(normalized, maxLength) : null;
+}
+
+function labelFromAxRole(role: string): string {
+  const withoutPrefix = role.startsWith("AX") ? role.slice(2) : role;
+  return withoutPrefix.replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2").toLowerCase();
+}
+
+function elementRoleLabel(element: AccessibilityElementSnapshot): string {
+  if (element.role === "AXWindow") {
+    if (element.subrole === "AXDialog") {
+      return "dialog";
+    }
+    return "standard window";
+  }
+  if (element.role === "AXWebArea") {
+    return formatText(element.roleDescription, 80) ?? "HTML content";
+  }
+  if (element.role) {
+    const label = ROLE_LABELS[element.role];
+    if (label) {
+      return label;
+    }
+  }
+  if (element.roleDescription) {
+    return formatText(element.roleDescription, 80) ?? "element";
+  }
+  return element.role ? labelFromAxRole(element.role) : "element";
+}
+
+function elementAnnotations(element: AccessibilityElementSnapshot): string[] {
+  const annotations: string[] = [];
+  if (element.valueSettable === true) {
+    annotations.push(
+      element.valueType ? `settable, ${element.valueType}` : "settable",
+    );
+  }
+  if (element.enabled === false) {
+    annotations.push("disabled");
+  }
+  if (element.selected === true) {
+    annotations.push("selected");
+  }
+  if (element.expanded === true) {
+    annotations.push("expanded");
+  }
+  return annotations;
+}
+
+function elementPrimaryText(
+  element: AccessibilityElementSnapshot,
+): string | null {
+  return (
+    formatText(element.name) ??
+    formatText(element.value) ??
+    formatText(element.description) ??
+    formatText(element.url, 240)
+  );
+}
+
+function actionLabel(action: string): string {
+  return ACTION_LABELS[action] ?? action.replace(/^AX/, "");
+}
+
+function secondaryActions(element: AccessibilityElementSnapshot): string[] {
+  return (element.actions ?? [])
+    .filter((action) => {
+      return !DEFAULT_ACTION_NAMES.has(action);
+    })
+    .map((action) => {
+      return actionLabel(action);
+    });
+}
+
+function elementDetails(
+  element: AccessibilityElementSnapshot,
+  primary: string | null,
+): string[] {
+  const details: string[] = [];
+  const description = formatText(element.description);
+  if (description && description !== primary) {
+    details.push(`Description: ${description}`);
+  }
+  const value = formatText(element.value);
+  if (value && value !== primary) {
+    details.push(`Value: ${value}`);
+  }
+  const url = formatText(element.url, 240);
+  if (url && url !== primary) {
+    details.push(`URL: ${url}`);
+  }
+  const help = formatText(element.help);
+  if (help && help !== primary) {
+    details.push(`Help: ${help}`);
+  }
+  const actions = secondaryActions(element);
+  if (actions.length > 0) {
+    details.push(`Secondary Actions: ${actions.join(", ")}`);
+  }
+  return details;
+}
+
+function elementIndex(element: AccessibilityElementSnapshot): number {
+  return element.index ?? 0;
+}
+
+function formatElementLine(
+  element: AccessibilityElementSnapshot,
+  depth: number,
+): string {
+  const primary = elementPrimaryText(element);
+  const annotations = elementAnnotations(element);
+  const details = elementDetails(element, primary);
+  let line = `${"\t".repeat(depth)}${elementIndex(element)} ${elementRoleLabel(
+    element,
+  )}`;
+  if (annotations.length > 0) {
+    line += ` (${annotations.join(", ")})`;
+  }
+  if (primary) {
+    line += ` ${primary}`;
+  }
+  if (details.length > 0) {
+    line += `${primary ? ", " : " "}${details.join(", ")}`;
+  }
+  return line;
+}
+
+function findElementByIndex(
+  elements: readonly AccessibilityElementSnapshot[],
+  index: number,
+): AccessibilityElementSnapshot | null {
+  for (const element of elements) {
+    if (element.index === index) {
+      return element;
+    }
+    const child = findElementByIndex(element.children ?? [], index);
+    if (child) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function focusedElementLine(
+  snapshot: AccessibilityAppStateSnapshot,
+): string | null {
+  if (snapshot.focusedElementIndex === undefined) {
+    return null;
+  }
+  const element = findElementByIndex(
+    snapshot.elements,
+    snapshot.focusedElementIndex,
+  );
+  if (!element) {
+    return `The focused UI element is ${snapshot.focusedElementIndex}.`;
+  }
+  return `The focused UI element is ${formatElementLine(element, 0)}.`;
+}
+
 export function renderAccessibilityTree(
   snapshot: AccessibilityAppStateSnapshot,
 ): string {
-  const lines = [`snapshot_id=${snapshot.snapshotId}`, `app=${snapshot.app}`];
+  const indexed = indexAccessibilitySnapshot(snapshot).snapshot;
+  const appName = indexed.appDisplayName ?? indexed.app;
+  const appIdentity = indexed.appPath ?? appName;
+  const appDetails = [
+    indexed.bundleId ? `bundleID ${indexed.bundleId}` : null,
+    indexed.pid !== undefined ? `pid ${indexed.pid}` : null,
+  ].filter((part): part is string => {
+    return part !== null;
+  });
+  const lines = [
+    "Computer Use state",
+    "<app_state>",
+    appDetails.length > 0
+      ? `App=${appIdentity} (${appDetails.join(", ")})`
+      : `App=${appIdentity}`,
+  ];
+  const windowTitle =
+    formatText(indexed.windowTitle) ?? formatText(indexed.elements[0]?.name);
+  if (windowTitle) {
+    lines.push(`Window: "${windowTitle}", App: ${appName}.`);
+  }
 
   const visit = (
     element: AccessibilityElementSnapshot,
     depth: number,
   ): void => {
-    const indent = "  ".repeat(depth);
-    const label = [
-      element.id,
-      element.role,
-      element.name ? `"${element.name}"` : null,
-      element.value ? `value="${element.value}"` : null,
-      element.actions && element.actions.length > 0
-        ? `actions=${element.actions.join(",")}`
-        : null,
-    ]
-      .filter((part): part is string => {
-        return part !== null && part !== undefined;
-      })
-      .join(" ");
-    lines.push(`${indent}${label}`);
+    lines.push(formatElementLine(element, depth));
     for (const child of element.children ?? []) {
       visit(child, depth + 1);
     }
   };
 
-  for (const element of snapshot.elements) {
+  for (const element of indexed.elements) {
     visit(element, 0);
   }
+  const focusedLine = focusedElementLine(indexed);
+  if (focusedLine) {
+    lines.push("", focusedLine);
+  }
+  lines.push("</app_state>");
   return lines.join("\n");
 }
 
@@ -745,12 +1060,44 @@ function snapshotWindowCaptureCandidates(
     });
 }
 
+function publicElementSnapshot(
+  element: AccessibilityElementSnapshot,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(element)) {
+    if (key !== "id" && key !== "children" && value !== undefined) {
+      result[key] = value;
+    }
+  }
+  if (element.children && element.children.length > 0) {
+    result.children = element.children.map((child) => {
+      return publicElementSnapshot(child);
+    });
+  }
+  return result;
+}
+
+function publicAppStateSnapshot(
+  snapshot: AccessibilityAppStateSnapshot,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (key !== "elements" && value !== undefined) {
+      result[key] = value;
+    }
+  }
+  result.elements = snapshot.elements.map((element) => {
+    return publicElementSnapshot(element);
+  });
+  return result;
+}
+
 function buildComputerUseAppStateResult(
   snapshot: AccessibilityAppStateSnapshot,
   screenshot: ComputerUseScreenshotCaptureResult,
 ): Record<string, unknown> {
   return {
-    ...snapshot,
+    ...publicAppStateSnapshot(snapshot),
     text: renderAccessibilityTree(snapshot),
     screenshot: screenshot.dataUrl,
     screenshotMimeType: "image/png",
@@ -781,12 +1128,13 @@ async function getAppState(
   const snapshot = normalizeAccessibilitySnapshot(
     await nativeBackend.getAppState(app, id),
   );
-  const windowBounds = snapshotWindowCaptureCandidates(snapshot);
+  const indexed = indexAccessibilitySnapshot(snapshot);
+  const windowBounds = snapshotWindowCaptureCandidates(indexed.snapshot);
   let screenshot: ComputerUseScreenshotCaptureResult;
   try {
     screenshot = await captureScreenshot({
       app,
-      windowNames: snapshotWindowNames(snapshot),
+      windowNames: snapshotWindowNames(indexed.snapshot),
       windowBounds,
     });
   } catch (error) {
@@ -799,8 +1147,12 @@ async function getAppState(
     };
   }
   snapshotStore.set({
-    app: snapshot.app,
-    snapshotId: snapshot.snapshotId,
+    app: indexed.snapshot.app,
+    snapshotId: indexed.snapshot.snapshotId,
+    elementIdsByIndex: indexed.elementIdsByIndex,
+    ...(indexed.focusedElementIndex !== undefined
+      ? { focusedElementIndex: indexed.focusedElementIndex }
+      : {}),
     screenshotWidth: screenshot.width,
     screenshotHeight: screenshot.height,
     screenshotSource: screenshot.source,
@@ -811,7 +1163,7 @@ async function getAppState(
   });
   return {
     status: "succeeded",
-    result: buildComputerUseAppStateResult(snapshot, screenshot),
+    result: buildComputerUseAppStateResult(indexed.snapshot, screenshot),
   };
 }
 
@@ -889,9 +1241,66 @@ function resolveClickSnapshot(args: {
   );
 }
 
+function resolveElementTarget(args: {
+  readonly app: string;
+  readonly elementId: string | null;
+  readonly elementIndex: number | null;
+  readonly snapshotId: string | null;
+  readonly snapshotStore: ComputerUseSnapshotStore;
+  readonly commandName: string;
+}): ComputerUseElementTarget | ComputerUseCommandFailure {
+  if (args.elementId) {
+    return { elementId: args.elementId };
+  }
+  if (args.elementIndex === null) {
+    return unsupportedCommand(
+      `${args.commandName} requires elementId or elementIndex`,
+    );
+  }
+
+  const snapshot = resolveClickSnapshot({
+    app: args.app,
+    snapshotId: args.snapshotId,
+    snapshotStore: args.snapshotStore,
+  });
+  if ("status" in snapshot) {
+    return snapshot;
+  }
+  const elementId = snapshot.elementIdsByIndex?.[args.elementIndex];
+  if (!elementId) {
+    return unsupportedCommand(
+      `Element index ${args.elementIndex} was not found in snapshot ${snapshot.snapshotId}`,
+    );
+  }
+  return {
+    elementId,
+    elementIndex: args.elementIndex,
+    snapshotId: snapshot.snapshotId,
+  };
+}
+
+function elementTargetResult(
+  target: ComputerUseElementTarget,
+): Record<string, unknown> {
+  if (target.elementIndex !== undefined) {
+    return {
+      elementIndex: target.elementIndex,
+      ...(target.snapshotId ? { snapshotId: target.snapshotId } : {}),
+    };
+  }
+  return { elementId: target.elementId };
+}
+
+function elementTargetText(target: ComputerUseElementTarget): string {
+  return target.elementIndex !== undefined
+    ? `elementIndex=${target.elementIndex}`
+    : target.elementId;
+}
+
 async function clickElement(args: {
   readonly app: string;
   readonly elementId: string | null;
+  readonly elementIndex: number | null;
   readonly snapshotId: string | null;
   readonly x: number | null;
   readonly y: number | null;
@@ -900,15 +1309,26 @@ async function clickElement(args: {
   readonly nativeBackend: ComputerUseNativeBackend;
   readonly snapshotStore: ComputerUseSnapshotStore;
 }): Promise<ComputerUseCommandExecutionResult> {
-  if (args.elementId) {
+  if (args.elementId || args.elementIndex !== null) {
     if (args.button !== "left") {
       return unsupportedCommand(
-        "element.click with element id only supports the left button; use coordinates for right or middle clicks",
+        "element.click with element target only supports the left button; use coordinates for right or middle clicks",
       );
+    }
+    const target = resolveElementTarget({
+      app: args.app,
+      elementId: args.elementId,
+      elementIndex: args.elementIndex,
+      snapshotId: args.snapshotId,
+      snapshotStore: args.snapshotStore,
+      commandName: "element.click",
+    });
+    if ("status" in target) {
+      return target;
     }
     await args.nativeBackend.clickElement({
       app: args.app,
-      elementId: args.elementId,
+      elementId: target.elementId,
       button: args.button,
       clickCount: args.clickCount,
     });
@@ -916,13 +1336,13 @@ async function clickElement(args: {
       status: "succeeded",
       result: {
         app: args.app,
-        elementId: args.elementId,
+        ...elementTargetResult(target),
         button: args.button,
         clickCount: args.clickCount,
         dispatchMode: "accessibility_action",
         dispatchTarget: "element",
         inputRisk: "targeted_app_action",
-        text: `Clicked ${args.elementId}`,
+        text: `Clicked ${elementTargetText(target)}`,
       },
     };
   }
@@ -965,42 +1385,50 @@ async function clickElement(args: {
     };
   }
   return unsupportedCommand(
-    "element.click requires an element id or coordinates",
+    "element.click requires elementId, elementIndex, or coordinates",
   );
 }
 
 async function setElementValue(
   app: string,
-  elementId: string,
+  target: ComputerUseElementTarget,
   value: string,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.setElementValue({ app, elementId, value });
+  await nativeBackend.setElementValue({
+    app,
+    elementId: target.elementId,
+    value,
+  });
   return {
     status: "succeeded",
     result: {
       app,
-      elementId,
+      ...elementTargetResult(target),
       dispatchMode: "accessibility_value",
       dispatchTarget: "element",
       inputRisk: "targeted_app_text",
-      text: `Set ${elementId}`,
+      text: `Set ${elementTargetText(target)}`,
     },
   };
 }
 
 async function performElementAction(
   app: string,
-  elementId: string,
+  target: ComputerUseElementTarget,
   action: string,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.performElementAction({ app, elementId, action });
+  await nativeBackend.performElementAction({
+    app,
+    elementId: target.elementId,
+    action,
+  });
   return {
     status: "succeeded",
     result: {
       app,
-      elementId,
+      ...elementTargetResult(target),
       action,
       dispatchMode: "accessibility_action",
       dispatchTarget: "element",
@@ -1058,23 +1486,28 @@ async function pressKey(
 
 async function scrollElement(
   app: string,
-  elementId: string,
+  target: ComputerUseElementTarget,
   direction: string,
   pages: number,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.scrollElement({ app, elementId, direction, pages });
+  await nativeBackend.scrollElement({
+    app,
+    elementId: target.elementId,
+    direction,
+    pages,
+  });
   return {
     status: "succeeded",
     result: {
       app,
-      elementId,
+      ...elementTargetResult(target),
       direction,
       pages,
       dispatchMode: "accessibility_action",
       dispatchTarget: "element",
       inputRisk: "targeted_app_action",
-      text: `Scrolled ${elementId}`,
+      text: `Scrolled ${elementTargetText(target)}`,
     },
   };
 }
@@ -1123,8 +1556,11 @@ export async function executeComputerUseCommand(
       const x = payloadNumber(command.payload, "x");
       const y = payloadNumber(command.payload, "y");
       const snapshotId = payloadString(command.payload, "snapshotId");
+      const elementId = payloadString(command.payload, "elementId");
+      const elementIndex = payloadElementIndex(command.payload);
       if (
-        !payloadString(command.payload, "elementId") &&
+        !elementId &&
+        elementIndex === null &&
         x !== null &&
         y !== null &&
         !snapshotId &&
@@ -1146,7 +1582,8 @@ export async function executeComputerUseCommand(
       }
       return await clickElement({
         app,
-        elementId: payloadString(command.payload, "elementId"),
+        elementId,
+        elementIndex,
         snapshotId,
         x,
         y,
@@ -1158,16 +1595,26 @@ export async function executeComputerUseCommand(
     }
     if (command.kind === "element.scroll") {
       const elementId = payloadString(command.payload, "elementId");
+      const elementIndex = payloadElementIndex(command.payload);
+      const snapshotId = payloadString(command.payload, "snapshotId");
       const direction = payloadString(command.payload, "direction");
-      if (!elementId) {
-        return missingField("elementId");
-      }
       if (!direction) {
         return missingField("direction");
       }
-      return await scrollElement(
+      const target = resolveElementTarget({
         app,
         elementId,
+        elementIndex,
+        snapshotId,
+        snapshotStore,
+        commandName: "element.scroll",
+      });
+      if ("status" in target) {
+        return target;
+      }
+      return await scrollElement(
+        app,
+        target,
         direction,
         payloadNumber(command.payload, "pages") ?? 1,
         nativeBackend,
@@ -1175,25 +1622,45 @@ export async function executeComputerUseCommand(
     }
     if (command.kind === "element.set_value") {
       const elementId = payloadString(command.payload, "elementId");
+      const elementIndex = payloadElementIndex(command.payload);
+      const snapshotId = payloadString(command.payload, "snapshotId");
       const value = payloadString(command.payload, "value");
-      if (!elementId) {
-        return missingField("elementId");
-      }
       if (!value) {
         return missingField("value");
       }
-      return await setElementValue(app, elementId, value, nativeBackend);
+      const target = resolveElementTarget({
+        app,
+        elementId,
+        elementIndex,
+        snapshotId,
+        snapshotStore,
+        commandName: "element.set_value",
+      });
+      if ("status" in target) {
+        return target;
+      }
+      return await setElementValue(app, target, value, nativeBackend);
     }
     if (command.kind === "element.perform_action") {
       const elementId = payloadString(command.payload, "elementId");
+      const elementIndex = payloadElementIndex(command.payload);
+      const snapshotId = payloadString(command.payload, "snapshotId");
       const action = payloadString(command.payload, "action");
-      if (!elementId) {
-        return missingField("elementId");
-      }
       if (!action) {
         return missingField("action");
       }
-      return await performElementAction(app, elementId, action, nativeBackend);
+      const target = resolveElementTarget({
+        app,
+        elementId,
+        elementIndex,
+        snapshotId,
+        snapshotStore,
+        commandName: "element.perform_action",
+      });
+      if ("status" in target) {
+        return target;
+      }
+      return await performElementAction(app, target, action, nativeBackend);
     }
     if (command.kind === "keyboard.type_text") {
       const text = payloadString(command.payload, "text");

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -467,9 +467,74 @@ describe("computer use desktop runtime", () => {
     };
     const text = renderAccessibilityTree(snapshot);
 
-    expect(text).toContain("snapshot_id=snap_1");
-    expect(text).toContain('w0 AXWindow "Example"');
-    expect(text).toContain('w0.e0 AXButton "Open" actions=AXPress');
+    expect(text).toContain("Computer Use state");
+    expect(text).toContain("<app_state>");
+    expect(text).toContain("App=Safari");
+    expect(text).toContain('Window: "Example", App: Safari.');
+    expect(text).toContain("0 standard window Example");
+    expect(text).toContain("\t1 button Open");
+    expect(text).not.toContain("w0.e0");
+  });
+
+  it("renders CUA-style element details and focused element summary", () => {
+    const snapshot = {
+      app: "Electron",
+      appDisplayName: "Zero",
+      bundleId: "com.github.Electron",
+      pid: 26037,
+      appPath: "/Applications/Zero.app",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "Zero | VM0",
+          children: [
+            {
+              id: "w0.e0",
+              role: "AXWebArea",
+              roleDescription: "HTML content",
+              name: "Zero | VM0",
+              url: "https://app.vm7.ai/agents/1/chat",
+              children: [
+                {
+                  id: "w0.e0.e0",
+                  role: "AXTextArea",
+                  name: "Ask me to automate workflows",
+                  valueSettable: true,
+                  valueType: "string",
+                  focused: true,
+                },
+                {
+                  id: "w0.e0.e1",
+                  role: "AXButton",
+                  description: "Invite people",
+                  actions: ["AXPress", "AXRaise"],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const text = renderAccessibilityTree(snapshot);
+
+    expect(text).toContain(
+      "App=/Applications/Zero.app (bundleID com.github.Electron, pid 26037)",
+    );
+    expect(text).toContain(
+      "\t1 HTML content Zero | VM0, URL: https://app.vm7.ai/agents/1/chat",
+    );
+    expect(text).toContain(
+      "\t\t2 text entry area (settable, string) Ask me to automate workflows",
+    );
+    expect(text).toContain(
+      "\t\t3 button Invite people, Secondary Actions: Raise",
+    );
+    expect(text).toContain(
+      "The focused UI element is 2 text entry area (settable, string) Ask me to automate workflows.",
+    );
   });
 
   it("compacts generic wrappers while preserving WebArea branching context", () => {
@@ -527,16 +592,11 @@ describe("computer use desktop runtime", () => {
       normalizeAccessibilitySnapshot(snapshot),
     );
 
-    expect(text).not.toContain("w0.e0 AXGroup");
-    expect(text).toContain("w0.e0.e0 AXWebArea");
-    expect(text).toContain("w0.e0.e0.e0 AXGroup");
-    expect(text).not.toContain("w0.e0.e0.e0.e0 AXGroup");
-    expect(text).toContain(
-      'w0.e0.e0.e0.e0.e0 AXButton "Send message" actions=AXPress',
-    );
-    expect(text).toContain(
-      'w0.e0.e0.e0.e1 AXStaticText value="release-notify"',
-    );
+    expect(text).not.toContain("w0.e0");
+    expect(text).toContain("\t1 HTML content");
+    expect(text).toContain("\t\t2 container");
+    expect(text).toContain("\t\t\t3 button Send message");
+    expect(text).toContain("\t\t\t4 text release-notify");
   });
 
   it("marks accessibility snapshots truncated at the output node budget", () => {
@@ -568,9 +628,9 @@ describe("computer use desktop runtime", () => {
     expect(normalized.truncated).toBe(true);
     expect(normalized.truncationReasons).toContain("max_nodes");
     expect(normalized.nodeCount).toBe(3);
-    expect(text).toContain('w0.e0 AXButton "Button 0"');
-    expect(text).toContain('w0.e1 AXButton "Button 1"');
-    expect(text).not.toContain("w0.e2");
+    expect(text).toContain("\t1 button Button 0");
+    expect(text).toContain("\t2 button Button 1");
+    expect(text).not.toContain("Button 2");
   });
 
   it("returns screenshot metadata with model-readable app state", async () => {
@@ -627,7 +687,14 @@ describe("computer use desktop runtime", () => {
         screenshotHeight: 600,
       },
     });
-    expect(result.result.text).toContain('w0 AXWindow "Example"');
+    expect(result.result.text).toContain("0 standard window Example");
+    expect(result.result.elements).toStrictEqual([
+      {
+        index: 0,
+        role: "AXWindow",
+        name: "Example",
+      },
+    ]);
   });
 
   it("normalizes deep accessibility state from the native helper", async () => {
@@ -713,9 +780,8 @@ describe("computer use desktop runtime", () => {
       snapshotId: expect.stringMatching(/^desktop_/),
     });
     expect(result.result.text).toContain("Release notes posted");
-    expect(result.result.text).toContain(
-      'w0.e0.e0.c0.v1 AXTextArea "Message composer"',
-    );
+    expect(result.result.text).toContain("text entry area Message composer");
+    expect(result.result.text).toContain("Secondary Actions: Confirm");
     expect(result.result.truncated).toBe(false);
   });
 
@@ -744,6 +810,114 @@ describe("computer use desktop runtime", () => {
       button: "left",
       clickCount: 1,
     });
+  });
+
+  it("maps model-facing element indexes back to internal element ids", async () => {
+    const snapshotStore = new ComputerUseSnapshotStore();
+    const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
+    const nativeBackend = createNativeBackend({
+      clickElement,
+      getAppState: async (app, snapshotId) => {
+        return {
+          app,
+          snapshotId,
+          elements: [
+            {
+              id: "w0",
+              role: "AXWindow",
+              name: "Example",
+              children: [
+                {
+                  id: "w0.e0",
+                  role: "AXButton",
+                  name: "Open",
+                  actions: ["AXPress"],
+                },
+              ],
+            },
+          ],
+        };
+      },
+    });
+
+    const state = await executeComputerUseCommand(
+      { id: "cmd_1", kind: "app.state", payload: { app: "Safari" } },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        snapshotStore,
+        nativeBackend,
+        captureScreenshot: async () => {
+          return {
+            dataUrl: "data:image/png;base64,abc123",
+            source: "window",
+            sourceName: "Example",
+            width: 800,
+            height: 600,
+          };
+        },
+      },
+    );
+    expect(state.status).toBe("succeeded");
+    if (state.status !== "succeeded") {
+      throw new Error("expected app.state to succeed");
+    }
+
+    const snapshotId = state.result.snapshotId;
+    expect(typeof snapshotId).toBe("string");
+    if (typeof snapshotId !== "string") {
+      throw new Error("expected snapshot id");
+    }
+    expect(state.result.elements).toStrictEqual([
+      {
+        index: 0,
+        role: "AXWindow",
+        name: "Example",
+        children: [
+          {
+            index: 1,
+            role: "AXButton",
+            name: "Open",
+            actions: ["AXPress"],
+          },
+        ],
+      },
+    ]);
+
+    const click = await executeComputerUseCommand(
+      {
+        id: "cmd_2",
+        kind: "element.click",
+        payload: { app: "Safari", snapshotId, elementIndex: 1 },
+      },
+      { accessibility: true, screenRecording: false },
+      {
+        platform: "darwin",
+        snapshotStore,
+        nativeBackend,
+        captureScreenshot: async () => {
+          throw new Error("unexpected screenshot capture");
+        },
+      },
+    );
+
+    expect(click.status).toBe("succeeded");
+    expect(clickElement).toHaveBeenCalledWith({
+      app: "Safari",
+      elementId: "w0.e0",
+      button: "left",
+      clickCount: 1,
+    });
+    if (click.status !== "succeeded") {
+      throw new Error("expected click to succeed");
+    }
+    expect(click.result).toMatchObject({
+      app: "Safari",
+      snapshotId,
+      elementIndex: 1,
+      dispatchMode: "accessibility_action",
+    });
+    expect(click.result).not.toHaveProperty("elementId");
   });
 
   it("maps screenshot coordinate clicks through cached snapshot bounds", async () => {

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -60,6 +60,7 @@ const supportedCapabilitiesSchema = z
 const appNameSchema = z.string().trim().min(1).max(256);
 const snapshotIdSchema = z.string().trim().min(1).max(256);
 const elementIdSchema = z.string().trim().min(1).max(256);
+const elementIndexSchema = z.number().int().min(0);
 
 const computerUsePermissionsSchema = z.object({
   accessibility: z.boolean(),
@@ -84,6 +85,7 @@ const computerUseCommandPayloadShape = {
   app: appNameSchema.optional(),
   snapshotId: snapshotIdSchema.optional(),
   elementId: elementIdSchema.optional(),
+  elementIndex: elementIndexSchema.optional(),
   x: z.number().int().min(0).optional(),
   y: z.number().int().min(0).optional(),
   button: z.enum(["left", "right", "middle"]).optional(),
@@ -143,11 +145,11 @@ function validateElementClickCommand(
   ctx: ComputerUseCommandValidationContext,
 ): void {
   const hasPoint = body.x !== undefined && body.y !== undefined;
-  if (!body.elementId && !hasPoint) {
+  if (!body.elementId && body.elementIndex === undefined && !hasPoint) {
     requireComputerUseField(
       ctx,
-      "elementId",
-      "element.click requires elementId or x/y",
+      "elementIndex",
+      "element.click requires elementId, elementIndex, or x/y",
     );
   }
   if ((body.x === undefined) !== (body.y === undefined)) {
@@ -163,11 +165,11 @@ function validateElementScrollCommand(
   body: ComputerUseWriteCommandCreateBody,
   ctx: ComputerUseCommandValidationContext,
 ): void {
-  if (!body.elementId) {
+  if (!body.elementId && body.elementIndex === undefined) {
     requireComputerUseField(
       ctx,
-      "elementId",
-      "element.scroll requires elementId",
+      "elementIndex",
+      "element.scroll requires elementId or elementIndex",
     );
   }
   if (!body.direction) {
@@ -183,11 +185,11 @@ function validateElementSetValueCommand(
   body: ComputerUseWriteCommandCreateBody,
   ctx: ComputerUseCommandValidationContext,
 ): void {
-  if (!body.elementId) {
+  if (!body.elementId && body.elementIndex === undefined) {
     requireComputerUseField(
       ctx,
-      "elementId",
-      "element.set_value requires elementId",
+      "elementIndex",
+      "element.set_value requires elementId or elementIndex",
     );
   }
   if (!body.value) {
@@ -199,11 +201,11 @@ function validateElementActionCommand(
   body: ComputerUseWriteCommandCreateBody,
   ctx: ComputerUseCommandValidationContext,
 ): void {
-  if (!body.elementId) {
+  if (!body.elementId && body.elementIndex === undefined) {
     requireComputerUseField(
       ctx,
-      "elementId",
-      "element.perform_action requires elementId",
+      "elementIndex",
+      "element.perform_action requires elementId or elementIndex",
     );
   }
   if (!body.action) {


### PR DESCRIPTION
## Summary

- render Desktop Computer Use app state in a Codex CUA-style format with numeric element indexes, readable roles, useful metadata, and focused element summaries
- expose `elementIndex` as the model-facing selector while keeping internal `elementId` resolution for compatibility
- extend native macOS snapshots with app metadata, value/settable details, URL/help state, and menu bar nodes
- add API and CLI support for `elementIndex` targeting

Closes #14511.

## Testing

- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts`
- `cd turbo && pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `cd turbo/apps/desktop/native/computer-use-helper && swift build -c release`

Note: `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts` is blocked locally because PostgreSQL is not running on `::1:5432` / `127.0.0.1:5432`; CI should run the DB-backed API route test in the configured environment.