### PR TITLE
fix: preserve openai websocket usage across frames

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -204,7 +204,7 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     if not isinstance(usage_target, dict):
         usage_target = {}
         flow.metadata["model_provider_usage"] = usage_target
-    usage_target.update(usage_result)
+    usage.merge_openai_responses_usage_result(usage_target, usage_result)
 
 
 def finalize_x_json_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -34,6 +34,7 @@ from .openai_responses import (
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event_json,
     extract_openai_responses_usage_from_json,
+    merge_openai_responses_usage_result,
 )
 from .providers.connectors import report_connector_usage, x
 from .providers.model_provider import report_model_provider_usage
@@ -48,6 +49,7 @@ __all__ = [
     "extract_openai_responses_usage_from_event_json",
     "extract_openai_responses_usage_from_json",
     "increment_in_flight_flows",
+    "merge_openai_responses_usage_result",
     "report_connector_usage",
     "report_model_provider_usage",
     "set_pending_path",

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -30,6 +30,12 @@ from .sse import SseUsageParser
 
 _RESPONSES_USAGE_EVENTS = frozenset(("response.completed", "response.done"))
 
+_OPENAI_RESPONSES_USAGE_CATEGORIES = (
+    MODEL_USAGE_CATEGORY_INPUT,
+    MODEL_USAGE_CATEGORY_OUTPUT,
+    MODEL_USAGE_CATEGORY_CACHE_READ,
+)
+
 _RESPONSES_RESPONSE_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
     ("model",): ScalarField("string", max_bytes=1024),
@@ -100,6 +106,19 @@ def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] =
         MODEL_USAGE_CATEGORY_CACHE_READ,
         cached_tokens,
     )
+
+
+def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
+    model = source.get("model")
+    if isinstance(model, str) and model:
+        target["model"] = model
+
+    message_id = source.get("message_id")
+    if isinstance(message_id, str) and message_id:
+        target["message_id"] = message_id
+
+    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
+        _store_quantity(target, category, source.get(category))
 
 
 def _has_response_wrapper_values(values: dict) -> bool:
@@ -179,14 +198,7 @@ class OpenAIResponsesJsonUsageExtractor:
         usage: dict = {}
         _store_response_values(result.values, usage)
 
-        if not any(
-            category in usage
-            for category in (
-                MODEL_USAGE_CATEGORY_INPUT,
-                MODEL_USAGE_CATEGORY_OUTPUT,
-                MODEL_USAGE_CATEGORY_CACHE_READ,
-            )
-        ):
+        if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
             return None, None
         return usage, None
 
@@ -241,13 +253,6 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
 
     usage: dict = {}
     _store_sse_result_values(result.values, usage, event_name=None)
