### PR TITLE
fix: keep user artifact links as chat text

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
@@ -48,6 +48,25 @@ describe("parseBodyRenderBlocks", () => {
     ]);
   });
 
+  it("keeps artifact URLs as markdown when previews are disabled", () => {
+    const imageUrl =
+      "https://cdn.vm7.io/artifacts/36PnTFtD4dBQ9zg5jj6E5r918aV/24b42fb4-4b7b-4521-800f-defc356ae7b4/image-24b42fb4.png";
+    const content = `图也存好了：${imageUrl}`;
+
+    const { cleanContent, blocks } = parseBodyRenderBlocks(content, {
+      previews: false,
+    });
+
+    expect(cleanContent).toBe(content);
+    expect(blocks).toStrictEqual([
+      {
+        type: "markdown",
+        id: "markdown-1",
+        content,
+      },
+    ]);
+  });
+
   it("renders hosted site URLs as html previews", () => {
     vi.stubEnv("VITE_ZERO_HOST_DOMAIN", "sites.example.com");
     const url = "https://demo-site-a1b2c3d4.sites.example.com";

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -821,7 +821,9 @@ function createAllMessagesComputed(
             message.interruptsRunId,
           );
         }
-        const { blocks } = parseBodyRenderBlocks(message.content ?? "");
+        const { blocks } = parseBodyRenderBlocks(message.content ?? "", {
+          previews: message.role === "assistant",
+        });
         const isUnassociatedUser =
           message.role === "user" && message.runId === undefined;
         const optimisticAssociation = entry.optimisticUserMessageAssociation;

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -556,10 +556,14 @@ function markdownTableRowIndexes(lines: string[]): Set<number> {
 // Block parsing (pure — no computeds)
 // ---------------------------------------------------------------------------
 
-export function parseBodyRenderBlocks(content: string): {
+export function parseBodyRenderBlocks(
+  content: string,
+  options: { previews?: boolean } = {},
+): {
   cleanContent: string;
   blocks: BodyRenderBlock[];
 } {
+  const previews = options.previews ?? true;
   const blocks: BodyRenderBlock[] = [];
   const lines = content.split("\n");
   const tableRowIndexes = markdownTableRowIndexes(lines);
@@ -619,7 +623,7 @@ export function parseBodyRenderBlocks(content: string): {
       continue;
     }
 
-    const extracted = extractPreviewUrlFromLine(line);
+    const extracted = previews ? extractPreviewUrlFromLine(line) : null;
     if (!extracted) {
       markdownBuffer.push(line);
       keptLines.push(line);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2875,7 +2875,7 @@ function PagedUserMessage({
       ? ""
       : cleanContent;
   const bodyBlocks = enrichBlocksWithTextPreviews(
-    parseBodyRenderBlocks(strippedContent).blocks,
+    parseBodyRenderBlocks(strippedContent, { previews: false }).blocks,
   );
   const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openAttachmentImageLightbox$);


### PR DESCRIPTION
## Summary
- add a parser option to disable artifact/hosted-site preview extraction
- keep user chat message bodies as markdown instead of converting artifact links into preview blocks
- leave assistant message parsing on the existing preview-enabled path

## Tests
- pnpm -F @vm0/app check-types
- pnpm exec vitest run src/signals/chat-page/__tests__/parse-body-blocks.test.ts