### PR TITLE
feat(connectors): gate local-agent connector entry behind staff-org switch

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/local-agent-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/local-agent-connector.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setupPage } from "../../../../__tests__/page-helper.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { setMockLocalAgentHosts } from "../../../../mocks/handlers/api-local-agent.ts";
@@ -34,6 +35,7 @@ describe("local-agent connector", () => {
       context,
       path: "/",
       withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalAgentConnector]: true },
     });
 
     const connectors = await context.store.get(allConnectorTypes$);

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -298,7 +298,9 @@ describe("connect modal - content by auth method", () => {
   });
 
   it("shows Local Agent connector-specific API content", async () => {
-    await openConnectModal("local-agent");
+    await openConnectModal("local-agent", {
+      featureSwitches: { [FeatureSwitchKey.LocalAgentConnector]: true },
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Online hosts")).toBeInTheDocument();
@@ -344,7 +346,9 @@ describe("connect modal - content by auth method", () => {
       }),
     );
 
-    await openConnectModal("github");
+    await openConnectModal("github", {
+      featureSwitches: { [FeatureSwitchKey.LocalAgentConnector]: true },
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();

--- a/turbo/packages/connectors/src/connectors/local-agent.ts
+++ b/turbo/packages/connectors/src/connectors/local-agent.ts
@@ -1,3 +1,4 @@
+import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
 
 export const localAgent = {
@@ -9,6 +10,7 @@ export const localAgent = {
       "Run local Codex or Claude Code hosts, then call them from chat with `/local-agent ${host} prompt`",
     authMethods: {
       api: {
+        featureFlag: FeatureSwitchKey.LocalAgentConnector,
         label: "CLI Host",
         helpText:
           "1. Run `npx -p @vm0/cli vm0 login`\n2. Start a host with `npx -p @vm0/cli vm0 local-agent start`\n3. Keep the host process running, then return here and click **Connect** once it appears online\n4. Run a connected host from chat with `/local-agent ${host} prompt`",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -37,6 +37,7 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   ComputerUse = "computerUse",
   LocalBrowserUse = "localBrowserUse",
+  LocalAgentConnector = "localAgentConnector",
   DesktopLocalAgent = "desktopLocalAgent",
   Lab = "lab",
   AuditLink = "auditLink",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -208,6 +208,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.LocalAgentConnector]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show the Local Agent connector entry on the Connectors settings page. Staff-only while adoption is being re-evaluated.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.DesktopLocalAgent]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Adds a new `FeatureSwitchKey.LocalAgentConnector` (staff-org gated, off by default for all other orgs) and wires it to the `api` auth method on the Local Agent connector. The connector entry now only appears on the Connectors settings page for vm0 staff while we re-evaluate local-agent adoption.
- Pattern mirrors the existing `LocalBrowserUse` gate at `turbo/packages/connectors/src/connectors/local-browser.ts:13` and the staff-org `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` style used by `GoogleAdsConnector`, `PwaOfflineCache`, `LocalBrowserUse`, `DesktopLocalAgent`, etc.

## Context

Past-7-day usage on prod (mask-db + axiom):
- 20 paired hosts, but only **4 users** actually dispatched a job (2 internal, 2 external) and **5 paired users / 3 orgs** total
- 124 job dispatches in 7d; 98 of them from a single internal user
- Heartbeats steady at 16K–32K/day — the few active hosts are healthy, but the funnel is narrow

Hiding the entry from non-staff orgs lets us avoid surfacing an under-adopted setup flow while we decide whether to invest further or fold it into the Desktop Local Agent surface (`DesktopLocalAgent`, #14055).

## What changes

- `turbo/packages/connectors/src/feature-switch-key.ts`: add `LocalAgentConnector = "localAgentConnector"`
- `turbo/packages/core/src/feature-switch.ts`: register the switch with `enabled: false` + `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`
- `turbo/packages/connectors/src/connectors/local-agent.ts`: set `featureFlag: FeatureSwitchKey.LocalAgentConnector` on the `api` auth method

`isConnectorAuthMethodAvailable` already filters connector auth methods by `featureFlag` at `turbo/packages/connectors/src/connector-utils.ts:117-127`, so the registry entry is automatically dropped from the user-visible connector list when the switch is off.

## What is _not_ changed

- API surfaces (`/api/zero/local-agent/*`) are untouched. Existing paired hosts and CLI runs continue to work — this only gates the **entry point** on the Connectors settings page.
- The separate `DesktopLocalAgent` switch (Desktop-owned Local Agent page) is unchanged.

## Test plan

- [x] `pnpm -F @vm0/connectors exec tsc --noEmit` — clean
- [x] `pnpm -F @vm0/core exec tsc --noEmit` — clean
- [x] `pnpm -F @vm0/connectors lint` — clean
- [x] `pnpm -F @vm0/core lint` — clean
- [x] `pnpm -F @vm0/connectors exec vitest run` — 683 / 683 pass
- [x] `pnpm -F @vm0/core exec vitest run` — 185 / 185 pass
- [ ] After merge, verify Local Agent card hidden on Connectors settings page for a non-staff org and visible for the vm0 staff org