### PR TITLE
fix(api): align Seedance first-frame requests

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -823,6 +823,102 @@ describe("POST /api/zero/video-io/generate", () => {
     });
   });
 
+  it("submits a single Dreamina first-frame image without a frame role", async () => {
+    const fixture = await track(seedVideoFixture({ withPricing: true }));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+      },
+      context.signal,
+    );
+
+    let observedBody: unknown = null;
+    server.use(
+      http.post(BYTEPLUS_VIDEO_TASKS_URL, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          id: "dreamina-video-task",
+          status: "queued",
+        });
+      }),
+      http.get(BYTEPLUS_VIDEO_URL, () => {
+        return new HttpResponse(VIDEO_BYTES, {
+          headers: { "content-type": "video/mp4" },
+        });
+      }),
+    );
+
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId,
+    });
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/video-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        prompt: "animate the photo with natural motion",
+        model: "dreamina-seedance-2.0",
+        duration: "6s",
+        resolution: "720p",
+        aspectRatio: "4:3",
+        firstFrameImageUrl: "https://example.com/first.png",
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const callbackUrl = readCallbackUrl(observedBody);
+
+    await postBytePlusWebhook(app, callbackUrl, {
+      id: "dreamina-video-task",
+      status: "succeeded",
+      content: {
+        video_url: {
+          url: BYTEPLUS_VIDEO_URL,
+          content_type: "video/mp4",
+        },
+      },
+      usage: {
+        completion_tokens: 100_000,
+      },
+    });
+    await clearAllDetached();
+
+    expect(observedBody).toMatchObject({
+      model: "dreamina-seedance-2-0-260128",
+      resolution: "720p",
+      ratio: "4:3",
+      duration: 6,
+      generate_audio: true,
+      content: [
+        {
+          type: "text",
+          text: "animate the photo with natural motion",
+        },
+        {
+          type: "image_url",
+          image_url: { url: "https://example.com/first.png" },
+        },
+      ],
+    });
+    const content = asRecord(observedBody).content;
+    expect(Array.isArray(content)).toBeTruthy();
+    if (!Array.isArray(content)) {
+      throw new Error("Expected BytePlus content array");
+    }
+    expect(asRecord(content[1]).role).toBeUndefined();
+  });
+
   it("submits multimodal Dreamina references and charges with-video pricing", async () => {
     const fixture = await track(seedVideoFixture({ credits: 10_000 }));
     await upsertDefaultVideoPricingRows();

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -444,7 +444,7 @@ type BytePlusContent =
   | {
       readonly type: "image_url";
       readonly image_url: { readonly url: string };
-      readonly role: "first_frame" | "last_frame" | "reference_image";
+      readonly role?: "first_frame" | "last_frame" | "reference_image";
     }
   | {
       readonly type: "video_url";
@@ -1084,11 +1084,13 @@ function bytePlusVideoContent(
       text: options.prompt,
     },
   ];
+  const hasFirstAndLastFrame =
+    Boolean(options.firstFrameImageUrl) && Boolean(options.lastFrameImageUrl);
   if (options.firstFrameImageUrl) {
     content.push({
       type: "image_url",
       image_url: { url: options.firstFrameImageUrl },
-      role: "first_frame",
+      ...(hasFirstAndLastFrame ? { role: "first_frame" } : {}),
     });
   }
   if (options.lastFrameImageUrl) {


### PR DESCRIPTION
## Summary
- Align BytePlus Seedance single first-frame image requests with the official API examples by omitting the frame role when only one first-frame image is provided.
- Keep explicit first_frame / last_frame roles for strict first-and-last-frame generation.
- Add regression coverage for the single first-frame request body.

## Context
BytePlus docs show single first-frame image-to-video requests as a plain image_url content item, while first-and-last-frame requests use role: first_frame and role: last_frame.

Docs checked:
- https://docs.byteplus.com/api/docs/ModelArk/2298881
- https://docs.byteplus.com/api/docs/ModelArk/2291680

## Verification
- pnpm exec prettier --write apps/api/src/signals/services/zero-video-io-generate.service.ts apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
- pnpm -F api lint
- NODE_OPTIONS=--max-old-space-size=6144 pnpm -F api check-types
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-video-io-generate.test.ts

Note: an initial target test run failed before DB migrations because the fresh local Postgres database had no schema; after running migrations, the target test file passed.