### PR TITLE
fix(desktop): skip native helper build on non-darwin platforms

### DIFF
--- a/turbo/apps/desktop/scripts/build-native-helper.js
+++ b/turbo/apps/desktop/scripts/build-native-helper.js
@@ -2,6 +2,13 @@ const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
 
+if (process.platform !== "darwin") {
+  console.log(
+    `Skipping native helper build on ${process.platform} (macOS-only).`,
+  );
+  process.exit(0);
+}
+
 const appRoot = path.resolve(__dirname, "..");
 const packageRoot = path.join(appRoot, "native", "computer-use-helper");
 const buildOutput = path.join(


### PR DESCRIPTION
## Summary
- `apps/desktop` 的 `build:native` 无条件调用 `swift build`，但 `computer-use-helper` 这个 Swift 包用了 `AppKit` / `ApplicationServices` / `CGEvent` 等 macOS-only API（`Package.swift` 也显式声明 `.macOS(.v13)`）。
- 在 Linux dev 容器里跑 `pnpm dev` 时，`swift` 不存在导致 `ENOENT`，整个 turbo pipeline（web/api/app/proxy/cli）被一起 SIGINT 拉下来。
- 加一个 `process.platform !== "darwin"` 的 early return，让非 macOS 平台静默跳过，不影响 macOS 行为。

引入回归的是 #14496 (commit 962d6cd81)。

## Test plan
- [ ] Linux: `pnpm -F @vm0/desktop build:native` 打印 skip 消息并 exit 0
- [ ] Linux: `cd turbo && pnpm dev` 不再因 desktop 失败
- [ ] macOS: `pnpm -F @vm0/desktop build:native` 仍然正常构建出 `computer-use-helper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)