### PR TITLE
feat(platform): add og and twitter card meta to index.html

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -73,6 +73,32 @@
       content="black-translucent"
     />
     <meta name="apple-mobile-web-app-title" content="Zero" />
+    <meta
+      name="description"
+      content="Zero is your AI coworker from vm0. Text Zero or chat on the web — research, email, docs, Slack, GitHub, Notion, and 100+ tools."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Zero" />
+    <meta property="og:title" content="Zero — Your AI coworker from vm0" />
+    <meta
+      property="og:description"
+      content="Zero is your AI coworker from vm0. Text Zero or chat on the web — research, email, docs, Slack, GitHub, Notion, and 100+ tools."
+    />
+    <meta property="og:image" content="https://www.vm0.ai/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Zero — Your AI coworker from vm0"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@vm0_ai" />
+    <meta name="twitter:title" content="Zero — Your AI coworker from vm0" />
+    <meta
+      name="twitter:description"
+      content="Zero is your AI coworker from vm0. Text Zero or chat on the web — research, email, docs, Slack, GitHub, Notion, and 100+ tools."
+    />
+    <meta name="twitter:image" content="https://www.vm0.ai/og-image.png" />
     <meta name="google" content="notranslate" />
     <meta
       name="theme-color"

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -87,10 +87,7 @@
     <meta property="og:image" content="https://www.vm0.ai/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta
-      property="og:image:alt"
-      content="Zero — Your AI coworker from vm0"
-    />
+    <meta property="og:image:alt" content="Zero — Your AI coworker from vm0" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@vm0_ai" />
     <meta name="twitter:title" content="Zero — Your AI coworker from vm0" />


### PR DESCRIPTION
## Summary

When `/agentphone/connect` (and every other platform SPA route) is shared on iMessage / Slack / Twitter / WhatsApp, the link unfurls into a gray bubble with just the page title and a tiny favicon — because the static \`apps/platform/index.html\` has zero Open Graph or Twitter Card metadata. iMessage's link-preview bot doesn't execute JS, so anything injected by the React app at runtime is invisible to it.

This PR adds the standard OG + Twitter Card meta block, plus a base \`description\` for SEO/search results. Every platform link (\`/agentphone/connect\`, \`/telegram/connect\`, \`/onboarding\`, chat threads, etc.) now unfurls with a rich card.

No new image asset shipped — \`og:image\` points at the existing \`https://www.vm0.ai/og-image.png\` (1200×630, ~65 KB), which is already used as the global fallback in \`apps/web/app/layout.tsx\`. iOS 17+ iMessage crops it to a square card; if/when design produces a 1200×1200 brand image, we can swap the URL in one line.

## Test plan

- [ ] Build platform locally and grep the built \`index.html\` for the new \`og:*\` tags
- [ ] Paste any \`https://app.vm0.ai/...\` URL into iMessage — verify a rich preview renders with the og-image, title, and description (was previously a gray bubble with apple-touch-icon)
- [ ] Same URL in Slack — verify unfurl shows the image and description
- [ ] [Open Graph Preview](https://www.opengraphpreview.com/imessage) → confirm tags parse correctly
- [ ] Existing \`index-html.test.ts\` still passes (only guards \`translate="no"\` + \`google notranslate\`, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)