### PR TITLE
feat: add oauth device authorization connector ui

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,6 +1,14 @@
-import { CONNECTOR_TYPE_KEYS } from "@vm0/connectors/connectors";
-import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  CONNECTOR_TYPE_KEYS,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+import type {
+  ConnectorOauthDeviceAuthSessionPollResponse,
+  ConnectorOauthDeviceAuthSessionStartResponse,
+  ConnectorResponse,
+} from "@vm0/api-contracts/contracts/connector-schemas";
+import {
+  zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorsByTypeContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
@@ -9,6 +17,18 @@ import { zeroCliAuthStripeContract } from "@vm0/api-contracts/contracts/zero-con
 import { mockApi } from "../msw-contract.ts";
 
 let mockConnectors: ConnectorResponse[] = [];
+type MockOauthDeviceAuthSessionStartResponse = Omit<
+  Partial<ConnectorOauthDeviceAuthSessionStartResponse>,
+  "verificationUriComplete"
+> & {
+  readonly verificationUriComplete?: string | undefined;
+};
+
+let mockOauthDeviceAuthSessionStartResponse:
+  | MockOauthDeviceAuthSessionStartResponse
+  | undefined;
+let mockOauthDeviceAuthSessionPollResponses: ConnectorOauthDeviceAuthSessionPollResponse[] =
+  [];
 
 type MockStripeCliAuthStartResponse = {
   sessionToken: string;
@@ -47,6 +67,40 @@ function createMockStripeConnector(): ConnectorResponse {
   };
 }
 
+function createMockOauthDeviceAuthConnector(
+  type: ConnectorType,
+): ConnectorResponse {
+  const now = "2026-01-01T00:00:00Z";
+  return {
+    id: crypto.randomUUID(),
+    type,
+    authMethod: "oauth",
+    externalId: `mock-${type}-external-id`,
+    externalUsername: `mock-${type}`,
+    externalEmail: null,
+    oauthScopes: ["read"],
+    needsReconnect: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function defaultOauthDeviceAuthSessionStartResponse(
+  type: ConnectorType,
+): ConnectorOauthDeviceAuthSessionStartResponse {
+  return {
+    sessionId: "00000000-0000-4000-8000-000000000001",
+    sessionToken: `mock-${type}-oauth-device-session-token`,
+    type,
+    status: "pending",
+    userCode: "VM0-DEVICE",
+    verificationUri: `https://oauth.test/${type}/device`,
+    verificationUriComplete: `https://oauth.test/${type}/device?user_code=VM0-DEVICE`,
+    expiresIn: 300,
+    interval: 1,
+  };
+}
+
 function defaultStripeCliAuthStartResponse(
   mode: "test" | "live",
 ): MockStripeCliAuthStartResponse {
@@ -76,6 +130,7 @@ export function setMockConnectors(connectors: ConnectorResponse[]): void {
 export function resetMockConnectors(): void {
   mockConnectors = [];
   resetMockStripeCliAuth();
+  resetMockOauthDeviceAuth();
 }
 
 export function upsertMockConnector(connector: ConnectorResponse): void {
@@ -92,10 +147,27 @@ function resetMockStripeCliAuth(): void {
   mockStripeCliAuthCompleteResponse = undefined;
 }
 
+function resetMockOauthDeviceAuth(): void {
+  mockOauthDeviceAuthSessionStartResponse = undefined;
+  mockOauthDeviceAuthSessionPollResponses = [];
+}
+
 export function setMockStripeCliAuthCompleteResponse(
   response: MockStripeCliAuthCompleteResponse,
 ): void {
   mockStripeCliAuthCompleteResponse = response;
+}
+
+export function setMockOauthDeviceAuthSessionStartResponse(
+  response: MockOauthDeviceAuthSessionStartResponse,
+): void {
+  mockOauthDeviceAuthSessionStartResponse = response;
+}
+
+export function setMockOauthDeviceAuthSessionPollResponses(
+  responses: ConnectorOauthDeviceAuthSessionPollResponse[],
+): void {
+  mockOauthDeviceAuthSessionPollResponses = responses;
 }
 
 export const apiConnectorsHandlers = [
@@ -133,6 +205,43 @@ export const apiConnectorsHandlers = [
       storedScopes: [],
     });
   }),
+
+  mockApi(
+    zeroConnectorOauthDeviceAuthSessionContract.create,
+    ({ params, respond }) => {
+      const response = {
+        ...defaultOauthDeviceAuthSessionStartResponse(params.type),
+        ...mockOauthDeviceAuthSessionStartResponse,
+        type: mockOauthDeviceAuthSessionStartResponse?.type ?? params.type,
+      };
+      if (
+        mockOauthDeviceAuthSessionStartResponse &&
+        "verificationUriComplete" in mockOauthDeviceAuthSessionStartResponse &&
+        mockOauthDeviceAuthSessionStartResponse.verificationUriComplete ===
+          undefined
+      ) {
+        delete response.verificationUriComplete;
+      }
+      return respond(200, response);
+    },
+  ),
+
+  mockApi(
+    zeroConnectorOauthDeviceAuthSessionContract.poll,
+    ({ params, respond }) => {
+      const response =
+        mockOauthDeviceAuthSessionPollResponses.shift() ??
+        ({
+          status: "complete",
+          connector: createMockOauthDeviceAuthConnector(params.type),
+        } satisfies ConnectorOauthDeviceAuthSessionPollResponse);
+
+      if (response.status === "complete") {
+        upsertMockConnector(response.connector);
+      }
+      return respond(200, response);
+    },
+  ),
 
   mockApi(zeroCliAuthStripeContract.start, ({ body, respond }) => {
     return respond(200, {

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -29,6 +29,7 @@ import {
   zeroVariablesContract,
 } from "@vm0/api-contracts/contracts/zero-secrets";
 import { createMockApi } from "../../../../mocks/msw-contract.ts";
+import { resetSignal } from "../../../utils.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -697,6 +698,69 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
     context.store.set(clearConnectorOAuthDeviceAuth$);
     await expect(connectPromise).resolves.toBeFalsy();
     expect(context.store.get(pollingOAuthDeviceAuthConnectorType$)).toBeNull();
+  });
+
+  it("clears active device auth state when the owning signal aborts", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    server.use(
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.create,
+        ({ params, respond }) => {
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000127",
+            sessionToken: "device-session-token",
+            type: params.type,
+            status: "pending",
+            userCode: "VM0-DEVICE",
+            verificationUri: "https://oauth.test/device",
+            verificationUriComplete:
+              "https://oauth.test/device?user_code=VM0-DEVICE",
+            expiresIn: 300,
+            interval: 1,
+          });
+        },
+      ),
+      mockApi(zeroConnectorOauthDeviceAuthSessionContract.poll, ({ never }) => {
+        return never();
+      }),
+    );
+
+    const flowReset$ = resetSignal();
+    const flowSignal = context.store.set(flowReset$, context.signal);
+    const connectPromise = (async () => {
+      try {
+        return await context.store.set(
+          connectConnectorOAuthDeviceAuth$,
+          "test-oauth-device",
+          {},
+          flowSignal,
+        );
+      } catch {
+        return false;
+      }
+    })();
+
+    await vi.waitFor(() => {
+      expect(context.store.get(connectorOAuthDeviceAuthState$).status).toBe(
+        "pending",
+      );
+    });
+
+    context.store.set(flowReset$, context.signal);
+
+    await expect(connectPromise).resolves.toBeFalsy();
+    await vi.waitFor(() => {
+      expect(context.store.get(connectorOAuthDeviceAuthState$)).toStrictEqual({
+        status: "idle",
+        connectorType: "test-oauth-device",
+      });
+    });
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -90,6 +90,16 @@ function createMockAuthWindow() {
   return { closed: false, close: vi.fn(), location: { href: "" } };
 }
 
+function returnFalseForAbortError(error: unknown): false {
+  if (
+    (error instanceof Error || error instanceof DOMException) &&
+    error.name === "AbortError"
+  ) {
+    return false;
+  }
+  throw error;
+}
+
 function makeTestOauthDeviceConnectorResponse(): ConnectorResponse {
   return {
     id: "00000000-0000-4000-8000-000000000124",
@@ -667,8 +677,8 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
           {},
           context.signal,
         );
-      } catch {
-        return false;
+      } catch (error) {
+        return returnFalseForAbortError(error);
       }
     })();
 
@@ -741,8 +751,8 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
           {},
           flowSignal,
         );
-      } catch {
-        return false;
+      } catch (error) {
+        return returnFalseForAbortError(error);
       }
     })();
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -3,14 +3,23 @@ import { server } from "../../../../mocks/server.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../../__tests__/page-helper.ts";
 import {
+  clearConnectorOAuthDeviceAuth$,
   connectConnectorOAuthAuthCode$,
+  connectConnectorOAuthDeviceAuth$,
+  connectorOAuthDeviceAuthState$,
+  openConnectorOAuthDeviceAuthVerificationPage$,
   permissionDialogType$,
   pollingOAuthAuthCodeConnectorType$,
+  pollingOAuthDeviceAuthConnectorType$,
   submitApiToken$,
 } from "../connectors.ts";
 import { triggerAblyEvent, hasSubscription } from "../../../../mocks/ably.ts";
