### PR TITLE
ci: use checkout merge parent for changed files

### DIFF
--- a/.github/scripts/changed-base-ref.sh
+++ b/.github/scripts/changed-base-ref.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event_name="${EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+
+case "$event_name" in
+  pull_request)
+    if [[ "${GITHUB_REF:-}" == refs/pull/*/merge ]] && git rev-parse -q --verify HEAD^2 >/dev/null; then
+      git rev-parse HEAD^1
+      exit 0
+    fi
+
+    if [ -z "${PULL_REQUEST_BASE_SHA:-}" ]; then
+      echo "missing PULL_REQUEST_BASE_SHA for pull_request event" >&2
+      exit 2
+    fi
+    git merge-base "$PULL_REQUEST_BASE_SHA" HEAD
+    ;;
+  merge_group)
+    if [ -z "${MERGE_GROUP_BASE_SHA:-}" ]; then
+      echo "missing MERGE_GROUP_BASE_SHA for merge_group event" >&2
+      exit 2
+    fi
+    printf '%s\n' "$MERGE_GROUP_BASE_SHA"
+    ;;
+  *)
+    printf 'HEAD^\n'
+    ;;
+esac

--- a/.github/scripts/changed-base-ref.sh
+++ b/.github/scripts/changed-base-ref.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 event_name="${EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+checkout_ref="${CHECKOUT_REF:-${GITHUB_REF:-}}"
 
 case "$event_name" in
   pull_request)
-    if [[ "${GITHUB_REF:-}" == refs/pull/*/merge ]] && git rev-parse -q --verify HEAD^2 >/dev/null; then
+    if [[ "$checkout_ref" == refs/pull/*/merge ]] && git rev-parse -q --verify HEAD^2 >/dev/null; then
       git rev-parse HEAD^1
       exit 0
     fi

--- a/.github/scripts/tests/changed-base-ref-test.sh
+++ b/.github/scripts/tests/changed-base-ref-test.sh
@@ -53,7 +53,7 @@ actual=$(
   cd "$repo"
   run_clean \
     GITHUB_EVENT_NAME=pull_request \
-    GITHUB_REF=refs/pull/123/merge \
+    CHECKOUT_REF=refs/pull/123/merge \
     PULL_REQUEST_BASE_SHA="$event_base" \
     "$CHANGED_BASE_REF"
 )
@@ -64,7 +64,7 @@ actual=$(
   cd "$repo"
   run_clean \
     GITHUB_EVENT_NAME=pull_request \
-    GITHUB_REF=refs/heads/feature \
+    CHECKOUT_REF=refs/heads/feature \
     PULL_REQUEST_BASE_SHA="$event_base" \
     "$CHANGED_BASE_REF"
 )
@@ -88,3 +88,5 @@ assert_eq "$actual" "HEAD^"
 git -C "$repo" switch -q --detach "$merge_ref"
 changed_files=$(git -C "$repo" diff --name-only "$merge_parent" HEAD)
 assert_eq "$changed_files" "crates/lib.rs"
+
+echo "changed-base-ref-test: ok"

--- a/.github/scripts/tests/changed-base-ref-test.sh
+++ b/.github/scripts/tests/changed-base-ref-test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHANGED_BASE_REF="${SCRIPT_DIR}/changed-base-ref.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local actual=$1 expected=$2
+  if [ "$actual" != "$expected" ]; then
+    fail "expected '${expected}', got '${actual}'"
+  fi
+}
+
+run_clean() {
+  env -i PATH="$PATH" HOME="${HOME:-/tmp}" "$@"
+}
+
+repo="${TMPDIR}/repo"
+mkdir "$repo"
+git -C "$repo" init -q -b main
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name Test
+
+mkdir -p "$repo/crates" "$repo/turbo"
+echo base > "$repo/README.md"
+git -C "$repo" add README.md
+git -C "$repo" commit -q -m "base"
+event_base=$(git -C "$repo" rev-parse HEAD)
+
+git -C "$repo" switch -q -c feature
+echo rust > "$repo/crates/lib.rs"
+git -C "$repo" add crates/lib.rs
+git -C "$repo" commit -q -m "feature"
+feature_head=$(git -C "$repo" rev-parse HEAD)
+
+git -C "$repo" switch -q main
+echo turbo > "$repo/turbo/file.ts"
+git -C "$repo" add turbo/file.ts
+git -C "$repo" commit -q -m "main advance"
+merge_parent=$(git -C "$repo" rev-parse HEAD)
+
+git -C "$repo" merge -q --no-ff feature -m "merge feature"
+merge_ref=$(git -C "$repo" rev-parse HEAD)
+
+actual=$(
+  cd "$repo"
+  run_clean \
+    GITHUB_EVENT_NAME=pull_request \
+    GITHUB_REF=refs/pull/123/merge \
+    PULL_REQUEST_BASE_SHA="$event_base" \
+    "$CHANGED_BASE_REF"
+)
+assert_eq "$actual" "$merge_parent"
+
+git -C "$repo" switch -q --detach "$feature_head"
+actual=$(
+  cd "$repo"
+  run_clean \
+    GITHUB_EVENT_NAME=pull_request \
+    GITHUB_REF=refs/heads/feature \
+    PULL_REQUEST_BASE_SHA="$event_base" \
+    "$CHANGED_BASE_REF"
+)
+assert_eq "$actual" "$event_base"
+
+actual=$(
+  cd "$repo"
+  run_clean \
+    GITHUB_EVENT_NAME=merge_group \
+    MERGE_GROUP_BASE_SHA="$merge_parent" \
+    "$CHANGED_BASE_REF"
+)
+assert_eq "$actual" "$merge_parent"
+
+actual=$(
+  cd "$repo"
+  run_clean GITHUB_EVENT_NAME=push "$CHANGED_BASE_REF"
+)
+assert_eq "$actual" "HEAD^"
+
+git -C "$repo" switch -q --detach "$merge_ref"
+changed_files=$(git -C "$repo" diff --name-only "$merge_parent" HEAD)
+assert_eq "$changed_files" "crates/lib.rs"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -89,7 +89,7 @@ jobs:
         id: detect
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
+          CHECKOUT_REF: ${{ github.ref }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -87,21 +87,18 @@ jobs:
 
       - name: Detect changed crates
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           # In CI containers, the repo may be owned by a different user (host vs container).
           # Git 2.35.2+ rejects such repos unless marked as safe.
           git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-            echo "PR mode: comparing against merge base $BASE_REF"
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-            echo "Merge queue mode: comparing against base $BASE_REF"
-          else
-            BASE_REF="HEAD^"
-            echo "Main push mode: comparing against HEAD^"
-          fi
+          BASE_REF=$(.github/scripts/changed-base-ref.sh)
+          echo "${{ github.event_name }} mode: comparing against base $BASE_REF"
           # Check if the workflow file or ansible playbooks changed
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
             echo "ci-changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -52,14 +52,13 @@ jobs:
       - name: Determine base ref
         id: base
         if: steps.identity.outputs.release-skip != 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="HEAD^"
-          fi
+          BASE_REF=$(.github/scripts/changed-base-ref.sh)
           echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
           echo "Base ref: ${BASE_REF}"
 

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -54,7 +54,7 @@ jobs:
         if: steps.identity.outputs.release-skip != 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
+          CHECKOUT_REF: ${{ github.ref }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -73,17 +73,14 @@ jobs:
 
       - name: Detect Turbo TypeScript check need
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-            echo "PR mode: comparing against merge base $BASE_REF"
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-            echo "Merge queue mode: comparing against base $BASE_REF"
-          else
-            BASE_REF="HEAD^"
-            echo "Main push mode: comparing against HEAD^"
-          fi
+          BASE_REF=$(.github/scripts/changed-base-ref.sh)
+          echo "${{ github.event_name }} mode: comparing against base $BASE_REF"
 
           CHANGED_FILES=$(git diff --name-only "$BASE_REF" HEAD)
 
@@ -136,20 +133,16 @@ jobs:
 
       - name: Detect changes
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           echo "Checking for changes..."
 
-          # Determine base ref based on event type
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-            echo "PR mode: comparing against merge base $BASE_REF"
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-            echo "Merge queue mode: comparing against base $BASE_REF"
-          else
-            BASE_REF="HEAD^"
-            echo "Main push mode: comparing against HEAD^"
-          fi
+          BASE_REF=$(.github/scripts/changed-base-ref.sh)
+          echo "${{ github.event_name }} mode: comparing against base $BASE_REF"
 
           echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
           CHANGED_FILES=$(git diff --name-only "$BASE_REF" HEAD)
@@ -315,13 +308,13 @@ jobs:
           fetch-depth: 0
 
       - name: Check file sizes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
-          # Get changed files in PR
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE_SHA="HEAD^"
-          fi
+          BASE_SHA=$(.github/scripts/changed-base-ref.sh)
 
           # Get list of added/modified files (exclude deleted)
           CHANGED_FILES=$(git diff --name-only --diff-filter=AM "$BASE_SHA" HEAD)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -75,7 +75,7 @@ jobs:
         id: detect
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
+          CHECKOUT_REF: ${{ github.ref }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
@@ -135,7 +135,7 @@ jobs:
         id: detect
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
+          CHECKOUT_REF: ${{ github.ref }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
@@ -310,7 +310,7 @@ jobs:
       - name: Check file sizes
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
+          CHECKOUT_REF: ${{ github.ref }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |


### PR DESCRIPTION
## Summary
- add a shared changed-base-ref helper for workflow changed-file detection
- use the checked-out PR merge commit first parent when Actions checks out refs/pull/*/merge
- update Turbo, Crates, and runner-image change detection to avoid counting unrelated main changes on reruns

## Testing
- bash .github/scripts/tests/changed-base-ref-test.sh
- bash -n .github/scripts/changed-base-ref.sh .github/scripts/tests/changed-base-ref-test.sh
- git diff --check
- reproduced PR #14537 stale-base merge-ref case locally