### PR TITLE
refactor: shorten oauth flow names

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -82,7 +82,7 @@ import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
 import { zeroCliAuthStripeRoutes } from "./routes/zero-connectors-cli-auth-stripe";
-import { zeroConnectorsOauthDeviceAuthorizationRoutes } from "./routes/zero-connectors-oauth-device-authorization";
+import { zeroConnectorsOauthDeviceAuthRoutes } from "./routes/zero-connectors-oauth-device-authorization";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
 import { zeroCustomConnectorsRoutes } from "./routes/zero-custom-connectors";
 import { zeroDefaultAgentRoutes } from "./routes/zero-default-agent";
@@ -168,7 +168,7 @@ import { storagesDownloadRoutes } from "./routes/storages-download";
 import { storagesListRoutes } from "./routes/storages-list";
 import { storagesPrepareRoutes } from "./routes/storages-prepare";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
-import { testOAuthProviderDeviceAuthorizationRoutes } from "./routes/test-oauth-provider-device-authorization";
+import { testOAuthProviderDeviceAuthRoutes } from "./routes/test-oauth-provider-device-authorization";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderTokenRoutes } from "./routes/test-oauth-provider-token";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
@@ -266,7 +266,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroComputerUseRoutes,
   ...zeroCodexDeviceAuthRoutes,
   ...zeroCliAuthStripeRoutes,
-  ...zeroConnectorsOauthDeviceAuthorizationRoutes,
+  ...zeroConnectorsOauthDeviceAuthRoutes,
   ...zeroConnectorsRoutes,
   ...zeroCustomConnectorsRoutes,
   ...zeroDefaultAgentRoutes,
@@ -356,7 +356,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...modelStatsRoutes,
   ...runnersRoutes,
   ...testOAuthProviderAuthorizeRoutes,
-  ...testOAuthProviderDeviceAuthorizationRoutes,
+  ...testOAuthProviderDeviceAuthRoutes,
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderTokenRoutes,
   ...testOAuthProviderUserinfoRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -40,7 +40,7 @@ interface TokenBody {
   readonly scope: string;
 }
 
