### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2943,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",


### PR DESCRIPTION
## Summary

Weekly Rust workspace dependency refresh (`cargo update`) on the `crates/` workspace.

### Updated

| Package | From | To |
|---|---|---|
| `serde_json` | 1.0.149 | 1.0.150 |

### Not updated (held back)

| Package | Locked | Available | Reason |
|---|---|---|---|
| `generic-array` | 0.14.7 | 0.14.9 | Hard-pinned via `crypto-common v0.1.7` (`generic-array = "=0.14.7"`), reached transitively through `aws-sdk-s3 → aws-smithy-checksums → crc-fast → digest`. Cannot be bumped without major-version churn upstream. |

### Manual Cargo.toml bumps

None. All workspace dependency specifiers already use loose constraints (`"1"`, `"0.4"`, etc.) that accept any compatible minor/patch — `cargo update` would already have taken anything we could safely take. The remaining outdated dep is held by a transitive `=` pin, not by our workspace specifier.

### Test status

`cargo test` was run per-crate across all 21 workspace members (sandbox memory was insufficient to link the whole workspace in a single invocation). All crates passed:

| Crate | Result |
|---|---|
| `api-contracts` | ok (65) |
| `vsock-proto` | ok (0) |
| `guest-common` | ok (5) |
| `process-control-ipc` | ok (11) |
| `agent-diagnostics` | ok (7+15+17) |
| `vsock-guest` | ok (5+9) |
| `vsock-host` | ok (14) |
| `sandbox` | ok (118+39) |
| `sandbox-mock` | ok (15) |
| `nbd-cow` | ok (52+5) |
| `guest-write-file` | ok (109) |
| `guest-reseed` | ok (196) |
| `guest-init` | ok (47, 2+11 ignored) |
| `sandbox-fc` | ok (11+13+19) |
| `guest-mock-codex` | ok (0) |
| `guest-mock-claude` | ok (454) |
| `ably-subscriber` | ok (14+35) |
| `guest-agent` | ok (47 + 17 doc-style) |
| `guest-download` | ok (43) |
| `vsock-test` | ok (26, 1 ignored) |
| `runner` | ok (1205+10, 1 ignored) |

**Total: 0 failures across the workspace.**