### PR TITLE
refactor(platform): merge Account into Preference settings section

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
@@ -39,7 +39,7 @@ describe("checkUnifiedSettingsParam$", () => {
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
   });
 
-  it("falls back to account for non-admin on admin-only section", async () => {
+  it("falls back to preference for non-admin on admin-only section", async () => {
     const { store, signal } = context;
     setupAuth(signal);
     setMockOrg({ role: "member" });
@@ -49,7 +49,7 @@ describe("checkUnifiedSettingsParam$", () => {
     await store.set(checkUnifiedSettingsParam$, signal);
 
     expect(store.get(settingsDialogOpen$)).toBeTruthy();
-    expect(store.get(settingsActiveSection$)).toBe("account");
+    expect(store.get(settingsActiveSection$)).toBe("preference");
   });
 
   it("does not open dialog for unknown settings value", async () => {
@@ -119,7 +119,7 @@ describe("setSettingsDialogOpen$", () => {
     const { store, signal } = context;
     setupAuth(signal);
     createPushStateMock(signal);
-    mockLocation({ pathname: "/", search: "?settings=account" }, signal);
+    mockLocation({ pathname: "/", search: "?settings=preference" }, signal);
 
     await store.set(setSettingsDialogOpen$, true, signal);
     expect(store.get(settingsDialogOpen$)).toBeTruthy();

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -5,7 +5,6 @@ import { isOrgAdmin$ } from "../../org.ts";
 import { initProfileName$ } from "./org-manage-tabs-state.ts";
 
 export const SETTINGS_SECTIONS = [
-  "account",
   "preference",
   "api-keys",
   "model",
@@ -39,7 +38,7 @@ export const settingsDialogOpen$ = computed((get) => {
   return get(internalSettingsDialogOpen$);
 });
 
-const internalActiveSection$ = state<SettingsSection>("account");
+const internalActiveSection$ = state<SettingsSection>("preference");
 
 export const settingsActiveSection$ = computed((get) => {
   return get(internalActiveSection$);
@@ -112,7 +111,9 @@ export const checkUnifiedSettingsParam$ = command(
       const isAdmin = await get(isOrgAdmin$);
       signal.throwIfAborted();
       const resolved =
-        !isAdmin && isAdminOnlySettingsSection(section) ? "account" : section;
+        !isAdmin && isAdminOnlySettingsSection(section)
+          ? "preference"
+          : section;
       set(internalActiveSection$, resolved);
       await set(setSettingsDialogOpen$, true, signal);
     }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -49,7 +49,7 @@ export function AccountSection() {
       </div>
       <Button onClick={handleOpen} disabled={!clerk} className="shrink-0">
         <IconUser size={14} />
-        Manage account
+        Manage
       </Button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
@@ -170,7 +170,7 @@ export function PreferenceSection() {
   return (
     <div className="flex flex-col gap-8">
       <section className="flex flex-col gap-3">
-        <SettingsSectionHeading title="Account" />
+        <SettingsSectionHeading title="Account & Security" />
         <AccountSection />
       </section>
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../../../../signals/zero-page/settings/preferences-page.ts";
 import { TimezoneSettings } from "../timezone-settings.tsx";
 import { SettingsSectionHeading } from "../settings-section-heading.tsx";
+import { AccountSection } from "./account-section.tsx";
 
 const THEME_OPTIONS: readonly {
   value: ThemePreference;
@@ -168,6 +169,11 @@ function EnterBlock() {
 export function PreferenceSection() {
   return (
     <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-3">
+        <SettingsSectionHeading title="Account" />
+        <AccountSection />
+      </section>
+
       <section className="flex flex-col gap-3">
         <SettingsSectionHeading
           title="Appearance"

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -22,7 +22,6 @@ import {
   IconCreditCard,
   IconFileInvoice,
   IconKey,
-  IconUserCircle,
   IconUsers,
 } from "@tabler/icons-react";
 
@@ -33,7 +32,6 @@ import {
   setSettingsActiveSection$,
   type SettingsSection,
 } from "../../../../signals/zero-page/settings/settings-dialog.ts";
-import { AccountSection } from "./sections/account-section.tsx";
 import { PreferenceSection } from "./sections/preference-section.tsx";
 import { ApiKeysSection } from "./sections/api-keys-section.tsx";
 import { ModelSection } from "./sections/model-section.tsx";
@@ -52,10 +50,6 @@ interface SettingsDialogProps {
 }
 
 const SECTION_META = {
-  account: {
-    title: "Account",
-    description: "Manage your personal profile and security settings.",
-  },
   preference: {
     title: "Preference",
     description: "Personalize how the app looks and behaves.",
@@ -113,7 +107,6 @@ interface SidebarGroup {
 const PERSONAL_GROUP = {
   label: null,
   items: [
-    { id: "account", label: "Account", icon: IconUserCircle },
     {
       id: "preference",
       label: "Preference",
@@ -143,9 +136,6 @@ const BILLING_GROUP = {
 } as const satisfies SidebarGroup;
 
 const SECTION_COMPONENTS = {
-  account: () => {
-    return <AccountSection />;
-  },
   preference: () => {
     return <PreferenceSection />;
   },
@@ -195,7 +185,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   // If the user lost admin while the dialog is open, fall back to a safe section
   const resolvedSection: SettingsSection =
     !isAdmin && isAdminOnlySettingsSection(activeSection)
-      ? "account"
+      ? "preference"
       : activeSection;
   const meta = SECTION_META[resolvedSection];
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -503,7 +503,7 @@ export function AccountDropdown({
   };
 
   const handleOpenSettings = () => {
-    detach(openSettings("account", pageSignal), Reason.DomCallback);
+    detach(openSettings("preference", pageSignal), Reason.DomCallback);
   };
 
   return (


### PR DESCRIPTION
## Summary

- Removed the standalone **Account** entry from the unified settings dialog sidebar.
- The existing `AccountSection` card (avatar / name / email / Manage account) now renders as the first row of the **Preference** section.
- `"account"` is no longer a valid `SettingsSection` value. Default active section and non-admin fallback both resolve to `"preference"` (in `settings-dialog.ts` signals and the dialog component). The sidebar account dropdown's "Settings" deep link opens `"preference"`.
- Updated the two unit tests that asserted on `"account"` (admin-fallback + `?settings=account` URL).

## Test plan

- [ ] Open the settings dialog from the sidebar account dropdown -> lands on Preference with the Account card at the top.
- [ ] Sidebar no longer shows a separate Account item.
- [ ] As a non-admin, deep-linking via `?settings=billing` falls back to Preference (was Account).
- [ ] `pnpm -F @vm0/platform exec vitest src/signals/zero-page/settings/__tests__/settings-dialog.test.ts` passes.
- [ ] `pnpm turbo run lint` and `pnpm check-types` pass.

Generated with Claude Code