### PR TITLE
test: clean vitest warning noise

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -289,26 +289,4 @@ describe("logger", () => {
   it("creates distinct loggers for different names", () => {
     expect(logger("A")).not.toBe(logger("B"));
   });
-
-  it("emits to console in addition to Axiom (dual-write)", () => {
-    // eslint-disable-next-line api/no-test-vi-mocks
-    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-    // eslint-disable-next-line api/no-test-vi-mocks
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-
-    // eslint-disable-next-line no-restricted-syntax
-    try {
-      const log = logger("dual");
-      log.info("dual msg");
-      log.error("dual error");
-
-      expect(consoleLog).toHaveBeenCalledWith(expect.any(String));
-      expect(consoleError).toHaveBeenCalledWith(expect.any(String));
-    } finally {
-      consoleLog.mockRestore();
-      consoleError.mockRestore();
-    }
-  });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-patch.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { and, eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
 import {
   OFFICIAL_TELEGRAM_BOT_ID,
   zeroIntegrationsTelegramContract,
@@ -21,6 +22,7 @@ import {
   type TelegramFixture,
 } from "./helpers/zero-telegram";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { server } from "../../../mocks/server";
 
 const context = testContext();
 const store = createStore();
@@ -52,6 +54,11 @@ describe("PATCH /api/integrations/telegram/:botId", () => {
       first_name: "Bot",
       username: "x",
     });
+    server.use(
+      http.head("https://oauth.telegram.org/auth", () => {
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
   });
 
   afterEach(async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -288,6 +288,12 @@ function setupGitHubApiMocks(args: {
       },
     ),
     http.post(
+      "https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments",
+      () => {
+        return HttpResponse.json({ id: 9876 });
+      },
+    ),
+    http.post(
       "https://api.github.com/repos/:owner/:repo/issues/comments/:commentId/reactions",
       () => {
         return HttpResponse.json({ id: 2468 });
@@ -1480,6 +1486,7 @@ describe("POST /api/webhooks/github", () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
+    await seedGitHubModelRoute({ fixture });
     mockGitHubWebhookEnv();
     const otherGithubUserId = remoteGitHubId();
 
@@ -1555,6 +1562,7 @@ describe("POST /api/webhooks/github", () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
+    await seedGitHubModelRoute({ fixture });
     mockGitHubWebhookEnv();
     mockGitHubAppCredentials();
     setupGitHubApiMocks({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -917,6 +917,7 @@ describe("POST /api/zero/chat/messages", () => {
 
   it("interrupts and cancels an active chat run", async () => {
     const fixture = await track(seedFixture());
+    proxyChatCallbackToApp();
     const first = await send({ agentId: fixture.agentId, prompt: "first" });
     await clearAllDetached();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -361,6 +361,7 @@ const trackFixture = createFixtureTracker<TelegramPostFixture>(
 beforeEach(() => {
   context.mocks.s3.send.mockResolvedValue({});
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  server.use(telegramOauthHead("1001"));
 });
 
 afterEach(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -6,7 +6,7 @@ import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
@@ -1159,6 +1159,11 @@ describe("POST /api/zero/slack/events", () => {
     );
     expect(fixture.defaultAgentId).toBeTruthy();
     const db = store.set(writeDb$);
+    await db
+      .delete(vm0ApiKeys)
+      .where(
+        and(eq(vm0ApiKeys.vendor, "openai"), eq(vm0ApiKeys.model, "gpt-5.5")),
+      );
     await db.insert(vm0ApiKeys).values({
       vendor: "openai",
       model: "gpt-5.5",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-posts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-posts.test.ts
@@ -36,6 +36,8 @@ const writeDb = store.set(writeDb$);
 const mocks = createZeroRouteMocks(context);
 const OPENAI_REALTIME_CLIENT_SECRETS_URL =
   "https://api.openai.com/v1/realtime/client_secrets";
+const VOICE_CHAT_CALLBACK_URL =
+  "http://localhost:3000/api/internal/callbacks/voice-chat";
 
 const track = createFixtureTracker<VoiceChatFixture>((fixture) => {
   return store.set(deleteVoiceChatFixture$, fixture, context.signal);
@@ -47,6 +49,19 @@ function client() {
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
+}
+
+function proxyVoiceChatCallbackToApp(): void {
+  server.use(
+    http.post(VOICE_CHAT_CALLBACK_URL, async ({ request }) => {
+      const app = createApp({ signal: context.signal });
+      return await app.request("/api/internal/callbacks/voice-chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: await request.text(),
+      });
+    }),
+  );
 }
 
 async function rawCreateSessionWithoutBody(): Promise<{
@@ -562,6 +577,8 @@ describe("POST /api/zero/voice-chat/:id/tasks (createTask)", () => {
   });
 
   it("creates a task, zero run, and voice-chat callback", async () => {
+    proxyVoiceChatCallbackToApp();
+
     const { fixture, agentId } = await seedEnabledFixture();
     const sessionId = await store.set(
       addVoiceChatSession$,

--- a/turbo/apps/cli/src/commands/auth/__tests__/login-with-proxy.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login-with-proxy.test.ts
@@ -29,6 +29,20 @@ describe("auth login: proxy configuration", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
   }) as never);
+  const emitWarningOriginal = process.emitWarning.bind(process);
+  const emitWarning = vi
+    .spyOn(process, "emitWarning")
+    .mockImplementation((warning, options) => {
+      if (
+        typeof options === "object" &&
+        options !== null &&
+        "code" in options &&
+        options.code === "UNDICI-EHPA"
+      ) {
+        return;
+      }
+      return emitWarningOriginal(warning as string, options as never);
+    });
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
   const mockConsoleError = vi
     .spyOn(console, "error")
@@ -39,6 +53,7 @@ describe("auth login: proxy configuration", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    emitWarning.mockClear();
     chalk.level = 0;
 
     vi.stubEnv("http_proxy", undefined);

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -82,6 +82,12 @@ export const apiHandlers = [
       { status: 200 },
     );
   }),
+  http.get("https://www.vm0.ai/api/zero/connectors", () => {
+    return HttpResponse.json(
+      { connectors: [], configuredTypes: [], connectorProvidedSecretNames: [] },
+      { status: 200 },
+    );
+  }),
 
   // GET /api/zero/connectors/search - searchZeroConnectors
   http.get("http://localhost:3000/api/zero/connectors/search", () => {

--- a/turbo/apps/platform/src/__tests__/setup-page.test.ts
+++ b/turbo/apps/platform/src/__tests__/setup-page.test.ts
@@ -1,12 +1,25 @@
 import { testContext } from "../signals/__tests__/test-helpers";
 import { detachedSetupPage } from "./page-helper";
-import { expect, it, describe } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Level, logger } from "../signals/log";
 import { localStorageSignals } from "../signals/external/local-storage";
 
 const context = testContext();
 
 describe("setupPage", () => {
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+  let consoleWarn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLog.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
   it("should set debug loggers correctly", () => {
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/lib/voice-chat/__tests__/usage-reporter.test.ts
+++ b/turbo/apps/platform/src/lib/voice-chat/__tests__/usage-reporter.test.ts
@@ -1,10 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import {
   buildUsageEventUrl,
   createUsageReporter,
   type UsageReportPayload,
 } from "../usage-reporter";
+import { getLoggers, Level } from "../../../signals/log";
 
 const API_BASE = "https://api.test.example";
 const SESSION_ID = "00000000-0000-0000-0000-000000000123";
@@ -45,13 +54,24 @@ async function flushMicrotasks(): Promise<void> {
 
 describe("createUsageReporter", () => {
   let originalFetch: typeof fetch;
+  const usageLogger = getLoggers().VoiceChatUsageReporter;
+  const usageLoggerLevel = usageLogger?.level;
 
   beforeEach(() => {
+    if (usageLogger) {
+      usageLogger.level = Level.Error;
+    }
     originalFetch = globalThis.fetch;
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    if (usageLogger && usageLoggerLevel) {
+      usageLogger.level = usageLoggerLevel;
+    }
   });
 
   it("buildUsageEventUrl strips trailing slash from apiBase", () => {

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
 import { testContext } from "./test-helpers";
 import { detachedSetupPage } from "../../__tests__/page-helper";
@@ -6,6 +6,19 @@ import { detachedSetupPage } from "../../__tests__/page-helper";
 const context = testContext();
 
 describe("global debug loggers", () => {
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+  let consoleWarn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLog.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
   it("should has vm0 method after init", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 

--- a/turbo/apps/platform/src/signals/__tests__/log.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/log.test.ts
@@ -8,6 +8,9 @@ import {
 
 describe("setLogErrorHandler", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     resetLoggerForTest();
@@ -15,10 +18,16 @@ describe("setLogErrorHandler", () => {
     // This test suite intentionally triggers console.error via the log module,
     // so we suppress it here.
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     errorSpy.mockRestore();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it("should invoke handler on error()", () => {

--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { http, HttpResponse } from "msw";
 import { zeroVoiceChatContract } from "@vm0/api-contracts/contracts/zero-voice-chat";
 import { server } from "../../../mocks/server.ts";
@@ -7,6 +15,7 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { detach, Reason } from "../../utils.ts";
+import { getLoggers, Level } from "../../log.ts";
 import {
   startVoiceChat$,
   endVoiceChat$,
@@ -20,6 +29,8 @@ import {
 
 const context = testContext();
 const mockApi = createMockApi(context);
+const voiceChatLogger = getLoggers().VoiceChat;
+const voiceChatLoggerLevel = voiceChatLogger?.level;
 
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const SESSION_ID = "11111111-1111-4111-8111-111111111111";
@@ -487,11 +498,20 @@ describe("voice-chat session", () => {
   }
 
   beforeEach(() => {
+    if (voiceChatLogger) {
+      voiceChatLogger.level = Level.Error;
+    }
     stubWebRTC();
   });
 
   afterEach(() => {
     clearWebRTC();
+  });
+
+  afterAll(() => {
+    if (voiceChatLogger && voiceChatLoggerLevel) {
+      voiceChatLogger.level = voiceChatLoggerLevel;
+    }
   });
 
   describe("startVoiceChat$", () => {

--- a/turbo/apps/platform/src/views/activity/__tests__/activity-inspect-page.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/activity-inspect-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -10,10 +10,25 @@ import {
   setInspectStepSearch$,
   type InspectLogData,
 } from "../../../signals/activity-page/inspect-log-signals.ts";
+import { getLoggers, Level } from "../../../signals/log.ts";
 import type { InspectLogMeta } from "../../../signals/activity-page/inspect-log-parser.ts";
 import type { AgentEvent } from "../../../signals/zero-page/log-types.ts";
 
 const context = testContext();
+const inspectLogger = getLoggers().InspectLogSignals;
+const inspectLoggerLevel = inspectLogger?.level;
+
+beforeEach(() => {
+  if (inspectLogger) {
+    inspectLogger.level = Level.Warn;
+  }
+});
+
+afterAll(() => {
+  if (inspectLogger && inspectLoggerLevel) {
+    inspectLogger.level = inspectLoggerLevel;
+  }
+});
 
 function makeInspectData(
   metaOverrides: Partial<InspectLogMeta> = {},

--- a/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
@@ -7,10 +7,25 @@ import {
   setInspectStepSearch$,
   type InspectLogData,
 } from "../../../signals/activity-page/inspect-log-signals.ts";
+import { getLoggers, Level } from "../../../signals/log.ts";
 import type { InspectLogMeta } from "../../../signals/activity-page/inspect-log-parser.ts";
 import type { AgentEvent } from "../../../signals/zero-page/log-types.ts";
 
 const context = testContext();
+const inspectLogger = getLoggers().InspectLogSignals;
+const inspectLoggerLevel = inspectLogger?.level;
+
+beforeEach(() => {
+  if (inspectLogger) {
+    inspectLogger.level = Level.Warn;
+  }
+});
+
+afterAll(() => {
+  if (inspectLogger && inspectLoggerLevel) {
+    inspectLogger.level = inspectLoggerLevel;
+  }
+});
 
 function makeInspectData(events: AgentEvent[]): InspectLogData {
   return {

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -14,6 +14,7 @@ import {
   CardContent,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   Button,
@@ -323,6 +324,9 @@ function CreateTeammateDialogContent({
     <DialogContent className="sm:max-w-[480px] p-0 gap-0 overflow-hidden">
       <DialogHeader className="sr-only">
         <DialogTitle>Create a new agent</DialogTitle>
+        <DialogDescription>
+          Name the new agent, choose its visibility, and customize its avatar.
+        </DialogDescription>
       </DialogHeader>
 
       {/* Avatar preview */}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -23,11 +23,17 @@ import {
   publicAttachmentUrl,
 } from "../zero-attachment-chips.tsx";
 import { setMockUserModelPreference } from "../../../mocks/handlers/api-user-model-preference.ts";
+import { getLoggers, Level } from "../../../signals/log.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
+const attachmentLogger = getLoggers()["zero-attachment-chips"];
+const attachmentLoggerLevel = attachmentLogger?.level;
 
 beforeEach(() => {
+  if (attachmentLogger) {
+    attachmentLogger.level = Level.Error;
+  }
   vi.stubEnv("VITE_API_URL", "https://www.vm0.ai");
   vi.stubEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://cdn.vm7.io");
   // Pin a vision-capable model — the workspace default model does not accept
@@ -36,6 +42,12 @@ beforeEach(() => {
     selectedModel: "claude-sonnet-4-6",
     updatedAt: "2026-03-10T00:00:00Z",
   });
+});
+
+afterAll(() => {
+  if (attachmentLogger && attachmentLoggerLevel) {
+    attachmentLogger.level = attachmentLoggerLevel;
+  }
 });
 
 function mockChatAPI() {

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   Tooltip,
@@ -341,6 +342,9 @@ function AvatarMakerDialogBody({
     <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-lg p-0 gap-0 overflow-hidden">
       <DialogHeader className="sr-only">
         <DialogTitle>Give your agent a face</DialogTitle>
+        <DialogDescription>
+          Customize the agent avatar style, color, and facial details.
+        </DialogDescription>
       </DialogHeader>
 
       {/* Preview section */}

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { HttpResponse, http } from "msw";
 import { server } from "../mocks/server";
 import {
   nextAfterArgForms,
@@ -8,6 +9,8 @@ import {
   flushNextAsyncHooks,
   resetNextAfterHooks,
 } from "./next-after-hooks";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
 // Stub environment variables before any imports.
 // Using vi.hoisted() ensures stubs run before module imports.
@@ -64,6 +67,8 @@ const resetEnv = vi.hoisted(() => {
     vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
     // OpenAI (voice-chat ephemeral token minting, STT, TTS) — required env
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+    // OpenRouter lightweight model tests mock the network boundary with MSW.
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     // Stripe billing — `vi.mock("stripe", ...)` replaces the constructor, but
     // init-services.ts throws before reaching it if STRIPE_SECRET_KEY is unset.
     vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake_for_testing");
@@ -285,6 +290,13 @@ beforeEach(() => {
   resetEnv();
   reloadEnv();
   resetNextAfterHooks();
+  server.use(
+    http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json({
+        choices: [{ message: { content: "Default OpenRouter response" } }],
+      });
+    }),
+  );
 });
 
 afterEach(async () => {

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -5,6 +5,7 @@ import { generateSandboxToken, generateZeroToken } from "../sandbox-token";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import { clearOrgMembersCacheEntry } from "../../../__tests__/api-test-helpers";
 import { testContext } from "../../../__tests__/test-helpers";
+import { reloadEnv } from "../../../env";
 
 const context = testContext();
 
@@ -12,6 +13,9 @@ describe("requireAuth", () => {
   const mockAuth = vi.mocked(auth);
 
   beforeEach(() => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VM0_API_BACKEND_URL", undefined);
+    reloadEnv();
     mockAuth.mockResolvedValue({
       userId: null,
     } as Awaited<ReturnType<typeof auth>>);

--- a/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 
@@ -39,13 +39,23 @@ import {
   ingestSandboxOpLog,
 } from "../client";
 
+let consoleError: ReturnType<typeof vi.spyOn>;
+let consoleWarn: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
+  consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.stubEnv("AXIOM_TOKEN_TELEMETRY", "test-telemetry-token");
   vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
   reloadEnv();
   mockQuery.mockReset();
   mockIngest.mockReset();
   mockFlush.mockReset();
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+  consoleWarn.mockRestore();
 });
 
 function axiomResponse(events: Array<Record<string, unknown>>) {

--- a/turbo/apps/web/src/lib/zero/ai/__tests__/lightweight-model.test.ts
+++ b/turbo/apps/web/src/lib/zero/ai/__tests__/lightweight-model.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { http } from "../../../../__tests__/msw";
-import { reloadEnv } from "../../../../env";
+import {
+  generateChatTitle,
+  generateRunSummary,
+  generateScheduleDescription,
+} from "../lightweight-model";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
@@ -12,397 +16,292 @@ function openRouterResponse(content: string | null) {
   };
 }
 
-describe("generateChatTitle", () => {
-  it("should return null when OPENROUTER_API_KEY is not configured", async () => {
-    // OPENROUTER_API_KEY is not stubbed by default in test setup
-    const { generateChatTitle } = await import("../lightweight-model");
+describe.sequential("lightweight-model", () => {
+  describe("generateChatTitle", () => {
+    it("should return a title on successful response", async () => {
+      const result = await generateChatTitle({
+        currentUserMessage: "Help me set up my project",
+      });
 
-    const result = await generateChatTitle({
-      currentUserMessage: "Hello, how are you?",
+      expect(result).toBe("Default OpenRouter response");
     });
 
-    expect(result).toBeNull();
-  });
+    it("should trim whitespace from returned content", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(openRouterResponse("  Padded Title  "));
+      });
+      server.use(handler.handler);
 
-  it("should return a title on successful response", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
+      const result = await generateChatTitle({
+        currentUserMessage: "Some user message",
+      });
 
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse("Project Setup Help"));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    const result = await generateChatTitle({
-      currentUserMessage: "Help me set up my project",
+      expect(result).toBe("Padded Title");
     });
 
-    expect(result).toBe("Project Setup Help");
-    expect(handler.mocked).toHaveBeenCalledTimes(1);
-  });
+    it("should throw when response content is empty", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(openRouterResponse(""));
+      });
+      server.use(handler.handler);
 
-  it("should trim whitespace from returned content", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse("  Padded Title  "));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    const result = await generateChatTitle({
-      currentUserMessage: "Some user message",
+      await expect(
+        generateChatTitle({ currentUserMessage: "Hello" }),
+      ).rejects.toThrow("OpenRouter returned empty content");
+      expect(handler.mocked).toHaveBeenCalledTimes(1);
     });
 
-    expect(result).toBe("Padded Title");
-  });
+    it("should throw when response content is null", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({ choices: [{ message: {} }] });
+      });
+      server.use(handler.handler);
 
-  it("should throw when response content is empty", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse(""));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    await expect(
-      generateChatTitle({ currentUserMessage: "Hello" }),
-    ).rejects.toThrow("OpenRouter returned empty content");
-    expect(handler.mocked).toHaveBeenCalledTimes(1);
-  });
-
-  it("should throw when response content is null", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json({ choices: [{ message: {} }] });
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    await expect(
-      generateChatTitle({ currentUserMessage: "Hello" }),
-    ).rejects.toThrow("OpenRouter returned empty content");
-  });
-
-  it.each([
-    ["**Bold** and `code` title", "Bold and code title"],
-    ["## Chat Title Here", "Chat Title Here"],
-    ["*Italic* setup guide", "Italic setup guide"],
-    ["__underscored__ text", "underscored text"],
-    ["[Click here](https://example.com) for help", "Click here for help"],
-    ["# **Bold Heading** with `code`", "Bold Heading with code"],
-    ["Plain text without markdown", "Plain text without markdown"],
-  ])("should strip markdown from %j → %j", async (raw, expected) => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse(raw));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    expect(await generateChatTitle({ currentUserMessage: "msg" })).toBe(
-      expected,
-    );
-  });
-
-  it("should throw on HTTP error", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.text("rate limited", { status: 429 });
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    await expect(
-      generateChatTitle({ currentUserMessage: "Hello" }),
-    ).rejects.toThrow("OpenRouter request failed: 429");
-  });
-
-  it("should label current user message, assistant reply, and prior rounds separately", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    let capturedBody: unknown;
-    const handler = http.post(OPENROUTER_URL, async ({ request }) => {
-      capturedBody = await request.json();
-      return HttpResponse.json(openRouterResponse("Debugging Help"));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    await generateChatTitle({
-      currentUserMessage: "Fix my bug",
-      currentAssistantReply: "Try logging the request body first.",
-      priorRounds: [
-        { role: "user", content: "Hello" },
-        { role: "assistant", content: "Hi, how can I help?" },
-      ],
+      await expect(
+        generateChatTitle({ currentUserMessage: "Hello" }),
+      ).rejects.toThrow("OpenRouter returned empty content");
     });
 
-    const body = capturedBody as {
-      messages: Array<{ role: string; content: string }>;
-    };
-    expect(body.messages).toHaveLength(2);
-    const userContent = body.messages[1]!.content;
-    expect(userContent).toContain("Previous conversation");
-    expect(userContent).toContain("user: Hello");
-    expect(userContent).toContain("assistant: Hi, how can I help?");
-    expect(userContent).toContain("Most recent user message:\nFix my bug");
-    expect(userContent).toContain(
-      "Most recent assistant reply:\nTry logging the request body first.",
-    );
-  });
+    it.each([
+      ["**Bold** and `code` title", "Bold and code title"],
+      ["## Chat Title Here", "Chat Title Here"],
+      ["*Italic* setup guide", "Italic setup guide"],
+      ["__underscored__ text", "underscored text"],
+      ["[Click here](https://example.com) for help", "Click here for help"],
+      ["# **Bold Heading** with `code`", "Bold Heading with code"],
+      ["Plain text without markdown", "Plain text without markdown"],
+    ])("should strip markdown from %j → %j", async (raw, expected) => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(openRouterResponse(raw));
+      });
+      server.use(handler.handler);
 
-  it("should cap prior rounds at the last 10 messages", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    let capturedBody: unknown;
-    const handler = http.post(OPENROUTER_URL, async ({ request }) => {
-      capturedBody = await request.json();
-      return HttpResponse.json(openRouterResponse("Title"));
+      expect(await generateChatTitle({ currentUserMessage: "msg" })).toBe(
+        expected,
+      );
     });
-    server.use(handler.handler);
 
-    const { generateChatTitle } = await import("../lightweight-model");
+    it("should throw on HTTP error", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.text("rate limited", { status: 429 });
+      });
+      server.use(handler.handler);
 
-    const priorRounds = Array.from({ length: 14 }, (_, i) => {
-      return {
-        role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
-        content: `msg-${i}`,
+      await expect(
+        generateChatTitle({ currentUserMessage: "Hello" }),
+      ).rejects.toThrow("OpenRouter request failed: 429");
+    });
+
+    it("should label current user message, assistant reply, and prior rounds separately", async () => {
+      let capturedBody: unknown;
+      const handler = http.post(OPENROUTER_URL, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(openRouterResponse("Debugging Help"));
+      });
+      server.use(handler.handler);
+
+      await generateChatTitle({
+        currentUserMessage: "Fix my bug",
+        currentAssistantReply: "Try logging the request body first.",
+        priorRounds: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi, how can I help?" },
+        ],
+      });
+
+      const body = capturedBody as {
+        messages: Array<{ role: string; content: string }>;
       };
-    });
-
-    await generateChatTitle({
-      currentUserMessage: "latest",
-      priorRounds,
-    });
-
-    const body = capturedBody as {
-      messages: Array<{ role: string; content: string }>;
-    };
-    const userContent = body.messages[1]!.content;
-    expect(userContent).toContain("last 10 messages");
-    expect(userContent).not.toContain("msg-0");
-    expect(userContent).not.toContain("msg-3");
-    expect(userContent).toContain("msg-4");
-    expect(userContent).toContain("msg-13");
-  });
-
-  it("should omit the assistant reply section when not provided", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    let capturedBody: unknown;
-    const handler = http.post(OPENROUTER_URL, async ({ request }) => {
-      capturedBody = await request.json();
-      return HttpResponse.json(openRouterResponse("Title"));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    await generateChatTitle({ currentUserMessage: "hello there" });
-
-    const body = capturedBody as {
-      messages: Array<{ role: string; content: string }>;
-    };
-    const userContent = body.messages[1]!.content;
-    expect(userContent).toContain("Most recent user message:\nhello there");
-    expect(userContent).not.toContain("Most recent assistant reply");
-    expect(userContent).not.toContain("Previous conversation");
-  });
-
-  it("should strip surrounding quotes from title", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse('"Some Quoted Title"'));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    expect(await generateChatTitle({ currentUserMessage: "msg" })).toBe(
-      "Some Quoted Title",
-    );
-  });
-
-  it("should strip horizontal rules from title", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse("---\nSome Title"));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    expect(await generateChatTitle({ currentUserMessage: "msg" })).toBe(
-      "Some Title",
-    );
-  });
-});
-
-describe("generateRunSummary", () => {
-  it("should return null when OPENROUTER_API_KEY is not configured", async () => {
-    const { generateRunSummary } = await import("../lightweight-model");
-
-    const result = await generateRunSummary("chat", "hello", "world");
-
-    expect(result).toBeNull();
-  });
-
-  it("should return a summary on successful response", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(
-        openRouterResponse(
-          "User asked about project setup. Agent provided step-by-step instructions.",
-        ),
+      expect(body.messages).toHaveLength(2);
+      const userContent = body.messages[1]!.content;
+      expect(userContent).toContain("Previous conversation");
+      expect(userContent).toContain("user: Hello");
+      expect(userContent).toContain("assistant: Hi, how can I help?");
+      expect(userContent).toContain("Most recent user message:\nFix my bug");
+      expect(userContent).toContain(
+        "Most recent assistant reply:\nTry logging the request body first.",
       );
     });
-    server.use(handler.handler);
 
-    const { generateRunSummary } = await import("../lightweight-model");
+    it("should cap prior rounds at the last 10 messages", async () => {
+      let capturedBody: unknown;
+      const handler = http.post(OPENROUTER_URL, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(openRouterResponse("Title"));
+      });
+      server.use(handler.handler);
 
-    const result = await generateRunSummary(
-      "chat",
-      "How do I set up this project?",
-      "First install dependencies with pnpm install, then run pnpm dev.",
-    );
+      const priorRounds = Array.from({ length: 14 }, (_, i) => {
+        return {
+          role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+          content: `msg-${i}`,
+        };
+      });
 
-    expect(result).toBe(
-      "User asked about project setup. Agent provided step-by-step instructions.",
-    );
-    expect(handler.mocked).toHaveBeenCalledTimes(1);
-  });
+      await generateChatTitle({
+        currentUserMessage: "latest",
+        priorRounds,
+      });
 
-  it("should include triggerSource in the system prompt", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    let capturedBody: unknown;
-    const handler = http.post(OPENROUTER_URL, async ({ request }) => {
-      capturedBody = await request.json();
-      return HttpResponse.json(openRouterResponse("Summary text"));
+      const body = capturedBody as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const userContent = body.messages[1]!.content;
+      expect(userContent).toContain("last 10 messages");
+      expect(userContent).not.toContain("msg-0");
+      expect(userContent).not.toContain("msg-3");
+      expect(userContent).toContain("msg-4");
+      expect(userContent).toContain("msg-13");
     });
-    server.use(handler.handler);
 
-    const { generateRunSummary } = await import("../lightweight-model");
+    it("should omit the assistant reply section when not provided", async () => {
+      let capturedBody: unknown;
+      const handler = http.post(OPENROUTER_URL, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(openRouterResponse("Title"));
+      });
+      server.use(handler.handler);
 
-    await generateRunSummary("slack", "prompt", "result");
+      await generateChatTitle({ currentUserMessage: "hello there" });
 
-    const body = capturedBody as {
-      messages: Array<{ role: string; content: string }>;
-    };
-    expect(body.messages[0]!.content).toContain("slack");
-  });
-
-  it("should truncate long input to 3 lines of 80 chars each", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    let capturedBody: unknown;
-    const handler = http.post(OPENROUTER_URL, async ({ request }) => {
-      capturedBody = await request.json();
-      return HttpResponse.json(openRouterResponse("Summary"));
+      const body = capturedBody as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const userContent = body.messages[1]!.content;
+      expect(userContent).toContain("Most recent user message:\nhello there");
+      expect(userContent).not.toContain("Most recent assistant reply");
+      expect(userContent).not.toContain("Previous conversation");
     });
-    server.use(handler.handler);
 
-    const { generateRunSummary } = await import("../lightweight-model");
+    it("should strip surrounding quotes from title", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(openRouterResponse('"Some Quoted Title"'));
+      });
+      server.use(handler.handler);
 
-    const longLine = "x".repeat(200);
-    const manyLines = Array.from({ length: 10 }, (_, i) => {
-      return `Line ${i}`;
-    }).join("\n");
-
-    await generateRunSummary("chat", longLine, manyLines);
-
-    const body = capturedBody as {
-      messages: Array<{ role: string; content: string }>;
-    };
-    const userContent = body.messages[1]!.content;
-
-    // Prompt should be truncated to 80 chars + ellipsis (single line)
-    expect(userContent).toContain("x".repeat(80) + "…");
-    expect(userContent).not.toContain("x".repeat(81));
-
-    // Result should only have first 3 lines
-    expect(userContent).toContain("Line 0");
-    expect(userContent).toContain("Line 2");
-    expect(userContent).not.toContain("Line 3");
-  });
-});
-
-describe("generateScheduleDescription", () => {
-  it("should return a description on successful response", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(
-        openRouterResponse("Runs daily backup for production database"),
+      expect(await generateChatTitle({ currentUserMessage: "msg" })).toBe(
+        "Some Quoted Title",
       );
     });
-    server.use(handler.handler);
 
-    const { generateScheduleDescription } =
-      await import("../lightweight-model");
+    it("should strip horizontal rules from title", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(openRouterResponse("---\nSome Title"));
+      });
+      server.use(handler.handler);
 
-    const result = await generateScheduleDescription(
-      "BackupBot",
-      "Daily Backup",
-      "Every day at 2am",
-      "Back up the production database",
-    );
-
-    expect(result).toBe("Runs daily backup for production database");
-    expect(handler.mocked).toHaveBeenCalledTimes(1);
-  });
-
-  it("should strip markdown from schedule descriptions", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(
-        openRouterResponse("**Daily** `backup` for [prod](https://db.io)"),
+      expect(await generateChatTitle({ currentUserMessage: "msg" })).toBe(
+        "Some Title",
       );
     });
-    server.use(handler.handler);
+  });
 
-    const { generateScheduleDescription } =
-      await import("../lightweight-model");
+  describe("generateRunSummary", () => {
+    it("should return a summary on successful response", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(
+          openRouterResponse(
+            "User asked about project setup. Agent provided step-by-step instructions.",
+          ),
+        );
+      });
+      server.use(handler.handler);
 
-    const result = await generateScheduleDescription(
-      "BackupBot",
-      "Daily Backup",
-      "Every day at 2am",
-      "Back up the production database",
-    );
+      const result = await generateRunSummary(
+        "chat",
+        "How do I set up this project?",
+        "First install dependencies with pnpm install, then run pnpm dev.",
+      );
 
-    expect(result).toBe("Daily backup for prod");
+      expect(result).toBe(
+        "User asked about project setup. Agent provided step-by-step instructions.",
+      );
+      expect(handler.mocked).toHaveBeenCalledTimes(1);
+    });
+
+    it("should include triggerSource in the system prompt", async () => {
+      let capturedBody: unknown;
+      const handler = http.post(OPENROUTER_URL, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(openRouterResponse("Summary text"));
+      });
+      server.use(handler.handler);
+
+      await generateRunSummary("slack", "prompt", "result");
+
+      const body = capturedBody as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      expect(body.messages[0]!.content).toContain("slack");
+    });
+
+    it("should truncate long input to 3 lines of 80 chars each", async () => {
+      let capturedBody: unknown;
+      const handler = http.post(OPENROUTER_URL, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(openRouterResponse("Summary"));
+      });
+      server.use(handler.handler);
+
+      const longLine = "x".repeat(200);
+      const manyLines = Array.from({ length: 10 }, (_, i) => {
+        return `Line ${i}`;
+      }).join("\n");
+
+      await generateRunSummary("chat", longLine, manyLines);
+
+      const body = capturedBody as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const userContent = body.messages[1]!.content;
+
+      // Prompt should be truncated to 80 chars + ellipsis (single line)
+      expect(userContent).toContain("x".repeat(80) + "…");
+      expect(userContent).not.toContain("x".repeat(81));
+
+      // Result should only have first 3 lines
+      expect(userContent).toContain("Line 0");
+      expect(userContent).toContain("Line 2");
+      expect(userContent).not.toContain("Line 3");
+    });
+  });
+
+  describe("generateScheduleDescription", () => {
+    it("should return a description on successful response", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(
+          openRouterResponse("Runs daily backup for production database"),
+        );
+      });
+      server.use(handler.handler);
+
+      const result = await generateScheduleDescription(
+        "BackupBot",
+        "Daily Backup",
+        "Every day at 2am",
+        "Back up the production database",
+      );
+
+      expect(result).toBe("Runs daily backup for production database");
+      expect(handler.mocked).toHaveBeenCalledTimes(1);
+    });
+
+    it("should strip markdown from schedule descriptions", async () => {
+      const handler = http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(
+          openRouterResponse("**Daily** `backup` for [prod](https://db.io)"),
+        );
+      });
+      server.use(handler.handler);
+
+      const result = await generateScheduleDescription(
+        "BackupBot",
+        "Daily Backup",
+        "Every day at 2am",
+        "Back up the production database",
+      );
+
+      expect(result).toBe("Daily backup for prod");
+    });
   });
 });

--- a/turbo/apps/web/src/lib/zero/telegram/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HttpResponse } from "msw";
 import {
   callTelegramApi,
@@ -25,6 +25,16 @@ describe("createTelegramClient", () => {
 });
 
 describe("callTelegramApi", () => {
+  let consoleWarn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+  });
+
   it("should call the Telegram API and return the result", async () => {
     const handler = http.post(
       `https://api.telegram.org/bot${TEST_TOKEN}/getMe`,


### PR DESCRIPTION
## Summary
- add missing dialog descriptions for Radix dialog accessibility warnings
- centralize the web OpenRouter test env/default MSW handler in setup instead of per-test env stubbing
- quiet expected failure-path logger noise locally while preserving real error-path coverage
- filter the known Undici EHPA process warning in the proxy login test

## Verification
- pnpm -F web exec vitest src/lib/zero/ai/__tests__/lightweight-model.test.ts --run
- pnpm -F @vm0/cli exec vitest src/commands/zero/doctor/__tests__/permission-change.test.ts --run
- pnpm test
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip