### PR TITLE
fix: cancel guest process before runner cleanup

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -4093,6 +4093,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_in_sandbox_returns_cancelled_when_wait_fails_after_process_cancel() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let wait_gate = Arc::new(tokio::sync::Notify::new());
+        let mut overrides = sandbox_mock::MockSandboxOverrides::with_wait_process_gate(wait_gate);
+        overrides.set_wait_process_error("wait failed after cancel");
+        let overrides = Arc::new(overrides);
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+        cancel.cancel();
+
+        let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            overrides.process_cancel_calls().as_slice(),
+            [sandbox_mock::ProcessCancelCall {
+                timeout: PROCESS_CANCEL_WRITE_TIMEOUT
+            }]
+        );
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.exit_code),
+            Some(EXIT_SIGKILL)
+        );
+    }
+
+    #[tokio::test]
     async fn run_in_sandbox_returns_cancelled_when_terminal_grace_times_out() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -457,7 +457,6 @@ async fn execute_new_sandbox(
         },
         telemetry,
         cancel.clone(),
-        PROCESS_CANCEL_TIMEOUTS,
     )
     .await;
 
@@ -546,7 +545,6 @@ async fn execute_reused_sandbox(
         },
         telemetry,
         cancel.clone(),
-        PROCESS_CANCEL_TIMEOUTS,
     )
     .await;
 
