### PR TITLE
fix: preserve binary body truncation signal

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -342,6 +342,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         stream_state = flow.metadata.get("stream_buffer_state")
         stream_truncated = False
         if stream_buf is not None:
+            # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
             if stream_buf:
                 if not stream_state:
                     raise KeyError("truncated")
@@ -363,7 +364,6 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         if body is None:
             return
         res_ct = flow.response.headers.get("content-type", "")
-        # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
         _set_body_fields(
             log_entry,

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -340,9 +340,14 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     if flow.response:
         stream_buf = flow.metadata.get("stream_buffer")
         stream_state = flow.metadata.get("stream_buffer_state")
+        stream_truncated = False
         if stream_buf is not None:
-            if stream_buf and not stream_state:
-                raise KeyError("truncated")
+            if stream_buf:
+                if not stream_state:
+                    raise KeyError("truncated")
+                stream_truncated = bool(stream_state["truncated"])
+            elif stream_state:
+                stream_truncated = bool(stream_state.get("truncated", False))
             body = decompress_body(
                 bytes(stream_buf),
                 flow.response.headers,
@@ -360,14 +365,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         res_ct = flow.response.headers.get("content-type", "")
         # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
-        already_truncated = bool(
-            stream_state
-            and (stream_state["truncated"] if body else stream_state.get("truncated", False))
-        )
         _set_body_fields(
             log_entry,
             "response",
             body,
             res_ct,
-            already_truncated=already_truncated,
+            already_truncated=stream_truncated,
         )

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -357,10 +357,14 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         res_ct = flow.response.headers.get("content-type", "")
         # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
+        already_truncated = bool(
+            stream_state
+            and (stream_state["truncated"] if body else stream_state.get("truncated", False))
+        )
         _set_body_fields(
             log_entry,
             "response",
             body,
             res_ct,
-            already_truncated=bool(stream_state and stream_state.get("truncated", False)),
+            already_truncated=already_truncated,
         )

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -287,20 +287,23 @@ def _set_body_fields(
     *,
     already_truncated: bool = False,
 ) -> None:
+    truncated = already_truncated or len(body) > STREAM_BUFFER_LIMIT
+    if truncated:
+        log_entry[f"{side}_body_truncated"] = True
+
     if not body:
         return
 
-    truncated = already_truncated or len(body) > STREAM_BUFFER_LIMIT
-    if truncated:
-        body = _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT)
-    encoded, encoding = _encode_body(body, content_type)
-    if encoded is not None:
-        log_entry[f"{side}_body"] = encoded
-        log_entry[f"{side}_body_encoding"] = encoding
-        if truncated:
-            log_entry[f"{side}_body_truncated"] = True
-    else:
+    encoded, encoding = _encode_body(
+        _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT) if truncated else body,
+        content_type,
+    )
+    if encoded is None:
         log_entry[f"{side}_body_encoding"] = "binary"
+        return
+
+    log_entry[f"{side}_body"] = encoded
+    log_entry[f"{side}_body_encoding"] = encoding
 
 
 def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
@@ -359,5 +362,5 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             "response",
             body,
             res_ct,
-            already_truncated=bool(body and stream_state and stream_state["truncated"]),
+            already_truncated=bool(stream_state and stream_state.get("truncated", False)),
         )

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -339,7 +339,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     # The buffer contains raw wire bytes (possibly gzip/br/zstd compressed).
     if flow.response:
         stream_buf = flow.metadata.get("stream_buffer")
+        stream_state = flow.metadata.get("stream_buffer_state")
         if stream_buf is not None:
+            if stream_buf and not stream_state:
+                raise KeyError("truncated")
             body = decompress_body(
                 bytes(stream_buf),
                 flow.response.headers,
@@ -354,12 +357,9 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 return
         if body is None:
             return
-        stream_state = flow.metadata.get("stream_buffer_state")
         res_ct = flow.response.headers.get("content-type", "")
         # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
-        if stream_buf is not None and body and not stream_state:
-            raise KeyError("truncated")
         already_truncated = bool(
             stream_state
             and (stream_state["truncated"] if body else stream_state.get("truncated", False))

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -289,6 +289,7 @@ def _set_body_fields(
 ) -> None:
     truncated = already_truncated or len(body) > STREAM_BUFFER_LIMIT
     if truncated:
+        # Truncation describes capture completeness, even when no body string is emitted.
         log_entry[f"{side}_body_truncated"] = True
 
     if not body:

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -358,6 +358,8 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         res_ct = flow.response.headers.get("content-type", "")
         # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
         # Also check decompressed size in case it expanded beyond the limit.
+        if stream_buf is not None and body and not stream_state:
+            raise KeyError("truncated")
         already_truncated = bool(
             stream_state
             and (stream_state["truncated"] if body else stream_state.get("truncated", False))

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -426,6 +426,7 @@ class TestAddCaptureFields:
         add_capture_fields(flow, entry)
         assert "request_body" not in entry
         assert entry["request_body_encoding"] == "binary"
+        assert "request_body_truncated" not in entry
         assert "request_headers" in entry  # headers still captured
 
     def test_large_binary_request_body_marks_truncated(self, real_flow):
@@ -457,6 +458,7 @@ class TestAddCaptureFields:
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
+        assert "response_body_truncated" not in entry
 
     def test_request_body_exactly_at_limit_not_truncated(self, real_flow):
         body = b"x" * STREAM_BUFFER_LIMIT

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -696,6 +696,20 @@ class TestAddCaptureFields:
         with pytest.raises(KeyError, match="truncated"):
             add_capture_fields(flow, entry)
 
+    def test_non_empty_compressed_stream_buffer_requires_state(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            response_encoding="gzip",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(gzip.compress(b""))
+        entry = {}
+        with pytest.raises(KeyError, match="truncated"):
+            add_capture_fields(flow, entry)
+
     def test_non_empty_stream_buffer_requires_truncated_state(self, real_flow):
         body = b'{"ok": true}'
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -428,6 +428,22 @@ class TestAddCaptureFields:
         assert entry["request_body_encoding"] == "binary"
         assert "request_headers" in entry  # headers still captured
 
+    def test_large_binary_request_body_marks_truncated(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=b"\x89PNG" + b"\x00" * STREAM_BUFFER_LIMIT,
+            request_content_type="image/png",
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+        assert entry["request_body_truncated"] is True
+        assert "request_headers" in entry
+
     def test_binary_response_body_marks_encoding(self, real_flow):
         flow = real_flow(
             method="POST",
@@ -628,6 +644,23 @@ class TestAddCaptureFields:
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
 
+    def test_binary_stream_buffer_truncated_marks_truncation(self, real_flow):
+        body = b"\x00" * STREAM_BUFFER_LIMIT
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/octet-stream",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+        assert entry["response_body_truncated"] is True
+
     def test_stream_buffer_gzip_decompressed(self, real_flow):
         """Gzip-compressed stream_buffer should be decompressed for capture."""
         original = b'{"result": "ok"}'
@@ -666,6 +699,25 @@ class TestAddCaptureFields:
         assert "response_body" not in entry
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry  # headers still captured
+
+    def test_truncated_stream_buffer_gzip_empty_body_marks_truncation(self, real_flow):
+        compressed = gzip.compress(b"")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_content_type="application/json",
+            response_encoding="gzip",
+        )
+        flow.metadata["stream_buffer"] = bytearray(compressed)
+        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert "response_body_encoding" not in entry
+        assert entry["response_body_truncated"] is True
+        assert "response_headers" in entry
 
 
 class TestDecompression:

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -667,6 +667,35 @@ class TestAddCaptureFields:
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry
 
+    def test_non_empty_stream_buffer_requires_state(self, real_flow):
+        body = b'{"ok": true}'
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(body)
+        entry = {}
+        with pytest.raises(KeyError, match="truncated"):
+            add_capture_fields(flow, entry)
+
+    def test_non_empty_stream_buffer_requires_non_empty_state(self, real_flow):
+        body = b'{"ok": true}'
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {}
+        entry = {}
+        with pytest.raises(KeyError, match="truncated"):
+            add_capture_fields(flow, entry)
+
     def test_non_empty_stream_buffer_requires_truncated_state(self, real_flow):
         body = b'{"ok": true}'
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -6,6 +6,7 @@ import json
 import zlib
 
 import brotli
+import pytest
 import zstandard
 from mitmproxy import http
 
@@ -665,6 +666,21 @@ class TestAddCaptureFields:
         assert "response_body" not in entry
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry
+
+    def test_non_empty_stream_buffer_requires_truncated_state(self, real_flow):
+        body = b'{"ok": true}'
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"total_bytes": len(body)}
+        entry = {}
+        with pytest.raises(KeyError, match="truncated"):
+            add_capture_fields(flow, entry)
 
     def test_stream_buffer_truncated_marks_truncation(self, real_flow):
         """When stream_buffer was truncated, response_body_truncated should be set."""

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -593,6 +593,27 @@ class TestAddCaptureFields:
         assert entry["response_body_encoding"] == "base64"
         assert base64.b64decode(entry["response_body"]) == response_body
 
+    def test_large_non_utf8_text_bodies_capture_truncated_base64(self, real_flow):
+        request_body = b"\xff" + b"r" * STREAM_BUFFER_LIMIT
+        response_body = b"\xfe" + b"s" * STREAM_BUFFER_LIMIT
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_body=request_body,
+            request_content_type="text/plain",
+            response_body=response_body,
+            response_content_type="text/plain",
+            include_request_id=True,
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == request_body[:STREAM_BUFFER_LIMIT]
+        assert entry["request_body_truncated"] is True
+        assert entry["response_body_encoding"] == "base64"
+        assert base64.b64decode(entry["response_body"]) == response_body[:STREAM_BUFFER_LIMIT]
+        assert entry["response_body_truncated"] is True
+
     def test_captures_response_body_from_stream_buffer(self, real_flow):
         """When stream_buffer is present, response body should be read from it."""
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -710,6 +710,22 @@ class TestAddCaptureFields:
         with pytest.raises(KeyError, match="truncated"):
             add_capture_fields(flow, entry)
 
+    def test_non_empty_compressed_stream_buffer_requires_truncated_state(self, real_flow):
+        compressed = gzip.compress(b"")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            response_encoding="gzip",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(compressed)
+        flow.metadata["stream_buffer_state"] = {"total_bytes": len(compressed)}
+        entry = {}
+        with pytest.raises(KeyError, match="truncated"):
+            add_capture_fields(flow, entry)
+
     def test_non_empty_stream_buffer_requires_truncated_state(self, real_flow):
         body = b'{"ok": true}'
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -646,6 +646,23 @@ class TestAddCaptureFields:
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
 
+    def test_binary_stream_buffer_exactly_at_limit_not_truncated(self, real_flow):
+        body = b"\x00" * STREAM_BUFFER_LIMIT
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/octet-stream",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+        assert "response_body_truncated" not in entry
+
     def test_binary_stream_buffer_truncated_marks_truncation(self, real_flow):
         body = b"\x00" * STREAM_BUFFER_LIMIT
         flow = real_flow(
@@ -702,8 +719,8 @@ class TestAddCaptureFields:
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry  # headers still captured
 
-    def test_truncated_stream_buffer_gzip_empty_body_marks_truncation(self, real_flow):
-        compressed = gzip.compress(b"")
+    def test_truncated_stream_buffer_gzip_prefix_marks_truncation(self, real_flow):
+        compressed = gzip.compress(b"hello world")[:10]
         flow = real_flow(
             method="POST",
             host="api.example.com",

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -460,6 +460,21 @@ class TestAddCaptureFields:
         assert entry["response_body_encoding"] == "binary"
         assert "response_body_truncated" not in entry
 
+    def test_large_binary_response_body_marks_truncated(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+            response_body=b"\x00" * (STREAM_BUFFER_LIMIT + 1),
+            response_content_type="application/octet-stream",
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+        assert entry["response_body_truncated"] is True
+
     def test_request_body_exactly_at_limit_not_truncated(self, real_flow):
         body = b"x" * STREAM_BUFFER_LIMIT
         flow = real_flow(


### PR DESCRIPTION
## Summary
- record `{request,response}_body_truncated` as capture completeness metadata before body encoding classification
- preserve response stream truncation even when decompression yields an empty body
- add regression coverage for truncated binary request/response bodies and empty decompressed truncated streams

Fixes #14485

## Tests
- `pytest tests/test_body_capture.py`
- `pytest tests/`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`