-    if not any(
-        category in usage
-        for category in (
-            MODEL_USAGE_CATEGORY_INPUT,
-            MODEL_USAGE_CATEGORY_OUTPUT,
-            MODEL_USAGE_CATEGORY_CACHE_READ,
-        )
-    ):
+    if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
         return None
     return usage

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -55,9 +55,19 @@ def _is_usage_quantity(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
-def _store_quantity(target: dict, category: str, value: object) -> None:
+def _store_quantity(target: dict, category: str, value: object) -> bool:
     if _is_usage_quantity(value) and (value > 0 or category not in target):
         target[category] = value
+        return True
+    return False
+
+
+def _has_positive_usage_quantity(values: dict) -> bool:
+    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
+        value = values.get(category)
+        if _is_usage_quantity(value) and value > 0:
+            return True
+    return False
 
 
 def _split_input_tokens(
@@ -109,6 +119,15 @@ def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] =
 
 
 def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
+    target_has_positive_quantity = _has_positive_usage_quantity(target)
+    source_has_positive_quantity = _has_positive_usage_quantity(source)
+    stored_quantity = False
+    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
+        stored_quantity = _store_quantity(target, category, source.get(category)) or stored_quantity
+
+    if not stored_quantity or (target_has_positive_quantity and not source_has_positive_quantity):
+        return
+
     model = source.get("model")
     if isinstance(model, str) and model:
         target["model"] = model
@@ -116,9 +135,6 @@ def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
     message_id = source.get("message_id")
     if isinstance(message_id, str) and message_id:
         target["message_id"] = message_id
-
-    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
-        _store_quantity(target, category, source.get(category))
 
 
 def _has_response_wrapper_values(values: dict) -> bool:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -71,6 +71,40 @@ def _response_stream(flow: http.HTTPFlow) -> Callable[[bytes], bytes | Iterable[
     return stream
 
 
+def _openai_model_websocket_flow(
+    tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
+) -> http.HTTPFlow:
+    flow = real_flow(with_response=False, host="api.openai.com")
+    flow.metadata["vm_run_id"] = "run-abc-123"
+    flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+    flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+    flow.metadata["firewall_action"] = "ALLOW"
+    flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+    flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+    flow.metadata["cli_agent_type"] = "codex"
+    flow.metadata["firewall_billable"] = True
+    flow.metadata["vm_sandbox_token"] = "tok-xyz"
+    flow.response = tutils.tresp(
+        status_code=101,
+        headers=http.Headers(upgrade="websocket"),
+    )
+
+    mitm_addon.responseheaders(flow)
+    return flow
+
+
+def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes | str) -> None:
+    flow.websocket = SimpleNamespace(
+        messages=[
+            SimpleNamespace(
+                from_client=False,
+                content=content,
+            )
+        ]
+    )
+    mitm_addon.websocket_message(flow)
+
+
 def _pending_state(path: Path) -> dict:
     return json.loads(path.read_text())
 
@@ -3347,6 +3381,174 @@ class TestResponseUsageReporting:
             "tokens.output": 20,
             "tokens.cache_read": 10,
         }
+
+    def test_model_websocket_zero_frame_preserves_prior_positive_usage(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 40,
+                            "input_tokens_details": {"cached_tokens": 25},
+                        },
+                    },
+                }
+            ).encode(),
+        )
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 75,
+            "tokens.output": 40,
+            "tokens.cache_read": 25,
+        }
+
+    def test_model_websocket_positive_frame_updates_prior_zero_usage(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    },
+                }
+            ).encode(),
+        )
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 10, "output_tokens": 4},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+
+    def test_model_websocket_accepts_text_frame_content(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_text",
+                        "model": "gpt-5.4",
+                        "usage": {"input_tokens": 3, "output_tokens": 2},
+                    },
+                }
+            ),
+        )
+
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_text",
+            "model": "gpt-5.4",
+            "tokens.input": 3,
+            "tokens.output": 2,
+        }
+
+    def test_model_websocket_malformed_frame_preserves_prior_usage(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata["model_provider_usage"] = {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+
+        _feed_websocket_server_message(flow, b'{"type":"response.completed"')
+
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+
+    def test_model_websocket_valid_usage_replaces_non_dict_usage_metadata(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata["model_provider_usage"] = "invalid"
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 10, "output_tokens": 4},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+
+    def test_model_websocket_ignores_invalid_frames_with_non_dict_usage_metadata(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata["model_provider_usage"] = "invalid"
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.in_progress",
+                    "response": {"id": "resp_ws_1", "model": "gpt-5.5"},
+                }
+            ).encode(),
+        )
+        assert flow.metadata["model_provider_usage"] == "invalid"
+
+        _feed_websocket_server_message(flow, b'{"type":"response.completed"')
+        assert flow.metadata["model_provider_usage"] == "invalid"
 
     def test_model_websocket_ignores_client_messages(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -12,13 +12,13 @@ from collections.abc import Callable, Iterable
 from email.message import Message
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from mitmproxy import http
+from mitmproxy import http, websocket
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
+from wsproto.frame_protocol import Opcode
 
 import auth
 import body_utils
@@ -93,15 +93,25 @@ def _openai_model_websocket_flow(
     return flow
 
 
-def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes | str) -> None:
-    flow.websocket = SimpleNamespace(
+def _set_websocket_message(
+    flow: http.HTTPFlow,
+    *,
+    from_client: bool,
+    content: bytes,
+) -> None:
+    flow.websocket = websocket.WebSocketData(
         messages=[
-            SimpleNamespace(
-                from_client=False,
+            websocket.WebSocketMessage(
+                Opcode.TEXT,
+                from_client=from_client,
                 content=content,
             )
         ]
     )
+
+
+def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
+    _set_websocket_message(flow, from_client=False, content=content)
     mitm_addon.websocket_message(flow)
 
 
@@ -3342,26 +3352,23 @@ class TestResponseUsageReporting:
         assert "model_json_usage_finish" not in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
 
-        flow.websocket = SimpleNamespace(
-            messages=[
-                SimpleNamespace(
-                    from_client=False,
-                    content=json.dumps(
-                        {
-                            "type": "response.completed",
-                            "response": {
-                                "id": "resp_ws_1",
-                                "model": "gpt-5.5",
-                                "usage": {
-                                    "input_tokens": 50,
-                                    "output_tokens": 20,
-                                    "input_tokens_details": {"cached_tokens": 10},
-                                },
-                            },
-                        }
-                    ).encode(),
-                )
-            ]
+        _set_websocket_message(
+            flow,
+            from_client=False,
+            content=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 50,
+                            "output_tokens": 20,
+                            "input_tokens_details": {"cached_tokens": 10},
+                        },
+                    },
+                }
+            ).encode(),
         )
 
         with (
@@ -3510,7 +3517,7 @@ class TestResponseUsageReporting:
     def test_model_websocket_accepts_text_frame_content(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
-        _feed_websocket_server_message(
+        response_streaming.feed_model_websocket_usage(
             flow,
             json.dumps(
                 {
@@ -3615,22 +3622,19 @@ class TestResponseUsageReporting:
         )
 
         mitm_addon.responseheaders(flow)
-        flow.websocket = SimpleNamespace(
-            messages=[
-                SimpleNamespace(
-                    from_client=True,
-                    content=json.dumps(
-                        {
-                            "type": "response.completed",
-                            "response": {
-                                "id": "resp_ws_1",
-                                "model": "gpt-5.5",
-                                "usage": {"input_tokens": 50, "output_tokens": 20},
-                            },
-                        }
-                    ).encode(),
-                )
-            ]
+        _set_websocket_message(
+            flow,
+            from_client=True,
+            content=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 50, "output_tokens": 20},
+                    },
+                }
+            ).encode(),
         )
 
         with (

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -3410,7 +3410,11 @@ class TestResponseUsageReporting:
                     "response": {
                         "id": "resp_ws_1",
                         "model": "gpt-5.5",
-                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                        "usage": {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "input_tokens_details": {"cached_tokens": 0},
+                        },
                     },
                 }
             ).encode(),

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -3461,6 +3461,48 @@ class TestResponseUsageReporting:
             "tokens.output": 4,
         }
 
