### PR TITLE
fix: improve mobile chat artifacts and video previews

### DIFF
--- a/turbo/.gitignore
+++ b/turbo/.gitignore
@@ -49,6 +49,7 @@ yarn-error.log*
 
 # Dev server files (written by /dev-start, read by /dev-logs)
 .dev-task-id
+.dev-process-pid
 .dev-server.log
 .dev-tunnel-url
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -637,6 +637,7 @@ describe("POST /api/zero/image-io/generate", () => {
   let releasePendingFalResponse: (() => void) | null = null;
 
   beforeEach(() => {
+    mockEnv("VM0_API_URL", WEB_ORIGIN);
     mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     context.mocks.clerk.authenticateRequest.mockReset();
     context.mocks.clerk.authenticateRequest.mockResolvedValue({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -460,6 +460,7 @@ describe("POST /api/zero/video-io/generate", () => {
   );
 
   beforeEach(() => {
+    mockEnv("VM0_API_URL", WEB_ORIGIN);
     mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     context.mocks.clerk.authenticateRequest.mockReset();
     context.mocks.clerk.authenticateRequest.mockResolvedValue({

--- a/turbo/apps/api/src/signals/services/built-in-generation-provider-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-generation-provider-webhooks.service.ts
@@ -54,7 +54,7 @@ export function falBuiltInGenerationWebhookUrl(args: {
 }): string {
   const baseUrl = new URL(
     `/api/webhooks/built-in-generations/fal/${args.generationId}`,
-    env("VM0_WEB_URL"),
+    env("VM0_API_URL"),
   );
   baseUrl.searchParams.set(
     "token",
@@ -76,7 +76,7 @@ export function bytePlusBuiltInGenerationWebhookUrl(args: {
 }): string {
   const baseUrl = new URL(
     `/api/webhooks/built-in-generations/byteplus/${args.generationId}`,
-    env("VM0_WEB_URL"),
+    env("VM0_API_URL"),
   );
   baseUrl.searchParams.set(
     "token",

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -15,6 +15,11 @@ type AttachmentLightboxState =
       kind: "markdown" | "text" | "json" | "csv" | "html" | "pdf";
       url: string;
       filename: string;
+    }
+  | {
+      kind: "video";
+      url: string;
+      filename: string;
     };
 
 const internalLightboxState$ = state<AttachmentLightboxState | null>(null);
@@ -37,6 +42,18 @@ export const openDocumentLightbox$ = command(
     },
   ) => {
     set(internalLightboxState$, value);
+  },
+);
+
+export const openVideoLightbox$ = command(
+  (
+    { set },
+    value: {
+      url: string;
+      filename: string;
+    },
+  ) => {
+    set(internalLightboxState$, { kind: "video", ...value });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -135,20 +135,20 @@ describe("attachment preview component", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("should render video preview for .mp4 files", () => {
+  it("should render video thumbnail for .mp4 files", () => {
     renderPreview({
       filename: "video.mp4",
       url: "https://example.com/video.mp4",
     });
     const preview = screen.getByTestId("attachment-preview-video");
+    const video = preview.querySelector("video");
+
     expect(preview).toBeInTheDocument();
     expect(
-      screen.getByLabelText("Video preview for video.mp4"),
-    ).toHaveAttribute("src", "https://example.com/video.mp4");
-    expect(screen.getByLabelText("Download video.mp4")).toHaveAttribute(
-      "type",
-      "button",
-    );
+      screen.getByLabelText("Open video preview for video.mp4"),
+    ).toHaveAttribute("type", "button");
+    expect(video?.getAttribute("src")).toBe("https://example.com/video.mp4");
+    expect(video?.hasAttribute("controls")).toBeFalsy();
   });
 
   it("should render a thumbnail preview block for non-inline upload file types", () => {
@@ -259,10 +259,9 @@ describe("attachment preview component", () => {
       contentType: "video/mp4",
     });
     expect(screen.getByTestId("attachment-preview-video")).toBeInTheDocument();
-    expect(screen.getByLabelText("Video preview for clip")).toHaveAttribute(
-      "src",
-      "https://example.com/clip",
-    );
+    expect(
+      screen.getByLabelText("Open video preview for clip"),
+    ).toHaveAttribute("type", "button");
   });
 
   // Charset suffix

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -135,12 +135,20 @@ describe("attachment preview component", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("should render null for video files (.mp4)", () => {
-    const { container } = renderPreview({
+  it("should render video preview for .mp4 files", () => {
+    renderPreview({
       filename: "video.mp4",
       url: "https://example.com/video.mp4",
     });
-    expect(container).toBeEmptyDOMElement();
+    const preview = screen.getByTestId("attachment-preview-video");
+    expect(preview).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Video preview for video.mp4"),
+    ).toHaveAttribute("src", "https://example.com/video.mp4");
+    expect(screen.getByLabelText("Download video.mp4")).toHaveAttribute(
+      "type",
+      "button",
+    );
   });
 
   it("should render a thumbnail preview block for non-inline upload file types", () => {
@@ -244,13 +252,17 @@ describe("attachment preview component", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("should return null for video content-type when filename has no extension", () => {
-    const { container } = renderPreview({
+  it("should classify by content-type video/mp4 when filename has no extension", () => {
+    renderPreview({
       filename: "clip",
       url: "https://example.com/clip",
       contentType: "video/mp4",
     });
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByTestId("attachment-preview-video")).toBeInTheDocument();
+    expect(screen.getByLabelText("Video preview for clip")).toHaveAttribute(
+      "src",
+      "https://example.com/clip",
+    );
   });
 
   // Charset suffix

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -839,9 +839,9 @@ describe("zero chat thread page display - body link document preview", () => {
   });
 });
 
-// CHAT-D-065: Video attachments render as playable previews with download.
+// CHAT-D-065: Video attachments render as poster buttons and open playback preview.
 describe("zero chat thread page display - attachment video preview", () => {
-  it("renders an mp4 attachment with a preview cover and download button", async () => {
+  it("renders an mp4 attachment poster and opens an autoplaying preview", async () => {
     const videoUrl = "https://example.com/clip.mp4";
     mockChatLifecycle({
       chatMessages: [
@@ -855,23 +855,35 @@ describe("zero chat thread page display - attachment video preview", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
-    const preview = await waitFor(() => {
-      return screen.getByTestId("attachment-preview-video");
+    const previewButton = await waitFor(() => {
+      return screen.getByLabelText("Preview clip.mp4");
     });
-    const video = screen.getByLabelText("Video preview for clip.mp4");
-    const download = screen.getByLabelText("Download clip.mp4");
+    const posterVideo = previewButton.querySelector("video");
 
-    expect(preview).toBeInTheDocument();
     expect(
-      within(preview).getByTestId("attachment-preview-video-icon"),
+      within(previewButton).getByTestId("chat-video-preview-poster"),
     ).toBeInTheDocument();
-    expect(video).toHaveAttribute("src", videoUrl);
-    expect(video).toHaveAttribute("preload", "metadata");
-    expect(download).toHaveAttribute("type", "button");
-    expect(download).not.toHaveAttribute("href");
+    expect(posterVideo?.getAttribute("src")).toBe(videoUrl);
+    expect(posterVideo?.hasAttribute("controls")).toBeFalsy();
+    expect(
+      screen.queryByLabelText("Video preview for clip.mp4"),
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector(`img[src="${videoUrl}"]`),
     ).not.toBeInTheDocument();
+
+    await userEvent.click(previewButton);
+
+    const lightbox = await waitFor(() => {
+      return screen.getByTestId("attachment-lightbox");
+    });
+    const video = within(lightbox).getByLabelText("Video preview for clip.mp4");
+
+    expect(video).toHaveAttribute("src", videoUrl);
+    expect(video).toHaveAttribute("controls");
+    expect((video as HTMLVideoElement).autoplay).toBeTruthy();
+    expect(within(lightbox).getByLabelText("Copy link")).toBeInTheDocument();
+    expect(within(lightbox).getByLabelText("Download")).toBeInTheDocument();
   });
 });
 
@@ -1186,6 +1198,9 @@ describe("zero chat thread page display - artifacts drawer", () => {
       expect(screen.getByText("Artifacts")).toBeInTheDocument();
       expect(screen.getAllByText("mobile.zip").length).toBeGreaterThan(0);
     });
+    expect(screen.getByRole("dialog", { name: "Artifacts" })).toHaveClass(
+      "max-w-[100vw]",
+    );
   });
 
   it("renders markdown artifacts through the text loader instead of an iframe", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -839,9 +839,9 @@ describe("zero chat thread page display - body link document preview", () => {
   });
 });
 
-// CHAT-D-065: Video attachments render as compact download chips.
-describe("zero chat thread page display - attachment video chip", () => {
-  it("renders a compact download chip for mp4 attachments", async () => {
+// CHAT-D-065: Video attachments render as playable previews with download.
+describe("zero chat thread page display - attachment video preview", () => {
+  it("renders an mp4 attachment with a preview cover and download button", async () => {
     const videoUrl = "https://example.com/clip.mp4";
     mockChatLifecycle({
       chatMessages: [
@@ -855,20 +855,22 @@ describe("zero chat thread page display - attachment video chip", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
-    const download = await waitFor(() => {
-      return screen.getByLabelText("Download clip.mp4");
+    const preview = await waitFor(() => {
+      return screen.getByTestId("attachment-preview-video");
     });
+    const video = screen.getByLabelText("Video preview for clip.mp4");
+    const download = screen.getByLabelText("Download clip.mp4");
 
+    expect(preview).toBeInTheDocument();
+    expect(
+      within(preview).getByTestId("attachment-preview-video-icon"),
+    ).toBeInTheDocument();
+    expect(video).toHaveAttribute("src", videoUrl);
+    expect(video).toHaveAttribute("preload", "metadata");
     expect(download).toHaveAttribute("type", "button");
     expect(download).not.toHaveAttribute("href");
     expect(
-      within(download).getByTestId("attachment-chip-file-icon"),
-    ).toBeInTheDocument();
-    expect(
       document.querySelector(`img[src="${videoUrl}"]`),
-    ).not.toBeInTheDocument();
-    expect(
-      document.querySelector(`video[src="${videoUrl}"]`),
     ).not.toBeInTheDocument();
   });
 });
@@ -1133,6 +1135,56 @@ describe("zero chat thread page display - artifacts drawer", () => {
       expect(within(table).getByText("value")).toBeInTheDocument();
       expect(within(table).getByText("alpha")).toBeInTheDocument();
       expect(within(table).getByText("1")).toBeInTheDocument();
+    });
+  });
+
+  it("opens artifacts from the mobile top bar icon", async () => {
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create a file",
+          runId: "run-mobile-artifacts",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-mobile-artifacts",
+              files: [
+                {
+                  id: "file-mobile",
+                  filename: "mobile.zip",
+                  contentType: "application/zip",
+                  size: 512,
+                  url: "https://example.com/mobile.zip",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Open mobile artifacts");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Artifacts")).toBeInTheDocument();
+      expect(screen.getAllByText("mobile.zip").length).toBeGreaterThan(0);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -8,6 +8,7 @@ import {
 } from "ccstate-react";
 import {
   IconMenu2,
+  IconPackage,
   IconPlus,
   IconUserPlus,
   IconVolume2,
@@ -21,6 +22,11 @@ import {
   currentChatAgentId$,
   earliestUnreadEndedThread$,
 } from "../../signals/agent-chat.ts";
+import {
+  currentLeftThread$,
+  currentRightThread$,
+} from "../../signals/chat-page/chat-thread-panes.ts";
+import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
@@ -179,6 +185,42 @@ function NewOrUnreadChatButtonLeaf() {
   );
 }
 
+function MobileArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
+  const open = useGet(thread.artifactsDrawerOpen$);
+  const setOpen = useSet(thread.setArtifactsDrawerOpen$);
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setOpen(true);
+      }}
+      className={cn(
+        "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors",
+        open
+          ? "bg-primary/10 text-primary"
+          : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+      )}
+      aria-label="Open mobile artifacts"
+      aria-pressed={open}
+    >
+      <IconPackage size={16} stroke={1.5} />
+    </button>
+  );
+}
+
+function MobileArtifactsButtonLeaf() {
+  const leftThread = useGet(currentLeftThread$);
+  const rightThread = useGet(currentRightThread$);
+  const thread = leftThread ?? rightThread;
+
+  if (!thread) {
+    return null;
+  }
+
+  return <MobileArtifactsButtonInner thread={thread} />;
+}
+
 function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const inChatRoute = isChatRoute(activeId);
   const features = useLastResolved(featureSwitch$);
@@ -187,6 +229,7 @@ function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
   return (
     <>
+      {inChatRoute && <MobileArtifactsButtonLeaf />}
       {inChatRoute && audioOutputEnabled && <AutoReadToggleLeaf />}
       {inChatRoute &&
         (newButtonEnabled ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -648,6 +648,86 @@ function ImageLightbox({ url }: { url: string }) {
   );
 }
 
+function VideoLightbox({ filename, url }: { filename: string; url: string }) {
+  const dialogRef = useSet(lightboxDialogRef$);
+  const closeLightbox = useSet(closeLightbox$);
+  const pageSignal = useGet(pageSignal$);
+  const videoUrl = publicAttachmentUrl(url);
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      closeLightbox();
+    }
+  };
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      tabIndex={-1}
+      className="pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      style={{ pointerEvents: "auto" }}
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      data-testid="attachment-lightbox"
+    >
+      <LightboxBodyScrollLock />
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            detach(
+              copyAttachmentLinkToClipboard(url),
+              Reason.DomCallback,
+              "attachment copy link",
+            );
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+          aria-label="Copy link"
+        >
+          <IconLink size={20} stroke={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            detach(
+              downloadAttachmentUrl(url, pageSignal, filename),
+              Reason.DomCallback,
+              "attachment download",
+            );
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+          aria-label="Download"
+        >
+          <IconDownload size={20} stroke={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            closeLightbox();
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+          aria-label="Close"
+        >
+          <IconX size={20} stroke={2} />
+        </button>
+      </div>
+      <div className="relative z-10 flex w-[min(92vw,1100px)] min-w-0 overflow-hidden rounded-2xl bg-black shadow-2xl animate-in zoom-in-95 duration-200">
+        <video
+          src={videoUrl}
+          controls
+          autoPlay
+          playsInline
+          preload="metadata"
+          className="block max-h-[78vh] w-full bg-black object-contain"
+          aria-label={`Video preview for ${filename}`}
+        />
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 export function AttachmentLightbox() {
   const preview = useGet(lightboxUrl$);
   const dialogRef = useSet(lightboxDialogRef$);
@@ -660,6 +740,10 @@ export function AttachmentLightbox() {
 
   if (preview.kind === "image") {
     return <ImageLightbox url={preview.url} />;
+  }
+
+  if (preview.kind === "video") {
+    return <VideoLightbox filename={preview.filename} url={preview.url} />;
   }
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -6,6 +6,7 @@ import {
   IconEye,
   IconFileMusic,
   IconLoader2,
+  IconVideo,
 } from "@tabler/icons-react";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Computed } from "ccstate";
@@ -322,6 +323,68 @@ function AudioPreview({ filename, url }: { filename: string; url: string }) {
   );
 }
 
+function VideoPreview({
+  contentType,
+  filename,
+  url,
+}: {
+  contentType?: string;
+  filename: string;
+  url: string;
+}) {
+  return (
+    <div
+      className="relative w-fit max-w-full overflow-hidden rounded-xl border border-foreground/10 bg-black"
+      data-testid="attachment-preview-video"
+    >
+      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-stone-900 text-white">
+        <div className="flex flex-col items-center gap-3 px-6 text-center">
+          <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/15 bg-white/10">
+            <FilePreviewIcon
+              filename={filename}
+              contentType={contentType ?? "video/mp4"}
+              testId="attachment-preview-video-icon"
+            />
+          </span>
+          <span className="max-w-[240px] truncate text-xs font-medium text-white/85">
+            {filename}
+          </span>
+        </div>
+      </div>
+      <video
+        src={url}
+        controls
+        preload="metadata"
+        className="relative block max-h-64 w-[min(360px,calc(100vw-3rem))] bg-transparent object-contain"
+        aria-label={`Video preview for ${filename}`}
+      />
+      <button
+        type="button"
+        onClick={() => {
+          detach(
+            downloadAttachmentUrl(
+              normalizePlatformFileUrl(url),
+              undefined,
+              filename,
+            ),
+            Reason.DomCallback,
+            "attachment download",
+          );
+        }}
+        title={filename}
+        aria-label={`Download ${filename}`}
+        className="absolute right-2 top-2 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+      >
+        <IconDownload size={13} />
+      </button>
+      <div className="pointer-events-none absolute left-2 top-2 inline-flex items-center gap-1.5 rounded-full bg-background/90 px-2 py-1 text-xs font-medium text-muted-foreground">
+        <IconVideo size={13} stroke={1.5} />
+        Video
+      </div>
+    </div>
+  );
+}
+
 export function AttachmentPreview({
   attachment,
   text$,
@@ -391,6 +454,15 @@ export function AttachmentPreview({
     case "audio": {
       return (
         <AudioPreview filename={attachment.filename} url={attachment.url} />
+      );
+    }
+    case "video": {
+      return (
+        <VideoPreview
+          contentType={attachment.contentType}
+          filename={attachment.filename}
+          url={attachment.url}
+        />
       );
     }
     case "file": {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -6,6 +6,7 @@ import {
   IconEye,
   IconFileMusic,
   IconLoader2,
+  IconPlayerPlay,
   IconVideo,
 } from "@tabler/icons-react";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
@@ -18,6 +19,7 @@ import {
 import {
   lightboxUrl$,
   openDocumentLightbox$,
+  openVideoLightbox$,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
   classifyChatAttachment,
@@ -27,7 +29,10 @@ import {
   FilePreviewIcon,
   getFilePreviewAccentClass,
 } from "./zero-file-preview-icon.tsx";
-import { downloadAttachmentUrl } from "./zero-attachment-chips.tsx";
+import {
+  downloadAttachmentUrl,
+  publicAttachmentUrl,
+} from "./zero-attachment-chips.tsx";
 
 interface ChatAttachmentDescriptor {
   filename: string;
@@ -323,7 +328,7 @@ function AudioPreview({ filename, url }: { filename: string; url: string }) {
   );
 }
 
-function VideoPreview({
+function VideoThumbnailPreview({
   contentType,
   filename,
   url,
@@ -332,13 +337,25 @@ function VideoPreview({
   filename: string;
   url: string;
 }) {
+  const openVideoLightbox = useSet(openVideoLightbox$);
+  const lightboxOpen = useGet(lightboxUrl$) !== null;
+  const videoUrl = publicAttachmentUrl(url);
+
   return (
-    <div
-      className="relative w-fit max-w-full overflow-hidden rounded-xl border border-foreground/10 bg-black"
+    <button
+      type="button"
+      onClick={(event) => {
+        event.currentTarget.blur();
+        openVideoLightbox({ url, filename });
+      }}
+      disabled={lightboxOpen}
+      title={filename}
+      aria-label={`Open video preview for ${filename}`}
       data-testid="attachment-preview-video"
+      className={`${lightboxOpen ? "" : "group/video-preview"} inline-flex w-fit self-start align-top text-left disabled:pointer-events-none`}
     >
-      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-stone-900 text-white">
-        <div className="flex flex-col items-center gap-3 px-6 text-center">
+      <div className="relative flex aspect-[4/3] w-[144px] items-center justify-center overflow-hidden rounded-xl border border-foreground/10 bg-black sm:w-[168px]">
+        <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-stone-900 text-white">
           <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/15 bg-white/10">
             <FilePreviewIcon
               filename={filename}
@@ -346,42 +363,32 @@ function VideoPreview({
               testId="attachment-preview-video-icon"
             />
           </span>
-          <span className="max-w-[240px] truncate text-xs font-medium text-white/85">
-            {filename}
+        </div>
+        <video
+          src={videoUrl}
+          preload="metadata"
+          muted
+          playsInline
+          aria-hidden="true"
+          className="relative z-10 block h-full w-full bg-transparent object-cover opacity-90"
+        />
+        <div className="absolute inset-0 z-20 bg-black/15 transition-colors group-hover/video-preview:bg-black/35" />
+        <span className="absolute inset-0 z-30 flex items-center justify-center">
+          <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-preview:scale-105">
+            <IconPlayerPlay size={20} stroke={1.8} />
           </span>
+        </span>
+        <div className="absolute right-2 top-2 z-30 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/video-preview:opacity-100">
+          <IconVideo size={10} />
+          Preview
+        </div>
+        <div className="absolute inset-x-0 bottom-0 z-30 flex items-end justify-between gap-2 bg-gradient-to-t from-black/65 via-black/20 to-transparent px-2.5 py-2.5 text-white opacity-0 transition-opacity duration-200 group-hover/video-preview:opacity-100">
+          <div className="min-w-0">
+            <div className="truncate text-xs font-medium">{filename}</div>
+          </div>
         </div>
       </div>
-      <video
-        src={url}
-        controls
-        preload="metadata"
-        className="relative block max-h-64 w-[min(360px,calc(100vw-3rem))] bg-transparent object-contain"
-        aria-label={`Video preview for ${filename}`}
-      />
-      <button
-        type="button"
-        onClick={() => {
-          detach(
-            downloadAttachmentUrl(
-              normalizePlatformFileUrl(url),
-              undefined,
-              filename,
-            ),
-            Reason.DomCallback,
-            "attachment download",
-          );
-        }}
-        title={filename}
-        aria-label={`Download ${filename}`}
-        className="absolute right-2 top-2 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-      >
-        <IconDownload size={13} />
-      </button>
-      <div className="pointer-events-none absolute left-2 top-2 inline-flex items-center gap-1.5 rounded-full bg-background/90 px-2 py-1 text-xs font-medium text-muted-foreground">
-        <IconVideo size={13} stroke={1.5} />
-        Video
-      </div>
-    </div>
+    </button>
   );
 }
 
@@ -458,7 +465,7 @@ export function AttachmentPreview({
     }
     case "video": {
       return (
-        <VideoPreview
+        <VideoThumbnailPreview
           contentType={attachment.contentType}
           filename={attachment.filename}
           url={attachment.url}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2384,11 +2384,14 @@ function BodyContentBlocks({
 
         if (block.preview.kind === "video") {
           return (
-            <video
+            <AttachmentPreview
               key={block.id}
-              src={block.preview.url}
-              controls
-              className="max-h-48 max-w-full rounded-lg border border-foreground/10"
+              attachment={{
+                filename: block.preview.filename,
+                url: block.preview.url,
+                contentType: contentTypeForBodyPreviewKind(block.preview.kind),
+              }}
+              text$={block.preview.text$}
             />
           );
         }
@@ -2787,6 +2790,18 @@ function UserMessageAttachments({
               }}
               placeholderClassName="h-9 w-[72px]"
               url={a.url}
+            />
+          );
+        }
+        if (a.kind === "video") {
+          return (
+            <AttachmentPreview
+              key={a.url}
+              attachment={{
+                filename: a.filename,
+                url: a.url,
+                contentType: a.contentType,
+              }}
             />
           );
         }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -18,7 +18,9 @@ import {
   IconHandStop,
   IconPhoto,
   IconChartLine,
+  IconPlayerPlay,
   IconPlayerStop,
+  IconVideo,
   IconCopy,
   IconCheck,
   IconDots,
@@ -98,6 +100,7 @@ import {
   lightboxUrl$ as attachmentLightboxUrl$,
   openDocumentLightbox$ as openAttachmentDocumentLightbox$,
   openImageLightbox$ as openAttachmentImageLightbox$,
+  openVideoLightbox$ as openAttachmentVideoLightbox$,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
   writeToClipboard,
@@ -1098,9 +1101,68 @@ function ChatImagePreviewButton({
   );
 }
 
+type ChatVideoPreviewButtonProps = {
+  ariaLabel: string;
+  buttonClassName: string;
+  filename: string;
+  onPreview: () => void;
+  posterClassName: string;
+  url: string;
+  videoClassName: string;
+};
+
+function ChatVideoPreviewButton({
+  ariaLabel,
+  buttonClassName,
+  filename,
+  onPreview,
+  posterClassName,
+  url,
+  videoClassName,
+}: ChatVideoPreviewButtonProps) {
+  const videoUrl = publicAttachmentUrl(url);
+
+  return (
+    <button
+      type="button"
+      onClick={onPreview}
+      title={filename}
+      aria-label={ariaLabel}
+      className={cn(
+        "group/video-preview relative overflow-hidden bg-black",
+        buttonClassName,
+      )}
+    >
+      <span
+        data-testid="chat-video-preview-poster"
+        className={cn(
+          "flex items-center justify-center bg-black text-white/70",
+          posterClassName,
+        )}
+      >
+        <IconVideo size={22} stroke={1.5} />
+      </span>
+      <video
+        src={videoUrl}
+        preload="metadata"
+        muted
+        playsInline
+        aria-hidden="true"
+        className={cn("absolute inset-0", videoClassName)}
+      />
+      <span className="absolute inset-0 flex items-center justify-center bg-black/10 transition-colors group-hover/video-preview:bg-black/35">
+        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-preview:scale-105">
+          <IconPlayerPlay size={17} stroke={1.8} />
+        </span>
+      </span>
+    </button>
+  );
+}
+
 function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openDocumentLightbox = useSet(openAttachmentDocumentLightbox$);
+  const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
   const previewKind = getArtifactPreviewKind(file);
 
   if (previewKind === "image") {
@@ -1121,11 +1183,19 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
 
   if (previewKind === "video") {
     return (
-      <video
-        src={file.url}
-        controls
-        preload="metadata"
-        className="h-full w-full bg-black object-contain"
+      <ChatVideoPreviewButton
+        ariaLabel={`Preview ${file.filename}`}
+        buttonClassName="flex h-full w-full items-center justify-center"
+        filename={file.filename}
+        onPreview={() => {
+          openVideoLightbox({
+            url: file.url,
+            filename: file.filename,
+          });
+        }}
+        posterClassName="h-full w-full"
+        url={file.url}
+        videoClassName="h-full w-full object-contain"
       />
     );
   }
@@ -1217,7 +1287,7 @@ function ArtifactPreviewPanel({
   const { file } = item;
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border/70 bg-background shadow-sm">
+    <div className="min-w-0 overflow-hidden rounded-lg border border-border/70 bg-background shadow-sm">
       <div className="h-[260px] border-b border-border/60 bg-muted/30">
         <ArtifactPreviewFrame file={file} />
       </div>
@@ -1430,7 +1500,7 @@ function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
   };
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex min-w-0 flex-col gap-5">
       {selectedItem && (
         <ArtifactPreviewPanel
           item={selectedItem}
@@ -1486,7 +1556,7 @@ function ChatArtifactsDrawer({ thread }: { thread: ChatThreadSignals }) {
     >
       <SheetContent
         side="right"
-        className="w-[420px] sm:max-w-[420px] flex flex-col"
+        className="flex w-[420px] max-w-[100vw] flex-col"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
         }}
@@ -2347,6 +2417,8 @@ function BodyContentBlocks({
   openLightbox: (url: string) => void;
   hardBreaks: boolean;
 }) {
+  const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
+
   return (
     <div className="flex flex-col gap-3">
       {blocks.map((block) => {
@@ -2384,14 +2456,20 @@ function BodyContentBlocks({
 
         if (block.preview.kind === "video") {
           return (
-            <AttachmentPreview
+            <ChatVideoPreviewButton
               key={block.id}
-              attachment={{
-                filename: block.preview.filename,
-                url: block.preview.url,
-                contentType: contentTypeForBodyPreviewKind(block.preview.kind),
+              ariaLabel={`Preview ${block.preview.filename}`}
+              buttonClassName="w-fit max-w-full rounded-lg border border-foreground/10"
+              filename={block.preview.filename}
+              onPreview={() => {
+                openVideoLightbox({
+                  url: block.preview.url,
+                  filename: block.preview.filename,
+                });
               }}
-              text$={block.preview.text$}
+              posterClassName="h-48 w-64 max-w-full"
+              url={block.preview.url}
+              videoClassName="h-full w-full object-contain"
             />
           );
         }
@@ -2770,6 +2848,8 @@ function UserMessageAttachments({
   attachments: ReturnType<typeof resolveAttachments>;
   onImageClick: (url: string) => void;
 }) {
+  const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
+
   if (attachments.length === 0) {
     return null;
   }
@@ -2795,13 +2875,20 @@ function UserMessageAttachments({
         }
         if (a.kind === "video") {
           return (
-            <AttachmentPreview
+            <ChatVideoPreviewButton
               key={a.url}
-              attachment={{
-                filename: a.filename,
-                url: a.url,
-                contentType: a.contentType,
+              ariaLabel={`Preview ${a.filename}`}
+              buttonClassName="rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
+              filename={a.filename}
+              onPreview={() => {
+                openVideoLightbox({
+                  url: a.url,
+                  filename: a.filename,
+                });
               }}
+              posterClassName="h-9 w-[72px]"
+              url={a.url}
+              videoClassName="h-full w-full object-cover"
             />
           );
         }

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -84,6 +84,9 @@ OPENROUTER_API_KEY=op://Development/openrouter/OPENROUTER_API_KEY
 # Optional: fal media generation
 FAL_KEY=op://Development/fal/FAL_KEY
 
+# Optional: BytePlus ModelArk video generation
+BYTEPLUS_API_KEY=op://Development/byteplus/BYTEPLUS_API_KEY
+
 # Optional: Airtable OAuth Connector
 AIRTABLE_OAUTH_CLIENT_ID=op://Development/airtable/AIRTABLE_OAUTH_CLIENT_ID
 AIRTABLE_OAUTH_CLIENT_SECRET=op://Development/airtable/AIRTABLE_OAUTH_CLIENT_SECRET


### PR DESCRIPTION
## Summary
- add a mobile top-bar artifact button for chat threads
- render video attachments as playable preview cards with a cover treatment and download action
- cover the mobile artifact button and video preview behavior in tests

## Verification
- pnpm vitest run src/views/zero-page/__tests__/zero-attachment-preview.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm check-types
- pnpm exec prettier --check src/views/zero-page/zero-attachment-preview.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/sidebar-layout.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm lint

## Browser smoke
- Started Vite locally and attempted a 390px mobile Chromium smoke test; local app bootstrap is blocked without VITE_CLERK_PUBLISHABLE_KEY, so the authenticated chat UI could not be exercised in browser.