### PR TITLE
refactor(mitm-addon): extract auth base forwarder test helper

### DIFF
--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1,10 +1,51 @@
 """Tests for auth.base low-level HTTP forwarding."""
 
+import contextlib
+from collections.abc import Iterator
+from typing import Literal, NamedTuple
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 import auth_base_forwarder as forwarder
+
+
+class ForwarderConnectionPatch(NamedTuple):
+    conn: MagicMock
+    resp: MagicMock
+    connection_cls: MagicMock
+
+
+@contextlib.contextmanager
+def _patched_forwarder_connection(
+    *,
+    scheme: Literal["http", "https"] = "https",
+    status: int = 200,
+    body: bytes = b"ok",
+    headers: list[tuple[str, str]] | None = None,
+    read_side_effect: Exception | None = None,
+    putrequest_side_effect: Exception | None = None,
+    getresponse_side_effect: Exception | None = None,
+) -> Iterator[ForwarderConnectionPatch]:
+    resp = MagicMock()
+    resp.status = status
+    if read_side_effect is None:
+        resp.read.return_value = body
+    else:
+        resp.read.side_effect = read_side_effect
+    resp.getheaders.return_value = [] if headers is None else headers
+
+    conn = MagicMock()
+    if putrequest_side_effect is not None:
+        conn.putrequest.side_effect = putrequest_side_effect
+    if getresponse_side_effect is None:
+        conn.getresponse.return_value = resp
+    else:
+        conn.getresponse.side_effect = getresponse_side_effect
+
+    connection_name = "HTTPSConnection" if scheme == "https" else "HTTPConnection"
+    with patch.object(forwarder.http_client, connection_name, return_value=conn) as cls:
+        yield ForwarderConnectionPatch(conn=conn, resp=resp, connection_cls=cls)
 
 
 class TestAuthBaseForwarderSecurity:
@@ -92,14 +133,11 @@ class TestAuthBaseForwarderSecurity:
         assert filtered.get_all("Link") == ["<next>; rel=next", "<prev>; rel=prev"]
 
     def test_returns_redirect_response_without_following(self):
