### PR TITLE
fix: track Google Ads subscriber conversions

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-billing-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-billing-conversion.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { googleAdsBillingConversionPayload } from "../bootstrap/billing-conversion.ts";
+
+describe("googleAdsBillingConversionPayload", () => {
+  it("builds Subscriber conversion payload for Pro checkout redirects", () => {
+    expect(
+      googleAdsBillingConversionPayload("pro", "cs_test_pro"),
+    ).toStrictEqual({
+      send_to: "AW-18144854014/3tdOCMimwK8cEP7_kcxD",
+      value: 20,
+      currency: "USD",
+      transaction_id: "cs_test_pro",
+    });
+  });
+
+  it("builds Subscriber conversion payload for Team checkout redirects", () => {
+    expect(
+      googleAdsBillingConversionPayload("team", "cs_test_team"),
+    ).toStrictEqual({
+      send_to: "AW-18144854014/3tdOCMimwK8cEP7_kcxD",
+      value: 200,
+      currency: "USD",
+      transaction_id: "cs_test_team",
+    });
+  });
+
+  it("ignores non-success billing redirects", () => {
+    expect(
+      googleAdsBillingConversionPayload("canceled", "cs_test_canceled"),
+    ).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -67,6 +67,7 @@ import { setupRealtime$ } from "./realtime.ts";
 
 import { setupSidebarShortcut$ } from "./zero-page/zero-nav.ts";
 import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
+import { googleAdsBillingConversionPayload } from "./bootstrap/billing-conversion.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -326,11 +327,13 @@ const setupRoutes$ = command(async ({ set }, signal: AbortSignal) => {
 const handleBillingRedirect$ = command(() => {
   const url = new URL(window.location.href);
   const billing = url.searchParams.get("billing");
+  const transactionId = url.searchParams.get("billing_session_id");
   if (!billing) {
     return;
   }
 
   url.searchParams.delete("billing");
+  url.searchParams.delete("billing_session_id");
   window.history.replaceState(null, "", url.toString());
 
   // Defer toast until Toaster component is mounted
@@ -339,9 +342,14 @@ const handleBillingRedirect$ = command(() => {
     // checkout. The `billing` param is set only on Stripe success redirect
     // and stripped above, so this fires at most once per real conversion.
     type GtagFn = (...args: unknown[]) => void;
-    (window as Window & { gtag?: GtagFn }).gtag?.("event", "conversion", {
-      send_to: "AW-18144854014/3tdOCMimwK8cEP7_kcxD",
-    });
+    const payload = googleAdsBillingConversionPayload(billing, transactionId);
+    if (payload) {
+      (window as Window & { gtag?: GtagFn }).gtag?.(
+        "event",
+        "conversion",
+        payload,
+      );
+    }
 
     const label = billing === "pro" ? "Pro" : "Team";
     window.addEventListener(

--- a/turbo/apps/platform/src/signals/bootstrap/billing-conversion.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/billing-conversion.ts
@@ -1,0 +1,25 @@
+const BILLING_CONVERSION_VALUE = {
+  pro: 20,
+  team: 200,
+} as const;
+
+export function googleAdsBillingConversionPayload(
+  billing: string | null,
+  transactionId: string | null,
+): {
+  readonly send_to: "AW-18144854014/3tdOCMimwK8cEP7_kcxD";
+  readonly value: number;
+  readonly currency: "USD";
+  readonly transaction_id?: string;
+} | null {
+  if (billing !== "pro" && billing !== "team") {
+    return null;
+  }
+
+  return {
+    send_to: "AW-18144854014/3tdOCMimwK8cEP7_kcxD",
+    value: BILLING_CONVERSION_VALUE[billing],
+    currency: "USD",
+    ...(transactionId ? { transaction_id: transactionId } : {}),
+  };
+}

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -90,6 +90,13 @@ export const startCheckout$ = command(
     const currentUrl = window.location.href;
     const successUrl = new URL(currentUrl);
     successUrl.searchParams.set("billing", tier);
+    successUrl.searchParams.set("billing_session_id", "{CHECKOUT_SESSION_ID}");
+    const stripeSuccessUrl = successUrl
+      .toString()
+      .replace(
+        "billing_session_id=%7BCHECKOUT_SESSION_ID%7D",
+        "billing_session_id={CHECKOUT_SESSION_ID}",
+      );
     const cancelUrl = new URL(currentUrl);
     cancelUrl.searchParams.set("billing", "canceled");
 
@@ -99,7 +106,7 @@ export const startCheckout$ = command(
       client.create({
         body: {
           tier,
-          successUrl: successUrl.toString(),
+          successUrl: stripeSuccessUrl,
           cancelUrl: cancelUrl.toString(),
         },
         fetchOptions: { signal },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -332,7 +332,12 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
     click(upgradeBtn1!);
 
     await waitFor(() => {
-      expect(capturedCheckoutBody).toMatchObject({ tier: "team" });
+      expect(capturedCheckoutBody).toMatchObject({
+        tier: "team",
+        successUrl: expect.stringContaining(
+          "billing_session_id={CHECKOUT_SESSION_ID}",
+        ),
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- add Stripe Checkout session id to the billing success redirect URL for use as the Google Ads transaction id
- send the Subscriber conversion with value, currency, and transaction_id on paid billing success redirects
- add focused coverage for conversion payloads and checkout success URL propagation

## Verification
- pnpm -F @vm0/app exec prettier --check src/signals/bootstrap.ts src/signals/bootstrap/billing-conversion.ts src/signals/zero-page/billing.ts src/signals/__tests__/bootstrap-billing-conversion.test.ts src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
- pnpm -F @vm0/app exec oxlint src/signals/bootstrap.ts src/signals/bootstrap/billing-conversion.ts src/signals/zero-page/billing.ts src/signals/__tests__/bootstrap-billing-conversion.test.ts src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
- pnpm -F @vm0/app exec tsc --noEmit --pretty false

## Notes
- Vitest did not complete locally for the targeted platform tests; the runner printed RUN and hung until terminated.
- API test attempts require a local Postgres on 127.0.0.1:5432 and failed with ECONNREFUSED in this environment.