### PR TITLE
fix(mitm-addon): capture terminal OpenAI Responses usage

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -131,8 +131,6 @@ def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
 
     if target_has_positive_quantity and not source_has_positive_quantity:
         return
-    if not stored_quantity and target_has_positive_quantity:
-        return
 
     model = source.get("model")
     if isinstance(model, str) and model:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -28,7 +28,11 @@ from .model_tokens import (
 )
 from .sse import SseUsageParser
 
-_RESPONSES_USAGE_EVENTS = frozenset(("response.completed", "response.done"))
+# Terminal Responses events whose Response object may carry usage. Keep this
+# narrow so high-volume delta events stay on the SSE discard path.
+_RESPONSES_TERMINAL_USAGE_EVENTS = frozenset(
+    ("response.completed", "response.done", "response.incomplete", "response.failed")
+)
 
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_INPUT,
@@ -148,7 +152,10 @@ def _store_sse_result_values(
     event_name: str | None,
 ) -> None:
     data_type = values.get(("type",))
-    if event_name not in _RESPONSES_USAGE_EVENTS and data_type not in _RESPONSES_USAGE_EVENTS:
+    if (
+        event_name not in _RESPONSES_TERMINAL_USAGE_EVENTS
+        and data_type not in _RESPONSES_TERMINAL_USAGE_EVENTS
+    ):
         return
 
     prefix = ("response",) if _has_response_wrapper_values(values) else ()
@@ -172,7 +179,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._extractor: JsonSelectiveExtractor | None = None
 
     def should_capture_event(self, event_name: str | None) -> bool:
-        return event_name is None or event_name in _RESPONSES_USAGE_EVENTS
+        return event_name is None or event_name in _RESPONSES_TERMINAL_USAGE_EVENTS
 
     def on_event_start(self, event_name: str | None) -> None:
         self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -125,9 +125,8 @@ def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] =
 def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
     target_has_positive_quantity = _has_positive_usage_quantity(target)
     source_has_positive_quantity = _has_positive_usage_quantity(source)
-    stored_quantity = False
     for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
-        stored_quantity = _store_quantity(target, category, source.get(category)) or stored_quantity
+        _store_quantity(target, category, source.get(category))
 
     if target_has_positive_quantity and not source_has_positive_quantity:
         return

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -129,7 +129,9 @@ def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
     for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
         stored_quantity = _store_quantity(target, category, source.get(category)) or stored_quantity
 
-    if not stored_quantity or (target_has_positive_quantity and not source_has_positive_quantity):
+    if target_has_positive_quantity and not source_has_positive_quantity:
+        return
+    if not stored_quantity and target_has_positive_quantity:
         return
 
     model = source.get("model")
@@ -159,7 +161,9 @@ def _store_sse_result_values(
         return
 
     prefix = ("response",) if _has_response_wrapper_values(values) else ()
-    _store_response_values(values, target, prefix)
+    source: dict = {}
+    _store_response_values(values, source, prefix)
+    merge_openai_responses_usage_result(target, source)
 
 
 def create_openai_responses_sse_usage_extractor() -> tuple[SseUsageParser, dict]:

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -56,6 +56,54 @@ def test_extracts_usage_from_wrapped_response_done_event():
     }
 
 
