### PR TITLE
refactor(mitm-addon): extract connection mock fixtures

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -25,6 +25,7 @@ from mitmproxy import http, tcp
 from mitmproxy.test import tflow, tutils
 
 import auth
+import auth_base_forwarder as forwarder
 import mitm_addon
 import registry
 import usage
@@ -53,6 +54,32 @@ def _reset_module_state() -> None:
 
 def _headers(*pairs: tuple[str, str]) -> http.Headers:
     return http.Headers([(k.encode(), v.encode()) for k, v in pairs])
+
+
+def _mock_forwarder_conn() -> tuple[MagicMock, MagicMock]:
+    resp = MagicMock()
+    resp.status = 200
+    resp.read.return_value = b"ok"
+    resp.getheaders.return_value = []
+    conn = MagicMock()
+    conn.getresponse.return_value = resp
+    return conn, resp
+
+
+@pytest.fixture
+def mock_https_conn() -> Iterator[tuple[MagicMock, MagicMock, MagicMock]]:
+    """Stub ``HTTPSConnection`` with a 200/``b"ok"``/no-headers response."""
+    conn, resp = _mock_forwarder_conn()
+    with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn) as cls:
+        yield conn, resp, cls
+
+
+@pytest.fixture
+def mock_http_conn() -> Iterator[tuple[MagicMock, MagicMock, MagicMock]]:
+    """Stub ``HTTPConnection`` with a 200/``b"ok"``/no-headers response."""
+    conn, resp = _mock_forwarder_conn()
+    with patch.object(forwarder.http_client, "HTTPConnection", return_value=conn) as cls:
+        yield conn, resp, cls
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1,6 +1,6 @@
 """Tests for auth.base low-level HTTP forwarding."""
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -91,41 +91,32 @@ class TestAuthBaseForwarderSecurity:
         assert filtered.get_all("Set-Cookie") == ["a=1", "b=2"]
         assert filtered.get_all("Link") == ["<next>; rel=next", "<prev>; rel=prev"]
 
-    def test_returns_redirect_response_without_following(self):
-        resp = MagicMock()
+    def test_returns_redirect_response_without_following(self, mock_https_conn):
+        _conn, resp, _https_conn = mock_https_conn
         resp.status = 302
         resp.read.return_value = b""
         resp.getheaders.return_value = [("Location", "https://evil.example.com")]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            status, body, headers = forwarder._forward_request_sync(
-                "https://example.com/redirect",
-                "GET",
-                [],
-                None,
-            )
+        status, body, headers = forwarder._forward_request_sync(
+            "https://example.com/redirect",
+            "GET",
+            [],
+            None,
+        )
 
         assert status == 302
         assert body == b""
         assert headers["Location"] == "https://evil.example.com"
 