+    def test_model_websocket_partial_frame_preserves_existing_categories(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 0,
+                            "input_tokens_details": {"cached_tokens": 25},
+                        },
+                    },
+                }
+            ).encode(),
+        )
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"output_tokens": 40},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 75,
+            "tokens.output": 40,
+            "tokens.cache_read": 25,
+        }
+
     def test_model_websocket_accepts_text_frame_content(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -3389,6 +3389,70 @@ class TestResponseUsageReporting:
             "tokens.cache_read": 10,
         }
 
+    def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 40,
+                        },
+                    },
+                }
+            ).encode(),
+        )
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_empty",
+                        "model": "gpt-5.4",
+                        "usage": {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "input_tokens_details": {"cached_tokens": 0},
+                        },
+                    },
+                }
+            ).encode(),
+        )
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.websocket_end(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
+        assert by_category == {
+            "tokens.input": 100,
+            "tokens.output": 40,
+        }
+        assert idempotency_by_category == {
+            "tokens.input": _model_usage_idempotency_key(
+                "run-abc-123", "resp_ws_1", "tokens.input"
+            ),
+            "tokens.output": _model_usage_idempotency_key(
+                "run-abc-123", "resp_ws_1", "tokens.output"
+            ),
+        }
+        assert {event["provider"] for event in events} == {"gpt-5.5"}
+
     def test_model_websocket_zero_frame_preserves_prior_positive_usage(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -174,6 +174,25 @@ def test_merge_preserves_positive_quantities_when_source_has_zero():
     }
 
 
+def test_merge_stores_zero_quantities_when_target_is_missing_category():
+    target = {}
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "tokens.input": 0,
+            "tokens.output": 0,
+            "tokens.cache_read": 0,
+        },
+    )
+
+    assert target == {
+        "tokens.input": 0,
+        "tokens.output": 0,
+        "tokens.cache_read": 0,
+    }
+
+
 def test_merge_updates_with_positive_quantities():
     target = {
         "tokens.input": 0,

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -176,7 +176,6 @@ def test_merge_preserves_positive_quantities_when_source_has_zero():
         "model": "gpt-5.5",
         "tokens.input": 75,
         "tokens.output": 40,
-        "tokens.cache_read": 25,
     }
 
     merge_openai_responses_usage_result(
@@ -184,6 +183,35 @@ def test_merge_preserves_positive_quantities_when_source_has_zero():
         {
             "message_id": "resp_1",
             "model": "gpt-5.5",
+            "tokens.input": 0,
+            "tokens.output": 0,
+            "tokens.cache_read": 0,
+        },
+    )
+
+    assert target == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 75,
+        "tokens.output": 40,
+        "tokens.cache_read": 0,
+    }
+
+
+def test_merge_zero_only_source_does_not_relabel_existing_positive_usage():
+    target = {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 75,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "message_id": "resp_empty",
+            "model": "gpt-5.4",
             "tokens.input": 0,
             "tokens.output": 0,
             "tokens.cache_read": 0,

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -198,6 +198,29 @@ def test_merge_updates_with_positive_quantities():
     }
 
 
