### PR TITLE
fix: validate video frame aspect ratios

### DIFF
--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/video.test.ts
@@ -15,6 +15,8 @@ import { zeroBuiltInCommand } from "../../index";
 import { videoCommand } from "../video";
 
 const VIDEO_URL = "http://localhost:3000/api/zero/video-io/generate";
+const FIRST_FRAME_URL = "https://example.com/first.png";
+const LAST_FRAME_URL = "https://example.com/last.png";
 const VIDEO_RESULT = {
   id: "video-file-id",
   filename: "video-video-fi.mp4",
@@ -32,6 +34,22 @@ const VIDEO_RESULT = {
   requestId: "video-request",
 };
 
+function pngWithDimensions(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(24);
+  buffer.write("\x89PNG\r\n\x1a\n", 0, "latin1");
+  buffer.writeUInt32BE(13, 8);
+  buffer.write("IHDR", 12, "ascii");
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+}
+
+function imageResponse(width: number, height: number) {
+  return new HttpResponse(pngWithDimensions(width, height), {
+    headers: { "content-type": "image/png" },
+  });
+}
+
 describe("zero built-in generate video command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -44,6 +62,7 @@ describe("zero built-in generate video command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-token");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
@@ -54,6 +73,12 @@ describe("zero built-in generate video command", () => {
 
   it("should generate a video and print the /f file URL", async () => {
     server.use(
+      http.get(FIRST_FRAME_URL, () => {
+        return imageResponse(900, 1600);
+      }),
+      http.get(LAST_FRAME_URL, () => {
+        return imageResponse(900, 1600);
+      }),
       http.post(VIDEO_URL, async ({ request }) => {
         expect(request.headers.get("authorization")).toBe("Bearer test-token");
         expect(request.headers.get("content-type")).toBe("application/json");
@@ -70,8 +95,8 @@ describe("zero built-in generate video command", () => {
           imageUrls: ["https://example.com/reference.png"],
           videoUrls: ["https://example.com/reference.mp4"],
           audioUrls: ["https://example.com/reference.mp3"],
-          firstFrameImageUrl: "https://example.com/first.png",
-          lastFrameImageUrl: "https://example.com/last.png",
+          firstFrameImageUrl: FIRST_FRAME_URL,
+          lastFrameImageUrl: LAST_FRAME_URL,
         });
 
         return HttpResponse.json(VIDEO_RESULT);
@@ -106,9 +131,9 @@ describe("zero built-in generate video command", () => {
       "--audio-url",
       "https://example.com/reference.mp3",
       "--first-frame-image-url",
-      "https://example.com/first.png",
+      FIRST_FRAME_URL,
       "--last-frame-image-url",
-      "https://example.com/last.png",
+      LAST_FRAME_URL,
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
@@ -119,6 +144,41 @@ describe("zero built-in generate video command", () => {
     expect(stdout).toContain("Aspect ratio: 9:16");
     expect(stdout).toContain("Audio: off");
     expect(stdout).toContain("Credits charged: 720");
+  });
+
+  it("should reject frame images that do not match --aspect-ratio before generating", async () => {
+    const postVideo = vi.fn();
+    server.use(
+      http.get(FIRST_FRAME_URL, () => {
+        return imageResponse(1920, 1080);
+      }),
+      http.post(VIDEO_URL, () => {
+        postVideo();
+        return HttpResponse.json(VIDEO_RESULT);
+      }),
+    );
+
+    await expect(async () => {
+      await zeroBuiltInCommand.parseAsync([
+        "node",
+        "cli",
+        "generate",
+        "video",
+        "--prompt",
+        "Animate this frame",
+        "--aspect-ratio",
+        "9:16",
+        "--first-frame-image-url",
+        FIRST_FRAME_URL,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(postVideo).not.toHaveBeenCalled();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "--first-frame-image-url has aspect ratio 16:9 (1920x1080), but --aspect-ratio is 9:16",
+      ),
+    );
   });
 
   it("should print JSON metadata when --json is provided", async () => {

--- a/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
@@ -29,6 +29,16 @@ interface VideoGenerateCommandConfig {
   examples: string;
 }
 
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+const FRAME_ASPECT_RATIO_TOLERANCE = 0.02;
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+
 function parseSeed(value: string): number {
   const seed = Number(value);
   if (!Number.isInteger(seed) || seed < 0 || !Number.isSafeInteger(seed)) {
@@ -39,6 +49,250 @@ function parseSeed(value: string): number {
 
 function collectUrl(value: string, previous: string[] = []): string[] {
   return [...previous, value];
+}
+
+function parseAspectRatio(value: string): ImageDimensions {
+  const [widthText, heightText] = value.split(":");
+  const width = Number(widthText);
+  const height = Number(heightText);
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(`Invalid --aspect-ratio "${value}"`);
+  }
+  return { width, height };
+}
+
+function readPngDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (
+    buffer.length < 24 ||
+    buffer.toString("latin1", 0, 8) !== "\x89PNG\r\n\x1a\n"
+  ) {
+    return undefined;
+  }
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+function readGifDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (
+    buffer.length < 10 ||
+    !buffer.toString("latin1", 0, 6).startsWith("GIF")
+  ) {
+    return undefined;
+  }
+  return {
+    width: buffer.readUInt16LE(6),
+    height: buffer.readUInt16LE(8),
+  };
+}
+
+function readJpegDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) {
+    return undefined;
+  }
+
+  let offset = 2;
+  while (offset + 9 < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+
+    const marker = buffer[offset + 1] as number;
+    if (marker === 0xd9 || marker === 0xda) {
+      break;
+    }
+
+    const segmentLength = buffer.readUInt16BE(offset + 2);
+    if (segmentLength < 2 || offset + 2 + segmentLength > buffer.length) {
+      break;
+    }
+
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      return {
+        height: buffer.readUInt16BE(offset + 5),
+        width: buffer.readUInt16BE(offset + 7),
+      };
+    }
+
+    offset += 2 + segmentLength;
+  }
+
+  return undefined;
+}
+
+function readUnsigned24LE(buffer: Buffer, offset: number): number {
+  return (
+    buffer.readUInt8(offset) +
+    (buffer.readUInt8(offset + 1) << 8) +
+    (buffer.readUInt8(offset + 2) << 16)
+  );
+}
+
+function readWebpDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (
+    buffer.length < 30 ||
+    buffer.toString("ascii", 0, 4) !== "RIFF" ||
+    buffer.toString("ascii", 8, 12) !== "WEBP"
+  ) {
+    return undefined;
+  }
+
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkType = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const payloadOffset = offset + 8;
+    if (payloadOffset + chunkSize > buffer.length) {
+      break;
+    }
+
+    if (chunkType === "VP8X" && chunkSize >= 10) {
+      return {
+        width: readUnsigned24LE(buffer, payloadOffset + 4) + 1,
+        height: readUnsigned24LE(buffer, payloadOffset + 7) + 1,
+      };
+    }
+
+    if (
+      chunkType === "VP8L" &&
+      chunkSize >= 5 &&
+      buffer[payloadOffset] === 0x2f
+    ) {
+      const byte1 = buffer.readUInt8(payloadOffset + 1);
+      const byte2 = buffer.readUInt8(payloadOffset + 2);
+      const byte3 = buffer.readUInt8(payloadOffset + 3);
+      const byte4 = buffer.readUInt8(payloadOffset + 4);
+      return {
+        width: 1 + byte1 + ((byte2 & 0x3f) << 8),
+        height:
+          1 + ((byte2 & 0xc0) >> 6) + (byte3 << 2) + ((byte4 & 0x0f) << 10),
+      };
+    }
+
+    if (
+      chunkType === "VP8 " &&
+      chunkSize >= 10 &&
+      buffer[payloadOffset + 3] === 0x9d &&
+      buffer[payloadOffset + 4] === 0x01 &&
+      buffer[payloadOffset + 5] === 0x2a
+    ) {
+      return {
+        width: buffer.readUInt16LE(payloadOffset + 6) & 0x3fff,
+        height: buffer.readUInt16LE(payloadOffset + 8) & 0x3fff,
+      };
+    }
+
+    offset = payloadOffset + chunkSize + (chunkSize % 2);
+  }
+
+  return undefined;
+}
+
+function readImageDimensions(buffer: Buffer): ImageDimensions | undefined {
+  return (
+    readPngDimensions(buffer) ??
+    readJpegDimensions(buffer) ??
+    readWebpDimensions(buffer) ??
+    readGifDimensions(buffer)
+  );
+}
+
+function formatDimensionsAsRatio({ width, height }: ImageDimensions): string {
+  const divisor = greatestCommonDivisor(width, height);
+  return `${width / divisor}:${height / divisor}`;
+}
+
+function greatestCommonDivisor(left: number, right: number): number {
+  let a = Math.abs(left);
+  let b = Math.abs(right);
+  while (b !== 0) {
+    const remainder = a % b;
+    a = b;
+    b = remainder;
+  }
+  return a || 1;
+}
+
+function hasMatchingAspectRatio(
+  actual: ImageDimensions,
+  expected: ImageDimensions,
+): boolean {
+  const actualRatio = actual.width / actual.height;
+  const expectedRatio = expected.width / expected.height;
+  return (
+    Math.abs(actualRatio - expectedRatio) / expectedRatio <=
+    FRAME_ASPECT_RATIO_TOLERANCE
+  );
+}
+
+async function fetchImageDimensions(
+  optionName: string,
+  imageUrl: string,
+): Promise<ImageDimensions> {
+  let url: URL;
+  try {
+    url = new URL(imageUrl);
+  } catch {
+    throw new Error(`${optionName} must be an absolute URL`);
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Could not validate ${optionName}: failed to fetch image (HTTP ${response.status})`,
+    );
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const dimensions = readImageDimensions(buffer);
+  if (!dimensions) {
+    throw new Error(
+      `Could not validate ${optionName}: unsupported image format or missing dimensions`,
+    );
+  }
+  return dimensions;
+}
+
+async function validateFrameImageAspectRatio(
+  optionName: string,
+  imageUrl: string | undefined,
+  aspectRatio: string,
+): Promise<void> {
+  if (!imageUrl) {
+    return;
+  }
+
+  const expected = parseAspectRatio(aspectRatio);
+  const actual = await fetchImageDimensions(optionName, imageUrl);
+  if (hasMatchingAspectRatio(actual, expected)) {
+    return;
+  }
+
+  throw new Error(
+    `${optionName} has aspect ratio ${formatDimensionsAsRatio(actual)} (${actual.width}x${actual.height}), but --aspect-ratio is ${aspectRatio}. Use --aspect-ratio ${formatDimensionsAsRatio(actual)} or provide a frame image with ${aspectRatio} dimensions.`,
+  );
+}
+
+async function validateVideoOptions(options: VideoOptions): Promise<void> {
+  await Promise.all([
+    validateFrameImageAspectRatio(
+      "--first-frame-image-url",
+      options.firstFrameImageUrl,
+      options.aspectRatio,
+    ),
+    validateFrameImageAspectRatio(
+      "--last-frame-image-url",
+      options.lastFrameImageUrl,
+      options.aspectRatio,
+    ),
+  ]);
 }
 
 function readPrompt(options: VideoOptions, usageCommand: string): string {
@@ -137,6 +391,7 @@ Models:
     .action(
       withErrorHandler(async (options: VideoOptions) => {
         const prompt = readPrompt(options, config.usageCommand);
+        await validateVideoOptions(options);
         const result = await generateWebVideo({
           prompt,
           model: options.model,


### PR DESCRIPTION
## Summary
- validate first/last video frame image dimensions before submitting CLI generation requests
- parse common image dimensions from JPEG, PNG, GIF, and WebP URLs
- add CLI coverage that rejects mismatched frame images before calling the video generation API

## Testing
- pnpm --dir turbo exec prettier --write apps/cli/src/commands/zero/shared/video-generate.ts apps/cli/src/commands/zero/built-in/generate/__tests__/video.test.ts
- pnpm --dir turbo --filter @vm0/cli lint
- pnpm --dir turbo --filter @vm0/cli check-types
- pnpm --dir turbo --filter @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/video.test.ts

Note: I accidentally invoked the broader CLI test script once with an argument forwarding issue; it ran many unrelated tests and failed due the sandbox's real ZERO_TOKEN environment leaking into auth-related test expectations. The targeted video test above passed after running it directly with vitest.