-    def test_repeated_request_headers_are_written_individually(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_repeated_request_headers_are_written_individually(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com/path?x=1",
-                "GET",
-                [("X-Repeat", "one"), ("X-Repeat", "two")],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com/path?x=1",
+            "GET",
+            [("X-Repeat", "one"), ("X-Repeat", "two")],
+            None,
+        )
 
         conn.putrequest.assert_called_once_with(
             "GET",
@@ -142,42 +133,30 @@ class TestAuthBaseForwarderSecurity:
         )
         assert call("Content-Length", "0") not in conn.putheader.call_args_list
 
-    def test_absent_body_strips_stale_content_length(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_absent_body_strips_stale_content_length(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com/path",
-                "POST",
-                [("Content-Length", "999"), ("X-Keep", "ok")],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com/path",
+            "POST",
+            [("Content-Length", "999"), ("X-Keep", "ok")],
+            None,
+        )
 
         header_names = [args[0].lower() for args, _ in conn.putheader.call_args_list]
         assert "content-length" not in header_names
         assert call("X-Keep", "ok") in conn.putheader.call_args_list
         conn.endheaders.assert_called_once_with(None)
 
-    def test_root_request_target_preserves_query(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_root_request_target_preserves_query(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com?wait=true",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com?wait=true",
+            "GET",
+            [],
+            None,
+        )
 
         conn.putrequest.assert_called_once_with(
             "GET",
@@ -186,21 +165,15 @@ class TestAuthBaseForwarderSecurity:
             skip_accept_encoding=True,
         )
 
-    def test_request_target_omits_fragment(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_request_target_omits_fragment(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com/path?x=1#client-only-secret",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com/path?x=1#client-only-secret",
+            "GET",
+            [],
+            None,
+        )
 
         conn.putrequest.assert_called_once_with(
             "GET",
@@ -209,21 +182,15 @@ class TestAuthBaseForwarderSecurity:
             skip_accept_encoding=True,
         )
 
-    def test_request_target_preserves_encoded_path_and_duplicate_query(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_request_target_preserves_encoded_path_and_duplicate_query(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com/%2Fsecret/a%20b?x=a%2Fb&x=&space=a+b",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com/%2Fsecret/a%20b?x=a%2Fb&x=&space=a+b",
+            "GET",
+            [],
+            None,
+        )
 
         conn.putrequest.assert_called_once_with(
             "GET",
@@ -232,21 +199,15 @@ class TestAuthBaseForwarderSecurity:
             skip_accept_encoding=True,
         )
 
-    def test_request_target_preserves_path_params(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_request_target_preserves_path_params(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com/hook;v=1/sub;mode=fast?x=1",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com/hook;v=1/sub;mode=fast?x=1",
+            "GET",
+            [],
+            None,
+        )
 
         conn.putrequest.assert_called_once_with(
             "GET",
@@ -255,91 +216,65 @@ class TestAuthBaseForwarderSecurity:
             skip_accept_encoding=True,
         )
 
-    def test_https_scheme_uses_https_connection_and_default_port_host(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_https_scheme_uses_https_connection_and_default_port_host(self, mock_https_conn):
+        conn, _resp, https_conn = mock_https_conn
 
-        with patch.object(
-            forwarder.http_client, "HTTPSConnection", return_value=conn
-        ) as https_conn:
-            forwarder._forward_request_sync(
-                "https://example.com:443/path",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://example.com:443/path",
+            "GET",
+            [],
+            None,
+        )
 
         https_conn.assert_called_once_with("example.com", port=443, timeout=30)
         assert call("Host", "example.com") in conn.putheader.call_args_list
 
-    def test_http_scheme_uses_http_connection_and_default_port_host(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_http_scheme_uses_http_connection_and_default_port_host(self, mock_http_conn):
+        conn, _resp, http_conn = mock_http_conn
 
-        with patch.object(forwarder.http_client, "HTTPConnection", return_value=conn) as http_conn:
-            forwarder._forward_request_sync(
-                "http://example.com:80/path",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "http://example.com:80/path",
+            "GET",
+            [],
+            None,
+        )
 
         http_conn.assert_called_once_with("example.com", port=80, timeout=30)
         assert call("Host", "example.com") in conn.putheader.call_args_list
 
-    def test_ipv6_host_header_is_bracketed(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_ipv6_host_header_is_bracketed(self, mock_https_conn):
+        conn, _resp, https_conn = mock_https_conn
 
-        with patch.object(
-            forwarder.http_client, "HTTPSConnection", return_value=conn
-        ) as https_conn:
-            forwarder._forward_request_sync(
-                "https://[2001:db8::1]:444/path",
-                "GET",
-                [],
-                None,
-            )
+        forwarder._forward_request_sync(
+            "https://[2001:db8::1]:444/path",
+            "GET",
+            [],
+            None,
+        )
 
         https_conn.assert_called_once_with("2001:db8::1", port=444, timeout=30)
         assert call("Host", "[2001:db8::1]:444") in conn.putheader.call_args_list
 
-    def test_filters_request_hop_by_hop_headers_and_recomputes_content_length(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_filters_request_hop_by_hop_headers_and_recomputes_content_length(
+        self, mock_https_conn
+    ):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com:444/path",
-                "PUT",
-                [
-                    ("Host", "agent.example.com"),
-                    ("Connection", "X-Remove, Keep-Alive"),
-                    ("X-Remove", "secret"),
-                    ("Keep-Alive", "timeout=5"),
-                    ("Proxy-Authorization", "Basic secret"),
-                    ("Content-Length", "999"),
-                    ("Transfer-Encoding", "chunked"),
-                    ("X-Keep", "ok"),
-                ],
-                b"abc",
-            )
+        forwarder._forward_request_sync(
+            "https://example.com:444/path",
+            "PUT",
+            [
+                ("Host", "agent.example.com"),
+                ("Connection", "X-Remove, Keep-Alive"),
+                ("X-Remove", "secret"),
+                ("Keep-Alive", "timeout=5"),
+                ("Proxy-Authorization", "Basic secret"),
+                ("Content-Length", "999"),
+                ("Transfer-Encoding", "chunked"),
+                ("X-Keep", "ok"),
+            ],
+            b"abc",
+        )
 
         header_calls = conn.putheader.call_args_list
         header_names = [args[0].lower() for args, _ in header_calls]
@@ -354,29 +289,23 @@ class TestAuthBaseForwarderSecurity:
         assert call("Content-Length", "999") not in header_calls
         conn.endheaders.assert_called_once_with(b"abc")
 
-    def test_explicit_empty_body_sets_zero_content_length(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
+    def test_explicit_empty_body_sets_zero_content_length(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
-                "https://example.com/path",
-                "POST",
-                [],
-                b"",
-            )
+        forwarder._forward_request_sync(
+            "https://example.com/path",
+            "POST",
+            [],
+            b"",
+        )
 
         assert call("Content-Length", "0") in conn.putheader.call_args_list
         conn.endheaders.assert_called_once_with(b"")
 
-    def test_preserves_duplicate_response_headers_and_filters_connection_names(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
+    def test_preserves_duplicate_response_headers_and_filters_connection_names(
+        self, mock_https_conn
+    ):
+        _conn, resp, _https_conn = mock_https_conn
         resp.getheaders.return_value = [
             ("Set-Cookie", "a=1"),
             ("Set-Cookie", "b=2"),
@@ -384,16 +313,13 @@ class TestAuthBaseForwarderSecurity:
             ("X-Remove", "drop"),
             ("X-Keep", "ok"),
         ]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            _status, _body, headers = forwarder._forward_request_sync(
-                "https://example.com",
-                "GET",
-                [],
-                None,
-            )
+        _status, _body, headers = forwarder._forward_request_sync(
+            "https://example.com",
+            "GET",
+            [],
+            None,
+        )
 
         pairs = list(headers.items(multi=True))
         assert pairs.count(("Set-Cookie", "a=1")) == 1
@@ -404,24 +330,17 @@ class TestAuthBaseForwarderSecurity:
 
 
 class TestAuthBaseForwarderResourceCleanup:
-    def test_closes_response_on_success(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
+    def test_closes_response_on_success(self, mock_https_conn):
+        conn, resp, _https_conn = mock_https_conn
         resp.getheaders.return_value = [("Content-Type", "application/json")]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            status, body, _ = forwarder._forward_request_sync(
-                "https://example.com", "GET", [], None
-            )
+        status, body, _ = forwarder._forward_request_sync("https://example.com", "GET", [], None)
         assert status == 200
         assert body == b"ok"
         resp.close.assert_called_once()
         conn.close.assert_called_once()
 
-    def test_preserves_duplicate_headers_on_error_status(self):
-        resp = MagicMock()
+    def test_preserves_duplicate_headers_on_error_status(self, mock_https_conn):
+        conn, resp, _https_conn = mock_https_conn
         resp.status = 429
         resp.read.return_value = b"rate limited"
         resp.getheaders.return_value = [
@@ -429,13 +348,10 @@ class TestAuthBaseForwarderResourceCleanup:
             ("WWW-Authenticate", "Bearer realm=two"),
             ("Content-Type", "text/plain"),
         ]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            status, body, headers = forwarder._forward_request_sync(
-                "https://example.com", "GET", [], None
-            )
+        status, body, headers = forwarder._forward_request_sync(
+            "https://example.com", "GET", [], None
+        )
 
         assert status == 429
         assert body == b"rate limited"
@@ -444,27 +360,17 @@ class TestAuthBaseForwarderResourceCleanup:
         resp.close.assert_called_once()
         conn.close.assert_called_once()
 
-    def test_closes_response_when_read_raises(self):
-        resp = MagicMock()
-        resp.status = 200
+    def test_closes_response_when_read_raises(self, mock_https_conn):
+        conn, resp, _https_conn = mock_https_conn
         resp.read.side_effect = OSError("socket closed")
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-        with (
-            patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn),
-            pytest.raises(OSError, match="socket closed"),
-        ):
+        with pytest.raises(OSError, match="socket closed"):
             forwarder._forward_request_sync("https://example.com", "GET", [], None)
         resp.close.assert_called_once()
         conn.close.assert_called_once()
 
-    def test_closes_connection_when_request_raises(self):
-        conn = MagicMock()
+    def test_closes_connection_when_request_raises(self, mock_https_conn):
+        conn, _resp, _https_conn = mock_https_conn
         conn.putrequest.side_effect = ConnectionError("connect failed")
-        with (
-            patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn),
-            pytest.raises(ConnectionError, match="connect failed"),
-        ):
+        with pytest.raises(ConnectionError, match="connect failed"):
             forwarder._forward_request_sync("https://example.com", "GET", [], None)
         conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add shared HTTP and HTTPS connection fixtures for auth base forwarder tests
- update auth base forwarder tests to customize fixture responses instead of duplicating connection setup

## Tests
- python3 -m ruff format --check .
- python3 -m ruff check .
- python3 -m basedpyright
- python3 -m pytest tests/ -q

Closes #14590