### PR TITLE
fix(mitm-addon): safe merge for WebSocket OpenAI Responses billing usage

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -204,7 +204,7 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     if not isinstance(usage_target, dict):
         usage_target = {}
         flow.metadata["model_provider_usage"] = usage_target
-    usage_target.update(usage_result)
+    usage.merge_openai_responses_usage_result(usage_target, usage_result)
 
 
 def finalize_x_json_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -34,6 +34,7 @@ from .openai_responses import (
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event_json,
     extract_openai_responses_usage_from_json,
+    merge_openai_responses_usage_result,
 )
 from .providers.connectors import report_connector_usage, x
 from .providers.model_provider import report_model_provider_usage
@@ -48,6 +49,7 @@ __all__ = [
     "extract_openai_responses_usage_from_event_json",
     "extract_openai_responses_usage_from_json",
     "increment_in_flight_flows",
+    "merge_openai_responses_usage_result",
     "report_connector_usage",
     "report_model_provider_usage",
     "set_pending_path",

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -251,3 +251,29 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
     ):
         return None
     return usage
+
+
+_OPENAI_RESPONSES_USAGE_CATEGORIES = (
+    MODEL_USAGE_CATEGORY_INPUT,
+    MODEL_USAGE_CATEGORY_OUTPUT,
+    MODEL_USAGE_CATEGORY_CACHE_READ,
+)
+
+
+def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
+    """Merge an OpenAI Responses usage extraction result into a target dict.
+
+    - copy/update non-empty 'model' and 'message_id' strings from 'source'
+    - for a local OpenAI Responses category tuple, call the existing '_store_quantity' rule
+    """
+    model = source.get("model")
+    if isinstance(model, str) and model:
+        target["model"] = model
+
+    message_id = source.get("message_id")
+    if isinstance(message_id, str) and message_id:
+        target["message_id"] = message_id
+
+    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
+        _store_quantity(target, category, source.get(category))
+

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -140,3 +140,152 @@ def test_clamps_cached_tokens_to_total_input_tokens():
         "tokens.output": 5,
         "tokens.cache_read": 10,
     }
+
+
+from response_streaming import feed_model_websocket_usage
+
+class MockFlow:
+    def __init__(self, metadata=None):
+        self.metadata = metadata or {}
+
+
+def test_feed_websocket_usage_retains_positive_tokens_on_subsequent_zero():
+    flow = MockFlow(metadata={"model_websocket_usage_enabled": True})
+    
+    # First frame: positive usage
+    frame_1 = json.dumps({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-5.5",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 40,
+                "input_tokens_details": {"cached_tokens": 25},
+            }
+        }
+    })
+    
+    # Second frame: zero usage
+    frame_2 = json.dumps({
+        "type": "response.done",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-5.5",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        }
+    })
+    
+    feed_model_websocket_usage(flow, frame_1)
+    assert flow.metadata["model_provider_usage"] == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 75,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+    
+    feed_model_websocket_usage(flow, frame_2)
+    # The non-zero usage must be retained!
+    assert flow.metadata["model_provider_usage"] == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 75,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+
+
+def test_feed_websocket_usage_allows_zero_then_positive():
+    flow = MockFlow(metadata={"model_websocket_usage_enabled": True})
+    
+    # First frame: zero usage
+    frame_1 = json.dumps({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-5.5",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        }
+    })
+    
+    # Second frame: positive usage
+    frame_2 = json.dumps({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-5.5",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 40,
+            }
+        }
+    })
+    
+    feed_model_websocket_usage(flow, frame_1)
+    assert flow.metadata["model_provider_usage"] == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 0,
+        "tokens.output": 0,
+    }
+    
+    feed_model_websocket_usage(flow, frame_2)
+    assert flow.metadata["model_provider_usage"] == {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.input": 100,
+        "tokens.output": 40,
+    }
+
+
+def test_feed_websocket_usage_supports_str_content():
+    flow = MockFlow(metadata={"model_websocket_usage_enabled": True})
+    frame = json.dumps({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-5.5",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 40,
+            }
+        }
+    })
+    # Pass as str
+    feed_model_websocket_usage(flow, frame)
+    assert flow.metadata["model_provider_usage"]["tokens.input"] == 100
+
+
+def test_feed_websocket_usage_ignores_malformed_json_without_raising():
+    flow = MockFlow(metadata={"model_websocket_usage_enabled": True})
+    feed_model_websocket_usage(flow, b'{"type":"response.completed"')
+    assert "model_provider_usage" not in flow.metadata
+
+
+def test_feed_websocket_usage_overwrites_preexisting_non_dict():
+    flow = MockFlow(metadata={
+        "model_websocket_usage_enabled": True,
+        "model_provider_usage": "not-a-dict",
+    })
+    frame = json.dumps({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-5.5",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 40,
+            }
+        }
+    })
+    feed_model_websocket_usage(flow, frame)
+    assert isinstance(flow.metadata["model_provider_usage"], dict)
+    assert flow.metadata["model_provider_usage"]["tokens.input"] == 100
+

