### PR TITLE
fix: keep Computer Use content mounted during refresh

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
@@ -1,9 +1,10 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -141,6 +142,65 @@ describe("zero desktop Computer Use page", () => {
     expect(screen.getByText("targeted_mouse_event")).toBeInTheDocument();
     expect(screen.getByText("targeted_app_pointer")).toBeInTheDocument();
     expect(screen.getByText("Approve")).toBeInTheDocument();
+  });
+
+  it("keeps previous runtime content mounted while a bridge refresh is loading", async () => {
+    const state = computerUseState();
+    const pendingReload = createDeferredPromise<TestDesktopComputerUseState>(
+      context.signal,
+    );
+    const getState = vi.fn((): Promise<TestDesktopComputerUseState> => {
+      return Promise.resolve(state);
+    });
+    let notifyComputerUseChange: (() => void) | null = null;
+    installDesktopComputerUseApi({
+      getState,
+      start() {
+        return Promise.resolve(state);
+      },
+      requestAccessibilityPermission() {
+        return Promise.resolve(state);
+      },
+      openAccessibilitySettings() {
+        return Promise.resolve();
+      },
+      openScreenRecordingSettings() {
+        return Promise.resolve();
+      },
+      decideCommand() {
+        return Promise.resolve(state);
+      },
+      subscribe(callback) {
+        notifyComputerUseChange = callback;
+        return () => {};
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/computer-use",
+      featureSwitches: {
+        [FeatureSwitchKey.ComputerUse]: true,
+      },
+    });
+
+    await screen.findByRole("heading", { name: "Computer Use" });
+    expect(screen.getByText("Recent command history")).toBeInTheDocument();
+    getState.mockImplementation(() => {
+      return pendingReload.promise;
+    });
+
+    expect(notifyComputerUseChange).not.toBeNull();
+    act(() => {
+      notifyComputerUseChange?.();
+    });
+
+    await waitFor(() => {
+      expect(getState).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByText("host-1")).toBeInTheDocument();
+    expect(screen.getByText("Recent command history")).toBeInTheDocument();
+    expect(screen.getAllByText("element.click")[0]).toBeInTheDocument();
   });
 
   it("submits pending approval decisions through the native bridge", async () => {

--- a/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLoadable } from "ccstate-react";
+import { useGet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconAlertCircle,
@@ -492,7 +492,7 @@ function DesktopComputerUseHeader() {
 }
 
 function DesktopComputerUsePageBody() {
-  const dataLoadable = useLoadable(desktopComputerUseData$);
+  const dataLoadable = useLastLoadable(desktopComputerUseData$);
   return (
     <main className="shrink-0 px-4 pb-16 pt-3 sm:px-6">
       <div className="mx-auto flex max-w-[1100px] flex-col gap-6">


### PR DESCRIPTION
## Summary

Closes #14539.

- keep the Desktop Computer Use page on the last resolved runtime state while bridge refreshes are in flight
- prevent heartbeat-driven refreshes from replacing the page body with the loading spinner
- add regression coverage for a pending bridge refresh preserving runtime/history content

## Tests

- `pnpm prettier --write apps/platform/src/views/zero-page/desktop-computer-use-page.tsx apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
