### PR TITLE
refactor: keep connector oauth provider map private

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -5,7 +5,8 @@ import {
   type ConnectorOAuthClientConfig,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
-import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/oauth-providers";
+import { testOauthProvider } from "@vm0/connectors/oauth-providers/providers/test-oauth-provider";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
@@ -235,7 +236,7 @@ function configureDynamicTestOAuthExchange(
 
   const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
   const originalClient = oauth.client;
-  const provider = CONNECTOR_OAUTH_PROVIDERS["test-oauth"];
+  const provider = testOauthProvider;
   const originalExchangeCode = provider.exchangeCode;
 
   mutableOAuth.client = dynamicPublicClient;
@@ -2189,22 +2190,21 @@ describe("GET /api/connectors/:type/callback", () => {
         needsReconnect: false,
       });
 
+      const secretMetadata = getConnectorOAuthSecretMetadata(providerCase.type);
       await expect(
         findDecryptedSecret({
           orgId,
           userId,
-          name: CONNECTOR_OAUTH_PROVIDERS[providerCase.type].getSecretName(),
+          name: secretMetadata.accessSecretName,
         }),
       ).resolves.toBe(accessToken);
 
-      const refreshSecretName =
-        CONNECTOR_OAUTH_PROVIDERS[providerCase.type].getRefreshSecretName?.();
-      if (refreshSecretName) {
+      if (secretMetadata.isRefreshable) {
         await expect(
           findDecryptedSecret({
             orgId,
             userId,
-            name: refreshSecretName,
+            name: secretMetadata.refreshSecretName,
           }),
         ).resolves.toBe(refreshToken);
         expect(connector?.tokenExpiresAt).toBeInstanceOf(Date);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -10,7 +10,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorOAuthClientConfig,
 } from "@vm0/connectors/connectors";
-import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { testOauthProvider } from "@vm0/connectors/oauth-providers/providers/test-oauth-provider";
 import { connectors } from "@vm0/db/schema/connector";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { modelProviders } from "@vm0/db/schema/model-provider";
@@ -320,7 +320,7 @@ function configureDynamicTestOAuthRefresh(
 
   const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
   const originalClient = oauth.client;
-  const provider = CONNECTOR_OAUTH_PROVIDERS["test-oauth"];
+  const provider = testOauthProvider;
   const originalRefreshToken = provider.refreshToken;
 
   mutableOAuth.client = dynamicPublicClient;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -4,7 +4,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorOAuthClientConfig,
 } from "@vm0/connectors/connectors";
-import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { testOauthProvider } from "@vm0/connectors/oauth-providers/providers/test-oauth-provider";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { secrets } from "@vm0/db/schema/secret";
@@ -99,7 +99,7 @@ function useDynamicTestOAuthAuthorize(): () => void {
 
   const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
   const originalClient = oauth.client;
-  const provider = CONNECTOR_OAUTH_PROVIDERS["test-oauth"];
+  const provider = testOauthProvider;
   const originalBuildAuthUrl = provider.buildAuthUrl;
 
   mutableOAuth.client = dynamicPublicClient;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { zeroConnectorOauthDeviceAuthSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { testOauthDeviceProvider } from "@vm0/connectors/oauth-providers/providers/test-oauth-device-provider";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { secrets } from "@vm0/db/schema/secret";
@@ -25,7 +25,6 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
-const testOauthDeviceProvider = CONNECTOR_OAUTH_PROVIDERS["test-oauth-device"];
 const originalPollDeviceAuth = testOauthDeviceProvider.pollDeviceAuth;
 const TEST_OAUTH_DEVICE_CODE_URL =
   "http://localhost:3000/api/test/oauth-provider/device/code";

--- a/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
@@ -8,10 +8,7 @@ import { userConnectors } from "@vm0/db/schema/user-connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { encryptSecretValue } from "../../lib/shared/crypto/secrets-encryption";
-import {
-  isOAuthRefreshProvider,
-  CONNECTOR_OAUTH_PROVIDERS,
-} from "@vm0/connectors/oauth-providers";
+import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/oauth-providers";
 
 // ---------------------------------------------------------------------------
 // DB-direct seeders for connector test setup.
@@ -87,15 +84,15 @@ export async function createTestOAuthConnectorRecord(options: {
 }): Promise<void> {
   initServices();
 
-  const handler = CONNECTOR_OAUTH_PROVIDERS[options.type];
-  const tokenExpiresAt = isOAuthRefreshProvider(handler)
+  const secretMetadata = getConnectorOAuthSecretMetadata(options.type);
+  const tokenExpiresAt = secretMetadata.isRefreshable
     ? new Date(Date.now() + 60 * 60 * 1000)
     : null;
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
   await globalThis.services.db
     .insert(secrets)
     .values({
-      name: handler.getSecretName(),
+      name: secretMetadata.accessSecretName,
       encryptedValue: encryptSecretValue(options.accessToken, encryptionKey),
       type: "connector",
       userId: options.userId,

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/google-ads.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/google-ads.test.ts
@@ -4,7 +4,7 @@ import { server } from "../../../../../mocks/server";
 import { http } from "../../../../../__tests__/msw";
 import { testContext } from "../../../../../__tests__/test-helpers";
 import { getConnectorOAuthCredentials } from "@vm0/connectors/connector-utils";
-import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { isOAuthConnectorType } from "@vm0/connectors/oauth-providers";
 import { googleAdsProvider } from "@vm0/connectors/oauth-providers/providers/google-ads-provider";
 
 const context = testContext();
@@ -17,8 +17,8 @@ describe("connector/providers/google-ads", () => {
   });
 
   describe("googleAdsProvider", () => {
-    it("is registered in CONNECTOR_OAUTH_PROVIDERS under google-ads key", () => {
-      expect(CONNECTOR_OAUTH_PROVIDERS["google-ads"]).toBe(googleAdsProvider);
+    it("registers google-ads as an OAuth connector type", () => {
+      expect(isOAuthConnectorType("google-ads")).toBe(true);
     });
 
     it("buildAuthUrl builds Google OAuth URL with Google Ads and userinfo scopes", () => {

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
@@ -4,7 +4,7 @@ import { server } from "../../../../../mocks/server";
 import { http } from "../../../../../__tests__/msw";
 import { testContext } from "../../../../../__tests__/test-helpers";
 import { getConnectorOAuthCredentials } from "@vm0/connectors/connector-utils";
-import { CONNECTOR_OAUTH_PROVIDERS } from "@vm0/connectors/oauth-providers";
+import { isOAuthConnectorType } from "@vm0/connectors/oauth-providers";
 import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
@@ -146,8 +146,8 @@ describe("connector/providers/meta-ads", () => {
   });
 
   describe("metaAdsProvider", () => {
-    it("is registered in CONNECTOR_OAUTH_PROVIDERS under meta-ads key", () => {
-      expect(CONNECTOR_OAUTH_PROVIDERS["meta-ads"]).toBe(metaAdsProvider);
+    it("registers meta-ads as an OAuth connector type", () => {
+      expect(isOAuthConnectorType("meta-ads")).toBe(true);
     });
 
     it("buildAuthUrl delegates to buildMetaAdsAuthorizationUrl", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -36,7 +36,6 @@ import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorOAuthAuthUrl,
   isOAuthConnectorType,
-  CONNECTOR_OAUTH_PROVIDERS,
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
   refreshConnectorOAuthToken,
@@ -211,16 +210,13 @@ describe("connector auth method config", () => {
   });
 });
 
-describe("CONNECTOR_OAUTH_PROVIDERS", () => {
-  it("contains exactly the connector types that declare OAuth auth", () => {
+describe("isOAuthConnectorType", () => {
+  it("matches exactly the connector types that declare OAuth auth", () => {
     const oauthConnectorTypes = connectorTypeSchema.options
       .filter((type) => {
         return "oauth" in CONNECTOR_TYPES[type].authMethods;
       })
       .sort();
-    const providerTypes = Object.keys(CONNECTOR_OAUTH_PROVIDERS).sort();
-
-    expect(providerTypes).toEqual(oauthConnectorTypes);
 
     for (const type of connectorTypeSchema.options) {
       expect(isOAuthConnectorType(type)).toBe(

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -143,7 +143,7 @@ function assertConfiguredConnectorOAuthCredentials(
   }
 }
 
-export const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
+const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
   ahrefs: ahrefsProvider,
   airtable: airtableProvider,
   asana: asanaProvider,

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -313,12 +313,6 @@ export type ConnectorOAuthProviderFor<T extends OAuthConnectorType> =
     (ConnectorOAuthRefreshProvider<T> | OAuthNoRefreshProvider) &
     (ConnectorOAuthRevocationProvider<T> | OAuthNoRevocationProvider);
 
-export type AnyConnectorOAuthProvider = {
-  [Type in OAuthConnectorType]: ConnectorOAuthProviderFor<Type>;
-}[OAuthConnectorType];
-
-export type OAuthConnectorProvider = AnyConnectorOAuthProvider;
-
 export function defineConnectorOAuthProvider<T extends OAuthConnectorType>(
   _type: T,
   provider: ConnectorOAuthProviderFor<T>,


### PR DESCRIPTION
## Summary

- make `CONNECTOR_OAUTH_PROVIDERS` module-private inside the OAuth provider registry
- remove exported connector provider-object types that no longer have consumers
- update tests and web seed helpers to use public wrappers or concrete test providers instead of the provider map

## Tests

- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/cli-auth.test.ts`
- `pnpm -F web exec vitest src/lib/zero/connector/providers/__tests__/google-ads.test.ts src/lib/zero/connector/providers/__tests__/meta-ads.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F web lint`
- pre-commit: prettier, knip, `pnpm check-types`