+def test_merge_allows_positive_corrections_to_lower_quantities():
+    target = {
+        "tokens.input": 20,
+        "tokens.output": 12,
+        "tokens.cache_read": 8,
+    }
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "tokens.input": 10,
+            "tokens.output": 7,
+            "tokens.cache_read": 3,
+        },
+    )
+
+    assert target == {
+        "tokens.input": 10,
+        "tokens.output": 7,
+        "tokens.cache_read": 3,
+    }
+
+
 def test_merge_ignores_unknown_keys():
     target = {}
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -77,6 +77,31 @@ def test_extracts_usage_from_flat_response_completed_event():
     }
 
 
+def test_extracts_zero_usage_quantities():
+    body = json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_zero",
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "input_tokens_details": {"cached_tokens": 0},
+                },
+            },
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "message_id": "resp_zero",
+        "model": "gpt-5.5",
+        "tokens.input": 0,
+        "tokens.output": 0,
+        "tokens.cache_read": 0,
+    }
+
+
 def test_returns_none_for_non_usage_event_type():
     body = json.dumps(
         {

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -2,7 +2,10 @@
 
 import json
 
-from usage import extract_openai_responses_usage_from_event_json
+from usage import (
+    extract_openai_responses_usage_from_event_json,
+    merge_openai_responses_usage_result,
+)
 
 
 def test_extracts_usage_from_wrapped_response_completed_event():
@@ -139,4 +142,94 @@ def test_clamps_cached_tokens_to_total_input_tokens():
         "tokens.input": 0,
         "tokens.output": 5,
         "tokens.cache_read": 10,
+    }
+
+
+def test_merge_preserves_positive_quantities_when_source_has_zero():
+    target = {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 75,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "message_id": "resp_1",
+            "model": "gpt-5.5",
+            "tokens.input": 0,
+            "tokens.output": 0,
+            "tokens.cache_read": 0,
+        },
+    )
+
+    assert target == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 75,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+
+
+def test_merge_updates_with_positive_quantities():
+    target = {
+        "tokens.input": 0,
+        "tokens.output": 0,
+    }
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "message_id": "resp_2",
+            "model": "gpt-5.4",
+            "tokens.input": 12,
+            "tokens.output": 7,
+        },
+    )
+
+    assert target == {
+        "message_id": "resp_2",
+        "model": "gpt-5.4",
+        "tokens.input": 12,
+        "tokens.output": 7,
+    }
+
+
+def test_merge_ignores_unknown_keys():
+    target = {}
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "tokens.input": 1,
+            "tokens.cache_creation": 99,
+            "unknown": "value",
+        },
+    )
+
+    assert target == {"tokens.input": 1}
+
+
+def test_merge_ignores_empty_metadata_strings():
+    target = {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+    }
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "message_id": "",
+            "model": "",
+            "tokens.output": 1,
+        },
+    )
+
+    assert target == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.output": 1,
     }


### PR DESCRIPTION
## Summary

- add an OpenAI Responses usage-result merge helper that preserves SSE-style quantity semantics across WebSocket frames
- replace the WebSocket `dict.update()` merge so later zero counts cannot overwrite earlier positive usage
- cover multi-frame WebSocket usage, text frame content, malformed frames, non-dict metadata, and helper merge behavior

Fixes #14526

## Tests

- `ruff check src/response_streaming.py src/usage/__init__.py src/usage/openai_responses.py tests/test_handlers.py tests/test_openai_responses_event_json.py`
- `ruff format --check src/response_streaming.py src/usage/__init__.py src/usage/openai_responses.py tests/test_handlers.py tests/test_openai_responses_event_json.py`
- `pytest tests/test_handlers.py -k websocket`
- `pytest tests/test_openai_responses_event_json.py`
- `pytest tests/`

## Notes

- `basedpyright src tests` was not run because `basedpyright` is not installed in this environment.
