### PR TITLE
refactor: hide connector oauth provider internals

### DIFF
--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -8,8 +8,8 @@ import {
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
+  getConnectorOAuthSecretMetadata,
   isOAuthConnectorType,
-  CONNECTOR_OAUTH_PROVIDERS,
 } from "@vm0/connectors/oauth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -214,8 +214,10 @@ const createTestConnector$ = command(
     if (!isOAuthConnectorType(connectorType)) {
       return stringError(400, `${connectorType} connector does not use OAuth`);
     }
-    const provider = CONNECTOR_OAUTH_PROVIDERS[connectorType];
-    const refreshSecretName = provider.getRefreshSecretName?.();
+    const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
+    const refreshSecretName = secretMetadata.isRefreshable
+      ? secretMetadata.refreshSecretName
+      : undefined;
     await set(
       upsertOAuthConnector$,
       {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -14,8 +14,8 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorOAuthCode,
+  getConnectorOAuthSecretMetadata,
   isOAuthConnectorType,
-  CONNECTOR_OAUTH_PROVIDERS,
   type OAuthTokenResult,
 } from "@vm0/connectors/oauth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -404,7 +404,7 @@ const completeOAuthCallback$ = command(
     });
     signal.throwIfAborted();
 
-    const provider = CONNECTOR_OAUTH_PROVIDERS[args.connectorType];
+    const secretMetadata = getConnectorOAuthSecretMetadata(args.connectorType);
     const result = await set(
       upsertOAuthConnector$,
       {
@@ -415,7 +415,9 @@ const completeOAuthCallback$ = command(
         userInfo: token.userInfo,
         oauthScopes: getRequestedScopes(args.connectorType),
         refreshToken: token.refreshToken,
-        refreshSecretName: provider.getRefreshSecretName?.(),
+        refreshSecretName: secretMetadata.isRefreshable
+          ? secretMetadata.refreshSecretName
+          : undefined,
         expiresIn: token.expiresIn,
       },
       signal,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -36,7 +36,7 @@ import {
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
 import {
-  getConnectorOAuthProvider,
+  getConnectorOAuthSecretMetadata,
   isOAuthRefreshProvider,
 } from "@vm0/connectors/oauth-providers";
 import { getModelProviderOAuthProvider } from "@vm0/connectors/oauth-providers/model-provider-registry";
@@ -1472,11 +1472,11 @@ async function loadOauthConnectorContext(
       }
     }
 
-    const provider = getConnectorOAuthProvider(connectorType);
-    if (!provider || !isOAuthRefreshProvider(provider)) {
+    const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
+    if (!secretMetadata?.isRefreshable) {
       continue;
     }
-    const secretName = provider.getSecretName();
+    const secretName = secretMetadata.accessSecretName;
     secretConnectorMap[secretName] = connectorType;
     for (const [envName, valueRef] of Object.entries(mapping)) {
       if (valueRef === `$secrets.${secretName}`) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -9,20 +9,16 @@ import type { OAuthConnectorType } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
-  getConnectorOAuthProvider,
+  getConnectorOAuthSecretMetadata,
   isOAuthConnectorType,
   isOAuthRefreshProvider,
   refreshConnectorOAuthToken,
   type ProviderEnv,
 } from "@vm0/connectors/oauth-providers";
-import type {
-  OAuthProviderMetadata,
-  OAuthRefreshProvider,
-} from "@vm0/connectors/oauth-providers/provider-types";
+import type { OAuthRefreshProvider } from "@vm0/connectors/oauth-providers/provider-types";
 import {
   getModelProviderOAuthProvider,
   isModelProviderOAuthProviderKey,
-  type ModelProviderOAuthProvider,
 } from "@vm0/connectors/oauth-providers/model-provider-registry";
 import { isChatgptRefreshError } from "@vm0/connectors/oauth-providers/providers/codex-oauth";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -48,9 +44,6 @@ import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
 type OAuthSecretSource = "connector" | "model-provider";
 type SecretType = OAuthSecretSource;
-type RegisteredOAuthProvider =
-  | OAuthProviderMetadata
-  | ModelProviderOAuthProvider;
 
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
@@ -274,17 +267,6 @@ function resolveRefreshMetadata(
   };
 }
 
-function getOAuthProviderByKey(
-  connectorType: string,
-  sourceType: OAuthSecretSource,
-): RegisteredOAuthProvider | null {
-  if (sourceType === "model-provider") {
-    return getModelProviderOAuthProvider(connectorType) ?? null;
-  }
-
-  return getConnectorOAuthProvider(connectorType) ?? null;
-}
-
 function currentProviderEnv(): ProviderEnv {
   return new Proxy(
     {},
@@ -366,15 +348,43 @@ async function upsertSecretValue(
     });
 }
 
+function getRefreshSecretNameForSource(
+  connectorType: string,
+  sourceType: OAuthSecretSource,
+): string | undefined {
+  if (sourceType === "model-provider") {
+    const provider = getModelProviderOAuthProvider(connectorType);
+    return provider && isOAuthRefreshProvider(provider)
+      ? provider.getRefreshSecretName()
+      : undefined;
+  }
+
+  const metadata = getConnectorOAuthSecretMetadata(connectorType);
+  return metadata?.isRefreshable ? metadata.refreshSecretName : undefined;
+}
+
+function getAccessSecretNameForSource(
+  connectorType: string,
+  sourceType: OAuthSecretSource,
+): string | undefined {
+  if (sourceType === "model-provider") {
+    return getModelProviderOAuthProvider(connectorType)?.getSecretName();
+  }
+
+  return getConnectorOAuthSecretMetadata(connectorType)?.accessSecretName;
+}
+
 async function getConnectorRefreshToken(
   args: SecretTokenLookupArgs,
 ): Promise<{ readonly secretName: string; readonly token: string } | null> {
-  const provider = getOAuthProviderByKey(args.connectorType, args.sourceType);
-  if (!provider || !isOAuthRefreshProvider(provider)) {
+  const secretName = getRefreshSecretNameForSource(
+    args.connectorType,
+    args.sourceType,
+  );
+  if (!secretName) {
     return null;
   }
 
-  const secretName = provider.getRefreshSecretName();
   const token = await getSecretValue({
     db: args.db,
     orgId: args.orgId,
@@ -393,8 +403,11 @@ async function getConnectorRefreshToken(
 async function getConnectorAccessToken(
   args: SecretTokenLookupArgs,
 ): Promise<string | null> {
-  const provider = getOAuthProviderByKey(args.connectorType, args.sourceType);
-  if (!provider) {
+  const secretName = getAccessSecretNameForSource(
+    args.connectorType,
+    args.sourceType,
+  );
+  if (!secretName) {
     return null;
   }
 
@@ -406,7 +419,7 @@ async function getConnectorAccessToken(
       args.userId,
       args.sourceUserId,
     ),
-    name: provider.getSecretName(),
+    name: secretName,
     type: args.sourceType,
     featureSwitchContext: args.featureSwitchContext,
   });
@@ -617,8 +630,8 @@ function prepareRefreshTokenContext(
     L.debug(`${args.connectorType} is not an OAuth connector type, skipping`);
     return null;
   }
-  const provider = getConnectorOAuthProvider(args.connectorType);
-  if (!provider || !isOAuthRefreshProvider(provider)) {
+  const secretMetadata = getConnectorOAuthSecretMetadata(args.connectorType);
+  if (!secretMetadata.isRefreshable) {
     return null;
   }
   const credentials = getConnectorOAuthCredentials(
@@ -634,7 +647,7 @@ function prepareRefreshTokenContext(
     return null;
   }
 
-  const refreshTokenSecret = provider.getRefreshSecretName();
+  const refreshTokenSecret = secretMetadata.refreshSecretName;
   const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
   if (!currentRefreshToken) {
     L.debug(`No ${args.connectorType} refresh token available, skipping`);
@@ -644,7 +657,7 @@ function prepareRefreshTokenContext(
   const context: RefreshTokenContext = {
     refreshTokenSecret,
     currentRefreshToken,
-    accessTokenSecret: provider.getSecretName(),
+    accessTokenSecret: secretMetadata.accessSecretName,
     secretUserId: resolveSecretUserId(
       args.sourceType,
       args.userId,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -16,7 +16,7 @@ import {
   isOAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
-  CONNECTOR_OAUTH_PROVIDERS,
+  getConnectorOAuthSecretMetadata,
   isOAuthConnectorType,
   pollConnectorOAuthDeviceAuth,
   startConnectorOAuthDeviceAuth,
@@ -872,7 +872,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       claimStartedAt,
       signal,
       persistConnector: async ({ result }) => {
-        const provider = CONNECTOR_OAUTH_PROVIDERS[resolvedType];
+        const secretMetadata = getConnectorOAuthSecretMetadata(resolvedType);
         const connectorResult = await set(
           upsertOAuthConnector$,
           {
@@ -883,7 +883,9 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
             userInfo: result.token.userInfo,
             oauthScopes: result.token.scopes,
             refreshToken: result.token.refreshToken,
-            refreshSecretName: provider.getRefreshSecretName?.(),
+            refreshSecretName: secretMetadata.isRefreshable
+              ? secretMetadata.refreshSecretName
+              : undefined,
             expiresIn: result.token.expiresIn,
           },
           signal,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -16,10 +16,7 @@ import {
   getScopeDiff,
   isConnectorAuthMethodAvailable,
 } from "@vm0/connectors/connector-utils";
-import {
-  CONNECTOR_OAUTH_PROVIDERS,
-  isOAuthRefreshProvider,
-} from "@vm0/connectors/oauth-providers";
+import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/oauth-providers";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -826,9 +823,9 @@ export const upsertOAuthConnector$ = command(
     readonly created: boolean;
   }> => {
     const writeDb = set(writeDb$);
-    const provider = CONNECTOR_OAUTH_PROVIDERS[args.type];
+    const secretMetadata = getConnectorOAuthSecretMetadata(args.type);
     const tokenExpiresAt = connectorTokenExpiresAt({
-      isRefreshable: isOAuthRefreshProvider(provider),
+      isRefreshable: secretMetadata.isRefreshable,
       expiresIn: args.expiresIn,
     });
     const apiTokenFields = getApiTokenFieldsByType(args.type);
@@ -850,7 +847,7 @@ export const upsertOAuthConnector$ = command(
     await upsertConnectorSecret(writeDb, {
       orgId: args.orgId,
       userId: args.userId,
-      name: provider.getSecretName(),
+      name: secretMetadata.accessSecretName,
       value: args.accessToken,
       description: `OAuth token for ${args.type} connector`,
       featureSwitchContext,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -35,6 +35,7 @@ import {
   buildConnectorOAuthAuthUrl,
   isOAuthConnectorType,
   CONNECTOR_OAUTH_PROVIDERS,
+  getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
   refreshConnectorOAuthToken,
   startConnectorOAuthDeviceAuth,
@@ -210,6 +211,19 @@ describe("CONNECTOR_OAUTH_PROVIDERS", () => {
         oauthConnectorTypes.includes(type),
       );
     }
+  });
+
+  it("exposes connector OAuth secret metadata without provider access", () => {
+    expect(getConnectorOAuthSecretMetadata("test-oauth")).toEqual({
+      accessSecretName: "TEST_OAUTH_ACCESS_TOKEN",
+      refreshSecretName: "TEST_OAUTH_REFRESH_TOKEN",
+      isRefreshable: true,
+    });
+    expect(getConnectorOAuthSecretMetadata("github")).toEqual({
+      accessSecretName: "GITHUB_ACCESS_TOKEN",
+      isRefreshable: false,
+    });
+    expect(getConnectorOAuthSecretMetadata("computer")).toBeUndefined();
   });
 
   it("builds the expected authorization URL base for every OAuth provider", async () => {

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -29,7 +29,6 @@ import {
   providerEnvFromObject,
   isOAuthRefreshProvider,
   type OAuthTokenResult,
-  type OAuthConnectorProvider,
   type ProviderEnv,
 } from "./provider-types";
 import { ahrefsProvider } from "./providers/ahrefs-provider";
@@ -196,15 +195,6 @@ export const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
 
 export function isOAuthConnectorType(type: string): type is OAuthConnectorType {
   return Object.hasOwn(CONNECTOR_OAUTH_PROVIDERS, type);
-}
-
-export function getConnectorOAuthProvider(
-  type: string,
-): OAuthConnectorProvider | undefined {
-  if (!isOAuthConnectorType(type)) {
-    return undefined;
-  }
-  return CONNECTOR_OAUTH_PROVIDERS[type];
 }
 
 export function getConnectorOAuthSecretMetadata(

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -103,6 +103,17 @@ type DispatchRefreshProvider = {
   refreshToken(args: OAuthRefreshArgs): Promise<OAuthRefreshResult>;
 };
 
+export type ConnectorOAuthSecretMetadata =
+  | {
+      readonly accessSecretName: string;
+      readonly isRefreshable: false;
+    }
+  | {
+      readonly accessSecretName: string;
+      readonly refreshSecretName: string;
+      readonly isRefreshable: true;
+    };
+
 function connectorProviderFor<T extends OAuthConnectorType>(
   type: T,
 ): ConnectorOAuthProviderFor<T> {
@@ -194,6 +205,35 @@ export function getConnectorOAuthProvider(
     return undefined;
   }
   return CONNECTOR_OAUTH_PROVIDERS[type];
+}
+
+export function getConnectorOAuthSecretMetadata(
+  type: OAuthConnectorType,
+): ConnectorOAuthSecretMetadata;
+export function getConnectorOAuthSecretMetadata(
+  type: string,
+): ConnectorOAuthSecretMetadata | undefined;
+export function getConnectorOAuthSecretMetadata(
+  type: string,
+): ConnectorOAuthSecretMetadata | undefined {
+  if (!isOAuthConnectorType(type)) {
+    return undefined;
+  }
+
+  const provider = connectorProviderFor(type);
+  const accessSecretName = provider.getSecretName();
+  if (!isOAuthRefreshProvider(provider)) {
+    return {
+      accessSecretName,
+      isRefreshable: false,
+    };
+  }
+
+  return {
+    accessSecretName,
+    refreshSecretName: provider.getRefreshSecretName(),
+    isRefreshable: true,
+  };
 }
 
 export async function buildConnectorOAuthAuthUrl<


### PR DESCRIPTION
## Summary

- add `getConnectorOAuthSecretMetadata` as the connector OAuth secret metadata boundary
- migrate API callback, device auth, run-create, firewall auth, and test-only connector seeding away from direct connector provider inspection
- keep model-provider OAuth provider access unchanged and add registry coverage for refreshable/non-refreshable metadata

Closes #14611

## Tests

- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/cli-auth.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- pre-commit: prettier, knip, `pnpm check-types`