### PR TITLE
refactor: clarify oauth auth-code connector commands

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -3,9 +3,9 @@ import { server } from "../../../../mocks/server.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../../__tests__/page-helper.ts";
 import {
-  connectConnector$,
+  connectConnectorOAuthAuthCode$,
   permissionDialogType$,
-  pollingConnectorType$,
+  pollingOAuthAuthCodeConnectorType$,
   submitApiToken$,
 } from "../connectors.ts";
 import { triggerAblyEvent, hasSubscription } from "../../../../mocks/ably.ts";
@@ -14,6 +14,7 @@ import {
   zeroConnectorOauthStartContract,
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroSecretsContract,
   zeroVariablesContract,
@@ -79,7 +80,7 @@ function createMockAuthWindow() {
   return { closed: false, close: vi.fn(), location: { href: "" } };
 }
 
-describe("connectConnector$", () => {
+describe("connectConnectorOAuthAuthCode$", () => {
   beforeEach(() => {
     mockConnectorOauthStart();
   });
@@ -102,7 +103,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       {},
       context.signal,
@@ -114,17 +115,17 @@ describe("connectConnector$", () => {
       expect(hasSubscription("connector:changed")).toBeTruthy();
     });
 
-    // Simulate the OAuth callback publishing the signal.
+    // Simulate the auth-code OAuth callback publishing the signal.
     triggerAblyEvent("connector:changed");
 
     const result = await connectPromise;
 
     expect(result).toBeTruthy();
     expect(pollCount).toBeGreaterThanOrEqual(2);
-    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
   });
 
-  it("clears polling when the oauth popup closes before connector appears", async () => {
+  it("clears polling when the auth-code OAuth popup closes before connector appears", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
     const mockWindow = createMockAuthWindow();
@@ -139,7 +140,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       {},
       context.signal,
@@ -148,13 +149,15 @@ describe("connectConnector$", () => {
     await vi.waitFor(() => {
       expect(pollCount).toBeGreaterThanOrEqual(1);
       expect(hasSubscription("connector:changed")).toBeTruthy();
-      expect(context.store.get(pollingConnectorType$)).toBe("github");
+      expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBe(
+        "github",
+      );
     });
 
     mockWindow.closed = true;
 
     await expect(connectPromise).resolves.toBeFalsy();
-    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
     expect(hasSubscription("connector:changed")).toBeFalsy();
   });
 
@@ -164,9 +167,14 @@ describe("connectConnector$", () => {
     vi.spyOn(window, "open").mockReturnValue(null);
 
     await expect(
-      context.store.set(connectConnector$, "github", {}, context.signal),
+      context.store.set(
+        connectConnectorOAuthAuthCode$,
+        "github",
+        {},
+        context.signal,
+      ),
     ).rejects.toThrow("Failed to open authorization window");
-    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
   });
 
   it("opens connector OAuth on the web host when apiBackend is enabled", async () => {
@@ -205,7 +213,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       {},
       context.signal,
@@ -276,7 +284,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       {},
       context.signal,
@@ -300,7 +308,7 @@ describe("connectConnector$", () => {
 
     expect(result).toBeTruthy();
     expect(pollCount).toBeGreaterThanOrEqual(3);
-    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
     expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 
@@ -317,7 +325,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       { showPermissionDialog: true },
       context.signal,
@@ -335,7 +343,7 @@ describe("connectConnector$", () => {
     expect(context.store.get(permissionDialogType$)).toBe("github");
   });
 
-  it("completes oauth flow in standalone mode without popup dimensions", async () => {
+  it("completes auth-code OAuth flow in standalone mode without popup dimensions", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
     mockMatchMedia(true);
@@ -348,7 +356,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       {},
       context.signal,
@@ -362,7 +370,7 @@ describe("connectConnector$", () => {
     const result = await connectPromise;
 
     expect(result).toBeTruthy();
-    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
     expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 
@@ -384,7 +392,7 @@ describe("connectConnector$", () => {
     );
 
     const connectPromise = context.store.set(
-      connectConnector$,
+      connectConnectorOAuthAuthCode$,
       "github",
       {},
       context.signal,
@@ -405,8 +413,43 @@ describe("connectConnector$", () => {
 
     expect(result).toBeTruthy();
     expect(pollCount).toBeGreaterThanOrEqual(3);
-    expect(context.store.get(pollingConnectorType$)).toBeNull();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
     expect(context.store.get(permissionDialogType$)).toBeNull();
+  });
+
+  it("rejects device-auth OAuth connectors before opening popup or starting auth-code OAuth", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    const open = vi.spyOn(window, "open");
+    let startCalled = false;
+    server.use(
+      mockApi(zeroConnectorOauthStartContract.start, ({ respond }) => {
+        startCalled = true;
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/test-oauth-device/authorize",
+        });
+      }),
+    );
+
+    await expect(
+      context.store.set(
+        connectConnectorOAuthAuthCode$,
+        "test-oauth-device",
+        {},
+        context.signal,
+      ),
+    ).rejects.toThrow(
+      "test-oauth-device does not use authorization-code OAuth",
+    );
+
+    expect(open).not.toHaveBeenCalled();
+    expect(startCalled).toBeFalsy();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -18,6 +18,7 @@ import {
   getConnectorCliAuthModes,
   getConnectorTags,
   hasRequiredScopes,
+  isOAuthAuthCodeConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
   zeroLocalAgentHostsContract,
@@ -635,11 +636,13 @@ export const submitApiToken$ = command(
 // Polling state (for connect flow)
 // ---------------------------------------------------------------------------
 
-const internalPollingType$ = state<ConnectorType | null>(null);
+const internalPollingOAuthAuthCodeConnectorType$ = state<ConnectorType | null>(
+  null,
+);
 const internalConnectFlowState$ = state<ConnectorConnectFlowState | null>(null);
 
-export const pollingConnectorType$ = computed((get) => {
-  return get(internalPollingType$);
+export const pollingOAuthAuthCodeConnectorType$ = computed((get) => {
+  return get(internalPollingOAuthAuthCodeConnectorType$);
 });
 
 export const connectFlowType$ = computed((get) => {
@@ -1582,9 +1585,9 @@ export function isStandaloneMode(): boolean {
   return window.matchMedia("(display-mode: standalone)").matches;
 }
 
-const OAUTH_POPUP_CLOSED_POLL_MS = 250;
+const OAUTH_AUTH_CODE_POPUP_CLOSED_POLL_MS = 250;
 
-function waitForOAuthPopupClosed(
+function waitForOAuthAuthCodePopupClosed(
   authWindow: Pick<Window, "closed">,
   signal: AbortSignal,
 ): Promise<"popupClosed"> {
@@ -1630,22 +1633,33 @@ function waitForOAuthPopupClosed(
     }
   }
 
-  intervalId = window.setInterval(checkClosed, OAUTH_POPUP_CLOSED_POLL_MS);
+  intervalId = window.setInterval(
+    checkClosed,
+    OAUTH_AUTH_CODE_POPUP_CLOSED_POLL_MS,
+  );
   signal.addEventListener("abort", onAbort, { once: true });
   checkClosed();
 
   return deferred.promise;
 }
 
-const resetOAuthConnectorLoopSignal$ = resetSignal();
-const resetOAuthConnectorPopupSignal$ = resetSignal();
+const resetOAuthAuthCodeConnectorLoopSignal$ = resetSignal();
+const resetOAuthAuthCodeConnectorPopupSignal$ = resetSignal();
 
 // ---------------------------------------------------------------------------
 // Connect command
 // ---------------------------------------------------------------------------
 
-const openConnectorOauthWindow$ = command(
+function assertConnectorUsesOAuthAuthCode(type: ConnectorType): void {
+  if (!isOAuthAuthCodeConnectorType(type)) {
+    throw new Error(`${type} does not use authorization-code OAuth`);
+  }
+}
+
+const openConnectorOAuthAuthCodeWindow$ = command(
   async ({ get }, type: ConnectorType, signal: AbortSignal) => {
+    assertConnectorUsesOAuthAuthCode(type);
+
     const standalone = isStandaloneMode();
 
     // In standalone (PWA) mode, omit popup features so iOS Safari opens the
@@ -1680,23 +1694,29 @@ const openConnectorOauthWindow$ = command(
   },
 );
 
-export const connectConnector$ = command(
+export const connectConnectorOAuthAuthCode$ = command(
   async (
     { get, set },
     type: ConnectorType,
     options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
+    assertConnectorUsesOAuthAuthCode(type);
+
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
-    set(internalPollingType$, type);
+    set(internalPollingOAuthAuthCodeConnectorType$, type);
 
     return await withCleanup(
       (async () => {
-        const authWindow = await set(openConnectorOauthWindow$, type, signal);
+        const authWindow = await set(
+          openConnectorOAuthAuthCodeWindow$,
+          type,
+          signal,
+        );
         signal.throwIfAborted();
 
-        // Wait for the OAuth flow to complete. The callback publishes
+        // Wait for the auth-code OAuth flow to complete. The callback publishes
         // `connector:changed`, and the subscription rechecks the server state.
         // Snapshot taken on the first body invocation: `null` marks "no
         // connector yet" and an `updatedAt` value marks "reconnect scenario —
@@ -1742,8 +1762,11 @@ export const connectConnector$ = command(
         await set(onConnectorChanged$, signal);
         signal.throwIfAborted();
 
-        const loopSignal = set(resetOAuthConnectorLoopSignal$, signal);
-        const popupSignal = set(resetOAuthConnectorPopupSignal$, signal);
+        const loopSignal = set(resetOAuthAuthCodeConnectorLoopSignal$, signal);
+        const popupSignal = set(
+          resetOAuthAuthCodeConnectorPopupSignal$,
+          signal,
+        );
 
         const completed = await withCleanup(
           (async () => {
@@ -1762,12 +1785,12 @@ export const connectConnector$ = command(
                 ? await changedPromise
                 : await Promise.race([
                     changedPromise,
-                    waitForOAuthPopupClosed(authWindow, popupSignal),
+                    waitForOAuthAuthCodePopupClosed(authWindow, popupSignal),
                   ]);
             signal.throwIfAborted();
 
             if (waitResult === "popupClosed") {
-              set(resetOAuthConnectorLoopSignal$, signal);
+              set(resetOAuthAuthCodeConnectorLoopSignal$, signal);
               const connectedAfterClose = await set(
                 onConnectorChanged$,
                 signal,
@@ -1780,8 +1803,8 @@ export const connectConnector$ = command(
             return true;
           })(),
           () => {
-            set(resetOAuthConnectorLoopSignal$, signal);
-            set(resetOAuthConnectorPopupSignal$, signal);
+            set(resetOAuthAuthCodeConnectorLoopSignal$, signal);
+            set(resetOAuthAuthCodeConnectorPopupSignal$, signal);
           },
         );
         if (!completed) {
@@ -1807,8 +1830,8 @@ export const connectConnector$ = command(
         const hidden = new Set(get(hiddenConnectorTypes$));
         hidden.delete(type);
         set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-        // Close connect modal on OAuth success. Only connectors-page flows should
-        // show the post-connect permission dialog.
+        // Close connect modal on auth-code OAuth success. Only connectors-page
+        // flows should show the post-connect permission dialog.
         if (isConnected) {
           set(internalSelectedConnectorType$, null);
           if (options.showPermissionDialog) {
@@ -1818,7 +1841,7 @@ export const connectConnector$ = command(
         return isConnected;
       })(),
       () => {
-        set(internalPollingType$, (current) => {
+        set(internalPollingOAuthAuthCodeConnectorType$, (current) => {
           return current === type ? null : current;
         });
         set(internalConnectFlowState$, (current) => {
@@ -1830,10 +1853,10 @@ export const connectConnector$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// Connect via OAuth, then run onSuccess callback (settling phase)
+// Connect via auth-code OAuth, then run onSuccess callback (settling phase)
 // ---------------------------------------------------------------------------
 
-export const connectAndSettle$ = command(
+export const connectConnectorOAuthAuthCodeAndSettle$ = command(
   async (
     { set },
     type: ConnectorType,
@@ -1841,7 +1864,12 @@ export const connectAndSettle$ = command(
     options: PostConnectOptions,
     signal: AbortSignal,
   ): Promise<void> => {
-    const connected = await set(connectConnector$, type, options, signal);
+    const connected = await set(
+      connectConnectorOAuthAuthCode$,
+      type,
+      options,
+      signal,
+    );
     if (connected) {
       await onSuccess();
     }

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -116,6 +116,23 @@ describe("connect modal - content by auth method", () => {
     });
   });
 
+  it("does not show auth-code OAuth button for device-auth OAuth connectors", async () => {
+    await openConnectModal("test-oauth-device", {
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Sign in with Test OAuth Device (internal)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Connection methods unavailable"),
+    ).toBeInTheDocument();
+  });
+
   it("shows API token form for api-token connectors (CONN-C-019)", async () => {
     await openConnectModal("axiom");
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -105,15 +105,17 @@ describe("onboarding connector permission dialog suppression", () => {
     });
 
     // Mock the connectors API to return GitHub as connected (simulates
-    // successful OAuth — the polling inside connectConnector$ will pick it up).
+    // successful auth-code OAuth — the polling inside
+    // connectConnectorOAuthAuthCode$ will pick it up).
     server.use(
       mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
         return respond(200, makeGithubConnectedResponse());
       }),
     );
 
-    // Click "Connect" on GitHub — this triggers connectConnector$ without
-    // opting into the post-connect permission dialog.
+    // Click "Connect" on GitHub — this triggers
+    // connectConnectorOAuthAuthCode$ without opting into the post-connect
+    // permission dialog.
     click(screen.getByText("Connect"));
 
     await waitFor(() => {
@@ -123,8 +125,8 @@ describe("onboarding connector permission dialog suppression", () => {
     });
 
     // Wait for the Ably subscription to be registered, then simulate the
-    // OAuth callback publishing `connector:changed` so connectConnector$
-    // observes the connector appear.
+    // Auth-code OAuth callback publishing `connector:changed` so
+    // connectConnectorOAuthAuthCode$ observes the connector appear.
     await waitFor(() => {
       expect(hasSubscription("connector:changed")).toBeTruthy();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -15,6 +15,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -24,6 +25,16 @@ const context = testContext();
 const mockApi = createMockApi(context);
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+function getButtonByText(text: string): HTMLElement {
+  const button = screen.getAllByRole("button").find((element) => {
+    return element.textContent?.trim() === text;
+  });
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
 
 function mockAgentWithName(agentId: string, displayName: string) {
   setMockTeam([
@@ -292,5 +303,21 @@ describe("directed authorize page", () => {
     expect(
       screen.queryByText(/Google will show a security warning/),
     ).not.toBeInTheDocument();
+  });
+
+  it("does not enable auth-code authorization for device-auth OAuth connectors", async () => {
+    detachedSetupPage({
+      context,
+      path: `/connectors/test-oauth-device/authorize?agentId=${AGENT_ID}`,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Test OAuth Device (internal) to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(getButtonByText("Authorize Zero")).toBeDisabled();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -17,6 +17,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
@@ -353,6 +354,42 @@ describe("directed connect page", () => {
         "https://oauth.test/gmail/authorize",
       );
     });
+  });
+
+  it("does not enable connect for device-auth OAuth connectors", async () => {
+    const openSpy = vi.spyOn(window, "open");
+    let startCalled = false;
+    server.use(
+      mockApi(zeroConnectorOauthStartContract.start, ({ respond }) => {
+        startCalled = true;
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/test-oauth-device/authorize",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/test-oauth-device/connect",
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Test OAuth Device (internal) to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    const connectButton = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Connect";
+    });
+    expect(connectButton).toBeDefined();
+    expect(connectButton).toBeDisabled();
+    click(connectButton!);
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(startCalled).toBeFalsy();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("save button submits the api token to the server (CONN-I-049)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -24,13 +24,14 @@ import type { LocalBrowserHost } from "@vm0/api-contracts/contracts/zero-local-b
 import {
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
+  isOAuthAuthCodeConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
   allConnectorTypes$,
   connectorCliAuthState$,
   connectFlowType$,
-  pollingConnectorType$,
-  connectAndSettle$,
+  pollingOAuthAuthCodeConnectorType$,
+  connectConnectorOAuthAuthCodeAndSettle$,
   runConnectorConnectSuccess$,
   submitApiToken$,
   setTokenFormValue$,
@@ -145,7 +146,7 @@ type SubmitApiTokenFn = (
   signal: AbortSignal,
 ) => Promise<void>;
 
-type ConnectAndSettleFn = (
+type ConnectOAuthAuthCodeAndSettleFn = (
   type: ConnectorType,
   onSuccess: () => void | Promise<void>,
   options: PostConnectOptions,
@@ -159,7 +160,7 @@ type ConnectModalContentProps = {
 };
 
 type ConnectMethodContentProps = ConnectModalContentProps & {
-  connectAndSettle: ConnectAndSettleFn;
+  connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   submitApiToken: SubmitApiTokenFn;
   credentialSubmitting: boolean;
   signal: AbortSignal;
@@ -607,14 +608,14 @@ function UnavailableConnectMethodsContent() {
   );
 }
 
-function getOAuthProgressContent({
+function getOAuthAuthCodeProgressContent({
   isPolling,
   settling,
 }: {
   isPolling: boolean;
   settling: boolean;
 }) {
-  // While OAuth is in progress, only show connecting state
+  // While auth-code OAuth is in progress, only show connecting state
   if (isPolling) {
     const standaloneHint = isStandaloneMode()
       ? " Switch back here after completing sign-in."
@@ -633,16 +634,16 @@ function getOAuthProgressContent({
   return null;
 }
 
-function OAuthConnectButton({
+function OAuthAuthCodeConnectButton({
   item,
   label,
   onSuccess,
   showPermissionDialogOnConnect,
-  connectAndSettle,
+  connectOAuthAuthCodeAndSettle,
   signal,
 }: ConnectModalContentProps & {
   label: string;
-  connectAndSettle: ConnectAndSettleFn;
+  connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   signal: AbortSignal;
 }) {
   return (
@@ -650,7 +651,7 @@ function OAuthConnectButton({
       variant="outline"
       onClick={() => {
         return detach(
-          connectAndSettle(
+          connectOAuthAuthCodeAndSettle(
             item.type,
             onSuccess,
             {
@@ -668,14 +669,14 @@ function OAuthConnectButton({
   );
 }
 
-function OAuthConnectMethodContent(props: ConnectMethodContentProps) {
+function OAuthAuthCodeConnectMethodContent(props: ConnectMethodContentProps) {
   return (
-    <OAuthConnectButton
+    <OAuthAuthCodeConnectButton
       item={props.item}
       label={CONNECTOR_TYPES[props.item.type].label}
       onSuccess={props.onSuccess}
       showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
-      connectAndSettle={props.connectAndSettle}
+      connectOAuthAuthCodeAndSettle={props.connectOAuthAuthCodeAndSettle}
       signal={props.signal}
     />
   );
@@ -716,7 +717,10 @@ function getConnectMethodContentComponent(
 ): ConnectMethodContentComponent | null {
   switch (authMethod) {
     case "oauth": {
-      return OAuthConnectMethodContent;
+      if (!isOAuthAuthCodeConnectorType(item.type)) {
+        return null;
+      }
+      return OAuthAuthCodeConnectMethodContent;
     }
     case "api-token": {
       return ApiTokenConnectMethodContent;
@@ -824,13 +828,13 @@ function StandardConnectMethodsContent({
   item,
   onSuccess,
   showPermissionDialogOnConnect,
-  connectAndSettle,
+  connectOAuthAuthCodeAndSettle,
   submitApiToken,
   credentialSubmitting,
   signal,
   entries,
 }: ConnectModalContentProps & {
-  connectAndSettle: ConnectAndSettleFn;
+  connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   submitApiToken: SubmitApiTokenFn;
   credentialSubmitting: boolean;
   signal: AbortSignal;
@@ -852,7 +856,7 @@ function StandardConnectMethodsContent({
           item,
           onSuccess,
           showPermissionDialogOnConnect,
-          connectAndSettle,
+          connectOAuthAuthCodeAndSettle,
           submitApiToken,
           credentialSubmitting,
           signal,
@@ -867,11 +871,13 @@ function ConnectModalContent({
   onSuccess,
   showPermissionDialogOnConnect,
 }: ConnectModalContentProps) {
-  const [settleLoadable, connectAndSettle] = useLoadableSet(connectAndSettle$);
+  const [settleLoadable, connectOAuthAuthCodeAndSettle] = useLoadableSet(
+    connectConnectorOAuthAuthCodeAndSettle$,
+  );
   const [apiTokenLoadable, submitApiToken] = useLoadableSet(submitApiToken$);
   const [, runConnectSuccess] = useLoadableSet(runConnectorConnectSuccess$);
   const pageSignal = useGet(pageSignal$);
-  const pollingType = useGet(pollingConnectorType$);
+  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const settling = settleLoadable.state === "loading";
   const credentialSubmitting = apiTokenLoadable.state === "loading";
   const isPolling = pollingType === item.type;
@@ -880,12 +886,14 @@ function ConnectModalContent({
     await runConnectSuccess(item.type, onSuccess, pageSignal);
   };
 
-  const progressContent = item.availableAuthMethods.includes("oauth")
-    ? getOAuthProgressContent({
-        isPolling,
-        settling,
-      })
-    : null;
+  const progressContent =
+    item.availableAuthMethods.includes("oauth") &&
+    isOAuthAuthCodeConnectorType(item.type)
+      ? getOAuthAuthCodeProgressContent({
+          isPolling,
+          settling,
+        })
+      : null;
   if (progressContent) {
     return progressContent;
   }
@@ -895,7 +903,7 @@ function ConnectModalContent({
       item={item}
       onSuccess={onConnectSuccess}
       showPermissionDialogOnConnect={showPermissionDialogOnConnect}
-      connectAndSettle={connectAndSettle}
+      connectOAuthAuthCodeAndSettle={connectOAuthAuthCodeAndSettle}
       submitApiToken={submitApiToken}
       credentialSubmitting={credentialSubmitting}
       signal={pageSignal}
@@ -921,7 +929,7 @@ export function ConnectModal({
   const connectorTypes = useLastResolved(allConnectorTypes$);
   const clearConnectorCliAuth = useSet(clearConnectorCliAuth$);
   const connectFlowType = useGet(connectFlowType$);
-  const pollingType = useGet(pollingConnectorType$);
+  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const connectorCliAuthState = useGet(connectorCliAuthState$);
 
   const item = connectorTypes?.find((c) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -94,7 +94,7 @@ import {
   selectedConnectorType$,
   setSelectedConnectorType$,
   justConnectedTypes$,
-  pollingConnectorType$,
+  pollingOAuthAuthCodeConnectorType$,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
@@ -1248,7 +1248,7 @@ export function ZeroChatComposer({
   const pendingConnectType = useGet(pendingConnectType$);
   const setPendingConnectType = useSet(setPendingConnectType$);
   const setSelectedConnType = useSet(setSelectedConnectorType$);
-  const pollingConnType = useGet(pollingConnectorType$);
+  const pollingConnType = useGet(pollingOAuthAuthCodeConnectorType$);
   const authorizeFn = useSet(authorizeConnector$);
   const deauthorizeFn = useSet(deauthorizeConnector$);
   const optimisticConnected = useGet(justConnectedTypes$);

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -20,7 +20,10 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
+import {
+  isGoogleOAuthConnector,
+  isOAuthAuthCodeConnectorType,
+} from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
@@ -32,13 +35,13 @@ import { CustomConnectorsPanel } from "./components/settings/custom-connectors-p
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
-  connectConnector$,
+  connectConnectorOAuthAuthCode$,
   connectorsSearch$,
   disconnectConnector$,
   setConnectorsSearch$,
   selectedConnectorType$,
   setSelectedConnectorType$,
-  pollingConnectorType$,
+  pollingOAuthAuthCodeConnectorType$,
   justConnectedTypes$,
   LOCAL_AGENT_CONNECTOR_TYPE,
   LOCAL_BROWSER_CONNECTOR_TYPE,
@@ -659,8 +662,8 @@ function renderBuiltinList({
 
 export function ZeroConnectorsPage() {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
-  const pollingType = useGet(pollingConnectorType$);
-  const connect = useSet(connectConnector$);
+  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const connect = useSet(connectConnectorOAuthAuthCode$);
   const [disconnectLoadable, disconnect] = useLoadableSet(disconnectConnector$);
   const signal = useGet(pageSignal$);
   const selectedType = useGet(selectedConnectorType$);
@@ -705,13 +708,12 @@ export function ZeroConnectorsPage() {
     const ct = allConnectors.find((c) => {
       return c.type === type;
     });
-    // Any connector without OAuth opens the ConnectModal for api-token entry.
-    // Only pure-OAuth connectors skip the modal and jump straight to the popup
-    // flow.
-    if (
-      (ct && !ct.availableAuthMethods.includes("oauth")) ||
-      isGoogleOAuthConnector(type)
-    ) {
+    const canLaunchOAuthAuthCode =
+      (ct?.availableAuthMethods.includes("oauth") ?? false) &&
+      isOAuthAuthCodeConnectorType(type);
+    // Connectors without auth-code OAuth open the ConnectModal for the
+    // available non-popup method.
+    if (!canLaunchOAuthAuthCode || isGoogleOAuthConnector(type)) {
       setSelected(type);
     } else {
       detach(

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -3,7 +3,10 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
+import {
+  isGoogleOAuthConnector,
+  isOAuthAuthCodeConnectorType,
+} from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
@@ -31,11 +34,13 @@ import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
 function AuthorizeAction({
   isAuthorized,
   isConnecting,
+  disabled,
   agentName,
   onAuthorize,
 }: {
   isAuthorized: boolean;
   isConnecting: boolean;
+  disabled: boolean;
   agentName: string;
   onAuthorize: () => void;
 }) {
@@ -50,7 +55,7 @@ function AuthorizeAction({
   return (
     <button
       type="button"
-      disabled={isConnecting}
+      disabled={isConnecting || disabled}
       onClick={onAuthorize}
       className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] px-4 text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
     >
@@ -103,8 +108,13 @@ function DirectedAuthorizeCard() {
     justAuthorized.has(connectorType) ||
     (enabledLoadable.state === "hasData" &&
       enabledLoadable.data.includes(connectorType));
+  const canAuthorize =
+    isConnected || isOAuthAuthCodeConnectorType(connectorType);
 
   const handleAuthorize = () => {
+    if (!canAuthorize) {
+      return;
+    }
     if (isConnected) {
       detach(authorize(connectorType, agentId, signal), Reason.DomCallback);
     } else {
@@ -155,6 +165,7 @@ function DirectedAuthorizeCard() {
               <AuthorizeAction
                 isAuthorized={isAuthorized}
                 isConnecting={isConnecting}
+                disabled={!canAuthorize}
                 agentName={agentName}
                 onAuthorize={handleAuthorize}
               />

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -7,9 +7,9 @@ import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
-  connectConnector$,
+  connectConnectorOAuthAuthCode$,
   justConnectedTypes$,
-  pollingConnectorType$,
+  pollingOAuthAuthCodeConnectorType$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -68,8 +68,8 @@ function DirectedAuthorizeCard() {
   const type = useGet(directedAuthorizeType$);
   const agentId = useGet(directedAuthorizeAgentId$);
   const agentNameLoadable = useLastLoadable(directedAuthorizeAgentName$);
-  const pollingType = useGet(pollingConnectorType$);
-  const connect = useSet(connectConnector$);
+  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
   const justConnected = useGet(justConnectedTypes$);

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -69,11 +69,9 @@ function runDirectedConnect(params: {
     params.openTokenDialog();
     return;
   }
-  // Defensive fallback for the degenerate empty-authMethods case — the
-  // contract disallows it today, so in practice this is unreachable after
-  // the api-token branch above.
+  // Device-auth OAuth needs a separate UI and must not fall through to the
+  // api-token dialog when no api-token method exists.
   if (!hasOAuthAuthCode) {
-    params.openTokenDialog();
     return;
   }
   detach(
@@ -222,10 +220,12 @@ function ApiTokenDialog({
 function ConnectActions({
   isConnected,
   isConnecting,
+  disabled,
   onConnect,
 }: {
   isConnected: boolean;
   isConnecting: boolean;
+  disabled: boolean;
   onConnect: () => void;
 }) {
   if (isConnected) {
@@ -237,7 +237,7 @@ function ConnectActions({
         </div>
         <button
           type="button"
-          disabled={isConnecting}
+          disabled={isConnecting || disabled}
           onClick={onConnect}
           className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60 inline-flex items-center gap-1.5"
         >
@@ -250,7 +250,7 @@ function ConnectActions({
   return (
     <button
       type="button"
-      disabled={isConnecting}
+      disabled={isConnecting || disabled}
       onClick={onConnect}
       className="inline-flex h-9 w-[100px] items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
     >
@@ -292,6 +292,12 @@ function DirectedConnectCard() {
   });
   const isConnected =
     justConnected.has(connectorType) || (item?.connected ?? false);
+  const authMethods =
+    item?.availableAuthMethods ?? Object.keys(config.authMethods);
+  const canConnect =
+    authMethods.includes("api-token") ||
+    (authMethods.includes("oauth") &&
+      isOAuthAuthCodeConnectorType(connectorType));
 
   const runPostConnectActions = async () => {
     if (agentId) {
@@ -300,9 +306,11 @@ function DirectedConnectCard() {
   };
 
   const handleConnect = () => {
+    if (!canConnect) {
+      return;
+    }
     runDirectedConnect({
-      authMethods:
-        item?.availableAuthMethods ?? Object.keys(config.authMethods),
+      authMethods,
       connectorType,
       signal,
       connect,
@@ -349,6 +357,7 @@ function DirectedConnectCard() {
                 <ConnectActions
                   isConnected={isConnected}
                   isConnecting={isConnecting}
+                  disabled={!canConnect}
                   onConnect={handleConnect}
                 />
               </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -6,6 +6,7 @@ import {
 import {
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
+  isOAuthAuthCodeConnectorType,
 } from "@vm0/connectors/connector-utils";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
@@ -17,9 +18,9 @@ import {
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
-  connectConnector$,
+  connectConnectorOAuthAuthCode$,
   justConnectedTypes$,
-  pollingConnectorType$,
+  pollingOAuthAuthCodeConnectorType$,
   submitApiToken$,
   tokenFormSubmitting$,
   setTokenFormValue$,
@@ -57,19 +58,21 @@ function runDirectedConnect(params: {
   onConnected: () => Promise<void>;
   openTokenDialog: () => void;
 }): void {
-  const hasOAuth = params.authMethods.includes("oauth");
+  const hasOAuthAuthCode =
+    params.authMethods.includes("oauth") &&
+    isOAuthAuthCodeConnectorType(params.connectorType);
   const hasApiToken = params.authMethods.includes("api-token");
 
-  // Priority: OAuth launches the external popup; api-token opens the modal so
-  // the user can enter credentials.
-  if (!hasOAuth && hasApiToken) {
+  // Priority: auth-code OAuth launches the external popup; api-token opens the
+  // modal so the user can enter credentials.
+  if (!hasOAuthAuthCode && hasApiToken) {
     params.openTokenDialog();
     return;
   }
   // Defensive fallback for the degenerate empty-authMethods case — the
   // contract disallows it today, so in practice this is unreachable after
   // the api-token branch above.
-  if (!hasOAuth) {
+  if (!hasOAuthAuthCode) {
     params.openTokenDialog();
     return;
   }
@@ -261,8 +264,8 @@ function DirectedConnectCard() {
   const type = useGet(directedConnectType$);
   const agentId = useGet(directedConnectAgentId$);
   const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
-  const pollingType = useGet(pollingConnectorType$);
-  const connect = useSet(connectConnector$);
+  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
   const justConnected = useGet(justConnectedTypes$);

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -19,6 +19,7 @@ import {
 import {
   getConnectorTags,
   isGoogleOAuthConnector,
+  isOAuthAuthCodeConnectorType,
 } from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -47,9 +48,9 @@ import {
 } from "../../signals/zero-page/zero-onboarding-actions.ts";
 import {
   allConnectorTypes$,
-  connectConnector$,
+  connectConnectorOAuthAuthCode$,
   matchesConnectorSearch,
-  pollingConnectorType$,
+  pollingOAuthAuthCodeConnectorType$,
   selectedConnectorType$,
   setSelectedConnectorType$,
   setPermissionDialogType$,
@@ -225,8 +226,8 @@ function ConnectStepContent() {
   const effectiveConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
   const connectorTypesLoadable = useLastLoadable(allConnectorTypes$);
-  const pollingType = useGet(pollingConnectorType$);
-  const connect = useSet(connectConnector$);
+  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const connect = useSet(connectConnectorOAuthAuthCode$);
   const setSelectedConnector = useSet(setSelectedConnectorType$);
   const clearPermissionDialog = useSet(setPermissionDialogType$);
   const pageSignal = useGet(pageSignal$);
@@ -261,7 +262,11 @@ function ConnectStepContent() {
     if (connector?.connected) {
       return;
     }
+    const canLaunchOAuthAuthCode =
+      (connector?.availableAuthMethods.includes("oauth") ?? false) &&
+      isOAuthAuthCodeConnectorType(type);
     if (
+      !canLaunchOAuthAuthCode ||
       connector?.availableAuthMethods.includes("api-token") ||
       isGoogleOAuthConnector(type)
     ) {

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -262,9 +262,10 @@ function ConnectStepContent() {
     if (connector?.connected) {
       return;
     }
+    const hasAvailableOAuth =
+      connector?.availableAuthMethods.includes("oauth") ?? true;
     const canLaunchOAuthAuthCode =
-      (connector?.availableAuthMethods.includes("oauth") ?? false) &&
-      isOAuthAuthCodeConnectorType(type);
+      hasAvailableOAuth && isOAuthAuthCodeConnectorType(type);
     if (
       !canLaunchOAuthAuthCode ||
       connector?.availableAuthMethods.includes("api-token") ||


### PR DESCRIPTION
## Summary
- rename the platform connector popup/callback command path to explicit OAuthAuthCode names
- guard auth-code connector commands before polling, popup open, and /oauth/start for device-auth connectors
- make UI auto-launch and modal content use auth-code OAuth capability instead of generic oauth auth-method presence
- add regression coverage for test-oauth-device staying out of the auth-code popup path

Closes #14528

## Tests
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts
- pnpm -F @vm0/app exec vitest run src/views/conn/__tests__/add-connection-dialog.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
- pnpm -F @vm0/app check-types
- pnpm turbo run lint --filter=@vm0/app
- pre-commit: prettier, knip, full turbo check-types
