### PR TITLE
fix: log built-in generation failure details

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { providerFailureDetailsForLog } from "../webhooks-built-in-generations";
+
+describe("providerFailureDetailsForLog", () => {
+  it("extracts common top-level provider failure fields", () => {
+    expect(
+      providerFailureDetailsForLog({
+        status: "failed",
+        reason: "content policy rejected the prompt",
+        error_code: "CONTENT_POLICY",
+        logs: ["validation failed", "retry not allowed"],
+      }),
+    ).toStrictEqual({
+      reason: "content policy rejected the prompt",
+      errorCode: "CONTENT_POLICY",
+      logs: "validation failed\nretry not allowed",
+    });
+  });
+
+  it("extracts nested Fal response failure fields", () => {
+    expect(
+      providerFailureDetailsForLog({
+        status: "ERROR",
+        response: {
+          error: {
+            message: "upstream worker timed out",
+            code: "TIMEOUT",
+          },
+        },
+      }),
+    ).toStrictEqual({
+      error: "upstream worker timed out",
+    });
+  });
+
+  it("extracts nested BytePlus payload failure fields", () => {
+    expect(
+      providerFailureDetailsForLog({
+        status: "failed",
+        data: {
+          error_message: "model capacity exceeded",
+          status_message: "no worker available",
+        },
+      }),
+    ).toStrictEqual({
+      errorMessage: "model capacity exceeded",
+      statusMessage: "no worker available",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -218,6 +218,98 @@ function bytePlusPayloadBody(payload: unknown): {
   };
 }
 
+const PROVIDER_FAILURE_DETAIL_KEYS = [
+  "reason",
+  "failure_reason",
+  "failureReason",
+  "error",
+  "error_message",
+  "errorMessage",
+  "message",
+  "detail",
+  "description",
+  "status_message",
+  "statusMessage",
+  "err_msg",
+  "code",
+  "error_code",
+  "errorCode",
+  "logs",
+] as const;
+
+const PROVIDER_FAILURE_FIELD_ALIASES: ReadonlyMap<string, string> = new Map([
+  ["failure_reason", "failureReason"],
+  ["error_message", "errorMessage"],
+  ["status_message", "statusMessage"],
+  ["err_msg", "errorMessage"],
+  ["error_code", "errorCode"],
+]);
+
+function providerFailureLogKey(key: string): string {
+  return PROVIDER_FAILURE_FIELD_ALIASES.get(key) ?? key;
+}
+
+function truncateProviderFailureDetail(value: string): string {
+  const maxLength = 1000;
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function stringifyProviderFailureDetail(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value ? truncateProviderFailureDetail(value) : undefined;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    const text = value
+      .map((item) => stringifyProviderFailureDetail(item))
+      .filter((item): item is string => Boolean(item))
+      .join("\n");
+    return text ? truncateProviderFailureDetail(text) : undefined;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  for (const key of PROVIDER_FAILURE_DETAIL_KEYS) {
+    const detail = stringifyProviderFailureDetail(value[key]);
+    if (detail) {
+      return detail;
+    }
+  }
+  try {
+    return truncateProviderFailureDetail(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
+export function providerFailureDetailsForLog(
+  payload: unknown,
+): Record<string, string> {
+  if (!isRecord(payload)) {
+    return {};
+  }
+  const details: Record<string, string> = {};
+  for (const source of [
+    payload,
+    payload.payload,
+    payload.data,
+    payload.response,
+  ]) {
+    if (!isRecord(source)) {
+      continue;
+    }
+    for (const key of PROVIDER_FAILURE_DETAIL_KEYS) {
+      const value = stringifyProviderFailureDetail(source[key]);
+      if (value) {
+        details[providerFailureLogKey(key)] ??= value;
+      }
+    }
+  }
+  return details;
+}
+
 const handleFalImageCompletion$ = command(
   async (
     { get, set },
@@ -531,11 +623,13 @@ const postFalBuiltInGenerationWebhook$ = command(
 
     const status = payload.status?.toUpperCase();
     if (status === "ERROR" || status === "FAILED") {
+      const failureDetails = providerFailureDetailsForLog(parsed);
       L.warn("Fal built-in generation webhook reported failed generation", {
         generationId: job.id,
         type: job.type,
         status: payload.status,
         visualKey: query.visualKey,
+        ...failureDetails,
       });
       await set(
         failBuiltInGenerationJob$,
@@ -640,6 +734,7 @@ const postBytePlusBuiltInGenerationWebhook$ = command(
     }
 
     if (status === "failed" || status === "expired") {
+      const failureDetails = providerFailureDetailsForLog(parsed);
       L.warn(
         "BytePlus built-in generation webhook reported failed generation",
         {
@@ -647,6 +742,7 @@ const postBytePlusBuiltInGenerationWebhook$ = command(
           type: job.type,
           status: payload.status,
           visualKey: query.visualKey,
+          ...failureDetails,
         },
       );
       await set(

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -7,7 +7,7 @@ import {
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
 import type { RouteEntry } from "../route";
-import { safeJsonParse } from "../utils";
+import { safeJsonParse, safeSync } from "../utils";
 import {
   downloadFalImage,
   getMissingImagePricing,
@@ -237,16 +237,27 @@ const PROVIDER_FAILURE_DETAIL_KEYS = [
   "logs",
 ] as const;
 
-const PROVIDER_FAILURE_FIELD_ALIASES: ReadonlyMap<string, string> = new Map([
-  ["failure_reason", "failureReason"],
-  ["error_message", "errorMessage"],
-  ["status_message", "statusMessage"],
-  ["err_msg", "errorMessage"],
-  ["error_code", "errorCode"],
-]);
-
 function providerFailureLogKey(key: string): string {
-  return PROVIDER_FAILURE_FIELD_ALIASES.get(key) ?? key;
+  switch (key) {
+    case "failure_reason": {
+      return "failureReason";
+    }
+    case "error_message": {
+      return "errorMessage";
+    }
+    case "err_msg": {
+      return "errorMessage";
+    }
+    case "status_message": {
+      return "statusMessage";
+    }
+    case "error_code": {
+      return "errorCode";
+    }
+    default: {
+      return key;
+    }
+  }
 }
 
 function truncateProviderFailureDetail(value: string): string {
@@ -263,8 +274,12 @@ function stringifyProviderFailureDetail(value: unknown): string | undefined {
   }
   if (Array.isArray(value)) {
     const text = value
-      .map((item) => stringifyProviderFailureDetail(item))
-      .filter((item): item is string => Boolean(item))
+      .map((item) => {
+        return stringifyProviderFailureDetail(item);
+      })
+      .filter((item): item is string => {
+        return Boolean(item);
+      })
       .join("\n");
     return text ? truncateProviderFailureDetail(text) : undefined;
   }
@@ -277,11 +292,12 @@ function stringifyProviderFailureDetail(value: unknown): string | undefined {
       return detail;
     }
   }
-  try {
-    return truncateProviderFailureDetail(JSON.stringify(value));
-  } catch {
-    return undefined;
-  }
+  const serialized = safeSync(() => {
+    return JSON.stringify(value);
+  });
+  return "ok" in serialized
+    ? truncateProviderFailureDetail(serialized.ok)
+    : undefined;
 }
 
 export function providerFailureDetailsForLog(


### PR DESCRIPTION
## Summary
- extract common provider failure details from Fal and BytePlus built-in generation webhook payloads
- include those details in failed generation warning logs
- add coverage for top-level and nested provider failure fields

## Tests
- pnpm --dir apps/api exec oxlint src/signals/routes/webhooks-built-in-generations.ts src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
- pnpm --dir apps/api exec vitest run src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
- NODE_OPTIONS=--max-old-space-size=6144 pnpm -F api check-types

Note: running `pnpm -F api check-types` without increased heap OOMed locally near the default Node heap limit; it passed with `--max-old-space-size=6144`.