@@ -672,6 +670,26 @@ struct RunStart<'a> {
 }
 
 async fn run_in_sandbox(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+    start: RunStart<'_>,
+    telemetry: &mut JobTelemetry,
+    cancel: CancellationToken,
+) -> RunnerResult<AgentExecutionResult> {
+    run_in_sandbox_with_process_cancel_timeouts(
+        sandbox,
+        context,
+        config,
+        start,
+        telemetry,
+        cancel,
+        PROCESS_CANCEL_TIMEOUTS,
+    )
+    .await
+}
+
+async fn run_in_sandbox_with_process_cancel_timeouts(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     config: &ExecutorConfig,
@@ -3890,7 +3908,7 @@ mod tests {
     ) -> tokio::task::JoinHandle<RunnerResult<AgentExecutionResult>> {
         tokio::spawn(async move {
             let mut telemetry = test_telemetry(&config, &ctx);
-            run_in_sandbox(
+            run_in_sandbox_with_process_cancel_timeouts(
                 &*sandbox,
                 &ctx,
                 &config,
@@ -3946,7 +3964,6 @@ mod tests {
             },
             &mut telemetry,
             cancel.clone(),
-            PROCESS_CANCEL_TIMEOUTS,
         )
         .await
         .unwrap();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -4111,7 +4111,7 @@ mod tests {
             cancel.clone(),
             ProcessCancelTimeouts {
                 write: PROCESS_CANCEL_WRITE_TIMEOUT,
-                terminal_grace: Duration::from_millis(1),
+                terminal_grace: Duration::ZERO,
             },
         );
         cancel.cancel();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -41,6 +41,8 @@ const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
 /// Maximum time to spend writing the guest cancel frame after a user cancel.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Grace period for the guest to report a terminal status after cancel is sent.
+/// This covers vsock-guest's 5s stdout/stderr drain deadline after it kills
+/// the cancelled process.
 const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(6);
 /// Exit code when a process is killed by SIGKILL (128 + 9).
 const EXIT_SIGKILL: i32 = 137;
@@ -1969,6 +1971,8 @@ mod tests {
     use async_trait::async_trait;
     use sandbox_mock::MockSandboxFactory;
     use std::sync::Arc;
+
+    const RUN_IN_SANDBOX_TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
     fn api_storage(name: &str, mount_path: &str, version: &str, archive_url: &str) -> StorageEntry {
         StorageEntry {
@@ -3950,11 +3954,11 @@ mod tests {
 
         assert!(
             overrides
-                .wait_for_process_cancel_calls(1, Duration::from_secs(1))
+                .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
                 .await
         );
 
-        let result = tokio::time::timeout(Duration::from_secs(1), run_task)
+        let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
             .await
             .unwrap()
             .unwrap()
@@ -3994,7 +3998,7 @@ mod tests {
         let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
         cancel.cancel();
 
-        let result = tokio::time::timeout(Duration::from_secs(1), run_task)
+        let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
             .await
             .unwrap()
             .unwrap()
@@ -4022,7 +4026,7 @@ mod tests {
         let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
         cancel.cancel();
 
-        let result = tokio::time::timeout(Duration::from_secs(1), run_task)
+        let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
             .await
             .unwrap()
             .unwrap()

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -44,6 +44,10 @@ const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 /// This covers vsock-guest's 5s stdout/stderr drain deadline after it kills
 /// the cancelled process.
 const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(6);
+const PROCESS_CANCEL_TIMEOUTS: ProcessCancelTimeouts = ProcessCancelTimeouts {
+    write: PROCESS_CANCEL_WRITE_TIMEOUT,
+    terminal_grace: PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT,
+};
 /// Exit code when a process is killed by SIGKILL (128 + 9).
 const EXIT_SIGKILL: i32 = 137;
 /// Raw SIGKILL signal number.
@@ -169,6 +173,12 @@ impl AgentStdoutStreamDiagnostics {
     fn is_empty(self) -> bool {
         !self.chunk_truncated && !self.stream_overflowed
     }
+}
+
+#[derive(Clone, Copy)]
+struct ProcessCancelTimeouts {
+    write: Duration,
+    terminal_grace: Duration,
 }
 
 struct AgentExecutionResult {
@@ -447,6 +457,7 @@ async fn execute_new_sandbox(
         },
         telemetry,
         cancel.clone(),
+        PROCESS_CANCEL_TIMEOUTS,
     )
     .await;
 
@@ -535,6 +546,7 @@ async fn execute_reused_sandbox(
         },
         telemetry,
         cancel.clone(),
+        PROCESS_CANCEL_TIMEOUTS,
     )
     .await;
 
@@ -666,6 +678,7 @@ async fn run_in_sandbox(
     start: RunStart<'_>,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
+    process_cancel_timeouts: ProcessCancelTimeouts,
 ) -> RunnerResult<AgentExecutionResult> {
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -800,10 +813,10 @@ async fn run_in_sandbox(
                 Ok(cancelled_agent_process_exit(process_pid, false))
             };
             match process_cancel {
-                Some(process_cancel) => match process_cancel.cancel(PROCESS_CANCEL_WRITE_TIMEOUT).await {
+                Some(process_cancel) => match process_cancel.cancel(process_cancel_timeouts.write).await {
                     Ok(()) => {
                         match tokio::time::timeout(
-                            PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT,
+                            process_cancel_timeouts.terminal_grace,
                             &mut wait_process,
                         )
                         .await
@@ -836,7 +849,7 @@ async fn run_in_sandbox(
                                 warn!(
                                     run_id = %context.run_id,
                                     pid = process_pid,
-                                    timeout_ms = PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT.as_millis(),
+                                    timeout_ms = process_cancel_timeouts.terminal_grace.as_millis(),
                                     "timed out waiting for cancelled guest process"
                                 );
                                 (cancelled_exit(), true, true)
@@ -3859,6 +3872,22 @@ mod tests {
         config: ExecutorConfig,
         cancel: tokio_util::sync::CancellationToken,
     ) -> tokio::task::JoinHandle<RunnerResult<AgentExecutionResult>> {
+        spawn_run_in_sandbox_test_with_timeouts(
+            sandbox,
+            ctx,
+            config,
+            cancel,
+            PROCESS_CANCEL_TIMEOUTS,
+        )
+    }
+
+    fn spawn_run_in_sandbox_test_with_timeouts(
+        sandbox: Box<dyn Sandbox>,
+        ctx: ExecutionContext,
+        config: ExecutorConfig,
+        cancel: tokio_util::sync::CancellationToken,
+        process_cancel_timeouts: ProcessCancelTimeouts,
+    ) -> tokio::task::JoinHandle<RunnerResult<AgentExecutionResult>> {
         tokio::spawn(async move {
             let mut telemetry = test_telemetry(&config, &ctx);
             run_in_sandbox(
@@ -3872,6 +3901,7 @@ mod tests {
                 },
                 &mut telemetry,
                 cancel,
+                process_cancel_timeouts,
             )
             .await
         })
@@ -3916,6 +3946,7 @@ mod tests {
             },
             &mut telemetry,
             cancel.clone(),
+            PROCESS_CANCEL_TIMEOUTS,
         )
         .await
         .unwrap();
@@ -4024,6 +4055,48 @@ mod tests {
         let ctx = minimal_context();
         let cancel = tokio_util::sync::CancellationToken::new();
         let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+        cancel.cancel();
+
+        let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            overrides.process_cancel_calls().as_slice(),
+            [sandbox_mock::ProcessCancelCall {
+                timeout: PROCESS_CANCEL_WRITE_TIMEOUT
+            }]
+        );
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.exit_code),
+            Some(EXIT_SIGKILL)
+        );
+    }
+
+    #[tokio::test]
+    async fn run_in_sandbox_returns_cancelled_when_terminal_grace_times_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let wait_gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+            wait_gate,
+        ));
+        overrides.set_process_cancel_releases_wait_gate(false);
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let run_task = spawn_run_in_sandbox_test_with_timeouts(
+            sandbox,
+            ctx,
+            config,
+            cancel.clone(),
+            ProcessCancelTimeouts {
+                write: PROCESS_CANCEL_WRITE_TIMEOUT,
+                terminal_grace: Duration::from_millis(1),
+            },
+        );
         cancel.cancel();
 
         let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -38,6 +38,10 @@ use crate::ids::RunId;
 
 /// Maximum wall-clock time for a single job (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
+/// Maximum time to spend writing the guest cancel frame after a user cancel.
+const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+/// Grace period for the guest to report a terminal status after cancel is sent.
+const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(6);
 /// Exit code when a process is killed by SIGKILL (128 + 9).
 const EXIT_SIGKILL: i32 = 137;
 /// Raw SIGKILL signal number.
@@ -213,6 +217,12 @@ fn non_empty_failure_error(exit_code: i32, error: String) -> String {
 
 fn agent_exit_failure_message(exit_code: i32) -> String {
     format!("Agent exited with code {exit_code}")
+}
+
+fn cancelled_agent_process_exit(pid: u32, stream_overflowed: bool) -> sandbox::ProcessExit {
+    let mut exit = sandbox::ProcessExit::new(pid, EXIT_SIGKILL, Vec::new(), Vec::new());
+    exit.stream_overflowed = stream_overflowed;
+    exit
 }
 
 /// Execute a single job inside a **new** Firecracker VM.
@@ -769,14 +779,87 @@ async fn run_in_sandbox(
         .take_stdout_receiver()
         .map(|stdout_rx| tokio::spawn(drain_stdout_to_file(stdout_rx, host_log_path)));
 
-    // 6. Wait for exit (or cancellation).
-    // On cancel we return immediately — the caller (execute_new_sandbox) will
-    // call sandbox.stop() + factory.destroy() in its cleanup path.
-    let (result, wait_cancelled) = tokio::select! {
-        result = sandbox.wait_process(handle, JOB_TIMEOUT) => (result, false),
+    // 6. Wait for exit (or cancellation). On cancel, ask the guest to cancel the
+    // supervised process and briefly wait for its terminal status so the vsock
+    // operation can be removed before sandbox cleanup closes the connection.
+    let process_pid = handle.pid;
+    let process_cancel = handle.take_cancel_handle();
+    let wait_process = sandbox.wait_process(handle, JOB_TIMEOUT);
+    tokio::pin!(wait_process);
+    let (result, wait_cancelled, abort_stdout_drain) = tokio::select! {
+        biased;
+        result = &mut wait_process => {
+            let abort_stdout_drain = result.is_err();
+            (result, false, abort_stdout_drain)
+        }
         () = cancel.cancelled() => {
-            info!(run_id = %context.run_id, "cancel received, aborting sandbox wait");
-            (Ok(sandbox::ProcessExit::new(0, EXIT_SIGKILL, Vec::new(), Vec::new())), true)
+            info!(run_id = %context.run_id, "cancel received, cancelling guest process");
+            let cancelled_exit = || -> sandbox::Result<sandbox::ProcessExit> {
+                Ok(cancelled_agent_process_exit(process_pid, false))
+            };
+            match process_cancel {
+                Some(process_cancel) => match process_cancel.cancel(PROCESS_CANCEL_WRITE_TIMEOUT).await {
+                    Ok(()) => {
+                        match tokio::time::timeout(
+                            PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT,
+                            &mut wait_process,
+                        )
+                        .await
+                        {
+                            Ok(Ok(exit)) => {
+                                info!(
+                                    run_id = %context.run_id,
+                                    pid = process_pid,
+                                    "cancelled guest process reached terminal status"
+                                );
+                                (
+                                    Ok(cancelled_agent_process_exit(
+                                        process_pid,
+                                        exit.stream_overflowed,
+                                    )),
+                                    true,
+                                    false,
+                                )
+                            }
+                            Ok(Err(error)) => {
+                                warn!(
+                                    run_id = %context.run_id,
+                                    pid = process_pid,
+                                    error = %error,
+                                    "guest process wait failed after cancellation"
+                                );
+                                (cancelled_exit(), true, true)
+                            }
+                            Err(_) => {
+                                warn!(
+                                    run_id = %context.run_id,
+                                    pid = process_pid,
+                                    timeout_ms = PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT.as_millis(),
+                                    "timed out waiting for cancelled guest process"
+                                );
+                                (cancelled_exit(), true, true)
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        warn!(
+                            run_id = %context.run_id,
+                            pid = process_pid,
+                            error = %error,
+                            "failed to send guest process cancellation"
+                        );
+                        (cancelled_exit(), true, true)
+                    }
+                },
+                None => {
+                    warn!(
+                        run_id = %context.run_id,
+                        pid = process_pid,
+                        "sandbox does not support guest process cancellation"
+                    );
+                    (cancelled_exit(), true, true)
+                }
+            }
         }
     };
 
@@ -785,7 +868,7 @@ async fn run_in_sandbox(
     // prevent blocking indefinitely on the drain task.
     let mut stdout_drain_report = StdoutDrainReport::default();
     if let Some(task) = stream_task {
-        if wait_cancelled || result.is_err() {
+        if abort_stdout_drain || result.is_err() {
             task.abort();
             let _ = task.await;
         } else {
@@ -3750,6 +3833,46 @@ mod tests {
         Ok((outcome.exit_code(), outcome.error().map(ToOwned::to_owned)))
     }
 
+    async fn create_overridden_sandbox(
+        overrides: Arc<sandbox_mock::MockSandboxOverrides>,
+    ) -> Box<dyn Sandbox> {
+        sandbox_mock::MockSandboxFactory::with_overrides(overrides)
+            .create(SandboxConfig {
+                id: SandboxId::new_v4(),
+                resources: sandbox::ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 2048,
+                },
+                device_rate_limits: None,
+            })
+            .await
+            .unwrap()
+    }
+
+    fn spawn_run_in_sandbox_test(
+        sandbox: Box<dyn Sandbox>,
+        ctx: ExecutionContext,
+        config: ExecutorConfig,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> tokio::task::JoinHandle<RunnerResult<AgentExecutionResult>> {
+        tokio::spawn(async move {
+            let mut telemetry = test_telemetry(&config, &ctx);
+            run_in_sandbox(
+                &*sandbox,
+                &ctx,
+                &config,
+                RunStart {
+                    restore_guest_state: false,
+                    reuse_result: SandboxReuseResult::PoolMiss,
+                    prev_storage: None,
+                },
+                &mut telemetry,
+                cancel,
+            )
+            .await
+        })
+    }
+
     #[tokio::test]
     async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
         let dir = tempfile::tempdir().unwrap();
@@ -3801,6 +3924,119 @@ mod tests {
                 chunk_truncated: true,
                 stream_overflowed: false,
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let wait_gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+            Arc::clone(&wait_gate),
+        ));
+        overrides.push_start_process_stdout_chunks(vec![ProcessOutputChunk {
+            bytes: b"partial stdout".to_vec(),
+            truncated: true,
+        }]);
+        let mut exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+        exit.stream_overflowed = true;
+        overrides.push_wait_process_exit(exit);
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+        cancel.cancel();
+
+        assert!(
+            overrides
+                .wait_for_process_cancel_calls(1, Duration::from_secs(1))
+                .await
+        );
+
+        let result = tokio::time::timeout(Duration::from_secs(1), run_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            overrides.process_cancel_calls().as_slice(),
+            [sandbox_mock::ProcessCancelCall {
+                timeout: PROCESS_CANCEL_WRITE_TIMEOUT
+            }]
+        );
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.exit_code),
+            Some(EXIT_SIGKILL)
+        );
+        assert_eq!(
+            result.stdout_stream_diagnostics,
+            AgentStdoutStreamDiagnostics {
+                chunk_truncated: true,
+                stream_overflowed: true,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn run_in_sandbox_returns_cancelled_when_cancel_handle_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let wait_gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+            wait_gate,
+        ));
+        overrides.set_process_cancel_supported(false);
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), run_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert!(overrides.process_cancel_calls().is_empty());
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.exit_code),
+            Some(EXIT_SIGKILL)
+        );
+    }
+
+    #[tokio::test]
+    async fn run_in_sandbox_returns_cancelled_when_process_cancel_send_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let wait_gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+            wait_gate,
+        ));
+        overrides.push_process_cancel_error("cancel write failed");
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), run_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            overrides.process_cancel_calls().as_slice(),
+            [sandbox_mock::ProcessCancelCall {
+                timeout: PROCESS_CANCEL_WRITE_TIMEOUT
+            }]
+        );
+        assert_eq!(
+            result.failure.as_ref().map(|failure| failure.exit_code),
+            Some(EXIT_SIGKILL)
         );
     }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -9,11 +9,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessControlHandle,
-    GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlMode, ProcessExit,
-    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxError,
-    SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
-    StartProcessRequest,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessCancelHandle,
+    GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
+    ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
+    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
+    SandboxOperationReason, StartProcessRequest,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -2013,13 +2013,22 @@ impl Sandbox for FirecrackerSandbox {
                 } else {
                     (None, None)
                 };
+                let process_cancel = handle.take_cancel_handle().map(|cancel| {
+                    GuestProcessCancelHandle::new(move |timeout| {
+                        Box::pin(async move { cancel.cancel(timeout).await })
+                    })
+                });
                 let wait = GuestProcessWaiter::new(move |timeout| {
                     Box::pin(async move {
                         let result = handle.wait(timeout).await?;
                         Ok(supervised_exec_result_to_process_exit(pid, result))
                     })
                 });
-                let public_handle = GuestProcessHandle::new(pid, stdout_rx, process_control, wait);
+                let mut public_handle =
+                    GuestProcessHandle::new(pid, stdout_rx, process_control, wait);
+                if let Some(process_cancel) = process_cancel {
+                    public_handle = public_handle.with_cancel_handle(process_cancel);
+                }
                 Ok(match close_stdout {
                     Some(close_stdout) => public_handle.with_unclaimed_stdout_cleanup(close_stdout),
                     None => public_handle,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -561,6 +561,12 @@ impl MockSandboxOverrides {
             .push_back(chunks);
     }
 
+    /// Configure `wait_process` to return an error while preserving any other
+    /// overrides already set on this instance.
+    pub fn set_wait_process_error(&mut self, msg: impl Into<String>) {
+        self.wait_process_error = Some(msg.into());
+    }
+
     /// Configure whether future `start_process` handles include a cancel handle.
     pub fn set_process_cancel_supported(&self, supported: bool) {
         *self.process_cancel_supported.lock_ignoring_poison() = supported;

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -331,6 +331,10 @@ pub struct MockSandboxOverrides {
     process_cancel_notify: tokio::sync::Notify,
     /// FIFO queue of process cancel errors consumed by cancel handles.
     process_cancel_errors: Mutex<VecDeque<String>>,
+    /// Whether a successful process cancel releases the configured
+    /// `wait_process` gate. Tests can disable this to exercise bounded wait
+    /// timeout paths after cancel is sent.
+    process_cancel_releases_wait_gate: Mutex<bool>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -363,6 +367,7 @@ impl MockSandboxOverrides {
             process_cancel_calls: Mutex::new(Vec::new()),
             process_cancel_notify: tokio::sync::Notify::new(),
             process_cancel_errors: Mutex::new(VecDeque::new()),
+            process_cancel_releases_wait_gate: Mutex::new(true),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
             destroy_calls: Mutex::new(0),
@@ -587,6 +592,14 @@ impl MockSandboxOverrides {
         self.process_cancel_errors
             .lock_ignoring_poison()
             .push_back(message.into());
+    }
+
+    /// Configure whether successful process cancellation releases a configured
+    /// `wait_process` gate.
+    pub fn set_process_cancel_releases_wait_gate(&self, releases: bool) {
+        *self
+            .process_cancel_releases_wait_gate
+            .lock_ignoring_poison() = releases;
     }
 }
 
@@ -1039,7 +1052,11 @@ impl Sandbox for MockSandbox {
                     {
                         return Err(std::io::Error::other(message));
                     }
-                    if let Some(gate) = &overrides.wait_process_gate {
+                    if *overrides
+                        .process_cancel_releases_wait_gate
+                        .lock_ignoring_poison()
+                        && let Some(gate) = &overrides.wait_process_gate
+                    {
                         gate.notify_one();
                     }
                     Ok(())

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -58,6 +58,11 @@ pub struct StartProcessCall {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessCancelCall {
+    pub timeout: Duration,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WriteFileCall {
     pub path: String,
     pub content: Vec<u8>,
@@ -317,6 +322,15 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of stdout chunk batches emitted by factory-created
     /// sandboxes during streaming start_process calls.
     start_process_stdout_chunks: Mutex<VecDeque<Vec<ProcessOutputChunk>>>,
+    /// Whether factory-created sandboxes expose a process cancel handle.
+    process_cancel_supported: Mutex<bool>,
+    /// Recorded process cancel calls across all sandboxes built from this
+    /// override set.
+    process_cancel_calls: Mutex<Vec<ProcessCancelCall>>,
+    /// Wakes tests waiting for process cancel calls to be recorded.
+    process_cancel_notify: tokio::sync::Notify,
+    /// FIFO queue of process cancel errors consumed by cancel handles.
+    process_cancel_errors: Mutex<VecDeque<String>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -345,6 +359,10 @@ impl MockSandboxOverrides {
             destroy_behaviors: Mutex::new(VecDeque::new()),
             start_process_calls: Mutex::new(Vec::new()),
             start_process_stdout_chunks: Mutex::new(VecDeque::new()),
+            process_cancel_supported: Mutex::new(true),
+            process_cancel_calls: Mutex::new(Vec::new()),
+            process_cancel_notify: tokio::sync::Notify::new(),
+            process_cancel_errors: Mutex::new(VecDeque::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
             destroy_calls: Mutex::new(0),
@@ -536,6 +554,39 @@ impl MockSandboxOverrides {
         self.start_process_stdout_chunks
             .lock_ignoring_poison()
             .push_back(chunks);
+    }
+
+    /// Configure whether future `start_process` handles include a cancel handle.
+    pub fn set_process_cancel_supported(&self, supported: bool) {
+        *self.process_cancel_supported.lock_ignoring_poison() = supported;
+    }
+
+    /// Recorded process cancel calls across all sandboxes built from this
+    /// override set, in call order.
+    pub fn process_cancel_calls(&self) -> Vec<ProcessCancelCall> {
+        self.process_cancel_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Wait until at least `expected` process cancel calls have been recorded.
+    pub async fn wait_for_process_cancel_calls(&self, expected: usize, timeout: Duration) -> bool {
+        tokio::time::timeout(timeout, async {
+            loop {
+                let notified = self.process_cancel_notify.notified();
+                if self.process_cancel_calls.lock_ignoring_poison().len() >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// Queue a process cancel send error consumed by the next cancel handle.
+    pub fn push_process_cancel_error(&self, message: impl Into<String>) {
+        self.process_cancel_errors
+            .lock_ignoring_poison()
+            .push_back(message.into());
     }
 }
 
@@ -969,15 +1020,45 @@ impl Sandbox for MockSandbox {
                 Box::pin(async move { Ok(ProcessControlAck { message_id }) })
             })
         });
+        let process_cancel = self.overrides.as_ref().and_then(|overrides| {
+            if !*overrides.process_cancel_supported.lock_ignoring_poison() {
+                return None;
+            }
+            let overrides = Arc::clone(overrides);
+            Some(GuestProcessCancelHandle::new(move |timeout| {
+                Box::pin(async move {
+                    overrides
+                        .process_cancel_calls
+                        .lock_ignoring_poison()
+                        .push(ProcessCancelCall { timeout });
+                    overrides.process_cancel_notify.notify_waiters();
+                    if let Some(message) = overrides
+                        .process_cancel_errors
+                        .lock_ignoring_poison()
+                        .pop_front()
+                    {
+                        return Err(std::io::Error::other(message));
+                    }
+                    if let Some(gate) = &overrides.wait_process_gate {
+                        gate.notify_one();
+                    }
+                    Ok(())
+                })
+            }))
+        });
 
-        Ok(GuestProcessHandle::new(
+        let mut handle = GuestProcessHandle::new(
             1,
             rx,
             control,
             GuestProcessWaiter::new(|_timeout| {
                 Box::pin(std::future::pending::<std::io::Result<ProcessExit>>())
             }),
-        ))
+        );
+        if let Some(process_cancel) = process_cancel {
+            handle = handle.with_cancel_handle(process_cancel);
+        }
+        Ok(handle)
     }
 
     async fn wait_process(

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -43,7 +43,8 @@ pub use snapshot::{
 };
 pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, GuestProcessControlHandle,
-    GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlMode, ProcessExit,
-    ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, GuestProcessCancelHandle,
+    GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
+    ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver,
+    StartProcessRequest,
 };

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -605,4 +605,22 @@ mod tests {
 
         assert!(closed.load(Ordering::SeqCst));
     }
+
+    #[test]
+    fn guest_process_handle_takes_cancel_handle_once() {
+        let mut handle = GuestProcessHandle::new(
+            42,
+            None,
+            None,
+            GuestProcessWaiter::new(|_| {
+                Box::pin(async { Ok(ProcessExit::new(42, 0, Vec::new(), Vec::new())) })
+            }),
+        )
+        .with_cancel_handle(GuestProcessCancelHandle::new(|_| {
+            Box::pin(async { Ok(()) })
+        }));
+
+        assert!(handle.take_cancel_handle().is_some());
+        assert!(handle.take_cancel_handle().is_none());
+    }
 }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -194,6 +194,33 @@ impl GuestProcessWaiter {
     }
 }
 
+/// Backend-owned future that resolves after a best-effort process cancel request
+/// has been sent to the guest.
+pub type GuestProcessCancelFuture =
+    Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + 'static>>;
+
+type GuestProcessCancelFn = dyn FnOnce(Duration) -> GuestProcessCancelFuture + Send + 'static;
+
+/// One-shot handle for asking the backend to cancel a started guest process.
+pub struct GuestProcessCancelHandle {
+    cancel: Box<GuestProcessCancelFn>,
+}
+
+impl GuestProcessCancelHandle {
+    pub fn new<F>(cancel: F) -> Self
+    where
+        F: FnOnce(Duration) -> GuestProcessCancelFuture + Send + 'static,
+    {
+        Self {
+            cancel: Box::new(cancel),
+        }
+    }
+
+    pub async fn cancel(self, timeout: Duration) -> std::io::Result<()> {
+        (self.cancel)(timeout).await
+    }
+}
+
 /// Backend-owned future that resolves when a process-control message is acknowledged.
 pub type GuestProcessControlFuture =
     Pin<Box<dyn Future<Output = std::io::Result<ProcessControlAck>> + Send + 'static>>;
@@ -245,6 +272,7 @@ pub struct GuestProcessHandle {
     /// `None` when the backend does not support streaming.
     stdout_rx: Option<ProcessOutputReceiver>,
     control: Option<GuestProcessControlHandle>,
+    cancel: Option<GuestProcessCancelHandle>,
     wait: Option<GuestProcessWaiter>,
     close_unclaimed_stdout: Option<Box<dyn FnOnce() + Send + 'static>>,
 }
@@ -261,6 +289,7 @@ impl GuestProcessHandle {
             pid,
             stdout_rx,
             control,
+            cancel: None,
             wait: Some(wait),
             close_unclaimed_stdout: None,
         }
@@ -285,6 +314,12 @@ impl GuestProcessHandle {
         self
     }
 
+    /// Attach a one-shot process cancel handle provided by the backend.
+    pub fn with_cancel_handle(mut self, cancel: GuestProcessCancelHandle) -> Self {
+        self.cancel = Some(cancel);
+        self
+    }
+
     /// Return a cloneable control handle when this process was started with a
     /// control sink.
     pub fn control_handle(&self) -> Option<GuestProcessControlHandle> {
@@ -298,6 +333,11 @@ impl GuestProcessHandle {
     /// pass the handle to that trait method instead.
     pub fn take_waiter(&mut self) -> Option<GuestProcessWaiter> {
         self.wait.take()
+    }
+
+    /// Consume the backend process cancel handle, if supported.
+    pub fn take_cancel_handle(&mut self) -> Option<GuestProcessCancelHandle> {
+        self.cancel.take()
     }
 
     /// Drop a stdout receiver that the caller did not take before waiting.

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -815,9 +815,44 @@ pub struct SupervisedExecHandle {
     seq: Option<u32>,
     pid: u32,
     diagnostic: ExecOperationDiagnostic,
+    cancel_handle_taken: bool,
     result_rx: Option<oneshot::Receiver<io::Result<ExecOperationResult>>>,
     stream_rx: Option<mpsc::Receiver<ExecOutputEvent>>,
     control: Option<ExecControlHandle>,
+}
+
+/// One-shot handle that sends `MSG_EXEC_CANCEL` for a supervised exec operation.
+pub struct SupervisedExecCancelHandle {
+    shared: Arc<Shared>,
+    seq: u32,
+    diagnostic: ExecOperationDiagnostic,
+}
+
+impl SupervisedExecCancelHandle {
+    /// Send the cancel frame without consuming the terminal exec result.
+    ///
+    /// The paired [`SupervisedExecHandle`] still owns the result receiver and must
+    /// be waited or abandoned by its caller.
+    pub async fn cancel(self, timeout: Duration) -> io::Result<()> {
+        tokio::time::timeout(
+            timeout,
+            send_supervised_exec_cancel_frame(&self.shared, self.seq, &self.diagnostic),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            tracing::warn!(
+                seq = self.seq,
+                label = %self.diagnostic.label_log,
+                elapsed_ms = self.diagnostic.elapsed_ms(),
+                "supervised exec operation cancel write timed out"
+            );
+            self.shared.poison_connection();
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "supervised exec cancel write timed out",
+            ))
+        })
+    }
 }
 
 impl SupervisedExecHandle {
@@ -829,6 +864,21 @@ impl SupervisedExecHandle {
     /// Return a cloneable exec-control handle when control was enabled.
     pub fn control_handle(&self) -> Option<ExecControlHandle> {
         self.control.clone()
+    }
+
+    /// Take a one-shot handle that can send `MSG_EXEC_CANCEL` without consuming
+    /// this handle's terminal result receiver.
+    pub fn take_cancel_handle(&mut self) -> Option<SupervisedExecCancelHandle> {
+        if self.cancel_handle_taken {
+            return None;
+        }
+        let seq = self.seq?;
+        self.cancel_handle_taken = true;
+        Some(SupervisedExecCancelHandle {
+            shared: Arc::clone(&self.shared),
+            seq,
+            diagnostic: self.diagnostic.clone(),
+        })
     }
 
     /// Send an exec-control request for this supervised operation.
@@ -919,23 +969,7 @@ impl SupervisedExecHandle {
                 "supervised exec operation closed",
             )
         })?;
-        let payload = vsock_proto::encode_exec_cancel();
-        write_frame(
-            &self.shared,
-            MSG_EXEC_CANCEL,
-            seq,
-            &payload,
-            Some(self.diagnostic.frame("cancel")),
-            None,
-            FrameWriteObserver::default(),
-        )
-        .await?;
-        tracing::info!(
-            seq = seq,
-            label = %self.diagnostic.label_log,
-            elapsed_ms = self.diagnostic.elapsed_ms(),
-            "supervised exec operation cancel sent"
-        );
+        send_supervised_exec_cancel_frame(&self.shared, seq, &self.diagnostic).await?;
 
         let result = self.wait_with_timeout(timeout, true).await?;
         Ok(ExecCancelWaitResult {
@@ -1165,6 +1199,31 @@ impl Drop for ExecOperationCancelOnDropGuard {
 
 fn exec_operation_protocol_error(error: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+async fn send_supervised_exec_cancel_frame(
+    shared: &Arc<Shared>,
+    seq: u32,
+    diagnostic: &ExecOperationDiagnostic,
+) -> io::Result<()> {
+    let payload = vsock_proto::encode_exec_cancel();
+    write_frame(
+        shared,
+        MSG_EXEC_CANCEL,
+        seq,
+        &payload,
+        Some(diagnostic.frame("cancel")),
+        None,
+        FrameWriteObserver::default(),
+    )
+    .await?;
+    tracing::info!(
+        seq = seq,
+        label = %diagnostic.label_log,
+        elapsed_ms = diagnostic.elapsed_ms(),
+        "supervised exec operation cancel sent"
+    );
+    Ok(())
 }
 
 fn exec_control_status_error(status: ExecControlStatus, diagnostic: &str) -> io::Error {
@@ -2366,6 +2425,7 @@ where
         seq: Some(seq),
         pid,
         diagnostic,
+        cancel_handle_taken: false,
         result_rx: Some(result_rx),
         stream_rx,
         control: control_nonce.map(|control_nonce| ExecControlHandle {

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -846,7 +846,6 @@ impl SupervisedExecCancelHandle {
                 elapsed_ms = self.diagnostic.elapsed_ms(),
                 "supervised exec operation cancel write timed out"
             );
-            self.shared.poison_connection();
             Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "supervised exec cancel write timed out",

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -51,8 +51,8 @@ use vsock_proto::{
 pub use exec_operation::{
     ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus, ExecControlHandle,
     ExecControlOutcome, ExecOperationHandle, ExecOperationRequest, ExecOperationResult,
-    ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest, SupervisedExecControl,
-    SupervisedExecHandle, SupervisedExecRequest,
+    ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest, SupervisedExecCancelHandle,
+    SupervisedExecControl, SupervisedExecHandle, SupervisedExecRequest,
 };
 pub use file::{CopyFileOptions, CopyFileResult};
 

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -21,7 +21,7 @@ use super::super::support::{
 use super::start_capture_operation;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
-use crate::{SupervisedExecControl, SupervisedExecRequest};
+use crate::{ExecOwnedCapturedOutput, SupervisedExecControl, SupervisedExecRequest};
 
 fn supervised_request(command: &str) -> SupervisedExecRequest<'_> {
     SupervisedExecRequest {
@@ -647,6 +647,56 @@ async fn supervised_exec_cancel_handle_timeout_before_write_does_not_poison_conn
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(is_connected(&host));
     assert_eq!(operation_count(&host), 0);
+}
+
+#[tokio::test]
+async fn supervised_exec_cancel_handle_after_terminal_result_preserves_wait_and_connection() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-handle-after-result"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let mut handle = task.await.unwrap().unwrap();
+    let cancel_handle = handle
+        .take_cancel_handle()
+        .expect("supervised handle should expose a cancel handle");
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"done",
+        b"",
+    )
+    .await;
+    wait_for_operation_count(&host, 0).await;
+
+    cancel_handle.cancel(Duration::from_secs(5)).await.unwrap();
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+    vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
+
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(
+        result.stdout,
+        ExecOwnedCapturedOutput::Captured {
+            bytes: b"done".to_vec(),
+            truncated: false,
+        }
+    );
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -570,6 +570,46 @@ async fn supervised_exec_cancel_and_wait_sends_cancel_and_waits_for_cancelled_re
 }
 
 #[tokio::test]
+async fn supervised_exec_cancel_handle_sends_cancel_without_consuming_wait() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-handle"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let mut handle = task.await.unwrap().unwrap();
+    let cancel_handle = handle
+        .take_cancel_handle()
+        .expect("supervised handle should expose a cancel handle");
+    assert!(handle.take_cancel_handle().is_none());
+
+    let cancel_task =
+        tokio::spawn(async move { cancel_handle.cancel(Duration::from_secs(5)).await });
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+    vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
+
+    cancel_task.await.unwrap().unwrap();
+    assert_eq!(operation_count(&host), 1);
+
+    send_exec_result(&mut guest, start.seq, ExecTermination::Cancelled, b"", b"").await;
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
 async fn supervised_exec_cancel_after_terminal_result_returns_result_without_cancel_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -629,10 +629,7 @@ async fn supervised_exec_cancel_handle_timeout_before_write_does_not_poison_conn
         .expect("supervised handle should expose a cancel handle");
     let writer_guard = host.shared.writer.lock().await;
 
-    let err = cancel_handle
-        .cancel(Duration::from_millis(1))
-        .await
-        .unwrap_err();
+    let err = cancel_handle.cancel(Duration::ZERO).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
     assert!(is_connected(&host));
     assert_eq!(operation_count(&host), 1);

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -610,6 +610,49 @@ async fn supervised_exec_cancel_handle_sends_cancel_without_consuming_wait() {
 }
 
 #[tokio::test]
+async fn supervised_exec_cancel_handle_timeout_before_write_does_not_poison_connection() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-lock-wait"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let mut handle = task.await.unwrap().unwrap();
+    let cancel_handle = handle
+        .take_cancel_handle()
+        .expect("supervised handle should expose a cancel handle");
+    let writer_guard = host.shared.writer.lock().await;
+
+    let err = cancel_handle
+        .cancel(Duration::from_millis(1))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 1);
+
+    drop(writer_guard);
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+}
+
+#[tokio::test]
 async fn supervised_exec_cancel_after_terminal_result_returns_result_without_cancel_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);


### PR DESCRIPTION
## Summary
- add one-shot supervised exec cancel handles through vsock-host and sandbox process handles
- cancel the guest agent process on runner cancellation, then wait briefly for terminal status before cleanup closes the connection
- extend sandbox-mock and runner/vsock-host tests for cancel success, missing cancel support, and cancel-send failures

Fixes #14507

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p sandbox
- cargo test --manifest-path crates/Cargo.toml -p sandbox-mock
- cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised_exec_cancel -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --no-run
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner -- -D warnings