### PR TITLE
docs(mitm-addon): fix firewall fixture reference

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -261,11 +261,11 @@ def fake_firewall_headers():
 
     Dispatcher tests that want to verify ``mitm_addon.request`` routed to
     ``handle_firewall_request`` should not patch the handler itself (that was
-    the Phase-3-forbidden pattern).  Instead they patch the handler's only
-    external dependency — the auth-service HTTP call behind
-    ``get_firewall_headers`` — and assert on ``flow.metadata["firewall_*"]``
-    written by the real handler at auth.py:327–333 before it ever reaches the
-    network.
+    the Phase-3-forbidden pattern). Instead they patch the auth-service
+    boundary behind ``get_firewall_headers`` and assert on
+    ``flow.metadata["firewall_*"]`` populated by
+    ``_prepare_firewall_metadata`` at the start of the real handler, before
+    auth resolution begins.
 
     Returns a context manager that yields the ``AsyncMock`` in case a test
     wants to inspect call arguments.


### PR DESCRIPTION
## Summary
- update the fake_firewall_headers fixture docstring to reference _prepare_firewall_metadata instead of a stale auth.py line range
- narrow the wording to the auth-service boundary behind get_firewall_headers

## Tests
- ruff check tests/conftest.py
- ruff format --check tests/conftest.py
- git diff --check

Closes #14523