--- a/crates/runner/mitm-addon/tests/test_openai_responses_merge.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_merge.py
@@ -1,0 +1,95 @@
+"""Tests for merging OpenAI Responses usage extraction results."""
+
+from usage import merge_openai_responses_usage_result
+
+
+def test_merge_copies_model_and_message_id():
+    target = {}
+    source = {
+        "model": "gpt-5.5",
+        "message_id": "resp_1",
+    }
+    merge_openai_responses_usage_result(target, source)
+    assert target == {
+        "model": "gpt-5.5",
+        "message_id": "resp_1",
+    }
+
+
+def test_merge_ignores_empty_model_and_message_id():
+    target = {
+        "model": "gpt-5.5",
+        "message_id": "resp_1",
+    }
+    source = {
+        "model": "",
+        "message_id": "",
+    }
+    merge_openai_responses_usage_result(target, source)
+    assert target == {
+        "model": "gpt-5.5",
+        "message_id": "resp_1",
+    }
+
+
+def test_merge_allows_positive_tokens_to_replace_prior():
+    target = {
+        "tokens.input": 50,
+        "tokens.output": 20,
+    }
+    source = {
+        "tokens.input": 100,
+        "tokens.output": 40,
+    }
+    merge_openai_responses_usage_result(target, source)
+    assert target == {
+        "tokens.input": 100,
+        "tokens.output": 40,
+    }
+
+
+def test_merge_preserves_existing_positive_tokens_when_source_is_zero():
+    target = {
+        "tokens.input": 100,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+    source = {
+        "tokens.input": 0,
+        "tokens.output": 0,
+        "tokens.cache_read": 0,
+    }
+    merge_openai_responses_usage_result(target, source)
+    assert target == {
+        "tokens.input": 100,
+        "tokens.output": 40,
+        "tokens.cache_read": 25,
+    }
+
+
+def test_merge_allows_zero_to_initialize_when_absent():
+    target = {}
+    source = {
+        "tokens.input": 0,
+        "tokens.output": 0,
+    }
+    merge_openai_responses_usage_result(target, source)
+    assert target == {
+        "tokens.input": 0,
+        "tokens.output": 0,
+    }
+
+
+def test_merge_only_applies_openai_categories():
+    target = {
+        "tokens.cache_creation": 15,
+    }
+    source = {
+        "tokens.input": 50,
+        "tokens.cache_creation": 99,  # Non-OpenAI category, should be ignored by the merge
+    }
+    merge_openai_responses_usage_result(target, source)
+    assert target == {
+        "tokens.input": 50,
+        "tokens.cache_creation": 15,  # Preserved, not overwritten or updated by Anthropic specific key in source
+    }


### PR DESCRIPTION
### Problem
In `feed_model_websocket_usage`, per-frame WebSocket usage results are merged via `usage_target.update(usage_result)`. Since `usage_result` constructs a fresh per-frame dict for each frame, late frames carrying zero usage counts (e.g., `response.done`) overwrite earlier positive counts (e.g., `response.completed`). This causes the aggregated `flow.metadata["model_provider_usage"]` to lose positive token counts, silently under-billing runs.

### Solution
1. Added a parser-owned merge helper `merge_openai_responses_usage_result` in `crates/runner/mitm-addon/src/usage/openai_responses.py`.
   - Copies and updates non-empty `model` and `message_id` from the source.
   - For OpenAI Responses categories (`MODEL_USAGE_CATEGORY_INPUT`, `MODEL_USAGE_CATEGORY_OUTPUT`, `MODEL_USAGE_CATEGORY_CACHE_READ`), it calls the existing `_store_quantity` rule:
     - Positive values update the target.
     - Zero values preserve pre-existing positive target values.
     - Allows zero to initialize the category only when it is absent (matching SSE behavior).
2. Exported `merge_openai_responses_usage_result` in `usage/__init__.py`.
3. Replaced `usage_target.update(usage_result)` with `usage.merge_openai_responses_usage_result(usage_target, usage_result)` in `feed_model_websocket_usage`.
4. Added comprehensive test coverage:
   - Unit tests covering merge edge cases in `tests/test_openai_responses_merge.py`.
   - Flow-level integration tests in `tests/test_openai_responses_event_json.py` driving multiple frames through `feed_model_websocket_usage`.

All tests pass perfectly!
