### PR TITLE
refactor: merge msgpack binary match arms

### DIFF
--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -160,7 +160,7 @@ fn rmpv_to_json(value: rmpv::Value) -> serde_json::Value {
                 serde_json::Value::String(String::new())
             }
         },
-        rmpv::Value::Binary(bytes) => {
+        rmpv::Value::Binary(bytes) | rmpv::Value::Ext(_, bytes) => {
             let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
             serde_json::Value::String(encoded)
         }
@@ -185,10 +185,6 @@ fn rmpv_to_json(value: rmpv::Value) -> serde_json::Value {
                 })
                 .collect();
             serde_json::Value::Object(obj)
-        }
-        rmpv::Value::Ext(_, bytes) => {
-            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-            serde_json::Value::String(encoded)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Merge the duplicate `rmpv::Value::Binary` and `rmpv::Value::Ext` conversion arms in `rmpv_to_json`
- Keep the change as a pure behavior-preserving cleanup for the existing opaque byte-to-base64 handling

Closes #14505

## Tests

- `cargo fmt --manifest-path crates/ably-subscriber/Cargo.toml --check`
- `cargo test -p ably-subscriber --manifest-path crates/Cargo.toml`
- `cargo clippy -p ably-subscriber --manifest-path crates/Cargo.toml --all-targets --all-features -- -D warnings`
- `git diff --check`

## Notes

- Did not add a dedicated `Ext` test because this PR intentionally does not expand or document `Ext` semantics beyond the existing behavior.
