### PR TITLE
chore(rust): weekly dependency update (2026-05-23)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -185,9 +185,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-credential-types"
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3754,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3764,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3774,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3787,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3830,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
## Summary

Weekly automated Rust dependency refresh in the `crates/` workspace via `cargo update`.

Nine transitive packages were bumped to their latest patch/minor versions compatible with the existing `Cargo.toml` constraints. No direct workspace dependencies needed manifest changes.

## Updated dependencies

All transitive; only `Cargo.lock` changed.

| Crate | From | To |
|-------|------|----|
| autocfg | 1.5.0 | 1.5.1 |
| bumpalo | 3.20.2 | 3.20.3 |
| js-sys | 0.3.98 | 0.3.99 |
| wasm-bindgen | 0.2.121 | 0.2.122 |
| wasm-bindgen-futures | 0.4.71 | 0.4.72 |
| wasm-bindgen-macro | 0.2.121 | 0.2.122 |
| wasm-bindgen-macro-support | 0.2.121 | 0.2.122 |
| wasm-bindgen-shared | 0.2.121 | 0.2.122 |
| web-sys | 0.3.98 | 0.3.99 |

## Dependencies that could NOT be updated

| Crate | Locked | Latest | Reason |
|-------|--------|--------|--------|
| generic-array | 0.14.7 | 0.14.9 (in 0.14 line); 1.x available | Pinned to 0.14 by `digest 0.10` (transitive via `aws-smithy-checksums`, `headers`, `tungstenite`). Bumping requires upgrading the `digest` chain in upstream crates — out of scope for a routine refresh. |

## Manual version bumps

None. The workspace `Cargo.toml` uses loose major-line specifiers (e.g. `serde = "1"`, `tokio = "1"`, `reqwest = "0.13"`); everything within those bounds was already auto-resolved by `cargo update`.

## Test status

- `cargo check --workspace --tests`: **PASS** (clean type-check of every workspace crate including test code, 4m14s).
- `cargo test` per crate: **PASS** on all crates except `runner` — every executed test passed (api-contracts 65, sandbox-fc 454, sandbox 199, vsock-host 118, runner unit subset via dependents 109, agent-diagnostics 47, guest-agent 39, etc.). 0 failures, 0 newly ignored.
- `cargo test -p runner`: **NOT EXECUTED in this environment.** The runner integration-test binary is large enough that the linker is OOM-killed on a 3.8 GiB sandbox host. The dependency delta is wasm-bindgen-ecosystem patch versions only (used only via `chrono`/`sentry` wasm32 cfg paths), which do not affect the aarch64 link graph — so runner is expected to be unaffected. CI will exercise it on the queue.

Branch: `chore/rust-deps-update-2026-05-23`