-interface DeviceAuthorizationBody {
+interface DeviceAuthBody {
   readonly device_code: string;
   readonly user_code: string;
   readonly verification_uri: string;
@@ -252,9 +252,7 @@ describe("/api/test/oauth-provider/*", () => {
       );
 
       expect(response.status).toBe(200);
-      await expect(
-        readJson<DeviceAuthorizationBody>(response),
-      ).resolves.toStrictEqual({
+      await expect(readJson<DeviceAuthBody>(response)).resolves.toStrictEqual({
         device_code: "test-device:test-oauth-device-client:read",
         user_code: "TEST-DEVICE",
         verification_uri: "https://oauth-device.test/device",
@@ -673,7 +671,7 @@ describe("/api/test/oauth-provider/*", () => {
           scope: "read",
         }),
       );
-      const deviceBody = await readJson<DeviceAuthorizationBody>(device);
+      const deviceBody = await readJson<DeviceAuthBody>(device);
       const response = await requestApp(
         TOKEN_ROUTE,
         tokenRequest({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -915,7 +915,7 @@ const seedClerkFixture$ = command(
   },
 );
 
-async function seedClerkOauthDeviceAuthorizationSession(
+async function seedClerkOauthDeviceAuthSession(
   fixture: ClerkFixture,
 ): Promise<void> {
   await store
@@ -2471,7 +2471,7 @@ describe("POST /api/webhooks/clerk", () => {
     const fixture = await trackClerk(
       store.set(seedClerkFixture$, undefined, context.signal),
     );
-    await seedClerkOauthDeviceAuthorizationSession(fixture);
+    await seedClerkOauthDeviceAuthSession(fixture);
     context.mocks.clerk.verifyWebhook.mockResolvedValue({
       type: "organization.deleted",
       data: { id: fixture.orgId },
@@ -2572,7 +2572,7 @@ describe("POST /api/webhooks/clerk", () => {
     const fixture = await trackClerk(
       store.set(seedClerkFixture$, undefined, context.signal),
     );
-    await seedClerkOauthDeviceAuthorizationSession(fixture);
+    await seedClerkOauthDeviceAuthSession(fixture);
     context.mocks.clerk.verifyWebhook.mockResolvedValue({
       type: "user.deleted",
       data: { id: fixture.userId },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { zeroConnectorOauthDeviceAuthorizationSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroConnectorOauthDeviceAuthSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
@@ -26,8 +26,7 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const testOauthDeviceProvider = CONNECTOR_OAUTH_PROVIDERS["test-oauth-device"];
-const originalPollDeviceAuthorization =
-  testOauthDeviceProvider.pollDeviceAuthorization;
+const originalPollDeviceAuth = testOauthDeviceProvider.pollDeviceAuth;
 const TEST_OAUTH_DEVICE_CODE_URL =
   "http://localhost:3000/api/test/oauth-provider/device/code";
 const TEST_OAUTH_TOKEN_URL =
@@ -245,8 +244,7 @@ describe("OAuth device authorization connector routes", () => {
   const users: { readonly userId: string; readonly orgId: string }[] = [];
 
   afterEach(async () => {
-    testOauthDeviceProvider.pollDeviceAuthorization =
-      originalPollDeviceAuthorization;
+    testOauthDeviceProvider.pollDeviceAuth = originalPollDeviceAuth;
     while (users.length > 0) {
       const user = users.pop();
       if (user) {
@@ -268,7 +266,7 @@ describe("OAuth device authorization connector routes", () => {
   it("starts a session and stores only encrypted provider state plus a token hash", async () => {
     const { userId, orgId } = await setupUser();
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(
@@ -311,7 +309,7 @@ describe("OAuth device authorization connector routes", () => {
   it("marks the previous active session as superseded when a new session starts", async () => {
     const { userId, orgId } = await setupUser();
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const first = await accept(
@@ -365,7 +363,7 @@ describe("OAuth device authorization connector routes", () => {
   it("does not persist a superseded session that completes after a new session starts", async () => {
     const { userId, orgId } = await setupUser();
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
     const first = await accept(
       client.create({
@@ -379,12 +377,12 @@ describe("OAuth device authorization connector routes", () => {
 
     let releaseProviderPoll: (() => void) | undefined;
     const providerPollStarted = new Promise<void>((resolve) => {
-      testOauthDeviceProvider.pollDeviceAuthorization = async (args) => {
+      testOauthDeviceProvider.pollDeviceAuth = async (args) => {
         resolve();
         await new Promise<void>((resolve) => {
           releaseProviderPoll = resolve;
         });
-        return await originalPollDeviceAuthorization(args);
+        return await originalPollDeviceAuth(args);
       };
     });
     const firstPoll = client.poll({
@@ -426,7 +424,7 @@ describe("OAuth device authorization connector routes", () => {
   it("rejects authorization-code OAuth connectors", async () => {
     await setupUser();
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(
@@ -449,7 +447,7 @@ describe("OAuth device authorization connector routes", () => {
     users.push({ userId, orgId });
     mocks.clerk.session(userId, orgId);
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(
@@ -474,7 +472,7 @@ describe("OAuth device authorization connector routes", () => {
       deviceCode: "pending",
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(
@@ -502,7 +500,7 @@ describe("OAuth device authorization connector routes", () => {
       intervalSeconds: 5,
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(
@@ -521,7 +519,7 @@ describe("OAuth device authorization connector routes", () => {
   it("completes a session through OAuth connector persistence without leaking tokens", async () => {
     const { userId, orgId } = await setupUser();
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
     const start = await accept(
       client.create({
@@ -531,8 +529,8 @@ describe("OAuth device authorization connector routes", () => {
       }),
       [200],
     );
-    testOauthDeviceProvider.pollDeviceAuthorization = async (args) => {
-      const result = await originalPollDeviceAuthorization(args);
+    testOauthDeviceProvider.pollDeviceAuth = async (args) => {
+      const result = await originalPollDeviceAuth(args);
       if (result.status !== "complete") {
         return result;
       }
@@ -577,7 +575,7 @@ describe("OAuth device authorization connector routes", () => {
   it("returns terminal denied, expired, and error states", async () => {
     const { userId, orgId } = await setupUser();
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
     const cases = [
       {
@@ -645,12 +643,12 @@ describe("OAuth device authorization connector routes", () => {
       updatedAt: nowDate(),
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
     let pollCount = 0;
-    testOauthDeviceProvider.pollDeviceAuthorization = () => {
+    testOauthDeviceProvider.pollDeviceAuth = () => {
       pollCount += 1;
-      return originalPollDeviceAuthorization({
+      return originalPollDeviceAuth({
         clientId: "test-oauth-device-client",
         deviceCode: "test-device:test-oauth-device-client:read",
       });
@@ -680,7 +678,7 @@ describe("OAuth device authorization connector routes", () => {
       deviceCode: "pending",
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(
@@ -705,12 +703,12 @@ describe("OAuth device authorization connector routes", () => {
       deviceCode: "pending",
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
     let pollCount = 0;
     let releaseProviderPoll: (() => void) | undefined;
     const providerPollStarted = new Promise<void>((resolve) => {
-      testOauthDeviceProvider.pollDeviceAuthorization = async () => {
+      testOauthDeviceProvider.pollDeviceAuth = async () => {
         pollCount += 1;
         resolve();
         await new Promise<void>((resolve) => {
@@ -759,10 +757,10 @@ describe("OAuth device authorization connector routes", () => {
       expiresAt: new Date(now.getTime() - 1000),
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
     let pollCount = 0;
-    testOauthDeviceProvider.pollDeviceAuthorization = () => {
+    testOauthDeviceProvider.pollDeviceAuth = () => {
       pollCount += 1;
       return Promise.resolve({ status: "pending" });
     };
@@ -789,7 +787,7 @@ describe("OAuth device authorization connector routes", () => {
       deviceCode: "test-device:test-oauth-device-client:read",
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const first = await accept(
@@ -802,7 +800,7 @@ describe("OAuth device authorization connector routes", () => {
     );
     expect(first.body.status).toBe("complete");
 
-    testOauthDeviceProvider.pollDeviceAuthorization = () => {
+    testOauthDeviceProvider.pollDeviceAuth = () => {
       return Promise.reject(
         new Error("Provider should not be called for terminal sessions"),
       );
@@ -829,7 +827,7 @@ describe("OAuth device authorization connector routes", () => {
       updatedAt: new Date(nowDate().getTime() - 60_000),
     });
     const client = setupApp({ context })(
-      zeroConnectorOauthDeviceAuthorizationSessionContract,
+      zeroConnectorOauthDeviceAuthSessionContract,
     );
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,13 +1,13 @@
 import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
-  isOAuthAuthorizationCodeConnectorType,
+  isOAuthAuthCodeConnectorType,
   type ConnectorEnvReader,
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorType,
-  OAuthAuthorizationCodeConnectorType,
+  OAuthAuthCodeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorOAuthAuthUrl,
@@ -37,7 +37,7 @@ type PrepareResolvedConnectorOAuthStartResult =
 type ResolveConnectorOAuthStartTypeResult =
   | {
       readonly ok: true;
-      readonly type: OAuthAuthorizationCodeConnectorType;
+      readonly type: OAuthAuthCodeConnectorType;
     }
   | {
       readonly ok: false;
@@ -60,7 +60,7 @@ export function resolveConnectorOAuthStartType(
   if (!isOAuthConnectorType(type)) {
     return { ok: false, reason: "oauth_provider_not_configured" };
   }
-  if (!isOAuthAuthorizationCodeConnectorType(type)) {
+  if (!isOAuthAuthCodeConnectorType(type)) {
     return { ok: false, reason: "unsupported_oauth_flow" };
   }
   return { ok: true, type };
@@ -70,7 +70,7 @@ export function resolveConnectorOAuthStartType(
 // ConnectorType first so non-OAuth connectors keep their route-specific errors,
 // then build the provider authorization URL at the normal async commit point.
 export function prepareResolvedConnectorOAuthStart(args: {
-  readonly type: OAuthAuthorizationCodeConnectorType;
+  readonly type: OAuthAuthCodeConnectorType;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareResolvedConnectorOAuthStartResult {
@@ -90,7 +90,7 @@ export function prepareResolvedConnectorOAuthStart(args: {
 }
 
 export async function buildResolvedConnectorOAuthAuthResult(args: {
-  readonly type: OAuthAuthorizationCodeConnectorType;
+  readonly type: OAuthAuthCodeConnectorType;
   readonly credentials: ConfiguredConnectorOAuthCredentials;
   readonly redirectUri: string;
   readonly state: string;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -3,13 +3,13 @@ import { unescape as decodeCookieComponent } from "node:querystring";
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
-  isOAuthAuthorizationCodeConnectorType,
+  isOAuthAuthCodeConnectorType,
   getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type OAuthAuthorizationCodeConnectorType,
+  type OAuthAuthCodeConnectorType,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -59,7 +59,7 @@ type CallbackIdentity = {
 };
 
 type CompleteOAuthCallbackInput = {
-  readonly connectorType: OAuthAuthorizationCodeConnectorType;
+  readonly connectorType: OAuthAuthCodeConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -109,7 +109,7 @@ type ClaimedCallbackState =
 type ResolvedOAuthConnectorType =
   | {
       readonly ok: true;
-      readonly connectorType: OAuthAuthorizationCodeConnectorType;
+      readonly connectorType: OAuthAuthCodeConnectorType;
     }
   | {
       readonly ok: false;
@@ -171,7 +171,7 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
 }
 
 async function exchangeTokenForConnector(args: {
-  readonly connectorType: OAuthAuthorizationCodeConnectorType;
+  readonly connectorType: OAuthAuthCodeConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -198,7 +198,7 @@ async function exchangeTokenForConnector(args: {
 }
 
 function getRequestedScopes(
-  connectorType: OAuthAuthorizationCodeConnectorType,
+  connectorType: OAuthAuthCodeConnectorType,
 ): readonly string[] {
   return getConnectorOAuthConfig(connectorType).scopes;
 }
@@ -236,7 +236,7 @@ function resolveOAuthConnectorType(
       ),
     };
   }
-  if (!isOAuthAuthorizationCodeConnectorType(connectorType)) {
+  if (!isOAuthAuthCodeConnectorType(connectorType)) {
     return {
       ok: false,
       response: redirectWithError(
@@ -253,7 +253,7 @@ function resolveOAuthConnectorType(
 async function claimStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: OAuthAuthorizationCodeConnectorType;
+  readonly connectorType: OAuthAuthCodeConnectorType;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
@@ -282,7 +282,7 @@ async function claimStoredOAuthStateForCallback(args: {
 async function rejectInvalidStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: OAuthAuthorizationCodeConnectorType;
+  readonly connectorType: OAuthAuthCodeConnectorType;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-device-authorization.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { testOAuthProviderDeviceAuthorizationContract } from "@vm0/api-contracts/contracts/test-oauth-provider-device-authorization";
+import { testOAuthProviderDeviceAuthContract } from "@vm0/api-contracts/contracts/test-oauth-provider-device-authorization";
 
 import { request$ } from "../context/hono";
 import type { RouteEntry } from "../route";
@@ -27,7 +27,7 @@ function errorResponse(
   };
 }
 
-const deviceAuthorization$ = command(async ({ get }, signal: AbortSignal) => {
+const deviceAuth$ = command(async ({ get }, signal: AbortSignal) => {
   const request = get(request$);
   if (!isTestEndpointAllowed(request)) {
     return testEndpointNotFoundResponse();
@@ -62,10 +62,9 @@ const deviceAuthorization$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
-export const testOAuthProviderDeviceAuthorizationRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: testOAuthProviderDeviceAuthorizationContract.deviceAuthorization,
-      handler: deviceAuthorization$,
-    },
-  ];
+export const testOAuthProviderDeviceAuthRoutes: readonly RouteEntry[] = [
+  {
+    route: testOAuthProviderDeviceAuthContract.deviceAuth,
+    handler: deviceAuth$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-connectors-oauth-device-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-oauth-device-authorization.ts
@@ -1,4 +1,4 @@
-import { zeroConnectorOauthDeviceAuthorizationSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroConnectorOauthDeviceAuthSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { command } from "ccstate";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -6,8 +6,8 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route";
 import {
-  pollConnectorOauthDeviceAuthorizationSession$,
-  startConnectorOauthDeviceAuthorizationSession$,
+  pollConnectorOauthDeviceAuthSession$,
+  startConnectorOauthDeviceAuthSession$,
 } from "../services/connector-oauth-device-authorization.service";
 
 const connectorWriteAuth = {
@@ -15,15 +15,15 @@ const connectorWriteAuth = {
   missingOrganizationStatus: 401,
 } as const;
 
-const startConnectorOauthDeviceAuthorizationSessionInner$ = command(
+const startConnectorOauthDeviceAuthSessionInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(
-      pathParamsOf(zeroConnectorOauthDeviceAuthorizationSessionContract.create),
+      pathParamsOf(zeroConnectorOauthDeviceAuthSessionContract.create),
     );
 
     return await set(
-      startConnectorOauthDeviceAuthorizationSession$,
+      startConnectorOauthDeviceAuthSession$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
@@ -34,14 +34,14 @@ const startConnectorOauthDeviceAuthorizationSessionInner$ = command(
   },
 );
 
-const pollConnectorOauthDeviceAuthorizationSessionInner$ = command(
+const pollConnectorOauthDeviceAuthSessionInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(
-      pathParamsOf(zeroConnectorOauthDeviceAuthorizationSessionContract.poll),
+      pathParamsOf(zeroConnectorOauthDeviceAuthSessionContract.poll),
     );
     const body = await get(
-      bodyResultOf(zeroConnectorOauthDeviceAuthorizationSessionContract.poll),
+      bodyResultOf(zeroConnectorOauthDeviceAuthSessionContract.poll),
     );
     signal.throwIfAborted();
     if (!body.ok) {
@@ -49,7 +49,7 @@ const pollConnectorOauthDeviceAuthorizationSessionInner$ = command(
     }
 
     return await set(
-      pollConnectorOauthDeviceAuthorizationSession$,
+      pollConnectorOauthDeviceAuthSession$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
@@ -62,20 +62,19 @@ const pollConnectorOauthDeviceAuthorizationSessionInner$ = command(
   },
 );
 
-export const zeroConnectorsOauthDeviceAuthorizationRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: zeroConnectorOauthDeviceAuthorizationSessionContract.create,
-      handler: authRoute(
-        connectorWriteAuth,
-        startConnectorOauthDeviceAuthorizationSessionInner$,
-      ),
-    },
-    {
-      route: zeroConnectorOauthDeviceAuthorizationSessionContract.poll,
-      handler: authRoute(
-        connectorWriteAuth,
-        pollConnectorOauthDeviceAuthorizationSessionInner$,
-      ),
-    },
-  ];
+export const zeroConnectorsOauthDeviceAuthRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroConnectorOauthDeviceAuthSessionContract.create,
+    handler: authRoute(
+      connectorWriteAuth,
+      startConnectorOauthDeviceAuthSessionInner$,
+    ),
+  },
+  {
+    route: zeroConnectorOauthDeviceAuthSessionContract.poll,
+    handler: authRoute(
+      connectorWriteAuth,
+      pollConnectorOauthDeviceAuthSessionInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-authorization.service.ts
@@ -2,28 +2,28 @@ import { createHash, randomBytes } from "node:crypto";
 
 import type {
   ConnectorResponse,
-  ConnectorOauthDeviceAuthorizationSessionPollResponse,
-  ConnectorOauthDeviceAuthorizationSessionStartResponse,
+  ConnectorOauthDeviceAuthSessionPollResponse,
+  ConnectorOauthDeviceAuthSessionStartResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
   ConnectorType,
-  OAuthDeviceAuthorizationConnectorType,
+  OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
   isConnectorAuthMethodAvailable,
-  isOAuthDeviceAuthorizationConnectorType,
+  isOAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
   CONNECTOR_OAUTH_PROVIDERS,
   isOAuthConnectorType,
-  pollConnectorOAuthDeviceAuthorization,
-  startConnectorOAuthDeviceAuthorization,
+  pollConnectorOAuthDeviceAuth,
+  startConnectorOAuthDeviceAuth,
 } from "@vm0/connectors/oauth-providers";
 import type {
-  OAuthDeviceAuthorizationCompleteResult,
-  OAuthDeviceAuthorizationPollResult,
+  OAuthDeviceAuthCompleteResult,
+  OAuthDeviceAuthPollResult,
 } from "@vm0/connectors/oauth-providers/provider-types";
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { command } from "ccstate";
@@ -58,11 +58,11 @@ type ConfiguredConnectorOAuthCredentials = Extract<
   { readonly configured: true }
 >;
 
-type DeviceAuthorizationSessionRow =
+type DeviceAuthSessionRow =
   typeof connectorOauthDeviceAuthorizationSessions.$inferSelect;
 
 type PendingPollBody = Extract<
-  ConnectorOauthDeviceAuthorizationSessionPollResponse,
+  ConnectorOauthDeviceAuthSessionPollResponse,
   { status: "pending" }
 >;
 
@@ -73,7 +73,7 @@ type PendingSuccess = {
 
 type PollSuccess = {
   readonly status: 200;
-  readonly body: ConnectorOauthDeviceAuthorizationSessionPollResponse;
+  readonly body: ConnectorOauthDeviceAuthSessionPollResponse;
 };
 
 const encryptedProviderStateSchema = z.object({
@@ -87,17 +87,17 @@ type PollClaimedSessionArgs = {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthorizationConnectorType;
+  readonly type: OAuthDeviceAuthConnectorType;
   readonly credentials: ConfiguredConnectorOAuthCredentials;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly signal: AbortSignal;
   readonly persistConnector: (args: {
-    readonly result: OAuthDeviceAuthorizationCompleteResult;
+    readonly result: OAuthDeviceAuthCompleteResult;
   }) => Promise<ConnectorResponse>;
 };
 
-const connectorOauthDeviceAuthorizationDisabled = Object.freeze({
+const connectorOauthDeviceAuthDisabled = Object.freeze({
   status: 403 as const,
   body: Object.freeze({
     error: Object.freeze({
@@ -128,8 +128,8 @@ function generateSessionToken(): string {
 }
 
 function terminalErrorBody(
-  session: DeviceAuthorizationSessionRow,
-): ConnectorOauthDeviceAuthorizationSessionPollResponse {
+  session: DeviceAuthSessionRow,
+): ConnectorOauthDeviceAuthSessionPollResponse {
   if (
     session.status !== "denied" &&
     session.status !== "expired" &&
@@ -147,19 +147,19 @@ function terminalErrorBody(
 }
 
 function pendingBody(
-  session: Pick<DeviceAuthorizationSessionRow, "intervalSeconds">,
+  session: Pick<DeviceAuthSessionRow, "intervalSeconds">,
 ): PendingPollBody {
   return { status: "pending", interval: session.intervalSeconds };
 }
 
 function pendingResponse(
-  session: Pick<DeviceAuthorizationSessionRow, "intervalSeconds">,
+  session: Pick<DeviceAuthSessionRow, "intervalSeconds">,
 ): PendingSuccess {
   return { status: 200, body: pendingBody(session) };
 }
 
 function shouldWaitBeforeProviderPoll(
-  session: DeviceAuthorizationSessionRow,
+  session: DeviceAuthSessionRow,
   now: Date,
 ): boolean {
   return (
@@ -169,7 +169,7 @@ function shouldWaitBeforeProviderPoll(
 }
 
 function isFreshPollingSession(
-  session: DeviceAuthorizationSessionRow,
+  session: DeviceAuthSessionRow,
   now: Date,
 ): boolean {
   return (
@@ -178,10 +178,10 @@ function isFreshPollingSession(
   );
 }
 
-function resolveDeviceAuthorizationType(
+function resolveDeviceAuthType(
   type: ConnectorType,
 ):
-  | OAuthDeviceAuthorizationConnectorType
+  | OAuthDeviceAuthConnectorType
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof internalServerError> {
   if (!getConnectorAuthMethod(type, "oauth")) {
@@ -190,7 +190,7 @@ function resolveDeviceAuthorizationType(
   if (!isOAuthConnectorType(type)) {
     return internalServerError(`${type} OAuth provider is not configured`);
   }
-  if (!isOAuthDeviceAuthorizationConnectorType(type)) {
+  if (!isOAuthDeviceAuthConnectorType(type)) {
     return badRequestMessage(
       `${type} connector does not support OAuth device authorization`,
     );
@@ -199,7 +199,7 @@ function resolveDeviceAuthorizationType(
 }
 
 function resolveConfiguredCredentials(
-  type: OAuthDeviceAuthorizationConnectorType,
+  type: OAuthDeviceAuthConnectorType,
 ):
   | ConfiguredConnectorOAuthCredentials
   | ReturnType<typeof internalServerError> {
@@ -210,11 +210,11 @@ function resolveConfiguredCredentials(
   return credentials;
 }
 
-async function lockDeviceAuthorizationSessionOwner(args: {
+async function lockDeviceAuthSessionOwner(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthorizationConnectorType;
+  readonly type: OAuthDeviceAuthConnectorType;
 }): Promise<void> {
   await args.writeDb.execute(
     sql`SELECT pg_advisory_xact_lock(hashtext('oauth_device_authorization:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type}))`,
@@ -225,7 +225,7 @@ async function markActiveSessionsSuperseded(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthorizationConnectorType;
+  readonly type: OAuthDeviceAuthConnectorType;
   readonly now: Date;
 }): Promise<void> {
   await args.writeDb
@@ -282,11 +282,11 @@ async function loadOwnedSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthorizationConnectorType;
+  readonly type: OAuthDeviceAuthConnectorType;
   readonly sessionId: string;
   readonly sessionToken: string;
   readonly signal: AbortSignal;
-}): Promise<DeviceAuthorizationSessionRow | null> {
+}): Promise<DeviceAuthSessionRow | null> {
   const [session] = await args.writeDb
     .select()
     .from(connectorOauthDeviceAuthorizationSessions)
@@ -309,7 +309,7 @@ async function loadOwnedSession(args: {
 
 async function expireSession(args: {
   readonly writeDb: Db;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly session: DeviceAuthSessionRow;
   readonly now: Date;
   readonly signal: AbortSignal;
 }): Promise<PollSuccess> {
@@ -349,10 +349,10 @@ async function expireSession(args: {
 
 async function claimSession(args: {
   readonly writeDb: Db;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly signal: AbortSignal;
-}): Promise<DeviceAuthorizationSessionRow | null> {
+}): Promise<DeviceAuthSessionRow | null> {
   const staleBefore = new Date(
     args.claimStartedAt.getTime() - POLLING_STALE_MS,
   );
@@ -383,8 +383,8 @@ async function claimSession(args: {
 }
 
 function parseEncryptedProviderState(args: {
-  readonly session: DeviceAuthorizationSessionRow;
-  readonly type: OAuthDeviceAuthorizationConnectorType;
+  readonly session: DeviceAuthSessionRow;
+  readonly type: OAuthDeviceAuthConnectorType;
 }): EncryptedProviderState {
   const providerState = encryptedProviderStateSchema.parse(
     JSON.parse(decryptSecretValue(args.session.encryptedProviderState)),
@@ -419,7 +419,7 @@ async function claimStillCurrent(args: {
 
 async function claimNoLongerCurrentResponse(args: {
   readonly writeDb: Db;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly session: DeviceAuthSessionRow;
   readonly signal: AbortSignal;
 }): Promise<PollSuccess> {
   const [currentSession] = await args.writeDb
@@ -441,10 +441,10 @@ async function claimNoLongerCurrentResponse(args: {
 
 async function markClaimTerminal(args: {
   readonly writeDb: Db;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly result: Extract<
-    OAuthDeviceAuthorizationPollResult,
+    OAuthDeviceAuthPollResult,
     { readonly status: "denied" | "expired" | "error" }
   >;
   readonly signal: AbortSignal;
@@ -484,7 +484,7 @@ async function markClaimTerminal(args: {
 
 async function markClaimComplete(args: {
   readonly writeDb: Db;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly connector: ConnectorResponse;
   readonly signal: AbortSignal;
@@ -523,17 +523,17 @@ async function completeClaimedSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthorizationConnectorType;
-  readonly session: DeviceAuthorizationSessionRow;
+  readonly type: OAuthDeviceAuthConnectorType;
+  readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
-  readonly result: OAuthDeviceAuthorizationCompleteResult;
+  readonly result: OAuthDeviceAuthCompleteResult;
   readonly signal: AbortSignal;
   readonly persistConnector: (args: {
-    readonly result: OAuthDeviceAuthorizationCompleteResult;
+    readonly result: OAuthDeviceAuthCompleteResult;
   }) => Promise<ConnectorResponse>;
 }): Promise<PollSuccess> {
   return await args.writeDb.transaction(async (tx) => {
-    await lockDeviceAuthorizationSessionOwner({
+    await lockDeviceAuthSessionOwner({
       writeDb: tx,
       orgId: args.orgId,
       userId: args.userId,
@@ -586,7 +586,7 @@ async function runClaimedSession(
     session: args.session,
     type: args.type,
   });
-  const pollResult = await pollConnectorOAuthDeviceAuthorization({
+  const pollResult = await pollConnectorOAuthDeviceAuth({
     type: args.type,
     credentials: args.credentials,
     deviceCode: providerState.deviceCode,
@@ -666,7 +666,7 @@ async function pollClaimedSession(
   throw result.error;
 }
 
-export const startConnectorOauthDeviceAuthorizationSession$ = command(
+export const startConnectorOauthDeviceAuthSession$ = command(
   async (
     { get, set },
     args: {
@@ -676,7 +676,7 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
     },
     signal: AbortSignal,
   ) => {
-    const resolvedType = resolveDeviceAuthorizationType(args.type);
+    const resolvedType = resolveDeviceAuthType(args.type);
     if (typeof resolvedType !== "string") {
       return resolvedType;
     }
@@ -687,7 +687,7 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
     signal.throwIfAborted();
 
     if (!isConnectorAuthMethodAvailable(resolvedType, "oauth", overrides)) {
-      return connectorOauthDeviceAuthorizationDisabled;
+      return connectorOauthDeviceAuthDisabled;
     }
 
     const credentials = resolveConfiguredCredentials(resolvedType);
@@ -695,7 +695,7 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
       return credentials;
     }
 
-    const startResult = await startConnectorOAuthDeviceAuthorization({
+    const startResult = await startConnectorOAuthDeviceAuth({
       type: resolvedType,
       credentials,
     });
@@ -714,7 +714,7 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
     );
 
     const [session] = await set(writeDb$).transaction(async (tx) => {
-      await lockDeviceAuthorizationSessionOwner({
+      await lockDeviceAuthSessionOwner({
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
@@ -754,7 +754,7 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
       throw new Error("Failed to create OAuth device authorization session");
     }
 
-    const body: ConnectorOauthDeviceAuthorizationSessionStartResponse = {
+    const body: ConnectorOauthDeviceAuthSessionStartResponse = {
       sessionId: session.id,
       sessionToken,
       type: resolvedType,
@@ -769,7 +769,7 @@ export const startConnectorOauthDeviceAuthorizationSession$ = command(
   },
 );
 
-export const pollConnectorOauthDeviceAuthorizationSession$ = command(
+export const pollConnectorOauthDeviceAuthSession$ = command(
   async (
     { get, set },
     args: {
@@ -781,7 +781,7 @@ export const pollConnectorOauthDeviceAuthorizationSession$ = command(
     },
     signal: AbortSignal,
   ) => {
-    const resolvedType = resolveDeviceAuthorizationType(args.type);
+    const resolvedType = resolveDeviceAuthType(args.type);
     if (typeof resolvedType !== "string") {
       return resolvedType;
     }
@@ -792,7 +792,7 @@ export const pollConnectorOauthDeviceAuthorizationSession$ = command(
     signal.throwIfAborted();
 
     if (!isConnectorAuthMethodAvailable(resolvedType, "oauth", overrides)) {
-      return connectorOauthDeviceAuthorizationDisabled;
+      return connectorOauthDeviceAuthDisabled;
     }
 
     const credentials = resolveConfiguredCredentials(resolvedType);

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -95,33 +95,31 @@ export type ConnectorOauthStartResponse = z.infer<
   typeof connectorOauthStartResponseSchema
 >;
 
-export const connectorOauthDeviceAuthorizationSessionStartResponseSchema =
-  z.object({
-    sessionId: z.uuid(),
-    sessionToken: z.string(),
-    type: connectorTypeSchema,
-    status: z.literal("pending"),
-    userCode: z.string(),
-    verificationUri: z.string(),
-    verificationUriComplete: z.string().optional(),
-    expiresIn: z.number(),
-    interval: z.number(),
-  });
+export const connectorOauthDeviceAuthSessionStartResponseSchema = z.object({
+  sessionId: z.uuid(),
+  sessionToken: z.string(),
+  type: connectorTypeSchema,
+  status: z.literal("pending"),
+  userCode: z.string(),
+  verificationUri: z.string(),
+  verificationUriComplete: z.string().optional(),
+  expiresIn: z.number(),
+  interval: z.number(),
+});
 
-export type ConnectorOauthDeviceAuthorizationSessionStartResponse = z.infer<
-  typeof connectorOauthDeviceAuthorizationSessionStartResponseSchema
+export type ConnectorOauthDeviceAuthSessionStartResponse = z.infer<
+  typeof connectorOauthDeviceAuthSessionStartResponseSchema
 >;
 
-export const connectorOauthDeviceAuthorizationSessionPollRequestSchema =
-  z.object({
-    sessionToken: z.string(),
-  });
+export const connectorOauthDeviceAuthSessionPollRequestSchema = z.object({
+  sessionToken: z.string(),
+});
 
-export type ConnectorOauthDeviceAuthorizationSessionPollRequest = z.infer<
-  typeof connectorOauthDeviceAuthorizationSessionPollRequestSchema
+export type ConnectorOauthDeviceAuthSessionPollRequest = z.infer<
+  typeof connectorOauthDeviceAuthSessionPollRequestSchema
 >;
 
-export const connectorOauthDeviceAuthorizationSessionPollResponseSchema =
+export const connectorOauthDeviceAuthSessionPollResponseSchema =
   z.discriminatedUnion("status", [
     z.object({
       status: z.literal("pending"),
@@ -148,8 +146,8 @@ export const connectorOauthDeviceAuthorizationSessionPollResponseSchema =
     }),
   ]);
 
-export type ConnectorOauthDeviceAuthorizationSessionPollResponse = z.infer<
-  typeof connectorOauthDeviceAuthorizationSessionPollResponseSchema
+export type ConnectorOauthDeviceAuthSessionPollResponse = z.infer<
+  typeof connectorOauthDeviceAuthSessionPollResponseSchema
 >;
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -320,11 +320,11 @@ export {
   type TestOAuthProviderTokenResponse,
 } from "./test-oauth-provider-token";
 export {
-  testOAuthProviderDeviceAuthorizationContract,
-  testOAuthProviderDeviceAuthorizationErrorSchema,
-  testOAuthProviderDeviceAuthorizationResponseSchema,
-  type TestOAuthProviderDeviceAuthorizationContract,
-  type TestOAuthProviderDeviceAuthorizationResponse,
+  testOAuthProviderDeviceAuthContract,
+  testOAuthProviderDeviceAuthErrorSchema,
+  testOAuthProviderDeviceAuthResponseSchema,
+  type TestOAuthProviderDeviceAuthContract,
+  type TestOAuthProviderDeviceAuthResponse,
 } from "./test-oauth-provider-device-authorization";
 export {
   testOAuthProviderUserinfoContract,
@@ -922,7 +922,7 @@ export {
   zeroConnectorsMainContract,
   zeroConnectorsByTypeContract,
   zeroConnectorScopeDiffContract,
-  zeroConnectorOauthDeviceAuthorizationSessionContract,
+  zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorsSearchContract,
   zeroConnectorSessionsContract,
   zeroConnectorSessionByIdContract,
@@ -933,7 +933,7 @@ export {
   type ZeroConnectorsMainContract,
   type ZeroConnectorsByTypeContract,
   type ZeroConnectorScopeDiffContract,
-  type ZeroConnectorOauthDeviceAuthorizationSessionContract,
+  type ZeroConnectorOauthDeviceAuthSessionContract,
   type ZeroConnectorsSearchContract,
   type ZeroConnectorSessionsContract,
   type ZeroConnectorSessionByIdContract,

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-device-authorization.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-device-authorization.ts
@@ -4,12 +4,12 @@ import { initContract } from "./base";
 
 const c = initContract();
 
-export const testOAuthProviderDeviceAuthorizationErrorSchema = z.object({
+export const testOAuthProviderDeviceAuthErrorSchema = z.object({
   error: z.string(),
   error_description: z.string().optional(),
 });
 
-export const testOAuthProviderDeviceAuthorizationResponseSchema = z.object({
+export const testOAuthProviderDeviceAuthResponseSchema = z.object({
   device_code: z.string(),
   user_code: z.string(),
   verification_uri: z.string(),
@@ -18,15 +18,15 @@ export const testOAuthProviderDeviceAuthorizationResponseSchema = z.object({
   interval: z.number(),
 });
 
-export const testOAuthProviderDeviceAuthorizationContract = c.router({
-  deviceAuthorization: {
+export const testOAuthProviderDeviceAuthContract = c.router({
+  deviceAuth: {
     method: "POST",
     path: "/api/test/oauth-provider/device/code",
     body: c.type<string>(),
     responses: {
-      200: testOAuthProviderDeviceAuthorizationResponseSchema,
-      400: testOAuthProviderDeviceAuthorizationErrorSchema,
-      401: testOAuthProviderDeviceAuthorizationErrorSchema,
+      200: testOAuthProviderDeviceAuthResponseSchema,
+      400: testOAuthProviderDeviceAuthErrorSchema,
+      401: testOAuthProviderDeviceAuthErrorSchema,
       404: z.string(),
     },
     summary:
@@ -34,8 +34,8 @@ export const testOAuthProviderDeviceAuthorizationContract = c.router({
   },
 });
 
-export type TestOAuthProviderDeviceAuthorizationContract =
-  typeof testOAuthProviderDeviceAuthorizationContract;
-export type TestOAuthProviderDeviceAuthorizationResponse = z.infer<
-  typeof testOAuthProviderDeviceAuthorizationResponseSchema
+export type TestOAuthProviderDeviceAuthContract =
+  typeof testOAuthProviderDeviceAuthContract;
+export type TestOAuthProviderDeviceAuthResponse = z.infer<
+  typeof testOAuthProviderDeviceAuthResponseSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -4,9 +4,9 @@ import { apiErrorSchema } from "./errors";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
   computerConnectorCreateResponseSchema,
-  connectorOauthDeviceAuthorizationSessionPollRequestSchema,
-  connectorOauthDeviceAuthorizationSessionPollResponseSchema,
-  connectorOauthDeviceAuthorizationSessionStartResponseSchema,
+  connectorOauthDeviceAuthSessionPollRequestSchema,
+  connectorOauthDeviceAuthSessionPollResponseSchema,
+  connectorOauthDeviceAuthSessionStartResponseSchema,
   connectorOauthStartResponseSchema,
   connectorListResponseSchema,
   connectorResponseSchema,
@@ -128,7 +128,7 @@ export const zeroConnectorOauthStartContract = c.router({
   },
 });
 
-export const zeroConnectorOauthDeviceAuthorizationSessionContract = c.router({
+export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
   create: {
     method: "POST",
     path: "/api/zero/connectors/:type/oauth/device/sessions",
@@ -136,7 +136,7 @@ export const zeroConnectorOauthDeviceAuthorizationSessionContract = c.router({
     pathParams: z.object({ type: connectorTypeSchema }),
     body: z.object({}).optional(),
     responses: {
-      200: connectorOauthDeviceAuthorizationSessionStartResponseSchema,
+      200: connectorOauthDeviceAuthSessionStartResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
@@ -152,9 +152,9 @@ export const zeroConnectorOauthDeviceAuthorizationSessionContract = c.router({
       type: connectorTypeSchema,
       sessionId: z.uuid(),
     }),
-    body: connectorOauthDeviceAuthorizationSessionPollRequestSchema,
+    body: connectorOauthDeviceAuthSessionPollRequestSchema,
     responses: {
-      200: connectorOauthDeviceAuthorizationSessionPollResponseSchema,
+      200: connectorOauthDeviceAuthSessionPollResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
@@ -345,8 +345,8 @@ export type ZeroConnectorScopeDiffContract =
   typeof zeroConnectorScopeDiffContract;
 export type ZeroConnectorAuthorizeContract =
   typeof zeroConnectorAuthorizeContract;
-export type ZeroConnectorOauthDeviceAuthorizationSessionContract =
-  typeof zeroConnectorOauthDeviceAuthorizationSessionContract;
+export type ZeroConnectorOauthDeviceAuthSessionContract =
+  typeof zeroConnectorOauthDeviceAuthSessionContract;
 export type ZeroConnectorsSearchContract = typeof zeroConnectorsSearchContract;
 export type ZeroConnectorSessionsContract =
   typeof zeroConnectorSessionsContract;

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
-  type OAuthAuthorizationCodeConnectorType,
+  type OAuthAuthCodeConnectorType,
 } from "../connectors";
 import {
   getApiTokenFieldStorageType,
@@ -17,14 +17,14 @@ import {
   getConnectorProvidedSecretNames,
   getConnectorAuthMethods,
   getConnectorOAuthClientConfig,
-  getConnectorOAuthDeviceAuthorizationConfig,
+  getConnectorOAuthDeviceAuthConfig,
   getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
   getConnectorOAuthConfigIfSupported,
   getConnectorOAuthFlow,
   getRuntimeAvailableConnectorTypes,
-  isOAuthAuthorizationCodeConnectorType,
-  isOAuthDeviceAuthorizationConnectorType,
+  isOAuthAuthCodeConnectorType,
+  isOAuthDeviceAuthConnectorType,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
   isGoogleOAuthConnector,
@@ -35,8 +35,8 @@ import {
   buildConnectorOAuthAuthUrl,
   isOAuthConnectorType,
   CONNECTOR_OAUTH_PROVIDERS,
-  pollConnectorOAuthDeviceAuthorization,
-  startConnectorOAuthDeviceAuthorization,
+  pollConnectorOAuthDeviceAuth,
+  startConnectorOAuthDeviceAuth,
 } from "../oauth-providers/provider-registry";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../oauth-providers/google-oauth-connectors";
 import { buildGoogleAuthorizationUrl } from "../oauth-providers/providers/google-oauth";
@@ -89,7 +89,7 @@ const EXPECTED_PROVIDER_AUTHORIZATION_BASE_URLS = {
   x: "https://twitter.com/i/oauth2/authorize",
   xero: "https://login.xero.com/identity/connect/authorize",
   zoom: "https://zoom.us/oauth/authorize",
-} as const satisfies Record<OAuthAuthorizationCodeConnectorType, string>;
+} as const satisfies Record<OAuthAuthCodeConnectorType, string>;
 
 function authorizationBaseUrl(url: string): string {
   const parsed = new URL(url);
@@ -222,7 +222,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
 
     try {
       const providerTypes = connectorTypeSchema.options.filter(
-        isOAuthAuthorizationCodeConnectorType,
+        isOAuthAuthCodeConnectorType,
       );
 
       for (const type of providerTypes) {
@@ -346,7 +346,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         throw new Error("Expected test-oauth-device OAuth credentials");
       }
 
-      const startResult = await startConnectorOAuthDeviceAuthorization({
+      const startResult = await startConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
         credentials,
       });
@@ -361,21 +361,21 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
       });
 
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: "pending",
         }),
       ).resolves.toStrictEqual({ status: "pending" });
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: "slow-down",
         }),
       ).resolves.toStrictEqual({ status: "slow_down" });
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: "denied",
@@ -386,7 +386,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         errorDescription: "User denied the device authorization request",
       });
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: "expired",
@@ -397,7 +397,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         errorDescription: "Device authorization expired",
       });
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: "error",
@@ -408,7 +408,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         errorDescription: "Synthetic device authorization error",
       });
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: "invalid-grant",
@@ -419,7 +419,7 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         errorDescription: "Unknown device authorization code",
       });
       await expect(
-        pollConnectorOAuthDeviceAuthorization({
+        pollConnectorOAuthDeviceAuth({
           type: "test-oauth-device",
           credentials,
           deviceCode: startResult.deviceCode,
@@ -965,7 +965,7 @@ describe("getConnectorOAuthConfigIfSupported", () => {
 describe("connector OAuth authorization-code config", () => {
   it("declares the current OAuth connectors as authorization-code flows", () => {
     for (const type of connectorTypeSchema.options) {
-      if (!isOAuthAuthorizationCodeConnectorType(type)) {
+      if (!isOAuthAuthCodeConnectorType(type)) {
         continue;
       }
 
@@ -996,17 +996,15 @@ describe("connector OAuth authorization-code config", () => {
 
 describe("connector OAuth device authorization config", () => {
   it("declares the test OAuth device connector as a device authorization flow", () => {
-    expect(isOAuthDeviceAuthorizationConnectorType("test-oauth-device")).toBe(
-      true,
-    );
+    expect(isOAuthDeviceAuthConnectorType("test-oauth-device")).toBe(true);
     expect(getConnectorOAuthFlow("test-oauth-device")).toBe(
       "device-authorization",
     );
     expect(
-      getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device"),
+      getConnectorOAuthDeviceAuthConfig("test-oauth-device"),
     ).toMatchObject({
       flow: "device-authorization",
-      deviceAuthorizationUrl: "/api/test/oauth-provider/device/code",
+      deviceAuthUrl: "/api/test/oauth-provider/device/code",
       tokenUrl: "/api/test/oauth-provider/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -15,9 +15,9 @@ import {
   type StaticConfidentialConnectorOAuthClientConfig,
   type StaticPublicConnectorOAuthClientConfig,
   type ConnectorType,
-  type OAuthAuthorizationCodeConnectorType,
+  type OAuthAuthCodeConnectorType,
   type OAuthConnectorType,
-  type OAuthDeviceAuthorizationConnectorType,
+  type OAuthDeviceAuthConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./oauth-providers/google-oauth-connectors";
@@ -477,24 +477,24 @@ export function getConnectorOAuthFlow(
   return getConnectorOAuthConfig(type).flow;
 }
 
-export function isOAuthAuthorizationCodeConnectorType(
+export function isOAuthAuthCodeConnectorType(
   type: ConnectorType,
-): type is OAuthAuthorizationCodeConnectorType {
+): type is OAuthAuthCodeConnectorType {
   return (
     getConnectorOAuthConfigIfSupported(type)?.flow === "authorization-code"
   );
 }
 
-export function isOAuthDeviceAuthorizationConnectorType(
+export function isOAuthDeviceAuthConnectorType(
   type: ConnectorType,
-): type is OAuthDeviceAuthorizationConnectorType {
+): type is OAuthDeviceAuthConnectorType {
   return (
     getConnectorOAuthConfigIfSupported(type)?.flow === "device-authorization"
   );
 }
 
-export function getConnectorOAuthDeviceAuthorizationConfig(
-  type: OAuthDeviceAuthorizationConnectorType,
+export function getConnectorOAuthDeviceAuthConfig(
+  type: OAuthDeviceAuthConnectorType,
 ): Extract<ConnectorOAuthConfig, { readonly flow: "device-authorization" }> {
   return CONNECTOR_TYPES[type].oauth;
 }

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -318,24 +318,24 @@ export type DynamicPublicConnectorOAuthClientConfig = Extract<
 
 export type ConnectorOAuthFlow = "authorization-code" | "device-authorization";
 
-export interface ConnectorOAuthAuthorizationCodeConfig {
+export interface ConnectorOAuthAuthCodeConfig {
   readonly flow: "authorization-code";
   readonly tokenUrl: string;
   readonly client: ConnectorOAuthClientConfig;
   readonly scopes: string[];
 }
 
-export interface ConnectorOAuthDeviceAuthorizationConfig {
+export interface ConnectorOAuthDeviceAuthConfig {
   readonly flow: "device-authorization";
-  readonly deviceAuthorizationUrl: string;
+  readonly deviceAuthUrl: string;
   readonly tokenUrl: string;
   readonly client: StaticPublicConnectorOAuthClientConfig;
   readonly scopes: string[];
 }
 
 export type ConnectorOAuthConfig =
-  | ConnectorOAuthAuthorizationCodeConfig
-  | ConnectorOAuthDeviceAuthorizationConfig;
+  | ConnectorOAuthAuthCodeConfig
+  | ConnectorOAuthDeviceAuthConfig;
 
 /**
  * CLI auth configuration for connectors that can import credentials through a
@@ -788,12 +788,12 @@ export type OAuthConnectorType = {
     ? Type
     : never;
 }[ConnectorType];
-export type OAuthAuthorizationCodeConnectorType = {
+export type OAuthAuthCodeConnectorType = {
   [Type in OAuthConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["flow"] extends "authorization-code"
     ? Type
     : never;
 }[OAuthConnectorType];
-export type OAuthDeviceAuthorizationConnectorType = {
+export type OAuthDeviceAuthConnectorType = {
   [Type in OAuthConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type]["oauth"]["flow"] extends "device-authorization"
     ? Type
     : never;

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -29,7 +29,7 @@ export const testOauthDevice = {
       // Relative paths — the provider resolves them against the concrete
       // app/API URL because the fake provider lives inside this same app and
       // the preview URL host changes per deploy.
-      deviceAuthorizationUrl: "/api/test/oauth-provider/device/code",
+      deviceAuthUrl: "/api/test/oauth-provider/device/code",
       tokenUrl: "/api/test/oauth-provider/token",
       client: {
         clientRegistration: "static",

--- a/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
+++ b/turbo/packages/connectors/src/oauth-providers/google-oauth-connectors.ts
@@ -1,7 +1,4 @@
-import type {
-  ConnectorType,
-  OAuthAuthorizationCodeConnectorType,
-} from "../connectors";
+import type { ConnectorType, OAuthAuthCodeConnectorType } from "../connectors";
 
 export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
   "gmail",
@@ -11,7 +8,7 @@ export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
   "google-drive",
   "google-meet",
   "google-sheets",
-] as const satisfies readonly OAuthAuthorizationCodeConnectorType[];
+] as const satisfies readonly OAuthAuthCodeConnectorType[];
 
 export type GoogleOAuthConnectorType =
   (typeof GOOGLE_OAUTH_CONNECTOR_TYPES)[number];

--- a/turbo/packages/connectors/src/oauth-providers/model-provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/model-provider-registry.ts
@@ -1,5 +1,5 @@
 import type {
-  OAuthAuthorizationCodeProvider,
+  OAuthAuthCodeProvider,
   OAuthRefreshProvider,
 } from "./provider-types";
 import { codexOauthProvider } from "./providers/codex-oauth-provider";
@@ -8,7 +8,7 @@ export const MODEL_PROVIDER_OAUTH_PROVIDERS = {
   "codex-oauth-token": codexOauthProvider,
 } as const satisfies Record<
   string,
-  OAuthAuthorizationCodeProvider | OAuthRefreshProvider
+  OAuthAuthCodeProvider | OAuthRefreshProvider
 >;
 
 export type ModelProviderOAuthProviderKey =

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -1,11 +1,11 @@
 import type {
   ConnectorType,
-  OAuthAuthorizationCodeConnectorType,
+  OAuthAuthCodeConnectorType,
   OAuthConnectorType,
-  OAuthDeviceAuthorizationConnectorType,
+  OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthDeviceAuthorizationConfig,
+  getConnectorOAuthDeviceAuthConfig,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
@@ -14,15 +14,15 @@ import {
 import {
   type AuthUrlResult,
   type ConnectorOAuthAuthorizeArgs,
-  type ConnectorOAuthDeviceAuthorizationPollArgs,
-  type ConnectorOAuthDeviceAuthorizationStartArgs,
+  type ConnectorOAuthDeviceAuthPollArgs,
+  type ConnectorOAuthDeviceAuthStartArgs,
   type ConnectorOAuthExchangeArgs,
   type ConnectorOAuthProviderFor,
   type OAuthAuthorizeArgs,
-  type OAuthDeviceAuthorizationPollArgs,
-  type OAuthDeviceAuthorizationPollResult,
-  type OAuthDeviceAuthorizationStartArgs,
-  type OAuthDeviceAuthorizationStartResult,
+  type OAuthDeviceAuthPollArgs,
+  type OAuthDeviceAuthPollResult,
+  type OAuthDeviceAuthStartArgs,
+  type OAuthDeviceAuthStartResult,
   type OAuthExchangeArgs,
   type OAuthRefreshArgs,
   type OAuthRefreshResult,
@@ -81,10 +81,10 @@ import { testOauthDeviceProvider } from "./providers/test-oauth-device-provider"
 
 export type {
   AuthUrlResult,
-  OAuthDeviceAuthorizationPollArgs,
-  OAuthDeviceAuthorizationPollResult,
-  OAuthDeviceAuthorizationStartArgs,
-  OAuthDeviceAuthorizationStartResult,
+  OAuthDeviceAuthPollArgs,
+  OAuthDeviceAuthPollResult,
+  OAuthDeviceAuthStartArgs,
+  OAuthDeviceAuthStartResult,
   OAuthAuthorizeArgs,
   OAuthExchangeArgs,
   OAuthRefreshArgs,
@@ -195,7 +195,7 @@ export function getConnectorOAuthProvider(
 }
 
 export async function buildConnectorOAuthAuthUrl<
-  T extends OAuthAuthorizationCodeConnectorType,
+  T extends OAuthAuthCodeConnectorType,
 >(args: {
   readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
@@ -212,7 +212,7 @@ export async function buildConnectorOAuthAuthUrl<
 }
 
 export async function exchangeConnectorOAuthCode<
-  T extends OAuthAuthorizationCodeConnectorType,
+  T extends OAuthAuthCodeConnectorType,
 >(args: {
   readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
@@ -234,34 +234,34 @@ export async function exchangeConnectorOAuthCode<
   } as ConnectorOAuthExchangeArgs<T>);
 }
 
-export async function startConnectorOAuthDeviceAuthorization<
-  T extends OAuthDeviceAuthorizationConnectorType,
+export async function startConnectorOAuthDeviceAuth<
+  T extends OAuthDeviceAuthConnectorType,
 >(args: {
   readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
-}): Promise<OAuthDeviceAuthorizationStartResult> {
+}): Promise<OAuthDeviceAuthStartResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const provider = connectorProviderFor(args.type);
-  const oauthConfig = getConnectorOAuthDeviceAuthorizationConfig(args.type);
-  return await provider.startDeviceAuthorization({
+  const oauthConfig = getConnectorOAuthDeviceAuthConfig(args.type);
+  return await provider.startDeviceAuth({
     ...connectorCredentialArgs(args.credentials),
     scopes: oauthConfig.scopes,
-  } as ConnectorOAuthDeviceAuthorizationStartArgs<T>);
+  } as ConnectorOAuthDeviceAuthStartArgs<T>);
 }
 
-export async function pollConnectorOAuthDeviceAuthorization<
-  T extends OAuthDeviceAuthorizationConnectorType,
+export async function pollConnectorOAuthDeviceAuth<
+  T extends OAuthDeviceAuthConnectorType,
 >(args: {
   readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
   readonly deviceCode: string;
-}): Promise<OAuthDeviceAuthorizationPollResult> {
+}): Promise<OAuthDeviceAuthPollResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const provider = connectorProviderFor(args.type);
-  return await provider.pollDeviceAuthorization({
+  return await provider.pollDeviceAuth({
     ...connectorCredentialArgs(args.credentials),
     deviceCode: args.deviceCode,
-  } as ConnectorOAuthDeviceAuthorizationPollArgs<T>);
+  } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
 
 export async function refreshConnectorOAuthToken(args: {

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -1,9 +1,9 @@
 import type {
   CONNECTOR_TYPES,
   ConnectorOAuthClientConfig,
-  OAuthAuthorizationCodeConnectorType,
+  OAuthAuthCodeConnectorType,
   OAuthConnectorType,
-  OAuthDeviceAuthorizationConnectorType,
+  OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 
 export interface ProviderEnv {
@@ -64,11 +64,11 @@ interface OAuthRevokeFlowArgs {
   readonly accessToken: string;
 }
 
-interface OAuthDeviceAuthorizationStartFlowArgs {
+interface OAuthDeviceAuthStartFlowArgs {
   readonly scopes: readonly string[];
 }
 
-interface OAuthDeviceAuthorizationPollFlowArgs {
+interface OAuthDeviceAuthPollFlowArgs {
   readonly deviceCode: string;
 }
 
@@ -89,11 +89,11 @@ export type OAuthRefreshArgs = OAuthRefreshFlowArgs &
 export type OAuthRevokeArgs = OAuthRevokeFlowArgs &
   OptionalClientCredentialArgs;
 
-export type OAuthDeviceAuthorizationStartArgs =
-  OAuthDeviceAuthorizationStartFlowArgs & OptionalClientCredentialArgs;
+export type OAuthDeviceAuthStartArgs = OAuthDeviceAuthStartFlowArgs &
+  OptionalClientCredentialArgs;
 
-export type OAuthDeviceAuthorizationPollArgs =
-  OAuthDeviceAuthorizationPollFlowArgs & OptionalClientCredentialArgs;
+export type OAuthDeviceAuthPollArgs = OAuthDeviceAuthPollFlowArgs &
+  OptionalClientCredentialArgs;
 
 export interface OAuthRefreshResult {
   readonly accessToken: string;
@@ -101,7 +101,7 @@ export interface OAuthRefreshResult {
   readonly expiresIn?: number;
 }
 
-export interface OAuthDeviceAuthorizationStartResult {
+export interface OAuthDeviceAuthStartResult {
   readonly deviceCode: string;
   readonly userCode: string;
   readonly verificationUri: string;
@@ -110,45 +110,45 @@ export interface OAuthDeviceAuthorizationStartResult {
   readonly interval?: number;
 }
 
-export interface OAuthDeviceAuthorizationPendingResult {
+export interface OAuthDeviceAuthPendingResult {
   readonly status: "pending";
   readonly interval?: number;
 }
 
-export interface OAuthDeviceAuthorizationSlowDownResult {
+export interface OAuthDeviceAuthSlowDownResult {
   readonly status: "slow_down";
 }
 
-export interface OAuthDeviceAuthorizationCompleteResult {
+export interface OAuthDeviceAuthCompleteResult {
   readonly status: "complete";
   readonly token: OAuthTokenResult;
 }
 
-export interface OAuthDeviceAuthorizationDeniedResult {
+export interface OAuthDeviceAuthDeniedResult {
   readonly status: "denied";
   readonly error?: string;
   readonly errorDescription?: string;
 }
 
-export interface OAuthDeviceAuthorizationExpiredResult {
+export interface OAuthDeviceAuthExpiredResult {
   readonly status: "expired";
   readonly error?: string;
   readonly errorDescription?: string;
 }
 
-export interface OAuthDeviceAuthorizationErrorResult {
+export interface OAuthDeviceAuthErrorResult {
   readonly status: "error";
   readonly error: string;
   readonly errorDescription?: string;
 }
 
-export type OAuthDeviceAuthorizationPollResult =
-  | OAuthDeviceAuthorizationPendingResult
-  | OAuthDeviceAuthorizationSlowDownResult
-  | OAuthDeviceAuthorizationCompleteResult
-  | OAuthDeviceAuthorizationDeniedResult
-  | OAuthDeviceAuthorizationExpiredResult
-  | OAuthDeviceAuthorizationErrorResult;
+export type OAuthDeviceAuthPollResult =
+  | OAuthDeviceAuthPendingResult
+  | OAuthDeviceAuthSlowDownResult
+  | OAuthDeviceAuthCompleteResult
+  | OAuthDeviceAuthDeniedResult
+  | OAuthDeviceAuthExpiredResult
+  | OAuthDeviceAuthErrorResult;
 
 export type BuildAuthUrlFn = (
   args: OAuthAuthorizeArgs,
@@ -164,13 +164,13 @@ export type RefreshTokenFn = (
 
 export type RevokeTokenFn = (args: OAuthRevokeArgs) => Promise<void>;
 
-export type StartDeviceAuthorizationFn = (
-  args: OAuthDeviceAuthorizationStartArgs,
-) => Promise<OAuthDeviceAuthorizationStartResult>;
+export type StartDeviceAuthFn = (
+  args: OAuthDeviceAuthStartArgs,
+) => Promise<OAuthDeviceAuthStartResult>;
 
-export type PollDeviceAuthorizationFn = (
-  args: OAuthDeviceAuthorizationPollArgs,
-) => Promise<OAuthDeviceAuthorizationPollResult>;
+export type PollDeviceAuthFn = (
+  args: OAuthDeviceAuthPollArgs,
+) => Promise<OAuthDeviceAuthPollResult>;
 
 type ConnectorOAuthClientFor<T extends OAuthConnectorType> =
   (typeof CONNECTOR_TYPES)[T]["oauth"]["client"];
@@ -207,21 +207,21 @@ export type ConnectorOAuthRefreshArgs<T extends OAuthConnectorType> =
 export type ConnectorOAuthRevokeArgs<T extends OAuthConnectorType> =
   OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthDeviceAuthorizationStartArgs<
-  T extends OAuthDeviceAuthorizationConnectorType,
-> = OAuthDeviceAuthorizationStartFlowArgs &
+export type ConnectorOAuthDeviceAuthStartArgs<
+  T extends OAuthDeviceAuthConnectorType,
+> = OAuthDeviceAuthStartFlowArgs &
   StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthDeviceAuthorizationPollArgs<
-  T extends OAuthDeviceAuthorizationConnectorType,
-> = OAuthDeviceAuthorizationPollFlowArgs &
+export type ConnectorOAuthDeviceAuthPollArgs<
+  T extends OAuthDeviceAuthConnectorType,
+> = OAuthDeviceAuthPollFlowArgs &
   TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-type BuildConnectorAuthUrlFn<T extends OAuthAuthorizationCodeConnectorType> = (
+type BuildConnectorAuthUrlFn<T extends OAuthAuthCodeConnectorType> = (
   args: ConnectorOAuthAuthorizeArgs<T>,
 ) => string | AuthUrlResult | Promise<string | AuthUrlResult>;
 
-type ExchangeConnectorCodeFn<T extends OAuthAuthorizationCodeConnectorType> = (
+type ExchangeConnectorCodeFn<T extends OAuthAuthCodeConnectorType> = (
   args: ConnectorOAuthExchangeArgs<T>,
 ) => Promise<OAuthTokenResult>;
 
@@ -233,17 +233,13 @@ type RevokeConnectorTokenFn<T extends OAuthConnectorType> = (
   args: ConnectorOAuthRevokeArgs<T>,
 ) => Promise<void>;
 
-type StartConnectorDeviceAuthorizationFn<
-  T extends OAuthDeviceAuthorizationConnectorType,
-> = (
-  args: ConnectorOAuthDeviceAuthorizationStartArgs<T>,
-) => Promise<OAuthDeviceAuthorizationStartResult>;
+type StartConnectorDeviceAuthFn<T extends OAuthDeviceAuthConnectorType> = (
+  args: ConnectorOAuthDeviceAuthStartArgs<T>,
+) => Promise<OAuthDeviceAuthStartResult>;
 
-type PollConnectorDeviceAuthorizationFn<
-  T extends OAuthDeviceAuthorizationConnectorType,
-> = (
-  args: ConnectorOAuthDeviceAuthorizationPollArgs<T>,
-) => Promise<OAuthDeviceAuthorizationPollResult>;
+type PollConnectorDeviceAuthFn<T extends OAuthDeviceAuthConnectorType> = (
+  args: ConnectorOAuthDeviceAuthPollArgs<T>,
+) => Promise<OAuthDeviceAuthPollResult>;
 
 export interface OAuthProviderMetadata {
   getSecretName(): string;
@@ -254,14 +250,14 @@ export interface OAuthProvider extends OAuthProviderMetadata {
   getClientSecret(currentEnv: ProviderEnv): string | undefined;
 }
 
-export type OAuthAuthorizationCodeProvider = OAuthProvider & {
+export type OAuthAuthCodeProvider = OAuthProvider & {
   buildAuthUrl: BuildAuthUrlFn;
   exchangeCode: ExchangeCodeFn;
 };
 
-export type OAuthDeviceAuthorizationProvider = OAuthProvider & {
-  startDeviceAuthorization: StartDeviceAuthorizationFn;
-  pollDeviceAuthorization: PollDeviceAuthorizationFn;
+export type OAuthDeviceAuthProvider = OAuthProvider & {
+  startDeviceAuth: StartDeviceAuthFn;
+  pollDeviceAuth: PollDeviceAuthFn;
 };
 
 export type OAuthRefreshProvider = OAuthProvider & {
@@ -282,18 +278,18 @@ type OAuthNoRevocationProvider = {
   revokeToken?: never;
 };
 
-export type ConnectorOAuthAuthorizationCodeProvider<
-  T extends OAuthAuthorizationCodeConnectorType,
+export type ConnectorOAuthAuthCodeProvider<
+  T extends OAuthAuthCodeConnectorType,
 > = OAuthProviderMetadata & {
   buildAuthUrl: BuildConnectorAuthUrlFn<T>;
   exchangeCode: ExchangeConnectorCodeFn<T>;
 };
 
-export type ConnectorOAuthDeviceAuthorizationProvider<
-  T extends OAuthDeviceAuthorizationConnectorType,
+export type ConnectorOAuthDeviceAuthProvider<
+  T extends OAuthDeviceAuthConnectorType,
 > = OAuthProviderMetadata & {
-  startDeviceAuthorization: StartConnectorDeviceAuthorizationFn<T>;
-  pollDeviceAuthorization: PollConnectorDeviceAuthorizationFn<T>;
+  startDeviceAuth: StartConnectorDeviceAuthFn<T>;
+  pollDeviceAuth: PollConnectorDeviceAuthFn<T>;
 };
 
 export type ConnectorOAuthRefreshProvider<T extends OAuthConnectorType> = {
@@ -306,10 +302,10 @@ export type ConnectorOAuthRevocationProvider<T extends OAuthConnectorType> = {
 };
 
 type ConnectorOAuthFlowProvider<T extends OAuthConnectorType> =
-  T extends OAuthAuthorizationCodeConnectorType
-    ? ConnectorOAuthAuthorizationCodeProvider<T>
-    : T extends OAuthDeviceAuthorizationConnectorType
-      ? ConnectorOAuthDeviceAuthorizationProvider<T>
+  T extends OAuthAuthCodeConnectorType
+    ? ConnectorOAuthAuthCodeProvider<T>
+    : T extends OAuthDeviceAuthConnectorType
+      ? ConnectorOAuthDeviceAuthProvider<T>
       : never;
 
 export type ConnectorOAuthProviderFor<T extends OAuthConnectorType> =

--- a/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthAuthorizationCodeConnectorType } from "@vm0/connectors/connectors";
+import type { OAuthAuthCodeConnectorType } from "@vm0/connectors/connectors";
 import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
@@ -9,7 +9,7 @@ const MICROSOFT_AUTHORIZATION_URL =
 const MICROSOFT_USERINFO_URL = "https://graph.microsoft.com/v1.0/me";
 
 type MicrosoftOAuthConnectorType = Extract<
-  OAuthAuthorizationCodeConnectorType,
+  OAuthAuthCodeConnectorType,
   "outlook-calendar" | "outlook-mail"
 >;
 

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
@@ -1,7 +1,7 @@
 import { defineConnectorOAuthProvider } from "../provider-types";
 import {
-  pollTestOAuthDeviceAuthorization,
-  startTestOAuthDeviceAuthorization,
+  pollTestOAuthDeviceAuth,
+  startTestOAuthDeviceAuth,
   TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
 } from "./test-oauth-device";
 
@@ -11,16 +11,16 @@ export const testOauthDeviceProvider = defineConnectorOAuthProvider(
     getSecretName: () => {
       return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
     },
-    startDeviceAuthorization: async (args) => {
+    startDeviceAuth: async (args) => {
       const { clientId } = args;
-      return await startTestOAuthDeviceAuthorization({
+      return await startTestOAuthDeviceAuth({
         clientId,
         scopes: args.scopes,
       });
     },
-    pollDeviceAuthorization: async (args) => {
+    pollDeviceAuth: async (args) => {
       const { clientId } = args;
-      return await pollTestOAuthDeviceAuthorization({
+      return await pollTestOAuthDeviceAuth({
         clientId,
         deviceCode: args.deviceCode,
       });

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device.ts
@@ -1,9 +1,9 @@
-import { getConnectorOAuthDeviceAuthorizationConfig } from "@vm0/connectors/connector-utils";
+import { getConnectorOAuthDeviceAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 
 import type {
-  OAuthDeviceAuthorizationPollResult,
-  OAuthDeviceAuthorizationStartResult,
+  OAuthDeviceAuthPollResult,
+  OAuthDeviceAuthStartResult,
 } from "../provider-types";
 import { throwOAuthError } from "./oauth-error";
 import {
@@ -20,7 +20,7 @@ export const TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME =
 
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
-const deviceAuthorizationResponseSchema = z.object({
+const deviceAuthResponseSchema = z.object({
   device_code: z.string(),
   user_code: z.string(),
   verification_uri: z.string(),
@@ -42,26 +42,25 @@ const tokenErrorResponseSchema = z.object({
   error_description: z.string().optional(),
 });
 
-function getDeviceAuthorizationUrl(): string {
+function getDeviceAuthUrl(): string {
   return resolveTestOAuthProviderUrl(
-    "deviceAuthorizationUrl",
-    getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device")
-      .deviceAuthorizationUrl,
+    "deviceAuthUrl",
+    getConnectorOAuthDeviceAuthConfig("test-oauth-device").deviceAuthUrl,
   );
 }
 
 function getDeviceTokenUrl(): string {
   return resolveTestOAuthProviderUrl(
     "tokenUrl",
-    getConnectorOAuthDeviceAuthorizationConfig("test-oauth-device").tokenUrl,
+    getConnectorOAuthDeviceAuthConfig("test-oauth-device").tokenUrl,
   );
 }
 
-export async function startTestOAuthDeviceAuthorization(args: {
+export async function startTestOAuthDeviceAuth(args: {
   readonly clientId: string;
   readonly scopes: readonly string[];
-}): Promise<OAuthDeviceAuthorizationStartResult> {
-  const response = await fetch(getDeviceAuthorizationUrl(), {
+}): Promise<OAuthDeviceAuthStartResult> {
+  const response = await fetch(getDeviceAuthUrl(), {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -77,7 +76,7 @@ export async function startTestOAuthDeviceAuthorization(args: {
     await throwOAuthError("TestOAuthDevice", "start", response);
   }
 
-  const data = deviceAuthorizationResponseSchema.parse(await response.json());
+  const data = deviceAuthResponseSchema.parse(await response.json());
   return {
     deviceCode: data.device_code,
     userCode: data.user_code,
@@ -91,7 +90,7 @@ export async function startTestOAuthDeviceAuthorization(args: {
 function devicePollErrorResult(args: {
   readonly error: string;
   readonly errorDescription: string | undefined;
-}): OAuthDeviceAuthorizationPollResult | null {
+}): OAuthDeviceAuthPollResult | null {
   if (args.error === "authorization_pending") {
     return { status: "pending" };
   }
@@ -122,10 +121,10 @@ function devicePollErrorResult(args: {
   return null;
 }
 
-export async function pollTestOAuthDeviceAuthorization(args: {
+export async function pollTestOAuthDeviceAuth(args: {
   readonly clientId: string;
   readonly deviceCode: string;
-}): Promise<OAuthDeviceAuthorizationPollResult> {
+}): Promise<OAuthDeviceAuthPollResult> {
   const response = await fetch(getDeviceTokenUrl(), {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary

- Rename connector OAuth flow-family types and helpers from AuthorizationCode/DeviceAuthorization to AuthCode/DeviceAuth
- Update connector OAuth provider registry, API contracts, route/service imports, and tests to use the shorter names
- Keep OAuth flow literals, API paths, DB schema/table names, and unrelated authorizationCode fields unchanged

Fixes #14534

## Tests

- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-oauth-device-authorization.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/test-oauth-provider-get.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-third-party.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-authorize.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F api exec vitest src/__tests__/web-api-compatibility.test.ts
- pnpm turbo run lint --filter=@vm0/connectors --filter=@vm0/api-contracts --filter=api
- pnpm check-types
- pnpm knip (via pre-commit)

Note: the first webhooks-third-party run failed because the local DB was missing github_installations.org_id; after pnpm -F web db:migrate, the test passed.