-        resp = MagicMock()
-        resp.status = 302
-        resp.read.return_value = b""
-        resp.getheaders.return_value = [("Location", "https://evil.example.com")]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection(
+            status=302,
+            body=b"",
+            headers=[("Location", "https://evil.example.com")],
+        ):
             status, body, headers = forwarder._forward_request_sync(
                 "https://example.com/redirect",
                 "GET",
@@ -112,14 +150,7 @@ class TestAuthBaseForwarderSecurity:
         assert headers["Location"] == "https://evil.example.com"
 
     def test_repeated_request_headers_are_written_individually(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 "https://example.com/path?x=1",
                 "GET",
@@ -127,30 +158,23 @@ class TestAuthBaseForwarderSecurity:
                 None,
             )
 
-        conn.putrequest.assert_called_once_with(
+        upstream.conn.putrequest.assert_called_once_with(
             "GET",
             "/path?x=1",
             skip_host=True,
             skip_accept_encoding=True,
         )
-        conn.putheader.assert_has_calls(
+        upstream.conn.putheader.assert_has_calls(
             [
                 call("Host", "example.com"),
                 call("X-Repeat", "one"),
                 call("X-Repeat", "two"),
             ]
         )
-        assert call("Content-Length", "0") not in conn.putheader.call_args_list
+        assert call("Content-Length", "0") not in upstream.conn.putheader.call_args_list
 
     def test_absent_body_strips_stale_content_length(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 "https://example.com/path",
                 "POST",
@@ -158,114 +182,49 @@ class TestAuthBaseForwarderSecurity:
                 None,
             )
 
-        header_names = [args[0].lower() for args, _ in conn.putheader.call_args_list]
+        header_names = [args[0].lower() for args, _ in upstream.conn.putheader.call_args_list]
         assert "content-length" not in header_names
-        assert call("X-Keep", "ok") in conn.putheader.call_args_list
-        conn.endheaders.assert_called_once_with(None)
+        assert call("X-Keep", "ok") in upstream.conn.putheader.call_args_list
+        upstream.conn.endheaders.assert_called_once_with(None)
 
-    def test_root_request_target_preserves_query(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
+    @pytest.mark.parametrize(
+        ("url", "expected_target"),
+        [
+            pytest.param(
                 "https://example.com?wait=true",
-                "GET",
-                [],
-                None,
-            )
-
-        conn.putrequest.assert_called_once_with(
-            "GET",
-            "/?wait=true",
-            skip_host=True,
-            skip_accept_encoding=True,
-        )
-
-    def test_request_target_omits_fragment(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
+                "/?wait=true",
+                id="root-query",
+            ),
+            pytest.param(
                 "https://example.com/path?x=1#client-only-secret",
-                "GET",
-                [],
-                None,
-            )
-
-        conn.putrequest.assert_called_once_with(
-            "GET",
-            "/path?x=1",
-            skip_host=True,
-            skip_accept_encoding=True,
-        )
-
-    def test_request_target_preserves_encoded_path_and_duplicate_query(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
+                "/path?x=1",
+                id="omit-fragment",
+            ),
+            pytest.param(
                 "https://example.com/%2Fsecret/a%20b?x=a%2Fb&x=&space=a+b",
-                "GET",
-                [],
-                None,
-            )
-
-        conn.putrequest.assert_called_once_with(
-            "GET",
-            "/%2Fsecret/a%20b?x=a%2Fb&x=&space=a+b",
-            skip_host=True,
-            skip_accept_encoding=True,
-        )
-
-    def test_request_target_preserves_path_params(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
-            forwarder._forward_request_sync(
+                "/%2Fsecret/a%20b?x=a%2Fb&x=&space=a+b",
+                id="encoded-path-duplicate-query",
+            ),
+            pytest.param(
                 "https://example.com/hook;v=1/sub;mode=fast?x=1",
-                "GET",
-                [],
-                None,
-            )
+                "/hook;v=1/sub;mode=fast?x=1",
+                id="path-params",
+            ),
+        ],
+    )
+    def test_request_target_preserves_url_parts(self, url, expected_target):
+        with _patched_forwarder_connection() as upstream:
+            forwarder._forward_request_sync(url, "GET", [], None)
 
-        conn.putrequest.assert_called_once_with(
+        upstream.conn.putrequest.assert_called_once_with(
             "GET",
-            "/hook;v=1/sub;mode=fast?x=1",
+            expected_target,
             skip_host=True,
             skip_accept_encoding=True,
         )
 
     def test_https_scheme_uses_https_connection_and_default_port_host(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(
-            forwarder.http_client, "HTTPSConnection", return_value=conn
-        ) as https_conn:
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 "https://example.com:443/path",
                 "GET",
@@ -273,18 +232,11 @@ class TestAuthBaseForwarderSecurity:
                 None,
             )
 
-        https_conn.assert_called_once_with("example.com", port=443, timeout=30)
-        assert call("Host", "example.com") in conn.putheader.call_args_list
+        upstream.connection_cls.assert_called_once_with("example.com", port=443, timeout=30)
+        assert call("Host", "example.com") in upstream.conn.putheader.call_args_list
 
     def test_http_scheme_uses_http_connection_and_default_port_host(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPConnection", return_value=conn) as http_conn:
+        with _patched_forwarder_connection(scheme="http") as upstream:
             forwarder._forward_request_sync(
                 "http://example.com:80/path",
                 "GET",
@@ -292,20 +244,11 @@ class TestAuthBaseForwarderSecurity:
                 None,
             )
 
-        http_conn.assert_called_once_with("example.com", port=80, timeout=30)
-        assert call("Host", "example.com") in conn.putheader.call_args_list
+        upstream.connection_cls.assert_called_once_with("example.com", port=80, timeout=30)
+        assert call("Host", "example.com") in upstream.conn.putheader.call_args_list
 
     def test_ipv6_host_header_is_bracketed(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(
-            forwarder.http_client, "HTTPSConnection", return_value=conn
-        ) as https_conn:
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 "https://[2001:db8::1]:444/path",
                 "GET",
@@ -313,18 +256,11 @@ class TestAuthBaseForwarderSecurity:
                 None,
             )
 
-        https_conn.assert_called_once_with("2001:db8::1", port=444, timeout=30)
-        assert call("Host", "[2001:db8::1]:444") in conn.putheader.call_args_list
+        upstream.connection_cls.assert_called_once_with("2001:db8::1", port=444, timeout=30)
+        assert call("Host", "[2001:db8::1]:444") in upstream.conn.putheader.call_args_list
 
     def test_filters_request_hop_by_hop_headers_and_recomputes_content_length(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 "https://example.com:444/path",
                 "PUT",
@@ -341,7 +277,7 @@ class TestAuthBaseForwarderSecurity:
                 b"abc",
             )
 
-        header_calls = conn.putheader.call_args_list
+        header_calls = upstream.conn.putheader.call_args_list
         header_names = [args[0].lower() for args, _ in header_calls]
         assert "connection" not in header_names
         assert "x-remove" not in header_names
@@ -352,17 +288,10 @@ class TestAuthBaseForwarderSecurity:
         assert call("X-Keep", "ok") in header_calls
         assert call("Content-Length", "3") in header_calls
         assert call("Content-Length", "999") not in header_calls
-        conn.endheaders.assert_called_once_with(b"abc")
+        upstream.conn.endheaders.assert_called_once_with(b"abc")
 
     def test_explicit_empty_body_sets_zero_content_length(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 "https://example.com/path",
                 "POST",
@@ -370,24 +299,19 @@ class TestAuthBaseForwarderSecurity:
                 b"",
             )
 
-        assert call("Content-Length", "0") in conn.putheader.call_args_list
-        conn.endheaders.assert_called_once_with(b"")
+        assert call("Content-Length", "0") in upstream.conn.putheader.call_args_list
+        upstream.conn.endheaders.assert_called_once_with(b"")
 
     def test_preserves_duplicate_response_headers_and_filters_connection_names(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = [
-            ("Set-Cookie", "a=1"),
-            ("Set-Cookie", "b=2"),
-            ("Connection", "X-Remove"),
-            ("X-Remove", "drop"),
-            ("X-Keep", "ok"),
-        ]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection(
+            headers=[
+                ("Set-Cookie", "a=1"),
+                ("Set-Cookie", "b=2"),
+                ("Connection", "X-Remove"),
+                ("X-Remove", "drop"),
+                ("X-Keep", "ok"),
+            ]
+        ):
             _status, _body, headers = forwarder._forward_request_sync(
                 "https://example.com",
                 "GET",
@@ -405,34 +329,27 @@ class TestAuthBaseForwarderSecurity:
 
 class TestAuthBaseForwarderResourceCleanup:
     def test_closes_response_on_success(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.return_value = b"ok"
-        resp.getheaders.return_value = [("Content-Type", "application/json")]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection(
+            headers=[("Content-Type", "application/json")]
+        ) as upstream:
             status, body, _ = forwarder._forward_request_sync(
                 "https://example.com", "GET", [], None
             )
         assert status == 200
         assert body == b"ok"
-        resp.close.assert_called_once()
-        conn.close.assert_called_once()
+        upstream.resp.close.assert_called_once()
+        upstream.conn.close.assert_called_once()
 
     def test_preserves_duplicate_headers_on_error_status(self):
-        resp = MagicMock()
-        resp.status = 429
-        resp.read.return_value = b"rate limited"
-        resp.getheaders.return_value = [
-            ("WWW-Authenticate", "Bearer realm=one"),
-            ("WWW-Authenticate", "Bearer realm=two"),
-            ("Content-Type", "text/plain"),
-        ]
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
-
-        with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn):
+        with _patched_forwarder_connection(
+            status=429,
+            body=b"rate limited",
+            headers=[
+                ("WWW-Authenticate", "Bearer realm=one"),
+                ("WWW-Authenticate", "Bearer realm=two"),
+                ("Content-Type", "text/plain"),
+            ],
+        ) as upstream:
             status, body, headers = forwarder._forward_request_sync(
                 "https://example.com", "GET", [], None
             )
@@ -441,30 +358,35 @@ class TestAuthBaseForwarderResourceCleanup:
         assert body == b"rate limited"
         assert headers.get_all("WWW-Authenticate") == ["Bearer realm=one", "Bearer realm=two"]
         assert headers["Content-Type"] == "text/plain"
-        resp.close.assert_called_once()
-        conn.close.assert_called_once()
+        upstream.resp.close.assert_called_once()
+        upstream.conn.close.assert_called_once()
 
     def test_closes_response_when_read_raises(self):
-        resp = MagicMock()
-        resp.status = 200
-        resp.read.side_effect = OSError("socket closed")
-        resp.getheaders.return_value = []
-        conn = MagicMock()
-        conn.getresponse.return_value = resp
         with (
-            patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn),
+            _patched_forwarder_connection(read_side_effect=OSError("socket closed")) as upstream,
             pytest.raises(OSError, match="socket closed"),
         ):
             forwarder._forward_request_sync("https://example.com", "GET", [], None)
-        resp.close.assert_called_once()
-        conn.close.assert_called_once()
+        upstream.resp.close.assert_called_once()
+        upstream.conn.close.assert_called_once()
 
     def test_closes_connection_when_request_raises(self):
-        conn = MagicMock()
-        conn.putrequest.side_effect = ConnectionError("connect failed")
         with (
-            patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn),
+            _patched_forwarder_connection(
+                putrequest_side_effect=ConnectionError("connect failed")
+            ) as upstream,
             pytest.raises(ConnectionError, match="connect failed"),
         ):
             forwarder._forward_request_sync("https://example.com", "GET", [], None)
-        conn.close.assert_called_once()
+        upstream.conn.close.assert_called_once()
+
+    def test_closes_connection_when_getresponse_raises(self):
+        with (
+            _patched_forwarder_connection(
+                getresponse_side_effect=ConnectionError("response failed")
+            ) as upstream,
+            pytest.raises(ConnectionError, match="response failed"),
+        ):
+            forwarder._forward_request_sync("https://example.com", "GET", [], None)
+        upstream.resp.close.assert_not_called()
+        upstream.conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add a local named helper for auth base forwarder HTTP connection patches
- reuse the helper across forwarding and cleanup tests instead of repeating MagicMock setup
- parametrize equivalent request-target preservation cases

## Tests
- cd crates/runner/mitm-addon && python3 -m pytest tests/test_auth_base_forwarder.py -q
- cd crates/runner/mitm-addon && python3 -m ruff format --check .
- cd crates/runner/mitm-addon && python3 -m ruff check .
- cd crates/runner/mitm-addon && python3 -m basedpyright
- cd crates/runner/mitm-addon && python3 -m pytest tests/ -q

Closes #14590