### PR TITLE
fix: harden github integration triggers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -822,7 +822,7 @@ describe("GitHub OAuth API routes", () => {
     expect(location).toContain("Missing%20default%20agent");
   });
 
-  it("creates a pending installation for request actions", async () => {
+  it("redirects request actions with an installation permission error", async () => {
     const fixture = await seedComposeFixture(cleanup);
     const targetId = "777888999";
     cleanup.targetIds.push(targetId);
@@ -839,18 +839,12 @@ describe("GitHub OAuth API routes", () => {
     const location = new URL(response.headers.get("location")!);
     expect(location.origin).toBe(APP_ORIGIN);
     expect(location.pathname).toBe("/works");
-    expect(location.searchParams.get("github")).toBe("pending");
+    expect(location.searchParams.get("error")).toBe(
+      "You don't have permission to install this GitHub App. Ask a GitHub organization owner to install it, then try again.",
+    );
+    expect(location.searchParams.has("github")).toBeFalsy();
     const installations = await findInstallationByTargetId(targetId);
-    expect(installations).toHaveLength(1);
-    expect(installations[0]).toMatchObject({
-      installationId: null,
-      encryptedAccessToken: null,
-      status: "pending",
-      targetId,
-      targetType: "Organization",
-      orgId: fixture.orgId,
-      defaultComposeId: fixture.composeId,
-    });
+    expect(installations).toHaveLength(0);
   });
 
   it("redirects callback with an error when installation id is missing", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { secrets } from "@vm0/db/schema/secret";
@@ -516,6 +517,65 @@ describe("GET /api/integrations/github", () => {
     );
 
     expect(response.body.installation.isAdmin).toBeFalsy();
+  });
+
+  it("marks label listeners manageable for their owner and org admins", async () => {
+    const fixture = await seedGithubFixture();
+    fixtures.push(fixture);
+    await writeDb.insert(githubLabelListeners).values([
+      {
+        installationId: fixture.installationRowId,
+        orgId: fixture.orgId,
+        createdByUserId: fixture.userId,
+        labelName: "Mine",
+        labelNameNormalized: "mine",
+        triggerMode: "anyone",
+        prompt: "Handle my label",
+        composeId: fixture.composeId,
+      },
+      {
+        installationId: fixture.installationRowId,
+        orgId: fixture.orgId,
+        createdByUserId: `user_${randomUUID()}`,
+        labelName: "Theirs",
+        labelNameNormalized: "theirs",
+        triggerMode: "anyone",
+        prompt: "Handle their label",
+        composeId: fixture.composeId,
+      },
+    ]);
+    mockSession(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const memberResponse = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(
+      memberResponse.body.labelListeners.map((listener) => {
+        return {
+          labelName: listener.labelName,
+          canManage: listener.canManage,
+        };
+      }),
+    ).toStrictEqual([
+      { labelName: "Mine", canManage: true },
+      { labelName: "Theirs", canManage: false },
+    ]);
+
+    mockSession(`user_${randomUUID()}`, fixture.orgId);
+
+    const adminResponse = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(
+      adminResponse.body.labelListeners.map((listener) => {
+        return listener.canManage;
+      }),
+    ).toStrictEqual([true, true]);
   });
 
   it("reports required and missing environment values from the default agent", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-label-listeners.test.ts
@@ -204,7 +204,7 @@ describe("GitHub label listener integration routes", () => {
     await expect(listenerRows(fixture)).resolves.toHaveLength(0);
   });
 
-  it("allows another org member to update and delete a label listener", async () => {
+  it("rejects another org member updating or deleting a label listener", async () => {
     const fixture = await seedFixture();
     fixtures.push(fixture);
     const db = store.set(writeDb$);
@@ -226,6 +226,50 @@ describe("GitHub label listener integration routes", () => {
     }
     const otherUserId = `user_${randomUUID()}`;
     mocks.clerk.session(otherUserId, fixture.orgId, "org:member");
+    const app = createApp({ signal: context.signal });
+
+    const updateResponse = await app.request(`${ROUTE_PATH}/${listener.id}`, {
+      method: "PATCH",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(updateResponse.status).toBe(403);
+    await expect(listenerRows(fixture)).resolves.toMatchObject([
+      { enabled: true },
+    ]);
+
+    const deleteResponse = await app.request(`${ROUTE_PATH}/${listener.id}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(deleteResponse.status).toBe(403);
+    await expect(listenerRows(fixture)).resolves.toHaveLength(1);
+  });
+
+  it("allows an org admin to update and delete another user's label listener", async () => {
+    const fixture = await seedFixture();
+    fixtures.push(fixture);
+    const db = store.set(writeDb$);
+    const [listener] = await db
+      .insert(githubLabelListeners)
+      .values({
+        installationId: fixture.installationId,
+        orgId: fixture.orgId,
+        createdByUserId: fixture.userId,
+        labelName: "Ready",
+        labelNameNormalized: "ready",
+        triggerMode: "created_by_me",
+        prompt: "Handle it",
+        composeId: fixture.composeId,
+      })
+      .returning({ id: githubLabelListeners.id });
+    if (!listener) {
+      throw new Error("Expected label listener insert to return a row");
+    }
+    const adminUserId = `user_${randomUUID()}`;
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
     const app = createApp({ signal: context.signal });
 
     const updateResponse = await app.request(`${ROUTE_PATH}/${listener.id}`, {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
@@ -669,8 +669,10 @@ describe("POST /api/internal/callbacks/github/issues", () => {
 
     expect(response.status).toBe(200);
     expect(capturedComments).toHaveLength(1);
-    expect(capturedComments[0]!.body).toContain("**Error:**");
-    expect(capturedComments[0]!.body).toContain("Agent crashed unexpectedly");
+    expect(capturedComments[0]!.body).not.toContain("**Error:**");
+    expect(capturedComments[0]!.body).toContain(
+      "Oops, something went wrong. Please try again later.",
+    );
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 
@@ -755,6 +757,56 @@ describe("POST /api/internal/callbacks/github/issues", () => {
     expect(issueSession).not.toBeNull();
     expect(issueSession!.agentSessionId).toBe(session.id);
     expect(issueSession!.userId).toBe(fixture.userId);
+    expect(issueSession!.lastCommentId).toBe(GITHUB_COMMENT_ID);
+  });
+
+  it("replaces a stale GitHub issue session when starting a new session", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    setupGithubApiMocks(installation.installationId);
+    const staleSession = await seedAgentSession(fixture);
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    await seedIssueSession({
+      userId: fixture.userId,
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+      agentSessionId: staleSession.id,
+      lastCommentId: "old-comment-id",
+    });
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    const newSession = await seedAgentSession(fixture);
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    const issueSession = await findIssueSession({
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+    });
+    expect(issueSession).not.toBeNull();
+    expect(issueSession!.agentSessionId).toBe(newSession.id);
     expect(issueSession!.lastCommentId).toBe(GITHUB_COMMENT_ID);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -10,20 +10,24 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { users } from "@vm0/db/schema/user";
+import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { storages } from "@vm0/db/schema/storage";
@@ -166,6 +170,10 @@ interface GitHubApiComment {
   };
   readonly body: string;
   readonly created_at: string;
+}
+
+interface CapturedGitHubIssueComment {
+  readonly body: string;
 }
 
 interface GitHubIssuesPayloadOverrides {
@@ -457,8 +465,11 @@ async function selectGitHubRuns(fixture: GitHubWebhookFixture) {
     .select({
       id: agentRuns.id,
       prompt: agentRuns.prompt,
+      sessionId: agentRuns.sessionId,
       appendSystemPrompt: agentRuns.appendSystemPrompt,
       triggerSource: zeroRuns.triggerSource,
+      modelProvider: zeroRuns.modelProvider,
+      selectedModel: zeroRuns.selectedModel,
     })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
@@ -482,8 +493,79 @@ async function selectGitHubCallbacks(runId: string) {
     .where(eq(agentRunCallbacks.runId, runId));
 }
 
+function expectGitHubIssueContextPrompt(
+  prompt: string | null | undefined,
+): void {
+  expect(prompt).toContain("You are currently running inside: GitHub");
+  expect(prompt).toContain(`Bot username: @${GITHUB_APP_SLUG}[bot]`);
+  expect(prompt).toContain(
+    "Issue URL: https://github.com/vm0-ai/vm0/issues/42",
+  );
+  expect(prompt).toContain("# GitHub Issue Context");
+  expect(prompt).not.toContain("# GitHub Label Trigger");
+  expect(prompt).toContain("Matched label: vm0-agent");
+  expect(prompt).toContain("- RELATIVE_INDEX: -2");
+  expect(prompt).toContain("- MSG_ID: issue:42");
+  expect(prompt).toContain("username: @linked-user, type: User");
+  expect(prompt).not.toContain("## Description");
+  expect(prompt).not.toContain("## Comments");
+  expect(prompt).toContain("This is a test issue body");
+  expect(prompt).toContain("Earlier discussion");
+}
+
 function remoteGitHubId(): string {
   return String(randomInt(1_000_000, 999_999_999));
+}
+
+async function seedGitHubModelRoute(args: {
+  readonly fixture: GitHubWebhookFixture;
+  readonly selectedModel?: string | null;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(orgModelPolicies).values([
+    {
+      orgId: args.fixture.orgId,
+      model: "claude-sonnet-4-6",
+      isDefault: true,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      createdByUserId: args.fixture.userId,
+      updatedByUserId: args.fixture.userId,
+    },
+    {
+      orgId: args.fixture.orgId,
+      model: "claude-opus-4-7",
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      createdByUserId: args.fixture.userId,
+      updatedByUserId: args.fixture.userId,
+    },
+  ]);
+  await db.insert(vm0ApiKeys).values([
+    {
+      vendor: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: "vm0-key-claude-sonnet-4-6",
+      label: args.fixture.composeId,
+    },
+    {
+      vendor: "anthropic",
+      model: "claude-opus-4-7",
+      apiKey: "vm0-key-claude-opus-4-7",
+      label: args.fixture.composeId,
+    },
+  ]);
+  await db
+    .insert(orgMembersMetadata)
+    .values({
+      orgId: args.fixture.orgId,
+      userId: args.fixture.userId,
+      selectedModel: args.selectedModel ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+      set: { selectedModel: args.selectedModel ?? null },
+    });
 }
 
 async function postRaw(args: {
@@ -690,6 +772,12 @@ const deleteGitHubFixture$ = command(
         .where(inArray(githubInstallations.id, installationIds));
       signal.throwIfAborted();
     }
+    await db
+      .delete(orgModelPolicies)
+      .where(eq(orgModelPolicies.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await db.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, fixture.composeId));
+    signal.throwIfAborted();
     signal.throwIfAborted();
     await set(deleteUsageInsightFixture$, fixture, signal);
     signal.throwIfAborted();
@@ -753,6 +841,13 @@ const seedGitHubWebhookFixture$ = command(
       orgId: fixture.orgId,
       credits: 100_000,
       tier: "pro",
+    });
+    signal.throwIfAborted();
+    await db.insert(vm0ApiKeys).values({
+      vendor: "deepseek",
+      model: "deepseek-v4-pro",
+      apiKey: "vm0-key-deepseek-v4-pro",
+      label: compose.id,
     });
     signal.throwIfAborted();
     await db.insert(userCache).values({
@@ -1028,6 +1123,10 @@ describe("POST /api/webhooks/github", () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
+    await seedGitHubModelRoute({
+      fixture,
+      selectedModel: "claude-opus-4-7",
+    });
     mockGitHubWebhookEnv();
     mockGitHubAppCredentials();
     setupGitHubApiMocks({
@@ -1054,13 +1153,10 @@ describe("POST /api/webhooks/github", () => {
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
     expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
-    expect(runs[0]?.appendSystemPrompt).toContain(
-      "You are currently running inside: GitHub",
-    );
-    expect(runs[0]?.appendSystemPrompt).toContain("Matched label: vm0-agent");
-    expect(runs[0]?.appendSystemPrompt).toContain("This is a test issue body");
-    expect(runs[0]?.appendSystemPrompt).toContain("Earlier discussion");
+    expectGitHubIssueContextPrompt(runs[0]?.appendSystemPrompt);
     expect(runs[0]?.triggerSource).toBe("github");
+    expect(runs[0]?.modelProvider).toBe("vm0");
+    expect(runs[0]?.selectedModel).toBe("claude-opus-4-7");
 
     const callbacks = await selectGitHubCallbacks(runs[0]?.id ?? "");
     expect(callbacks).toHaveLength(1);
@@ -1071,6 +1167,53 @@ describe("POST /api/webhooks/github", () => {
       issueNumber: 42,
       agentId: fixture.composeId,
     });
+  });
+
+  it("posts a formatted failure comment when the GitHub trigger run is rejected", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockGitHubWebhookEnv();
+    mockGitHubAppCredentials();
+    setupGitHubApiMocks({
+      installationId: fixture.remoteInstallationId,
+    });
+
+    const capturedComments: CapturedGitHubIssueComment[] = [];
+    server.use(
+      http.post(
+        "https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments",
+        async ({ request }) => {
+          const body = (await request.json()) as { readonly body: string };
+          capturedComments.push({ body: body.body });
+          return HttpResponse.json({ id: 9876 });
+        },
+      ),
+    );
+
+    await store
+      .set(writeDb$)
+      .update(zeroAgents)
+      .set({
+        owner: `user_${randomUUID()}`,
+        visibility: "private",
+      })
+      .where(eq(zeroAgents.id, fixture.composeId));
+
+    const response = await postGitHubWebhook({
+      event: "issues",
+      payload: buildGitHubIssuesPayload(fixture, { action: "opened" }),
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(capturedComments).toHaveLength(1);
+    expect(capturedComments[0]?.body).toContain(
+      "Oops, something went wrong. Please try again later.",
+    );
+    expect(capturedComments[0]?.body).not.toContain("Failed to start");
+    await expect(selectGitHubRuns(fixture)).resolves.toHaveLength(0);
   });
 
   it("dispatches labeled issues only when the added label is the app slug", async () => {
@@ -1098,6 +1241,76 @@ describe("POST /api/webhooks/github", () => {
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
     expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
+  });
+
+  it("continues an existing session for the same GitHub issue", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockGitHubWebhookEnv();
+    mockGitHubAppCredentials();
+    setupGitHubApiMocks({
+      installationId: fixture.remoteInstallationId,
+      comments: [
+        {
+          id: 12,
+          user: { login: "maintainer", type: "User" },
+          body: "Earlier discussion",
+          created_at: "2026-05-20T00:00:00Z",
+        },
+        {
+          id: 13,
+          user: { login: "maintainer", type: "User" },
+          body: "New detail",
+          created_at: "2026-05-21T00:00:00Z",
+        },
+      ],
+    });
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .insert(agentSessions)
+      .values({
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        agentComposeId: fixture.composeId,
+      })
+      .returning({ id: agentSessions.id });
+    if (!session) {
+      throw new Error("agent session insert returned no row");
+    }
+    await db.insert(githubIssueSessions).values({
+      userId: fixture.userId,
+      installationId: fixture.installationDbId,
+      repo: "vm0-ai/vm0",
+      issueNumber: 42,
+      agentSessionId: session.id,
+      lastCommentId: "12",
+    });
+
+    const response = await postGitHubWebhook({
+      event: "issues",
+      payload: buildGitHubIssuesPayload(fixture, {
+        action: "labeled",
+        labels: [{ id: 1, name: GITHUB_APP_SLUG }],
+        label: { id: 1, name: GITHUB_APP_SLUG },
+      }),
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    const runs = await selectGitHubRuns(fixture);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.sessionId).toBe(session.id);
+    expect(runs[0]?.appendSystemPrompt).toContain("Earlier discussion");
+    expect(runs[0]?.appendSystemPrompt).toContain("New detail");
+    expect(runs[0]?.appendSystemPrompt).toContain("- MSG_ID: issue:42");
+    expect(runs[0]?.appendSystemPrompt).toContain("- MSG_ID: comment:12");
+    expect(runs[0]?.appendSystemPrompt).toContain("- MSG_ID: comment:13");
+
+    const callbacks = await selectGitHubCallbacks(runs[0]?.id ?? "");
+    expect(callbacks[0]?.payload).toMatchObject({
+      existingSessionId: session.id,
+    });
   });
 
   it("dispatches pull requests with a matching label listener", async () => {
@@ -1130,6 +1343,12 @@ describe("POST /api/webhooks/github", () => {
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
     expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
+    expect(runs[0]?.appendSystemPrompt).toContain(
+      "Pull Request URL: https://github.com/vm0-ai/vm0/pull/42",
+    );
+    expect(runs[0]?.appendSystemPrompt).toContain(
+      "# GitHub Pull Request Context",
+    );
     expect(runs[0]?.appendSystemPrompt).toContain("Pull Request: #42");
   });
 
@@ -1329,12 +1548,11 @@ describe("POST /api/webhooks/github", () => {
     expect(response.body).toBe("OK");
   });
 
-  it("activates matching pending installations", async () => {
+  it("ignores installation created events without activating pending records", async () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
     mockGitHubWebhookEnv();
-    mockGitHubAppCredentials();
 
     const db = store.set(writeDb$);
     const targetId = remoteGitHubId();
@@ -1347,7 +1565,6 @@ describe("POST /api/webhooks/github", () => {
       targetName: "pending-org",
       defaultComposeId: fixture.composeId,
     });
-    setupGitHubApiMocks({ installationId });
 
     const response = await postGitHubWebhook({
       event: "installation",
@@ -1375,17 +1592,15 @@ describe("POST /api/webhooks/github", () => {
       .where(eq(githubInstallations.targetId, targetId));
 
     expect(installation).toMatchObject({
-      status: "active",
-      installationId,
-      targetName: "activated-org",
-      adminGithubUserId: fixture.githubUserId,
+      status: "pending",
+      installationId: null,
+      encryptedAccessToken: null,
+      targetName: "pending-org",
+      adminGithubUserId: null,
     });
-    expect(installation?.encryptedAccessToken).toStrictEqual(
-      expect.any(String),
-    );
   });
 
-  it("ignores installation events without a matching pending record", async () => {
+  it("ignores installation created events without a local record", async () => {
     mockGitHubWebhookEnv();
 
     const response = await postGitHubWebhook({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -176,6 +176,15 @@ interface CapturedGitHubIssueComment {
   readonly body: string;
 }
 
+interface CapturedRunCallback {
+  readonly callbackId: string;
+  readonly runId: string;
+  readonly status: "completed" | "failed";
+  readonly result?: Record<string, unknown>;
+  readonly error?: string;
+  readonly payload?: unknown;
+}
+
 interface GitHubIssuesPayloadOverrides {
   readonly action?: string;
   readonly labels?: readonly GitHubLabelPayload[];
@@ -464,6 +473,8 @@ async function selectGitHubRuns(fixture: GitHubWebhookFixture) {
   return await db
     .select({
       id: agentRuns.id,
+      status: agentRuns.status,
+      error: agentRuns.error,
       prompt: agentRuns.prompt,
       sessionId: agentRuns.sessionId,
       appendSystemPrompt: agentRuns.appendSystemPrompt,
@@ -1214,6 +1225,84 @@ describe("POST /api/webhooks/github", () => {
     );
     expect(capturedComments[0]?.body).not.toContain("Failed to start");
     await expect(selectGitHubRuns(fixture)).resolves.toHaveLength(0);
+  });
+
+  it("lets failed GitHub trigger runs with callbacks report the failure", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockGitHubWebhookEnv();
+    mockGitHubAppCredentials();
+    setupGitHubApiMocks({
+      installationId: fixture.remoteInstallationId,
+    });
+
+    const capturedComments: CapturedGitHubIssueComment[] = [];
+    const capturedCallbacks: CapturedRunCallback[] = [];
+    server.use(
+      http.post(
+        "https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments",
+        async ({ request }) => {
+          const body = (await request.json()) as { readonly body: string };
+          capturedComments.push({ body: body.body });
+          return HttpResponse.json({ id: 9876 });
+        },
+      ),
+      http.post(
+        "http://localhost:3000/api/internal/callbacks/github/issues",
+        async ({ request }) => {
+          const body = (await request.json()) as CapturedRunCallback;
+          capturedCallbacks.push(body);
+          return HttpResponse.json({ ok: true });
+        },
+      ),
+    );
+
+    const db = store.set(writeDb$);
+    const [compose] = await db
+      .select({ name: agentComposes.name })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, fixture.composeId))
+      .limit(1);
+    if (!compose) {
+      throw new Error("GitHub fixture compose not found");
+    }
+    await db
+      .update(agentComposeVersions)
+      .set({
+        content: {
+          version: "1.0",
+          agents: {
+            [compose.name]: {
+              framework: "claude-code",
+              environment: { ANTHROPIC_API_KEY: "test-key" },
+              experimental_runner: { group: "custom/test" },
+            },
+          },
+        },
+      })
+      .where(eq(agentComposeVersions.composeId, fixture.composeId));
+
+    const response = await postGitHubWebhook({
+      event: "issues",
+      payload: buildGitHubIssuesPayload(fixture, { action: "opened" }),
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(capturedComments).toHaveLength(0);
+    expect(capturedCallbacks).toHaveLength(1);
+    expect(capturedCallbacks[0]?.status).toBe("failed");
+    expect(capturedCallbacks[0]?.error).toBe(
+      "Only vm0/* runner groups are supported",
+    );
+
+    const runs = await selectGitHubRuns(fixture);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(capturedCallbacks[0]?.runId);
+    expect(runs[0]?.status).toBe("failed");
+    expect(runs[0]?.error).toBe("Only vm0/* runner groups are supported");
   });
 
   it("dispatches labeled issues only when the added label is the app slug", async () => {

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -1,8 +1,5 @@
 import { command } from "ccstate";
-import {
-  githubOauthContract,
-  type GithubAppSetupCallbackQuery,
-} from "@vm0/api-contracts/contracts/github-oauth";
+import { githubOauthContract } from "@vm0/api-contracts/contracts/github-oauth";
 import {
   getConnectorOAuthConfig,
   getConnectorOAuthCredentials,
@@ -26,7 +23,6 @@ import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
 import {
   buildGithubOauthState,
   createOrActivateGithubInstallation,
-  createPendingGithubInstallation,
   findGithubInstallationByInstallationId,
   getGithubInstallationAccessToken,
   getGithubInstallationInfo,
@@ -124,6 +120,9 @@ const GITHUB_INSTALL_ADMIN_REQUIRED =
 
 const GITHUB_SINGLE_INSTALLATION_REQUIRED =
   "GitHub is already installed for this organization";
+
+const GITHUB_INSTALL_GITHUB_ADMIN_REQUIRED =
+  "You don't have permission to install this GitHub App. Ask a GitHub organization owner to install it, then try again.";
 
 type ParsedGithubOauthState = NonNullable<
   ReturnType<typeof parseGithubOauthState>
@@ -293,25 +292,6 @@ const resolveGithubCallbackAccess$ = command(
     return { ok: true, orgAlreadyHasActiveInstallation };
   },
 );
-
-async function handlePendingGithubInstallation(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly composeId: string;
-  readonly query: GithubAppSetupCallbackQuery;
-  readonly signal: AbortSignal;
-}): Promise<Response> {
-  await createPendingGithubInstallation({
-    db: args.db,
-    orgId: args.orgId,
-    targetId: args.query.target_id ?? null,
-    targetType: args.query.target_type ?? "Organization",
-    composeId: args.composeId,
-    signal: args.signal,
-  });
-
-  return redirectResponse(appUrl("/works?github=pending"));
-}
 
 const connectGithubUserAfterSetup$ = command(
   async (
@@ -756,17 +736,7 @@ const callbackGithubOauth$ = command(
     }
 
     if (query.setup_action === "request") {
-      if (access.orgAlreadyHasActiveInstallation) {
-        return worksErrorRedirect(GITHUB_SINGLE_INSTALLATION_REQUIRED);
-      }
-
-      return await handlePendingGithubInstallation({
-        db,
-        orgId,
-        composeId,
-        query,
-        signal,
-      });
+      return worksErrorRedirect(GITHUB_INSTALL_GITHUB_ADMIN_REQUIRED);
     }
 
     const installationId = query.installation_id;

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
@@ -11,6 +11,7 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, desc, eq, gte } from "drizzle-orm";
 
 import {
@@ -29,8 +30,12 @@ import {
 } from "../services/github-issues-api.service";
 import { getRunOutputText } from "../services/run-output.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { formatRunErrorLikeWebMessage } from "../services/zero-chat-thread.service";
 
 const L = logger("InternalCallbacksGithubIssues");
+const RUN_COMPLETED_FALLBACK_MESSAGE = "Task completed successfully.";
+const RUN_FAILED_FALLBACK_MESSAGE =
+  "The agent encountered an error during execution.";
 
 function successResponse(): {
   readonly status: 200;
@@ -129,6 +134,28 @@ async function saveIssueSession(args: {
     : undefined;
 
   if (!args.existingSessionId && newSessionId) {
+    const updated = await args.db
+      .update(githubIssueSessions)
+      .set({
+        userId: run.userId,
+        agentSessionId: newSessionId,
+        lastCommentId: args.commentId,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          eq(githubIssueSessions.installationId, args.installationId),
+          eq(githubIssueSessions.repo, args.repo),
+          eq(githubIssueSessions.issueNumber, args.issueNumber),
+        ),
+      )
+      .returning({ id: githubIssueSessions.id });
+    args.signal.throwIfAborted();
+
+    if (updated.length > 0) {
+      return;
+    }
+
     await args.db
       .insert(githubIssueSessions)
       .values({
@@ -163,19 +190,23 @@ async function saveIssueSession(args: {
   }
 }
 
-function formatGitHubComment(args: {
-  readonly status: "completed" | "failed";
-  readonly agentName: string;
+function buildGitHubResponse(args: {
+  readonly markdown: string;
   readonly logsUrl?: string;
-  readonly output?: string;
-  readonly error?: string;
+}): string {
+  const parts = [args.markdown];
+  if (args.logsUrl) {
+    parts.push(`<sub>📋 [Audit](${args.logsUrl})</sub>`);
+  }
+  return parts.join("\n\n");
+}
+
+function formatGitHubComment(args: {
+  readonly agentName: string;
+  readonly response: string;
+  readonly logsUrl?: string;
   readonly triggerCommentBody?: string;
 }): string {
-  const content =
-    args.status === "completed"
-      ? (args.output ?? "Task completed successfully.")
-      : `**Error:** ${args.error ?? "Agent execution failed."}`;
-
   const parts: string[] = [];
   if (args.triggerCommentBody) {
     const quoted = args.triggerCommentBody
@@ -187,10 +218,14 @@ function formatGitHubComment(args: {
     parts.push(quoted, "");
   }
 
-  parts.push(`<sub>🤖 **${args.agentName}**</sub>`, "", content);
-  if (args.logsUrl) {
-    parts.push("", `<sub>📋 [Audit](${args.logsUrl})</sub>`);
-  }
+  parts.push(
+    `<sub>🤖 **${args.agentName}**</sub>`,
+    "",
+    buildGitHubResponse({
+      markdown: args.response,
+      logsUrl: args.logsUrl,
+    }),
+  );
 
   return parts.join("\n");
 }
@@ -230,6 +265,32 @@ async function resolveGitHubAuditLogsUrl(args: {
   }
 
   return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+}
+
+async function resolveGitHubRunError(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly errorMessage: string | undefined;
+  readonly formatRunError: (params: {
+    readonly chatThreadId: string | null | undefined;
+    readonly runId: string;
+    readonly errorMessage: string;
+  }) => Promise<string>;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const [run] = await args.db
+    .select({ chatThreadId: zeroRuns.chatThreadId })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, args.runId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return await args.formatRunError({
+    chatThreadId: run?.chatThreadId,
+    runId: args.runId,
+    errorMessage:
+      args.errorMessage ?? "The agent encountered an error during execution.",
+  });
 }
 
 const handleGithubIssuesCallback$ = command(
@@ -305,12 +366,28 @@ const handleGithubIssuesCallback$ = command(
       },
       signal,
     });
+    const errorDetail =
+      status === "failed"
+        ? await resolveGitHubRunError({
+            db,
+            runId,
+            errorMessage: error,
+            formatRunError: (params) => {
+              return get(formatRunErrorLikeWebMessage(params));
+            },
+            signal,
+          })
+        : undefined;
+    signal.throwIfAborted();
+    const responseText =
+      status === "completed"
+        ? (output ?? RUN_COMPLETED_FALLBACK_MESSAGE)
+        : (errorDetail ?? RUN_FAILED_FALLBACK_MESSAGE);
+
     const commentBody = formatGitHubComment({
-      status,
       agentName: agent.label,
+      response: responseText,
       logsUrl,
-      output,
-      error,
       triggerCommentBody: payload.triggerCommentBody,
     });
     const commentId = await postGithubIssueComment({

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -661,26 +661,6 @@ export async function findGithubInstallationByInstallationId(args: {
   return existing ?? null;
 }
 
-export async function createPendingGithubInstallation(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly targetId: string | null;
-  readonly targetType: string;
-  readonly composeId: string;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  await args.db.insert(githubInstallations).values({
-    installationId: null,
-    encryptedAccessToken: null,
-    status: "pending",
-    orgId: args.orgId,
-    targetId: args.targetId,
-    targetType: args.targetType,
-    defaultComposeId: args.composeId,
-  });
-  args.signal.throwIfAborted();
-}
-
 export async function createOrActivateGithubInstallation(args: {
   readonly db: Db;
   readonly orgId: string;

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -245,6 +245,7 @@ interface ListenerRow {
   readonly enabled: boolean;
   readonly createdAt: Date;
   readonly updatedAt: Date;
+  readonly createdByUserId: string;
   readonly agentId: string | null;
   readonly agentName: string | null;
 }
@@ -259,13 +260,35 @@ function canManageInstallation(args: {
   return args.orgRole === "admin";
 }
 
-function serializeListener(row: ListenerRow): GithubLabelListener {
+function canManageLabelListener(args: {
+  readonly createdByUserId: string;
+  readonly userId: string;
+  readonly orgRole: string | undefined;
+}): boolean {
+  return (
+    canManageInstallation({ orgRole: args.orgRole }) ||
+    args.createdByUserId === args.userId
+  );
+}
+
+function serializeListener(
+  row: ListenerRow,
+  args: {
+    readonly userId: string;
+    readonly orgRole: string | undefined;
+  },
+): GithubLabelListener {
   return {
     id: row.id,
     labelName: row.labelName,
     triggerMode: row.triggerMode,
     prompt: row.prompt,
     enabled: row.enabled,
+    canManage: canManageLabelListener({
+      createdByUserId: row.createdByUserId,
+      userId: args.userId,
+      orgRole: args.orgRole,
+    }),
     agent:
       row.agentId && row.agentName
         ? { id: row.agentId, name: row.agentName }
@@ -400,6 +423,8 @@ async function buildEnvironment(args: {
 async function loadListeners(args: {
   readonly db: ReadonlyDb;
   readonly installationId: string;
+  readonly userId: string;
+  readonly orgRole: string | undefined;
 }): Promise<readonly GithubLabelListener[]> {
   const rows = await args.db
     .select({
@@ -410,6 +435,7 @@ async function loadListeners(args: {
       enabled: githubLabelListeners.enabled,
       createdAt: githubLabelListeners.createdAt,
       updatedAt: githubLabelListeners.updatedAt,
+      createdByUserId: githubLabelListeners.createdByUserId,
       agentId: agentComposes.id,
       agentName: agentComposes.name,
     })
@@ -422,7 +448,10 @@ async function loadListeners(args: {
     .orderBy(asc(githubLabelListeners.labelNameNormalized));
 
   return rows.map((row) => {
-    return serializeListener(row);
+    return serializeListener(row, {
+      userId: args.userId,
+      orgRole: args.orgRole,
+    });
   });
 }
 
@@ -430,13 +459,7 @@ async function loadListener(args: {
   readonly db: ReadonlyDb;
   readonly listenerId: string;
   readonly orgId: string;
-}): Promise<
-  | (ListenerRow & {
-      readonly installationId: string;
-      readonly createdByUserId: string;
-    })
-  | null
-> {
+}): Promise<(ListenerRow & { readonly installationId: string }) | null> {
   const [row] = await args.db
     .select({
       id: githubLabelListeners.id,
@@ -512,6 +535,8 @@ async function loadCreatedListener(args: {
   readonly db: ReadonlyDb;
   readonly listenerId: string;
   readonly orgId: string;
+  readonly userId: string;
+  readonly orgRole: string | undefined;
 }): Promise<GithubLabelListener> {
   const listener = await loadListener({
     db: args.db,
@@ -523,7 +548,10 @@ async function loadCreatedListener(args: {
     throw new Error(`GitHub label listener not found: ${args.listenerId}`);
   }
 
-  return serializeListener(listener);
+  return serializeListener(listener, {
+    userId: args.userId,
+    orgRole: args.orgRole,
+  });
 }
 
 export const connectGithubUser$ = command(
@@ -774,6 +802,8 @@ export const createGithubLabelListener$ = command(
           db,
           listenerId: listener.id,
           orgId: auth.orgId,
+          userId: auth.userId,
+          orgRole: auth.orgRole,
         }),
       },
     };
@@ -800,6 +830,20 @@ export const updateGithubLabelListener$ = command(
 
     if (!existing) {
       return errorResponse(404, "GitHub label listener not found", "NOT_FOUND");
+    }
+
+    if (
+      !canManageLabelListener({
+        createdByUserId: existing.createdByUserId,
+        userId: auth.userId,
+        orgRole: auth.orgRole,
+      })
+    ) {
+      return errorResponse(
+        403,
+        "Only the label listener owner or an org admin can update this listener",
+        "FORBIDDEN",
+      );
     }
 
     const values: Partial<typeof githubLabelListeners.$inferInsert> = {
@@ -885,6 +929,8 @@ export const updateGithubLabelListener$ = command(
           db,
           listenerId: existing.id,
           orgId: auth.orgId,
+          userId: auth.userId,
+          orgRole: auth.orgRole,
         }),
       },
     };
@@ -908,6 +954,20 @@ export const deleteGithubLabelListener$ = command(
 
     if (!existing) {
       return errorResponse(404, "GitHub label listener not found", "NOT_FOUND");
+    }
+
+    if (
+      !canManageLabelListener({
+        createdByUserId: existing.createdByUserId,
+        userId: auth.userId,
+        orgRole: auth.orgRole,
+      })
+    ) {
+      return errorResponse(
+        403,
+        "Only the label listener owner or an org admin can delete this listener",
+        "FORBIDDEN",
+      );
     }
 
     await db
@@ -966,7 +1026,12 @@ export const getGithubInstallation$ = computed(async (get) => {
       get(userSecrets({ orgId: auth.orgId, userId: auth.userId })),
       get(userVariables({ orgId: auth.orgId, userId: auth.userId })),
       get(zeroConnectorList({ orgId: auth.orgId, userId: auth.userId })),
-      loadListeners({ db, installationId: installation.id }),
+      loadListeners({
+        db,
+        installationId: installation.id,
+        userId: auth.userId,
+        orgRole: auth.orgRole,
+      }),
     ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   githubIssuesCallbackPayloadSchema,
   type GitHubIssuesCallbackPayload,
@@ -12,7 +13,7 @@ import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { command } from "ccstate";
+import { command, type Setter } from "ccstate";
 import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -21,7 +22,6 @@ import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { nowDate } from "../external/time";
-import { settle } from "../utils";
 import {
   addGithubCommentReaction,
   fetchGithubIssueComments,
@@ -30,11 +30,16 @@ import {
   type GithubIssueComment,
 } from "./github-issues-api.service";
 import { getGithubInstallationAccessToken } from "./github-app.service";
-import { encryptPersistentSecretValue } from "./crypto.utils";
-import { loadComposeFeatureSwitchContext } from "./github-oauth.service";
-import { createZeroIntegrationRun$ } from "./zero-runs-create.service";
+import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import {
+  resolveIntegrationModelRouteForUser,
+  type IntegrationModelRoutePin,
+} from "./integration-model-route.service";
+import { createZeroRun$ } from "./zero-runs-create.service";
 
 const L = logger("WebhookGithub");
+const RUN_START_FALLBACK_MESSAGE =
+  "An unexpected error occurred. Please try again later.";
 
 const gitHubUserSchema = z.object({
   id: z.number(),
@@ -137,7 +142,6 @@ interface DispatchParams {
   readonly matchedLabelName: string;
   readonly commentId?: string;
   readonly comment?: GitHubComment;
-  readonly forceNewSession?: boolean;
   readonly apiStartTime: number;
 }
 
@@ -146,7 +150,6 @@ type ExistingSessionResult =
   | {
       readonly kind: "resolved";
       readonly sessionId: string | undefined;
-      readonly lastCommentId: string | null | undefined;
     };
 
 interface GitHubRunTarget {
@@ -155,16 +158,56 @@ interface GitHubRunTarget {
   readonly zeroAgentId: string;
 }
 
+interface GitHubRunDispatchResult {
+  readonly status: "accepted" | "queued" | "failed";
+  readonly runId?: string;
+  readonly response?: string;
+}
+
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
 
-function buildIntegrationPrompt(platform: "GitHub"): string {
-  return `# Current Integration\nYou are currently running inside: ${platform}`;
+function githubSubjectLabel(subjectKind: GitHubTriggerKind): string {
+  return subjectKind === "pull_request" ? "Pull Request" : "Issue";
 }
 
-function buildGitHubPrompt(issueContext: string): string {
-  return [buildIntegrationPrompt("GitHub"), issueContext]
+function githubSubjectUrl(args: {
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly subjectKind: GitHubTriggerKind;
+}): string {
+  const pathSegment = args.subjectKind === "pull_request" ? "pull" : "issues";
+  return `https://github.com/${args.repo}/${pathSegment}/${args.issueNumber}`;
+}
+
+function githubAppBotUsername(): string | undefined {
+  const appSlug = optionalEnv("GITHUB_APP_SLUG")?.trim();
+  if (!appSlug) {
+    return undefined;
+  }
+  return `@${appSlug}[bot]`;
+}
+
+function buildIntegrationPrompt(): string {
+  const headerParts = [
+    "# Current Integration",
+    "You are currently running inside: GitHub",
+  ];
+  const botUsername = githubAppBotUsername();
+  if (botUsername) {
+    headerParts.push(`Bot username: ${botUsername}`);
+  }
+  return headerParts.join("\n");
+}
+
+function buildGitHubPrompt(args: {
+  readonly issueContext: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly subjectKind: GitHubTriggerKind;
+}): string {
+  return [buildIntegrationPrompt(), args.issueContext]
     .filter((part): part is string => {
       return Boolean(part);
     })
@@ -177,14 +220,76 @@ function normalizeLabelName(labelName: string): string {
 
 function buildPromptParts(
   prompt: string,
-  issueContext: string,
+  args: {
+    readonly issueContext: string;
+    readonly repo: string;
+    readonly issueNumber: number;
+    readonly subjectKind: GitHubTriggerKind;
+  },
 ): {
   readonly prompt: string;
   readonly appendSystemPrompt: string | undefined;
 } {
-  const appendSystemPrompt = buildGitHubPrompt(issueContext) || undefined;
+  const appendSystemPrompt = buildGitHubPrompt(args) || undefined;
 
   return { prompt, appendSystemPrompt };
+}
+
+function formatGithubContextSender(args: {
+  readonly login: string;
+  readonly type: string;
+  readonly id?: number;
+}): string {
+  const senderParts =
+    args.type === "Bot"
+      ? ["id: BOT"]
+      : [args.id !== undefined ? `id: ${args.id}` : null].filter(
+          (part): part is string => {
+            return part !== null;
+          },
+        );
+
+  senderParts.push(`username: @${args.login}`, `type: ${args.type}`);
+  return `{${senderParts.join(", ")}}`;
+}
+
+function formatGitHubIssueContextMessage(args: {
+  readonly issue: GitHubIssue;
+  readonly relativeIndex: number;
+  readonly subjectLabel: string;
+}): string {
+  return [
+    "---",
+    "",
+    `- RELATIVE_INDEX: ${args.relativeIndex}`,
+    `- MSG_ID: ${args.subjectLabel.toLowerCase().replaceAll(" ", "_")}:${args.issue.number}`,
+    `- SENDER: ${formatGithubContextSender({
+      id: args.issue.user.id,
+      login: args.issue.user.login,
+      type: args.issue.user.type,
+    })}`,
+    `- SOURCE: ${args.subjectLabel}`,
+    "",
+    `Title: ${args.issue.title}`,
+    "",
+    args.issue.body ?? "_No description provided._",
+  ].join("\n");
+}
+
+function formatGitHubCommentContextMessage(args: {
+  readonly comment: GithubIssueComment;
+  readonly relativeIndex: number;
+}): string {
+  return [
+    "---",
+    "",
+    `- RELATIVE_INDEX: ${args.relativeIndex}`,
+    `- MSG_ID: comment:${args.comment.id}`,
+    `- SENDER: ${formatGithubContextSender(args.comment.user)}`,
+    "- SOURCE: comment",
+    "",
+    args.comment.body,
+  ].join("\n");
 }
 
 function formatIssueContext(args: {
@@ -193,55 +298,47 @@ function formatIssueContext(args: {
   readonly repo: string;
   readonly matchedLabelName: string;
   readonly comments: readonly GithubIssueComment[];
-  readonly lastCommentId: string | undefined;
   readonly currentCommentId: string | undefined;
 }): string {
-  let relevantComments = args.lastCommentId
+  const relevantComments = args.currentCommentId
     ? args.comments.filter((comment) => {
-        return comment.id > Number(args.lastCommentId);
+        return String(comment.id) !== args.currentCommentId;
       })
     : args.comments;
 
-  if (args.currentCommentId) {
-    relevantComments = relevantComments.filter((comment) => {
-      return String(comment.id) !== args.currentCommentId;
-    });
-  }
+  const subjectLabel = githubSubjectLabel(args.subjectKind);
+  const messages = [
+    formatGitHubIssueContextMessage({
+      issue: args.issue,
+      subjectLabel,
+      relativeIndex: -relevantComments.length - 1,
+    }),
+    ...relevantComments.map((comment, index) => {
+      return formatGitHubCommentContextMessage({
+        comment,
+        relativeIndex: index - relevantComments.length,
+      });
+    }),
+  ];
 
-  if (relevantComments.length === 0 && args.lastCommentId) {
-    return "";
-  }
-
-  const subjectLabel =
-    args.subjectKind === "pull_request" ? "Pull Request" : "Issue";
   const parts: string[] = [
-    "# GitHub Label Trigger",
+    `# GitHub ${subjectLabel} Context`,
     "",
     `Repository: ${args.repo}`,
     `${subjectLabel}: #${args.issue.number}`,
+    `${subjectLabel} URL: ${githubSubjectUrl({
+      repo: args.repo,
+      issueNumber: args.issue.number,
+      subjectKind: args.subjectKind,
+    })}`,
     `Matched label: ${args.matchedLabelName}`,
     "",
-    `# GitHub ${subjectLabel} Context`,
+    "The messages below are from the GitHub issue conversation. Messages closer to RELATIVE_INDEX 0 are more recent.",
+    "",
+    messages.join("\n\n"),
+    "",
+    "---",
   ];
-
-  if (!args.lastCommentId) {
-    parts.push(
-      "",
-      `**${args.issue.title}** (#${args.issue.number})`,
-      "",
-      args.issue.body ?? "_No description provided._",
-    );
-  }
-
-  if (relevantComments.length > 0) {
-    parts.push("", "## Comments", "");
-    for (const comment of relevantComments) {
-      const role = comment.user.type === "Bot" ? "bot" : "user";
-      parts.push(`**@${comment.user.login}** (${role}):`, comment.body, "");
-    }
-  }
-
-  parts.push("---");
   return parts.join("\n");
 }
 
@@ -313,6 +410,7 @@ async function resolveExistingSession(args: {
   readonly composeId: string;
   readonly vm0UserId: string;
   readonly commentId: string | undefined;
+  readonly modelRoute: IntegrationModelRoutePin | undefined;
   readonly signal: AbortSignal;
 }): Promise<ExistingSessionResult> {
   const [found] = await args.db
@@ -332,7 +430,7 @@ async function resolveExistingSession(args: {
   args.signal.throwIfAborted();
 
   if (!found) {
-    return { kind: "resolved", sessionId: undefined, lastCommentId: undefined };
+    return { kind: "resolved", sessionId: undefined };
   }
 
   if (args.commentId && found.lastCommentId === args.commentId) {
@@ -346,38 +444,61 @@ async function resolveExistingSession(args: {
     expectedComposeId: args.composeId,
     signal: args.signal,
   });
+  if (!sessionId) {
+    return {
+      kind: "resolved",
+      sessionId: undefined,
+    };
+  }
+
+  if (
+    !(await canReuseIntegrationSessionForModelRoute({
+      db: args.db,
+      sessionId,
+      modelRoute: args.modelRoute,
+    }))
+  ) {
+    return {
+      kind: "resolved",
+      sessionId: undefined,
+    };
+  }
 
   return {
     kind: "resolved",
     sessionId,
-    lastCommentId: sessionId ? found.lastCommentId : undefined,
   };
 }
 
-function createRunErrorMessage(result: {
-  readonly status: number;
-  readonly body: unknown;
-}): string {
-  if (
-    typeof result.body === "object" &&
-    result.body !== null &&
-    "error" in result.body
-  ) {
-    const error = result.body.error;
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "message" in error &&
-      typeof error.message === "string"
-    ) {
-      return error.message;
-    }
+function routeErrorMessage(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null || !("error" in body)) {
+    return undefined;
   }
-  return `GitHub-triggered agent run failed with status ${result.status}`;
+  const error = body.error;
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return undefined;
+  }
+  const message = error.message;
+  if (typeof message !== "string") {
+    return undefined;
+  }
+  const code =
+    "code" in error && typeof error.code === "string"
+      ? error.code
+      : "INTERNAL_SERVER_ERROR";
+  return formatRunErrorForExternalSurface({ code, message });
+}
+
+function stringField(body: unknown, key: string): string | undefined {
+  if (typeof body !== "object" || body === null || !(key in body)) {
+    return undefined;
+  }
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
 }
 
 async function handleDispatchError(args: {
-  readonly error: unknown;
+  readonly message: string | undefined;
   readonly token: string | undefined;
   readonly repo: string;
   readonly issueNumber: number;
@@ -406,15 +527,12 @@ async function handleDispatchError(args: {
     : "";
 
   if (args.token) {
-    const message =
-      args.error instanceof Error
-        ? args.error.message
-        : "An unexpected error occurred.";
+    const message = args.message ?? RUN_START_FALLBACK_MESSAGE;
     await postGithubIssueCommentBestEffort({
       token: args.token,
       repo: args.repo,
       issueNumber: args.issueNumber,
-      body: `${quotePrefix}Failed to start the agent: ${message}`,
+      body: `${quotePrefix}${message}`,
       signal: args.signal,
     });
   }
@@ -510,37 +628,10 @@ async function loadGitHubRunTarget(args: {
   };
 }
 
-async function resolveDispatchSession(args: {
-  readonly db: Db;
-  readonly params: DispatchParams;
-  readonly installationDbId: string;
-  readonly issueNumber: number;
-  readonly composeId: string;
-  readonly vm0UserId: string;
-  readonly signal: AbortSignal;
-}): Promise<ExistingSessionResult> {
-  if (args.params.forceNewSession) {
-    return { kind: "resolved", sessionId: undefined, lastCommentId: undefined };
-  }
-
-  return await resolveExistingSession({
-    db: args.db,
-    installationDbId: args.installationDbId,
-    repo: args.params.repo,
-    issueNumber: args.issueNumber,
-    composeId: args.composeId,
-    vm0UserId: args.vm0UserId,
-    commentId: args.params.commentId,
-    signal: args.signal,
-  });
-}
-
 async function buildIssueContextForRun(args: {
   readonly token: string | undefined;
   readonly params: DispatchParams;
   readonly issueNumber: number;
-  readonly existingSessionId: string | undefined;
-  readonly lastCommentId: string | null | undefined;
   readonly signal: AbortSignal;
 }): Promise<string> {
   if (!args.token) {
@@ -561,9 +652,6 @@ async function buildIssueContextForRun(args: {
     repo: args.params.repo,
     matchedLabelName: args.params.matchedLabelName,
     comments,
-    lastCommentId: args.existingSessionId
-      ? (args.lastCommentId ?? undefined)
-      : undefined,
     currentCommentId: args.params.commentId,
   });
 }
@@ -612,6 +700,77 @@ async function updateExistingSessionComment(args: {
         eq(githubIssueSessions.issueNumber, args.issueNumber),
       ),
     );
+}
+
+async function runAgentForGitHub(args: {
+  readonly set: Setter;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly sessionId: string | undefined;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string | undefined;
+  readonly modelRoute: IntegrationModelRoutePin | undefined;
+  readonly callbackPayload: GitHubIssuesCallbackPayload;
+  readonly apiStartTime: number;
+  readonly signal: AbortSignal;
+}): Promise<GitHubRunDispatchResult> {
+  const result = await args.set(
+    createZeroRun$,
+    {
+      auth: {
+        tokenType: "session",
+        userId: args.userId,
+        orgId: args.orgId,
+        orgRole: "member",
+      },
+      body: {
+        prompt: args.prompt,
+        agentId: args.agentId,
+        sessionId: args.sessionId,
+        ...(args.modelRoute?.modelProviderType
+          ? { modelProvider: args.modelRoute.modelProviderType }
+          : {}),
+      },
+      apiStartTime: args.apiStartTime,
+      triggerSource: "github",
+      appendSystemPrompt: args.appendSystemPrompt,
+      modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
+      modelProviderCredentialScope:
+        args.modelRoute?.modelProviderCredentialScope,
+      selectedModelOverride: args.modelRoute?.selectedModel,
+      callbacks: [
+        {
+          url: `${env("VM0_API_URL")}/api/internal/callbacks/github/issues`,
+          secret: generateCallbackSecret(),
+          payload: args.callbackPayload,
+        },
+      ],
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  if (result.status !== 201) {
+    return {
+      status: "failed",
+      response: routeErrorMessage(result.body) ?? RUN_START_FALLBACK_MESSAGE,
+    };
+  }
+
+  const status = stringField(result.body, "status");
+  const runId = stringField(result.body, "runId");
+  if (status === "queued") {
+    return { status: "queued", runId };
+  }
+  if (status === "failed") {
+    return {
+      status: "failed",
+      runId,
+      response: stringField(result.body, "error") ?? RUN_START_FALLBACK_MESSAGE,
+    };
+  }
+  return { status: "accepted", runId };
 }
 
 function labelsForAction(args: {
@@ -765,7 +924,6 @@ const dispatchMatchingLabelListener$ = command(
         composeId: listener.composeId,
         prompt: listener.prompt,
         matchedLabelName: listener.labelName,
-        forceNewSession: true,
         apiStartTime: args.apiStartTime,
       },
       signal,
@@ -846,7 +1004,7 @@ export const handleGithubIssueCommentEvent$ = command(
 
 const dispatchGithubAgentRun$ = command(
   async (
-    { set },
+    { get, set },
     params: DispatchParams,
     signal: AbortSignal,
   ): Promise<void> => {
@@ -874,13 +1032,24 @@ const dispatchGithubAgentRun$ = command(
       composeId: params.composeId,
       signal,
     });
-    const sessionResult = await resolveDispatchSession({
+    const modelRoute = await resolveIntegrationModelRouteForUser({
+      get,
+      set,
+      orgId: target.orgId,
+      userId: params.vm0UserId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const sessionResult = await resolveExistingSession({
       db,
-      params,
       installationDbId: installation.id,
+      repo: params.repo,
       issueNumber,
       composeId: target.composeId,
       vm0UserId: params.vm0UserId,
+      commentId: params.commentId,
+      modelRoute,
       signal,
     });
     if (sessionResult.kind === "duplicate") {
@@ -892,11 +1061,14 @@ const dispatchGithubAgentRun$ = command(
       token,
       params,
       issueNumber,
-      existingSessionId,
-      lastCommentId: sessionResult.lastCommentId,
       signal,
     });
-    const promptParts = buildPromptParts(params.prompt, issueContext);
+    const promptParts = buildPromptParts(params.prompt, {
+      issueContext,
+      repo: params.repo,
+      issueNumber,
+      subjectKind: params.subjectKind,
+    });
 
     const callbackPayload = buildCallbackPayload({
       installationDbId: installation.id,
@@ -907,57 +1079,23 @@ const dispatchGithubAgentRun$ = command(
       reactionId,
     });
 
-    const dispatchResult = await settle(
-      (async () => {
-        const result = await set(
-          createZeroIntegrationRun$,
-          {
-            userId: params.vm0UserId,
-            orgId: target.orgId,
-            agentId: target.zeroAgentId,
-            sessionId: existingSessionId,
-            prompt: promptParts.prompt,
-            appendSystemPrompt: promptParts.appendSystemPrompt,
-            triggerSource: "github",
-            callbacks: [
-              {
-                url: `${env("VM0_API_URL")}/api/internal/callbacks/github/issues`,
-                secret: generateCallbackSecret(),
-                payload: callbackPayload,
-              },
-            ],
-            apiStartTime: params.apiStartTime,
-          },
-          signal,
-        );
-        signal.throwIfAborted();
+    const dispatchResult = await runAgentForGitHub({
+      set,
+      userId: params.vm0UserId,
+      orgId: target.orgId,
+      agentId: target.zeroAgentId,
+      sessionId: existingSessionId,
+      prompt: promptParts.prompt,
+      appendSystemPrompt: promptParts.appendSystemPrompt,
+      modelRoute,
+      callbackPayload,
+      apiStartTime: params.apiStartTime,
+      signal,
+    });
 
-        if (result.status !== 201) {
-          throw new Error(createRunErrorMessage(result));
-        }
-
-        L.debug("Agent run dispatched for GitHub issue", {
-          runId: result.body.runId,
-          repo: params.repo,
-          issueNumber,
-        });
-
-        await updateExistingSessionComment({
-          db,
-          installationDbId: installation.id,
-          repo: params.repo,
-          issueNumber,
-          existingSessionId,
-          commentId: params.commentId,
-        });
-        signal.throwIfAborted();
-      })(),
-    );
-    signal.throwIfAborted();
-
-    if (!dispatchResult.ok) {
+    if (dispatchResult.status === "failed") {
       await handleDispatchError({
-        error: dispatchResult.error,
+        message: dispatchResult.response,
         token,
         repo: params.repo,
         issueNumber,
@@ -967,8 +1105,25 @@ const dispatchGithubAgentRun$ = command(
         signal,
       });
       signal.throwIfAborted();
-      throw dispatchResult.error;
+      return;
     }
+
+    L.debug("Agent run dispatched for GitHub issue", {
+      runId: dispatchResult.runId,
+      status: dispatchResult.status,
+      repo: params.repo,
+      issueNumber,
+    });
+
+    await updateExistingSessionComment({
+      db,
+      installationDbId: installation.id,
+      repo: params.repo,
+      issueNumber,
+      existingSessionId,
+      commentId: params.commentId,
+    });
+    signal.throwIfAborted();
   },
 );
 
@@ -1070,66 +1225,9 @@ export const handleGithubInstallationEvent$ = command(
       return;
     }
 
-    const targetId = String(payload.installation.account.id);
-
-    const [pending] = await db
-      .select()
-      .from(githubInstallations)
-      .where(
-        and(
-          eq(githubInstallations.targetId, targetId),
-          eq(githubInstallations.status, "pending"),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-
-    if (!pending) {
-      L.debug("No pending installation found for target", { targetId });
-      return;
-    }
-
-    const appId = optionalEnv("GITHUB_APP_ID");
-    const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
-    if (!appId || !privateKey) {
-      throw new Error(
-        "GitHub App not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing), cannot activate pending installation",
-      );
-    }
-
-    const { token } = await getGithubInstallationAccessToken({
-      appId,
-      privateKey,
+    L.debug("Ignoring GitHub installation created event", {
       installationId: ghInstallationId,
-      signal,
-    });
-    signal.throwIfAborted();
-    const featureSwitchContext = await loadComposeFeatureSwitchContext({
-      db,
-      composeId: pending.defaultComposeId,
-      signal,
-    });
-
-    await db
-      .update(githubInstallations)
-      .set({
-        status: "active",
-        installationId: ghInstallationId,
-        encryptedAccessToken: await encryptPersistentSecretValue(
-          token,
-          featureSwitchContext,
-        ),
-        targetName: payload.installation.account.login,
-        adminGithubUserId: payload.sender ? String(payload.sender.id) : null,
-        updatedAt: nowDate(),
-      })
-      .where(eq(githubInstallations.id, pending.id));
-    signal.throwIfAborted();
-
-    L.debug("Activated pending GitHub installation", {
-      installationId: ghInstallationId,
-      targetId,
-      recordId: pending.id,
+      targetId: String(payload.installation.account.id),
     });
   },
 );

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -1094,17 +1094,19 @@ const dispatchGithubAgentRun$ = command(
     });
 
     if (dispatchResult.status === "failed") {
-      await handleDispatchError({
-        message: dispatchResult.response,
-        token,
-        repo: params.repo,
-        issueNumber,
-        commentId: params.commentId,
-        reactionId,
-        commentBody: params.comment?.body,
-        signal,
-      });
-      signal.throwIfAborted();
+      if (!dispatchResult.runId) {
+        await handleDispatchError({
+          message: dispatchResult.response,
+          token,
+          repo: params.repo,
+          issueNumber,
+          commentId: params.commentId,
+          reactionId,
+          commentBody: params.comment?.body,
+          signal,
+        });
+        signal.throwIfAborted();
+      }
       return;
     }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
@@ -67,6 +67,7 @@ function createMockListener(
     triggerMode: body.triggerMode,
     prompt: body.prompt.trim(),
     enabled: body.enabled ?? true,
+    canManage: true,
     agent: {
       id: body.agentId,
       name: listenerAgentName(body.agentId),
@@ -227,6 +228,11 @@ export const apiIntegrationsGithubHandlers = [
           error: { message: "Label listener not found", code: "NOT_FOUND" },
         });
       }
+      if (!listener.canManage) {
+        return respond(403, {
+          error: { message: "Forbidden", code: "FORBIDDEN" },
+        });
+      }
       if (body.labelName) {
         const duplicate = getExistingListener(body.labelName);
         if (duplicate && duplicate.id !== listener.id) {
@@ -271,13 +277,24 @@ export const apiIntegrationsGithubHandlers = [
           },
         });
       }
+      const listener = mockGithubIntegration.labelListeners.find((item) => {
+        return item.id === params.listenerId;
+      });
+      if (!listener) {
+        return respond(404, {
+          error: { message: "Label listener not found", code: "NOT_FOUND" },
+        });
+      }
+      if (!listener.canManage) {
+        return respond(403, {
+          error: { message: "Forbidden", code: "FORBIDDEN" },
+        });
+      }
       mockGithubIntegration = {
         ...mockGithubIntegration,
-        labelListeners: mockGithubIntegration.labelListeners.filter(
-          (listener) => {
-            return listener.id !== params.listenerId;
-          },
-        ),
+        labelListeners: mockGithubIntegration.labelListeners.filter((item) => {
+          return item.id !== params.listenerId;
+        }),
       };
       return respond(200, { ok: true });
     },

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -33,6 +33,7 @@ export interface GithubLabelListenerForm {
   readonly agentId: string;
   readonly triggerMode: GithubLabelTriggerMode;
   readonly prompt: string;
+  readonly enabled: boolean;
 }
 
 interface UpdateGithubLabelListenerInput {
@@ -56,6 +57,7 @@ const internalLabelListenerForm$ = state<GithubLabelListenerForm>({
   agentId: "",
   triggerMode: "created_by_me",
   prompt: "",
+  enabled: true,
 });
 
 const GITHUB_CHANGED_TOPIC = "github:changed";
@@ -187,6 +189,7 @@ export const resetGithubLabelListenerForm$ = command(({ set }) => {
     agentId: "",
     triggerMode: "created_by_me",
     prompt: "",
+    enabled: true,
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -47,6 +47,7 @@ interface GithubIntegrationStatus {
 
 const internalReload$ = state(0);
 const internalAddListenerDialogOpen$ = state(false);
+const internalEditingListenerId$ = state<string | null>(null);
 const internalGithubIntegrationStatus$ = state<GithubIntegrationStatus | null>(
   null,
 );
@@ -156,9 +157,19 @@ export const githubAddListenerDialogOpen$ = computed((get) => {
   return get(internalAddListenerDialogOpen$);
 });
 
+export const githubEditingListenerId$ = computed((get) => {
+  return get(internalEditingListenerId$);
+});
+
 export const setGithubAddListenerDialogOpen$ = command(
   ({ set }, open: boolean) => {
     set(internalAddListenerDialogOpen$, open);
+  },
+);
+
+export const setGithubEditingListenerId$ = command(
+  ({ set }, listenerId: string | null) => {
+    set(internalEditingListenerId$, listenerId);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
@@ -154,8 +154,7 @@ describe("github settings page", () => {
       "Review the labeled issue or pull request.",
     );
 
-    click(within(dialog).getByRole("combobox", { name: "Trigger mode" }));
-    click(screen.getByRole("option", { name: "Any issue/PR with this label" }));
+    click(within(dialog).getByText("Any author"));
 
     click(within(dialog).getByText("Add listener"));
 
@@ -165,12 +164,13 @@ describe("github settings page", () => {
       expect(integration?.labelListeners[0]?.triggerMode).toBe("anyone");
     });
     expect(screen.getByText("ready-for-zero")).toBeInTheDocument();
+    expect(screen.getByText("Any author")).toBeInTheDocument();
     expect(
-      screen.getAllByText(/Any issue\/PR with this label/u).length,
-    ).toBeGreaterThan(0);
+      screen.queryByText(/Any issue\/PR with this label/u),
+    ).not.toBeInTheDocument();
   });
 
-  it("toggles a GitHub label listener", async () => {
+  it("edits and deletes a GitHub label listener from the actions menu", async () => {
     setMockGithubIntegration(
       createDefaultMockGithubIntegration({
         labelListeners: [
@@ -180,6 +180,7 @@ describe("github settings page", () => {
             triggerMode: "created_by_me",
             prompt: "Review the labeled issue or pull request.",
             enabled: true,
+            canManage: true,
             agent: {
               id: "c0000000-0000-4000-a000-000000000001",
               name: "zero",
@@ -192,16 +193,68 @@ describe("github settings page", () => {
     );
     setupGithubPage();
 
-    const toggle = await screen.findByRole("switch", {
-      name: "Toggle ready-for-zero listener",
-    });
-    expect(toggle).toBeChecked();
-    click(toggle);
+    await expect(
+      screen.findByText("ready-for-zero"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Created by me")).toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+
+    click(screen.getByLabelText("Actions for ready-for-zero"));
+    click(await screen.findByText("Edit"));
+
+    const editDialog = await screen.findByRole("dialog");
+    await fill(within(editDialog).getByLabelText("Label"), "needs-agent");
+    await fill(
+      within(editDialog).getByLabelText("Prompt"),
+      "Review and fix the labeled issue or pull request.",
+    );
+    click(within(editDialog).getByText("Save changes"));
 
     await waitFor(() => {
       const integration = getMockGithubIntegration();
-      expect(integration?.labelListeners[0]?.enabled).toBeFalsy();
-      expect(screen.getByText("Disabled")).toBeInTheDocument();
+      expect(integration?.labelListeners[0]?.labelName).toBe("needs-agent");
+      expect(screen.getByText("needs-agent")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Actions for needs-agent"));
+    click(await screen.findByText("Delete"));
+
+    await waitFor(() => {
+      const integration = getMockGithubIntegration();
+      expect(integration?.labelListeners).toHaveLength(0);
+      expect(screen.queryByText("needs-agent")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows read-only label listeners without row actions", async () => {
+    setMockGithubIntegration(
+      createDefaultMockGithubIntegration({
+        labelListeners: [
+          {
+            id: "b0000000-0000-4000-a000-000000000001",
+            labelName: "ready-for-zero",
+            triggerMode: "created_by_me",
+            prompt: "Review the labeled issue or pull request.",
+            enabled: true,
+            canManage: false,
+            agent: {
+              id: "c0000000-0000-4000-a000-000000000001",
+              name: "zero",
+            },
+            createdAt: new Date(0).toISOString(),
+            updatedAt: new Date(0).toISOString(),
+          },
+        ],
+      }),
+    );
+    setupGithubPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("ready-for-zero")).toBeInTheDocument();
+      expect(screen.getByText("Created by me")).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Actions for ready-for-zero"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
@@ -162,6 +162,7 @@ describe("github settings page", () => {
       const integration = getMockGithubIntegration();
       expect(integration?.labelListeners).toHaveLength(1);
       expect(integration?.labelListeners[0]?.triggerMode).toBe("anyone");
+      expect(integration?.labelListeners[0]?.enabled).toBeTruthy();
     });
     expect(screen.getByText("ready-for-zero")).toBeInTheDocument();
     expect(screen.getByText("Any author")).toBeInTheDocument();
@@ -179,7 +180,7 @@ describe("github settings page", () => {
             labelName: "ready-for-zero",
             triggerMode: "created_by_me",
             prompt: "Review the labeled issue or pull request.",
-            enabled: true,
+            enabled: false,
             canManage: true,
             agent: {
               id: "c0000000-0000-4000-a000-000000000001",
@@ -197,12 +198,20 @@ describe("github settings page", () => {
       screen.findByText("ready-for-zero"),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("Created by me")).toBeInTheDocument();
-    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
 
     click(screen.getByLabelText("Actions for ready-for-zero"));
     click(await screen.findByText("Edit"));
 
     const editDialog = await screen.findByRole("dialog");
+    const enableSwitch = within(editDialog).getByRole("switch", {
+      name: "Enable listener",
+    });
+    expect(enableSwitch).not.toBeChecked();
+    click(enableSwitch);
+    expect(
+      within(editDialog).getByRole("switch", { name: "Disable listener" }),
+    ).toBeChecked();
     await fill(within(editDialog).getByLabelText("Label"), "needs-agent");
     await fill(
       within(editDialog).getByLabelText("Prompt"),
@@ -213,7 +222,9 @@ describe("github settings page", () => {
     await waitFor(() => {
       const integration = getMockGithubIntegration();
       expect(integration?.labelListeners[0]?.labelName).toBe("needs-agent");
+      expect(integration?.labelListeners[0]?.enabled).toBeTruthy();
       expect(screen.getByText("needs-agent")).toBeInTheDocument();
+      expect(screen.queryByText("Disabled")).not.toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Actions for needs-agent"));

--- a/turbo/apps/platform/src/views/zero-page/zero-github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-settings-page.tsx
@@ -61,6 +61,7 @@ import {
   type GithubLabelTriggerMode,
 } from "../../signals/zero-page/zero-github.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { Link } from "../router/link.tsx";
 import githubIconImg from "./components/settings/icons/github.svg";
 
@@ -163,7 +164,7 @@ function GithubListenerList({
             key={listener.id}
             className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-3"
           >
-            <div className="flex min-w-0 items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <span className="min-w-0 truncate text-sm font-medium text-foreground">
                 {listener.labelName}
               </span>
@@ -172,6 +173,11 @@ function GithubListenerList({
               >
                 {triggerModeBadge.label}
               </span>
+              {!listener.enabled ? (
+                <span className="shrink-0 rounded border border-muted-foreground/20 bg-muted px-1.5 py-0.5 text-[11px] font-medium leading-none text-muted-foreground">
+                  Disabled
+                </span>
+              ) : null}
             </div>
             {listener.canManage ? (
               <DropdownMenu>
@@ -197,6 +203,7 @@ function GithubListenerList({
                         agentId: listener.agent?.id ?? "",
                         triggerMode: listener.triggerMode,
                         prompt: listener.prompt,
+                        enabled: listener.enabled,
                       });
                       setEditingListenerId(listener.id);
                       setOpen(true);
@@ -364,6 +371,33 @@ function GithubPromptField({
   );
 }
 
+function GithubListenerEnabledField({
+  creating,
+  enabled,
+  setForm,
+}: {
+  readonly creating: boolean;
+  readonly enabled: boolean;
+  readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-4 rounded-lg bg-card px-4 py-3"
+      style={ZERO_BORDER}
+    >
+      <span className="text-sm font-medium text-foreground">Enabled</span>
+      <LoadingSwitch
+        checked={enabled}
+        loading={creating}
+        ariaLabel={enabled ? "Disable listener" : "Enable listener"}
+        onCheckedChange={(nextEnabled) => {
+          setForm({ enabled: nextEnabled });
+        }}
+      />
+    </div>
+  );
+}
+
 function GithubListenerForm({
   agents,
   onCancel,
@@ -411,6 +445,7 @@ function GithubListenerForm({
                 agentId: selectedAgentId,
                 triggerMode: form.triggerMode,
                 prompt,
+                enabled: form.enabled,
               },
             },
             pageSignal,
@@ -422,6 +457,7 @@ function GithubListenerForm({
               agentId: selectedAgentId,
               triggerMode: form.triggerMode,
               prompt,
+              enabled: form.enabled,
             },
             pageSignal,
           );
@@ -445,6 +481,11 @@ function GithubListenerForm({
       <GithubTriggerModeField
         creating={saving}
         triggerMode={form.triggerMode}
+        setForm={setForm}
+      />
+      <GithubListenerEnabledField
+        creating={saving}
+        enabled={form.enabled}
         setForm={setForm}
       />
       <GithubPromptField

--- a/turbo/apps/platform/src/views/zero-page/zero-github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-settings-page.tsx
@@ -3,11 +3,22 @@ import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconArrowLeft,
-  IconLoader2,
+  IconDotsVertical,
+  IconPencil,
   IconPlus,
   IconTrash,
 } from "@tabler/icons-react";
-import { Button, Card, CardContent } from "@vm0/ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  cn,
+} from "@vm0/ui";
 import {
   Dialog,
   DialogClose,
@@ -36,10 +47,12 @@ import {
   deleteGithubLabelListener$,
   disconnectGithubInstallation$,
   githubAddListenerDialogOpen$,
+  githubEditingListenerId$,
   githubIntegrationData$,
   githubLabelListenerForm$,
   resetGithubLabelListenerForm$,
   setGithubAddListenerDialogOpen$,
+  setGithubEditingListenerId$,
   setGithubLabelListenerForm$,
   uninstallGithubInstallation$,
   updateGithubLabelListener$,
@@ -48,7 +61,6 @@ import {
   type GithubLabelTriggerMode,
 } from "../../signals/zero-page/zero-github.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { Link } from "../router/link.tsx";
 import githubIconImg from "./components/settings/icons/github.svg";
 
@@ -63,11 +75,38 @@ interface GithubAgentOption {
   readonly displayName?: string | null;
 }
 
-function getTriggerModeLabel(mode: GithubLabelTriggerMode): string {
-  if (mode === "created_by_me") {
-    return "Only issues/PRs I create";
+const TRIGGER_MODE_OPTIONS: readonly {
+  readonly value: GithubLabelTriggerMode;
+  readonly label: string;
+  readonly description: string;
+  readonly badgeClassName: string;
+}[] = [
+  {
+    value: "created_by_me",
+    label: "Created by me",
+    description:
+      "Runs only when the issue or PR author is your connected GitHub account.",
+    badgeClassName:
+      "bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/20",
+  },
+  {
+    value: "anyone",
+    label: "Any author",
+    description:
+      "Runs when any issue or PR receives the matching GitHub label.",
+    badgeClassName:
+      "bg-sky-500/10 text-sky-700 dark:text-sky-300 border-sky-500/20",
+  },
+];
+
+function getTriggerModeOption(mode: GithubLabelTriggerMode) {
+  const option = TRIGGER_MODE_OPTIONS.find((item) => {
+    return item.value === mode;
+  });
+  if (!option) {
+    throw new Error(`Unknown GitHub trigger mode: ${mode}`);
   }
-  return "Any issue/PR with this label";
+  return option;
 }
 
 function GithubSettingsSkeleton() {
@@ -98,14 +137,13 @@ function GithubListenerList({
   readonly listeners: readonly GithubListener[];
 }) {
   const pageSignal = useGet(pageSignal$);
+  const setOpen = useSet(setGithubAddListenerDialogOpen$);
+  const setEditingListenerId = useSet(setGithubEditingListenerId$);
+  const setForm = useSet(setGithubLabelListenerForm$);
   const [deleteLoadable, deleteListener] = useLoadableSet(
     deleteGithubLabelListener$,
   );
-  const [updateLoadable, updateListener] = useLoadableSet(
-    updateGithubLabelListener$,
-  );
   const deleting = deleteLoadable.state === "loading";
-  const updating = updateLoadable.state === "loading";
 
   if (listeners.length === 0) {
     return (
@@ -119,62 +157,71 @@ function GithubListenerList({
   return (
     <div className="divide-y divide-border/50">
       {listeners.map((listener) => {
+        const triggerModeBadge = getTriggerModeOption(listener.triggerMode);
         return (
           <div
             key={listener.id}
-            className="flex items-center gap-3 px-3 py-2.5"
+            className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-3"
           >
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 items-center gap-2">
-                <span className="truncate text-sm font-medium text-foreground">
-                  {listener.labelName}
-                </span>
-                {!listener.enabled ? (
-                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                    Disabled
-                  </span>
-                ) : null}
-              </div>
-              <div className="truncate text-xs text-muted-foreground">
-                {listener.agent?.name ?? "Unknown agent"} -{" "}
-                {getTriggerModeLabel(listener.triggerMode)}
-              </div>
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                {listener.labelName}
+              </span>
+              <span
+                className={`shrink-0 rounded border px-1.5 py-0.5 text-[11px] font-medium leading-none ${triggerModeBadge.badgeClassName}`}
+              >
+                {triggerModeBadge.label}
+              </span>
             </div>
-            <LoadingSwitch
-              checked={listener.enabled}
-              loading={updating}
-              size="sm"
-              ariaLabel={`Toggle ${listener.labelName} listener`}
-              onCheckedChange={(enabled) => {
-                detach(
-                  updateListener(
-                    { listenerId: listener.id, body: { enabled } },
-                    pageSignal,
-                  ),
-                  Reason.DomCallback,
-                );
-              }}
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 shrink-0"
-              disabled={deleting || updating}
-              aria-label={`Delete ${listener.labelName}`}
-              onClick={() => {
-                detach(
-                  deleteListener(listener.id, pageSignal),
-                  Reason.DomCallback,
-                );
-              }}
-            >
-              {deleting ? (
-                <IconLoader2 size={15} className="animate-spin" />
-              ) : (
-                <IconTrash size={15} />
-              )}
-            </Button>
+            {listener.canManage ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 rounded-lg text-muted-foreground hover:text-foreground"
+                    disabled={deleting}
+                    aria-label={`Actions for ${listener.labelName}`}
+                  >
+                    <IconDotsVertical size={14} stroke={1.5} />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuItem
+                    className="gap-2"
+                    disabled={deleting}
+                    onSelect={() => {
+                      setForm({
+                        labelName: listener.labelName,
+                        agentId: listener.agent?.id ?? "",
+                        triggerMode: listener.triggerMode,
+                        prompt: listener.prompt,
+                      });
+                      setEditingListenerId(listener.id);
+                      setOpen(true);
+                    }}
+                  >
+                    <IconPencil size={14} stroke={1.5} />
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="gap-2 text-destructive focus:text-destructive"
+                    disabled={deleting}
+                    onSelect={() => {
+                      detach(
+                        deleteListener(listener.id, pageSignal),
+                        Reason.DomCallback,
+                      );
+                    }}
+                  >
+                    <IconTrash size={14} stroke={1.5} />
+                    {deleting ? "Deleting..." : "Delete"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
           </div>
         );
       })}
@@ -245,54 +292,49 @@ function GithubTriggerModeField({
   readonly triggerMode: GithubLabelTriggerMode;
   readonly setForm: (patch: Partial<GithubLabelListenerForm>) => void;
 }) {
-  const choices: readonly {
-    readonly value: GithubLabelTriggerMode;
-    readonly label: string;
-  }[] = [
-    {
-      value: "created_by_me",
-      label: getTriggerModeLabel("created_by_me"),
-    },
-    {
-      value: "anyone",
-      label: getTriggerModeLabel("anyone"),
-    },
-  ];
-
   return (
-    <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
-      Trigger mode
-      <Select
-        value={triggerMode}
-        disabled={creating}
-        onValueChange={(value) => {
-          const choice = choices.find((item) => {
-            return item.value === value;
-          });
-          if (!choice) {
-            throw new Error(`Unknown GitHub trigger mode: ${value}`);
-          }
-          setForm({ triggerMode: choice.value });
-        }}
+    <div className="flex flex-col gap-2">
+      <div className="text-sm font-medium text-foreground">Trigger mode</div>
+      <div
+        role="radiogroup"
+        aria-label="Trigger mode"
+        className="grid gap-2 sm:grid-cols-2"
       >
-        <SelectTrigger
-          aria-label="Trigger mode"
-          className="h-10 rounded-lg"
-          style={ZERO_BORDER}
-        >
-          <SelectValue placeholder="Select trigger mode" />
-        </SelectTrigger>
-        <SelectContent>
-          {choices.map((choice) => {
-            return (
-              <SelectItem key={choice.value} value={choice.value}>
-                {choice.label}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
-    </label>
+        {TRIGGER_MODE_OPTIONS.map((option) => {
+          const active = option.value === triggerMode;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              disabled={creating}
+              style={{
+                border: active
+                  ? "0.7px solid hsl(var(--primary))"
+                  : ZERO_BORDER.border,
+              }}
+              className={cn(
+                "flex min-h-[86px] flex-col gap-1 rounded-lg bg-card px-4 py-3 text-left transition-colors",
+                active && "bg-primary/5",
+                !active && !creating && "hover:bg-muted/40",
+                creating && "cursor-not-allowed opacity-50",
+              )}
+              onClick={() => {
+                setForm({ triggerMode: option.value });
+              }}
+            >
+              <span className="text-sm font-medium text-foreground">
+                {option.label}
+              </span>
+              <span className="text-[13px] leading-snug text-muted-foreground">
+                {option.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -325,11 +367,13 @@ function GithubPromptField({
 function GithubListenerForm({
   agents,
   onCancel,
-  onCreated,
+  onSaved,
+  listenerId,
 }: {
   readonly agents: readonly GithubAgentOption[];
   readonly onCancel: () => void;
-  readonly onCreated: () => void;
+  readonly onSaved: () => void;
+  readonly listenerId: string | null;
 }) {
   const form = useGet(githubLabelListenerForm$);
   const setForm = useSet(setGithubLabelListenerForm$);
@@ -338,7 +382,11 @@ function GithubListenerForm({
   const [createLoadable, createListener] = useLoadableSet(
     createGithubLabelListener$,
   );
-  const creating = createLoadable.state === "loading";
+  const [updateLoadable, updateListener] = useLoadableSet(
+    updateGithubLabelListener$,
+  );
+  const saving =
+    createLoadable.state === "loading" || updateLoadable.state === "loading";
   const selectedAgentId = form.agentId || agents[0]?.id || "";
   const canCreate = Boolean(
     form.labelName.trim() && form.prompt.trim() && selectedAgentId,
@@ -348,23 +396,38 @@ function GithubListenerForm({
     event.preventDefault();
     const labelName = form.labelName.trim();
     const prompt = form.prompt.trim();
-    if (!labelName || !prompt || !selectedAgentId || creating) {
+    if (!labelName || !prompt || !selectedAgentId || saving) {
       return;
     }
 
     detach(
       (async () => {
-        await createListener(
-          {
-            labelName,
-            agentId: selectedAgentId,
-            triggerMode: form.triggerMode,
-            prompt,
-          },
-          pageSignal,
-        );
+        if (listenerId) {
+          await updateListener(
+            {
+              listenerId,
+              body: {
+                labelName,
+                agentId: selectedAgentId,
+                triggerMode: form.triggerMode,
+                prompt,
+              },
+            },
+            pageSignal,
+          );
+        } else {
+          await createListener(
+            {
+              labelName,
+              agentId: selectedAgentId,
+              triggerMode: form.triggerMode,
+              prompt,
+            },
+            pageSignal,
+          );
+        }
         resetForm();
-        onCreated();
+        onSaved();
       })(),
       Reason.DomCallback,
     );
@@ -374,18 +437,18 @@ function GithubListenerForm({
     <form className="flex flex-col gap-5" onSubmit={submit}>
       <GithubListenerPrimaryFields
         agents={agents}
-        creating={creating}
+        creating={saving}
         form={form}
         selectedAgentId={selectedAgentId}
         setForm={setForm}
       />
       <GithubTriggerModeField
-        creating={creating}
+        creating={saving}
         triggerMode={form.triggerMode}
         setForm={setForm}
       />
       <GithubPromptField
-        creating={creating}
+        creating={saving}
         prompt={form.prompt}
         setForm={setForm}
       />
@@ -393,13 +456,19 @@ function GithubListenerForm({
         <Button
           type="button"
           variant="outline"
-          disabled={creating}
+          disabled={saving}
           onClick={onCancel}
         >
           Cancel
         </Button>
-        <Button type="submit" disabled={!canCreate || creating}>
-          {creating ? "Adding..." : "Add listener"}
+        <Button type="submit" disabled={!canCreate || saving}>
+          {saving
+            ? listenerId
+              ? "Saving..."
+              : "Adding..."
+            : listenerId
+              ? "Save changes"
+              : "Add listener"}
         </Button>
       </DialogFooter>
     </form>
@@ -414,12 +483,23 @@ function AddGithubListenerDialog({
   readonly disabled: boolean;
 }) {
   const open = useGet(githubAddListenerDialogOpen$);
+  const editingListenerId = useGet(githubEditingListenerId$);
   const setOpen = useSet(setGithubAddListenerDialogOpen$);
+  const setEditingListenerId = useSet(setGithubEditingListenerId$);
   const resetForm = useSet(resetGithubLabelListenerForm$);
 
   const close = () => {
     setOpen(false);
+    setEditingListenerId(null);
+    resetForm();
   };
+
+  const title = editingListenerId
+    ? "Edit GitHub label listener"
+    : "Add GitHub label listener";
+  const description = editingListenerId
+    ? "Update this label trigger for GitHub issues and pull requests."
+    : "Create a label trigger for GitHub issues and pull requests.";
 
   return (
     <Dialog
@@ -427,6 +507,7 @@ function AddGithubListenerDialog({
       onOpenChange={(nextOpen) => {
         setOpen(nextOpen);
         if (!nextOpen) {
+          setEditingListenerId(null);
           resetForm();
         }
       }}
@@ -437,6 +518,10 @@ function AddGithubListenerDialog({
           variant="outline"
           disabled={disabled}
           className="h-8 gap-2 rounded-lg px-3 text-sm"
+          onClick={() => {
+            setEditingListenerId(null);
+            resetForm();
+          }}
         >
           <IconPlus size={14} stroke={1.8} />
           Add listener
@@ -444,15 +529,14 @@ function AddGithubListenerDialog({
       </DialogTrigger>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Add GitHub label listener</DialogTitle>
-          <DialogDescription>
-            Create a label trigger for GitHub issues and pull requests.
-          </DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <GithubListenerForm
           agents={agents}
           onCancel={close}
-          onCreated={close}
+          onSaved={close}
+          listenerId={editingListenerId}
         />
       </DialogContent>
     </Dialog>

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -23,6 +23,7 @@ export const githubLabelListenerSchema = z.object({
   triggerMode: githubLabelTriggerModeSchema,
   prompt: z.string(),
   enabled: z.boolean(),
+  canManage: z.boolean(),
   agent: z
     .object({
       id: z.string(),


### PR DESCRIPTION
## Summary
- refine GitHub label listener management UI and permissions
- align GitHub trigger runs with Telegram-style sessions, errors, and context prompts
- remove the unsafe GitHub App request/pending activation path and surface an install permission error instead

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/github-oauth.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts -t "GitHub"
- pnpm -F api exec vitest run src/signals/routes/__tests__/integrations-github-get.test.ts src/signals/routes/__tests__/integrations-github-label-listeners.test.ts src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-github-settings-page.test.tsx
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- git diff --check
- pre-commit: prettier, knip, turbo check-types