### PR TITLE
fix(mitm-addon): prevent rewrite query shadowing

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -668,20 +668,7 @@ async def handle_firewall_request(
     resolved_base = token_meta.get("base")
     if resolved_base:
         orig_query = urllib.parse.urlparse(flow.request.path).query
-        new_url = build_rewrite_url(resolved_base, match_info, orig_query)
-
-        # Merge resolved auth.query params into the forwarded URL.
-        # Uses parse_qs + merge so auth.query overwrites duplicate keys
-        # (consistent with the standard path's flow.request.query[k] = v).
-        if resolved_query:
-            parsed = urllib.parse.urlparse(new_url)
-            existing_qs = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
-            for key, value in resolved_query.items():
-                existing_qs[key] = [value]
-            new_qs = urllib.parse.urlencode(existing_qs, doseq=True)
-            new_url = urllib.parse.urlunparse(
-                (parsed.scheme, parsed.netloc, parsed.path, "", new_qs, "")
-            )
+        new_url = build_rewrite_url(resolved_base, match_info, orig_query, resolved_query)
 
         # Merge original request headers with resolved auth headers
         req_headers = dict(flow.request.headers)

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -225,16 +225,24 @@ def _query_pair_keys(pairs: list[_QueryPair]) -> set[str]:
     return {_query_pair_key(pair) for pair in pairs}
 
 
-def _filter_query_pairs(pairs: list[_QueryPair], blocked_keys: set[str]) -> list[_QueryPair]:
+def _filter_query_pairs(
+    pairs: list[_QueryPair],
+    blocked_keys: set[str],
+) -> tuple[list[_QueryPair], bool]:
     if not blocked_keys:
-        return pairs
-    return [pair for pair in pairs if _query_pair_key(pair) not in blocked_keys]
+        return pairs, False
+    filtered = [pair for pair in pairs if _query_pair_key(pair) not in blocked_keys]
+    return filtered, len(filtered) != len(pairs)
 
 
-def _join_query_pairs(pairs: list[_QueryPair]) -> str:
+def _join_query_pairs(pairs: list[_QueryPair], *, preserve_separators: bool) -> str:
     query_parts: list[str] = []
     for index, (separator, raw_pair) in enumerate(pairs):
-        query_parts.append(raw_pair if index == 0 else f"{separator or '&'}{raw_pair}")
+        if index == 0:
+            query_parts.append(raw_pair)
+            continue
+        selected_separator = separator if preserve_separators else "&"
+        query_parts.append(f"{selected_separator or '&'}{raw_pair}")
     return "".join(query_parts)
 
 
@@ -245,9 +253,14 @@ def _drop_leading_separator(pairs: list[_QueryPair]) -> list[_QueryPair]:
     return [("", raw_pair), *pairs[1:]]
 
 
-def _join_query_sources(*sources: list[_QueryPair]) -> str:
+def _join_query_sources(*sources: tuple[list[_QueryPair], bool]) -> str:
     source_queries = [
-        _join_query_pairs(_drop_leading_separator(source)) for source in sources if source
+        _join_query_pairs(
+            _drop_leading_separator(source),
+            preserve_separators=not had_filtered_pair,
+        )
+        for source, had_filtered_pair in sources
+        if source
     ]
     return "&".join(query for query in source_queries if query)
 
@@ -267,12 +280,16 @@ def _merge_rewrite_query(
     orig_pairs = _split_query_pairs(orig_query)
     auth_keys = set(resolved_query or {})
 
-    filtered_base_pairs = _filter_query_pairs(base_pairs, auth_keys)
+    filtered_base_pairs, filtered_base = _filter_query_pairs(base_pairs, auth_keys)
     blocked_orig_keys = auth_keys | _query_pair_keys(filtered_base_pairs)
-    filtered_orig_pairs = _filter_query_pairs(orig_pairs, blocked_orig_keys)
+    filtered_orig_pairs, filtered_orig = _filter_query_pairs(orig_pairs, blocked_orig_keys)
     auth_pairs = _encode_query_pairs(resolved_query)
 
-    return _join_query_sources(filtered_base_pairs, filtered_orig_pairs, auth_pairs)
+    return _join_query_sources(
+        (filtered_base_pairs, filtered_base),
+        (filtered_orig_pairs, filtered_orig),
+        (auth_pairs, False),
+    )
 
 
 def build_rewrite_url(

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -238,6 +238,20 @@ def _join_query_pairs(pairs: list[_QueryPair]) -> str:
     return "".join(query_parts)
 
 
+def _drop_leading_separator(pairs: list[_QueryPair]) -> list[_QueryPair]:
+    if not pairs:
+        return []
+    _, raw_pair = pairs[0]
+    return [("", raw_pair), *pairs[1:]]
+
+
+def _join_query_sources(*sources: list[_QueryPair]) -> str:
+    source_queries = [
+        _join_query_pairs(_drop_leading_separator(source)) for source in sources if source
+    ]
+    return "&".join(query for query in source_queries if query)
+
+
 def _encode_query_pairs(query: dict[str, str] | None) -> list[_QueryPair]:
     if not query:
         return []
@@ -258,7 +272,7 @@ def _merge_rewrite_query(
     filtered_orig_pairs = _filter_query_pairs(orig_pairs, blocked_orig_keys)
     auth_pairs = _encode_query_pairs(resolved_query)
 
-    return _join_query_pairs([*filtered_base_pairs, *filtered_orig_pairs, *auth_pairs])
+    return _join_query_sources(filtered_base_pairs, filtered_orig_pairs, auth_pairs)
 
 
 def build_rewrite_url(

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -228,21 +228,29 @@ def _query_pair_keys(pairs: list[_QueryPair]) -> set[str]:
 def _filter_query_pairs(
     pairs: list[_QueryPair],
     blocked_keys: set[str],
-) -> tuple[list[_QueryPair], bool]:
+) -> list[_QueryPair]:
     if not blocked_keys:
-        return pairs, False
-    filtered = [pair for pair in pairs if _query_pair_key(pair) not in blocked_keys]
-    return filtered, len(filtered) != len(pairs)
+        return pairs
+    filtered: list[_QueryPair] = []
+    removed_since_last_kept = False
+    for separator, raw_pair in pairs:
+        if _query_pair_key((separator, raw_pair)) in blocked_keys:
+            removed_since_last_kept = True
+            continue
+        if removed_since_last_kept and filtered:
+            separator = "&"
+        filtered.append((separator, raw_pair))
+        removed_since_last_kept = False
+    return filtered
 
 
-def _join_query_pairs(pairs: list[_QueryPair], *, preserve_separators: bool) -> str:
+def _join_query_pairs(pairs: list[_QueryPair]) -> str:
     query_parts: list[str] = []
     for index, (separator, raw_pair) in enumerate(pairs):
         if index == 0:
             query_parts.append(raw_pair)
             continue
-        selected_separator = separator if preserve_separators else "&"
-        query_parts.append(f"{selected_separator or '&'}{raw_pair}")
+        query_parts.append(f"{separator or '&'}{raw_pair}")
     return "".join(query_parts)
 
 
@@ -253,14 +261,9 @@ def _drop_leading_separator(pairs: list[_QueryPair]) -> list[_QueryPair]:
     return [("", raw_pair), *pairs[1:]]
 
 
-def _join_query_sources(*sources: tuple[list[_QueryPair], bool]) -> str:
+def _join_query_sources(*sources: list[_QueryPair]) -> str:
     source_queries = [
-        _join_query_pairs(
-            _drop_leading_separator(source),
-            preserve_separators=not had_filtered_pair,
-        )
-        for source, had_filtered_pair in sources
-        if source
+        _join_query_pairs(_drop_leading_separator(source)) for source in sources if source
     ]
     return "&".join(query for query in source_queries if query)
 
@@ -280,16 +283,12 @@ def _merge_rewrite_query(
     orig_pairs = _split_query_pairs(orig_query)
     auth_keys = set(resolved_query or {})
 
-    filtered_base_pairs, filtered_base = _filter_query_pairs(base_pairs, auth_keys)
+    filtered_base_pairs = _filter_query_pairs(base_pairs, auth_keys)
     blocked_orig_keys = auth_keys | _query_pair_keys(filtered_base_pairs)
-    filtered_orig_pairs, filtered_orig = _filter_query_pairs(orig_pairs, blocked_orig_keys)
+    filtered_orig_pairs = _filter_query_pairs(orig_pairs, blocked_orig_keys)
     auth_pairs = _encode_query_pairs(resolved_query)
 
-    return _join_query_sources(
-        (filtered_base_pairs, filtered_base),
-        (filtered_orig_pairs, filtered_orig),
-        (auth_pairs, False),
-    )
+    return _join_query_sources(filtered_base_pairs, filtered_orig_pairs, auth_pairs)
 
 
 def build_rewrite_url(

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -222,7 +222,7 @@ def _query_pair_key(pair: _QueryPair) -> str:
 
 
 def _query_pair_keys(pairs: list[_QueryPair]) -> set[str]:
-    return {_query_pair_key(pair) for pair in pairs}
+    return {_query_pair_key(pair) for pair in pairs if pair[1]}
 
 
 def _filter_query_pairs(
@@ -234,12 +234,14 @@ def _filter_query_pairs(
     filtered: list[_QueryPair] = []
     removed_since_last_kept = False
     for separator, raw_pair in pairs:
+        if not raw_pair:
+            if not removed_since_last_kept:
+                filtered.append((separator, raw_pair))
+            continue
         if _query_pair_key((separator, raw_pair)) in blocked_keys:
             while filtered and not filtered[-1][1]:
                 filtered.pop()
             removed_since_last_kept = True
-            continue
-        if removed_since_last_kept and not raw_pair:
             continue
         if removed_since_last_kept and filtered:
             separator = "&"

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -197,32 +197,51 @@ def get_original_url(flow: http.HTTPFlow) -> str:
     return get_trusted_authority(flow).url
 
 
-def _split_query_pairs(query: str) -> list[str]:
+_QueryPair = tuple[str, str]
+
+
+def _split_query_pairs(query: str) -> list[_QueryPair]:
     if not query:
         return []
-    return query.split("&")
+    pairs: list[_QueryPair] = []
+    separator = ""
+    start = 0
+    for index, char in enumerate(query):
+        if char in ("&", ";"):
+            pairs.append((separator, query[start:index]))
+            separator = char
+            start = index + 1
+    pairs.append((separator, query[start:]))
+    return pairs
 
 
-def _query_pair_key(pair: str) -> str:
-    raw_key, _, _ = pair.partition("=")
+def _query_pair_key(pair: _QueryPair) -> str:
+    _, raw_pair = pair
+    raw_key, _, _ = raw_pair.partition("=")
     return urllib.parse.unquote_plus(raw_key)
 
 
-def _query_pair_keys(pairs: list[str]) -> set[str]:
+def _query_pair_keys(pairs: list[_QueryPair]) -> set[str]:
     return {_query_pair_key(pair) for pair in pairs}
 
 
-def _filter_query_pairs(pairs: list[str], blocked_keys: set[str]) -> list[str]:
+def _filter_query_pairs(pairs: list[_QueryPair], blocked_keys: set[str]) -> list[_QueryPair]:
     if not blocked_keys:
         return pairs
     return [pair for pair in pairs if _query_pair_key(pair) not in blocked_keys]
 
 
-def _encode_query_pairs(query: dict[str, str] | None) -> list[str]:
+def _join_query_pairs(pairs: list[_QueryPair]) -> str:
+    query_parts: list[str] = []
+    for index, (separator, raw_pair) in enumerate(pairs):
+        query_parts.append(raw_pair if index == 0 else f"{separator or '&'}{raw_pair}")
+    return "".join(query_parts)
+
+
+def _encode_query_pairs(query: dict[str, str] | None) -> list[_QueryPair]:
     if not query:
         return []
-    encoded = urllib.parse.urlencode(query)
-    return _split_query_pairs(encoded)
+    return _split_query_pairs(urllib.parse.urlencode(query))
 
 
 def _merge_rewrite_query(
@@ -239,7 +258,7 @@ def _merge_rewrite_query(
     filtered_orig_pairs = _filter_query_pairs(orig_pairs, blocked_orig_keys)
     auth_pairs = _encode_query_pairs(resolved_query)
 
-    return "&".join([*filtered_base_pairs, *filtered_orig_pairs, *auth_pairs])
+    return _join_query_pairs([*filtered_base_pairs, *filtered_orig_pairs, *auth_pairs])
 
 
 def build_rewrite_url(

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -197,13 +197,64 @@ def get_original_url(flow: http.HTTPFlow) -> str:
     return get_trusted_authority(flow).url
 
 
-def build_rewrite_url(resolved_base: str, match_info: dict, orig_query: str) -> str:
+def _split_query_pairs(query: str) -> list[str]:
+    if not query:
+        return []
+    return query.split("&")
+
+
+def _query_pair_key(pair: str) -> str:
+    raw_key, _, _ = pair.partition("=")
+    return urllib.parse.unquote_plus(raw_key)
+
+
+def _query_pair_keys(pairs: list[str]) -> set[str]:
+    return {_query_pair_key(pair) for pair in pairs}
+
+
+def _filter_query_pairs(pairs: list[str], blocked_keys: set[str]) -> list[str]:
+    if not blocked_keys:
+        return pairs
+    return [pair for pair in pairs if _query_pair_key(pair) not in blocked_keys]
+
+
+def _encode_query_pairs(query: dict[str, str] | None) -> list[str]:
+    if not query:
+        return []
+    encoded = urllib.parse.urlencode(query)
+    return _split_query_pairs(encoded)
+
+
+def _merge_rewrite_query(
+    base_query: str,
+    orig_query: str,
+    resolved_query: dict[str, str] | None,
+) -> str:
+    base_pairs = _split_query_pairs(base_query)
+    orig_pairs = _split_query_pairs(orig_query)
+    auth_keys = set(resolved_query or {})
+
+    filtered_base_pairs = _filter_query_pairs(base_pairs, auth_keys)
+    blocked_orig_keys = auth_keys | _query_pair_keys(filtered_base_pairs)
+    filtered_orig_pairs = _filter_query_pairs(orig_pairs, blocked_orig_keys)
+    auth_pairs = _encode_query_pairs(resolved_query)
+
+    return "&".join([*filtered_base_pairs, *filtered_orig_pairs, *auth_pairs])
+
+
+def build_rewrite_url(
+    resolved_base: str,
+    match_info: dict,
+    orig_query: str,
+    resolved_query: dict[str, str] | None = None,
+) -> str:
     """Build the final URL for auth.base URL rewriting.
 
     Combines the resolved base URL (with credentials in path), the relative
-    path from the firewall match, and query strings from both base and
-    original request. ``orig_query`` is the raw query string of the
-    incoming request (no leading ``?``).
+    path from the firewall match, and query strings from trusted auth data
+    and the original request. ``orig_query`` is the raw query string of the
+    incoming request (no leading ``?``). Query key precedence is
+    ``resolved_query`` > resolved base query > original request query.
     """
     base_parsed = urllib.parse.urlparse(resolved_base)
 
@@ -211,13 +262,7 @@ def build_rewrite_url(resolved_base: str, match_info: dict, orig_query: str) -> 
     rel_path = match_info.get("rel_path", "/")
     base_path = base_parsed.path.rstrip("/") + rel_path if rel_path != "/" else base_parsed.path
 
-    # Merge query strings: base qs + original request qs
-    qs_parts: list[str] = []
-    if base_parsed.query:
-        qs_parts.append(base_parsed.query)
-    if orig_query:
-        qs_parts.append(orig_query)
-    merged_qs = "&".join(qs_parts)
+    merged_qs = _merge_rewrite_query(base_parsed.query, orig_query, resolved_query)
 
     return urllib.parse.urlunparse(
         (base_parsed.scheme, base_parsed.netloc, base_path, "", merged_qs, "")

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -237,6 +237,8 @@ def _filter_query_pairs(
         if _query_pair_key((separator, raw_pair)) in blocked_keys:
             removed_since_last_kept = True
             continue
+        if removed_since_last_kept and not raw_pair:
+            continue
         if removed_since_last_kept and filtered:
             separator = "&"
         filtered.append((separator, raw_pair))

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -235,6 +235,8 @@ def _filter_query_pairs(
     removed_since_last_kept = False
     for separator, raw_pair in pairs:
         if _query_pair_key((separator, raw_pair)) in blocked_keys:
+            while filtered and not filtered[-1][1]:
+                filtered.pop()
             removed_since_last_kept = True
             continue
         if removed_since_last_kept and not raw_pair:

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -459,6 +459,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_original_semicolon_duplicate_between_kept_pairs_uses_safe_separator(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "keep=1;token=attacker;wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&keep=1&wait=true"
+
     def test_duplicate_trusted_base_query_keys_preserved(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=first&token=second",
@@ -500,6 +508,15 @@ class TestBuildRewriteUrl:
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_semicolon_base_between_kept_pairs(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?tenant=one;api_key=base;region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?tenant=one&region=us&q=test&api_key=trusted+key"
 
     def test_trailing_slash_on_base_deduped(self):
         url = url_utils.build_rewrite_url(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -435,6 +435,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_all_original_duplicate_query_keys_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=first&token=second",
+        )
+        assert url == "https://example.com/hook?token=secret"
+
     def test_original_encoded_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
@@ -532,6 +540,15 @@ class TestBuildRewriteUrl:
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?api_key=trusted+key"
+
+    def test_auth_query_overrides_duplicate_trusted_base_query_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=first&api_key=second&region=us",
+            {"rel_path": "/"},
+            "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
 
     def test_auth_query_overrides_encoded_base_and_original_query_keys(self):
         url = url_utils.build_rewrite_url(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -443,6 +443,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_original_semicolon_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "wait=true;token=attacker",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
     def test_duplicate_trusted_base_query_keys_preserved(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=first&token=second",
@@ -450,6 +458,14 @@ class TestBuildRewriteUrl:
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token=first&token=second&wait=true"
+
+    def test_duplicate_trusted_base_query_keys_with_semicolon_preserved(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=first;token=second",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=first;token=second&wait=true"
 
     def test_blank_trusted_base_query_value_is_authoritative(self):
         url = url_utils.build_rewrite_url(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -564,6 +564,15 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
 
+    def test_auth_query_empty_key_overrides_base_and_original_empty_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?=base&region=us",
+            {"rel_path": "/"},
+            "=agent&q=test",
+            {"": "trusted"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&=trusted"
+
     def test_auth_query_overrides_base_query_without_leading_empty_segment(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&&region=us",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -451,6 +451,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?to%6ben=secret&wait=true"
 
+    def test_original_plus_encoded_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api+key=secret",
+            {"rel_path": "/"},
+            "api%20key=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?api+key=secret&wait=true"
+
     def test_original_semicolon_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
@@ -533,6 +541,15 @@ class TestBuildRewriteUrl:
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_plus_encoded_lower_priority_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api+key=base&region=us",
+            {"rel_path": "/"},
+            "api%20key=agent&q=test",
+            {"api key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api+key=trusted+key"
 
     def test_auth_query_overrides_semicolon_base_without_prefixing_kept_pair(self):
         url = url_utils.build_rewrite_url(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -435,6 +435,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_original_duplicate_query_key_followed_by_empty_segment_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=attacker&&wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
     def test_all_original_duplicate_query_keys_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
@@ -528,6 +536,15 @@ class TestBuildRewriteUrl:
             "https://example.com/hook?api_key=base&region=us",
             {"rel_path": "/"},
             "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_base_query_without_leading_empty_segment(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base&&region=us",
+            {"rel_path": "/"},
+            "q=test",
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -451,6 +451,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_original_semicolon_duplicate_before_kept_pair_uses_source_separator(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=attacker;wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
     def test_duplicate_trusted_base_query_keys_preserved(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=first&token=second",
@@ -480,6 +488,15 @@ class TestBuildRewriteUrl:
             "https://example.com/hook?api_key=base&region=us",
             {"rel_path": "/"},
             "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_semicolon_base_without_prefixing_kept_pair(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base;region=us",
+            {"rel_path": "/"},
+            "q=test",
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -443,6 +443,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_original_duplicate_query_key_preceded_by_empty_segment_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "wait=true&&token=attacker",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
     def test_all_original_duplicate_query_keys_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
@@ -543,6 +551,15 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_base_query_without_leading_empty_segment(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&&region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_base_query_without_trailing_empty_segment(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?region=us&&api_key=base",
             {"rel_path": "/"},
             "q=test",
             {"api_key": "trusted key"},

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -518,6 +518,15 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?tenant=one&region=us&q=test&api_key=trusted+key"
 
+    def test_auth_query_filter_preserves_existing_semicolon_value(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?redirect=a;b&api_key=base&region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?redirect=a;b&region=us&q=test&api_key=trusted+key"
+
     def test_trailing_slash_on_base_deduped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook/",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -539,6 +539,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token&wait=true"
 
+    def test_empty_trusted_base_query_key_is_authoritative(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?=secret",
+            {"rel_path": "/"},
+            "=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?=secret&wait=true"
+
     def test_auth_query_overrides_base_and_original_query(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&region=us",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -443,6 +443,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
 
+    def test_original_duplicate_of_encoded_trusted_base_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?to%6ben=secret",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?to%6ben=secret&wait=true"
+
     def test_original_semicolon_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
@@ -496,6 +504,15 @@ class TestBuildRewriteUrl:
             "https://example.com/hook?api_key=base&region=us",
             {"rel_path": "/"},
             "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_encoded_base_and_original_query_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api%5Fkey=base&region=us",
+            {"rel_path": "/"},
+            "api%5fkey=agent&q=test",
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -547,6 +547,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?=secret&wait=true"
 
+    def test_empty_trusted_base_query_segments_do_not_block_empty_original_key(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?&&region=us",
+            {"rel_path": "/"},
+            "=agent&q=test",
+        )
+        assert url == "https://example.com/hook?&&region=us&=agent&q=test"
+
     def test_auth_query_overrides_base_and_original_query(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&region=us",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -290,6 +290,59 @@ class TestAuthBaseUrlRewrite:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert mock_forward.call_args[0][0] == "https://example.com/hook?token=abc&wait=true"
 
+    async def test_url_rewrite_auth_query_overrides_base_and_original_query(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
+        """auth.query is the highest-priority trusted query source for URL rewrites."""
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/discord-webhook/hook?api_key=agent&q=test",
+        )
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
+            "auth": {
+                "headers": {},
+                "base": "${{ secrets.WEBHOOK_URL }}",
+                "query": {"api_key": "${{ secrets.API_KEY }}"},
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "billableFirewalls": [],
+        }
+        match_info = {
+            "name": "test",
+            "permission": "send",
+            "rule": "POST /",
+            "params": {},
+            "rel_path": "/",
+        }
+        token_meta = {
+            "headers": {},
+            "base": "https://example.com/hook?api_key=base&region=us",
+            "query": {"api_key": "trusted key"},
+            "resolved_secrets": ["WEBHOOK_URL", "API_KEY"],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert (
+            mock_forward.call_args[0][0]
+            == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+        )
+
     async def test_no_url_rewrite_when_auth_base_absent(
         self, real_flow, headers, mitm_ctx, tmp_path
     ):
@@ -373,6 +426,47 @@ class TestBuildRewriteUrl:
             "extra=1",
         )
         assert url == "https://example.com/hook/sub?token=abc&extra=1"
+
+    def test_original_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_original_encoded_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "to%6ben=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_duplicate_trusted_base_query_keys_preserved(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=first&token=second",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=first&token=second&wait=true"
+
+    def test_blank_trusted_base_query_value_is_authoritative(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=&wait=true"
+
+    def test_auth_query_overrides_base_and_original_query(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base&region=us",
+            {"rel_path": "/"},
+            "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
 
     def test_trailing_slash_on_base_deduped(self):
         url = url_utils.build_rewrite_url(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -499,6 +499,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://example.com/hook?token=&wait=true"
 
+    def test_valueless_trusted_base_query_key_is_authoritative(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token&wait=true"
+
     def test_auth_query_overrides_base_and_original_query(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&region=us",
@@ -507,6 +515,15 @@ class TestBuildRewriteUrl:
             {"api_key": "trusted key"},
         )
         assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_all_lower_priority_duplicates(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base",
+            {"rel_path": "/"},
+            "api_key=agent",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?api_key=trusted+key"
 
     def test_auth_query_overrides_encoded_base_and_original_query_keys(self):
         url = url_utils.build_rewrite_url(


### PR DESCRIPTION
## Summary

- Centralize URL-rewrite query precedence in `build_rewrite_url`
- Preserve trusted base query pairs while dropping sandbox pairs that collide by decoded key
- Keep `auth.query` as the highest-priority query source on rewrite forwarding
- Add regression coverage for duplicate, encoded duplicate, blank trusted, duplicate trusted, and `auth.query` precedence cases

Closes #14524

## Tests

- `pytest tests/test_firewall_rewrite.py -q`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_firewall_rewrite.py -q`
- `git diff --check`
