### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.148"
+CLAUDE_CODE_VERSION="2.1.149"
 CODEX_CLI_VERSION="0.133.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Update pinned tool versions in `crates/runner/scripts/build-template.sh`.

| Package | Old | New |
|---|---|---|
| claude-code | 2.1.148 | 2.1.149 |

All other pinned versions (Go 1.26.3, codex 0.133.0, gws-cli 0.22.5, xurl 1.0.3, agent-browser 0.27.0, pnpm 11.2.2) are already at latest.

## Test plan

- [ ] CI builds the rootfs template successfully with the updated claude-code version