### PR TITLE
refactor(mitm-addon): consolidate firewall failure responses

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -105,7 +105,7 @@ def _prepare_firewall_metadata(
     flow.metadata["model_usage_provider"] = vm_info.get("modelUsageProvider")
 
 
-def _set_firewall_failure_response(
+def _set_matched_firewall_failure_response(
     flow: http.HTTPFlow,
     *,
     status: int,
@@ -113,15 +113,15 @@ def _set_firewall_failure_response(
     error_code: str,
     message: str,
     permission: str,
-    firewall_base: str,
     connectors: list[str] | None = None,
 ) -> None:
-    """Set the common firewall failure metadata and JSON response envelope."""
+    """Set the common matched-firewall auth/forward failure response."""
     # `firewall_action` records the firewall permission decision
     # (ALLOW/DENY/BLOCK); `firewall_error` records post-decision execution
     # failures. They are orthogonal: for example, action=ALLOW can pair with
     # an auth or forwarding error when the firewall granted the request but
     # the addon could not fulfill it. See #10493.
+    firewall_base = flow.metadata["firewall_base"]
     flow.metadata["firewall_action"] = action
     flow.metadata["firewall_error"] = error_code
     body: dict[str, object] = {
@@ -579,14 +579,13 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        _set_firewall_failure_response(
+        _set_matched_firewall_failure_response(
             flow,
             status=502,
             action="ALLOW",
             error_code="auth_unavailable",
             message="Auth secrets not configured",
             permission=match_info.get("name", ""),
-            firewall_base=firewall_base,
         )
         return
 
@@ -613,14 +612,13 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        _set_firewall_failure_response(
+        _set_matched_firewall_failure_response(
             flow,
             status=424,
             action="BLOCK",
             error_code="connector_not_configured",
             message=str(e),
             permission=fw_name,
-            firewall_base=firewall_base,
             connectors=[fw_name] if fw_name else None,
         )
         return
@@ -632,14 +630,13 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        _set_firewall_failure_response(
+        _set_matched_firewall_failure_response(
             flow,
             status=402,
             action="BLOCK",
             error_code="insufficient_credits",
             message=str(e),
             permission=match_info.get("name", ""),
-            firewall_base=firewall_base,
         )
         return
     except Exception as e:
@@ -650,14 +647,13 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        _set_firewall_failure_response(
+        _set_matched_firewall_failure_response(
             flow,
             status=502,
             action="ALLOW",
             error_code="auth_failed",
             message=f"Failed to resolve auth headers: {e}",
             permission=match_info.get("name", ""),
-            firewall_base=firewall_base,
         )
         return
 
@@ -696,14 +692,13 @@ async def handle_firewall_request(
                 type="firewall",
                 firewall_base=firewall_base,
             )
-            _set_firewall_failure_response(
+            _set_matched_firewall_failure_response(
                 flow,
                 status=502,
                 action="ALLOW",
                 error_code="url_rewrite_forward_failed",
                 message="Failed to forward request to upstream",
                 permission=match_info.get("name", ""),
-                firewall_base=firewall_base,
             )
             return
 

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -105,6 +105,40 @@ def _prepare_firewall_metadata(
     flow.metadata["model_usage_provider"] = vm_info.get("modelUsageProvider")
 
 
+def _set_firewall_failure_response(
+    flow: http.HTTPFlow,
+    *,
+    status: int,
+    action: str,
+    error_code: str,
+    message: str,
+    permission: str,
+    firewall_base: str,
+    connectors: list[str] | None = None,
+) -> None:
+    """Set the common firewall failure metadata and JSON response envelope."""
+    # `firewall_action` records the firewall permission decision
+    # (ALLOW/DENY/BLOCK); `firewall_error` records post-decision execution
+    # failures. They are orthogonal: for example, action=ALLOW can pair with
+    # an auth or forwarding error when the firewall granted the request but
+    # the addon could not fulfill it. See #10493.
+    flow.metadata["firewall_action"] = action
+    flow.metadata["firewall_error"] = error_code
+    body: dict[str, object] = {
+        "error": error_code,
+        "message": message,
+        "permission": permission,
+        "base": firewall_base,
+    }
+    if connectors:
+        body["connectors"] = connectors
+    flow.response = http.Response.make(
+        status,
+        json.dumps(body).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
 def request_force_refresh(cache_key: tuple[str, str]) -> None:
     """Request a forced token refresh on the next /firewall/auth fetch.
 
@@ -545,28 +579,14 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        # `firewall_action` records the firewall's permission decision
-        # (ALLOW/DENY/BLOCK); `firewall_error` records post-decision
-        # execution failures. They are orthogonal — the firewall granted
-        # the request, but we cannot fulfill it because auth is missing,
-        # so action=ALLOW + error=<reason> is the correct combination
-        # (applies to the two analogous 502 paths below as well).
-        # Permission-usage analytics should read `action`; execution error
-        # rates should aggregate independently on `firewall_error`.
-        # See #10493 for why this is not a miscategorization.
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_error"] = "auth_unavailable"
-        flow.response = http.Response.make(
-            502,
-            json.dumps(
-                {
-                    "error": "auth_unavailable",
-                    "message": "Auth secrets not configured",
-                    "permission": match_info.get("name", ""),
-                    "base": firewall_base,
-                }
-            ).encode(),
-            {"Content-Type": "application/json"},
+        _set_firewall_failure_response(
+            flow,
+            status=502,
+            action="ALLOW",
+            error_code="auth_unavailable",
+            message="Auth secrets not configured",
+            permission=match_info.get("name", ""),
+            firewall_base=firewall_base,
         )
         return
 
@@ -593,20 +613,15 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        flow.metadata["firewall_action"] = "BLOCK"
-        flow.metadata["firewall_error"] = "connector_not_configured"
-        error_body: dict = {
-            "error": "connector_not_configured",
-            "message": str(e),
-            "permission": fw_name,
-            "base": firewall_base,
-        }
-        if fw_name:
-            error_body["connectors"] = [fw_name]
-        flow.response = http.Response.make(
-            424,
-            json.dumps(error_body).encode(),
-            {"Content-Type": "application/json"},
+        _set_firewall_failure_response(
+            flow,
+            status=424,
+            action="BLOCK",
+            error_code="connector_not_configured",
+            message=str(e),
+            permission=fw_name,
+            firewall_base=firewall_base,
+            connectors=[fw_name] if fw_name else None,
         )
         return
     except InsufficientCreditsError as e:
@@ -617,19 +632,14 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        flow.metadata["firewall_action"] = "BLOCK"
-        flow.metadata["firewall_error"] = "insufficient_credits"
-        flow.response = http.Response.make(
-            402,
-            json.dumps(
-                {
-                    "error": "insufficient_credits",
-                    "message": str(e),
-                    "permission": match_info.get("name", ""),
-                    "base": firewall_base,
-                }
-            ).encode(),
-            {"Content-Type": "application/json"},
+        _set_firewall_failure_response(
+            flow,
+            status=402,
+            action="BLOCK",
+            error_code="insufficient_credits",
+            message=str(e),
+            permission=match_info.get("name", ""),
+            firewall_base=firewall_base,
         )
         return
     except Exception as e:
@@ -640,19 +650,14 @@ async def handle_firewall_request(
             type="firewall",
             firewall_base=firewall_base,
         )
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_error"] = "auth_failed"
-        flow.response = http.Response.make(
-            502,
-            json.dumps(
-                {
-                    "error": "auth_failed",
-                    "message": f"Failed to resolve auth headers: {e}",
-                    "permission": match_info.get("name", ""),
-                    "base": firewall_base,
-                }
-            ).encode(),
-            {"Content-Type": "application/json"},
+        _set_firewall_failure_response(
+            flow,
+            status=502,
+            action="ALLOW",
+            error_code="auth_failed",
+            message=f"Failed to resolve auth headers: {e}",
+            permission=match_info.get("name", ""),
+            firewall_base=firewall_base,
         )
         return
 
@@ -691,18 +696,14 @@ async def handle_firewall_request(
                 type="firewall",
                 firewall_base=firewall_base,
             )
-            flow.metadata["firewall_action"] = "ALLOW"
-            flow.metadata["firewall_error"] = "url_rewrite_forward_failed"
-            flow.response = http.Response.make(
-                502,
-                json.dumps(
-                    {
-                        "error": "url_rewrite_forward_failed",
-                        "message": "Failed to forward request to upstream",
-                        "permission": match_info.get("name", ""),
-                    }
-                ).encode(),
-                {"Content-Type": "application/json"},
+            _set_firewall_failure_response(
+                flow,
+                status=502,
+                action="ALLOW",
+                error_code="url_rewrite_forward_failed",
+                message="Failed to forward request to upstream",
+                permission=match_info.get("name", ""),
+                firewall_base=firewall_base,
             )
             return
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -686,6 +686,7 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_error"] == "connector_not_configured"
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
+        assert body["message"] == "Connector not configured"
         assert body["connectors"] == ["github"]
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
@@ -763,6 +764,7 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_error"] == "connector_not_configured"
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
+        assert body["message"] == "Connector not configured"
         assert body["permission"] == ""
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
@@ -825,6 +827,7 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_error"] == "auth_unavailable"
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_unavailable"
+        assert body["message"] == "Auth secrets not configured"
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -723,6 +723,7 @@ class TestHandleFirewallRequest:
         assert body["message"] == "Insufficient credits"
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
+        assert "connectors" not in body
 
     async def test_connector_not_configured_without_name_omits_connectors(
         self, real_flow, headers, mitm_ctx, tmp_path

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -724,6 +724,47 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
 
+    async def test_connector_not_configured_without_name_omits_connectors(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
+        """Connector references are only returned when the firewall name is known."""
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "billableFirewalls": [],
+        }
+        match_info = {}
+
+        with (
+            patch.object(
+                auth,
+                "get_firewall_headers",
+                AsyncMock(
+                    side_effect=auth.ConnectorNotConfiguredError(
+                        "Connector not configured",
+                    )
+                ),
+            ),
+            mitm_ctx(),
+            patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 424
+        assert flow.metadata["firewall_action"] == "BLOCK"
+        assert flow.metadata["firewall_error"] == "connector_not_configured"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "connector_not_configured"
+        assert body["permission"] == ""
+        assert body["base"] == "https://api.github.com"
+        assert "connectors" not in body
+
     async def test_missing_vars_only_returns_424(self, real_flow, headers, mitm_ctx, tmp_path):
         """When connector not configured, return 424 with connector ref."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -612,6 +612,7 @@ class TestHandleFirewallRequest:
         assert body["error"] == "auth_failed"
         assert "API unreachable" in body["message"]
         assert body["permission"] == "github"
+        assert body["base"] == "https://api.github.com"
 
     async def test_no_response_set_on_success(self, real_flow, headers, mitm_ctx):
         """On success, flow.response should remain None (request continues to origin)."""
@@ -688,6 +689,41 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
 
+    async def test_insufficient_credits_returns_402(self, real_flow, headers, mitm_ctx, tmp_path):
+        """Billable firewall auth denied for credits returns 402 and blocks usage."""
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "billableFirewalls": ["github"],
+        }
+        match_info = {"name": "github"}
+
+        with (
+            patch.object(
+                auth,
+                "get_firewall_headers",
+                AsyncMock(side_effect=auth.InsufficientCreditsError("Insufficient credits")),
+            ),
+            mitm_ctx(),
+            patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 402
+        assert flow.metadata["firewall_action"] == "BLOCK"
+        assert flow.metadata["firewall_error"] == "insufficient_credits"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "insufficient_credits"
+        assert body["message"] == "Insufficient credits"
+        assert body["permission"] == "github"
+        assert body["base"] == "https://api.github.com"
+
     async def test_missing_vars_only_returns_424(self, real_flow, headers, mitm_ctx, tmp_path):
         """When connector not configured, return 424 with connector ref."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
@@ -722,6 +758,7 @@ class TestHandleFirewallRequest:
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
         assert body["connectors"] == ["htmlcsstoimage"]
+        assert body["base"] == "https://hcti.io"
 
     async def test_missing_encrypted_secrets_returns_502(self, real_flow, headers, mitm_ctx):
         """When encryptedSecrets is missing from vm_info, return 502."""
@@ -746,6 +783,7 @@ class TestHandleFirewallRequest:
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_unavailable"
         assert body["permission"] == "github"
+        assert body["base"] == "https://api.github.com"
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -613,6 +613,7 @@ class TestHandleFirewallRequest:
         assert "API unreachable" in body["message"]
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
+        assert "connectors" not in body
 
     async def test_no_response_set_on_success(self, real_flow, headers, mitm_ctx):
         """On success, flow.response should remain None (request continues to origin)."""
@@ -826,6 +827,7 @@ class TestHandleFirewallRequest:
         assert body["error"] == "auth_unavailable"
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
+        assert "connectors" not in body
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -827,6 +827,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert flow.response.status_code == 502
         body = json.loads(flow.response.content)
         assert body["error"] == "url_rewrite_forward_failed"
+        assert body["base"] == api_entry["base"]
         # Failure must not masquerade as a successful rewrite.
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.metadata["firewall_action"] == "ALLOW"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -827,6 +827,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert flow.response.status_code == 502
         body = json.loads(flow.response.content)
         assert body["error"] == "url_rewrite_forward_failed"
+        assert body["message"] == "Failed to forward request to upstream"
         assert body["base"] == api_entry["base"]
         # Failure must not masquerade as a successful rewrite.
         assert "auth_url_rewrite" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -829,7 +829,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
         body = json.loads(flow.response.content)
         assert body["error"] == "url_rewrite_forward_failed"
         assert body["message"] == "Failed to forward request to upstream"
+        assert body["permission"] == match_info["name"]
         assert body["base"] == api_entry["base"]
+        assert "connectors" not in body
         # Failure must not masquerade as a successful rewrite.
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.metadata["firewall_action"] == "ALLOW"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -825,6 +825,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.response is not None
         assert flow.response.status_code == 502
+        assert flow.response.headers["Content-Type"] == "application/json"
         body = json.loads(flow.response.content)
         assert body["error"] == "url_rewrite_forward_failed"
         assert body["message"] == "Failed to forward request to upstream"


### PR DESCRIPTION
## Summary

- centralize firewall failure metadata and JSON response construction in a narrow helper
- keep branch-specific logging local while making `base` part of every firewall failure envelope
- add behavior coverage for failure response `base` fields, including URL rewrite forwarding failures

Closes #14520

## Tests

- `python3 -m pytest tests/test_firewall_auth.py tests/test_firewall_rewrite.py -v`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/ -v`