-import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import type {
+  ConnectorListResponse,
+  ConnectorResponse,
+} from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorOauthStartContract,
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -78,6 +87,21 @@ function mockConnectorOauthStart() {
 
 function createMockAuthWindow() {
   return { closed: false, close: vi.fn(), location: { href: "" } };
+}
+
+function makeTestOauthDeviceConnectorResponse(): ConnectorResponse {
+  return {
+    id: "00000000-0000-4000-8000-000000000124",
+    type: "test-oauth-device",
+    authMethod: "oauth",
+    externalId: "test-oauth-device-user",
+    externalUsername: "device-user",
+    externalEmail: null,
+    oauthScopes: ["read"],
+    needsReconnect: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
 }
 
 describe("connectConnectorOAuthAuthCode$", () => {
@@ -450,6 +474,229 @@ describe("connectConnectorOAuthAuthCode$", () => {
     expect(open).not.toHaveBeenCalled();
     expect(startCalled).toBeFalsy();
     expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
+  });
+});
+
+describe("connectConnectorOAuthDeviceAuth$", () => {
+  it("shows a code before opening the verification page and polling completion", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    let authCodeStartCalled = false;
+    server.use(
+      mockApi(zeroConnectorOauthStartContract.start, ({ respond }) => {
+        authCodeStartCalled = true;
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/test-oauth-device/authorize",
+        });
+      }),
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.create,
+        ({ params, respond }) => {
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000123",
+            sessionToken: "device-session-token",
+            type: params.type,
+            status: "pending",
+            userCode: "VM0-DEVICE",
+            verificationUri: "https://oauth.test/device",
+            verificationUriComplete:
+              "https://oauth.test/device?user_code=VM0-DEVICE",
+            expiresIn: 300,
+            interval: 0,
+          });
+        },
+      ),
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.poll,
+        ({ respond }) => {
+          return respond(200, {
+            status: "complete",
+            connector: makeTestOauthDeviceConnectorResponse(),
+          });
+        },
+      ),
+    );
+
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(createMockAuthWindow() as unknown as Window);
+
+    const connectPromise = context.store.set(
+      connectConnectorOAuthDeviceAuth$,
+      "test-oauth-device",
+      {},
+      context.signal,
+    );
+
+    await vi.waitFor(() => {
+      const state = context.store.get(connectorOAuthDeviceAuthState$);
+      expect(state.status).toBe("pending");
+      if (state.status === "pending") {
+        expect(state.userCode).toBe("VM0-DEVICE");
+      }
+    });
+
+    expect(authCodeStartCalled).toBeFalsy();
+    expect(open).not.toHaveBeenCalled();
+
+    context.store.set(
+      openConnectorOAuthDeviceAuthVerificationPage$,
+      "test-oauth-device",
+    );
+
+    await expect(connectPromise).resolves.toBeTruthy();
+    expect(open).toHaveBeenCalledWith(
+      "https://oauth.test/device?user_code=VM0-DEVICE",
+      "_blank",
+    );
+    expect(context.store.get(pollingOAuthDeviceAuthConnectorType$)).toBeNull();
+  });
+
+  it("opens the verification URI when complete verification URI is absent", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    server.use(
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.create,
+        ({ params, respond }) => {
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000125",
+            sessionToken: "device-session-token",
+            type: params.type,
+            status: "pending",
+            userCode: "VM0-DEVICE",
+            verificationUri: "https://oauth.test/device/manual",
+            expiresIn: 300,
+            interval: 0,
+          });
+        },
+      ),
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.poll,
+        ({ respond }) => {
+          return respond(200, {
+            status: "complete",
+            connector: makeTestOauthDeviceConnectorResponse(),
+          });
+        },
+      ),
+    );
+
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(createMockAuthWindow() as unknown as Window);
+
+    const connectPromise = context.store.set(
+      connectConnectorOAuthDeviceAuth$,
+      "test-oauth-device",
+      {},
+      context.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(context.store.get(connectorOAuthDeviceAuthState$).status).toBe(
+        "pending",
+      );
+    });
+
+    context.store.set(
+      openConnectorOAuthDeviceAuthVerificationPage$,
+      "test-oauth-device",
+    );
+
+    await expect(connectPromise).resolves.toBeTruthy();
+    expect(open).toHaveBeenCalledWith(
+      "https://oauth.test/device/manual",
+      "_blank",
+    );
+  });
+
+  it("keeps pending state active and updates the poll interval", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    server.use(
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.create,
+        ({ params, respond }) => {
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000126",
+            sessionToken: "device-session-token",
+            type: params.type,
+            status: "pending",
+            userCode: "VM0-DEVICE",
+            verificationUri: "https://oauth.test/device",
+            verificationUriComplete:
+              "https://oauth.test/device?user_code=VM0-DEVICE",
+            expiresIn: 300,
+            interval: 0,
+          });
+        },
+      ),
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.poll,
+        ({ respond }) => {
+          return respond(200, {
+            status: "pending",
+            interval: 2,
+          });
+        },
+      ),
+    );
+
+    const connectPromise = (async () => {
+      try {
+        return await context.store.set(
+          connectConnectorOAuthDeviceAuth$,
+          "test-oauth-device",
+          {},
+          context.signal,
+        );
+      } catch {
+        return false;
+      }
+    })();
+
+    await vi.waitFor(() => {
+      expect(context.store.get(connectorOAuthDeviceAuthState$).status).toBe(
+        "pending",
+      );
+    });
+
+    vi.spyOn(window, "open").mockReturnValue(
+      createMockAuthWindow() as unknown as Window,
+    );
+    context.store.set(
+      openConnectorOAuthDeviceAuthVerificationPage$,
+      "test-oauth-device",
+    );
+
+    await vi.waitFor(() => {
+      const state = context.store.get(connectorOAuthDeviceAuthState$);
+      expect(state.status).toBe("pending");
+      if (state.status === "pending") {
+        expect(state.approvalOpened).toBeTruthy();
+        expect(state.pollIntervalMs).toBe(2000);
+      }
+    });
+
+    context.store.set(clearConnectorOAuthDeviceAuth$);
+    await expect(connectPromise).resolves.toBeFalsy();
+    expect(context.store.get(pollingOAuthDeviceAuthConnectorType$)).toBeNull();
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,6 +3,7 @@ import { delay } from "signal-timers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
+  CONNECTOR_AUTH_METHOD_TYPES,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorAuthMethodType,
@@ -18,7 +19,9 @@ import {
   getConnectorCliAuthModes,
   getConnectorTags,
   hasRequiredScopes,
+  isGoogleOAuthConnector,
   isOAuthAuthCodeConnectorType,
+  isOAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
   zeroLocalAgentHostsContract,
@@ -33,6 +36,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-local-browser";
 import {
   zeroConnectorScopeDiffContract,
+  zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorOauthStartContract,
   zeroLocalBrowserConnectorContract,
   zeroConnectorsMainContract,
@@ -44,6 +48,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-secrets";
 import { zeroCliAuthStripeContract } from "@vm0/api-contracts/contracts/zero-connectors-cli-auth-stripe";
 import type {
+  ConnectorOauthDeviceAuthSessionPollResponse,
   ConnectorListResponse,
   ConnectorResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
@@ -124,6 +129,38 @@ export interface ConnectorTypeWithStatus {
   localAgentHosts?: LocalAgentHost[];
   /** Online local browser hosts for the virtual local-browser connector. */
   localBrowserHosts?: LocalBrowserHost[];
+}
+
+type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
+
+export function getConfiguredConnectorAuthMethods(
+  type: ConnectorType,
+): ConnectorAuthMethodType[] {
+  return CONNECTOR_AUTH_METHOD_TYPES.filter((authMethod) => {
+    return authMethod in CONNECTOR_TYPES[type].authMethods;
+  });
+}
+
+export function getConnectorConnectLaunchMode({
+  type,
+  availableAuthMethods,
+  preferModalForGoogleOAuth = false,
+}: {
+  readonly type: ConnectorType;
+  readonly availableAuthMethods: readonly ConnectorAuthMethodType[];
+  readonly preferModalForGoogleOAuth?: boolean;
+}): ConnectorConnectLaunchMode {
+  const hasOAuth = availableAuthMethods.includes("oauth");
+  if (!hasOAuth) {
+    return "modal";
+  }
+  if (!isOAuthAuthCodeConnectorType(type)) {
+    return "modal";
+  }
+  if (preferModalForGoogleOAuth && isGoogleOAuthConnector(type)) {
+    return "modal";
+  }
+  return "oauth-auth-code";
 }
 
 const internalReloadLocalAgentHosts$ = state(0);
@@ -462,6 +499,39 @@ export type ConnectorCliAuthState =
       readonly message: string;
     };
 
+type ActiveConnectorOAuthDeviceAuthState = {
+  readonly connectorType: ConnectorType;
+  readonly requestId: string;
+  readonly sessionId: string;
+  readonly sessionToken: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string;
+  readonly expiresAtMs: number;
+  readonly pollIntervalMs: number;
+  readonly approvalOpened: boolean;
+  readonly errorMessage: string | null;
+};
+
+export type ConnectorOAuthDeviceAuthState =
+  | {
+      readonly status: "idle";
+      readonly connectorType: ConnectorType | null;
+    }
+  | {
+      readonly status: "starting";
+      readonly connectorType: ConnectorType;
+      readonly requestId: string;
+    }
+  | (ActiveConnectorOAuthDeviceAuthState & {
+      readonly status: "pending" | "polling";
+    })
+  | {
+      readonly status: "denied" | "expired" | "error";
+      readonly connectorType: ConnectorType | null;
+      readonly message: string;
+    };
+
 type ConnectorConnectFlowState = {
   readonly type: ConnectorType;
   readonly id: string;
@@ -474,10 +544,21 @@ function createIdleConnectorCliAuthState(
   return { status: "idle", connectorType, mode };
 }
 
+function createIdleConnectorOAuthDeviceAuthState(
+  connectorType: ConnectorType | null = null,
+): ConnectorOAuthDeviceAuthState {
+  return { status: "idle", connectorType };
+}
+
 const internalConnectorCliAuthState$ = state<ConnectorCliAuthState>(
   createIdleConnectorCliAuthState(),
 );
 const resetConnectorCliAuthFlowSignal$ = resetSignal();
+const internalConnectorOAuthDeviceAuthState$ =
+  state<ConnectorOAuthDeviceAuthState>(
+    createIdleConnectorOAuthDeviceAuthState(),
+  );
+const resetConnectorOAuthDeviceAuthFlowSignal$ = resetSignal();
 
 export const selectedConnectorType$ = computed((get) => {
   return get(internalSelectedConnectorType$);
@@ -490,11 +571,23 @@ export const setSelectedConnectorType$ = command(
       set(resetConnectorCliAuthFlowSignal$);
       set(internalConnectorCliAuthState$, createIdleConnectorCliAuthState());
     }
+    const deviceAuthCurrent = get(internalConnectorOAuthDeviceAuthState$);
+    if (type !== deviceAuthCurrent.connectorType) {
+      set(resetConnectorOAuthDeviceAuthFlowSignal$);
+      set(
+        internalConnectorOAuthDeviceAuthState$,
+        createIdleConnectorOAuthDeviceAuthState(type),
+      );
+    }
   },
 );
 
 export const connectorCliAuthState$ = computed((get) => {
   return get(internalConnectorCliAuthState$);
+});
+
+export const connectorOAuthDeviceAuthState$ = computed((get) => {
+  return get(internalConnectorOAuthDeviceAuthState$);
 });
 
 // ---------------------------------------------------------------------------
@@ -562,6 +655,44 @@ export const setTokenFormSubmitting$ = command(
   },
 );
 
+type FinishConnectorConnectionOptions = PostConnectOptions & {
+  readonly clearSelectedConnector?: boolean;
+  readonly toastMessage?: string | null;
+};
+
+const finishConnectorConnection$ = command(
+  (
+    { get, set },
+    type: ConnectorType,
+    options: FinishConnectorConnectionOptions = {},
+  ): boolean => {
+    set(internalJustConnectedTypes$, (prev) => {
+      return new Set([...prev, type]);
+    });
+    set(reloadConnectors$);
+
+    const hidden = new Set(get(hiddenConnectorTypes$));
+    hidden.delete(type);
+    set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
+
+    if (options.toastMessage !== null) {
+      toast.success(
+        options.toastMessage ?? `${CONNECTOR_TYPES[type].label} connected`,
+        {
+          id: `connector-connected-${type}`,
+        },
+      );
+    }
+    if (options.showPermissionDialog) {
+      set(internalPermissionDialogType$, type);
+    }
+    if (options.clearSelectedConnector) {
+      set(internalSelectedConnectorType$, null);
+    }
+    return true;
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Submit API token command
 // ---------------------------------------------------------------------------
@@ -608,20 +739,10 @@ export const submitApiToken$ = command(
           signal.throwIfAborted();
         }
         signal.throwIfAborted();
-        set(internalJustConnectedTypes$, (prev) => {
-          return new Set([...prev, type]);
+        set(finishConnectorConnection$, type, {
+          ...options,
+          toastMessage: `${CONNECTOR_TYPES[type].label} connected successfully`,
         });
-        set(reloadConnectors$);
-        // Show in connections list
-        const hidden = new Set(get(hiddenConnectorTypes$));
-        hidden.delete(type);
-        set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-        toast.success(`${CONNECTOR_TYPES[type].label} connected successfully`, {
-          id: `connector-connected-${type}`,
-        });
-        if (options.showPermissionDialog) {
-          set(internalPermissionDialogType$, type);
-        }
       })(),
       () => {
         set(internalConnectFlowState$, (current) => {
@@ -643,6 +764,13 @@ const internalConnectFlowState$ = state<ConnectorConnectFlowState | null>(null);
 
 export const pollingOAuthAuthCodeConnectorType$ = computed((get) => {
   return get(internalPollingOAuthAuthCodeConnectorType$);
+});
+
+export const pollingOAuthDeviceAuthConnectorType$ = computed((get) => {
+  const current = get(internalConnectorOAuthDeviceAuthState$);
+  return current.status === "pending" || current.status === "polling"
+    ? current.connectorType
+    : null;
 });
 
 export const connectFlowType$ = computed((get) => {
@@ -994,25 +1122,8 @@ export const connectLocalAgentConnector$ = command(
         );
         signal.throwIfAborted();
 
-        set(internalJustConnectedTypes$, (prev) => {
-          return new Set([...prev, LOCAL_AGENT_CONNECTOR_TYPE]);
-        });
-        set(reloadConnectors$);
         set(reloadLocalAgentHosts$);
-
-        const hidden = new Set(get(hiddenConnectorTypes$));
-        hidden.delete(LOCAL_AGENT_CONNECTOR_TYPE);
-        set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-
-        toast.success(
-          `${CONNECTOR_TYPES[LOCAL_AGENT_CONNECTOR_TYPE].label} connected`,
-          {
-            id: `connector-connected-${LOCAL_AGENT_CONNECTOR_TYPE}`,
-          },
-        );
-        if (options.showPermissionDialog) {
-          set(internalPermissionDialogType$, LOCAL_AGENT_CONNECTOR_TYPE);
-        }
+        set(finishConnectorConnection$, LOCAL_AGENT_CONNECTOR_TYPE, options);
       })(),
       () => {
         set(internalConnectFlowState$, (current) => {
@@ -1046,25 +1157,8 @@ export const connectLocalBrowserConnector$ = command(
         );
         signal.throwIfAborted();
 
-        set(internalJustConnectedTypes$, (prev) => {
-          return new Set([...prev, LOCAL_BROWSER_CONNECTOR_TYPE]);
-        });
-        set(reloadConnectors$);
         set(reloadLocalBrowserHosts$);
-
-        const hidden = new Set(get(hiddenConnectorTypes$));
-        hidden.delete(LOCAL_BROWSER_CONNECTOR_TYPE);
-        set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-
-        toast.success(
-          `${CONNECTOR_TYPES[LOCAL_BROWSER_CONNECTOR_TYPE].label} connected`,
-          {
-            id: `connector-connected-${LOCAL_BROWSER_CONNECTOR_TYPE}`,
-          },
-        );
-        if (options.showPermissionDialog) {
-          set(internalPermissionDialogType$, LOCAL_BROWSER_CONNECTOR_TYPE);
-        }
+        set(finishConnectorConnection$, LOCAL_BROWSER_CONNECTOR_TYPE, options);
       })(),
       () => {
         set(internalConnectFlowState$, (current) => {
@@ -1325,22 +1419,8 @@ export const clearConnectorCliAuth$ = command(({ set }) => {
 });
 
 const finishConnectorCliAuthConnection$ = command(
-  ({ get, set }, type: ConnectorType, options: PostConnectOptions) => {
-    set(internalJustConnectedTypes$, (prev) => {
-      return new Set([...prev, type]);
-    });
-    set(reloadConnectors$);
-
-    const hidden = new Set(get(hiddenConnectorTypes$));
-    hidden.delete(type);
-    set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-
-    toast.success(`${CONNECTOR_TYPES[type].label} connected`, {
-      id: `connector-connected-${type}`,
-    });
-    if (options.showPermissionDialog) {
-      set(internalPermissionDialogType$, type);
-    }
+  ({ set }, type: ConnectorType, options: PostConnectOptions) => {
+    set(finishConnectorConnection$, type, options);
     set(internalConnectorCliAuthState$, createIdleConnectorCliAuthState());
     return true;
   },
@@ -1570,6 +1650,334 @@ export const runConnectorCliAuth$ = command(
         });
       },
     );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// OAuth device authorization flow state
+// ---------------------------------------------------------------------------
+
+const OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS = IN_VITEST ? 10 : 1000;
+
+type PollConnectorOAuthDeviceAuthArgs = {
+  readonly type: ConnectorType;
+  readonly requestId: string;
+  readonly createClient: ZeroClientFactory;
+  readonly options: PostConnectOptions;
+};
+
+function createConnectorOAuthDeviceAuthRequestId(type: ConnectorType): string {
+  return `${type}-oauth-device-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function oauthDeviceAuthErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Connection failed";
+}
+
+function getOAuthDeviceAuthTerminalMessage(
+  result: Extract<
+    ConnectorOauthDeviceAuthSessionPollResponse,
+    { readonly status: "denied" | "expired" | "error" }
+  >,
+): string {
+  if (result.errorMessage) {
+    return result.errorMessage;
+  }
+  switch (result.status) {
+    case "denied": {
+      return "Connection was denied. Start again to retry.";
+    }
+    case "expired": {
+      return "Connection session expired. Start again to retry.";
+    }
+    case "error": {
+      return "Connection failed. Start again to retry.";
+    }
+  }
+}
+
+function isCurrentConnectorOAuthDeviceAuthRequest(
+  state: ConnectorOAuthDeviceAuthState,
+  type: ConnectorType,
+  requestId: string,
+): state is ActiveConnectorOAuthDeviceAuthState & {
+  readonly status: "pending" | "polling";
+} {
+  return (
+    (state.status === "pending" || state.status === "polling") &&
+    state.connectorType === type &&
+    state.requestId === requestId
+  );
+}
+
+export const clearConnectorOAuthDeviceAuth$ = command(({ set }) => {
+  set(resetConnectorOAuthDeviceAuthFlowSignal$);
+  set(
+    internalConnectorOAuthDeviceAuthState$,
+    createIdleConnectorOAuthDeviceAuthState(),
+  );
+});
+
+export const openConnectorOAuthDeviceAuthVerificationPage$ = command(
+  ({ get, set }, type: ConnectorType): boolean => {
+    const current = get(internalConnectorOAuthDeviceAuthState$);
+    if (
+      (current.status !== "pending" && current.status !== "polling") ||
+      current.connectorType !== type
+    ) {
+      return false;
+    }
+
+    const verificationUrl =
+      current.verificationUriComplete ?? current.verificationUri;
+    const verificationWindow = window.open(verificationUrl, "_blank");
+    if (!verificationWindow) {
+      set(internalConnectorOAuthDeviceAuthState$, {
+        ...current,
+        errorMessage: "Could not open the verification page. Try again.",
+      });
+      return false;
+    }
+
+    verificationWindow.opener = null;
+    set(internalConnectorOAuthDeviceAuthState$, {
+      ...current,
+      status: "pending",
+      approvalOpened: true,
+      errorMessage: null,
+    });
+    return true;
+  },
+);
+
+const pollConnectorOAuthDeviceAuth$ = command(
+  async (
+    { get, set },
+    {
+      type,
+      requestId,
+      createClient,
+      options,
+    }: PollConnectorOAuthDeviceAuthArgs,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const client = createClient(zeroConnectorOauthDeviceAuthSessionContract);
+
+    while (true) {
+      const current = get(internalConnectorOAuthDeviceAuthState$);
+      if (!isCurrentConnectorOAuthDeviceAuthRequest(current, type, requestId)) {
+        return false;
+      }
+
+      const remainingMs = current.expiresAtMs - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+
+      if (!current.approvalOpened) {
+        await delay(
+          Math.min(OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS, remainingMs),
+          { signal },
+        );
+        signal.throwIfAborted();
+        continue;
+      }
+
+      set(internalConnectorOAuthDeviceAuthState$, {
+        ...current,
+        status: "polling",
+      });
+
+      const pollSettled = await settle(
+        accept(
+          client.poll({
+            params: { type, sessionId: current.sessionId },
+            body: { sessionToken: current.sessionToken },
+            fetchOptions: { signal },
+          }),
+          [200],
+          { toast: false },
+        ),
+        signal,
+      );
+      const pollResult = pollSettled.ok
+        ? pollSettled.value.body
+        : {
+            status: "error" as const,
+            errorMessage: oauthDeviceAuthErrorMessage(pollSettled.error),
+          };
+
+      const latest = get(internalConnectorOAuthDeviceAuthState$);
+      if (!isCurrentConnectorOAuthDeviceAuthRequest(latest, type, requestId)) {
+        return false;
+      }
+
+      if (pollResult.status === "complete") {
+        set(finishConnectorConnection$, type, {
+          ...options,
+          clearSelectedConnector: true,
+        });
+        set(
+          internalConnectorOAuthDeviceAuthState$,
+          createIdleConnectorOAuthDeviceAuthState(),
+        );
+        return true;
+      }
+
+      if (pollResult.status !== "pending") {
+        set(internalConnectorOAuthDeviceAuthState$, {
+          status: pollResult.status,
+          connectorType: type,
+          message: getOAuthDeviceAuthTerminalMessage(pollResult),
+        });
+        return false;
+      }
+
+      const pollIntervalMs = Math.max(
+        secondsToMilliseconds(pollResult.interval),
+        OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS,
+      );
+      set(internalConnectorOAuthDeviceAuthState$, {
+        ...latest,
+        status: "pending",
+        pollIntervalMs,
+        errorMessage: null,
+      });
+
+      const nextRemainingMs = latest.expiresAtMs - Date.now();
+      if (nextRemainingMs <= 0) {
+        break;
+      }
+      await delay(Math.min(pollIntervalMs, nextRemainingMs), { signal });
+      signal.throwIfAborted();
+    }
+
+    const latest = get(internalConnectorOAuthDeviceAuthState$);
+    if (isCurrentConnectorOAuthDeviceAuthRequest(latest, type, requestId)) {
+      set(internalConnectorOAuthDeviceAuthState$, {
+        status: "expired",
+        connectorType: type,
+        message: "Connection session expired. Start again to retry.",
+      });
+    }
+    return false;
+  },
+);
+
+export const connectConnectorOAuthDeviceAuth$ = command(
+  async (
+    { get, set },
+    type: ConnectorType,
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    if (!isOAuthDeviceAuthConnectorType(type)) {
+      throw new Error(`${type} does not use device authorization OAuth`);
+    }
+
+    const flow = createConnectorConnectFlowState(type);
+    set(internalConnectFlowState$, flow);
+    return await withCleanup(
+      (async () => {
+        const requestId = createConnectorOAuthDeviceAuthRequestId(type);
+        const flowSignal = set(
+          resetConnectorOAuthDeviceAuthFlowSignal$,
+          signal,
+        );
+        set(internalConnectorOAuthDeviceAuthState$, {
+          status: "starting",
+          connectorType: type,
+          requestId,
+        });
+
+        const createClient = get(zeroClient$);
+        const client = createClient(
+          zeroConnectorOauthDeviceAuthSessionContract,
+        );
+        const startSettled = await settle(
+          accept(
+            client.create({
+              params: { type },
+              body: {},
+              fetchOptions: { signal: flowSignal },
+            }),
+            [200],
+            { toast: false },
+          ),
+          flowSignal,
+        );
+        const startResult = startSettled.ok ? startSettled.value.body : null;
+        if (!startSettled.ok) {
+          if (flowSignal.aborted) {
+            return false;
+          }
+          set(internalConnectorOAuthDeviceAuthState$, {
+            status: "error",
+            connectorType: type,
+            message: oauthDeviceAuthErrorMessage(startSettled.error),
+          });
+        }
+        flowSignal.throwIfAborted();
+        if (!startResult) {
+          return false;
+        }
+
+        set(internalConnectorOAuthDeviceAuthState$, {
+          status: "pending",
+          connectorType: type,
+          requestId,
+          sessionId: startResult.sessionId,
+          sessionToken: startResult.sessionToken,
+          userCode: startResult.userCode,
+          verificationUri: startResult.verificationUri,
+          verificationUriComplete: startResult.verificationUriComplete,
+          expiresAtMs:
+            Date.now() + secondsToMilliseconds(startResult.expiresIn),
+          pollIntervalMs: Math.max(
+            secondsToMilliseconds(startResult.interval),
+            OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS,
+          ),
+          approvalOpened: false,
+          errorMessage: null,
+        });
+
+        return await set(
+          pollConnectorOAuthDeviceAuth$,
+          {
+            type,
+            requestId,
+            createClient,
+            options,
+          },
+          flowSignal,
+        );
+      })(),
+      () => {
+        set(internalConnectFlowState$, (current) => {
+          return current?.id === flow.id ? null : current;
+        });
+      },
+    );
+  },
+);
+
+export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
+  async (
+    { set },
+    type: ConnectorType,
+    onSuccess: () => void | Promise<void>,
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const connected = await set(
+      connectConnectorOAuthDeviceAuth$,
+      type,
+      options,
+      signal,
+    );
+    if (connected) {
+      await onSuccess();
+    }
   },
 );
 
@@ -1822,21 +2230,11 @@ export const connectConnectorOAuthAuthCode$ = command(
           return c.type === type;
         });
         if (isConnected) {
-          set(internalJustConnectedTypes$, (prev) => {
-            return new Set([...prev, type]);
+          set(finishConnectorConnection$, type, {
+            ...options,
+            clearSelectedConnector: true,
+            toastMessage: null,
           });
-        }
-        // Show in connections list again when user connects
-        const hidden = new Set(get(hiddenConnectorTypes$));
-        hidden.delete(type);
-        set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-        // Close connect modal on auth-code OAuth success. Only connectors-page
-        // flows should show the post-connect permission dialog.
-        if (isConnected) {
-          set(internalSelectedConnectorType$, null);
-          if (options.showPermissionDialog) {
-            set(internalPermissionDialogType$, type);
-          }
         }
         return isConnected;
       })(),

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1877,9 +1877,10 @@ export const connectConnectorOAuthDeviceAuth$ = command(
 
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
+    let requestId: string | null = null;
     return await withCleanup(
       (async () => {
-        const requestId = createConnectorOAuthDeviceAuthRequestId(type);
+        requestId = createConnectorOAuthDeviceAuthRequestId(type);
         const flowSignal = set(
           resetConnectorOAuthDeviceAuthFlowSignal$,
           signal,
@@ -1955,6 +1956,20 @@ export const connectConnectorOAuthDeviceAuth$ = command(
       () => {
         set(internalConnectFlowState$, (current) => {
           return current?.id === flow.id ? null : current;
+        });
+        set(internalConnectorOAuthDeviceAuthState$, (current) => {
+          if (
+            !signal.aborted ||
+            requestId === null ||
+            current.connectorType !== type ||
+            (current.status !== "starting" &&
+              current.status !== "pending" &&
+              current.status !== "polling") ||
+            current.requestId !== requestId
+          ) {
+            return current;
+          }
+          return createIdleConnectorOAuthDeviceAuthState(type);
         });
       },
     );

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -657,6 +657,7 @@ export const setTokenFormSubmitting$ = command(
 
 type FinishConnectorConnectionOptions = PostConnectOptions & {
   readonly clearSelectedConnector?: boolean;
+  readonly reloadConnectors?: boolean;
   readonly toastMessage?: string | null;
 };
 
@@ -669,7 +670,9 @@ const finishConnectorConnection$ = command(
     set(internalJustConnectedTypes$, (prev) => {
       return new Set([...prev, type]);
     });
-    set(reloadConnectors$);
+    if (options.reloadConnectors !== false) {
+      set(reloadConnectors$);
+    }
 
     const hidden = new Set(get(hiddenConnectorTypes$));
     hidden.delete(type);
@@ -2248,6 +2251,7 @@ export const connectConnectorOAuthAuthCode$ = command(
           set(finishConnectorConnection$, type, {
             ...options,
             clearSelectedConnector: true,
+            reloadConnectors: false,
             toastMessage: null,
           });
         }

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -24,7 +24,11 @@ import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { setSelectedConnectorType$ } from "../../../signals/zero-page/settings/connectors.ts";
 import { mockConnectors } from "../../zero-page/__tests__/zero-connectors-page-test-helpers.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
-import { setMockStripeCliAuthCompleteResponse } from "../../../mocks/handlers/api-connectors.ts";
+import {
+  setMockOauthDeviceAuthSessionStartResponse,
+  setMockOauthDeviceAuthSessionPollResponses,
+  setMockStripeCliAuthCompleteResponse,
+} from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -116,7 +120,28 @@ describe("connect modal - content by auth method", () => {
     });
   });
 
-  it("does not show auth-code OAuth button for device-auth OAuth connectors", async () => {
+  it("shows device auth code before opening provider verification", async () => {
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(createMockAuthWindow(false) as unknown as Window);
+    setMockOauthDeviceAuthSessionPollResponses([
+      {
+        status: "complete",
+        connector: {
+          id: "00000000-0000-4000-8000-000000000101",
+          type: "test-oauth-device",
+          authMethod: "oauth",
+          externalId: "test-oauth-device-user",
+          externalUsername: "device-user",
+          externalEmail: null,
+          oauthScopes: ["read"],
+          needsReconnect: false,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+    ]);
+
     await openConnectModal("test-oauth-device", {
       featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
     });
@@ -129,8 +154,137 @@ describe("connect modal - content by auth method", () => {
       screen.queryByText("Sign in with Test OAuth Device (internal)"),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Connection methods unavailable"),
-    ).toBeInTheDocument();
+      screen.queryByText("Connection methods unavailable"),
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByText("Connect Test OAuth Device (internal)"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("connector-oauth-device-code"),
+      ).toHaveTextContent("VM0-DEVICE");
+    });
+    expect(open).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByText("Open verification page"));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        "https://oauth.test/test-oauth-device/device?user_code=VM0-DEVICE",
+        "_blank",
+      );
+    });
+    expect(
+      screen.queryByText("Connection methods unavailable"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the verification URI when the complete verification URI is absent", async () => {
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(createMockAuthWindow(false) as unknown as Window);
+    setMockOauthDeviceAuthSessionStartResponse({
+      verificationUri: "https://oauth.test/test-oauth-device/manual",
+      verificationUriComplete: undefined,
+    });
+    setMockOauthDeviceAuthSessionPollResponses([
+      {
+        status: "complete",
+        connector: {
+          id: "00000000-0000-4000-8000-000000000102",
+          type: "test-oauth-device",
+          authMethod: "oauth",
+          externalId: "test-oauth-device-user",
+          externalUsername: "device-user",
+          externalEmail: null,
+          oauthScopes: ["read"],
+          needsReconnect: false,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+    ]);
+
+    await openConnectModal("test-oauth-device", {
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await userEvent.click(
+      await screen.findByText("Connect Test OAuth Device (internal)"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("connector-oauth-device-code"),
+      ).toHaveTextContent("VM0-DEVICE");
+    });
+    await userEvent.click(getButtonByText("Open verification page"));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        "https://oauth.test/test-oauth-device/manual",
+        "_blank",
+      );
+    });
+  });
+
+  it.each([
+    ["denied", "The device request was denied."],
+    ["expired", "The device request expired."],
+    ["error", "The device request failed."],
+  ] as const)(
+    "shows terminal device auth %s state with retry",
+    async (status, message) => {
+      setMockOauthDeviceAuthSessionPollResponses([
+        {
+          status,
+          errorMessage: message,
+        },
+      ]);
+
+      await openConnectModal("test-oauth-device", {
+        featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+      });
+
+      await userEvent.click(
+        await screen.findByText("Connect Test OAuth Device (internal)"),
+      );
+      vi.spyOn(window, "open").mockReturnValue(
+        createMockAuthWindow(false) as unknown as Window,
+      );
+      await userEvent.click(await screen.findByText("Open verification page"));
+
+      await waitFor(() => {
+        expect(screen.getByText(message)).toBeInTheDocument();
+      });
+      expect(screen.getByText("Try again")).toBeInTheDocument();
+    },
+  );
+
+  it("clears device auth state when the dialog closes", async () => {
+    await openConnectModal("test-oauth-device", {
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await userEvent.click(
+      await screen.findByText("Connect Test OAuth Device (internal)"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("connector-oauth-device-code"),
+      ).toHaveTextContent("VM0-DEVICE");
+    });
+
+    click(screen.getByLabelText(/close/i));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("connector-oauth-device-code"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows API token form for api-token connectors (CONN-C-019)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -19,6 +19,8 @@ import {
 } from "@vm0/api-contracts/contracts/onboarding";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { triggerAblyEvent, hasSubscription } from "../../../mocks/ably.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { setMockOauthDeviceAuthSessionPollResponses } from "../../../mocks/handlers/api-connectors.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -142,5 +144,70 @@ describe("onboarding connector permission dialog suppression", () => {
     await waitFor(() => {
       expect(context.store.get(permissionDialogType$)).toBeNull();
     });
+  });
+
+  it("opens device auth dialog during onboarding before provider verification", async () => {
+    mockAdminOnboarding();
+    setMockOauthDeviceAuthSessionPollResponses([
+      {
+        status: "complete",
+        connector: {
+          id: "00000000-0000-4000-8000-000000000301",
+          type: "test-oauth-device",
+          authMethod: "oauth",
+          externalId: "test-oauth-device-user",
+          externalUsername: "device-user",
+          externalEmail: null,
+          oauthScopes: ["read"],
+          needsReconnect: false,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+    ]);
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(createMockAuthWindow() as unknown as Window);
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hello&connector=test-oauth-device",
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Name your workspace/)).toBeInTheDocument();
+    });
+    await fill(screen.getByPlaceholderText("e.g. Acme Corp"), "Test Workspace");
+    click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect your apps")).toBeInTheDocument();
+    });
+    click(screen.getByText("Connect"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Test OAuth Device (internal)" }),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByText("Connect Test OAuth Device (internal)"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("connector-oauth-device-code"),
+      ).toHaveTextContent("VM0-DEVICE");
+    });
+    expect(open).not.toHaveBeenCalled();
+
+    click(screen.getByText("Open verification page"));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        "https://oauth.test/test-oauth-device/device?user_code=VM0-DEVICE",
+        "_blank",
+      );
+    });
+    expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -266,6 +266,40 @@ describe("connectors page - connector status indicators", () => {
     expect(screen.getByText("Review")).toBeInTheDocument();
   });
 
+  it("device auth connector opens connect dialog instead of OAuth popup", async () => {
+    const open = vi.spyOn(window, "open");
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("Find connectors"),
+      ).toBeInTheDocument();
+    });
+    await userEvent.type(
+      screen.getByPlaceholderText("Find connectors"),
+      "device",
+    );
+    await userEvent.click(
+      await screen.findByLabelText(/Connect .*Test OAuth Device \(internal\)/),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", {
+          name: /Test OAuth Device \(internal\)/,
+        }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Connect .*Test OAuth Device \(internal\)/),
+    ).toBeInTheDocument();
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it("connected connector shows username (CONN-D-006)", async () => {
     // Pass the required GitHub OAuth scopes to avoid triggering scope mismatch state
     mockConnectors([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -21,7 +21,10 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import {
+  setMockConnectors,
+  setMockOauthDeviceAuthSessionPollResponses,
+} from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
@@ -356,7 +359,7 @@ describe("directed connect page", () => {
     });
   });
 
-  it("does not enable connect for device-auth OAuth connectors", async () => {
+  it("opens device auth dialog before provider verification for device-auth OAuth connectors", async () => {
     const openSpy = vi.spyOn(window, "open");
     let startCalled = false;
     server.use(
@@ -384,12 +387,18 @@ describe("directed connect page", () => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectButton).toBeDefined();
-    expect(connectButton).toBeDisabled();
     click(connectButton!);
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Test OAuth Device (internal)" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Connect Test OAuth Device (internal)"),
+    ).toBeInTheDocument();
     expect(openSpy).not.toHaveBeenCalled();
     expect(startCalled).toBeFalsy();
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("save button submits the api token to the server (CONN-I-049)", async () => {
@@ -503,6 +512,60 @@ describe("directed connect page", () => {
     });
     expect(saveBtn).toBeDefined();
     click(saveBtn!);
+
+    await waitFor(() => {
+      expect(authorizeCalled).toBeTruthy();
+    });
+  });
+
+  it("auto-authorizes agent after device auth connect when agentId is present", async () => {
+    mockUserConnectors();
+    setMockOauthDeviceAuthSessionPollResponses([
+      {
+        status: "complete",
+        connector: {
+          id: "00000000-0000-4000-8000-000000000201",
+          type: "test-oauth-device",
+          authMethod: "oauth",
+          externalId: "test-oauth-device-user",
+          externalUsername: "device-user",
+          externalEmail: null,
+          oauthScopes: ["read"],
+          needsReconnect: false,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+    ]);
+
+    let authorizeCalled = false;
+    server.use(
+      mockApi(zeroUserConnectorsContract.update, ({ respond }) => {
+        authorizeCalled = true;
+        return respond(200, { enabledTypes: ["test-oauth-device"] });
+      }),
+    );
+    vi.spyOn(window, "open").mockReturnValue(
+      createMockAuthWindow() as unknown as Window,
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/test-oauth-device/connect?agentId=${AGENT_ID}`,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Test OAuth Device (internal) to proceed"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByText("Connect"));
+
+    await userEvent.click(
+      await screen.findByText("Connect Test OAuth Device (internal)"),
+    );
+    await userEvent.click(await screen.findByText("Open verification page"));
 
     await waitFor(() => {
       expect(authorizeCalled).toBeTruthy();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -7,6 +7,7 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Input } from "@vm0/ui/components/ui/input";
 import { Button } from "@vm0/ui/components/ui/button";
+import { CopyButton } from "@vm0/ui/components/ui/copy-button";
 import {
   Dialog,
   DialogContent,
@@ -25,13 +26,18 @@ import {
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
   isOAuthAuthCodeConnectorType,
+  isOAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
   allConnectorTypes$,
   connectorCliAuthState$,
   connectFlowType$,
   pollingOAuthAuthCodeConnectorType$,
+  connectorOAuthDeviceAuthState$,
   connectConnectorOAuthAuthCodeAndSettle$,
+  connectConnectorOAuthDeviceAuthAndSettle$,
+  openConnectorOAuthDeviceAuthVerificationPage$,
+  clearConnectorOAuthDeviceAuth$,
   runConnectorConnectSuccess$,
   submitApiToken$,
   setTokenFormValue$,
@@ -56,6 +62,7 @@ import {
   localAgentHosts$,
   type LocalBrowserExtensionStatus,
   type ConnectorCliAuthState,
+  type ConnectorOAuthDeviceAuthState,
   type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
@@ -153,6 +160,8 @@ type ConnectOAuthAuthCodeAndSettleFn = (
   signal: AbortSignal,
 ) => Promise<void>;
 
+type ConnectOAuthDeviceAuthAndSettleFn = ConnectOAuthAuthCodeAndSettleFn;
+
 type ConnectModalContentProps = {
   item: ConnectorTypeWithStatus;
   onSuccess: () => void | Promise<void>;
@@ -161,6 +170,7 @@ type ConnectModalContentProps = {
 
 type ConnectMethodContentProps = ConnectModalContentProps & {
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
+  connectOAuthDeviceAuthAndSettle: ConnectOAuthDeviceAuthAndSettleFn;
   submitApiToken: SubmitApiTokenFn;
   credentialSubmitting: boolean;
   signal: AbortSignal;
@@ -181,6 +191,18 @@ type ConnectMethodContentEntry = {
 
 function connectorCliAuthFlowIsActive(
   state: ConnectorCliAuthState,
+  type: ConnectorType,
+): boolean {
+  return (
+    state.connectorType === type &&
+    (state.status === "starting" ||
+      state.status === "pending" ||
+      state.status === "polling")
+  );
+}
+
+function connectorOAuthDeviceAuthFlowIsActive(
+  state: ConnectorOAuthDeviceAuthState,
   type: ConnectorType,
 ): boolean {
   return (
@@ -682,6 +704,155 @@ function OAuthAuthCodeConnectMethodContent(props: ConnectMethodContentProps) {
   );
 }
 
+function getOAuthDeviceAuthStatusText(
+  state: Extract<
+    ConnectorOAuthDeviceAuthState,
+    { readonly status: "pending" | "polling" }
+  >,
+): string {
+  if (!state.approvalOpened) {
+    return "Copy this code, then open the verification page to approve access.";
+  }
+  if (state.status === "polling") {
+    return "Checking for approval...";
+  }
+  return "Waiting for approval. Keep this dialog open.";
+}
+
+function OAuthDeviceAuthCodePanel({
+  state,
+  onOpenVerificationPage,
+}: {
+  state: Extract<
+    ConnectorOAuthDeviceAuthState,
+    { readonly status: "pending" | "polling" }
+  >;
+  onOpenVerificationPage: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-muted-foreground">
+        Enter this code on the provider verification page to approve access.
+      </p>
+      <div className="rounded-lg border border-border bg-muted/30 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs text-muted-foreground">Device code</p>
+            <p
+              className="mt-1 break-all font-mono text-2xl font-semibold tracking-normal"
+              data-testid="connector-oauth-device-code"
+            >
+              {state.userCode}
+            </p>
+          </div>
+          <CopyButton
+            type="button"
+            text={state.userCode}
+            className="-m-1 p-1.5 hover:bg-accent"
+          />
+        </div>
+      </div>
+      {state.errorMessage && (
+        <p className="text-xs text-destructive" role="alert">
+          {state.errorMessage}
+        </p>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={onOpenVerificationPage}
+        data-testid="connector-oauth-device-open"
+      >
+        Open verification page
+      </Button>
+      <p className="text-xs text-muted-foreground" role="status">
+        {getOAuthDeviceAuthStatusText(state)}
+      </p>
+    </div>
+  );
+}
+
+function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
+  const state = useGet(connectorOAuthDeviceAuthState$);
+  const openVerificationPage = useSet(
+    openConnectorOAuthDeviceAuthVerificationPage$,
+  );
+  const current = state.connectorType === props.item.type ? state : null;
+  const starting = current?.status === "starting";
+
+  const start = onDomEventFn(async () => {
+    await props.connectOAuthDeviceAuthAndSettle(
+      props.item.type,
+      props.onSuccess,
+      {
+        showPermissionDialog: props.showPermissionDialogOnConnect,
+      },
+      props.signal,
+    );
+  });
+
+  if (current?.status === "starting") {
+    return (
+      <p className="text-sm text-muted-foreground">Starting connection...</p>
+    );
+  }
+
+  if (current?.status === "pending" || current?.status === "polling") {
+    return (
+      <OAuthDeviceAuthCodePanel
+        state={current}
+        onOpenVerificationPage={() => {
+          openVerificationPage(props.item.type);
+        }}
+      />
+    );
+  }
+
+  if (
+    current?.status === "denied" ||
+    current?.status === "expired" ||
+    current?.status === "error"
+  ) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-destructive" role="alert">
+          {current.message}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={start}
+          disabled={starting}
+          className="w-full"
+        >
+          {starting ? "Starting..." : "Try again"}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-muted-foreground">
+        Start the connection to get a code, then approve access on the provider
+        verification page.
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={start}
+        disabled={starting}
+        className="w-full"
+      >
+        {starting
+          ? "Starting..."
+          : `Connect ${CONNECTOR_TYPES[props.item.type].label}`}
+      </Button>
+    </div>
+  );
+}
+
 function ApiTokenConnectMethodContent(props: ConnectMethodContentProps) {
   return (
     <ApiTokenForm
@@ -717,10 +888,13 @@ function getConnectMethodContentComponent(
 ): ConnectMethodContentComponent | null {
   switch (authMethod) {
     case "oauth": {
-      if (!isOAuthAuthCodeConnectorType(item.type)) {
-        return null;
+      if (isOAuthAuthCodeConnectorType(item.type)) {
+        return OAuthAuthCodeConnectMethodContent;
       }
-      return OAuthAuthCodeConnectMethodContent;
+      if (isOAuthDeviceAuthConnectorType(item.type)) {
+        return OAuthDeviceAuthConnectMethodContent;
+      }
+      return null;
     }
     case "api-token": {
       return ApiTokenConnectMethodContent;
@@ -829,12 +1003,14 @@ function StandardConnectMethodsContent({
   onSuccess,
   showPermissionDialogOnConnect,
   connectOAuthAuthCodeAndSettle,
+  connectOAuthDeviceAuthAndSettle,
   submitApiToken,
   credentialSubmitting,
   signal,
   entries,
 }: ConnectModalContentProps & {
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
+  connectOAuthDeviceAuthAndSettle: ConnectOAuthDeviceAuthAndSettleFn;
   submitApiToken: SubmitApiTokenFn;
   credentialSubmitting: boolean;
   signal: AbortSignal;
@@ -857,6 +1033,7 @@ function StandardConnectMethodsContent({
           onSuccess,
           showPermissionDialogOnConnect,
           connectOAuthAuthCodeAndSettle,
+          connectOAuthDeviceAuthAndSettle,
           submitApiToken,
           credentialSubmitting,
           signal,
@@ -873,6 +1050,9 @@ function ConnectModalContent({
 }: ConnectModalContentProps) {
   const [settleLoadable, connectOAuthAuthCodeAndSettle] = useLoadableSet(
     connectConnectorOAuthAuthCodeAndSettle$,
+  );
+  const [, connectOAuthDeviceAuthAndSettle] = useLoadableSet(
+    connectConnectorOAuthDeviceAuthAndSettle$,
   );
   const [apiTokenLoadable, submitApiToken] = useLoadableSet(submitApiToken$);
   const [, runConnectSuccess] = useLoadableSet(runConnectorConnectSuccess$);
@@ -904,6 +1084,7 @@ function ConnectModalContent({
       onSuccess={onConnectSuccess}
       showPermissionDialogOnConnect={showPermissionDialogOnConnect}
       connectOAuthAuthCodeAndSettle={connectOAuthAuthCodeAndSettle}
+      connectOAuthDeviceAuthAndSettle={connectOAuthDeviceAuthAndSettle}
       submitApiToken={submitApiToken}
       credentialSubmitting={credentialSubmitting}
       signal={pageSignal}
@@ -928,9 +1109,11 @@ export function ConnectModal({
   const selectedType = useGet(selectedConnectorType$);
   const connectorTypes = useLastResolved(allConnectorTypes$);
   const clearConnectorCliAuth = useSet(clearConnectorCliAuth$);
+  const clearConnectorOAuthDeviceAuth = useSet(clearConnectorOAuthDeviceAuth$);
   const connectFlowType = useGet(connectFlowType$);
   const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const connectorCliAuthState = useGet(connectorCliAuthState$);
+  const connectorOAuthDeviceAuthState = useGet(connectorOAuthDeviceAuthState$);
 
   const item = connectorTypes?.find((c) => {
     return c.type === selectedType;
@@ -944,7 +1127,11 @@ export function ConnectModal({
   const connectFlowActive =
     connectFlowType === selectedType ||
     pollingType === selectedType ||
-    connectorCliAuthFlowIsActive(connectorCliAuthState, selectedType);
+    connectorCliAuthFlowIsActive(connectorCliAuthState, selectedType) ||
+    connectorOAuthDeviceAuthFlowIsActive(
+      connectorOAuthDeviceAuthState,
+      selectedType,
+    );
 
   return (
     <Dialog
@@ -952,6 +1139,7 @@ export function ConnectModal({
       onOpenChange={(open) => {
         if (!open) {
           clearConnectorCliAuth();
+          clearConnectorOAuthDeviceAuth();
           onClose();
         }
       }}
@@ -986,6 +1174,7 @@ export function ConnectModal({
           onSuccess={async () => {
             await onSuccess?.();
             clearConnectorCliAuth();
+            clearConnectorOAuthDeviceAuth();
             onClose();
           }}
         />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -56,6 +56,7 @@ import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-provider
 import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isOAuthAuthCodeConnectorType } from "@vm0/connectors/connector-utils";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
@@ -682,6 +683,10 @@ function startGoogleDriveConnectAndSync(params: {
   }
   if (!params.agentId) {
     toast.error("Agent is still loading");
+    return;
+  }
+  if (!isOAuthAuthCodeConnectorType("google-drive")) {
+    toast.error("Google Drive connection is not available");
     return;
   }
   const authWindow = window.open(

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -20,10 +20,7 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  isGoogleOAuthConnector,
-  isOAuthAuthCodeConnectorType,
-} from "@vm0/connectors/connector-utils";
+import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
@@ -42,6 +39,7 @@ import {
   selectedConnectorType$,
   setSelectedConnectorType$,
   pollingOAuthAuthCodeConnectorType$,
+  pollingOAuthDeviceAuthConnectorType$,
   justConnectedTypes$,
   LOCAL_AGENT_CONNECTOR_TYPE,
   LOCAL_BROWSER_CONNECTOR_TYPE,
@@ -52,6 +50,8 @@ import {
   setPermissionDialogType$,
   isStandaloneMode,
   matchesConnectorSearch,
+  getConfiguredConnectorAuthMethods,
+  getConnectorConnectLaunchMode,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import {
@@ -662,7 +662,8 @@ function renderBuiltinList({
 
 export function ZeroConnectorsPage() {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
-  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const [disconnectLoadable, disconnect] = useLoadableSet(disconnectConnector$);
   const signal = useGet(pageSignal$);
@@ -708,12 +709,13 @@ export function ZeroConnectorsPage() {
     const ct = allConnectors.find((c) => {
       return c.type === type;
     });
-    const canLaunchOAuthAuthCode =
-      (ct?.availableAuthMethods.includes("oauth") ?? false) &&
-      isOAuthAuthCodeConnectorType(type);
-    // Connectors without auth-code OAuth open the ConnectModal for the
-    // available non-popup method.
-    if (!canLaunchOAuthAuthCode || isGoogleOAuthConnector(type)) {
+    const launchMode = getConnectorConnectLaunchMode({
+      type,
+      availableAuthMethods:
+        ct?.availableAuthMethods ?? getConfiguredConnectorAuthMethods(type),
+      preferModalForGoogleOAuth: true,
+    });
+    if (launchMode === "modal") {
       setSelected(type);
     } else {
       detach(
@@ -738,12 +740,14 @@ export function ZeroConnectorsPage() {
 
   const renderCard = (c: ConnectorTypeWithStatus) => {
     const effectiveConnector = getEffective(c);
+    const isPolling =
+      pollingAuthCodeType === c.type || pollingDeviceAuthType === c.type;
     if (!effectiveConnector.connected) {
       return (
         <AvailableConnectorCard
           key={c.type}
           connector={effectiveConnector}
-          isPolling={pollingType === c.type}
+          isPolling={isPolling}
           onConnect={() => {
             return connectHandler(c.type);
           }}
@@ -754,7 +758,7 @@ export function ZeroConnectorsPage() {
       <GlobalConnectorCard
         key={c.type}
         connector={effectiveConnector}
-        isPolling={pollingType === c.type}
+        isPolling={isPolling}
         isDisconnecting={disconnecting}
         onConnect={() => {
           return connectHandler(c.type);

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,12 +1,12 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
-  isOAuthAuthCodeConnectorType,
 } from "@vm0/connectors/connector-utils";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
@@ -19,8 +19,13 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
   connectConnectorOAuthAuthCode$,
+  getConfiguredConnectorAuthMethods,
+  getConnectorConnectLaunchMode,
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,
+  pollingOAuthDeviceAuthConnectorType$,
+  selectedConnectorType$,
+  setSelectedConnectorType$,
   submitApiToken$,
   tokenFormSubmitting$,
   setTokenFormValue$,
@@ -45,9 +50,10 @@ import { authorizeConnector$ } from "../../signals/connectors-page/directed-auth
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
 import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
+import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
 function runDirectedConnect(params: {
-  authMethods: string[];
+  authMethods: readonly ConnectorAuthMethodType[];
   connectorType: ConnectorType;
   signal: AbortSignal;
   connect: (
@@ -56,24 +62,29 @@ function runDirectedConnect(params: {
     signal: AbortSignal,
   ) => Promise<boolean>;
   onConnected: () => Promise<void>;
+  openConnectModal: () => void;
   openTokenDialog: () => void;
 }): void {
-  const hasOAuthAuthCode =
-    params.authMethods.includes("oauth") &&
-    isOAuthAuthCodeConnectorType(params.connectorType);
+  const launchMode = getConnectorConnectLaunchMode({
+    type: params.connectorType,
+    availableAuthMethods: params.authMethods,
+  });
+  if (launchMode === "modal" && params.authMethods.includes("oauth")) {
+    params.openConnectModal();
+    return;
+  }
+
   const hasApiToken = params.authMethods.includes("api-token");
 
-  // Priority: auth-code OAuth launches the external popup; api-token opens the
-  // modal so the user can enter credentials.
-  if (!hasOAuthAuthCode && hasApiToken) {
+  if (launchMode === "modal" && hasApiToken) {
     params.openTokenDialog();
     return;
   }
-  // Device-auth OAuth needs a separate UI and must not fall through to the
-  // api-token dialog when no api-token method exists.
-  if (!hasOAuthAuthCode) {
+  if (launchMode === "modal") {
+    params.openConnectModal();
     return;
   }
+
   detach(
     (async () => {
       let connected = true;
@@ -260,11 +271,27 @@ function ConnectActions({
   );
 }
 
+function DirectedConnectModal({
+  open,
+  onClose,
+  onSuccess,
+}: {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onSuccess: () => Promise<void>;
+}) {
+  if (!open) {
+    return null;
+  }
+  return <ConnectModal onClose={onClose} onSuccess={onSuccess} />;
+}
+
 function DirectedConnectCard() {
   const type = useGet(directedConnectType$);
   const agentId = useGet(directedConnectAgentId$);
   const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
-  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
@@ -272,6 +299,8 @@ function DirectedConnectCard() {
   const allLoadable = useLastLoadable(allConnectorTypes$);
   const tokenDialogOpen = useGet(tokenDialogOpen$);
   const setTokenDialogOpen = useSet(setTokenDialogOpen$);
+  const selectedConnectorType = useGet(selectedConnectorType$);
+  const setSelectedConnectorType = useSet(setSelectedConnectorType$);
 
   if (!type || !(type in CONNECTOR_TYPES)) {
     return null;
@@ -283,7 +312,9 @@ function DirectedConnectCard() {
     agentNameLoadable.state === "hasData" && agentNameLoadable.data
       ? agentNameLoadable.data
       : "Zero";
-  const isConnecting = pollingType === connectorType;
+  const isConnecting =
+    pollingAuthCodeType === connectorType ||
+    pollingDeviceAuthType === connectorType;
   const isLoading =
     !justConnected.has(connectorType) && allLoadable.state === "loading";
   const allData = allLoadable.state === "hasData" ? allLoadable.data : [];
@@ -293,11 +324,9 @@ function DirectedConnectCard() {
   const isConnected =
     justConnected.has(connectorType) || (item?.connected ?? false);
   const authMethods =
-    item?.availableAuthMethods ?? Object.keys(config.authMethods);
-  const canConnect =
-    authMethods.includes("api-token") ||
-    (authMethods.includes("oauth") &&
-      isOAuthAuthCodeConnectorType(connectorType));
+    item?.availableAuthMethods ??
+    getConfiguredConnectorAuthMethods(connectorType);
+  const canConnect = authMethods.length > 0;
 
   const runPostConnectActions = async () => {
     if (agentId) {
@@ -317,6 +346,9 @@ function DirectedConnectCard() {
       onConnected: runPostConnectActions,
       openTokenDialog: () => {
         return setTokenDialogOpen(true);
+      },
+      openConnectModal: () => {
+        setSelectedConnectorType(connectorType);
       },
     });
   };
@@ -376,6 +408,13 @@ function DirectedConnectCard() {
               }
             : undefined
         }
+      />
+      <DirectedConnectModal
+        open={selectedConnectorType === connectorType}
+        onClose={() => {
+          setSelectedConnectorType(null);
+        }}
+        onSuccess={runPostConnectActions}
       />
     </>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -16,11 +16,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import {
-  getConnectorTags,
-  isGoogleOAuthConnector,
-  isOAuthAuthCodeConnectorType,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorTags } from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   zeroWorkspaceName$,
@@ -51,9 +47,12 @@ import {
   connectConnectorOAuthAuthCode$,
   matchesConnectorSearch,
   pollingOAuthAuthCodeConnectorType$,
+  pollingOAuthDeviceAuthConnectorType$,
   selectedConnectorType$,
   setSelectedConnectorType$,
   setPermissionDialogType$,
+  getConfiguredConnectorAuthMethods,
+  getConnectorConnectLaunchMode,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -226,7 +225,8 @@ function ConnectStepContent() {
   const effectiveConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
   const connectorTypesLoadable = useLastLoadable(allConnectorTypes$);
-  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const setSelectedConnector = useSet(setSelectedConnectorType$);
   const clearPermissionDialog = useSet(setPermissionDialogType$);
@@ -262,15 +262,14 @@ function ConnectStepContent() {
     if (connector?.connected) {
       return;
     }
-    const hasAvailableOAuth =
-      connector?.availableAuthMethods.includes("oauth") ?? true;
-    const canLaunchOAuthAuthCode =
-      hasAvailableOAuth && isOAuthAuthCodeConnectorType(type);
-    if (
-      !canLaunchOAuthAuthCode ||
-      connector?.availableAuthMethods.includes("api-token") ||
-      isGoogleOAuthConnector(type)
-    ) {
+    const launchMode = getConnectorConnectLaunchMode({
+      type,
+      availableAuthMethods:
+        connector?.availableAuthMethods ??
+        getConfiguredConnectorAuthMethods(type),
+      preferModalForGoogleOAuth: true,
+    });
+    if (launchMode === "modal") {
       setSelectedConnector(type);
     } else {
       detach(
@@ -307,7 +306,8 @@ function ConnectStepContent() {
         <div className="w-full flex flex-col gap-3">
           {selectedEntries.map(([type, config]) => {
             const isConnected = connectedSet.has(type);
-            const isPolling = pollingType === type;
+            const isPolling =
+              pollingAuthCodeType === type || pollingDeviceAuthType === type;
             return (
               <div
                 key={type}


### PR DESCRIPTION
## Summary
- add independent OAuth device authorization state, start/poll commands, and ConnectModal UI
- route connectors page, onboarding, and directed connect through a shared launch boundary so device auth shows a code before provider navigation
- add platform mock handlers and integration coverage for complete, pending interval updates, terminal states, fallback verification URIs, close cleanup, and directed-connect agent authorization

Closes #14424

## Tests
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm knip
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
- pre-commit hook: prettier, knip --cache, turbo run check-types --concurrency=1