### PR TITLE
Fix permissions dialog connector state reset

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
@@ -23,22 +23,12 @@ export const setPermissionUnknownPolicy$ = command(
   },
 );
 
-const internalInitialized$ = state(false);
+const internalFormKey$ = state<string | null>(null);
 
-export const initPermissionPolicies$ = command(
-  (
-    { get, set },
-    policies: Record<string, Record<string, PermissionPolicy>>,
-    unknownPolicy: FirewallPolicyValue,
-  ) => {
-    if (get(internalInitialized$)) {
-      return;
-    }
-    set(internalInitialized$, true);
-    set(internalAllPolicies$, policies);
-    set(internalUnknownPolicy$, unknownPolicy);
-  },
-);
+interface ApplyPermissionPoliciesOptions {
+  formKey: string;
+  ref: string;
+}
 
 export const setPermissionPolicy$ = command(
   ({ get, set }, ref: string, name: string, policy: PermissionPolicy) => {
@@ -91,6 +81,37 @@ export const togglePermissionGroup$ = command(
   },
 );
 
+export const initPermissionPolicies$ = command(
+  (
+    { get, set },
+    formKey: string,
+    policies: Record<string, Record<string, PermissionPolicy>>,
+    unknownPolicy: FirewallPolicyValue,
+  ) => {
+    if (get(internalFormKey$) === formKey) {
+      return;
+    }
+    set(internalFormKey$, formKey);
+    set(internalAllPolicies$, policies);
+    set(internalUnknownPolicy$, unknownPolicy);
+    set(internalScrolled$, false);
+    set(internalExpandedGroups$, new Set());
+  },
+);
+
+export const resetPermissionPolicies$ = command(
+  ({ get, set }, formKey: string) => {
+    if (get(internalFormKey$) !== formKey) {
+      return;
+    }
+    set(internalFormKey$, null);
+    set(internalAllPolicies$, {});
+    set(internalUnknownPolicy$, "allow");
+    set(internalScrolled$, false);
+    set(internalExpandedGroups$, new Set());
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Apply (save) command
 // ---------------------------------------------------------------------------
@@ -98,6 +119,7 @@ export const togglePermissionGroup$ = command(
 export const applyPermissionPolicies$ = command(
   async (
     { get },
+    options: ApplyPermissionPoliciesOptions,
     onApply: (
       policies: Record<string, Record<string, PermissionPolicy>>,
       unknownPolicy: FirewallPolicyValue,
@@ -105,7 +127,13 @@ export const applyPermissionPolicies$ = command(
     onClose: () => void,
     _signal: AbortSignal,
   ): Promise<void> => {
+    if (get(internalFormKey$) !== options.formKey) {
+      throw new Error("Permission policies form is not initialized");
+    }
     const policies = get(internalAllPolicies$);
+    if (policies[options.ref] === undefined) {
+      throw new Error("Permission policies form is missing connector state");
+    }
     const unknownPolicy = get(internalUnknownPolicy$);
     await onApply(policies, unknownPolicy);
     onClose();

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -20,9 +20,16 @@ const mockApi = createMockApi(context);
 
 function mockAPIs({
   connectorType = "slack" as ConnectorType,
+  connectorTypes,
   ownerId = "test-user-123",
   permissionPolicies = null as FirewallPolicies | null,
+}: {
+  connectorType?: ConnectorType;
+  connectorTypes?: readonly ConnectorType[];
+  ownerId?: string;
+  permissionPolicies?: FirewallPolicies | null;
 } = {}) {
+  const enabledTypes = [...(connectorTypes ?? [connectorType])];
   setMockTeam([
     {
       id: "c0000000-0000-4000-a000-000000000001",
@@ -60,23 +67,25 @@ function mockAPIs({
       return respond(200, { content: null, filename: null });
     }),
     mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
-      return respond(200, { enabledTypes: [connectorType] });
+      return respond(200, { enabledTypes });
     }),
   );
-  setMockConnectors([
-    {
-      id: "d0000001-0000-4000-a000-000000000001",
-      type: connectorType,
-      authMethod: "oauth",
-      externalId: null,
-      externalUsername: "testuser",
-      externalEmail: null,
-      oauthScopes: [],
-      needsReconnect: false,
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-01T00:00:00Z",
-    },
-  ]);
+  setMockConnectors(
+    enabledTypes.map((type, index) => {
+      return {
+        id: `d0000001-0000-4000-a000-${String(index + 1).padStart(12, "0")}`,
+        type,
+        authMethod: "oauth",
+        externalId: null,
+        externalUsername: "testuser",
+        externalEmail: null,
+        oauthScopes: [],
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+    }),
+  );
   server.use(
     mockApi(zeroAgentPermissionPoliciesContract.update, ({ body, respond }) => {
       return respond(200, {
@@ -118,6 +127,38 @@ async function openPermissionsDrawer(connectorLabel: string) {
       }),
     ).toBeInTheDocument();
   });
+}
+
+function getPermissionRow(permissionName: string): HTMLElement {
+  const permissionCode = screen.getAllByRole("code").find((el) => {
+    return el.textContent === permissionName;
+  });
+  const permissionRow = permissionCode?.closest("div")?.parentElement;
+  if (!(permissionRow instanceof HTMLElement)) {
+    throw new Error(`Permission row not found: ${permissionName}`);
+  }
+  return permissionRow;
+}
+
+function getPolicyButton(row: HTMLElement, label: string): HTMLElement {
+  const button = within(row)
+    .getAllByRole("button")
+    .find((el) => {
+      return el.textContent?.includes(label) ?? false;
+    });
+  if (!(button instanceof HTMLElement)) {
+    throw new Error(`Policy button not found: ${label}`);
+  }
+  return button;
+}
+
+function requireSavedPolicies(
+  savedPolicies: FirewallPolicies | null,
+): FirewallPolicies {
+  if (savedPolicies === null) {
+    throw new Error("Permission policies were not saved");
+  }
+  return savedPolicies;
 }
 
 describe("permissions dialog - flat list connector (Notion)", () => {
@@ -176,6 +217,71 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 });
 
 describe("permissions dialog - grouped connector (Slack)", () => {
+  it("reinitializes connector policies and preserves untouched connectors on save", async () => {
+    let savedPolicies: FirewallPolicies | null = null;
+    const permissionPolicies: FirewallPolicies = {
+      slack: {
+        policies: { "channels:read": "deny" },
+        unknownPolicy: "deny",
+      },
+      notion: {
+        policies: { insert_comments: "deny" },
+        unknownPolicy: "deny",
+      },
+    };
+    mockAPIs({
+      connectorTypes: ["slack", "notion"],
+      permissionPolicies,
+    });
+    server.use(
+      mockApi(
+        zeroAgentPermissionPoliciesContract.update,
+        ({ body, respond }) => {
+          savedPolicies = body.policies;
+          return respond(200, {
+            agentId: "e0000000-0000-4000-a000-000000000010",
+            ownerId: "test-user-123",
+            description: "A helpful agent",
+            displayName: "My Agent",
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: body.policies,
+            customSkills: [],
+          });
+        },
+      ),
+    );
+    detachedSetupPage({ context, path: "/agents/my-agent" });
+
+    await openPermissionsDrawer("Slack");
+    click(screen.getByText("Cancel"));
+    await waitFor(() => {
+      return expect(
+        screen.queryByRole("heading", { name: /Slack permissions/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    await openPermissionsDrawer("Notion");
+    await waitFor(() => {
+      const denyButton = getPolicyButton(
+        getPermissionRow("insert_comments"),
+        "Deny",
+      );
+      expect(denyButton).toHaveAttribute("aria-pressed", "true");
+    });
+
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      return expect(savedPolicies).not.toBeNull();
+    });
+    const appliedPolicies = requireSavedPolicies(savedPolicies);
+    expect(appliedPolicies.slack?.policies["channels:read"]).toBe("deny");
+    expect(appliedPolicies.slack?.unknownPolicy).toBe("deny");
+    expect(appliedPolicies.notion?.policies.insert_comments).toBe("deny");
+    expect(appliedPolicies.notion?.unknownPolicy).toBe("deny");
+  });
+
   it("renders group categories with permission counts (FW-D-032)", async () => {
     mockAPIs({ connectorType: "slack" });
     detachedSetupPage({ context, path: "/agents/my-agent" });

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -615,6 +615,7 @@ function JobPermissionsTab({
 
           {connectorType && (
             <PermissionsDrawer
+              agentId={agentId}
               connectorType={connectorType}
               displayName={displayName}
               initialPolicies={permissionPolicies ?? {}}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -31,6 +31,7 @@ import type { PermissionPolicy } from "../../../../signals/zero-page/settings/pe
 import {
   permissionAllPolicies$,
   initPermissionPolicies$,
+  resetPermissionPolicies$,
   setPermissionPolicy$,
   setPermissionAllPolicies$,
   permissionScrolled$,
@@ -51,6 +52,7 @@ interface ConnectorPermission {
 }
 
 interface PermissionsDrawerProps {
+  agentId: string;
   connectorType: ConnectorType;
   displayName: string;
   initialPolicies: FirewallPolicies;
@@ -238,6 +240,7 @@ function UnknownEndpointsToggle({
 }
 
 export function PermissionsDrawer({
+  agentId,
   connectorType,
   displayName,
   initialPolicies,
@@ -252,8 +255,11 @@ export function PermissionsDrawer({
     : null;
 
   const initialUnknownPolicy = initialPolicies[ref]?.unknownPolicy ?? "allow";
+  const initialPolicyState = buildInitialPolicies(ref, config, initialPolicies);
+  const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}`;
   useSet(initPermissionPolicies$)(
-    buildInitialPolicies(ref, config, initialPolicies),
+    initialPolicyKey,
+    initialPolicyState,
     initialUnknownPolicy,
   );
 
@@ -266,6 +272,7 @@ export function PermissionsDrawer({
   const toggleGroup = useSet(togglePermissionGroup$);
   const setPolicyFn = useSet(setPermissionPolicy$);
   const setAllPoliciesFn = useSet(setPermissionAllPolicies$);
+  const resetPermissionPolicies = useSet(resetPermissionPolicies$);
   const [applyLoadable, applyFn] = useLoadableSet(applyPermissionPolicies$);
   const saving = applyLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
@@ -298,19 +305,37 @@ export function PermissionsDrawer({
     setAllPoliciesFn(ref, next);
   };
 
+  const handleClose = () => {
+    resetPermissionPolicies(initialPolicyKey);
+    onClose();
+  };
+
   const handleApply = () => {
     const wrappedApply = async (
       perms: Record<string, Record<string, PermissionPolicy>>,
       unknownFlag: FirewallPolicyValue,
     ): Promise<void> => {
       // Convert dialog state (flat perms + unknownPolicy) to unified FirewallPolicies
-      const unified: FirewallPolicies = {};
+      const unified: FirewallPolicies = { ...initialPolicies };
       for (const [r, p] of Object.entries(perms)) {
-        unified[r] = { policies: p, unknownPolicy: unknownFlag };
+        const nextUnknownPolicy =
+          r === ref ? unknownFlag : initialPolicies[r]?.unknownPolicy;
+        unified[r] =
+          nextUnknownPolicy === undefined
+            ? { policies: p }
+            : { policies: p, unknownPolicy: nextUnknownPolicy };
       }
       await onApply(unified);
     };
-    detach(applyFn(wrappedApply, onClose, pageSignal), Reason.DomCallback);
+    detach(
+      applyFn(
+        { formKey: initialPolicyKey, ref },
+        wrappedApply,
+        handleClose,
+        pageSignal,
+      ),
+      Reason.DomCallback,
+    );
   };
 
   const connectorLabel = CONNECTOR_TYPES[connectorType]?.label ?? connectorType;
@@ -319,7 +344,7 @@ export function PermissionsDrawer({
     <Sheet
       open
       onOpenChange={(open) => {
-        return !open && onClose();
+        return !open && handleClose();
       }}
     >
       <SheetContent side="right">
@@ -481,7 +506,7 @@ export function PermissionsDrawer({
         )}
 
         <SheetFooter>
-          <Button variant="outline" onClick={onClose}>
+          <Button variant="outline" onClick={handleClose}>
             {readOnly ? "Close" : "Cancel"}
           </Button>
           {!readOnly && (


### PR DESCRIPTION
## Summary
- reset permissions dialog form state per agent and connector instead of using a global initialized latch
- preserve existing policies for untouched connectors when applying one connector's permissions
- add a regression test that opens Slack then Notion and verifies saved policies are not overwritten

Fixes #14313

## Tests
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip
- pnpm -F @vm0/app exec vitest run src/views/fw/__tests__/permissions-dialog.test.tsx