+def test_extracts_usage_from_wrapped_response_incomplete_event():
+    body = json.dumps(
+        {
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_incomplete",
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 8000,
+                    "output_tokens": 1024,
+                    "input_tokens_details": {"cached_tokens": 2000},
+                },
+            },
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "message_id": "resp_incomplete",
+        "model": "gpt-5.5",
+        "tokens.input": 6000,
+        "tokens.output": 1024,
+        "tokens.cache_read": 2000,
+    }
+
+
+def test_extracts_usage_from_wrapped_response_failed_event():
+    body = json.dumps(
+        {
+            "type": "response.failed",
+            "response": {
+                "id": "resp_failed",
+                "model": "gpt-5.4",
+                "usage": {
+                    "input_tokens": 12000,
+                    "output_tokens": 0,
+                },
+            },
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "message_id": "resp_failed",
+        "model": "gpt-5.4",
+        "tokens.input": 12000,
+        "tokens.output": 0,
+    }
+
+
 def test_extracts_usage_from_flat_response_completed_event():
     body = json.dumps(
         {

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -39,6 +39,45 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["tokens.output"] == 7
         assert "tokens.cache_read" not in usage
 
+    def test_extracts_usage_from_response_incomplete(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.incomplete\n"
+            b'data: {"type":"response.incomplete","response":{"id":"resp_incomplete",'
+            b'"model":"gpt-5.5","usage":{"input_tokens":8000,'
+            b'"output_tokens":1024,"input_tokens_details":{"cached_tokens":2000}}}}\n\n'
+        )
+        assert usage == {
+            "message_id": "resp_incomplete",
+            "model": "gpt-5.5",
+            "tokens.input": 6000,
+            "tokens.output": 1024,
+            "tokens.cache_read": 2000,
+        }
+
+    def test_extracts_usage_from_response_failed(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.failed\n"
+            b'data: {"type":"response.failed","response":{"id":"resp_failed",'
+            b'"model":"gpt-5.4","usage":{"input_tokens":12000,"output_tokens":0}}}\n\n'
+        )
+        assert usage == {
+            "message_id": "resp_failed",
+            "model": "gpt-5.4",
+            "tokens.input": 12000,
+            "tokens.output": 0,
+        }
+
+    def test_ignores_response_in_progress(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.in_progress\n"
+            b'data: {"type":"response.in_progress","response":{"id":"resp_ignored",'
+            b'"model":"gpt-5.5","usage":{"input_tokens":10,"output_tokens":4}}}\n\n'
+        )
+        assert usage == {}
+
     def test_accepts_data_level_type_without_event_line(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -316,6 +316,50 @@ class TestResponseUsageReporting:
             "tokens.cache_read": 10,
         }
 
+    def test_full_pipeline_model_sse_reports_response_incomplete_usage(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "text/event-stream"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        _response_stream(flow)(
+            b"event: response.incomplete\n"
+            b'data: {"response":{"id":"resp_incomplete","model":"gpt-5.5",'
+            b'"usage":{"input_tokens":8000,"output_tokens":1024,'
+            b'"input_tokens_details":{"cached_tokens":2000}}}}\n\n'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 6000,
+            "tokens.output": 1024,
+            "tokens.cache_read": 2000,
+        }
+        assert {event["provider"] for event in events} == {"gpt-5.5"}
+
     def test_full_pipeline_model_websocket_reports_usage(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -360,6 +360,60 @@ class TestResponseUsageReporting:
         }
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
+    def test_full_pipeline_model_sse_zero_event_preserves_billed_usage_and_id(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "text/event-stream"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        _response_stream(flow)(
+            b"event: response.completed\n"
+            b'data: {"response":{"id":"resp_sse_1","model":"gpt-5.5",'
+            b'"usage":{"input_tokens":100,"output_tokens":40}}}\n\n'
+            b"event: response.failed\n"
+            b'data: {"response":{"id":"resp_sse_empty","model":"gpt-5.4",'
+            b'"usage":{"input_tokens":0,"output_tokens":0}}}\n\n'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
+        assert by_category == {
+            "tokens.input": 100,
+            "tokens.output": 40,
+        }
+        assert idempotency_by_category == {
+            "tokens.input": _model_usage_idempotency_key(
+                "run-abc-123", "resp_sse_1", "tokens.input"
+            ),
+            "tokens.output": _model_usage_idempotency_key(
+                "run-abc-123", "resp_sse_1", "tokens.output"
+            ),
+        }
+        assert {event["provider"] for event in events} == {"gpt-5.5"}
+
     def test_full_pipeline_model_websocket_reports_usage(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):


### PR DESCRIPTION
## Summary
- Treat `response.incomplete` and `response.failed` as terminal OpenAI Responses events that may carry usage.
- Keep the SSE parser's narrow event allowlist so high-volume delta events stay on the discard path.
- Add SSE extractor, event JSON, and full pipeline usage-event coverage for terminal Responses usage.

## Tests
- `python3 -m pytest tests/test_handlers.py::TestOpenAIResponsesSseUsageExtractor tests/test_openai_responses_event_json.py`
- `python3 -m pytest tests/test_handlers.py -k 'model_provider and (sse or websocket or response_incomplete or response_failed)'`
- `python3 -m ruff check src tests`
- `python3 -m basedpyright`
- `python3 -m pytest tests`

Closes #14592
