### PR TITLE
feat: expose AX-derived computer use visible text

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -21,7 +21,36 @@ struct ChildEntry {
     let segment: String
 }
 
+struct ChildSource: Sendable {
+    let attribute: String
+    let prefix: String
+}
+
 let limits = SnapshotLimits()
+
+let childSources = [
+    ChildSource(attribute: kAXChildrenAttribute as String, prefix: "e"),
+    ChildSource(attribute: "AXRows", prefix: "r"),
+    ChildSource(attribute: "AXContents", prefix: "c"),
+    ChildSource(attribute: "AXVisibleChildren", prefix: "v"),
+    ChildSource(attribute: "AXVisibleRows", prefix: "a"),
+    ChildSource(attribute: "AXVisibleCells", prefix: "b"),
+    ChildSource(attribute: "AXVisibleColumns", prefix: "d"),
+    ChildSource(attribute: "AXSelectedChildren", prefix: "s"),
+    ChildSource(attribute: "AXSelectedRows", prefix: "q"),
+    ChildSource(attribute: "AXSelectedCells", prefix: "l"),
+]
+
+let visibleCollectionChildSources = [
+    ChildSource(attribute: "AXVisibleRows", prefix: "a"),
+    ChildSource(attribute: "AXVisibleCells", prefix: "b"),
+    ChildSource(attribute: "AXVisibleColumns", prefix: "d"),
+    ChildSource(attribute: "AXSelectedRows", prefix: "q"),
+    ChildSource(attribute: "AXSelectedCells", prefix: "l"),
+    ChildSource(attribute: "AXSelectedChildren", prefix: "s"),
+    ChildSource(attribute: "AXVisibleChildren", prefix: "v"),
+    ChildSource(attribute: "AXContents", prefix: "c"),
+]
 
 func isRecord(_ value: Any) -> [String: Any]? {
     return value as? [String: Any]
@@ -194,6 +223,23 @@ func stringValue(_ value: Any?) -> String? {
     return nil
 }
 
+func stringArrayValue(_ value: Any?) -> [String] {
+    if let strings = value as? [String] {
+        return strings.compactMap { entry in
+            stringValue(entry)
+        }
+    }
+    if let entries = value as? [Any] {
+        return entries.compactMap { entry in
+            stringValue(entry)
+        }
+    }
+    if let string = stringValue(value) {
+        return [string]
+    }
+    return []
+}
+
 func urlStringValue(_ value: Any?) -> String? {
     if let url = value as? URL {
         return stringValue(url.absoluteString)
@@ -313,6 +359,15 @@ func valueTypeDescription(_ value: Any?) -> String? {
     return nil
 }
 
+func titleElementText(_ element: AXUIElement) -> String? {
+    guard let titleElement = axElementValue(attribute(element, kAXTitleUIElementAttribute as CFString)) else {
+        return nil
+    }
+    return stringValue(attribute(titleElement, kAXTitleAttribute as CFString)) ??
+        stringValue(attribute(titleElement, kAXValueAttribute as CFString)) ??
+        stringValue(attribute(titleElement, kAXDescriptionAttribute as CFString))
+}
+
 func setAttribute(_ element: AXUIElement, _ name: CFString, _ value: CFTypeRef) throws {
     let error = AXUIElementSetAttributeValue(element, name, value)
     if error != .success {
@@ -362,15 +417,38 @@ func prefixedChildren(
         }
 }
 
-func collectChildren(_ element: AXUIElement) -> [ChildEntry] {
-    let candidates = prefixedChildren(element, kAXChildrenAttribute as CFString, "e") +
-        prefixedChildren(element, "AXRows" as CFString, "r") +
-        prefixedChildren(element, "AXContents" as CFString, "c") +
-        prefixedChildren(element, "AXVisibleChildren" as CFString, "v")
+func elementUsesVisibleCollectionSources(_ element: AXUIElement) -> Bool {
+    guard let role = role(element),
+          role == "AXList" || role == "AXOutline" || role == "AXTable"
+    else {
+        return false
+    }
+    return !attributeArray(element, "AXVisibleRows" as CFString).isEmpty ||
+        !attributeArray(element, "AXVisibleCells" as CFString).isEmpty ||
+        !attributeArray(element, "AXVisibleColumns" as CFString).isEmpty ||
+        !attributeArray(element, "AXSelectedChildren" as CFString).isEmpty ||
+        !attributeArray(element, "AXSelectedRows" as CFString).isEmpty ||
+        !attributeArray(element, "AXSelectedCells" as CFString).isEmpty
+}
 
+func collectChildren(_ element: AXUIElement) -> [ChildEntry] {
+    let sources = elementUsesVisibleCollectionSources(element)
+        ? visibleCollectionChildSources
+        : childSources
+    let candidates = sources.flatMap { source in
+        prefixedChildren(element, source.attribute as CFString, source.prefix)
+    }
+
+    var seenElements = Set<CFHashCode>()
     var seen = Set<String>()
     var children: [ChildEntry] = []
     for candidate in candidates {
+        let elementHash = CFHash(candidate.element)
+        if seenElements.contains(elementHash) {
+            continue
+        }
+        seenElements.insert(elementHash)
+
         let fingerprint = childFingerprint(candidate.element)
         if !fingerprint.isEmpty {
             if seen.contains(fingerprint) {
@@ -435,6 +513,22 @@ func describe(
     if let help = stringValue(attribute(element, kAXHelpAttribute as CFString)) {
         node["help"] = help
     }
+    if let placeholderValue = stringValue(attribute(element, kAXPlaceholderValueAttribute as CFString)) {
+        node["placeholderValue"] = placeholderValue
+    }
+    if let visibleText = stringValue(attribute(element, kAXVisibleTextAttribute as CFString)) {
+        node["visibleText"] = visibleText
+    }
+    if let text = stringValue(attribute(element, kAXTextAttribute as CFString)) {
+        node["text"] = text
+    }
+    if let titleElementText = titleElementText(element) {
+        node["titleElementText"] = titleElementText
+    }
+    let columnTitles = stringArrayValue(attribute(element, kAXColumnTitlesAttribute as CFString))
+    if !columnTitles.isEmpty {
+        node["columnTitles"] = columnTitles
+    }
     if let identifier = stringValue(attribute(element, kAXIdentifierAttribute as CFString)) {
         node["identifier"] = identifier
     }
@@ -452,6 +546,9 @@ func describe(
     }
     if let expanded = boolValue(attribute(element, kAXExpandedAttribute as CFString)) {
         node["expanded"] = expanded
+    }
+    if let hidden = boolValue(attribute(element, "AXHidden" as CFString)) {
+        node["hidden"] = hidden
     }
     let actions = actionNames(element)
     if !actions.isEmpty {
@@ -482,8 +579,11 @@ func describe(
 }
 
 func resolveIndex(_ segment: Substring) throws -> Int {
-    guard segment.count > 1,
-          let index = Int(segment.dropFirst()),
+    let indexText = segment.drop(while: { character in
+        !character.isNumber
+    })
+    guard !indexText.isEmpty,
+          let index = Int(indexText),
           index >= 0
     else {
         throw HelperFailure(
@@ -496,21 +596,15 @@ func resolveIndex(_ segment: Substring) throws -> Int {
 
 func childForSegment(_ element: AXUIElement, _ segment: Substring) throws -> AXUIElement {
     let index = try resolveIndex(segment)
-    let children: [AXUIElement]
-    if segment.hasPrefix("e") {
-        children = attributeArray(element, kAXChildrenAttribute as CFString)
-    } else if segment.hasPrefix("r") {
-        children = attributeArray(element, "AXRows" as CFString)
-    } else if segment.hasPrefix("c") {
-        children = attributeArray(element, "AXContents" as CFString)
-    } else if segment.hasPrefix("v") {
-        children = attributeArray(element, "AXVisibleChildren" as CFString)
-    } else {
+    guard let source = childSources.first(where: { source in
+        segment.hasPrefix(source.prefix)
+    }) else {
         throw HelperFailure(
             code: "unsupported_command",
             message: "Invalid element id segment: \(segment)"
         )
     }
+    let children = attributeArray(element, source.attribute as CFString)
 
     guard index < children.count else {
         throw HelperFailure(

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -31,23 +31,57 @@ export interface AccessibilityElementSnapshot {
   readonly id: string;
   readonly index?: number;
   readonly role?: string;
-  readonly roleDescription?: string;
   readonly subrole?: string;
+  readonly roleDescription?: string;
   readonly name?: string;
   readonly value?: string;
   readonly valueType?: string;
   readonly valueSettable?: boolean;
   readonly description?: string;
   readonly help?: string;
+  readonly placeholderValue?: string;
+  readonly visibleText?: string;
+  readonly text?: string;
+  readonly titleElementText?: string;
+  readonly columnTitles?: readonly string[];
   readonly identifier?: string;
   readonly url?: string;
   readonly focused?: boolean;
   readonly enabled?: boolean;
   readonly selected?: boolean;
   readonly expanded?: boolean;
+  readonly hidden?: boolean;
   readonly actions?: readonly string[];
   readonly bounds?: ComputerUseCoordinateBounds;
   readonly children?: readonly AccessibilityElementSnapshot[];
+}
+
+type AccessibilityTextSourceAttribute =
+  | "AXTitle"
+  | "AXValue"
+  | "AXDescription"
+  | "AXHelp"
+  | "AXPlaceholderValue"
+  | "AXVisibleText"
+  | "AXText"
+  | "AXTitleUIElement"
+  | "AXColumnTitles"
+  | "AXIdentifier"
+  | "AXURL";
+
+interface AccessibilityVisibleElement {
+  readonly elementIndex?: number;
+  readonly elementId: string;
+  readonly role?: string;
+  readonly text: string;
+  readonly source: "accessibility";
+  readonly sourceAttributes: readonly AccessibilityTextSourceAttribute[];
+  readonly bounds?: ComputerUseCoordinateBounds;
+  readonly focused?: boolean;
+  readonly enabled?: boolean;
+  readonly selected?: boolean;
+  readonly expanded?: boolean;
+  readonly actions?: readonly string[];
 }
 
 export interface AccessibilityAppStateSnapshot {
@@ -491,6 +525,19 @@ function stringHasValue(value: string | undefined): boolean {
   return value !== undefined && value.trim().length > 0;
 }
 
+function normalizeDisplayText(value: string): string {
+  return value.trim().replaceAll(/\s+/g, " ");
+}
+
+function stringArrayHasValue(value: readonly string[] | undefined): boolean {
+  return (
+    value !== undefined &&
+    value.some((entry) => {
+      return normalizeDisplayText(entry).length > 0;
+    })
+  );
+}
+
 function elementIsWebArea(element: AccessibilityElementSnapshot): boolean {
   return (
     element.role === "AXWebArea" ||
@@ -505,8 +552,18 @@ function elementHasMeaningfulContent(
     stringHasValue(element.name) ||
     stringHasValue(element.value) ||
     stringHasValue(element.description) ||
+    stringHasValue(element.help) ||
+    stringHasValue(element.placeholderValue) ||
+    stringHasValue(element.visibleText) ||
+    stringHasValue(element.text) ||
+    stringHasValue(element.titleElementText) ||
+    stringArrayHasValue(element.columnTitles) ||
+    stringHasValue(element.identifier) ||
+    stringHasValue(element.url) ||
     element.focused === true ||
     element.enabled === false ||
+    element.selected === true ||
+    element.expanded !== undefined ||
     (element.actions !== undefined && element.actions.length > 0)
   );
 }
@@ -548,6 +605,14 @@ export function normalizeAccessibilitySnapshot(
   ): AccessibilityElementSnapshot[] => {
     if (depth > limits.maxDepth) {
       pushUniqueReason(truncationReasons, "max_depth");
+      return [];
+    }
+    if (
+      depth > 0 &&
+      element.hidden === true &&
+      element.focused !== true &&
+      element.selected !== true
+    ) {
       return [];
     }
 
@@ -612,6 +677,191 @@ export function normalizeAccessibilitySnapshot(
         ? [...new Set(combinedReasons)]
         : snapshot.truncationReasons,
   };
+}
+
+function boundsIntersect(
+  lhs: ComputerUseCoordinateBounds,
+  rhs: ComputerUseCoordinateBounds,
+): boolean {
+  const lhsRight = lhs.x + lhs.width;
+  const lhsBottom = lhs.y + lhs.height;
+  const rhsRight = rhs.x + rhs.width;
+  const rhsBottom = rhs.y + rhs.height;
+  return (
+    lhs.width > 0 &&
+    lhs.height > 0 &&
+    rhs.width > 0 &&
+    rhs.height > 0 &&
+    lhs.x < rhsRight &&
+    lhsRight > rhs.x &&
+    lhs.y < rhsBottom &&
+    lhsBottom > rhs.y
+  );
+}
+
+function elementIsInCapturedSource(
+  element: AccessibilityElementSnapshot,
+  sourceBounds: ComputerUseCoordinateBounds | undefined,
+): boolean {
+  if (!sourceBounds || !element.bounds) {
+    return true;
+  }
+  return (
+    boundsIntersect(element.bounds, sourceBounds) ||
+    element.focused === true ||
+    element.selected === true
+  );
+}
+
+interface AccessibilityTextCandidate {
+  readonly text: string;
+  readonly sourceAttribute: AccessibilityTextSourceAttribute;
+}
+
+function pushTextCandidate(
+  candidates: AccessibilityTextCandidate[],
+  value: string | undefined,
+  sourceAttribute: AccessibilityTextSourceAttribute,
+): void {
+  if (!value) {
+    return;
+  }
+  const text = normalizeDisplayText(value);
+  if (text.length === 0) {
+    return;
+  }
+  candidates.push({ text, sourceAttribute });
+}
+
+function pushTextArrayCandidate(
+  candidates: AccessibilityTextCandidate[],
+  value: readonly string[] | undefined,
+  sourceAttribute: AccessibilityTextSourceAttribute,
+): void {
+  if (!value) {
+    return;
+  }
+  const text = value
+    .map(normalizeDisplayText)
+    .filter((entry) => {
+      return entry.length > 0;
+    })
+    .join(", ");
+  if (text.length === 0) {
+    return;
+  }
+  candidates.push({ text, sourceAttribute });
+}
+
+function elementTextCandidates(
+  element: AccessibilityElementSnapshot,
+): readonly AccessibilityTextCandidate[] {
+  const candidates: AccessibilityTextCandidate[] = [];
+  pushTextCandidate(candidates, element.name, "AXTitle");
+  pushTextCandidate(candidates, element.value, "AXValue");
+  pushTextCandidate(candidates, element.description, "AXDescription");
+  pushTextCandidate(candidates, element.help, "AXHelp");
+  pushTextCandidate(candidates, element.placeholderValue, "AXPlaceholderValue");
+  pushTextCandidate(candidates, element.visibleText, "AXVisibleText");
+  pushTextCandidate(candidates, element.text, "AXText");
+  pushTextCandidate(candidates, element.titleElementText, "AXTitleUIElement");
+  pushTextArrayCandidate(candidates, element.columnTitles, "AXColumnTitles");
+  pushTextCandidate(candidates, element.identifier, "AXIdentifier");
+  pushTextCandidate(candidates, element.url, "AXURL");
+  return candidates;
+}
+
+function visibleElementForSnapshotElement(
+  element: AccessibilityElementSnapshot,
+  sourceBounds: ComputerUseCoordinateBounds | undefined,
+): AccessibilityVisibleElement | null {
+  if (
+    element.hidden === true &&
+    element.focused !== true &&
+    element.selected !== true
+  ) {
+    return null;
+  }
+  if (!elementIsInCapturedSource(element, sourceBounds)) {
+    return null;
+  }
+
+  const candidates = elementTextCandidates(element);
+  const primary = candidates[0];
+  if (!primary) {
+    return null;
+  }
+
+  const sourceAttributes = candidates
+    .filter((candidate) => {
+      return candidate.text === primary.text;
+    })
+    .map((candidate) => {
+      return candidate.sourceAttribute;
+    });
+
+  return {
+    ...(element.index !== undefined ? { elementIndex: element.index } : {}),
+    elementId: element.id,
+    ...(element.role ? { role: element.role } : {}),
+    text: primary.text,
+    source: "accessibility",
+    sourceAttributes: [...new Set(sourceAttributes)],
+    ...(element.bounds ? { bounds: element.bounds } : {}),
+    ...(element.focused !== undefined ? { focused: element.focused } : {}),
+    ...(element.enabled !== undefined ? { enabled: element.enabled } : {}),
+    ...(element.selected !== undefined ? { selected: element.selected } : {}),
+    ...(element.expanded !== undefined ? { expanded: element.expanded } : {}),
+    ...(element.actions && element.actions.length > 0
+      ? { actions: element.actions }
+      : {}),
+  };
+}
+
+export function collectAccessibilityVisibleElements(
+  snapshot: AccessibilityAppStateSnapshot,
+  sourceBounds?: ComputerUseCoordinateBounds,
+): readonly AccessibilityVisibleElement[] {
+  const result: AccessibilityVisibleElement[] = [];
+  const seen = new Set<string>();
+
+  const visit = (element: AccessibilityElementSnapshot): void => {
+    const visibleElement = visibleElementForSnapshotElement(
+      element,
+      sourceBounds,
+    );
+    if (visibleElement) {
+      const key = `${visibleElement.elementId}\0${visibleElement.text}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(visibleElement);
+      }
+    }
+    for (const child of element.children ?? []) {
+      visit(child);
+    }
+  };
+
+  for (const element of snapshot.elements) {
+    visit(element);
+  }
+  return result;
+}
+
+function renderAccessibilityVisibleText(
+  visibleElements: readonly AccessibilityVisibleElement[],
+): string {
+  return visibleElements
+    .map((element) => {
+      const role = element.role ? ` ${element.role}` : "";
+      const source = element.sourceAttributes.join("+");
+      const selector =
+        element.elementIndex !== undefined
+          ? String(element.elementIndex)
+          : element.elementId;
+      return `${selector}${role} [${source}] ${element.text}`;
+    })
+    .join("\n");
 }
 
 function normalizeKeyToken(value: string): string {
@@ -882,7 +1132,12 @@ function elementPrimaryText(
   return (
     formatText(element.name) ??
     formatText(element.value) ??
+    formatText(element.visibleText) ??
+    formatText(element.text) ??
+    formatText(element.titleElementText) ??
     formatText(element.description) ??
+    formatText(element.placeholderValue) ??
+    formatText(element.identifier) ??
     formatText(element.url, 240)
   );
 }
@@ -913,6 +1168,30 @@ function elementDetails(
   const value = formatText(element.value);
   if (value && value !== primary) {
     details.push(`Value: ${value}`);
+  }
+  const visibleText = formatText(element.visibleText);
+  if (visibleText && visibleText !== primary) {
+    details.push(`Visible Text: ${visibleText}`);
+  }
+  const text = formatText(element.text);
+  if (text && text !== primary) {
+    details.push(`Text: ${text}`);
+  }
+  const titleElementText = formatText(element.titleElementText);
+  if (titleElementText && titleElementText !== primary) {
+    details.push(`Title Element: ${titleElementText}`);
+  }
+  const placeholderValue = formatText(element.placeholderValue);
+  if (placeholderValue && placeholderValue !== primary) {
+    details.push(`Placeholder: ${placeholderValue}`);
+  }
+  const columnTitles = formatText(element.columnTitles?.join(", "));
+  if (columnTitles && columnTitles !== primary) {
+    details.push(`Columns: ${columnTitles}`);
+  }
+  const identifier = formatText(element.identifier, 120);
+  if (identifier && identifier !== primary) {
+    details.push(`Identifier: ${identifier}`);
   }
   const url = formatText(element.url, 240);
   if (url && url !== primary) {
@@ -1096,9 +1375,16 @@ function buildComputerUseAppStateResult(
   snapshot: AccessibilityAppStateSnapshot,
   screenshot: ComputerUseScreenshotCaptureResult,
 ): Record<string, unknown> {
+  const visibleElements = collectAccessibilityVisibleElements(
+    snapshot,
+    screenshot.sourceBounds,
+  );
   return {
     ...publicAppStateSnapshot(snapshot),
     text: renderAccessibilityTree(snapshot),
+    visibleTextSource: "accessibility",
+    visibleText: renderAccessibilityVisibleText(visibleElements),
+    visibleElements,
     screenshot: screenshot.dataUrl,
     screenshotMimeType: "image/png",
     screenshotSource: screenshot.source,

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS,
   ComputerUseSnapshotStore,
+  collectAccessibilityVisibleElements,
   executeComputerUseCommand,
   normalizeAccessibilitySnapshot,
   renderAccessibilityTree,
@@ -537,6 +538,84 @@ describe("computer use desktop runtime", () => {
     );
   });
 
+  it("builds an AX-derived visible element summary", () => {
+    const snapshot = normalizeAccessibilitySnapshot({
+      app: "Things",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "Things",
+          bounds: { x: 0, y: 0, width: 800, height: 600 },
+          children: [
+            {
+              id: "w0.a0",
+              role: "AXRow",
+              description: "Hello Computer Use",
+              selected: true,
+              bounds: { x: 24, y: 120, width: 360, height: 24 },
+            },
+            {
+              id: "w0.a1",
+              role: "AXRow",
+              help: "Can you see this?",
+              bounds: { x: 24, y: 152, width: 360, height: 24 },
+            },
+            {
+              id: "w0.a2",
+              role: "AXRow",
+              value: "Hidden old task",
+              hidden: true,
+              bounds: { x: 24, y: 184, width: 360, height: 24 },
+            },
+            {
+              id: "w0.a3",
+              role: "AXRow",
+              value: "Scrolled away task",
+              bounds: { x: 24, y: 900, width: 360, height: 24 },
+            },
+          ],
+        },
+      ],
+    });
+
+    const visibleElements = collectAccessibilityVisibleElements(snapshot, {
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+
+    expect(visibleElements).toStrictEqual([
+      {
+        elementId: "w0",
+        role: "AXWindow",
+        text: "Things",
+        source: "accessibility",
+        sourceAttributes: ["AXTitle"],
+        bounds: { x: 0, y: 0, width: 800, height: 600 },
+      },
+      {
+        elementId: "w0.a0",
+        role: "AXRow",
+        text: "Hello Computer Use",
+        source: "accessibility",
+        sourceAttributes: ["AXDescription"],
+        bounds: { x: 24, y: 120, width: 360, height: 24 },
+        selected: true,
+      },
+      {
+        elementId: "w0.a1",
+        role: "AXRow",
+        text: "Can you see this?",
+        source: "accessibility",
+        sourceAttributes: ["AXHelp"],
+        bounds: { x: 24, y: 152, width: 360, height: 24 },
+      },
+    ]);
+  });
+
   it("compacts generic wrappers while preserving WebArea branching context", () => {
     const snapshot = {
       app: "Slack",
@@ -679,6 +758,18 @@ describe("computer use desktop runtime", () => {
       result: {
         app: "Safari",
         snapshotId: expect.stringMatching(/^desktop_/),
+        visibleTextSource: "accessibility",
+        visibleText: "0 AXWindow [AXTitle] Example",
+        visibleElements: [
+          {
+            elementIndex: 0,
+            elementId: "w0",
+            role: "AXWindow",
+            text: "Example",
+            source: "accessibility",
+            sourceAttributes: ["AXTitle"],
+          },
+        ],
         screenshot: "data:image/png;base64,abc123",
         screenshotMimeType: "image/png",
         screenshotSource: "window",
@@ -744,6 +835,7 @@ describe("computer use desktop runtime", () => {
                                   id: "w0.e0.e0.c0.v1",
                                   role: "AXTextArea",
                                   name: "Message composer",
+                                  placeholderValue: "Type a message",
                                   actions: ["AXConfirm"],
                                 },
                               ],
@@ -782,6 +874,22 @@ describe("computer use desktop runtime", () => {
     expect(result.result.text).toContain("Release notes posted");
     expect(result.result.text).toContain("text entry area Message composer");
     expect(result.result.text).toContain("Secondary Actions: Confirm");
+    expect(result.result.visibleText).toContain(
+      "AXStaticText [AXValue] Release notes posted",
+    );
+    expect(result.result.visibleElements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          elementIndex: expect.any(Number),
+          elementId: "w0.e0.e0.c0.v1",
+          role: "AXTextArea",
+          text: "Message composer",
+          source: "accessibility",
+          sourceAttributes: ["AXTitle"],
+          actions: ["AXConfirm"],
+        }),
+      ]),
+    );
     expect(result.result.truncated).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- expand the native macOS helper to walk visible/selected AX collection attributes and capture more AX text/state fields
- add AX-derived `visibleText` and structured `visibleElements` to Desktop Computer Use app state results
- keep screenshot fallback semantics explicit by marking the new summary as `accessibility` sourced, not OCR

Closes #14503

## Validation

- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
