### PR TITLE
feat(agentphone): rewrite iMessage connect prompt as Zero intro

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1423,7 +1423,14 @@ function formatConnectPrompt(event: AgentPhoneMessageEvent): string {
   });
 
   return [
-    "To use Zero by text message, connect this phone number to your VM0 account:",
+    "Hi, I'm Zero, your AI coworker from vm0.",
+    "",
+    "You can text me like a teammate and I'll actually do the work: research something, draft and send emails, summarize long documents, update spreadsheets, triage tickets, post to Slack, dig through your GitHub or Notion, and a lot more.",
+    "",
+    "I'm most useful once I'm connected to the tools you already use — GitHub, Gmail, Notion, Google Drive / Sheets / Docs / Calendar, Slack, Sentry, X, and 100+ others.",
+    "",
+    "Click the link below to start to use zero",
+    "",
     connectUrl,
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

When a new phone number texts Zero on iMessage/SMS, the bot replies with a connect link prompt. The old copy was a single utilitarian line:

> To use Zero by text message, connect this phone number to your VM0 account:

Replaces it with a short (~95 word) Zero intro that mirrors the tone of the post-connect welcome message in `zero-integrations-agentphone.ts` — so the first impression already explains what Zero is and what it can do, instead of just asking the user to click a link.

## New copy

\`\`\`
Hi, I'm Zero, your AI coworker from vm0.

You can text me like a teammate and I'll actually do the work: research something, draft and send emails, summarize long documents, update spreadsheets, triage tickets, post to Slack, dig through your GitHub or Notion, and a lot more.

I'm most useful once I'm connected to the tools you already use — GitHub, Gmail, Notion, Google Drive / Sheets / Docs / Calendar, Slack, Sentry, X, and 100+ others.

Click the link below to start to use zero

<connectUrl>
\`\`\`

The blank line before \`<connectUrl>\` keeps the link on its own block so iMessage / SMS clients render it cleanly as a tappable card.

## Test plan

- [ ] Send any iMessage/SMS to the Zero agent from an unlinked number — verify the new intro is sent
- [ ] \`/connect\` slash command from an unlinked number renders the same intro (with the existing SMS/MMS risk warning appended on those channels)
- [ ] Already-linked users still get "You are already connected…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)