### PR TITLE
feat(web): add gpt-5 series and image/video models to /models

### DIFF
--- a/turbo/apps/web/app/[locale]/models/ModelsClient.tsx
+++ b/turbo/apps/web/app/[locale]/models/ModelsClient.tsx
@@ -10,13 +10,13 @@ import { MODELS, type ModelEntry, vendorIconPath } from "./data";
 const MAX_WIDTH = 1200;
 const PAGE_PADDING = 24;
 
-type FilterKey = "all" | "recommended" | "multimodal" | "cost-saving";
+type FilterKey = "all" | "reasoning" | "image" | "video";
 
 const FILTER_LABEL_MAP: Record<FilterKey, string> = {
   all: "filterAll",
-  recommended: "filterRecommended",
-  multimodal: "filterMultimodal",
-  "cost-saving": "filterCostSaving",
+  reasoning: "filterReasoning",
+  image: "filterImage",
+  video: "filterVideo",
 };
 
 const FILTERS: {
@@ -30,23 +30,21 @@ const FILTERS: {
     },
   },
   {
-    key: "recommended",
+    key: "reasoning",
     match: (m) => {
-      return m.vm0Tier === "core";
+      return m.category === "reasoning";
     },
   },
   {
-    key: "multimodal",
+    key: "image",
     match: (m) => {
-      return m.modalities.some((mod) => {
-        return ["Vision", "Image", "Video"].includes(mod);
-      });
+      return m.category === "image";
     },
   },
   {
-    key: "cost-saving",
+    key: "video",
     match: (m) => {
-      return m.vm0Tier === "cost-saving";
+      return m.category === "video";
     },
   },
 ];

--- a/turbo/apps/web/app/[locale]/models/[slug]/ModelDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/models/[slug]/ModelDetailClient.tsx
@@ -6,7 +6,13 @@ import { Link } from "../../../../navigation";
 import { Footer } from "../../../components/Footer";
 import { Particles } from "../../../components/Particles";
 import { getAppUrl } from "../../../../src/lib/zero/url";
-import { MODELS, type ModelEntry, vendorIconPath } from "../data";
+import {
+  MODELS,
+  type GenerationPricingUnit,
+  type ModelEntry,
+  isReasoningModel,
+  vendorIconPath,
+} from "../data";
 
 const MAX_WIDTH = 880;
 const PAGE_PADDING = 24;
@@ -20,6 +26,19 @@ function formatUsd(n: number): string {
 function formatContextWindow(k: number): string {
   if (k >= 1000) return `${(k / 1000).toFixed(0)}M tokens`;
   return `${k}K tokens`;
+}
+
+function generationUnitKey(unit: GenerationPricingUnit): string {
+  switch (unit) {
+    case "image":
+      return "generationUnitImage";
+    case "megapixel":
+      return "generationUnitMegapixel";
+    case "video-second":
+      return "generationUnitVideoSecond";
+    case "audio-second":
+      return "generationUnitAudioSecond";
+  }
 }
 
 function Section({
@@ -133,11 +152,13 @@ export function ModelDetailClient({ model, related }: Props) {
     return `content.${slug}.${key}`;
   };
 
-  const heroMeta = [
-    formatContextWindow(model.contextWindowK),
-    model.modalities.join(" / "),
-    model.promptCaching ? "Prompt cache" : null,
-  ].filter(Boolean);
+  const heroMeta = isReasoningModel(model)
+    ? [
+        formatContextWindow(model.contextWindowK),
+        model.modalities.join(" / "),
+        model.promptCaching ? "Prompt cache" : null,
+      ].filter(Boolean)
+    : [model.modalities.join(" / ")];
 
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
@@ -305,34 +326,56 @@ export function ModelDetailClient({ model, related }: Props) {
           )}
 
           {/* Pricing */}
-          <Section
-            title={t("pricingHeading", { name: model.name })}
-            subtitle={t("pricingSubtitle")}
-          >
-            <Card>
-              <DataRow
-                label={t("labelInput")}
-                value={formatUsd(model.pricing.inputUsd)}
-              />
-              <DataRow
-                label={t("labelOutput")}
-                value={formatUsd(model.pricing.outputUsd)}
-              />
-              <DataRow
-                label={t("labelCacheRead")}
-                value={formatUsd(model.pricing.cacheReadUsd)}
-              />
-              <DataRow
-                label={t("labelCacheWrite")}
-                value={
-                  model.pricing.cacheWriteUsd === null
-                    ? t("labelNotBilled")
-                    : formatUsd(model.pricing.cacheWriteUsd)
-                }
-                last
-              />
-            </Card>
-          </Section>
+          {isReasoningModel(model) ? (
+            <Section
+              title={t("pricingHeading", { name: model.name })}
+              subtitle={t("pricingSubtitle")}
+            >
+              <Card>
+                <DataRow
+                  label={t("labelInput")}
+                  value={formatUsd(model.pricing.inputUsd)}
+                />
+                <DataRow
+                  label={t("labelOutput")}
+                  value={formatUsd(model.pricing.outputUsd)}
+                />
+                <DataRow
+                  label={t("labelCacheRead")}
+                  value={formatUsd(model.pricing.cacheReadUsd)}
+                />
+                <DataRow
+                  label={t("labelCacheWrite")}
+                  value={
+                    model.pricing.cacheWriteUsd === null
+                      ? t("labelNotBilled")
+                      : formatUsd(model.pricing.cacheWriteUsd)
+                  }
+                  last
+                />
+              </Card>
+            </Section>
+          ) : (
+            <Section
+              title={t("pricingHeading", { name: model.name })}
+              subtitle={t("generationPricingSubtitle")}
+            >
+              <Card>
+                <DataRow
+                  label={t(generationUnitKey(model.generationPricing.unit))}
+                  value={formatUsd(model.generationPricing.priceUsd)}
+                  last={!model.generationPricing.note}
+                />
+                {model.generationPricing.note && (
+                  <DataRow
+                    label={t("generationPricingDetail")}
+                    value={model.generationPricing.note}
+                    last
+                  />
+                )}
+              </Card>
+            </Section>
+          )}
 
           {/* Performance */}
           <Section
@@ -479,51 +522,66 @@ export function ModelDetailClient({ model, related }: Props) {
           {/* Using on VM0 */}
           <Section title={t("usingOnVm0Heading", { name: model.name })}>
             <div className="flex flex-col gap-5">
-              <div>
-                <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
-                  {t("twoWaysToAccessHeading", { name: model.name })}
-                </h3>
-                <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
-                  {t("twoWaysToAccessBody", {
-                    name: model.name,
-                    byoKey: model.byoKeyLabel,
-                  })}
-                </p>
-              </div>
+              {isReasoningModel(model) && (
+                <>
+                  <div>
+                    <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
+                      {t("twoWaysToAccessHeading", { name: model.name })}
+                    </h3>
+                    <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
+                      {t("twoWaysToAccessBody", {
+                        name: model.name,
+                        byoKey: model.byoKeyLabel,
+                      })}
+                    </p>
+                  </div>
 
-              <div>
-                <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
-                  {t("vm0RecommendationHeading")}
-                </h3>
-                <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
-                  {t(
-                    model.vm0Tier === "core"
-                      ? "tierExplanationCore"
-                      : "tierExplanationCostSaving",
-                    { name: model.name },
-                  )}
-                </p>
-              </div>
+                  <div>
+                    <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
+                      {t("vm0RecommendationHeading")}
+                    </h3>
+                    <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
+                      {t(
+                        model.vm0Tier === "core"
+                          ? "tierExplanationCore"
+                          : "tierExplanationCostSaving",
+                        { name: model.name },
+                      )}
+                    </p>
+                  </div>
 
-              <div>
-                <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
-                  {t("creditsMultiplierHeading", {
-                    multiplier: model.multiplier,
-                  })}
-                </h3>
-                <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
-                  {t("creditsMultiplierBodyP1", {
-                    name: model.name,
-                    multiplier: model.multiplier,
-                  })}
-                </p>
-                <p className="mt-3 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
-                  {t(getMultiplierKey(model.multiplier), {
-                    name: model.name,
-                    multiplier: model.multiplier,
-                  })}
-                </p>
-              </div>
+                  <div>
+                    <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
+                      {t("creditsMultiplierHeading", {
+                        multiplier: model.multiplier,
+                      })}
+                    </h3>
+                    <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
+                      {t("creditsMultiplierBodyP1", {
+                        name: model.name,
+                        multiplier: model.multiplier,
+                      })}
+                    </p>
+                    <p className="mt-3 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
+                      {t(getMultiplierKey(model.multiplier), {
+                        name: model.name,
+                        multiplier: model.multiplier,
+                      })}
+                    </p>
+                  </div>
+                </>
+              )}
+
+              {!isReasoningModel(model) && (
+                <div>
+                  <h3 className="text-[18px] font-medium text-[hsl(var(--foreground))]">
+                    {t("generationAccessHeading", { name: model.name })}
+                  </h3>
+                  <p className="mt-2 text-[16px] leading-relaxed text-[hsl(var(--foreground))]">
+                    {t("generationAccessBody", { name: model.name })}
+                  </p>
+                </div>
+              )}
 
               <p className="text-[14px] text-[hsl(var(--muted-foreground))]">
                 {t("availableSince", { date: model.releasedToVm0 })}

--- a/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-providers";
 
-import { MODELS } from "../data";
+import { MODELS, isReasoningModel } from "../data";
 
 describe("models page data", () => {
-  it("only documents VM0 managed models", () => {
-    const modelIds = MODELS.map((model) => {
-      return model.modelId;
+  it("has unique slugs and modelIds", () => {
+    const slugs = MODELS.map((m) => {
+      return m.slug;
+    });
+    const modelIds = MODELS.map((m) => {
+      return m.modelId;
+    });
+    expect(new Set(slugs).size).toBe(slugs.length);
+    expect(new Set(modelIds).size).toBe(modelIds.length);
+  });
+
+  it("documents only VM0-managed reasoning models", () => {
+    const reasoningIds = MODELS.filter(isReasoningModel).map((m) => {
+      return m.modelId;
     });
     const vm0ModelIds = new Set(Object.keys(VM0_MODEL_TO_PROVIDER));
-    expect(new Set(modelIds).size).toBe(modelIds.length);
     expect(
-      modelIds.every((modelId) => {
+      reasoningIds.every((modelId) => {
         return vm0ModelIds.has(modelId);
       }),
     ).toBe(true);

--- a/turbo/apps/web/app/[locale]/models/data.ts
+++ b/turbo/apps/web/app/[locale]/models/data.ts
@@ -1,12 +1,16 @@
 // ---------------------------------------------------------------------------
 // Models. Built-in lineup shown on /models and /models/[slug].
 //
-// Order, multipliers, pricing, and routing facts mirror the platform:
+// Reasoning models: order, multipliers, pricing, and routing facts mirror the
+// platform at:
 //   - turbo/packages/api-contracts/src/contracts/model-providers.ts
 //     (VM0_MODEL_TO_PROVIDER, MODEL_PROVIDER_TYPES)
 //   - turbo/apps/platform/.../settings/provider-ui-config.ts
 //     (VM0_MODEL_CREDIT_MULTIPLIER)
 //   - turbo/apps/web/scripts/dev-seed.ts (MODEL_PRICING. USD per 1M tokens)
+//
+// Generation models (image, video, audio): per-unit pricing mirrors the same
+// dev-seed.ts table (USD per image / megapixel / video-second / audio-second).
 //
 // Translatable content lives in messages/<locale>.json under
 // models.content.<slug>.* — see the use-cases page for the same pattern.
@@ -14,6 +18,8 @@
 
 const VENDOR_ICONS: Readonly<Record<string, string>> = {
   Anthropic: "/assets/connectors/anthropic.svg",
+  OpenAI: "/assets/connectors/openai.svg",
+  Google: "/assets/connectors/gemini.svg",
   "Z.AI": "/assets/connectors/chatglm.svg",
   Moonshot: "/assets/connectors/kimi.svg",
   DeepSeek: "/assets/connectors/deepseek.svg",
@@ -24,7 +30,9 @@ export function vendorIconPath(vendor: string): string | null {
   return VENDOR_ICONS[vendor] ?? null;
 }
 
-export interface ModelPricing {
+type ModelCategory = "reasoning" | "image" | "video" | "audio";
+
+interface ModelPricing {
   inputUsd: number;
   outputUsd: number;
   cacheReadUsd: number;
@@ -32,28 +40,55 @@ export interface ModelPricing {
   cacheWriteUsd: number | null;
 }
 
-export interface ModelEntry {
+export type GenerationPricingUnit =
+  | "image"
+  | "megapixel"
+  | "video-second"
+  | "audio-second";
+
+interface GenerationPricing {
+  unit: GenerationPricingUnit;
+  priceUsd: number;
+  /** Free-form qualifier shown next to the price, e.g. "1080p" or "low/standard tier". */
+  note?: string;
+}
+
+interface BaseModelEntry {
   slug: string;
   modelId: string;
   name: string;
   vendor: string;
-  multiplier: number;
-
-  contextWindowK: number;
-  promptCaching: boolean;
+  category: ModelCategory;
   modalities: string[];
   releasedToVm0: string;
-
-  pricing: ModelPricing;
-  vm0Tier: "core" | "cost-saving";
-  vm0TimeoutMin?: number;
-  byoKeyLabel: string;
-  defaultFor: string[];
 
   /** Model names of comparison targets (used in heading template and as content lookup keys). */
   comparisonSlugs: string[];
   /** Slugs of alternative models for the "Alternatives" card row. */
   alternativeSlugs: string[];
+}
+
+export interface ReasoningModelEntry extends BaseModelEntry {
+  category: "reasoning";
+  multiplier: number;
+  contextWindowK: number;
+  promptCaching: boolean;
+  pricing: ModelPricing;
+  vm0Tier: "core" | "cost-saving";
+  vm0TimeoutMin?: number;
+  byoKeyLabel: string;
+  defaultFor: string[];
+}
+
+export interface GenerationModelEntry extends BaseModelEntry {
+  category: "image" | "video" | "audio";
+  generationPricing: GenerationPricing;
+}
+
+export type ModelEntry = ReasoningModelEntry | GenerationModelEntry;
+
+export function isReasoningModel(m: ModelEntry): m is ReasoningModelEntry {
+  return m.category === "reasoning";
 }
 
 export const MODELS: ModelEntry[] = [
@@ -62,6 +97,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "claude-opus-4-7",
     name: "Claude Opus 4.7",
     vendor: "Anthropic",
+    category: "reasoning",
     multiplier: 1.7,
     contextWindowK: 1000,
     promptCaching: true,
@@ -91,6 +127,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "claude-opus-4-6",
     name: "Claude Opus 4.6",
     vendor: "Anthropic",
+    category: "reasoning",
     multiplier: 1.7,
     contextWindowK: 1000,
     promptCaching: true,
@@ -110,10 +147,35 @@ export const MODELS: ModelEntry[] = [
   },
 
   {
+    slug: "gpt-5-5",
+    modelId: "gpt-5.5",
+    name: "GPT-5.5",
+    vendor: "OpenAI",
+    category: "reasoning",
+    multiplier: 2,
+    contextWindowK: 400,
+    promptCaching: true,
+    modalities: ["Text", "Vision", "Code"],
+    releasedToVm0: "April 2026",
+    pricing: {
+      inputUsd: 5,
+      outputUsd: 30,
+      cacheReadUsd: 0.5,
+      cacheWriteUsd: null,
+    },
+    vm0Tier: "core",
+    byoKeyLabel: "OpenAI API key",
+    defaultFor: ["OpenAI", "ChatGPT (Codex)"],
+    comparisonSlugs: ["GPT-5.4", "Claude Opus 4.7", "Gemini 3 Pro"],
+    alternativeSlugs: ["gpt-5-4", "claude-opus-4-7", "claude-sonnet-4-6"],
+  },
+
+  {
     slug: "claude-sonnet-4-6",
     modelId: "claude-sonnet-4-6",
     name: "Claude Sonnet 4.6",
     vendor: "Anthropic",
+    category: "reasoning",
     multiplier: 1,
     contextWindowK: 1000,
     promptCaching: true,
@@ -137,10 +199,35 @@ export const MODELS: ModelEntry[] = [
   },
 
   {
+    slug: "gpt-5-4",
+    modelId: "gpt-5.4",
+    name: "GPT-5.4",
+    vendor: "OpenAI",
+    category: "reasoning",
+    multiplier: 1,
+    contextWindowK: 400,
+    promptCaching: true,
+    modalities: ["Text", "Vision", "Code"],
+    releasedToVm0: "April 2026",
+    pricing: {
+      inputUsd: 2.5,
+      outputUsd: 15,
+      cacheReadUsd: 0.25,
+      cacheWriteUsd: null,
+    },
+    vm0Tier: "core",
+    byoKeyLabel: "OpenAI API key",
+    defaultFor: [],
+    comparisonSlugs: ["GPT-5.5", "Claude Sonnet 4.6", "GPT-5.4 Mini"],
+    alternativeSlugs: ["gpt-5-5", "gpt-5-4-mini", "claude-sonnet-4-6"],
+  },
+
+  {
     slug: "glm-5-1",
     modelId: "glm-5.1",
     name: "GLM-5.1",
     vendor: "Z.AI",
+    category: "reasoning",
     multiplier: 0.4,
     contextWindowK: 1000,
     promptCaching: true,
@@ -165,6 +252,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "claude-haiku-4-5",
     name: "Claude Haiku 4.5",
     vendor: "Anthropic",
+    category: "reasoning",
     multiplier: 0.3,
     contextWindowK: 200,
     promptCaching: true,
@@ -188,10 +276,35 @@ export const MODELS: ModelEntry[] = [
   },
 
   {
+    slug: "gpt-5-4-mini",
+    modelId: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    vendor: "OpenAI",
+    category: "reasoning",
+    multiplier: 0.3,
+    contextWindowK: 400,
+    promptCaching: true,
+    modalities: ["Text", "Vision", "Code"],
+    releasedToVm0: "April 2026",
+    pricing: {
+      inputUsd: 0.75,
+      outputUsd: 4.5,
+      cacheReadUsd: 0.075,
+      cacheWriteUsd: null,
+    },
+    vm0Tier: "cost-saving",
+    byoKeyLabel: "OpenAI API key",
+    defaultFor: [],
+    comparisonSlugs: ["GPT-5.4", "Claude Haiku 4.5", "DeepSeek V4 Flash"],
+    alternativeSlugs: ["gpt-5-4", "claude-haiku-4-5", "deepseek-v4-flash"],
+  },
+
+  {
     slug: "kimi-k2-6",
     modelId: "kimi-k2.6",
     name: "Kimi K2.6",
     vendor: "Moonshot",
+    category: "reasoning",
     multiplier: 0.3,
     contextWindowK: 256,
     promptCaching: true,
@@ -215,6 +328,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "deepseek-v4-pro",
     name: "DeepSeek V4 Pro",
     vendor: "DeepSeek",
+    category: "reasoning",
     multiplier: 0.3,
     contextWindowK: 1000,
     promptCaching: true,
@@ -239,6 +353,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "kimi-k2.5",
     name: "Kimi K2.5",
     vendor: "Moonshot",
+    category: "reasoning",
     multiplier: 0.2,
     contextWindowK: 256,
     promptCaching: true,
@@ -262,6 +377,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "MiniMax-M2.7",
     name: "MiniMax M2.7",
     vendor: "MiniMax",
+    category: "reasoning",
     multiplier: 0.1,
     contextWindowK: 200,
     promptCaching: true,
@@ -286,6 +402,7 @@ export const MODELS: ModelEntry[] = [
     modelId: "deepseek-v4-flash",
     name: "DeepSeek V4 Flash",
     vendor: "DeepSeek",
+    category: "reasoning",
     multiplier: 0.02,
     contextWindowK: 1000,
     promptCaching: true,
@@ -303,6 +420,149 @@ export const MODELS: ModelEntry[] = [
     defaultFor: ["DeepSeek"],
     comparisonSlugs: ["DeepSeek V4 Pro", "Claude Haiku 4.5", "MiniMax M2.7"],
     alternativeSlugs: ["deepseek-v4-pro", "claude-haiku-4-5", "minimax-m2-7"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Image generation models.
+  // -------------------------------------------------------------------------
+
+  {
+    slug: "gemini-2-5-flash-image",
+    modelId: "gemini-2.5-flash-image",
+    name: "Gemini 2.5 Flash Image",
+    vendor: "Google",
+    category: "image",
+    modalities: ["Image", "Text-to-image", "Image edit"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "image",
+      priceUsd: 0.0387,
+      note: "1024×1024 standard",
+    },
+    comparisonSlugs: ["GPT Image 1", "SeedDream 4", "Flux Pro 1.1 Ultra"],
+    alternativeSlugs: ["gpt-image-1", "seedream-4", "flux-pro-1-1-ultra"],
+  },
+
+  {
+    slug: "gpt-image-1",
+    modelId: "gpt-image-1",
+    name: "GPT Image 1",
+    vendor: "OpenAI",
+    category: "image",
+    modalities: ["Image", "Text-to-image", "Image edit"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "image",
+      priceUsd: 0.05,
+      note: "Medium standard tier (1024×1024)",
+    },
+    comparisonSlugs: [
+      "Gemini 2.5 Flash Image",
+      "SeedDream 4",
+      "Flux Pro 1.1 Ultra",
+    ],
+    alternativeSlugs: [
+      "gemini-2-5-flash-image",
+      "flux-pro-1-1-ultra",
+      "seedream-4",
+    ],
+  },
+
+  {
+    slug: "flux-pro-1-1-ultra",
+    modelId: "fal-ai/flux-pro/v1.1-ultra",
+    name: "Flux Pro 1.1 Ultra",
+    vendor: "Black Forest Labs",
+    category: "image",
+    modalities: ["Image", "Text-to-image"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "image",
+      priceUsd: 0.072,
+      note: "Per generated image",
+    },
+    comparisonSlugs: ["GPT Image 1", "SeedDream 4", "Gemini 2.5 Flash Image"],
+    alternativeSlugs: ["gpt-image-1", "seedream-4", "gemini-2-5-flash-image"],
+  },
+
+  {
+    slug: "seedream-4",
+    modelId: "fal-ai/bytedance/seedream/v4/text-to-image",
+    name: "SeedDream 4",
+    vendor: "ByteDance",
+    category: "image",
+    modalities: ["Image", "Text-to-image"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "image",
+      priceUsd: 0.036,
+      note: "Per generated image",
+    },
+    comparisonSlugs: [
+      "GPT Image 1",
+      "Flux Pro 1.1 Ultra",
+      "Gemini 2.5 Flash Image",
+    ],
+    alternativeSlugs: [
+      "gpt-image-1",
+      "flux-pro-1-1-ultra",
+      "gemini-2-5-flash-image",
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Video generation models.
+  // -------------------------------------------------------------------------
+
+  {
+    slug: "veo-3-1-fast",
+    modelId: "veo3.1-fast",
+    name: "Veo 3.1 Fast",
+    vendor: "Google",
+    category: "video",
+    modalities: ["Video", "Text-to-video", "Image-to-video", "Audio"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "video-second",
+      priceUsd: 0.15,
+      note: "Approximate, 720p with native audio",
+    },
+    comparisonSlugs: ["Kling V3 4K", "Dreamina Seedance 2.0"],
+    alternativeSlugs: ["kling-v3-4k", "dreamina-seedance-2-0"],
+  },
+
+  {
+    slug: "kling-v3-4k",
+    modelId: "kling-v3-4k",
+    name: "Kling V3 4K",
+    vendor: "Kuaishou",
+    category: "video",
+    modalities: ["Video", "Text-to-video", "Image-to-video"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "video-second",
+      priceUsd: 0.28,
+      note: "Approximate, 4K standard generation",
+    },
+    comparisonSlugs: ["Veo 3.1 Fast", "Dreamina Seedance 2.0"],
+    alternativeSlugs: ["veo-3-1-fast", "dreamina-seedance-2-0"],
+  },
+
+  {
+    slug: "dreamina-seedance-2-0",
+    modelId: "dreamina-seedance-2-0-260128",
+    name: "Dreamina Seedance 2.0",
+    vendor: "ByteDance",
+    category: "video",
+    modalities: ["Video", "Text-to-video", "Image-to-video"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "video-second",
+      priceUsd: 0.05,
+      note: "Approximate, 1080p with image conditioning",
+    },
+    comparisonSlugs: ["Veo 3.1 Fast", "Kling V3 4K"],
+    alternativeSlugs: ["veo-3-1-fast", "kling-v3-4k"],
   },
 ];
 

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -3862,10 +3862,10 @@
     "back": "← Zurück"
   },
   "models": {
-    "listingPageTitle": "Modelle — Agents mit Claude und mehr ausführen",
-    "listingPageDescription": "Alle KI-Modelle für VM0-Agents — Claude Opus 4.7, Sonnet 4.6, Haiku 4.5 und mehr. Kurze Einführung und wofür jedes Modell auf VM0 am besten geeignet ist.",
+    "listingPageTitle": "Modelle — Reasoning, Bild und Video auf VM0",
+    "listingPageDescription": "Jedes KI-Modell, das VM0-Agenten zur Verfügung steht — Reasoning-Modelle von Anthropic, OpenAI, DeepSeek, Moonshot und mehr, plus Modelle zur Bild- und Videogenerierung. Kurze Einführung und wofür jedes Modell auf VM0 am besten geeignet ist.",
     "jsonLdListName": "Auf VM0 verfügbare KI-Modelle",
-    "jsonLdListDescription": "Alle KI-Modelle für VM0-Agents — Claude und mehr.",
+    "jsonLdListDescription": "Jedes KI-Modell, das VM0-Agenten zur Verfügung steht — Reasoning, Bild und Video.",
     "breadcrumbHome": "Startseite",
     "breadcrumbModels": "Modelle",
     "notFound": "Nicht gefunden",
@@ -3873,9 +3873,9 @@
     "heroDescription": "Jedes Modell, das deinen Agents zur Verfügung steht. Was es gut kann und wann du es wählen solltest.",
     "filterAriaLabel": "Modelle filtern",
     "filterAll": "Alle",
-    "filterRecommended": "Empfohlen",
-    "filterMultimodal": "Multimodal",
-    "filterCostSaving": "Kostensparend",
+    "filterReasoning": "Reasoning",
+    "filterImage": "Bilder",
+    "filterVideo": "Video",
     "readMoreAbout": "Mehr über {name}",
     "backToAllModels": "Alle Modelle",
     "useModelButton": "{name} auf VM0 nutzen",
@@ -3914,6 +3914,14 @@
     "tierExplanationCore": "VM0 positioniert {name} als Core-Agent-Modell, empfohlen neben Claude Opus 4.7, Claude Opus 4.6 und Claude Sonnet 4.6 für die Schritte, die das tatsächliche Ergebnis eines Agent-Durchlaufs bestimmen. Das sind die Modelle, die wir für die Orchestrator-Rolle, für code-bearbeitende Agents und für jeden Schritt wählen, bei dem eine falsche Antwort teuer ist.",
     "tierExplanationCostSaving": "VM0 positioniert {name} als kostensparende Option statt als Core-Agent-Modell. Nutze es zur Optimierung der Stückkosten bei Nicht-Kernarbeit wie Massenklassifikation, Vorfiltern, latenzkritischen Kurzantworten oder fest zugewiesenen Legacy-Agents, während Claude Opus 4.7, Claude Opus 4.6 oder Claude Sonnet 4.6 die entscheidenden Schritte übernehmen.",
     "availableSince": "Verfügbar auf VM0 seit {date}.",
+    "generationPricingSubtitle": "Anbieter-Listenpreis pro generierter Einheit.",
+    "generationPricingDetail": "Details",
+    "generationUnitImage": "Pro generiertem Bild",
+    "generationUnitMegapixel": "Pro Output-Megapixel",
+    "generationUnitVideoSecond": "Pro Sekunde Video",
+    "generationUnitAudioSecond": "Pro Sekunde Audio",
+    "generationAccessHeading": "{name} auf VM0 nutzen",
+    "generationAccessBody": "VM0-Agenten können {name} im Rahmen eines Agent-Runs aufrufen, abgerechnet über VM0-Credits. Der oben gelistete Preis ist der Anbieter-Listenpreis; VM0 reicht diesen mit der Standard-Credit-Umrechnung weiter.",
     "content": {
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
@@ -4283,6 +4291,165 @@
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and as the default model on the Anthropic API-key and Claude Code OAuth providers.",
         "vm0Notes": "Opus 4.6 carries the highest vendor list price per token of any Built-in model, so prompt caching matters here more than anywhere else and is on by default. It's still the default model on the Anthropic API-key and Claude Code OAuth providers, which means it's likely the model your team already has muscle memory for, even though Opus 4.7 is the recommended choice for new work."
       },
+      "gpt-5-5": {
+        "name": "GPT-5.5",
+        "pageTitle": "GPT-5.5 on VM0. OpenAI's flagship reasoning model",
+        "tagline": "OpenAIs Flaggschiff der GPT-5-Familie. Die stärkste Wahl für agentisches Coding, tiefes Reasoning und Computer-Use-Schleifen in der OpenAI-Klasse.",
+        "cardIntro": "OpenAIs Flaggschiff-Reasoning-Modell. Erstklassiges Coding und Tool-Use, auf VM0 über das Codex-Framework geroutet.",
+        "metaTitle": "GPT-5.5: Benchmarks, Preise & Fähigkeiten",
+        "metaDescription": "GPT-5.5 im Test. OpenAIs Flaggschiff-Reasoning-Modell der GPT-5-Familie mit 400K Kontext, multimodaler Vision, $5/$30 Anbieterpreisen und Benchmark-Führerschaft bei SWE-bench Verified, AIME 2025 und GPQA Diamond.",
+        "summary": "GPT-5.5 ist das Modell, zu dem du greifst, wenn die Arbeit sowohl tiefes Reasoning als auch zuverlässigen Tool-Use braucht: Orchestrierung mehrstufiger Agent-Schleifen, Code-Änderungen, die im ersten Versuch sitzen müssen, und Computer-Use-Workflows über viele GUI-Aktionen. Anbieter-Benchmarks (SWE-bench Verified, AIME 2025, GPQA Diamond) liefern konkrete Zahlen zu den Fortschritten gegenüber GPT-5.4.\n\nListenpreis des Anbieters ist $5 / $30 pro 1M Tokens mit gecachtem Input zu $0,50 / 1M. Es ist das teuerste Modell im Built-in-Katalog von VM0 mit ×2 Credits, daher besteht das kosteneffiziente Muster darin, GPT-5.4 oder Claude Sonnet 4.6 als Standard überall laufen zu lassen und nur die schwierigsten Schritte an GPT-5.5 zu routen.",
+        "releaseDate": "April 2026 (Nachfolger von GPT-5.4)",
+        "familyPosition": "Spitzenmodell der GPT-5-Familie. OpenAIs Flaggschiff für agentisches Coding und Reasoning.",
+        "background": [
+          "GPT-5.5 ist das Flaggschiff der GPT-5-Generation von OpenAI, veröffentlicht im April 2026 als empfohlenes Upgrade von GPT-5.4. OpenAI positioniert es als sprunghafte Verbesserung bei agentischem Tool-Use und Computer-Use-Aufgaben statt als oberflächliches API-Refresh. Das mit GPT-5 eingeführte 400K-Token-Kontextfenster und der reasoning_effort-Parameter bleiben unverändert, sodass bestehende Codex-Agenten ohne Umschreibungen übernommen werden können.",
+          "Verglichen mit GPT-5.4 (dem Arbeitstier derselben Familie) investiert GPT-5.5 mehr Rechenleistung pro Token in Reasoning. Der Nutzen zeigt sich in drei Bereichen: stärkere First-Attempt-Code-Patches bei Multi-File-Refactorings, deutlich weniger fehlgeleitete Tool-Calls in langen Agent-Schleifen und spürbare Fortschritte bei wissenschaftlichem Reasoning auf Graduiertenniveau (GPQA Diamond) und Wettbewerbsmathematik (AIME 2025). Der Preis dafür ist der höchste Listenpreis unter den GPT-5-Varianten ($5 / $30 pro 1M Tokens) und ein ×2 Credit-Multiplikator auf VM0, weshalb OpenAI selbst GPT-5.5 als Planner- oder Eskalationsebene positioniert statt als Standard überall.",
+          "Unabhängige Leaderboards (Artificial Analysis, Vellum) bestätigen die relative Reihenfolge gegenüber GPT-5.4 und platzieren GPT-5.5 bei den meisten agentischen Coding-Aufgaben innerhalb weniger Punkte von Claude Opus 4.7. Absolute Zahlen verschieben sich wöchentlich, und OpenAI selbst hat Trainingsdaten-Kontamination bei SWE-bench Verified über alle Frontier-Modelle hinweg markiert. Behandle die öffentlichen Werte als richtungsweisend statt autoritativ; die strukturellen Verhaltensunterschiede (Tool-Call-Genauigkeit, Computer-Use-Zuverlässigkeit, First-Attempt-Patch-Qualität) sind das verlässlichere Signal."
+        ],
+        "architecture": "GPT-5.5 behält das 400K-Token-Kontextfenster von GPT-5.4 und berechnet über das gesamte Fenster den Standard-Input-Preis. Es unterstützt den `reasoning_effort`-Parameter auf vier Stufen (minimal, niedrig, mittel, hoch), Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses API, die codex CLI standardmäßig nutzt. Tool-Use, Structured Outputs und Computer-Use sind gegenüber 5.4 unverändert. Eingaben sind multimodal über Text, Vision und Code; das Modell hat keine native Bildgenerierung (nutze dafür die Images API).",
+        "specs": [
+          { "label": "Familie", "value": "GPT-5 Generation" },
+          { "label": "Modalitäten", "value": "Text, Vision, Code" },
+          { "label": "Sprachen", "value": "Englisch-zentriert, mehrsprachig" },
+          { "label": "Prompt Caching", "value": "Unterstützt (OpenAI)" },
+          { "label": "Kontextfenster", "value": "400K Token" },
+          { "label": "Max Output", "value": "Bis zu 128K Token" },
+          {
+            "label": "Reasoning Effort",
+            "value": "Minimal / Niedrig / Mittel / Hoch"
+          },
+          { "label": "Listenpreis", "value": "$5 Input / $30 Output pro 1M" }
+        ],
+        "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5.5-Release-Materialien, mit Deltas gegenüber den öffentlichen GPT-5.4-Zahlen. Unabhängige Reviews platzieren 5.5 bei agentischen Coding-Aufgaben innerhalb weniger Punkte von Claude Opus 4.7. Behandle absolute Prozente als richtungsweisend; OpenAI hat Trainingsdaten-Kontamination bei SWE-bench Verified über alle Frontier-Modelle gemeldet.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~82%",
+            "note": "vendor-reported; up from 5.4's 74.9%"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~69%",
+            "note": "vendor-reported tool use"
+          },
+          {
+            "name": "AIME 2025 (no tools)",
+            "score": "~96%",
+            "note": "vendor-reported competition math"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~89%",
+            "note": "vendor-reported graduate science"
+          },
+          {
+            "name": "OSWorld (computer use)",
+            "score": "~74%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "MMMU (multimodal)",
+            "score": "Leads GPT-5 family",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Speed",
+            "score": "~70 tokens/sec",
+            "note": "Artificial Analysis, medium effort"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Tool-Routing",
+            "body": "Niedrigste Rate fehlgeleiteter Tool-Calls in der GPT-5-Familie. Der Abstand zu 5.4 wird bei harten Randfällen größer: bedingte Tool-Auswahl, tief verschachtelte Argumente und Tool-Calls nach langen Reasoning-Strecken."
+          },
+          {
+            "title": "First-Attempt-Code-Edits",
+            "body": "Stärkste Patch-Qualität in der GPT-5-Familie. Die richtige Wahl, wenn ein Agent Code ändern muss, der weiter kompilieren und Tests bestehen muss, besonders bei Multi-File-Patches. Vom Anbieter gemeldete SWE-bench-Verified-Werte spiegeln das direkt wider."
+          },
+          {
+            "title": "Computer Use",
+            "body": "Deutlich zuverlässiger als 5.4 bei mehrstufigen GUI-Sequenzen, was das OSWorld-Delta erfasst. Greife danach, wenn der Agent über Dutzende Schritte einen Browser oder eine Desktop-App steuert und ein Mid-Run-Abriss teuer wäre."
+          },
+          {
+            "title": "Geschwindigkeit",
+            "body": "Langsamer als 5.4 und merklich langsamer als 5.4 Mini. Etwa 70 Tokens/sec bei mittlerem Effort laut Artificial Analysis. Reserviere es für Schritte, die die zusätzliche Reasoning-Tiefe wirklich brauchen, und lasse leichtere Stufen parallel laufen."
+          },
+          {
+            "title": "Halluzinationsverhalten",
+            "body": "GPT-5.5 trägt die strengere Kalibrierung der GPT-5-Generation und gibt Unsicherheit eher zu, statt zu konfabulieren. Deshalb zahlen Produktionsteams trotz günstigerer Alternativen wie DeepSeek V4 Pro, die ihn in Benchmarks mittlerweile erreichen, weiter den Aufpreis für High-Stakes-Reasoning."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Orchestrator, der einen Multi-Tool-Plan ausführt",
+            "body": "Nutze GPT-5.5 als Planner, der die Anfrage eines Kunden in zehn Schritte zerlegt, jeden Schritt an einen Sub-Agenten der GPT-5.4- oder 5.4-Mini-Klasse delegiert und die Ergebnisse wieder zusammenfügt. 5.5 nur auf der Planner-Ebene laufen zu lassen (und die günstigeren Stufen überall sonst) kostet einen Bruchteil davon, 5.5 durchgängig laufen zu lassen — bei weitgehend gleicher Qualität."
+          },
+          {
+            "title": "Code-Edits im ersten Versuch, die keinen CI-Lauf verschwenden",
+            "body": "Lass GPT-5.5 eine 50-Datei-Codebasis von einem ORM zu einem anderen migrieren, ein verworrenes Modul refactoren oder einen Security-Fix über das Repo anwenden. Der Patch lässt sich öfter im ersten Versuch sauber anwenden als bei jedem anderen Modell der Familie — und genau das wird deine CI-Rechnung widerspiegeln."
+          },
+          {
+            "title": "Der Computer-Use-Agent, der den Workflow zu Ende bringt",
+            "body": "Wenn der Agent einen Browser durch einen mehrstufigen Buchungsflow, eine Desktop-App oder eine Legacy-Admin-UI steuert, übersetzt sich 5.5's stärkerer OSWorld-Wert in weniger Mid-Run-Abrisse und weniger menschliche Übernahmen. Der Aufpreis rechnet sich beim ersten langen Session, die nicht neu gestartet werden muss."
+          },
+          {
+            "title": "Der harte Mathematik- oder Wissenschafts-Forschungsschritt",
+            "body": "Wirf einen Mathematik-Aufgabenkatalog auf Wettbewerbsniveau oder eine Physik-Herleitung auf Graduiertenniveau hinein, und 5.5 arbeitet sie ohne die Off-by-One-Ausrutscher von 5.4 durch. AIME 2025 und GPQA Diamond erfassen genau dieses Verhalten."
+          }
+        ],
+        "avoidFor": "Verzichte auf GPT-5.5 bei volumenstarker Routine-Arbeit, bei der GPT-5.4 zur halben Credit-Last dieselbe Qualität liefert, bei latenzempfindlichen Chat-Antworten, wo GPT-5.4 Mini deutlich schneller ist, und bei Bulk-Klassifikation oder Extraktionsjobs, wo DeepSeek V4 Flash beim Anbieter ungefähr 35× günstiger ist.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "GPT-5.4 ist das Arbeitstier-Default in der GPT-5-Familie und die richtige Wahl für die meisten Agenten. Promote auf GPT-5.5 nur, wenn 5.4 sichtbar an hartem Reasoning, langen agentischen Schleifen oder First-Attempt-Code-Edits scheitert, in der Regel als Orchestrator, der nach unten an Sub-Agenten der 5.4- oder 5.4-Mini-Klasse delegiert."
+          },
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "Gleiche Rolle in verschiedenen Familien: der High-Stakes-Orchestrator und das Modell, auf das du eskalierst, wenn die günstigere Stufe versagt. Opus 4.7 hat das 1M-Token-Kontextfenster und Anthropics Sicherheitsprofil; GPT-5.5 hat stärkere Computer-Use-Werte und ist die natürliche Wahl für Teams, die bereits auf dem Codex-Framework sind. Wähle nach Framework und Ökosystem, auf das deine bestehenden Agenten zielen."
+          },
+          {
+            "vs": "Gemini 3 Pro",
+            "body": "Gemini 3 Pro führt bei reinem Long-Context-Reasoning (2M-Token-Fenster) und bei einigen multimodalen Benchmarks. GPT-5.5 führt bei agentischem Coding (SWE-bench Verified, Terminal-Bench) und Computer Use. Wähle GPT-5.5, wenn der Agent Code editiert oder eine UI steuert; wähle Gemini 3 Pro, wenn die Last auf Dokumenten- oder Video-Verständnis liegt."
+          }
+        ],
+        "verdict": "GPT-5.5 ist die Eskalationsebene auf der OpenAI-Seite. Standardmäßig GPT-5.4; auf 5.5 nur bei den spezifischen Schritten promoten, an denen 5.4 sichtbar scheitert.",
+        "faqs": [
+          {
+            "q": "Was ist das Kontextfenster von GPT-5.5?",
+            "a": "400.000 Token, mit bis zu 128K Token Output pro Antwort. Das gesamte Fenster wird zu Standardpreisen berechnet."
+          },
+          {
+            "q": "Kann GPT-5.5 Bilder verarbeiten?",
+            "a": "Ja. GPT-5.5 ist multimodal. Es akzeptiert Bildeingaben neben Text und Code, sodass Screenshot- und Document-Vision-Agenten nativ funktionieren. Für Bildgenerierung die OpenAI Images API nutzen."
+          },
+          {
+            "q": "Wann GPT-5.5 statt GPT-5.4 wählen?",
+            "a": "Wenn (a) der Agent Planner / Orchestrator ist und Entscheidungen kaskadieren, (b) der Lauf lang genug ist, dass 5.4 anfängt, Tool-Calls fehlzuleiten, oder (c) die Ausgabe im ersten Versuch sauber anwendbar sein muss (Code-Edits, strukturierte Payloads, Computer-Use-Workflows)."
+          },
+          {
+            "q": "Unterstützt GPT-5.5 Prompt Caching?",
+            "a": "Ja. Gecachter Input wird mit $0,50 pro 1M Token berechnet — ein 10×-Rabatt auf den gecachten Anteil. Lohnt sich, wenn dein System-Prompt oder Tool-Schema über Calls hinweg stabil ist."
+          },
+          {
+            "q": "Welches Framework nutzt GPT-5.5 auf VM0?",
+            "a": "Codex. VM0 routet GPT-5.5 über die Responses-API-Oberfläche des Codex-Frameworks, die codex CLI standardmäßig nutzt. Agenten des Claude-Code-Frameworks sind auf VM0 nicht mit GPT-5-Modellen kompatibel."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-5-4", "reason": "Halbe Credits, gleiche Familie" },
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Peer-Flaggschiff auf der Claude-Seite"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Arbeitstier-Default zu ×1 Credits"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Exposed four ways: through the VM0 Managed credit pool, through a direct OpenAI API key, through a ChatGPT (Codex) OAuth login, and through OpenRouter / Vercel AI Gateway in their Codex variants.",
+        "vm0Notes": "GPT-5.5 sits at the ×2 credit multiplier — the highest in the Built-in catalogue. Prompt caching is enabled by default through VM0, which substantially cuts the cost of repeated system prompts on agents that issue many turns from the same prefix. The standard pattern is to keep GPT-5.4 or Claude Sonnet 4.6 running everywhere and escalate only the steps that genuinely need 5.5's reasoning depth."
+      },
       "claude-sonnet-4-6": {
         "name": "Claude Sonnet 4.6",
         "pageTitle": "Claude Sonnet 4.6 on VM0. The default agent model",
@@ -4429,6 +4596,159 @@
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Default model on VM0 Managed.",
         "vm0Notes": "Sonnet 4.6 is the credit baseline (×1) that every other Built-in model's multiplier is normalised against, which is the main reason it stays the first choice for new agents on VM0; escalate to Opus only when Sonnet visibly underperforms on a specific task. Native prompt caching pairs well with VM0's stable system prompts and tool definitions, and keeps the per-turn cost of long-running agents predictable."
+      },
+      "gpt-5-4": {
+        "name": "GPT-5.4",
+        "pageTitle": "GPT-5.4 on VM0. The OpenAI workhorse",
+        "tagline": "OpenAIs Arbeitstier der GPT-5-Familie. Sitzt auf der ×1 Credit-Basislinie neben Claude Sonnet 4.6 und ist der richtige Standard für die meisten Codex-Framework-Agenten.",
+        "cardIntro": "OpenAIs Arbeitstier-Modell. ×1 Credits, multimodale Vision, starkes Coding und Tool-Use — der Standard-GPT-5 für die meisten Agenten.",
+        "metaTitle": "GPT-5.4 auf VM0: Benchmarks, Preise & Vergleich",
+        "metaDescription": "GPT-5.4 im Test auf VM0. Das Arbeitstier-OpenAI-GPT-5-Modell mit 400K Kontext, multimodaler Vision, $2,5/$15 Preisen und ×1 Credits auf VM0 Managed. Spezifikationen und Claude-Vergleich.",
+        "summary": "GPT-5.4 ist das Arbeitstier der GPT-5-Familie von OpenAI — das Modell, das du standardmäßig überall laufen lässt. Vom Anbieter gemeldete SWE-bench Verified bei 74,9% platziert es beim Coding im selben Bereich wie Claude Sonnet 4.6, und seine Tool-Use-Genauigkeit ist das, worauf die meisten produktiven Codex-Framework-Agenten getunt sind.\n\nListenpreis des Anbieters ist $2,5 / $15 pro 1M Tokens mit gecachtem Input zu $0,25 / 1M. Es liegt bei ×1 Credits auf VM0 Managed — dieselbe Basislinie wie Claude Sonnet 4.6 — was es zur natürlichen Wahl macht, wenn dein Agent bereits auf dem Codex-Framework läuft und du einen ausgewogenen Kosten/Qualitäts-Default willst.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Arbeitstier der GPT-5-Familie. Der empfohlene Standard für die meisten Codex-Framework-Agenten.",
+        "background": [
+          "GPT-5.4 ist das Arbeitstier der GPT-5-Generation von OpenAI, veröffentlicht im April 2026 neben dem Flaggschiff GPT-5.5 und dem kostenoptimierten GPT-5.4 Mini. OpenAI positioniert es als Standard überall für Agenten auf dem Codex-Framework — das Modell, das du auf jedem Schritt laufen lässt, sofern ein spezifischer Schritt keine Eskalation auf 5.5 rechtfertigt.",
+          "Architektonisch teilt GPT-5.4 das 400K-Token-Kontextfenster, den `reasoning_effort`-Parameter, Prompt Caching und die Responses-API-Oberfläche mit dem Rest der GPT-5-Familie. Der Unterschied zu GPT-5.5 ist die Rechen-Investition pro Token: 5.4 läuft schneller und günstiger, 5.5 investiert mehr in Reasoning-Tiefe. Der Unterschied zu GPT-5.4 Mini ist umgekehrt — 5.4 trägt mehr Qualität für die Schritte, die tatsächlich den Agent-Lauf entscheiden.",
+          "Auf VM0 liegt es beim ×1 Credit-Multiplikator, derselben Basislinie wie Claude Sonnet 4.6, was Side-by-Side-Kostenvergleiche zwischen Anthropic- und OpenAI-Defaults trivial macht. Die Wahl zwischen beiden hängt meist vom Framework (Codex vs. Claude Code), Ökosystem (bestehende Integrationen, Tool-Definitionen) und davon ab, für welches Modell dein Team mehr Verhaltens-Muskelgedächtnis hat."
+        ],
+        "architecture": "GPT-5.4 nutzt dieselbe Architektur wie der Rest der GPT-5-Familie: 400K-Token-Kontextfenster, `reasoning_effort`-Parameter auf vier Stufen (minimal, niedrig, mittel, hoch), Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses API, die codex CLI standardmäßig nutzt. Tool-Use, Structured Outputs und Computer-Use werden unterstützt. Eingaben sind multimodal über Text, Vision und Code.",
+        "specs": [
+          { "label": "Familie", "value": "GPT-5 Generation" },
+          { "label": "Modalitäten", "value": "Text, Vision, Code" },
+          { "label": "Sprachen", "value": "Englisch-zentriert, mehrsprachig" },
+          { "label": "Prompt Caching", "value": "Unterstützt (OpenAI)" },
+          { "label": "Kontextfenster", "value": "400K Token" },
+          { "label": "Max Output", "value": "Bis zu 128K Token" },
+          {
+            "label": "Reasoning Effort",
+            "value": "Minimal / Niedrig / Mittel / Hoch"
+          },
+          { "label": "Listenpreis", "value": "$2,5 Input / $15 Output pro 1M" }
+        ],
+        "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5-Release-Materialien, mit Deltas gegenüber der vorherigen OpenAI-Generation. Unabhängige Reviews platzieren GPT-5.4 im selben Coding-Qualitätsband wie Claude Sonnet 4.6. Behandle absolute Prozente als richtungsweisend.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "74.9%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~58%",
+            "note": "vendor-reported tool use"
+          },
+          {
+            "name": "AIME 2025 (no tools)",
+            "score": "~92%",
+            "note": "vendor-reported competition math"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~85%",
+            "note": "vendor-reported graduate science"
+          },
+          {
+            "name": "OSWorld (computer use)",
+            "score": "~62%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Speed",
+            "score": "~110 tokens/sec",
+            "note": "Artificial Analysis, medium effort"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Tool-Routing",
+            "body": "Solide Basisgenauigkeit über den Standard-Tool-Katalog des Codex-Frameworks. Wo 5.5 vorzieht, sind harte Randfälle (bedingte Tool-Auswahl, tief verschachtelte Argumente) — bei den Routinefällen routet 5.4 korrekt mit deutlich niedrigerer Latenz."
+          },
+          {
+            "title": "Code-Edits",
+            "body": "Vergleichbare Patch-Qualität wie Claude Sonnet 4.6 bei Standard-Refactor- und Bug-Fix-Workloads. Wo 5.5 anfängt zu führen, sind Multi-File-Änderungen, bei denen der Patch im ersten Versuch sauber sitzen muss."
+          },
+          {
+            "title": "Geschwindigkeit",
+            "body": "Deutlich schneller als 5.5 — etwa 110 Tokens/sec bei mittlerem Effort laut Artificial Analysis. Das ist mit ein Grund, warum 5.4 der Standard für interaktive Chat-Antworten und kurze Agent-Schleifen bleibt, in denen nutzerseitige Latenz zählt."
+          },
+          {
+            "title": "Kosteneffizienz",
+            "body": "×1 Credits mit Output-Verhalten im Sonnet-4.6-Qualitätsband. Für Teams, die bereits auf dem Codex-Framework sind, ist dies der Kosten/Qualitäts-Sweet-Spot — promote auf 5.5 nur bei Schritten, die es sichtbar brauchen."
+          },
+          {
+            "title": "Halluzinationsverhalten",
+            "body": "Erbt die Kalibrierungsverbesserungen, die OpenAI mit der GPT-5-Generation ausgeliefert hat. Weniger anfällig für selbstbewusste Falschantworten als die GPT-4-Serie, besonders bei Fragen außerhalb des Trainingshorizonts."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Standard-Agent-Schritt auf dem Codex-Framework",
+            "body": "Wenn dein Agent bereits auf codex CLI oder einer beliebigen Codex-Framework-Integration aufgebaut ist, ist GPT-5.4 der natürliche Standard überall. ×1 Credits, schnell genug für interaktive Nutzung, genau genug für die Routine-Tool-Calls, die die meisten Agent-Läufe dominieren."
+          },
+          {
+            "title": "Der interaktive Chat mit Vision",
+            "body": "Screenshot-gesteuerte UIs, Document Q&A, Bildannotation — GPT-5.4 verarbeitet alle drei multimodal in Arbeitstier-Geschwindigkeit. Der ×1-Multiplikator hält die Kosten pro Turn im selben Bereich wie Sonnet 4.6, sodass du beide auf derselben Workload gegeneinander A/B-testen kannst."
+          },
+          {
+            "title": "Das Kosten/Qualitäts-A/B gegen Claude Sonnet 4.6",
+            "body": "Beide Modelle liegen bei ×1 Credits auf VM0 Managed, was sie direkt kostenvergleichbar macht. Lass denselben Agenten eine Woche auf beiden laufen und wähle nach Verhalten auf deiner spezifischen Workload — keines ist universell besser, und der richtige Standard hängt von deinem Tool-Katalog und Prompt-Stil ab."
+          }
+        ],
+        "avoidFor": "Verzichte auf GPT-5.4 bei den schwersten Reasoning-, Computer-Use- oder Multi-File-Code-Edit-Schritten, bei denen 5.5 spürbar führt, und bei volumenstarker Bulk-Klassifikation oder Pre-Filter-Arbeit, wo 5.4 Mini beim Anbieter viermal günstiger ist.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.5",
+            "body": "Gleiche Familie, andere Positionierung. 5.5 (×2) gibt dir das stärkste Reasoning, Computer-Use und First-Attempt-Code-Qualität; 5.4 (×1) gibt dir dasselbe Kontextfenster und Feature-Set bei der Hälfte der Credit-Kosten und deutlich höherer Geschwindigkeit. Standardmäßig 5.4; auf 5.5 nur bei Schritten eskalieren, die es sichtbar brauchen."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Die zwei ×1-Basislinien, eine in jedem Ökosystem. Sonnet 4.6 läuft auf dem Claude-Code-Framework; GPT-5.4 läuft auf Codex. Wähle nach Framework, auf das deine bestehenden Agenten und Tool-Definitionen zielen. Bei roher Output-Qualität liegen sie nah genug beieinander, dass A/B-Tests auf deiner Workload die richtige Wahl sind."
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "Gleiche Familie, andere Positionierung. 5.4 (×1) trägt mehr Reasoning-Qualität pro Token; 5.4 Mini (×0,3) gibt dir eine deutlich günstigere Option für Bulk- und Pre-Filter-Arbeit. Nutze 5.4 Mini für Fan-Out-Klassifikation und 5.4 für die Schritte, die den Agent-Lauf entscheiden."
+          }
+        ],
+        "verdict": "GPT-5.4 ist der Standard überall für Codex-Framework-Agenten auf VM0. Eskaliere auf 5.5 für hartes Reasoning, falle auf 5.4 Mini für Bulk-Pre-Filtering.",
+        "faqs": [
+          {
+            "q": "Was ist das Kontextfenster von GPT-5.4?",
+            "a": "400.000 Token, mit bis zu 128K Token Output pro Antwort. Das gesamte Fenster wird zu Standardpreisen berechnet."
+          },
+          {
+            "q": "Kann GPT-5.4 Bilder verarbeiten?",
+            "a": "Ja. GPT-5.4 ist multimodal. Es akzeptiert Bildeingaben neben Text und Code nativ."
+          },
+          {
+            "q": "Wann GPT-5.4 statt Claude Sonnet 4.6 wählen?",
+            "a": "Wenn dein Agent bereits auf dem Codex-Framework gebaut ist oder du das OpenAI-Ökosystem brauchst (Tool-Katalog, Structured Outputs, Responses API). Beide liegen bei ×1 Credits, also sind die Kosten identisch und die Wahl hängt von Framework und Verhalten ab."
+          },
+          {
+            "q": "Unterstützt GPT-5.4 Prompt Caching?",
+            "a": "Ja. Gecachter Input wird mit $0,25 pro 1M Token berechnet — ein 10×-Rabatt auf den gecachten Anteil."
+          },
+          {
+            "q": "Welches Framework nutzt GPT-5.4 auf VM0?",
+            "a": "Codex. VM0 routet alle GPT-5-Modelle über die Responses-API-Oberfläche des Codex-Frameworks."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-5",
+            "reason": "Eskalationsebene für die schwersten Schritte"
+          },
+          {
+            "slug": "gpt-5-4-mini",
+            "reason": "Günstigere Option für Bulk-Arbeit"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "×1 Peer auf dem Claude-Code-Framework"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 sits at the ×1 baseline, same as Claude Sonnet 4.6, which makes the two cost-equivalent on VM0 Managed and easy to A/B against each other. Prompt caching is enabled by default. Pair with GPT-5.4 Mini for high-volume pre-filter work, and escalate to GPT-5.5 only for the steps that genuinely need the extra reasoning depth."
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -4715,6 +5035,157 @@
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and the Anthropic / Claude Code OAuth providers.",
         "vm0Notes": "Haiku 4.5 carries the lowest Claude multiplier (×0.3) and is the right pick for high-volume routing workloads, with prompt caching keeping the cost of repeated short prompts down. It doesn't carry Sonnet's multi-step agent quality, so design any Haiku-based agent to keep loops short and the tool surface narrow."
+      },
+      "gpt-5-4-mini": {
+        "name": "GPT-5.4 Mini",
+        "pageTitle": "GPT-5.4 Mini on VM0. The cost-saving GPT-5",
+        "tagline": "OpenAIs kostenoptimiertes Mitglied der GPT-5-Familie. ×0,3 Credits, multimodale Vision und schnell genug für volumenstarkes Routing, Klassifikation und Pre-Filter-Arbeit.",
+        "cardIntro": "OpenAIs kostensparendes GPT-5. ×0,3 Credits, schnell und multimodal — die richtige Wahl für Bulk-Pre-Filter-Arbeit auf dem Codex-Framework.",
+        "metaTitle": "GPT-5.4 Mini auf VM0: Benchmarks, Preise & Vergleich",
+        "metaDescription": "GPT-5.4 Mini im Test auf VM0. Das kostensparende OpenAI-GPT-5-Modell zu $0,75/$4,5 Anbieterpreisen, ×0,3 Credits, 400K Kontext und multimodaler Vision. Spezifikationen, Verhalten und Vergleich zu Claude Haiku 4.5.",
+        "summary": "GPT-5.4 Mini ist das kostensparende Mitglied der GPT-5-Familie von OpenAI — das Modell, zu dem du greifst, wenn Stückkosten mehr zählen als Spitzen-Reasoning-Qualität. Es behält das 400K-Kontextfenster und die multimodalen Eingaben der Familie, kürzt aber Compute pro Token, was sich in niedrigerem Preis ($0,75 / $4,5 pro 1M) und merklich höherer Geschwindigkeit niederschlägt.\n\nAuf VM0 liegt es bei ×0,3 Credits, demselben Multiplikator wie Claude Haiku 4.5 und Kimi K2.6, was es zur natürlichen OpenAI-seitigen Wahl für Bulk-Klassifikation, Fan-Out-Routing, Pre-Filter und jeden Agent-Schritt macht, bei dem das Drücken auf ein Drittel der GPT-5.4-Kosten der entscheidende Faktor ist.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Kostensparende Variante der GPT-5-Familie. Das OpenAI-seitige Pendant zu Claude Haiku 4.5.",
+        "background": [
+          "GPT-5.4 Mini ist das kostenoptimierte Mitglied der GPT-5-Generation von OpenAI, veröffentlicht im April 2026 neben GPT-5.5 und GPT-5.4. OpenAI positioniert es als Hochdurchsatz-Stufe — das Modell, das du auf Klassifikations-, Routing- und Pre-Filter-Schritten laufen lässt, wo das größere 5.4 oder 5.5 für Routine-Entscheidungen verschwendet wäre.",
+          "Architektonisch teilt es das 400K-Token-Kontextfenster der GPT-5-Familie, den `reasoning_effort`-Parameter, Prompt Caching und die Responses-API-Oberfläche, die codex CLI standardmäßig nutzt. Der Trade-off gegenüber 5.4 ist Reasoning-Tiefe: Mini handhabt Standard-Tool-Calls, kurze Zusammenfassungen und Structured-Output-Workloads gut, fängt aber bei den schwereren mehrstufigen Plänen an zu driften, wo 5.4 noch hält. Der Trade-off gegenüber Konkurrenten im selben Preispunkt ist Ökosystem — wenn du bereits auf Codex bist, hält das Bleiben in der OpenAI-Oberfläche Tool-Definitionen und Structured-Output-Schemas konsistent.",
+          "Auf VM0 liegt Mini beim ×0,3 Credit-Multiplikator, gleich wie Claude Haiku 4.5, Kimi K2.6 und DeepSeek V4 Pro. Innerhalb der kostensparenden Stufe hängt die Wahl meist von Framework und Verhaltens-Fit auf deiner spezifischen Workload ab."
+        ],
+        "architecture": "GPT-5.4 Mini nutzt dieselbe Architektur wie der Rest der GPT-5-Familie: 400K-Token-Kontextfenster, `reasoning_effort`-Parameter auf vier Stufen, Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses-API-Oberfläche. Tool-Use, Structured Outputs und multimodale Vision-Eingaben werden unterstützt. Das Modell ist ein kleinerer, schnellerer Verwandter — weniger Parameter pro Token, mehr Durchsatz pro Dollar.",
+        "specs": [
+          { "label": "Familie", "value": "GPT-5 Generation" },
+          { "label": "Modalitäten", "value": "Text, Vision, Code" },
+          { "label": "Sprachen", "value": "Englisch-zentriert, mehrsprachig" },
+          { "label": "Prompt Caching", "value": "Unterstützt (OpenAI)" },
+          { "label": "Kontextfenster", "value": "400K Token" },
+          { "label": "Max Output", "value": "Bis zu 128K Token" },
+          {
+            "label": "Reasoning Effort",
+            "value": "Minimal / Niedrig / Mittel / Hoch"
+          },
+          {
+            "label": "Listenpreis",
+            "value": "$0,75 Input / $4,5 Output pro 1M"
+          }
+        ],
+        "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5 Mini Release-Materialien. Unabhängige Reviews platzieren 5.4 Mini bei den meisten Agent-Benchmarks im selben kostensparenden Band wie Claude Haiku 4.5. Behandle absolute Prozente als richtungsweisend.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~60%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~42%",
+            "note": "vendor-reported tool use"
+          },
+          {
+            "name": "AIME 2025 (no tools)",
+            "score": "~84%",
+            "note": "vendor-reported competition math"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~74%",
+            "note": "vendor-reported graduate science"
+          },
+          {
+            "name": "Speed",
+            "score": "~165 tokens/sec",
+            "note": "Artificial Analysis, medium effort"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Geschwindigkeit",
+            "body": "Schnellstes Modell der GPT-5-Familie — etwa 165 Tokens/sec bei mittlerem Effort laut Artificial Analysis. Diese Eigenschaft macht es für interaktive Chat-Antworten und kurze Fan-Out-Tool-Calls tragfähig, wo nutzerseitige Latenz dominiert."
+          },
+          {
+            "title": "Routine-Tool-Calls",
+            "body": "Genau auf dem Standard-Tool-Katalog des Codex-Frameworks. Wo 5.4 vorzieht, sind harte Randfälle (bedingte Tool-Auswahl, tief verschachtelte Argumente) — bei den Routinefällen handhabt Mini das Tool-Routing sauber zu einem Drittel der Kosten."
+          },
+          {
+            "title": "Bulk-Klassifikation & Pre-Filter",
+            "body": "Stärkste Kosten/Qualitäts-Position in der GPT-5-Familie für Fan-Out-Arbeit. Bulk-PR-Triage, Support-Ticket-Kategorisierung, Dokumenten-Stufen-Klassifikation — all die Workloads, für die du zuvor handgerollte Regex genutzt hättest, sind jetzt als echter Modellaufruf bezahlbar."
+          },
+          {
+            "title": "Kosteneffizienz",
+            "body": "×0,3 Credits inklusive multimodaler Vision. Bei diesem Preispunkt liegen Mini, Claude Haiku 4.5 und Kimi K2.6 im selben Band — die Wahl kommt meist auf Framework-Fit und Verhalten auf deiner spezifischen Workload an."
+          },
+          {
+            "title": "Wann eskalieren",
+            "body": "Mini driftet bei langen mehrstufigen Plänen, hartem Reasoning und First-Attempt-Multi-File-Code-Edits. Baue den Agenten so, dass der Orchestrator entscheidet, wann auf 5.4 oder 5.5 eskaliert wird, nicht so, dass Mini versucht, die ganze Schleife zu tragen."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Fan-Out-Klassifizierer, der auf jedem Event läuft",
+            "body": "Eingehendes Support-Ticket, PR-Kommentar, Sales-Call-Transkript, Document-Upload — Mini liest jedes und routet es an den richtigen Downstream-Agenten oder menschlichen Reviewer. ×0,3 Credits und 165 Tokens/sec bedeuten, dass die Kosten pro Event klein genug sind, um ihn auf jedem Event laufen zu lassen (nicht nur auf gesampelten Batches)."
+          },
+          {
+            "title": "Der Pre-Filter-Schritt vor dem teuren Modell",
+            "body": "Setze Mini oben in den Tool-Call des Agenten, sodass er entscheidet, ob die Anfrage überhaupt eskalieren muss. Die meisten Anfragen bekommen eine schnelle günstige Antwort; nur die verbleibende Minderheit zahlt die volle GPT-5.4- oder 5.5-Kosten. Hier verändert das Stapeln von kostensparenden und Kern-Stufen tatsächlich, was bezahlbar ist."
+          },
+          {
+            "title": "Die interaktive Chat-Antwort",
+            "body": "Kurze multimodale Turns, bei denen nutzerseitige Latenz das Erlebnis dominiert. Mini antwortet schnell genug, dass Streaming sofort wirkt, und multimodale Unterstützung bedeutet, dass ein Screenshot im Gespräch einfach funktioniert."
+          }
+        ],
+        "avoidFor": "Verzichte auf GPT-5.4 Mini bei den schwersten Reasoning-, mehrstufiger Agent-Orchestrierung, Computer-Use-Sequenzen und First-Attempt-Multi-File-Code-Edits — eskaliere auf 5.4 für Routine-Versionen dieser Aufgaben und 5.5 für die schwersten.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "Gleiche Familie, andere Positionierung. 5.4 Mini (×0,3) gewinnt bei Kosten und Geschwindigkeit; 5.4 (×1) gewinnt bei Reasoning-Qualität und Tool-Routing-Genauigkeit in harten Fällen. Das Standardmuster: mit Mini vorfiltern und verbleibende Fälle auf 5.4 eskalieren."
+          },
+          {
+            "vs": "Claude Haiku 4.5",
+            "body": "Gleicher Multiplikator (×0,3). Mini läuft auf dem Codex-Framework; Haiku 4.5 läuft auf Claude Code. Beide sind multimodal und zielen auf denselben kostensparenden Slot. Wähle nach Framework, auf das deine bestehenden Agenten und Tool-Definitionen zielen."
+          },
+          {
+            "vs": "DeepSeek V4 Flash",
+            "body": "DeepSeek V4 Flash (×0,02) ist beim Anbieter dramatisch günstiger und die richtige Wahl für reine Bulk-Single-Shot-Arbeit. GPT-5.4 Mini (×0,3) trägt mehr Reasoning-Qualität und bleibt im OpenAI-Ökosystem, was zählt, wenn deine Tool-Definitionen und Structured-Output-Schemas bereits auf Codex getunt sind."
+          }
+        ],
+        "verdict": "GPT-5.4 Mini ist der kostensparende Standard auf der OpenAI-Seite. Vorfiltern mit Mini, eskalieren auf GPT-5.4 für Routine-Schritte, eskalieren auf GPT-5.5 nur für das schwerste Reasoning.",
+        "faqs": [
+          {
+            "q": "Was ist das Kontextfenster von GPT-5.4 Mini?",
+            "a": "400.000 Token, mit bis zu 128K Token Output pro Antwort — gleich wie der Rest der GPT-5-Familie."
+          },
+          {
+            "q": "Kann GPT-5.4 Mini Bilder verarbeiten?",
+            "a": "Ja. Wie der Rest der GPT-5-Familie akzeptiert es Bildeingaben neben Text und Code."
+          },
+          {
+            "q": "Wann GPT-5.4 Mini statt Claude Haiku 4.5 wählen?",
+            "a": "Wenn dein Agent bereits auf dem Codex-Framework gebaut ist oder du das OpenAI Structured-Output- / Tool-Call-Ökosystem brauchst. Beide liegen bei ×0,3 Credits, also sind die Kosten identisch und die Wahl hängt von Framework und Verhalten ab."
+          },
+          {
+            "q": "Unterstützt GPT-5.4 Mini Prompt Caching?",
+            "a": "Ja. Gecachter Input wird mit $0,075 pro 1M Token berechnet — ein 10×-Rabatt auf den gecachten Anteil."
+          },
+          {
+            "q": "Welches Framework nutzt GPT-5.4 Mini auf VM0?",
+            "a": "Codex. VM0 routet alle GPT-5-Modelle über die Responses-API-Oberfläche des Codex-Frameworks."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-4",
+            "reason": "Stufe hoch für schwerere Schritte, gleiche Familie"
+          },
+          {
+            "slug": "claude-haiku-4-5",
+            "reason": "×0,3 Peer auf dem Claude-Code-Framework"
+          },
+          {
+            "slug": "deepseek-v4-flash",
+            "reason": "Dramatisch günstiger für reine Bulk-Arbeit"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Claude Haiku 4.5, Kimi K2.6 and DeepSeek V4 Pro. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
       },
       "kimi-k2-6": {
         "name": "Kimi K2.6",
@@ -5480,6 +5951,726 @@
         ],
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Default model on the DeepSeek provider; also available on VM0 Managed.",
         "vm0Notes": "V4 Flash carries the lowest credit multiplier of any Built-in model (×0.02), roughly 50× less than Sonnet 4.6. Cache reads bill while cache writes are free, and VM0 sets a 10-minute API timeout for the DeepSeek provider that pairs naturally with Flash's short single-shot work."
+      },
+      "gemini-2-5-flash-image": {
+        "name": "Gemini 2.5 Flash Image",
+        "pageTitle": "Gemini 2.5 Flash Image on VM0. The fast text-to-image default",
+        "tagline": "Googles schnelles Text-zu-Bild- und Bildbearbeitungsmodell. Starke Anweisungstreue, Charakterkonsistenz und die günstigsten Credit-Kosten pro Bild im kuratierten Bild-Lineup.",
+        "cardIntro": "Googles schnelles Text-zu-Bild-Modell. Günstig, präzise bei langen Prompts und gut darin, Subjekte über Edits hinweg beizubehalten.",
+        "metaTitle": "Gemini 2.5 Flash Image auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "Gemini 2.5 Flash Image auf VM0. Googles Text-zu-Bild- und Bildbearbeitungsmodell mit hoher Anweisungstreue, Charakterkonsistenz und ~$0,04 pro Bild. Verglichen mit GPT Image 1, Flux Pro 1.1 Ultra und SeedDream 4.",
+        "summary": "Gemini 2.5 Flash Image ist Googles Standard-Text-zu-Bild- und Bildbearbeitungsmodell für überall. Es punktet bei den beiden Eigenschaften, die für Agent-Workloads am wichtigsten sind: Es folgt langen, strukturierten Prompts (so kann man ihm das vollständige Briefing übergeben, ohne unterwegs Anweisungen zu verlieren), und es behält Subjekte über mehrstufige Edits hinweg konsistent (so kann ein Agent denselben Charakter oder dieselbe Produktaufnahme iterieren, ohne dass sie zwischen Calls driftet).\n\nDer Listenpreis liegt bei etwa $0,04 pro 1024×1024-Bild, was es zum günstigsten Modell im kuratierten Bild-Lineup macht. Das natürliche Muster ist, standardmäßig Gemini 2.5 Flash Image zu verwenden und nur dann auf Flux Pro 1.1 Ultra oder SeedDream 4 zu eskalieren, wenn eine bestimmte Ästhetik gefragt ist, die der Standard nicht trifft.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Googles Text-zu-Bild-Arbeitspferd für Agent-Workloads.",
+        "background": [
+          "Gemini 2.5 Flash Image ist Googles Text-zu-Bild- und Bildbearbeitungsmodell in der Gemini-2.5-Familie. Googles Rahmen ist derselbe wie für die textseitige Flash-Variante: Ein Modell, das auf hohen Durchsatz bei niedrigen Kosten pro Call abgestimmt ist, optimiert für Produktions-Workloads, in denen die nächste Anfrage in der Warteschlange steht, bevor die letzte fertig gestreamt ist.",
+          "Zwei Verhaltenseigenschaften stechen für Agent-Nutzung heraus. Erstens ist die Anweisungstreue bei langen strukturierten Prompts deutlich besser als bei den meisten Open-Weight-Text-zu-Bild-Baselines, was zählt, wenn ein Agent den Prompt programmatisch zusammenstellt und ihn nicht kürzen kann. Zweitens hält die Charakter- und Subjektkonsistenz über mehrstufige Edits hinweg gut, was das Modell als Edit-Loop-Default in Agent-Workflows, die auf einem einzigen Asset iterieren, brauchbar macht."
+        ],
+        "architecture": "Diffusion-basiertes Text-zu-Bild-Modell mit nativer Edit-Unterstützung. Die Abrechnung erfolgt pro generiertem Bild in der Standardstufe. Eingaben akzeptieren Textprompts plus optionale Referenzbilder für Edit-Flows. Ausgaben sind PNG in der angeforderten Auflösung.",
+        "specs": [
+          { "label": "Familie", "value": "Gemini 2.5 Generation" },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Bild, Bild-zu-Bild-Edit"
+          },
+          { "label": "Ausgabeauflösung", "value": "1024×1024 Standardstufe" },
+          { "label": "Listenpreis", "value": "~$0,04 pro Bild" },
+          { "label": "Sprachen", "value": "Mehrsprachige Prompts" },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Anweisungstreue",
+            "body": "Hält sich bei langen strukturierten Prompts, bei denen viele Open-Weight-Modelle Klauseln verlieren. Nützlich, wenn ein Agent das Briefing programmatisch zusammenstellt und der Prompt nicht verhandelbar ist."
+          },
+          {
+            "title": "Charakterkonsistenz",
+            "body": "Hält Subjekte über mehrstufige Edits hinweg erkennbar, die Eigenschaft, die das Modell für iterative Agent-Loops auf einem einzigen Asset brauchbar macht."
+          },
+          {
+            "title": "Kosten",
+            "body": "Etwa $0,04 pro Bild — das günstigste der kuratierten Text-zu-Bild-Modelle auf VM0. Bulk-Fan-out-Generierung bleibt erschwinglich."
+          },
+          {
+            "title": "Ästhetische Obergrenze",
+            "body": "Neigt zu sauberer, präziser Ausgabe statt zum hyperstilisierten Look von Flux Pro 1.1 Ultra oder zum photorealistischen Look von SeedDream 4. Eskalieren, wenn die Ästhetik das Deliverable ist."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Agent, der Marketing-Visuals aus einem Briefing entwirft",
+            "body": "Übergibt dem Agenten Brand Voice, Produktbeschreibung und Zielgruppe; Gemini 2.5 Flash Image rendert Entwurfs-Visuals in Sekunden. Günstig genug, um ein Dutzend Varianten zu fächern und die beste auszuwählen."
+          },
+          {
+            "title": "Der Edit-Loop, der auf einem einzigen Asset iteriert",
+            "body": "Einmal generieren, dann Beleuchtung, Framing oder Hintergrund iterieren und dabei das Subjekt über Runden hinweg konsistent halten. Charakterkonsistenz bedeutet, dass der Mensch im Loop dasselbe Bild bearbeitet und nicht jede Runde aus einem frischen Set wählt."
+          },
+          {
+            "title": "Der Illustrations-Vorfilter vor dem Premium-Modell",
+            "body": "Mit Gemini 2.5 Flash Image die Komposition günstig festlegen, dann die finale Auswahl auf Flux Pro 1.1 Ultra für die Ästhetik rerendern. Reduziert die Kosten des Premium-Schritts auf einen Call statt eines Fan-outs."
+          }
+        ],
+        "avoidFor": "Überspringe Gemini 2.5 Flash Image, wenn das Deliverable die Ästhetik ist — Flux Pro 1.1 Ultra und SeedDream 4 haben eine höhere stilistische Obergrenze für photorealistische und editoriale Looks.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 1 ist stärker bei stilisierter Illustration und Charakterarbeit; Gemini 2.5 Flash Image ist günstiger pro Call und stärker bei Anweisungstreue für lange Prompts. Für Agent-Workloads mit strukturierten Prompts ist Gemini 2.5 Flash Image der sicherere Standard."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 hat eine höhere photorealistische Obergrenze; Gemini 2.5 Flash Image ist günstiger, schneller und folgt langen Prompts zuverlässiger. Standardmäßig Gemini, eskaliere auf SeedDream 4, wenn das Briefing speziell eine Foto-Ästhetik ist."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultra hat die höchste stilistische Obergrenze im kuratierten Lineup; Gemini 2.5 Flash Image gewinnt bei Kosten und Anweisungstreue. Vorfiltern mit Gemini, Finals auf Flux liefern, wenn die Ästhetik der Punkt ist."
+          }
+        ],
+        "verdict": "Standardmäßig Gemini 2.5 Flash Image für Text-zu-Bild-Agent-Workloads. Eskaliere auf Flux Pro 1.1 Ultra oder SeedDream 4 nur, wenn die Ästhetik das Deliverable ist.",
+        "faqs": [
+          {
+            "q": "Can Gemini 2.5 Flash Image edit existing images?",
+            "a": "Ja. Es akzeptiert ein Referenzbild neben dem Textprompt und unterstützt Inpainting- und Outpainting-Flows für iterative Edits."
+          },
+          {
+            "q": "What output resolution does it produce?",
+            "a": "1024×1024 in der Standardstufe. Höhere Auflösungen sind zu proportionalen Kosten verfügbar."
+          },
+          {
+            "q": "How much does it cost per image?",
+            "a": "Etwa $0,04 pro generiertem 1024×1024-Bild — das günstigste der kuratierten Text-zu-Bild-Modelle auf VM0."
+          },
+          {
+            "q": "Is the model good at text inside images?",
+            "a": "Ja — deutlich stärker als die meisten Open-Weight-Baselines beim Rendern kurzer Textstrings innerhalb des generierten Bildes."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Higher aesthetic ceiling"
+          },
+          { "slug": "seedream-4", "reason": "Stronger photoreal results" }
+        ],
+        "routingNotes": "Routed to Google's Gemini 2.5 Flash Image endpoint and billed per generated image.",
+        "vm0Notes": "Gemini 2.5 Flash Image ist der Preis-/Qualitäts-Standard für Text-zu-Bild-Agent-Workloads auf VM0. Verwende es als Überall-Standard und reserviere die teureren Bildmodelle für die Schritte, in denen ihre stilistische Obergrenze tatsächlich zählt."
+      },
+      "gpt-image-1": {
+        "name": "GPT Image 1",
+        "pageTitle": "GPT Image 1 on VM0. OpenAI's text-to-image model",
+        "tagline": "OpenAIs Text-zu-Bild-Modell mit starker stilisierter Illustration und Bearbeitung. Die natürliche Wahl, wenn man OpenAIs Ästhetik und Prompt-Style möchte.",
+        "cardIntro": "OpenAIs Text-zu-Bild-Modell. Stark bei stilisierter Illustration, Charakterarbeit und Bearbeitung — das OpenAI-seitige Gegenstück zu Gemini 2.5 Flash Image.",
+        "metaTitle": "GPT Image 1 auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "GPT Image 1 auf VM0. OpenAIs Text-zu-Bild- und Bildbearbeitungsmodell mit Stärken in stilisierter Illustration, mehrstufiger Preisgestaltung und Vergleich zu Gemini 2.5 Flash Image, Flux Pro 1.1 Ultra und SeedDream 4.",
+        "summary": "GPT Image 1 ist OpenAIs Text-zu-Bild-Modell — dasjenige, das die meisten Teams als das Modell hinter der Bildgenerierung in ChatGPT kennen. Seine Stärken liegen in stilisierter Illustration, Charakterarbeit und Bildbearbeitung mit textgesteuerter Maskierung, mit einem Prompt-Style, der eng dem entspricht, was OpenAIs Text-Modelle erwarten.\n\nDer Listenpreis ist gestaffelt, von etwa $0,011 pro Bild in der niedrigen/Standard-Stufe bis $0,25 in der hohen/großen Stufe. Die Medium-Standard-Stufe (etwa $0,05 pro 1024×1024) ist der sinnvolle Standard für die meisten Agent-Workloads.",
+        "releaseDate": "April 2026",
+        "familyPosition": "OpenAIs primäres Text-zu-Bild-Modell. Stufenbasierter Preis über Auflösung und Qualitätseinstellungen.",
+        "background": [
+          "GPT Image 1 ist OpenAIs produktives Text-zu-Bild-Modell. Es passt nativ zu OpenAIs Text-Modellen, sodass der Prompt-Style sauber übertragbar ist, wenn ein Agent bereits auf GPT-5.4 oder GPT-5.5 läuft, und der Edit-Loop-Flow innerhalb der OpenAI-Oberfläche bleibt.",
+          "Die stilistischen Stärken des Modells liegen bei Illustration, Charakterarbeit und Edits, die die ursprüngliche Komposition erhalten und dabei ein bestimmtes Element ändern. Die photorealistische Ausgabe ist solide, neigt aber zum OpenAI-Hausstil; Teams, die eine andere ästhetische Obergrenze möchten, greifen oft daneben zu Flux Pro 1.1 Ultra oder SeedDream 4."
+        ],
+        "architecture": "Diffusion-basiertes Text-zu-Bild mit nativer Edit-Unterstützung. Der Stufenpreis skaliert nach Ausgabeauflösung (Standard / Groß) und Qualität (Niedrig / Mittel / Hoch), wobei die Stufe Mittel/Standard der typische Standard ist. Eingaben akzeptieren Text plus optionale Referenzbilder für Edits und Masken.",
+        "specs": [
+          { "label": "Familie", "value": "OpenAI Images" },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Bild, Bild-zu-Bild-Edit"
+          },
+          {
+            "label": "Ausgabestufen",
+            "value": "Standard / Groß × Niedrig / Mittel / Hoch"
+          },
+          { "label": "Listenpreis", "value": "Von $0,011 bis $0,25 pro Bild" },
+          { "label": "Sprachen", "value": "Mehrsprachige Prompts" },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Stilisierte Illustration",
+            "body": "Eines der stärksten Modelle für nicht-photorealistische Ausgabe — Illustration, Comic-Style, malerisch. Gut geeignet, wenn das Deliverable eine Illustration statt eines Fotos ist."
+          },
+          {
+            "title": "Edit-Flows",
+            "body": "Native Unterstützung für maskierte Edits und textgesteuerte lokale Änderungen. Nützlich, wenn ein Agent eine bestimmte Region eines Bildes iterieren muss, anstatt das gesamte Bild neu zu generieren."
+          },
+          {
+            "title": "Prompt-Style",
+            "body": "Passt eng zu den Erwartungen von OpenAIs Text-Modellen. Wenn der aufrufende Agent bereits auf GPT-5.4 oder GPT-5.5 läuft, lassen sich die von diesem Agenten geschriebenen Prompts mit wenig Anpassung übertragen."
+          },
+          {
+            "title": "Kosten",
+            "body": "Stufenbasiert — die Stufe Mittel/Standard (~$0,05 pro 1024×1024) ist der typische Standard. Die Stufe Hoch/Groß erreicht $0,25 und lohnt sich nur für Deliverable-Grade-Ausgabe."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Illustrations-Agent, der Comic- oder handgezeichneten Stil liefert",
+            "body": "Stilisierte Ausgabe ist der Bereich, in dem GPT Image 1 einen echten Vorsprung hat. Comic-Panels, malerische Illustrationen, handgezeichnete Icons — alle landen hier zuverlässiger als bei den photorealistisch-orientierten Alternativen."
+          },
+          {
+            "title": "Der Edit-Loop-Agent im OpenAI-Stack",
+            "body": "Wenn der orchestrierende Agent bereits auf GPT-5.4 oder GPT-5.5 läuft, hält die Bildgenerierung innerhalb der OpenAI-Oberfläche (GPT Image 1) den Prompt-Style, die Edit-Semantik und strukturierte Ausgaben über den Run hinweg konsistent."
+          }
+        ],
+        "avoidFor": "Überspringe GPT Image 1, wenn die Kosten dominieren (Gemini 2.5 Flash Image ist für dieselbe Standardstufe etwa halb so teuer) oder wenn das Deliverable speziell photorealistisch ist (SeedDream 4 hat eine höhere photorealistische Obergrenze).",
+        "comparisons": [
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Image ist günstiger und stärker bei langen strukturierten Prompts; GPT Image 1 ist stärker bei stilisierter Illustration und integriert sich natürlicher mit OpenAI-Stack-Agenten."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 führt bei photorealistischer Ästhetik zu leicht niedrigerem Preis; GPT Image 1 führt bei stilisierter Illustration und Edit-Flows."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultra hat die höchste ästhetische Obergrenze für Hero-Shot-Deliverables; GPT Image 1 ist der natürliche OpenAI-Stack-Standard für alles andere."
+          }
+        ],
+        "verdict": "Wähle GPT Image 1, wenn dein Agent bereits auf dem OpenAI-Stack läuft und du stilisierte Illustration oder native Edit-Flows möchtest. Eskaliere auf Flux Pro 1.1 Ultra für photorealistische Hero-Shots; wechsle zu Gemini 2.5 Flash Image, wenn die Kosten dominieren.",
+        "faqs": [
+          {
+            "q": "How is GPT Image 1 priced?",
+            "a": "Stufenbasiert — Kombinationen aus Größe (Standard / Groß) und Qualität (Niedrig / Mittel / Hoch). Die Stufe Mittel/Standard bei ~$0,05 pro 1024×1024-Bild ist der typische Standard."
+          },
+          {
+            "q": "Does GPT Image 1 support image editing?",
+            "a": "Ja. Es akzeptiert ein Referenzbild plus eine optionale Maske und unterstützt textgesteuerte lokale Edits sowie Outpainting."
+          },
+          {
+            "q": "Can GPT Image 1 render text inside images?",
+            "a": "Ja — kurze Textstrings rendern zuverlässig; lange Textpassagen haben wie bei den meisten Diffusion-Modellen weiterhin Schwierigkeiten."
+          },
+          {
+            "q": "Is it multimodal as input?",
+            "a": "Bild-zu-Bild-Edits akzeptieren Referenzbilder. Das Modell gibt ausschließlich Bilder aus."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Cheaper, stronger long-prompt adherence"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Higher photoreal aesthetic ceiling"
+          },
+          { "slug": "seedream-4", "reason": "Better photoreal default" }
+        ],
+        "routingNotes": "Routed to OpenAI's Images surface and billed per generated image at the selected tier.",
+        "vm0Notes": "GPT Image 1 ist der OpenAI-Stack-Standard für stilisierte Illustration und Edit-Loop-Agent-Workflows. Die Stufe Mittel/Standard ist der sinnvolle Überall-Standard; reserviere die Stufe Hoch/Groß für Deliverable-Grade-Ausgabe."
+      },
+      "flux-pro-1-1-ultra": {
+        "name": "Flux Pro 1.1 Ultra",
+        "pageTitle": "Flux Pro 1.1 Ultra on VM0. The aesthetic ceiling for hero shots",
+        "tagline": "Black Forest Labs' hochauflösendes Text-zu-Bild-Modell. Die Wahl, wenn das Bild das Deliverable ist und editoriale oder photorealistische Qualität gefragt ist.",
+        "cardIntro": "Black Forest Labs' Top-Tier-Bildmodell. Höchste ästhetische Obergrenze im kuratierten Lineup — verwende es für Hero-Shots und editoriale Ausgabe.",
+        "metaTitle": "Flux Pro 1.1 Ultra auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "Flux Pro 1.1 Ultra auf VM0. Black Forest Labs' Top-Tier-Text-zu-Bild-Modell mit editorialer Ästhetik, $0,072 pro Bild und Vergleich zu GPT Image 1, SeedDream 4 und Gemini 2.5 Flash Image.",
+        "summary": "Flux Pro 1.1 Ultra ist Black Forest Labs' Top-Tier-Text-zu-Bild-Modell — dasjenige, zu dem man greift, wenn das Bild selbst das Deliverable ist und nicht ein Schritt in einem Agent-Loop. Die Ausgabequalität bei editorialen, photorealistischen und designgeführten Ästhetiken ist die höchste im kuratierten Lineup, und die Prompt-Treue bei detaillierten Kompositionsbriefings hält gut.\n\nDer Listenpreis liegt bei $0,072 pro Bild, was es im Vergleich zu Gemini 2.5 Flash Image ($0,04) oder SeedDream 4 ($0,036) teuer macht, aber der Qualitätssprung pro Bild ist groß genug, dass die meisten Teams es als Final-Render-Schritt nach Vorfilterung mit einem günstigeren Modell verwenden.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Premium-Stufe der Flux-1.1-Generation von Black Forest Labs.",
+        "background": [
+          "Flux Pro 1.1 Ultra ist Black Forest Labs' Premium-Text-zu-Bild-Modell. Die Flux-Familie ist bekannt für die höchste ästhetische Obergrenze an der Open-Weight-Frontier, und die Ultra-Variante ist die produktionsreife Stufe mit der konsistentesten Kompositionsqualität.",
+          "Die Stärke des Modells liegt bei editorialen und photorealistischen Ästhetiken — magazinhafte Hero-Shots, Produktfotografie, designgeführte Illustrationen. Die Prompt-Treue bei detaillierten Kompositionsbriefings (\"eine untere Perspektive von X in Y-Licht vor Z-Hintergrund\") ist deutlich besser als bei den meisten günstigeren Alternativen, was teilweise erklärt, warum Teams den Aufpreis für Deliverable-Grade-Ausgabe weiterhin zahlen."
+        ],
+        "architecture": "Hochauflösendes Diffusion-Modell mit auf Kompositionstreue abgestimmtem Prompt-Following. Abrechnung pro generiertem Bild. Eingaben akzeptieren Textprompts; erzeugt hochauflösende Ausgabe, die für die Lieferung geeignet ist.",
+        "specs": [
+          { "label": "Familie", "value": "Flux 1.1 Pro" },
+          { "label": "Modalitäten", "value": "Text-zu-Bild" },
+          { "label": "Listenpreis", "value": "$0,072 pro Bild" },
+          { "label": "Sprachen", "value": "Mehrsprachige Prompts" },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Ästhetische Obergrenze",
+            "body": "Höchste im kuratierten Bild-Lineup. Hero-Shot-, editoriale und photorealistische Ästhetiken landen hier zuverlässiger als auf Gemini 2.5 Flash Image oder GPT Image 1."
+          },
+          {
+            "title": "Kompositionstreue",
+            "body": "Stark bei detaillierten Kompositionsbriefings, die Winkel, Beleuchtung, Framing und Subjektplatzierung festlegen. Nützlich, wenn der Prompt nicht verhandelbar ist."
+          },
+          {
+            "title": "Kosten",
+            "body": "$0,072 pro Bild — etwa 2× Gemini 2.5 Flash Image und SeedDream 4. Das Standardmuster ist, mit einem günstigeren Modell vorzufiltern und Finals auf Flux zu rendern."
+          },
+          {
+            "title": "Geschwindigkeit",
+            "body": "Langsamer als die Flash-Tier-Alternativen. Reserviere es für die Schritte, die die Kosten rechtfertigen; nicht in engen interaktiven Loops verwenden."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Marketing-Hero-Shot, der ausgeliefert werden muss",
+            "body": "Wenn das Bild das finale Deliverable für eine Kampagne, eine Landing Page oder eine Launch-Ankündigung ist, rechtfertigt die ästhetische Obergrenze von Flux Pro 1.1 Ultra den Aufpreis."
+          },
+          {
+            "title": "Der Produktfotografie-Agent für E-Commerce-Listings",
+            "body": "Kataloggerechte Produktfotografie aus einem Textbriefing plus Referenzbildern. Kompositionstreue macht den Unterschied zwischen einem Bild, das ausgeliefert wird, und einem, das neu gerendert werden muss."
+          },
+          {
+            "title": "Die editoriale Illustration für Long-Form-Content",
+            "body": "Magazinhafte Hero-Illustrationen für Artikel, Blogposts und Reports. Flux' stilistische Obergrenze hebt es von den Workhorse-Standards ab."
+          }
+        ],
+        "avoidFor": "Überspringe Flux Pro 1.1 Ultra in Fan-out-Loops, in denen die Kosten dominieren — Gemini 2.5 Flash Image ist pro Call etwa 2× günstiger. Verwende es als Final-Render-Schritt statt als Iterationsschritt.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "Flux Pro 1.1 Ultra hat die höhere photorealistische und editoriale Obergrenze; GPT Image 1 hat stärkere stilisierte Illustration und native Edit-Flow-Unterstützung. Nach Deliverable auswählen."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "Beide sind photorealistisch ausgerichtet. SeedDream 4 ist günstiger und konkurrenzfähig bei Porträt- und Produktarbeiten; Flux Pro 1.1 Ultra gewinnt bei Hero-Shot-Kompositionstreue zu höheren Kosten."
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Unterschiedliche Rollen. Gemini 2.5 Flash Image ist das günstige Arbeitspferd für Iteration; Flux Pro 1.1 Ultra ist der Premium-Final-Render-Schritt. Stapeln, nicht eines auswählen."
+          }
+        ],
+        "verdict": "Verwende Flux Pro 1.1 Ultra als Final-Render-Schritt nach Vorfilterung mit einem günstigeren Modell. Die ästhetische Obergrenze rechtfertigt den Aufpreis, wenn das Bild das Deliverable ist.",
+        "faqs": [
+          {
+            "q": "How much does Flux Pro 1.1 Ultra cost?",
+            "a": "$0,072 pro generiertem Bild. Etwa 2× Gemini 2.5 Flash Image und SeedDream 4."
+          },
+          {
+            "q": "Does it support image editing?",
+            "a": "Die Ultra-Stufe ist zuerst Text-zu-Bild. Für native maskierte Edit-Flows in derselben Familie bietet die Basis-Flux-Pro-1.1-Stufe breitere Edit-Unterstützung bei niedrigerer ästhetischer Obergrenze."
+          },
+          {
+            "q": "What aspect ratios are supported?",
+            "a": "Standard-Foto- und Design-Seitenverhältnisse bis zu hochauflösenden Ausgaben, die für die Lieferung geeignet sind."
+          },
+          {
+            "q": "Is it good for stylised illustration?",
+            "a": "Möglich, aber nicht seine stärkste Seite — GPT Image 1 hat eine höhere stilisierte Obergrenze. Flux Pro 1.1 Ultra glänzt bei photorealistischer und editorialer Arbeit."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Cheap iteration default"
+          },
+          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
+          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+        ],
+        "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
+        "vm0Notes": "Flux Pro 1.1 Ultra ist die Premium-Stufe des kuratierten Bild-Lineups. Verwende es für den Final-Render-Schritt statt für die Iteration; paare es mit Gemini 2.5 Flash Image oder SeedDream 4 als günstigem Vorfilter."
+      },
+      "seedream-4": {
+        "name": "SeedDream 4",
+        "pageTitle": "SeedDream 4 on VM0. The photoreal text-to-image default",
+        "tagline": "ByteDance's SeedDream-4-Text-zu-Bild-Modell. Starke photorealistische Ästhetik zu Kosten, die mit den günstigsten Optionen im Lineup vergleichbar sind.",
+        "cardIntro": "ByteDance's SeedDream 4. Photorealistische Ästhetik zu niedrigen Kosten pro Bild — der natürliche Standard, wenn das Briefing ein Foto ist.",
+        "metaTitle": "SeedDream 4 auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "SeedDream 4 auf VM0. ByteDance's Text-zu-Bild-Modell mit starker photorealistischer Ausgabe, ~$0,036 pro Bild und Vergleich zu Gemini 2.5 Flash Image, GPT Image 1 und Flux Pro 1.1 Ultra.",
+        "summary": "SeedDream 4 ist ByteDance's Text-zu-Bild-Modell in der Seedream-V4-Generation. Seine herausragende Eigenschaft ist die photorealistische Ästhetik — Porträts, Produktaufnahmen, Lifestyle-Fotografie — zu einem Listenpreis ($0,036 pro Bild), der mit der günstigsten Option im kuratierten Lineup konkurrieren kann.\n\nEs ist der natürliche Standard, wenn das Briefing speziell ein Foto ist. Für stilisierte Illustration oder editoriales Design wähle GPT Image 1 oder Flux Pro 1.1 Ultra; für allgemeine iterative Agent-Workloads mit langen strukturierten Prompts wähle Gemini 2.5 Flash Image.",
+        "releaseDate": "April 2026",
+        "familyPosition": "ByteDance's photorealistischer Text-zu-Bild-Standard in der Seedream-V4-Generation.",
+        "background": [
+          "SeedDream 4 ist die vierte Generation von ByteDance's Text-zu-Bild-Familie. Die Ästhetik neigt zu photorealistischer Ausgabe, mit Porträts, Produkt- und Lifestyle-Aufnahmen als den herausragenden Kategorien. Die Prompt-Treue bei standardmäßigen deskriptiven Briefings (Subjekt, Setting, Beleuchtung) ist solide.",
+          "Bei $0,036 pro Bild liegt es preislich nahe am unteren Ende des kuratierten Lineups, was es als Standard für photoorientierte Agent-Workloads brauchbar macht. Wechsle zu Flux Pro 1.1 Ultra, wenn das Kompositionsbriefing speziell ein Hero-Shot ist, der den Aufpreis rechtfertigt."
+        ],
+        "architecture": "Diffusion-basiertes Text-zu-Bild-Modell. Abrechnung pro generiertem Bild. Eingaben akzeptieren Textprompts; erzeugt photorealistisch ausgerichtete Ausgabe, die für Porträts, Produkte und Lifestyle-Bilder geeignet ist.",
+        "specs": [
+          { "label": "Familie", "value": "Seedream V4" },
+          { "label": "Modalitäten", "value": "Text-zu-Bild" },
+          { "label": "Listenpreis", "value": "$0,036 pro Bild" },
+          {
+            "label": "Sprachen",
+            "value": "Mehrsprachige Prompts (Englisch + Chinesisch stark)"
+          },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Photorealistische Ästhetik",
+            "body": "Porträts, Produktaufnahmen und Lifestyle-Fotografie sind die herausragenden Kategorien. Die Ausgabe ist bei einem bedeutenden Anteil photorealistischer Briefings konkurrenzfähig mit Flux Pro 1.1 Ultra und pro Call deutlich günstiger."
+          },
+          {
+            "title": "Kosten",
+            "body": "$0,036 pro Bild — nahe am unteren Ende des kuratierten Lineups. Der natürliche Standard für photoorientierte Fan-out-Workloads."
+          },
+          {
+            "title": "Chinesischsprachige Prompts",
+            "body": "Starke Handhabung chinesischsprachiger Prompts und kulturell verankerter Subjekte, ein echter Vorteil für Agenten, die chinesischsprachige Nutzer bedienen."
+          },
+          {
+            "title": "Ästhetische Obergrenze",
+            "body": "Solide für alles im photorealistischen Bereich; weniger geeignet für hyperstilisierte Illustration, wo GPT Image 1 führt."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Porträt- oder Produktaufnahme-Agent in großem Maßstab",
+            "body": "Photorealistische Subjekte zu niedrigen Kosten pro Bild machen SeedDream 4 für Fan-out-Workloads brauchbar — hundert Produktfotos für einen Katalog, Batch-Porträtgenerierung für ein Creator-Tool."
+          },
+          {
+            "title": "Der chinesischsprachige Marketing-Agent",
+            "body": "Starke Handhabung chinesischer Prompts und kulturell verankerter Subjekte. Der richtige Standard für Agenten, die chinesischsprachige Märkte bedienen."
+          },
+          {
+            "title": "Die günstigere Alternative zu Flux Pro 1.1 Ultra",
+            "body": "Wenn das Briefing photorealistisch ist, das Deliverable aber den Flux-Aufpreis nicht rechtfertigt, liefert SeedDream 4 den Großteil der Qualität zum halben Preis."
+          }
+        ],
+        "avoidFor": "Überspringe SeedDream 4 für stilisierte Illustration (GPT Image 1 führt), Iteration bei langen strukturierten Prompts (Gemini 2.5 Flash Image führt) oder Hero-Shot-Editorial-Arbeit, bei der der Flux-Aufpreis gerechtfertigt ist.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "SeedDream 4 führt bei photorealistischer Ästhetik zu niedrigeren Kosten; GPT Image 1 führt bei stilisierter Illustration und nativen Edit-Flows."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Beide sind photorealistisch ausgerichtet. SeedDream 4 ist halb so teuer und konkurrenzfähig bei Porträt- und Produktarbeiten; Flux Pro 1.1 Ultra gewinnt bei Hero-Shot-Kompositionstreue."
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Image ist der günstige Allzweck-Standard mit stärkerer Anweisungstreue bei langen Prompts; SeedDream 4 ist der photorealistik-spezifische Standard mit einer höheren Obergrenze bei Foto-Briefings."
+          }
+        ],
+        "verdict": "Standardmäßig SeedDream 4, wenn das Briefing speziell ein Foto ist und Kosten zählen. Eskaliere auf Flux Pro 1.1 Ultra nur, wenn der Hero-Shot den Aufpreis rechtfertigt.",
+        "faqs": [
+          {
+            "q": "How much does SeedDream 4 cost?",
+            "a": "$0,036 pro generiertem Bild — nahe am unteren Ende des kuratierten Lineups beim Preis."
+          },
+          {
+            "q": "Is it good at Chinese prompts?",
+            "a": "Ja — deutlich stärker als die meisten westlich trainierten Baselines bei chinesischsprachigen Prompts und kulturell verankerten Subjekten."
+          },
+          {
+            "q": "What's its strongest aesthetic?",
+            "a": "Photorealistisch: Porträts, Produktaufnahmen, Lifestyle-Fotografie. Weniger geeignet für stilisierte Illustration."
+          },
+          {
+            "q": "Does it support image editing?",
+            "a": "Der kuratierte Eintrag auf VM0 deckt Text-zu-Bild ab. Edit-Flows sind nicht die primäre Stärke des Modells."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Cheaper general-purpose default"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Premium hero-shot quality"
+          },
+          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" }
+        ],
+        "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
+        "vm0Notes": "SeedDream 4 ist der photorealistik-spezifische Standard im kuratierten Bild-Lineup. Paare es mit Flux Pro 1.1 Ultra für Hero-Shots und mit Gemini 2.5 Flash Image für Nicht-Foto-Iteration."
+      },
+      "veo-3-1-fast": {
+        "name": "Veo 3.1 Fast",
+        "pageTitle": "Veo 3.1 Fast on VM0. Google's fast text-to-video model",
+        "tagline": "Googles schnelles Text-zu-Video-Modell mit nativem Audio. Die Wahl für Short-Form-Social- und Produktclips, bei denen kinoreife Qualität und Audio in einem Durchgang zählen.",
+        "cardIntro": "Googles Text-zu-Video-Modell mit nativem Audio. Schnelle Generierung, kinoreifer Stil und synchronisierter Soundtrack in einem Durchgang.",
+        "metaTitle": "Veo 3.1 Fast auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "Veo 3.1 Fast auf VM0. Googles schnelles Text-zu-Video-Modell mit nativem Audio, 4–8 Sekunden Clips bis zu 4K und Vergleich zu Kling V3 4K und Dreamina Seedance 2.0.",
+        "summary": "Veo 3.1 Fast ist die Fast-Stufe von Googles Veo-3-Videogenerierungs-Familie. Es generiert kurze Clips (4 / 6 / 8 Sekunden) bei 720p, 1080p oder 4K und rendert synchronisiertes natives Audio — Stimme, Umgebungsgeräusche und Effekte — im selben Durchgang wie die Visuals. Dieses Single-Pass-Audio ist die Eigenschaft, die es von den meisten Alternativen im kuratierten Lineup abhebt.\n\nDer Listenpreis liegt in der Größenordnung von $0,15 pro Sekunde 720p-Ausgabe mit Audio, was es kostenmäßig in die Mitte des Lineups stellt. Das natürliche Muster ist, standardmäßig Veo 3.1 Fast für Social- und Produktclips zu verwenden, bei denen Audio zählt, zu Dreamina Seedance 2.0 zu wechseln, wenn die Kosten dominieren, und zu Kling V3 4K zu wechseln, wenn eine längere oder höher aufgelöste Aufnahme benötigt wird.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Fast-Stufe von Googles Veo-3-Familie. Optimiert für Short-Form-Ausgabe mit nativem Audio.",
+        "background": [
+          "Veo 3.1 ist Googles Videogenerierungs-Familie in der Veo-3-Generation, und die Fast-Stufe ist die durchsatzoptimierte Variante — schnellere Generierung, niedrigere Kosten pro Clip, aber auf kurze Cliplängen begrenzt. Native Audio-Unterstützung ist die Signatur-Eigenschaft: Stimme, Umgebungsgeräusche und Effekte rendern im selben Durchgang wie die Visuals, anstatt in einem separaten Post-Schritt hinzugefügt zu werden.",
+          "Veos Ausgabe neigt zu einem kinoreifen Look — saubere Bewegung, durchdachtes Framing, akkurate Beleuchtung. Es ist stark bei Text-zu-Video-Briefings, die eine einzelne Aufnahme detailliert beschreiben (Kamerawinkel, Subjektaktion, Setting, Beleuchtung), weniger geeignet für hochstilisierte oder Anime-Ästhetiken, bei denen die stilistische Obergrenze von Kling V3 4K voranzieht."
+        ],
+        "architecture": "Text-zu-Video- und Bild-zu-Video-Diffusion-Modell mit nativer Audio-Synthese im selben Durchgang. Ausgabedauern sind 4, 6 oder 8 Sekunden bei 720p, 1080p oder 4K. Abrechnung pro generierter Videosekunde mit Qualitätsstufen-Modifikatoren.",
+        "specs": [
+          { "label": "Familie", "value": "Google Veo 3" },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Video, Bild-zu-Video, natives Audio"
+          },
+          { "label": "Cliplängen", "value": "4s / 6s / 8s" },
+          { "label": "Ausgabeauflösungen", "value": "720p / 1080p / 4K" },
+          {
+            "label": "Listenpreis",
+            "value": "~$0,15 pro Sekunde (720p + Audio)"
+          },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Natives Audio",
+            "body": "Die Signatur-Eigenschaft. Stimme, Umgebungsgeräusche und Effekte rendern im selben Durchgang wie die Visuals — kein separater Post-Schritt nötig. Der richtige Standard für Social- und Produktclips, bei denen Audio zählt."
+          },
+          {
+            "title": "Kinoreife Bewegung",
+            "body": "Die Ausgabe neigt zu sauberer Bewegung, durchdachtem Framing und akkurater Beleuchtung. Stark bei Text-zu-Video-Briefings, die eine einzelne Aufnahme detailliert beschreiben."
+          },
+          {
+            "title": "Geschwindigkeit",
+            "body": "Fast-Stufe — Generierung ist deutlich schneller als die Standard-Veo-3-Stufe, zu Lasten leicht niedrigerer Treue bei den anspruchsvollsten Briefings."
+          },
+          {
+            "title": "Ästhetische Obergrenze",
+            "body": "Kinoreife/photorealistische Bahn ist der Sweet Spot. Für stilisierte oder Anime-Ausgabe ist die stilistische Obergrenze von Kling V3 4K höher."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Social-Clip-Agent, der in einem Durchgang ausliefert",
+            "body": "Short-Form-Social-Video mit Stimme und Umgebungsgeräuschen, generiert in einem einzigen Call. Kein separater TTS- oder Audio-Post-Schritt, kein Synchronisieren — der Clip landet veröffentlichungsreif."
+          },
+          {
+            "title": "Das Produktdemo-Video für eine Landing Page",
+            "body": "8-Sekunden-Produktclip bei 1080p mit einem Voice-over, das das Feature beschreibt. Kinoreife Bewegung und synchronisiertes Audio lassen das Ergebnis produziert statt generiert wirken."
+          },
+          {
+            "title": "Der Bild-zu-Video-Schritt in einer Kampagne",
+            "body": "Starte von einem auf Flux Pro 1.1 Ultra oder SeedDream 4 gerenderten Standbild-Hero-Image und erweitere zu einem kurzen Bewegungsclip. Bildkonditionierung hält den Look konsistent."
+          }
+        ],
+        "avoidFor": "Überspringe Veo 3.1 Fast, wenn das Briefing stilisiert oder im Anime-Stil ist (die Obergrenze von Kling V3 4K ist höher), wenn ein Clip länger als 8 Sekunden benötigt wird oder wenn die Kosten dominieren und die Audio-Eigenschaft nicht zählt (Dreamina Seedance 2.0 ist etwa 3× günstiger).",
+        "comparisons": [
+          {
+            "vs": "Kling V3 4K",
+            "body": "Veo 3.1 Fast führt bei nativem Audio und kinoreifen/photorealistischen Ästhetiken; Kling V3 4K führt bei stilisierter/Anime-Ausgabe und bei längeren Cliplängen bei 4K. Nach Ästhetik auswählen."
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "Unterschiedliche Positionierung. Dreamina Seedance 2.0 ist etwa 3× günstiger pro Sekunde und die richtige Wahl, wenn die Kosten dominieren; Veo 3.1 Fast hat die Führung bei nativem Audio und kinoreifer Bewegung."
+          }
+        ],
+        "verdict": "Standardmäßig Veo 3.1 Fast für Short-Form-Social- und Produktclips, bei denen Audio zählt. Wechsle zu Kling V3 4K für stilisierte Ausgabe oder längere Dauern; wechsle zu Dreamina Seedance 2.0, wenn die Kosten dominieren.",
+        "faqs": [
+          {
+            "q": "Does Veo 3.1 Fast generate audio?",
+            "a": "Ja. Natives Audio — Stimme, Umgebungsgeräusche, Effekte — rendert im selben Durchgang wie die Visuals."
+          },
+          {
+            "q": "What clip durations are supported?",
+            "a": "4, 6 oder 8 Sekunden. Für längere Aufnahmen wechsle zu Kling V3 4K."
+          },
+          {
+            "q": "What resolutions does it support?",
+            "a": "720p, 1080p und 4K. Die Kosten skalieren mit Auflösung und Dauer."
+          },
+          {
+            "q": "Does it accept image conditioning?",
+            "a": "Ja — Bild-zu-Video-Flows erlauben es, von einem Standbild zu starten und zu einem kurzen Bewegungsclip zu erweitern."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "kling-v3-4k",
+            "reason": "Stylised / anime ceiling, longer clips"
+          },
+          { "slug": "dreamina-seedance-2-0", "reason": "Cheaper per second" }
+        ],
+        "routingNotes": "Routed to Google's Veo 3.1 Fast video generation endpoint and billed per generated video-second with quality-tier modifiers.",
+        "vm0Notes": "Veo 3.1 Fast ist der kinoreife/Audio-tragende Standard im kuratierten Video-Lineup auf VM0. Paare es mit Dreamina Seedance 2.0 für günstige Iteration und mit Kling V3 4K für stilisierte oder Long-Form-Clips."
+      },
+      "kling-v3-4k": {
+        "name": "Kling V3 4K",
+        "pageTitle": "Kling V3 4K on VM0. The 4K text-to-video ceiling",
+        "tagline": "Kuaishou's Kling-V3-4K-Text-zu-Video-Modell. Die Wahl, wenn man lange Clips, 4K-Auflösung oder eine stilisierte Ästhetik braucht, die die anderen Modelle nicht erreichen.",
+        "cardIntro": "Kuaishou's Kling V3 4K. Stilisierte Ästhetik, lange Clips bis zu 15 Sekunden, 4K-Ausgabe — die Obergrenze für editoriale und Anime-Style-Videos.",
+        "metaTitle": "Kling V3 4K auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "Kling V3 4K auf VM0. Kuaishou's Text-zu-Video-Modell mit 4K-Auflösung, 3–15 Sekunden Clips, stilisierter ästhetischer Obergrenze und Vergleich zu Veo 3.1 Fast und Dreamina Seedance 2.0.",
+        "summary": "Kling V3 4K ist Kuaishou's Top-Tier-Text-zu-Video-Modell. Die herausragenden Eigenschaften sind die Cliplänge (bis zu 15 Sekunden, gegenüber der 8-Sekunden-Grenze von Veo 3.1 Fast), 4K-Auflösung als Standardstufe und eine stilistische Obergrenze bei Anime-Style- und editorialen Ästhetiken, die die kinoreif ausgerichteten Alternativen nicht erreichen.\n\nDer Listenpreis liegt in der Größenordnung von $0,28 pro Sekunde 4K-Ausgabe, was es zur teuersten Option im kuratierten Video-Lineup macht. Das natürliche Muster ist, danach zu greifen, wenn lange oder 4K-Aufnahmen benötigt werden oder wenn das Briefing speziell stilisiert ist und die ästhetische Obergrenze der Alternativen nicht trifft.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Top-Tier der Kling-V3-Generation von Kuaishou. 4K- und Long-Clip-Obergrenze.",
+        "background": [
+          "Kling V3 4K ist die High-End-Variante von Kuaishou's Kling-V3-Videogenerierungs-Familie. Es bietet die längsten Standard-Cliplängen im kuratierten Lineup (3 bis 15 Sekunden), native 4K-Ausgabe in der Standardstufe und eine stilistische Obergrenze bei Anime- und editorialen Ästhetiken, die die kinoreif ausgerichteten Alternativen nicht erreichen.",
+          "Die Stärke des Modells liegt bei stilisierten und editorialen Briefings — Anime-Style-Sequenzen, Tanz- und bewegungsintensive Clips, Musikvideo-Ästhetiken. Für kinoreife photorealistische Ausgabe ist Veo 3.1 Fast zu niedrigeren Kosten und mit nativem Audio vergleichbar; für massenhafte kostengetriebene Generierung ist Dreamina Seedance 2.0 dramatisch günstiger. Die Rolle von Kling V3 4K ist der High-Ceiling-, Long-Clip-Schritt statt der Überall-Standard."
+        ],
+        "architecture": "Text-zu-Video- und Bild-zu-Video-Diffusion-Modell. Die Standardstufe rendert in 4K mit Cliplängen von 3 bis 15 Sekunden. Abrechnung pro generierter Videosekunde.",
+        "specs": [
+          { "label": "Familie", "value": "Kling V3" },
+          { "label": "Modalitäten", "value": "Text-zu-Video, Bild-zu-Video" },
+          { "label": "Cliplängen", "value": "3 bis 15 Sekunden" },
+          { "label": "Ausgabeauflösung", "value": "4K (Standardstufe)" },
+          { "label": "Listenpreis", "value": "~$0,28 pro Sekunde (4K)" },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Cliplänge",
+            "body": "Bis zu 15 Sekunden in der Standardstufe — die längste im kuratierten Lineup. Die richtige Wahl, wenn eine einzige ununterbrochene Aufnahme länger als 8 Sekunden zählt."
+          },
+          {
+            "title": "4K-Auflösung",
+            "body": "Natives 4K in der Standardstufe statt als Aufpreis in einer höheren Stufe. Nützlich, wenn das Deliverable Großformat-Display oder kinoreife Ausgabe ist."
+          },
+          {
+            "title": "Stilisierte ästhetische Obergrenze",
+            "body": "Stark bei Anime, Tanz, bewegungsintensiven und editorialen Ästhetiken. Hier zieht Kling vor den kinoreif ausgerichteten Alternativen voran."
+          },
+          {
+            "title": "Kosten",
+            "body": "~$0,28 pro Sekunde — die teuerste Option im kuratierten Lineup. Reserviere es für die Schritte, in denen die Obergrenze den Aufpreis rechtfertigt."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Anime-Style- oder stilisierte Social-Clip",
+            "body": "Stilisierte Ästhetiken — Anime, motion-design-geführt, Musikvideo-Stil — sind die Bereiche, in denen Kling einen echten Obergrenzen-Vorteil hat. Die kinoreif ausgerichteten Alternativen erreichen denselben Look nicht."
+          },
+          {
+            "title": "Die lange ununterbrochene Aufnahme",
+            "body": "Wenn das Briefing eine einzige 12- bis 15-Sekunden-Aufnahme statt eines Schnitts zwischen kürzeren Clips verlangt, ist Kling V3 4K die einzige Option im kuratierten Lineup, die die Dauergrenze erreicht."
+          },
+          {
+            "title": "Das 4K-Deliverable für Großformat-Display",
+            "body": "Natives 4K in der Standardstufe macht Kling zur richtigen Wahl, wenn die Ausgabe für eine Billboard-, Kino- oder Großformat-Social-Kampagne bestimmt ist."
+          }
+        ],
+        "avoidFor": "Überspringe Kling V3 4K, wenn das Briefing kinoreif photorealistisch mit Audio ist (Veo 3.1 Fast ist natürlicher zu niedrigeren Kosten) oder wenn die Kosten dominieren (Dreamina Seedance 2.0 ist etwa 5× günstiger pro Sekunde).",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Veo 3.1 Fast führt bei nativem Audio und kinoreifen/photorealistischen Ästhetiken; Kling V3 4K führt bei stilisierter/Anime-Ausgabe, bei längeren Cliplängen und bei nativer 4K-Ausgabe. Nach Ästhetik und Dauer auswählen."
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "Unterschiedliche Kosten-Tiers. Dreamina Seedance 2.0 ist dramatisch günstiger und die richtige Wahl, wenn die Kosten dominieren; Kling V3 4K hat die Obergrenze bei Dauer, 4K und stilisierter Ästhetik."
+          }
+        ],
+        "verdict": "Wähle Kling V3 4K für stilisierte, lange oder 4K-Video-Deliverables. Wechsle zu Veo 3.1 Fast für kinoreife Clips mit Audio; wechsle zu Dreamina Seedance 2.0 für kostengetriebenen Fan-out.",
+        "faqs": [
+          {
+            "q": "What's the longest clip Kling V3 4K can generate?",
+            "a": "15 Sekunden in der Standardstufe — die längste einzelne Aufnahme im kuratierten Video-Lineup auf VM0."
+          },
+          {
+            "q": "Does Kling V3 4K support audio?",
+            "a": "Nicht nativ im selben Durchgang. Für Video mit synchronisiertem Audio in einem Call verwende Veo 3.1 Fast."
+          },
+          {
+            "q": "What resolution does Kling produce?",
+            "a": "4K in der Standardstufe. Niedrigere Auflösungsvarianten sind in derselben Familie zu niedrigeren Kosten verfügbar."
+          },
+          {
+            "q": "Does it accept image conditioning?",
+            "a": "Ja — Bild-zu-Video-Flows erlauben es, von einem Referenzstandbild zu starten und zu einem längeren Bewegungsclip zu erweitern."
+          }
+        ],
+        "alternatives": [
+          { "slug": "veo-3-1-fast", "reason": "Cinematic / native audio" },
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "Cheaper bulk generation"
+          }
+        ],
+        "routingNotes": "Routed to Kuaishou's Kling V3 4K endpoint and billed per generated video-second.",
+        "vm0Notes": "Kling V3 4K ist die High-Ceiling-Option im kuratierten Video-Lineup auf VM0. Reserviere es für stilisierte, Long-Form- oder 4K-Deliverables — als Überall-Standard greife zu Veo 3.1 Fast oder Dreamina Seedance 2.0."
+      },
+      "dreamina-seedance-2-0": {
+        "name": "Dreamina Seedance 2.0",
+        "pageTitle": "Dreamina Seedance 2.0 on VM0. The cost-optimised video model",
+        "tagline": "ByteDance's Dreamina-Seedance-2.0-Videomodell. Der richtige Standard, wenn die Kosten dominieren — dramatisch günstiger pro Sekunde als die Alternativen.",
+        "cardIntro": "ByteDance's Dreamina Seedance 2.0. Günstigstes Video pro Sekunde im kuratierten Lineup — die richtige Wahl für massenhafte und kostengetriebene Generierung.",
+        "metaTitle": "Dreamina Seedance 2.0 auf VM0: Preise, Specs & Vergleich",
+        "metaDescription": "Dreamina Seedance 2.0 auf VM0. ByteDance's Text-zu-Video-Modell mit den günstigsten Kosten pro Sekunde im kuratierten Lineup, 4–15 Sekunden Clips bis zu 1080p und Vergleich zu Veo 3.1 Fast und Kling V3 4K.",
+        "summary": "Dreamina Seedance 2.0 ist das kostenoptimierte Mitglied von ByteDance's Seedance-Video-Familie. Die Ausgabedauern reichen von 4 bis 15 Sekunden bei 480p, 720p oder 1080p, mit Text-zu-Video- und Bild-zu-Video-Flows. Die herausragende Eigenschaft sind die Kosten — etwa $0,05 pro Sekunde 1080p-Ausgabe mit Bildkonditionierung, dramatisch günstiger als Veo 3.1 Fast oder Kling V3 4K.\n\nEs ist der natürliche Standard, wenn die Kosten dominieren: Bulk-Fan-out-Generierung, Social-Clip-Varianten, Entwurfsdurchgänge vor einem Premium-Final-Render. Für natives Audio greife zu Veo 3.1 Fast; für stilisierte Long-Form-Ausgabe greife zu Kling V3 4K.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Kostenoptimierte Stufe der Seedance-Video-Familie von ByteDance.",
+        "background": [
+          "Dreamina Seedance 2.0 ist das Seedance-Videomodell der zweiten Generation von ByteDance, gepaart mit einer Fast-Variante und einer Pro-Variante in derselben Familie. Der Standard-2.0-Eintrag im kuratierten Lineup ist der Kosten/Qualitäts-Sweet-Spot — günstiger als die Pro-Stufe, deutlich höhere Qualität als die Fast-Stufe.",
+          "Das Modell handhabt Text-zu-Video- und Bild-zu-Video-Flows bei Dauern von 4 bis 15 Sekunden bei 480p, 720p oder 1080p. Die Ausgabe neigt zu verbraucherfreundlichen Ästhetiken: Short-Form-Social, Lifestyle, Produktclips. Nicht die Obergrenze für kinoreife oder stilisierte Arbeit, aber die günstigste brauchbare Option im kuratierten Lineup."
+        ],
+        "architecture": "Text-zu-Video- und Bild-zu-Video-Diffusion-Modell mit drei Qualitätsstufen (Fast, Standard, Pro). Der kuratierte Eintrag deckt die Standard-2.0-Stufe ab. Abrechnung pro generierter Videosekunde mit Modifikatoren für Auflösung und ob Bildkonditionierung verwendet wird.",
+        "specs": [
+          { "label": "Familie", "value": "Seedance 2.0" },
+          { "label": "Modalitäten", "value": "Text-zu-Video, Bild-zu-Video" },
+          { "label": "Cliplängen", "value": "4 bis 15 Sekunden" },
+          { "label": "Ausgabeauflösungen", "value": "480p / 720p / 1080p" },
+          {
+            "label": "Listenpreis",
+            "value": "~$0,05 pro Sekunde (1080p + Bild)"
+          },
+          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Kosten",
+            "body": "Günstigstes Video-Modell pro Sekunde im kuratierten Lineup. Etwa 3× günstiger als Veo 3.1 Fast und 5× günstiger als Kling V3 4K."
+          },
+          {
+            "title": "Geschwindigkeit",
+            "body": "Schnelle Generierung in der Standardstufe — vergleichbar mit der günstigeren Fast-Variante derselben Familie bei deutlich besserer Qualität."
+          },
+          {
+            "title": "Bild-zu-Video",
+            "body": "Starke Handhabung von Bildkonditionierungs-Flows. Nützlich, wenn ein Agent ein Standbild (günstig generiert auf Gemini 2.5 Flash Image oder SeedDream 4) in einen kurzen Bewegungsclip erweitern möchte."
+          },
+          {
+            "title": "Ästhetische Obergrenze",
+            "body": "Niedriger als Veo 3.1 Fast bei kinoreifer Bewegung und niedriger als Kling V3 4K bei stilisierten Ästhetiken. Die richtige Wahl, wenn die Kosten der entscheidende Faktor sind, nicht die Obergrenze."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Der Bulk-Fan-out-Videogenerierungsschritt",
+            "body": "Kosten pro Sekunde niedrig genug, um die Generierung eines Dutzends Varianten desselben Clips brauchbar zu machen. Günstig vorfiltern, dann die gewählte Variante auf Veo 3.1 Fast oder Kling V3 4K für den Final-Render eskalieren, wenn die Qualität es rechtfertigt."
+          },
+          {
+            "title": "Die Bild-zu-Video-Erweiterung in einer Kampagne",
+            "body": "Starte von einem Standbild-Hero-Image und erweitere zu einem kurzen Bewegungsclip, ohne den Premium-Tier-Preis zu zahlen. Bildkonditionierung hält den Look konsistent."
+          },
+          {
+            "title": "Der Entwurfsdurchgang vor dem Premium-Render",
+            "body": "Lege Bewegung, Framing und Pacing günstig auf Dreamina Seedance 2.0 fest, dann rerendere das Finale auf Veo 3.1 Fast oder Kling V3 4K nur für die gewählte Variante."
+          }
+        ],
+        "avoidFor": "Überspringe Dreamina Seedance 2.0, wenn natives Audio zählt (Veo 3.1 Fast), wenn stilisierte oder Anime-Ästhetiken zählen (Kling V3 4K) oder wenn das Briefing Deliverable-Grade-Kinoreife ist, bei der die Obergrenze der Alternativen ihren Aufpreis rechtfertigt.",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Unterschiedliche Positionierung. Veo 3.1 Fast hat natives Audio und kinoreife Bewegung; Dreamina Seedance 2.0 ist dramatisch günstiger und die richtige Wahl, wenn die Kosten dominieren. Stapeln — Entwurf auf Dreamina, Finale auf Veo."
+          },
+          {
+            "vs": "Kling V3 4K",
+            "body": "Vollständig unterschiedliche Stufen. Kling V3 4K ist die Obergrenze bei Dauer, 4K und stilisierter Ästhetik; Dreamina Seedance 2.0 ist der günstige Standard für alles andere."
+          }
+        ],
+        "verdict": "Standardmäßig Dreamina Seedance 2.0, wenn die Kosten den Videogenerierungsschritt dominieren. Stapeln mit Veo 3.1 Fast für Audio-Finals und Kling V3 4K für stilisierte oder 4K-Hero-Ausgabe.",
+        "faqs": [
+          {
+            "q": "How much does Dreamina Seedance 2.0 cost per second?",
+            "a": "Etwa $0,05 pro Sekunde 1080p-Ausgabe mit Bildkonditionierung — der günstigste im kuratierten Video-Lineup."
+          },
+          {
+            "q": "Does it support audio?",
+            "a": "Nicht nativ im selben Durchgang. Für Video mit synchronisiertem Audio in einem Call verwende Veo 3.1 Fast."
+          },
+          {
+            "q": "What clip durations and resolutions are supported?",
+            "a": "4- bis 15-Sekunden-Clips bei 480p, 720p oder 1080p."
+          },
+          {
+            "q": "Is there a higher-quality tier of Seedance on VM0?",
+            "a": "Die Seedance-Familie enthält Fast- und Pro-Varianten neben dem Standard-2.0-Eintrag. Die Preisgestaltung skaliert mit der Stufe; die Standardstufe ist der Kosten/Qualitäts-Sweet-Spot."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "Native audio, cinematic motion"
+          },
+          { "slug": "kling-v3-4k", "reason": "Stylised, longer, 4K" }
+        ],
+        "routingNotes": "Routed to ByteDance's Dreamina Seedance 2.0 endpoint and billed per generated video-second with resolution and image-conditioning modifiers.",
+        "vm0Notes": "Dreamina Seedance 2.0 ist der kostenoptimierte Standard im kuratierten Video-Lineup auf VM0. Das Standardmuster ist, es für Iteration und Fan-out zu verwenden und dann die gewählte Variante nur auf Veo 3.1 Fast oder Kling V3 4K zu eskalieren, wenn der Final-Render den Aufpreis rechtfertigt."
       }
     }
   },

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -3863,10 +3863,10 @@
     "back": "← Back"
   },
   "models": {
-    "listingPageTitle": "Models — Run agents on Claude and more",
-    "listingPageDescription": "Every AI model available to VM0 agents — Claude Opus 4.7, Sonnet 4.6, Haiku 4.5, and more. Short intro and what each model is best for on VM0.",
+    "listingPageTitle": "Models — Reasoning, image and video on VM0",
+    "listingPageDescription": "Every AI model available to VM0 agents — reasoning models from Anthropic, OpenAI, DeepSeek, Moonshot and more, plus image and video generation models. Short intro and what each model is best for on VM0.",
     "jsonLdListName": "AI models available on VM0",
-    "jsonLdListDescription": "Every AI model available to VM0 agents — Claude and more.",
+    "jsonLdListDescription": "Every AI model available to VM0 agents — reasoning, image and video.",
     "breadcrumbHome": "Home",
     "breadcrumbModels": "Models",
     "notFound": "Not Found",
@@ -3874,9 +3874,9 @@
     "heroDescription": "Every model available to your agents. What it's good at, and when to pick it.",
     "filterAriaLabel": "Filter models",
     "filterAll": "All",
-    "filterRecommended": "Recommended",
-    "filterMultimodal": "Multimodal",
-    "filterCostSaving": "Cost-saving",
+    "filterReasoning": "Reasoning",
+    "filterImage": "Image",
+    "filterVideo": "Video",
     "readMoreAbout": "Read more about {name}",
     "backToAllModels": "All models",
     "useModelButton": "Use {name} on VM0",
@@ -3915,6 +3915,14 @@
     "tierExplanationCore": "VM0 positions {name} as a core agent model, recommended alongside Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6 for the steps that drive the actual outcome of an agent run. These are the models we'd pick for the orchestrator role, for code-touching agents, and for any step where a wrong answer is expensive.",
     "tierExplanationCostSaving": "VM0 positions {name} as a cost-saving option rather than a core agent model. Use it to optimise unit cost on non-core work, such as bulk classification, pre-filters, latency-critical short replies, or pinned legacy agents, while keeping Claude Opus 4.7, Claude Opus 4.6, or Claude Sonnet 4.6 on the steps that decide the run.",
     "availableSince": "Available on VM0 since {date}.",
+    "generationPricingSubtitle": "Vendor list price per generated unit.",
+    "generationPricingDetail": "Detail",
+    "generationUnitImage": "Per generated image",
+    "generationUnitMegapixel": "Per output megapixel",
+    "generationUnitVideoSecond": "Per second of video",
+    "generationUnitAudioSecond": "Per second of audio",
+    "generationAccessHeading": "Using {name} on VM0",
+    "generationAccessBody": "VM0 agents can call {name} as part of an agent run, billed against your VM0 credits. The list price above is what the upstream provider charges; VM0 passes that through with the standard credit conversion.",
     "content": {
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
@@ -4288,6 +4296,168 @@
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and as the default model on the Anthropic API-key and Claude Code OAuth providers.",
         "vm0Notes": "Opus 4.6 carries the highest vendor list price per token of any Built-in model, so prompt caching matters here more than anywhere else and is on by default. It's still the default model on the Anthropic API-key and Claude Code OAuth providers, which means it's likely the model your team already has muscle memory for, even though Opus 4.7 is the recommended choice for new work."
       },
+      "gpt-5-5": {
+        "name": "GPT-5.5",
+        "pageTitle": "GPT-5.5 on VM0. OpenAI's flagship reasoning model",
+        "tagline": "OpenAI's flagship of the GPT-5 family. The strongest pick for agentic coding, deep reasoning and computer-use loops at the OpenAI tier.",
+        "cardIntro": "OpenAI's flagship reasoning model. Top-tier coding and tool-use, routed through the Codex framework on VM0.",
+        "metaTitle": "GPT-5.5: Benchmarks, Pricing & Capabilities",
+        "metaDescription": "GPT-5.5 review. OpenAI's flagship GPT-5 reasoning model with 400K context, multimodal vision, $5/$30 vendor pricing, and benchmark leadership on SWE-bench Verified, AIME 2025 and GPQA Diamond.",
+        "summary": "GPT-5.5 is the model you reach for when the work needs both deep reasoning and reliable tool use: orchestrating multi-step agent loops, code edits that have to land first try, and computer-use workflows that span many GUI actions. Vendor benchmarks (SWE-bench Verified, AIME 2025, GPQA Diamond) put concrete numbers on the gains over GPT-5.4.\n\nVendor list price is $5 / $30 per 1M tokens with cached input at $0.50 / 1M. It's the most expensive model in VM0's Built-in catalogue at ×2 credits, so the cost-effective pattern is to keep GPT-5.4 or Claude Sonnet 4.6 as the everywhere-default and route only the hardest steps to GPT-5.5.",
+        "releaseDate": "April 2026 (successor to GPT-5.4)",
+        "familyPosition": "Top-tier of the GPT-5 family. OpenAI's flagship for agentic coding and reasoning.",
+        "background": [
+          "GPT-5.5 is the flagship of OpenAI's GPT-5 generation, released in April 2026 as the recommended upgrade from GPT-5.4. OpenAI frames it as a step-change improvement on agentic tool use and computer-use tasks rather than a refresh on the surface API. The 400K-token context window and reasoning_effort parameter introduced with GPT-5 carry over unchanged, so existing Codex agents drop in without rewrites.",
+          "Compared to GPT-5.4 (the workhorse in the same family), GPT-5.5 invests more compute per token on reasoning. The behavioural payoff shows up in three places: stronger first-attempt code patches on multi-file refactors, materially fewer mis-routed tool calls on long agent loops, and noticeable gains on graduate-level science reasoning (GPQA Diamond) and competition math (AIME 2025). The trade-off is the highest list price among GPT-5 variants ($5 / $30 per 1M tokens) and a ×2 credit multiplier on VM0, which is why OpenAI itself positions GPT-5.5 as the planner or escalation tier rather than the everywhere-default.",
+          "Independent leaderboards (Artificial Analysis, Vellum) corroborate the relative ordering against GPT-5.4 and place GPT-5.5 within a few points of Claude Opus 4.7 on most agentic-coding tasks. Absolute numbers shift weekly and OpenAI itself has flagged training-data contamination on SWE-bench Verified across frontier models. Treat the public scores as directional rather than authoritative; the structured behavioural differences (tool-call accuracy, computer-use reliability, first-attempt patch quality) are the more durable signal."
+        ],
+        "architecture": "GPT-5.5 keeps the 400K-token context window from GPT-5.4, billed at standard input pricing across the entire window. It supports the `reasoning_effort` parameter at four levels (minimal, low, medium, high), prompt caching where cached input bills at one-tenth the input rate, and the Responses API surface that codex CLI uses by default. Tool-use, structured outputs and computer-use are unchanged from 5.4. Inputs are multimodal across text, vision and code; the model has no native image generation (use the Images API for that).",
+        "specs": [
+          { "label": "Family", "value": "GPT-5 generation" },
+          { "label": "Modalities", "value": "Text, vision, code" },
+          { "label": "Languages", "value": "English-first, multilingual" },
+          { "label": "Prompt caching", "value": "Supported (OpenAI)" },
+          { "label": "Context window", "value": "400K tokens" },
+          { "label": "Max output", "value": "Up to 128K tokens" },
+          {
+            "label": "Reasoning effort",
+            "value": "Minimal / Low / Medium / High"
+          },
+          {
+            "label": "Vendor list price",
+            "value": "$5 input / $30 output per 1M"
+          }
+        ],
+        "benchmarksNote": "Vendor-reported scores from OpenAI's GPT-5.5 release materials, with deltas shown against the public GPT-5.4 numbers. Independent reviews place 5.5 within a few points of Claude Opus 4.7 on agentic-coding tasks. Treat absolute percentages as directional; OpenAI has flagged training-data contamination on SWE-bench Verified across all frontier models.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~82%",
+            "note": "vendor-reported; up from 5.4's 74.9%"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~69%",
+            "note": "vendor-reported tool use"
+          },
+          {
+            "name": "AIME 2025 (no tools)",
+            "score": "~96%",
+            "note": "vendor-reported competition math"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~89%",
+            "note": "vendor-reported graduate science"
+          },
+          {
+            "name": "OSWorld (computer use)",
+            "score": "~74%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "MMMU (multimodal)",
+            "score": "Leads GPT-5 family",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Speed",
+            "score": "~70 tokens/sec",
+            "note": "Artificial Analysis, medium effort"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Tool routing",
+            "body": "Lowest rate of mis-routed tool calls in the GPT-5 family. The gap versus 5.4 widens on hard edge cases such as conditional tool selection, deeply nested arguments, and tool calls dispatched after long stretches of reasoning."
+          },
+          {
+            "title": "First-attempt code edits",
+            "body": "Strongest patch quality in the GPT-5 family. The right pick when an agent has to modify code that must keep compiling and passing tests, especially when the patch spans multiple files. Vendor-reported SWE-bench Verified reflects this directly."
+          },
+          {
+            "title": "Computer use",
+            "body": "Materially more reliable than 5.4 on multi-step GUI sequences, which is what the OSWorld delta captures. Reach for it when the agent is driving a browser or desktop app over dozens of steps and the cost of a mid-run derailment is high."
+          },
+          {
+            "title": "Speed",
+            "body": "Slower than 5.4 and noticeably slower than 5.4 Mini. Around 70 tokens/sec at medium effort per Artificial Analysis. Reserve it for the steps that actually need the extra reasoning depth and run lighter tiers in parallel."
+          },
+          {
+            "title": "Hallucination behaviour",
+            "body": "GPT-5.5 carries OpenAI's stricter calibration from the GPT-5 generation and tends to admit uncertainty rather than confabulate, which is the reason production teams keep paying the premium for high-stakes reasoning despite cheaper alternatives like DeepSeek V4 Pro now matching it on benchmarks."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The orchestrator running a multi-tool plan",
+            "body": "Use GPT-5.5 as the planner that breaks a customer's request into ten steps, dispatches each step to a GPT-5.4- or 5.4 Mini-tier sub-agent, and stitches the results back together. Running 5.5 only at the planner layer (and the cheaper tiers everywhere else) costs a fraction of running 5.5 end-to-end, with most of the quality preserved."
+          },
+          {
+            "title": "The first-try code edits that don't waste a CI run",
+            "body": "Ask GPT-5.5 to migrate a 50-file codebase from one ORM to another, refactor a tangled module, or apply a security fix across the repo. The patch applies cleanly on the first attempt more often than any other model in the family, and that's exactly what your CI bill will reflect."
+          },
+          {
+            "title": "The computer-use agent that has to finish the workflow",
+            "body": "When the agent is driving a browser through a multi-step booking flow, a desktop app, or a legacy admin UI, 5.5's stronger OSWorld score translates to fewer mid-run derailments and fewer human takeovers. The premium pays for itself the first time a long session doesn't have to be restarted."
+          },
+          {
+            "title": "The hard-math or hard-science research step",
+            "body": "Drop a competition-grade math problem set or a graduate physics derivation in and 5.5 will work through it without the off-by-one slips you see in 5.4. AIME 2025 and GPQA Diamond pick up exactly this kind of behaviour."
+          }
+        ],
+        "avoidFor": "Skip GPT-5.5 on high-volume routine work where GPT-5.4 hits the same quality bar at half the credit cost, on latency-sensitive chat replies where GPT-5.4 Mini is much faster, and on bulk classification or extraction jobs where DeepSeek V4 Flash is roughly 35× cheaper at the vendor level.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "GPT-5.4 is the workhorse default in the GPT-5 family and the right pick for most agents. Promote to GPT-5.5 only when 5.4 visibly fails on hard reasoning, long agentic loops or first-attempt code edits, usually as the orchestrator that delegates downward to 5.4- or 5.4 Mini-tier sub-agents."
+          },
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "Same role in different families: the high-stakes orchestrator and the model you escalate to when the cheaper tier fails. Opus 4.7 has the 1M-token context window and Anthropic's safety profile; GPT-5.5 has stronger computer-use scores and is the natural pick for teams already on the Codex framework. Pick by which framework and ecosystem your existing agents target."
+          },
+          {
+            "vs": "Gemini 3 Pro",
+            "body": "Gemini 3 Pro leads on raw long-context reasoning (2M-token window) and on some multimodal benchmarks. GPT-5.5 leads on agentic coding (SWE-bench Verified, Terminal-Bench) and computer use. Pick GPT-5.5 when the agent edits code or drives a UI; pick Gemini 3 Pro when the workload is heavy document or video understanding."
+          }
+        ],
+        "verdict": "GPT-5.5 is the escalation tier on the OpenAI side. Default to GPT-5.4; promote to 5.5 only on the specific steps where 5.4 visibly fails.",
+        "faqs": [
+          {
+            "q": "What is GPT-5.5's context window?",
+            "a": "400,000 tokens, with up to 128K tokens of output per response. The full window bills at standard rates."
+          },
+          {
+            "q": "Can GPT-5.5 handle images?",
+            "a": "Yes. GPT-5.5 is multimodal. It accepts image inputs alongside text and code, so screenshot-driven and document-vision agents work natively. For image generation use the OpenAI Images API."
+          },
+          {
+            "q": "When should I pick GPT-5.5 over GPT-5.4?",
+            "a": "When (a) the agent is the planner / orchestrator and decisions cascade, (b) the run is long enough that 5.4 starts mis-routing tool calls, or (c) the output must apply cleanly on the first attempt (code edits, structured payloads, computer-use workflows)."
+          },
+          {
+            "q": "Does GPT-5.5 support prompt caching?",
+            "a": "Yes. Cached input bills at $0.50 per 1M tokens — a 10× discount on the cached portion. Worth using whenever your system prompt or tool schema is stable across calls."
+          },
+          {
+            "q": "What framework does GPT-5.5 use on VM0?",
+            "a": "Codex. VM0 routes GPT-5.5 through the Codex framework's Responses API surface, which is what codex CLI uses by default. Claude Code-framework agents are not compatible with GPT-5 models on VM0."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-5-4", "reason": "Half the credits, same family" },
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Peer flagship on the Claude side"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Workhorse default at ×1 credits"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Exposed four ways: through the VM0 Managed credit pool, through a direct OpenAI API key, through a ChatGPT (Codex) OAuth login, and through OpenRouter / Vercel AI Gateway in their Codex variants.",
+        "vm0Notes": "GPT-5.5 sits at the ×2 credit multiplier — the highest in the Built-in catalogue. Prompt caching is enabled by default through VM0, which substantially cuts the cost of repeated system prompts on agents that issue many turns from the same prefix. The standard pattern is to keep GPT-5.4 or Claude Sonnet 4.6 running everywhere and escalate only the steps that genuinely need 5.5's reasoning depth."
+      },
       "claude-sonnet-4-6": {
         "name": "Claude Sonnet 4.6",
         "pageTitle": "Claude Sonnet 4.6 on VM0. The default agent model",
@@ -4442,6 +4612,159 @@
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Default model on VM0 Managed.",
         "vm0Notes": "Sonnet 4.6 is the credit baseline (×1) that every other Built-in model's multiplier is normalised against, which is the main reason it stays the first choice for new agents on VM0; escalate to Opus only when Sonnet visibly underperforms on a specific task. Native prompt caching pairs well with VM0's stable system prompts and tool definitions, and keeps the per-turn cost of long-running agents predictable."
+      },
+      "gpt-5-4": {
+        "name": "GPT-5.4",
+        "pageTitle": "GPT-5.4 on VM0. The OpenAI workhorse",
+        "tagline": "OpenAI's workhorse of the GPT-5 family. Sits at the ×1 credit baseline alongside Claude Sonnet 4.6 and is the right default for most Codex-framework agents.",
+        "cardIntro": "OpenAI's workhorse model. ×1 credits, multimodal vision, strong code and tool use — the default GPT-5 for most agents.",
+        "metaTitle": "GPT-5.4 on VM0: Benchmarks, Pricing & Comparison",
+        "metaDescription": "GPT-5.4 review on VM0. The workhorse OpenAI GPT-5 model with 400K context, multimodal vision, $2.5/$15 pricing and ×1 credits on VM0 Managed. Specs and Claude comparison.",
+        "summary": "GPT-5.4 is the workhorse of OpenAI's GPT-5 family — the model you keep running everywhere by default. Vendor-reported SWE-bench Verified at 74.9% places it in the same range as Claude Sonnet 4.6 on coding, and its tool-use accuracy is what most production Codex-framework agents are tuned against.\n\nVendor list price is $2.5 / $15 per 1M tokens with cached input at $0.25 / 1M. It sits at ×1 credits on VM0 Managed — the same baseline as Claude Sonnet 4.6 — which makes it the natural pick when your agent is already on the Codex framework and you want a balanced cost/quality default.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Workhorse of the GPT-5 family. The recommended default for most Codex-framework agents.",
+        "background": [
+          "GPT-5.4 is the workhorse of OpenAI's GPT-5 generation, released in April 2026 alongside the flagship GPT-5.5 and the cost-optimised GPT-5.4 Mini. OpenAI positions it as the everywhere-default for agents on the Codex framework — the model you keep running on every step unless a specific step justifies escalation to 5.5.",
+          "Architecturally GPT-5.4 shares the 400K-token context window, the `reasoning_effort` parameter, prompt caching and the Responses API surface with the rest of the GPT-5 family. The split versus GPT-5.5 is compute investment per token: 5.4 runs faster and cheaper, 5.5 invests more in reasoning depth. The split versus GPT-5.4 Mini is the opposite — 5.4 carries more quality for the steps that actually decide the agent run.",
+          "On VM0 it sits at the ×1 credit multiplier, the same baseline as Claude Sonnet 4.6, which makes side-by-side cost comparisons between Anthropic and OpenAI defaults trivial. The choice between the two usually comes down to framework (Codex vs Claude Code), ecosystem (existing integrations, tool definitions) and which model your team has more behavioural muscle memory for."
+        ],
+        "architecture": "GPT-5.4 uses the same architecture as the rest of the GPT-5 family: 400K-token context window, `reasoning_effort` parameter at four levels (minimal, low, medium, high), prompt caching where cached input bills at one-tenth the input rate, and the Responses API surface that codex CLI uses by default. Tool-use, structured outputs and computer-use are supported. Inputs are multimodal across text, vision and code.",
+        "specs": [
+          { "label": "Family", "value": "GPT-5 generation" },
+          { "label": "Modalities", "value": "Text, vision, code" },
+          { "label": "Languages", "value": "English-first, multilingual" },
+          { "label": "Prompt caching", "value": "Supported (OpenAI)" },
+          { "label": "Context window", "value": "400K tokens" },
+          { "label": "Max output", "value": "Up to 128K tokens" },
+          {
+            "label": "Reasoning effort",
+            "value": "Minimal / Low / Medium / High"
+          },
+          {
+            "label": "Vendor list price",
+            "value": "$2.5 input / $15 output per 1M"
+          }
+        ],
+        "benchmarksNote": "Vendor-reported scores from OpenAI's GPT-5 release materials, with deltas shown against the previous OpenAI generation. Independent reviews place GPT-5.4 in the same coding-quality band as Claude Sonnet 4.6. Treat absolute percentages as directional.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "74.9%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~58%",
+            "note": "vendor-reported tool use"
+          },
+          {
+            "name": "AIME 2025 (no tools)",
+            "score": "~92%",
+            "note": "vendor-reported competition math"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~85%",
+            "note": "vendor-reported graduate science"
+          },
+          {
+            "name": "OSWorld (computer use)",
+            "score": "~62%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Speed",
+            "score": "~110 tokens/sec",
+            "note": "Artificial Analysis, medium effort"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Tool routing",
+            "body": "Solid baseline accuracy across the standard Codex-framework tool catalogue. Where 5.5 pulls ahead is on hard edge cases (conditional tool selection, deeply nested arguments) — for the routine cases 5.4 routes correctly with significantly lower latency."
+          },
+          {
+            "title": "Code edits",
+            "body": "Comparable patch quality to Claude Sonnet 4.6 on standard refactor and bug-fix workloads. Where 5.5 starts to pull ahead is on multi-file changes where the patch has to apply cleanly on the first try."
+          },
+          {
+            "title": "Speed",
+            "body": "Materially faster than 5.5 — around 110 tokens/sec at medium effort per Artificial Analysis. This is part of why 5.4 stays the default for interactive chat replies and short agent loops where user-visible latency matters."
+          },
+          {
+            "title": "Cost efficiency",
+            "body": "×1 credits with output behaviour in the Sonnet 4.6 quality band. For teams already on the Codex framework, this is the cost/quality sweet spot — promote to 5.5 only on steps that visibly need it."
+          },
+          {
+            "title": "Hallucination behaviour",
+            "body": "Inherits the calibration improvements OpenAI shipped with the GPT-5 generation. Less prone to confident wrong answers than the GPT-4 series, especially on questions outside its training horizon."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The default agent step on the Codex framework",
+            "body": "If your agent is already built on codex CLI or any Codex-framework integration, GPT-5.4 is the natural everywhere-default. ×1 credits, fast enough for interactive use, accurate enough for the routine tool calls that dominate most agent runs."
+          },
+          {
+            "title": "The interactive chat with vision",
+            "body": "Screenshot-driven UIs, document Q&A, image annotation — GPT-5.4 handles all three multimodally at workhorse speed. The ×1 multiplier keeps the per-turn cost in the same band as Sonnet 4.6, so you can A/B the two against each other on the same workload."
+          },
+          {
+            "title": "The cost/quality A/B against Claude Sonnet 4.6",
+            "body": "Both models sit at ×1 credits on VM0 Managed, which makes them directly comparable on cost. Run the same agent on both for a week and pick by behaviour on your specific workload — neither is universally better, and the right default depends on your tool catalogue and prompt style."
+          }
+        ],
+        "avoidFor": "Skip GPT-5.4 on the hardest reasoning, computer-use or multi-file code-edit steps where 5.5 noticeably leads, and on high-volume bulk classification or pre-filter work where 5.4 Mini is four times cheaper at the vendor level.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.5",
+            "body": "Same family, different positioning. 5.5 (×2) gives you the strongest reasoning, computer-use and first-attempt code quality; 5.4 (×1) gives you the same context window and feature set at half the credit cost and noticeably higher speed. Default to 5.4; escalate to 5.5 only on the steps that visibly need it."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "The two ×1 baselines, one in each ecosystem. Sonnet 4.6 runs on the Claude Code framework; GPT-5.4 runs on Codex. Pick by which framework your existing agents and tool definitions target. On raw output quality they're close enough that A/B-testing on your workload is the right call."
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "Same family, different positioning. 5.4 (×1) carries more reasoning quality per token; 5.4 Mini (×0.3) gives you a much cheaper option for bulk and pre-filter work. Use 5.4 Mini for fan-out classification and 5.4 for the steps that decide the agent run."
+          }
+        ],
+        "verdict": "GPT-5.4 is the everywhere-default for Codex-framework agents on VM0. Escalate to 5.5 for hard reasoning, drop to 5.4 Mini for bulk pre-filtering.",
+        "faqs": [
+          {
+            "q": "What is GPT-5.4's context window?",
+            "a": "400,000 tokens, with up to 128K tokens of output per response. The full window bills at standard rates."
+          },
+          {
+            "q": "Can GPT-5.4 handle images?",
+            "a": "Yes. GPT-5.4 is multimodal. It accepts image inputs alongside text and code natively."
+          },
+          {
+            "q": "When should I pick GPT-5.4 over Claude Sonnet 4.6?",
+            "a": "When your agent is already built on the Codex framework or you need the OpenAI ecosystem (tool catalogue, structured outputs, Responses API). Both sit at ×1 credits, so cost is identical and the choice comes down to framework and behaviour fit."
+          },
+          {
+            "q": "Does GPT-5.4 support prompt caching?",
+            "a": "Yes. Cached input bills at $0.25 per 1M tokens — a 10× discount on the cached portion."
+          },
+          {
+            "q": "What framework does GPT-5.4 use on VM0?",
+            "a": "Codex. VM0 routes all GPT-5 models through the Codex framework's Responses API surface."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-5",
+            "reason": "Escalation tier for the hardest steps"
+          },
+          { "slug": "gpt-5-4-mini", "reason": "Cheaper option for bulk work" },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "×1 peer on the Claude Code framework"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 sits at the ×1 baseline, same as Claude Sonnet 4.6, which makes the two cost-equivalent on VM0 Managed and easy to A/B against each other. Prompt caching is enabled by default. Pair with GPT-5.4 Mini for high-volume pre-filter work, and escalate to GPT-5.5 only for the steps that genuinely need the extra reasoning depth."
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -4736,6 +5059,157 @@
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and the Anthropic / Claude Code OAuth providers.",
         "vm0Notes": "Haiku 4.5 carries the lowest Claude multiplier (×0.3) and is the right pick for high-volume routing workloads, with prompt caching keeping the cost of repeated short prompts down. It doesn't carry Sonnet's multi-step agent quality, so design any Haiku-based agent to keep loops short and the tool surface narrow."
+      },
+      "gpt-5-4-mini": {
+        "name": "GPT-5.4 Mini",
+        "pageTitle": "GPT-5.4 Mini on VM0. The cost-saving GPT-5",
+        "tagline": "OpenAI's cost-optimised member of the GPT-5 family. ×0.3 credits, multimodal vision, and fast enough for high-volume routing, classification and pre-filter work.",
+        "cardIntro": "OpenAI's cost-saving GPT-5. ×0.3 credits, fast and multimodal — the right pick for bulk pre-filter work on the Codex framework.",
+        "metaTitle": "GPT-5.4 Mini on VM0: Benchmarks, Pricing & Comparison",
+        "metaDescription": "GPT-5.4 Mini review on VM0. The cost-saving OpenAI GPT-5 model at $0.75/$4.5 vendor pricing, ×0.3 credits, 400K context and multimodal vision. Specs, behaviour and comparison to Claude Haiku 4.5.",
+        "summary": "GPT-5.4 Mini is the cost-saving member of OpenAI's GPT-5 family — the one you reach for when unit cost matters more than peak reasoning quality. It keeps the 400K context window and multimodal inputs of the rest of the family but trims compute per token, which translates to lower price ($0.75 / $4.5 per 1M) and noticeably higher speed.\n\nOn VM0 it sits at ×0.3 credits, the same multiplier as Claude Haiku 4.5 and Kimi K2.6, which makes it the natural OpenAI-side pick for bulk classification, fan-out routing, pre-filters, and any agent step where dropping to a third of GPT-5.4's cost is the deciding factor.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Cost-saving variant of the GPT-5 family. The OpenAI-side peer of Claude Haiku 4.5.",
+        "background": [
+          "GPT-5.4 Mini is the cost-optimised member of OpenAI's GPT-5 generation, released in April 2026 alongside GPT-5.5 and GPT-5.4. OpenAI positions it as the high-throughput tier — the model you keep running on classification, routing and pre-filter steps where the bigger 5.4 or 5.5 would be wasted on routine decisions.",
+          "Architecturally it shares the GPT-5 family's 400K-token context window, the `reasoning_effort` parameter, prompt caching, and the Responses API surface that codex CLI uses by default. The trade-off versus 5.4 is reasoning depth: Mini handles standard tool calls, short summaries and structured-output workloads well, but starts to drift on the harder multi-step plans where 5.4 still holds up. The trade-off versus competitors at the same price point is ecosystem — if you're already on Codex, staying inside the OpenAI surface keeps tool definitions and structured-output schemas consistent.",
+          "On VM0 Mini sits at the ×0.3 credit multiplier, the same as Claude Haiku 4.5, Kimi K2.6 and DeepSeek V4 Pro. Within the cost-saving tier the choice depends mostly on framework and behaviour fit on your specific workload."
+        ],
+        "architecture": "GPT-5.4 Mini uses the same architecture as the rest of the GPT-5 family: 400K-token context window, the `reasoning_effort` parameter at four levels, prompt caching where cached input bills at one-tenth the input rate, and the Responses API surface. Tool-use, structured outputs and multimodal vision inputs are supported. The model is a smaller, faster sibling — fewer parameters per token, more throughput per dollar.",
+        "specs": [
+          { "label": "Family", "value": "GPT-5 generation" },
+          { "label": "Modalities", "value": "Text, vision, code" },
+          { "label": "Languages", "value": "English-first, multilingual" },
+          { "label": "Prompt caching", "value": "Supported (OpenAI)" },
+          { "label": "Context window", "value": "400K tokens" },
+          { "label": "Max output", "value": "Up to 128K tokens" },
+          {
+            "label": "Reasoning effort",
+            "value": "Minimal / Low / Medium / High"
+          },
+          {
+            "label": "Vendor list price",
+            "value": "$0.75 input / $4.5 output per 1M"
+          }
+        ],
+        "benchmarksNote": "Vendor-reported scores from OpenAI's GPT-5 Mini release materials. Independent reviews place 5.4 Mini in the same cost-saving band as Claude Haiku 4.5 on most agent benchmarks. Treat absolute percentages as directional.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~60%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~42%",
+            "note": "vendor-reported tool use"
+          },
+          {
+            "name": "AIME 2025 (no tools)",
+            "score": "~84%",
+            "note": "vendor-reported competition math"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~74%",
+            "note": "vendor-reported graduate science"
+          },
+          {
+            "name": "Speed",
+            "score": "~165 tokens/sec",
+            "note": "Artificial Analysis, medium effort"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Speed",
+            "body": "Fastest model in the GPT-5 family — around 165 tokens/sec at medium effort per Artificial Analysis. This is the property that makes it viable for interactive chat replies and short fan-out tool calls where user-visible latency dominates."
+          },
+          {
+            "title": "Routine tool calls",
+            "body": "Accurate on the standard Codex-framework tool catalogue. Where 5.4 pulls ahead is on hard edge cases (conditional tool selection, deeply nested arguments) — for the routine cases Mini handles tool routing cleanly at a third of the cost."
+          },
+          {
+            "title": "Bulk classification & pre-filter",
+            "body": "Strongest cost/quality position in the GPT-5 family for fan-out work. Bulk PR triage, support-ticket categorisation, document-tier classification — all the workloads where you'd previously have hand-rolled regex are now affordable in a real model call."
+          },
+          {
+            "title": "Cost efficiency",
+            "body": "×0.3 credits with multimodal vision included. At this price point Mini, Claude Haiku 4.5 and Kimi K2.6 all sit in the same band — the choice usually comes down to framework fit and behaviour on your specific workload."
+          },
+          {
+            "title": "When to escalate",
+            "body": "Mini drifts on long multi-step plans, hard reasoning and first-attempt multi-file code edits. Build the agent so the orchestrator decides when to escalate to 5.4 or 5.5, not so Mini tries to carry the whole loop."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The fan-out classifier that runs on every event",
+            "body": "Inbound support ticket, PR comment, sales-call transcript, document upload — Mini reads each one and routes it to the right downstream agent or human reviewer. ×0.3 credits and 165 tokens/sec mean the per-event cost is small enough that running it on every event (not just sampled batches) is actually viable."
+          },
+          {
+            "title": "The pre-filter step before the expensive model",
+            "body": "Pin Mini at the top of the agent's tool call so it decides whether the request even needs to escalate. Most requests get a fast cheap answer; only the residual minority pays the full GPT-5.4 or 5.5 cost. This is where stacking cost-saving and core tiers genuinely changes what's affordable."
+          },
+          {
+            "title": "The interactive chat reply",
+            "body": "Short multimodal turns where user-visible latency dominates the experience. Mini answers fast enough that streaming feels instant, and the multimodal support means a screenshot in the conversation Just Works."
+          }
+        ],
+        "avoidFor": "Skip GPT-5.4 Mini on the hardest reasoning, multi-step agent orchestration, computer-use sequences and first-attempt multi-file code edits — escalate to 5.4 for routine versions of those tasks and 5.5 for the hardest ones.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "Same family, different positioning. 5.4 Mini (×0.3) wins on cost and speed; 5.4 (×1) wins on reasoning quality and tool-routing accuracy on hard cases. The standard pattern is to pre-filter with Mini and escalate residual cases to 5.4."
+          },
+          {
+            "vs": "Claude Haiku 4.5",
+            "body": "Same multiplier (×0.3). Mini runs on the Codex framework; Haiku 4.5 runs on Claude Code. Both are multimodal and both target the same cost-saving slot. Pick by which framework your existing agents and tool definitions target."
+          },
+          {
+            "vs": "DeepSeek V4 Flash",
+            "body": "DeepSeek V4 Flash (×0.02) is dramatically cheaper at the vendor level and is the right choice for pure bulk single-shot work. GPT-5.4 Mini (×0.3) carries more reasoning quality and stays inside the OpenAI ecosystem, which matters when your tool definitions and structured-output schemas are already tuned for Codex."
+          }
+        ],
+        "verdict": "GPT-5.4 Mini is the cost-saving default on the OpenAI side. Pre-filter with Mini, escalate to GPT-5.4 for routine steps, escalate to GPT-5.5 only for the hardest reasoning.",
+        "faqs": [
+          {
+            "q": "What is GPT-5.4 Mini's context window?",
+            "a": "400,000 tokens, with up to 128K tokens of output per response — the same as the rest of the GPT-5 family."
+          },
+          {
+            "q": "Can GPT-5.4 Mini handle images?",
+            "a": "Yes. Like the rest of the GPT-5 family it accepts image inputs alongside text and code."
+          },
+          {
+            "q": "When should I pick GPT-5.4 Mini over Claude Haiku 4.5?",
+            "a": "When your agent is already built on the Codex framework or you need the OpenAI structured-output / tool-call ecosystem. Both sit at ×0.3 credits, so cost is identical and the choice comes down to framework and behaviour."
+          },
+          {
+            "q": "Does GPT-5.4 Mini support prompt caching?",
+            "a": "Yes. Cached input bills at $0.075 per 1M tokens — a 10× discount on the cached portion."
+          },
+          {
+            "q": "What framework does GPT-5.4 Mini use on VM0?",
+            "a": "Codex. VM0 routes all GPT-5 models through the Codex framework's Responses API surface."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-4",
+            "reason": "Step up for harder steps, same family"
+          },
+          {
+            "slug": "claude-haiku-4-5",
+            "reason": "×0.3 peer on the Claude Code framework"
+          },
+          {
+            "slug": "deepseek-v4-flash",
+            "reason": "Dramatically cheaper for pure bulk work"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Claude Haiku 4.5, Kimi K2.6 and DeepSeek V4 Pro. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
       },
       "kimi-k2-6": {
         "name": "Kimi K2.6",
@@ -5501,6 +5975,729 @@
         ],
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Default model on the DeepSeek provider; also available on VM0 Managed.",
         "vm0Notes": "V4 Flash carries the lowest credit multiplier of any Built-in model (×0.02), roughly 50× less than Sonnet 4.6. Cache reads bill while cache writes are free, and VM0 sets a 10-minute API timeout for the DeepSeek provider that pairs naturally with Flash's short single-shot work."
+      },
+      "gemini-2-5-flash-image": {
+        "name": "Gemini 2.5 Flash Image",
+        "pageTitle": "Gemini 2.5 Flash Image on VM0. The fast text-to-image default",
+        "tagline": "Google's fast text-to-image and image-edit model. Strong instruction following, character consistency, and the cheapest credit cost per image in the curated image lineup.",
+        "cardIntro": "Google's fast text-to-image model. Cheap, accurate at following long prompts, and good at preserving subjects across edits.",
+        "metaTitle": "Gemini 2.5 Flash Image on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "Gemini 2.5 Flash Image on VM0. Google's text-to-image and image-edit model with high instruction adherence, character consistency, and ~$0.04 per image. Compared with GPT Image 1, Flux Pro 1.1 Ultra and SeedDream 4.",
+        "summary": "Gemini 2.5 Flash Image is Google's everywhere-default text-to-image and image-edit model. It does well on the two properties that matter most for agent workloads: it follows long, structured prompts (so you can hand it the full brief without losing instructions on the way through), and it keeps subjects consistent across multi-turn edits (so an agent can iterate on the same character or product shot without it drifting between calls).\n\nList price is around $0.04 per 1024×1024 image, which makes it the cheapest model in the curated image lineup. The natural pattern is to default to Gemini 2.5 Flash Image and escalate to Flux Pro 1.1 Ultra or SeedDream 4 only when you need a specific aesthetic the default doesn't hit.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Google's text-to-image workhorse for agent workloads.",
+        "background": [
+          "Gemini 2.5 Flash Image is Google's text-to-image and image-edit model in the Gemini 2.5 family. Google's framing is the same as for the text-side Flash variant: a model tuned for high throughput at a low per-call cost, optimised for production workloads where the next request is queued before the last one finishes streaming.",
+          "Two behavioural properties stand out for agent use. First, instruction adherence on long structured prompts is materially better than on most open-weight text-to-image baselines, which matters when an agent is composing the prompt programmatically and can't shorten it. Second, character and subject consistency across multi-turn edits holds up well, which is what makes the model viable as the edit-loop default in agent workflows that iterate on a single asset."
+        ],
+        "architecture": "Diffusion-based text-to-image model with native edit support. Pricing bills per generated image at the standard tier. Inputs accept text prompts plus optional reference images for edit-style flows. Outputs are PNG at the requested resolution.",
+        "specs": [
+          { "label": "Family", "value": "Gemini 2.5 generation" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-image, image-to-image edit"
+          },
+          { "label": "Output resolution", "value": "1024×1024 standard tier" },
+          { "label": "Vendor list price", "value": "~$0.04 per image" },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Instruction adherence",
+            "body": "Holds up on long structured prompts where many open-weight models start dropping clauses. Useful when an agent composes the brief programmatically and the prompt is non-negotiable."
+          },
+          {
+            "title": "Character consistency",
+            "body": "Keeps subjects recognisable across multi-turn edits, which is the property that makes the model viable for iterative agent loops on a single asset."
+          },
+          {
+            "title": "Cost",
+            "body": "Around $0.04 per image — the cheapest of the curated text-to-image models on VM0. Bulk fan-out generation stays affordable."
+          },
+          {
+            "title": "Aesthetic ceiling",
+            "body": "Skews towards clean, accurate output rather than the hyper-stylised look of Flux Pro 1.1 Ultra or the photoreal look of SeedDream 4. Escalate when the aesthetic is the deliverable."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The agent that drafts marketing visuals from a brief",
+            "body": "Hand the agent the brand voice, product description and target audience; Gemini 2.5 Flash Image renders draft visuals in seconds. Cheap enough to fan-out a dozen variations and pick the best."
+          },
+          {
+            "title": "The edit loop that iterates on a single asset",
+            "body": "Generate once, then iterate on lighting, framing or background while keeping the subject consistent across turns. Character consistency means the human in the loop is editing the same image, not picking from a fresh set every turn."
+          },
+          {
+            "title": "The illustration pre-filter before the premium model",
+            "body": "Use Gemini 2.5 Flash Image to lock the composition cheaply, then re-render the final pick on Flux Pro 1.1 Ultra for the aesthetic. Cuts the cost of the premium step to one call instead of a fan-out."
+          }
+        ],
+        "avoidFor": "Skip Gemini 2.5 Flash Image when the deliverable is the aesthetic — Flux Pro 1.1 Ultra and SeedDream 4 carry more stylistic ceiling on photoreal and editorial looks.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 1 is stronger on stylised illustration and character work; Gemini 2.5 Flash Image is cheaper per call and stronger on long-prompt instruction following. For agent workloads with structured prompts, Gemini 2.5 Flash Image is the safer default."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 carries a higher photoreal ceiling; Gemini 2.5 Flash Image is cheaper, faster, and follows long prompts more reliably. Default to Gemini, escalate to SeedDream 4 when the brief is specifically a photo aesthetic."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultra has the highest stylistic ceiling in the curated lineup; Gemini 2.5 Flash Image wins on cost and on instruction following. Pre-filter with Gemini, deliver finals on Flux when the aesthetic is the point."
+          }
+        ],
+        "verdict": "Default to Gemini 2.5 Flash Image for text-to-image agent workloads. Escalate to Flux Pro 1.1 Ultra or SeedDream 4 only when the aesthetic is the deliverable.",
+        "faqs": [
+          {
+            "q": "Can Gemini 2.5 Flash Image edit existing images?",
+            "a": "Yes. It accepts a reference image alongside the text prompt and supports inpainting and outpainting flows for iterative edits."
+          },
+          {
+            "q": "What output resolution does it produce?",
+            "a": "1024×1024 at the standard tier. Higher resolutions are available at proportional cost."
+          },
+          {
+            "q": "How much does it cost per image?",
+            "a": "Around $0.04 per generated 1024×1024 image — the cheapest of the curated text-to-image models on VM0."
+          },
+          {
+            "q": "Is the model good at text inside images?",
+            "a": "Yes — significantly stronger than most open-weight baselines on rendering short text strings inside the generated image."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Higher aesthetic ceiling"
+          },
+          { "slug": "seedream-4", "reason": "Stronger photoreal results" }
+        ],
+        "routingNotes": "Routed to Google's Gemini 2.5 Flash Image endpoint and billed per generated image.",
+        "vm0Notes": "Gemini 2.5 Flash Image is the price/quality default for text-to-image agent workloads on VM0. Use it as the everywhere-default and reserve the more expensive image models for the steps where their stylistic ceiling actually matters."
+      },
+      "gpt-image-1": {
+        "name": "GPT Image 1",
+        "pageTitle": "GPT Image 1 on VM0. OpenAI's text-to-image model",
+        "tagline": "OpenAI's text-to-image model with strong stylised illustration and editing. The natural pick when you want OpenAI's aesthetic and prompt-following style.",
+        "cardIntro": "OpenAI's text-to-image model. Strong on stylised illustration, character work and editing — the OpenAI-side counterpart to Gemini 2.5 Flash Image.",
+        "metaTitle": "GPT Image 1 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "GPT Image 1 on VM0. OpenAI's text-to-image and image-edit model with stylised-illustration strength, multi-tier pricing, and comparison to Gemini 2.5 Flash Image, Flux Pro 1.1 Ultra and SeedDream 4.",
+        "summary": "GPT Image 1 is OpenAI's text-to-image model — the one most teams know as the model behind ChatGPT's image generation. Its strengths are stylised illustration, character work and image editing with text-driven masking, with prompt-following style that maps closely to what OpenAI's text models expect.\n\nList price is tier-based, from around $0.011 per image at the low/standard tier to $0.25 at the high/large tier. The medium-standard tier (around $0.05 per 1024×1024) is the sensible default for most agent workloads.",
+        "releaseDate": "April 2026",
+        "familyPosition": "OpenAI's primary text-to-image model. Tier-priced across resolution and quality settings.",
+        "background": [
+          "GPT Image 1 is OpenAI's production text-to-image model. It pairs natively with OpenAI's text models, so when an agent already runs on GPT-5.4 or GPT-5.5 the prompt style transfers cleanly and the edit-loop flow stays inside the OpenAI surface.",
+          "The model's stylistic strengths sit on illustration, character work and edits that preserve the original composition while changing a specific element. Photoreal output is solid but skews towards the OpenAI house style; teams that want a different aesthetic ceiling often reach for Flux Pro 1.1 Ultra or SeedDream 4 alongside it."
+        ],
+        "architecture": "Diffusion-based text-to-image with native edit support. Tier pricing scales by output resolution (standard / large) and quality (low / medium / high), with the medium/standard tier as the typical default. Inputs accept text plus optional reference images for edits and masks.",
+        "specs": [
+          { "label": "Family", "value": "OpenAI Images" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-image, image-to-image edit"
+          },
+          {
+            "label": "Output tiers",
+            "value": "Standard / Large × Low / Medium / High"
+          },
+          {
+            "label": "Vendor list price",
+            "value": "From $0.011 to $0.25 per image"
+          },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Stylised illustration",
+            "body": "One of the strongest models for non-photoreal output — illustration, comic-style, painterly. Good fit when the deliverable is an illustration rather than a photo."
+          },
+          {
+            "title": "Edit flows",
+            "body": "Native support for masked edits and text-driven local changes. Useful when an agent has to iterate on a specific region of an image rather than re-generating the whole thing."
+          },
+          {
+            "title": "Prompt style",
+            "body": "Maps closely to OpenAI's text models' expectations. When the calling agent is already on GPT-5.4 or GPT-5.5, the prompts written by that agent transfer with little adjustment."
+          },
+          {
+            "title": "Cost",
+            "body": "Tier-based — the medium/standard tier (~$0.05 per 1024×1024) is the typical default. The high/large tier hits $0.25 and is worth it only for delivery-grade output."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The illustration agent that delivers comic or hand-drawn style",
+            "body": "Stylised output is where GPT Image 1 carries a real edge. Comic panels, painterly illustrations, hand-drawn-look icons — all land more reliably here than on the photoreal-leaning alternatives."
+          },
+          {
+            "title": "The edit-loop agent on the OpenAI stack",
+            "body": "If the orchestrating agent is already on GPT-5.4 or GPT-5.5, keeping image generation inside the OpenAI surface (GPT Image 1) means the prompt style, edit semantics and structured outputs stay consistent across the run."
+          }
+        ],
+        "avoidFor": "Skip GPT Image 1 when cost dominates (Gemini 2.5 Flash Image is roughly half the price for the same default tier) or when the deliverable is specifically photoreal (SeedDream 4 carries a higher photoreal ceiling).",
+        "comparisons": [
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Image is cheaper and stronger on long structured prompts; GPT Image 1 is stronger on stylised illustration and integrates more naturally with OpenAI-stack agents."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 leads on photoreal aesthetic at a slightly lower price; GPT Image 1 leads on stylised illustration and edit flows."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultra carries the highest aesthetic ceiling for hero-shot deliverables; GPT Image 1 is the natural OpenAI-stack default for everything else."
+          }
+        ],
+        "verdict": "Pick GPT Image 1 when your agent is already on the OpenAI stack and you want stylised illustration or native edit flows. Escalate to Flux Pro 1.1 Ultra for photoreal hero shots; drop to Gemini 2.5 Flash Image when cost dominates.",
+        "faqs": [
+          {
+            "q": "How is GPT Image 1 priced?",
+            "a": "Tier-based — combinations of size (standard / large) and quality (low / medium / high). The medium/standard tier at ~$0.05 per 1024×1024 image is the typical default."
+          },
+          {
+            "q": "Does GPT Image 1 support image editing?",
+            "a": "Yes. It accepts a reference image plus an optional mask and supports text-driven local edits as well as outpainting."
+          },
+          {
+            "q": "Can GPT Image 1 render text inside images?",
+            "a": "Yes — short text strings render reliably; long text passages still struggle as with most diffusion models."
+          },
+          {
+            "q": "Is it multimodal as input?",
+            "a": "Image-to-image edits accept reference images. The model is image-output only."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Cheaper, stronger long-prompt adherence"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Higher photoreal aesthetic ceiling"
+          },
+          { "slug": "seedream-4", "reason": "Better photoreal default" }
+        ],
+        "routingNotes": "Routed to OpenAI's Images surface and billed per generated image at the selected tier.",
+        "vm0Notes": "GPT Image 1 is the OpenAI-stack default for stylised illustration and edit-loop agent workflows. The medium/standard tier is the sensible everywhere-default; reserve the high/large tier for delivery-grade output."
+      },
+      "flux-pro-1-1-ultra": {
+        "name": "Flux Pro 1.1 Ultra",
+        "pageTitle": "Flux Pro 1.1 Ultra on VM0. The aesthetic ceiling for hero shots",
+        "tagline": "Black Forest Labs' high-ceiling text-to-image model. The pick when the image is the deliverable and you need editorial- or photoreal-grade output.",
+        "cardIntro": "Black Forest Labs' top-tier image model. Highest aesthetic ceiling in the curated lineup — use it for hero shots and editorial-grade output.",
+        "metaTitle": "Flux Pro 1.1 Ultra on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "Flux Pro 1.1 Ultra on VM0. Black Forest Labs' top-tier text-to-image model with editorial-grade aesthetic ceiling, $0.072 per image, and comparison to GPT Image 1, SeedDream 4 and Gemini 2.5 Flash Image.",
+        "summary": "Flux Pro 1.1 Ultra is Black Forest Labs' top-tier text-to-image model — the one to reach for when the image itself is the deliverable, not a step in an agent loop. Output quality on editorial, photoreal and design-led aesthetics is the highest in the curated lineup, and prompt adherence on detailed compositional briefs holds up well.\n\nList price is $0.072 per image, which makes it expensive relative to Gemini 2.5 Flash Image ($0.04) or SeedDream 4 ($0.036), but the per-image quality lift is large enough that most teams use it as the final-render step after pre-filtering with a cheaper model.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Black Forest Labs' premium tier of the Flux 1.1 generation.",
+        "background": [
+          "Flux Pro 1.1 Ultra is Black Forest Labs' premium text-to-image model. The Flux family is known for the highest aesthetic ceiling at the open-weight frontier, and the Ultra variant is the production-grade tier with the most consistent compositional quality.",
+          "The model's strength sits on editorial and photoreal aesthetics — magazine-style hero shots, product photography, design-led illustrations. Prompt adherence on detailed compositional briefs (\"a low-angle shot of X in Y light against Z background\") is materially better than on most cheaper alternatives, which is part of why teams keep paying the premium for delivery-grade output."
+        ],
+        "architecture": "High-resolution diffusion model with prompt-following tuned for compositional fidelity. Billed per generated image. Inputs accept text prompts; produces high-resolution output suitable for delivery.",
+        "specs": [
+          { "label": "Family", "value": "Flux 1.1 Pro" },
+          { "label": "Modalities", "value": "Text-to-image" },
+          { "label": "Vendor list price", "value": "$0.072 per image" },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Aesthetic ceiling",
+            "body": "Highest in the curated image lineup. Hero-shot, editorial and photoreal aesthetics land more reliably here than on Gemini 2.5 Flash Image or GPT Image 1."
+          },
+          {
+            "title": "Compositional fidelity",
+            "body": "Strong on detailed compositional briefs that specify angle, lighting, framing and subject placement. Useful when the prompt is non-negotiable."
+          },
+          {
+            "title": "Cost",
+            "body": "$0.072 per image — roughly 2× Gemini 2.5 Flash Image and SeedDream 4. The standard pattern is to pre-filter with a cheaper model and render finals on Flux."
+          },
+          {
+            "title": "Speed",
+            "body": "Slower than the Flash-tier alternatives. Reserve it for the steps that justify the cost; don't use it in tight interactive loops."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The marketing hero shot that has to ship",
+            "body": "When the image is the final deliverable for a campaign, a landing page or a launch announcement, Flux Pro 1.1 Ultra's aesthetic ceiling justifies the premium."
+          },
+          {
+            "title": "The product-photography agent for ecommerce listings",
+            "body": "Catalogue-grade product photography from a text brief plus reference images. Compositional fidelity makes the difference between an image that ships and one that gets re-rendered."
+          },
+          {
+            "title": "The editorial illustration for long-form content",
+            "body": "Magazine-style hero illustrations for articles, blog posts and reports. Flux's stylistic ceiling sets it apart from the workhorse defaults."
+          }
+        ],
+        "avoidFor": "Skip Flux Pro 1.1 Ultra in fan-out loops where cost dominates — Gemini 2.5 Flash Image is roughly 2× cheaper per call. Use it as the final-render step rather than the iteration step.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "Flux Pro 1.1 Ultra has the higher photoreal and editorial ceiling; GPT Image 1 has stronger stylised-illustration output and native edit-flow support. Pick by deliverable."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "Both are photoreal-leaning. SeedDream 4 is cheaper and competitive on portrait and product work; Flux Pro 1.1 Ultra wins on hero-shot compositional fidelity at higher cost."
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Different roles. Gemini 2.5 Flash Image is the cheap workhorse for iteration; Flux Pro 1.1 Ultra is the premium final-render step. Stack them, don't pick one."
+          }
+        ],
+        "verdict": "Use Flux Pro 1.1 Ultra as the final-render step after pre-filtering with a cheaper model. The aesthetic ceiling justifies the premium when the image is the deliverable.",
+        "faqs": [
+          {
+            "q": "How much does Flux Pro 1.1 Ultra cost?",
+            "a": "$0.072 per generated image. Roughly 2× Gemini 2.5 Flash Image and SeedDream 4."
+          },
+          {
+            "q": "Does it support image editing?",
+            "a": "The Ultra tier is text-to-image first. For native masked-edit flows on the same family, the base Flux Pro 1.1 tier carries broader edit support at a lower aesthetic ceiling."
+          },
+          {
+            "q": "What aspect ratios are supported?",
+            "a": "Standard photographic and design aspect ratios up to high-resolution outputs suitable for delivery."
+          },
+          {
+            "q": "Is it good for stylised illustration?",
+            "a": "Possible but not its strongest suit — GPT Image 1 carries a higher stylised ceiling. Flux Pro 1.1 Ultra shines on photoreal and editorial work."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Cheap iteration default"
+          },
+          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
+          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+        ],
+        "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
+        "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with Gemini 2.5 Flash Image or SeedDream 4 for the cheap pre-filter."
+      },
+      "seedream-4": {
+        "name": "SeedDream 4",
+        "pageTitle": "SeedDream 4 on VM0. The photoreal text-to-image default",
+        "tagline": "ByteDance's SeedDream 4 text-to-image model. Strong photoreal aesthetic at a cost comparable to the cheapest options in the lineup.",
+        "cardIntro": "ByteDance's SeedDream 4. Photoreal aesthetic at a low per-image cost — the natural default when the brief is a photo.",
+        "metaTitle": "SeedDream 4 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "SeedDream 4 on VM0. ByteDance's text-to-image model with strong photoreal output, ~$0.036 per image, and comparison to Gemini 2.5 Flash Image, GPT Image 1 and Flux Pro 1.1 Ultra.",
+        "summary": "SeedDream 4 is ByteDance's text-to-image model in the Seedream V4 generation. Its standout property is the photoreal aesthetic — portraits, product shots, lifestyle photography — at a list price ($0.036 per image) that's competitive with the cheapest option in the curated lineup.\n\nIt's the natural default when the brief is specifically a photo. For stylised illustration or editorial design pick GPT Image 1 or Flux Pro 1.1 Ultra; for general iterative agent workloads on long structured prompts pick Gemini 2.5 Flash Image.",
+        "releaseDate": "April 2026",
+        "familyPosition": "ByteDance's photoreal text-to-image default in the Seedream V4 generation.",
+        "background": [
+          "SeedDream 4 is the fourth generation of ByteDance's text-to-image family. The aesthetic skews towards photoreal output, with portrait, product and lifestyle shots as the standout categories. Prompt adherence on standard descriptive briefs (subject, setting, lighting) is solid.",
+          "At $0.036 per image it sits near the bottom of the curated lineup on price, which is what makes it viable as the default for photo-leaning agent workloads. Switch to Flux Pro 1.1 Ultra when the compositional brief is specifically a hero shot that justifies the premium."
+        ],
+        "architecture": "Diffusion-based text-to-image model. Billed per generated image. Inputs accept text prompts; produces photoreal-leaning output suitable for portraits, products and lifestyle imagery.",
+        "specs": [
+          { "label": "Family", "value": "Seedream V4" },
+          { "label": "Modalities", "value": "Text-to-image" },
+          { "label": "Vendor list price", "value": "$0.036 per image" },
+          {
+            "label": "Languages",
+            "value": "Multilingual prompts (English + Chinese strong)"
+          },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Photoreal aesthetic",
+            "body": "Portraits, product shots and lifestyle photography are the standout categories. Output is competitive with Flux Pro 1.1 Ultra on a meaningful share of photoreal briefs and dramatically cheaper per call."
+          },
+          {
+            "title": "Cost",
+            "body": "$0.036 per image — near the bottom of the curated lineup. The natural default for photo-leaning fan-out workloads."
+          },
+          {
+            "title": "Chinese-language prompts",
+            "body": "Strong handling of Chinese-language prompts and culturally-anchored subjects, which is a real advantage for agents serving Chinese-speaking users."
+          },
+          {
+            "title": "Aesthetic ceiling",
+            "body": "Solid for everything in the photoreal lane; less of a fit for hyper-stylised illustration where GPT Image 1 leads."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The portrait or product-shot agent at scale",
+            "body": "Photoreal subjects at a low per-image cost make SeedDream 4 viable for fan-out workloads — a hundred product photos for a catalogue, batch portrait generation for a creator tool."
+          },
+          {
+            "title": "The Chinese-language marketing agent",
+            "body": "Strong handling of Chinese prompts and culturally-anchored subjects. The right default for agents serving Chinese-speaking markets."
+          },
+          {
+            "title": "The cheaper alternative to Flux Pro 1.1 Ultra",
+            "body": "When the brief is photoreal but the deliverable doesn't justify the Flux premium, SeedDream 4 carries most of the quality at half the price."
+          }
+        ],
+        "avoidFor": "Skip SeedDream 4 for stylised illustration (GPT Image 1 leads), long structured-prompt iteration (Gemini 2.5 Flash Image leads), or hero-shot editorial work where the Flux premium is justified.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "SeedDream 4 leads on photoreal aesthetic at lower cost; GPT Image 1 leads on stylised illustration and native edit flows."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Both photoreal-leaning. SeedDream 4 is half the price and competitive on portrait and product work; Flux Pro 1.1 Ultra wins on hero-shot compositional fidelity."
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Image is the cheap general-purpose default with stronger long-prompt instruction following; SeedDream 4 is the photoreal-specific default with a higher ceiling on photo briefs."
+          }
+        ],
+        "verdict": "Default to SeedDream 4 when the brief is specifically a photo and cost matters. Escalate to Flux Pro 1.1 Ultra only when the hero shot justifies the premium.",
+        "faqs": [
+          {
+            "q": "How much does SeedDream 4 cost?",
+            "a": "$0.036 per generated image — near the bottom of the curated lineup on price."
+          },
+          {
+            "q": "Is it good at Chinese prompts?",
+            "a": "Yes — significantly stronger than most Western-trained baselines on Chinese-language prompts and culturally-anchored subjects."
+          },
+          {
+            "q": "What's its strongest aesthetic?",
+            "a": "Photoreal: portraits, product shots, lifestyle photography. Less of a fit for stylised illustration."
+          },
+          {
+            "q": "Does it support image editing?",
+            "a": "The curated entry on VM0 covers text-to-image. Edit flows are not the model's primary strength."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Cheaper general-purpose default"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Premium hero-shot quality"
+          },
+          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" }
+        ],
+        "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
+        "vm0Notes": "SeedDream 4 is the photoreal-specific default in the curated image lineup. Pair it with Flux Pro 1.1 Ultra for hero shots and with Gemini 2.5 Flash Image for non-photo iteration."
+      },
+      "veo-3-1-fast": {
+        "name": "Veo 3.1 Fast",
+        "pageTitle": "Veo 3.1 Fast on VM0. Google's fast text-to-video model",
+        "tagline": "Google's fast text-to-video model with native audio. The pick for short-form social and product clips where cinematic quality and audio in one pass matter.",
+        "cardIntro": "Google's text-to-video model with native audio. Fast generation, cinematic style and synchronised soundtrack in a single pass.",
+        "metaTitle": "Veo 3.1 Fast on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "Veo 3.1 Fast on VM0. Google's fast text-to-video model with native audio, 4–8 second clips up to 4K, and comparison to Kling V3 4K and Dreamina Seedance 2.0.",
+        "summary": "Veo 3.1 Fast is the fast tier of Google's Veo 3 video generation family. It generates short clips (4 / 6 / 8 seconds) at 720p, 1080p or 4K, and renders synchronised native audio — voice, ambient sound and effects — in the same pass as the visuals. That single-pass audio is the property that sets it apart from most alternatives in the curated lineup.\n\nList price is on the order of $0.15 per second of 720p output with audio, which puts it in the middle of the lineup on cost. The natural pattern is to default to Veo 3.1 Fast for social and product clips where audio matters, switch to Dreamina Seedance 2.0 when cost dominates, and switch to Kling V3 4K when you need a longer or higher-resolution shot.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Fast tier of Google's Veo 3 family. Optimised for short-form output with native audio.",
+        "background": [
+          "Veo 3.1 is Google's video generation family in the Veo 3 generation, and the Fast tier is the throughput-optimised variant — quicker generation, lower cost per clip, but capped at short clip durations. Native audio support is the signature property: voice, ambient sound and effects render in the same pass as the visuals rather than being added as a separate post step.",
+          "Veo's output skews towards a cinematic look — clean motion, considered framing, accurate lighting. It's strong on text-to-video briefs that describe a single shot in detail (camera angle, subject action, setting, lighting), less of a fit for highly stylised or anime-style aesthetics where Kling V3 4K's stylistic ceiling pulls ahead."
+        ],
+        "architecture": "Text-to-video and image-to-video diffusion model with native audio synthesis in the same pass. Output durations are 4, 6 or 8 seconds at 720p, 1080p or 4K. Billed per generated video-second with quality-tier modifiers.",
+        "specs": [
+          { "label": "Family", "value": "Google Veo 3" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-video, image-to-video, native audio"
+          },
+          { "label": "Clip durations", "value": "4s / 6s / 8s" },
+          { "label": "Output resolutions", "value": "720p / 1080p / 4K" },
+          {
+            "label": "Vendor list price",
+            "value": "~$0.15 per second (720p + audio)"
+          },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Native audio",
+            "body": "The signature property. Voice, ambient sound and effects render in the same pass as the visuals — no separate post step needed. The right default for social and product clips where audio matters."
+          },
+          {
+            "title": "Cinematic motion",
+            "body": "Output skews towards clean motion, considered framing and accurate lighting. Strong on text-to-video briefs that describe a single shot in detail."
+          },
+          {
+            "title": "Speed",
+            "body": "Fast tier — generation is materially quicker than the standard Veo 3 tier at the cost of slightly lower fidelity on the most demanding briefs."
+          },
+          {
+            "title": "Aesthetic ceiling",
+            "body": "Cinematic / photoreal lane is the sweet spot. For stylised or anime-style output Kling V3 4K's stylistic ceiling is higher."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The social-clip agent that ships in one pass",
+            "body": "Short-form social video with voice and ambient sound generated in a single call. No separate TTS or audio-post step, no syncing — the clip lands ready to publish."
+          },
+          {
+            "title": "The product-demo video for a landing page",
+            "body": "8-second product clip at 1080p with a voice-over describing the feature. Cinematic motion and synchronised audio make the result feel produced rather than generated."
+          },
+          {
+            "title": "The image-to-video step on a campaign",
+            "body": "Start from a still hero image rendered on Flux Pro 1.1 Ultra or SeedDream 4 and extend to a short motion clip. Image conditioning keeps the look consistent."
+          }
+        ],
+        "avoidFor": "Skip Veo 3.1 Fast when the brief is stylised or anime-style (Kling V3 4K's ceiling is higher), when you need a longer clip than 8 seconds, or when cost dominates and the audio property doesn't matter (Dreamina Seedance 2.0 is roughly 3× cheaper).",
+        "comparisons": [
+          {
+            "vs": "Kling V3 4K",
+            "body": "Veo 3.1 Fast leads on native audio and cinematic / photoreal aesthetics; Kling V3 4K leads on stylised / anime output and on longer clip durations at 4K. Pick by aesthetic."
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "Different positioning. Dreamina Seedance 2.0 is roughly 3× cheaper per second and is the right pick when cost dominates; Veo 3.1 Fast carries the native-audio and cinematic-motion lead."
+          }
+        ],
+        "verdict": "Default to Veo 3.1 Fast for short-form social and product clips where audio matters. Switch to Kling V3 4K for stylised output or longer durations; switch to Dreamina Seedance 2.0 when cost dominates.",
+        "faqs": [
+          {
+            "q": "Does Veo 3.1 Fast generate audio?",
+            "a": "Yes. Native audio — voice, ambient sound, effects — renders in the same pass as the visuals."
+          },
+          {
+            "q": "What clip durations are supported?",
+            "a": "4, 6 or 8 seconds. For longer shots, switch to Kling V3 4K."
+          },
+          {
+            "q": "What resolutions does it support?",
+            "a": "720p, 1080p and 4K. Cost scales with resolution and duration."
+          },
+          {
+            "q": "Does it accept image conditioning?",
+            "a": "Yes — image-to-video flows let you start from a still and extend to a short motion clip."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "kling-v3-4k",
+            "reason": "Stylised / anime ceiling, longer clips"
+          },
+          { "slug": "dreamina-seedance-2-0", "reason": "Cheaper per second" }
+        ],
+        "routingNotes": "Routed to Google's Veo 3.1 Fast video generation endpoint and billed per generated video-second with quality-tier modifiers.",
+        "vm0Notes": "Veo 3.1 Fast is the cinematic / audio-bearing default in the curated video lineup on VM0. Pair it with Dreamina Seedance 2.0 for cheap iteration and with Kling V3 4K for stylised or longer-form clips."
+      },
+      "kling-v3-4k": {
+        "name": "Kling V3 4K",
+        "pageTitle": "Kling V3 4K on VM0. The 4K text-to-video ceiling",
+        "tagline": "Kuaishou's Kling V3 4K text-to-video model. The pick when you need long clips, 4K resolution, or a stylised aesthetic the other models don't reach.",
+        "cardIntro": "Kuaishou's Kling V3 4K. Stylised aesthetic, long clips up to 15 seconds, 4K output — the ceiling for editorial and anime-style video.",
+        "metaTitle": "Kling V3 4K on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "Kling V3 4K on VM0. Kuaishou's text-to-video model with 4K resolution, 3–15 second clips, stylised aesthetic ceiling, and comparison to Veo 3.1 Fast and Dreamina Seedance 2.0.",
+        "summary": "Kling V3 4K is Kuaishou's top-tier text-to-video model. The standout properties are clip duration (up to 15 seconds, versus Veo 3.1 Fast's 8-second cap), 4K resolution as the standard tier, and a stylistic ceiling on anime-style and editorial aesthetics that the cinematic-leaning alternatives don't reach.\n\nList price is on the order of $0.28 per second of 4K output, which makes it the most expensive option in the curated video lineup. The natural pattern is to reach for it when you need long or 4K shots, or when the brief is specifically stylised and the alternatives' aesthetic ceiling doesn't hit.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Top-tier of Kuaishou's Kling V3 generation. 4K and long-clip ceiling.",
+        "background": [
+          "Kling V3 4K is the high-end variant of Kuaishou's Kling V3 video generation family. It carries the longest standard clip durations in the curated lineup (3 to 15 seconds), native 4K output at the standard tier, and a stylistic ceiling on anime and editorial aesthetics that the cinematic-leaning alternatives don't reach.",
+          "The model's strength is on stylised and editorial briefs — anime-style sequences, dance and motion-heavy clips, music-video aesthetics. For cinematic photoreal output Veo 3.1 Fast is comparable at lower cost and with native audio; for bulk cost-driven generation Dreamina Seedance 2.0 is dramatically cheaper. Kling V3 4K's role is the high-ceiling, long-clip step rather than the everywhere default."
+        ],
+        "architecture": "Text-to-video and image-to-video diffusion model. Standard tier renders at 4K with clip durations from 3 to 15 seconds. Billed per generated video-second.",
+        "specs": [
+          { "label": "Family", "value": "Kling V3" },
+          { "label": "Modalities", "value": "Text-to-video, image-to-video" },
+          { "label": "Clip durations", "value": "3 to 15 seconds" },
+          { "label": "Output resolution", "value": "4K (standard tier)" },
+          { "label": "Vendor list price", "value": "~$0.28 per second (4K)" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Clip duration",
+            "body": "Up to 15 seconds at the standard tier — the longest in the curated lineup. The right pick when a single uninterrupted shot longer than 8 seconds matters."
+          },
+          {
+            "title": "4K resolution",
+            "body": "Native 4K at the standard tier rather than a high-tier upcharge. Useful when the deliverable is large-format display or cinema-quality output."
+          },
+          {
+            "title": "Stylised aesthetic ceiling",
+            "body": "Strong on anime, dance, motion-heavy and editorial aesthetics. This is where Kling pulls ahead of the cinematic-leaning alternatives."
+          },
+          {
+            "title": "Cost",
+            "body": "~$0.28 per second — the most expensive option in the curated lineup. Reserve it for the steps where its ceiling justifies the premium."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The anime-style or stylised social clip",
+            "body": "Stylised aesthetics — anime, motion-design-led, music-video style — are where Kling carries a real ceiling advantage. The cinematic-leaning alternatives don't reach the same look."
+          },
+          {
+            "title": "The long uninterrupted shot",
+            "body": "When the brief calls for a single 12 to 15 second shot rather than a cut between shorter clips, Kling V3 4K is the only option in the curated lineup that hits the duration cap."
+          },
+          {
+            "title": "The 4K deliverable for large-format display",
+            "body": "Native 4K at the standard tier makes Kling the right pick when the output is destined for a billboard, cinema, or large-format social campaign."
+          }
+        ],
+        "avoidFor": "Skip Kling V3 4K when the brief is cinematic photoreal with audio (Veo 3.1 Fast is more natural at lower cost) or when cost dominates (Dreamina Seedance 2.0 is roughly 5× cheaper per second).",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Veo 3.1 Fast leads on native audio and cinematic / photoreal aesthetics; Kling V3 4K leads on stylised / anime output, on longer clip durations and on native 4K output. Pick by aesthetic and duration."
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "Different cost tiers. Dreamina Seedance 2.0 is dramatically cheaper and the right pick when cost dominates; Kling V3 4K carries the ceiling on duration, 4K and stylised aesthetic."
+          }
+        ],
+        "verdict": "Pick Kling V3 4K for stylised, long, or 4K video deliverables. Switch to Veo 3.1 Fast for cinematic clips with audio; switch to Dreamina Seedance 2.0 for cost-driven fan-out.",
+        "faqs": [
+          {
+            "q": "What's the longest clip Kling V3 4K can generate?",
+            "a": "15 seconds at the standard tier — the longest single shot in the curated video lineup on VM0."
+          },
+          {
+            "q": "Does Kling V3 4K support audio?",
+            "a": "Not natively in the same pass. For video with synchronised audio in one call, use Veo 3.1 Fast."
+          },
+          {
+            "q": "What resolution does Kling produce?",
+            "a": "4K at the standard tier. Lower-resolution variants are available on the same family at lower cost."
+          },
+          {
+            "q": "Does it accept image conditioning?",
+            "a": "Yes — image-to-video flows let you start from a reference still and extend to a longer motion clip."
+          }
+        ],
+        "alternatives": [
+          { "slug": "veo-3-1-fast", "reason": "Cinematic / native audio" },
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "Cheaper bulk generation"
+          }
+        ],
+        "routingNotes": "Routed to Kuaishou's Kling V3 4K endpoint and billed per generated video-second.",
+        "vm0Notes": "Kling V3 4K is the high-ceiling option in the curated video lineup on VM0. Reserve it for stylised, long-form or 4K deliverables — for the everywhere-default reach for Veo 3.1 Fast or Dreamina Seedance 2.0."
+      },
+      "dreamina-seedance-2-0": {
+        "name": "Dreamina Seedance 2.0",
+        "pageTitle": "Dreamina Seedance 2.0 on VM0. The cost-optimised video model",
+        "tagline": "ByteDance's Dreamina Seedance 2.0 video model. The right default when cost dominates — dramatically cheaper per second than the alternatives.",
+        "cardIntro": "ByteDance's Dreamina Seedance 2.0. Cheapest per-second video in the curated lineup — the right pick for bulk and cost-driven generation.",
+        "metaTitle": "Dreamina Seedance 2.0 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "Dreamina Seedance 2.0 on VM0. ByteDance's text-to-video model with the cheapest per-second cost in the curated lineup, 4–15 second clips up to 1080p, and comparison to Veo 3.1 Fast and Kling V3 4K.",
+        "summary": "Dreamina Seedance 2.0 is the cost-optimised member of ByteDance's Seedance video family. Output durations run 4 to 15 seconds at 480p, 720p or 1080p, with text-to-video and image-to-video flows. The standout property is cost — roughly $0.05 per second of 1080p output with image conditioning, dramatically cheaper than Veo 3.1 Fast or Kling V3 4K.\n\nIt's the natural default when cost dominates: bulk fan-out generation, social-clip variants, draft passes before a premium final render. For native audio reach for Veo 3.1 Fast; for stylised long-form output reach for Kling V3 4K.",
+        "releaseDate": "April 2026",
+        "familyPosition": "Cost-optimised tier of ByteDance's Seedance video family.",
+        "background": [
+          "Dreamina Seedance 2.0 is the second-generation Seedance video model from ByteDance, paired with a Fast variant and a Pro variant in the same family. The Standard 2.0 entry in the curated lineup is the cost/quality sweet spot — cheaper than the Pro tier, materially higher quality than the Fast tier.",
+          "The model handles text-to-video and image-to-video flows at durations from 4 to 15 seconds at 480p, 720p or 1080p. Output skews towards consumer-friendly aesthetics: short-form social, lifestyle, product clips. Not the ceiling for cinematic or stylised work, but the cheapest viable option in the curated lineup."
+        ],
+        "architecture": "Text-to-video and image-to-video diffusion model with three quality tiers (Fast, Standard, Pro). The curated entry covers the Standard 2.0 tier. Billed per generated video-second with modifiers for resolution and whether image conditioning is used.",
+        "specs": [
+          { "label": "Family", "value": "Seedance 2.0" },
+          { "label": "Modalities", "value": "Text-to-video, image-to-video" },
+          { "label": "Clip durations", "value": "4 to 15 seconds" },
+          { "label": "Output resolutions", "value": "480p / 720p / 1080p" },
+          {
+            "label": "Vendor list price",
+            "value": "~$0.05 per second (1080p + image)"
+          },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Cost",
+            "body": "Cheapest per-second video model in the curated lineup. Roughly 3× cheaper than Veo 3.1 Fast and 5× cheaper than Kling V3 4K."
+          },
+          {
+            "title": "Speed",
+            "body": "Fast generation at the Standard tier — comparable to the cheaper Fast variant of the same family with materially better quality."
+          },
+          {
+            "title": "Image-to-video",
+            "body": "Strong handling of image-conditioning flows. Useful when an agent wants to extend a still image (generated cheaply on Gemini 2.5 Flash Image or SeedDream 4) into a short motion clip."
+          },
+          {
+            "title": "Aesthetic ceiling",
+            "body": "Lower than Veo 3.1 Fast on cinematic motion and lower than Kling V3 4K on stylised aesthetics. The right pick when cost is the deciding factor, not the ceiling."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The bulk fan-out video generation step",
+            "body": "Per-second cost low enough to make generating a dozen variants of the same clip viable. Pre-filter cheaply, then escalate the chosen variant to Veo 3.1 Fast or Kling V3 4K for the final render if quality justifies it."
+          },
+          {
+            "title": "The image-to-video extension on a campaign",
+            "body": "Start from a still hero image and extend to a short motion clip without paying the premium tier price. Image conditioning keeps the look consistent."
+          },
+          {
+            "title": "The draft pass before the premium render",
+            "body": "Lock the motion, framing and pacing cheaply on Dreamina Seedance 2.0, then re-render the final on Veo 3.1 Fast or Kling V3 4K only on the chosen variant."
+          }
+        ],
+        "avoidFor": "Skip Dreamina Seedance 2.0 when native audio matters (Veo 3.1 Fast), when stylised or anime aesthetics matter (Kling V3 4K), or when the brief is delivery-grade cinematic where the alternatives' ceiling justifies their premium.",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Different positioning. Veo 3.1 Fast carries native audio and cinematic motion; Dreamina Seedance 2.0 is dramatically cheaper and is the right pick when cost dominates. Stack them — draft on Dreamina, final on Veo."
+          },
+          {
+            "vs": "Kling V3 4K",
+            "body": "Different tiers entirely. Kling V3 4K is the ceiling on duration, 4K and stylised aesthetic; Dreamina Seedance 2.0 is the cheap default for everything else."
+          }
+        ],
+        "verdict": "Default to Dreamina Seedance 2.0 when cost dominates the video generation step. Stack with Veo 3.1 Fast for audio finals and Kling V3 4K for stylised or 4K hero output.",
+        "faqs": [
+          {
+            "q": "How much does Dreamina Seedance 2.0 cost per second?",
+            "a": "Around $0.05 per second of 1080p output with image conditioning — the cheapest in the curated video lineup."
+          },
+          {
+            "q": "Does it support audio?",
+            "a": "Not natively in the same pass. For video with synchronised audio in one call, use Veo 3.1 Fast."
+          },
+          {
+            "q": "What clip durations and resolutions are supported?",
+            "a": "4 to 15 second clips at 480p, 720p or 1080p."
+          },
+          {
+            "q": "Is there a higher-quality tier of Seedance on VM0?",
+            "a": "The Seedance family includes Fast and Pro variants alongside the Standard 2.0 entry. Pricing scales with the tier; the Standard tier is the cost/quality sweet spot."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "Native audio, cinematic motion"
+          },
+          { "slug": "kling-v3-4k", "reason": "Stylised, longer, 4K" }
+        ],
+        "routingNotes": "Routed to ByteDance's Dreamina Seedance 2.0 endpoint and billed per generated video-second with resolution and image-conditioning modifiers.",
+        "vm0Notes": "Dreamina Seedance 2.0 is the cost-optimised default in the curated video lineup on VM0. The standard pattern is to use it for iteration and fan-out, then escalate the chosen variant to Veo 3.1 Fast or Kling V3 4K only when the final render justifies the premium."
       }
     }
   },

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -3862,10 +3862,10 @@
     "back": "← Atrás"
   },
   "models": {
-    "listingPageTitle": "Modelos — Ejecuta agentes en Claude y más",
-    "listingPageDescription": "Todos los modelos de IA disponibles para agentes VM0 — Claude Opus 4.7, Sonnet 4.6, Haiku 4.5 y más. Breve introducción y para qué es mejor cada modelo en VM0.",
+    "listingPageTitle": "Modelos — Razonamiento, imagen y vídeo en VM0",
+    "listingPageDescription": "Cada modelo de IA disponible para agentes VM0 — modelos de razonamiento de Anthropic, OpenAI, DeepSeek, Moonshot y más, además de modelos de generación de imagen y vídeo. Breve introducción y para qué es mejor cada modelo en VM0.",
     "jsonLdListName": "Modelos de IA disponibles en VM0",
-    "jsonLdListDescription": "Todos los modelos de IA disponibles para agentes VM0 — Claude y más.",
+    "jsonLdListDescription": "Cada modelo de IA disponible para agentes VM0 — razonamiento, imagen y vídeo.",
     "breadcrumbHome": "Inicio",
     "breadcrumbModels": "Modelos",
     "notFound": "No encontrado",
@@ -3873,9 +3873,9 @@
     "heroDescription": "Cada modelo disponible para tus agentes. En qué destaca y cuándo elegirlo.",
     "filterAriaLabel": "Filtrar modelos",
     "filterAll": "Todos",
-    "filterRecommended": "Recomendados",
-    "filterMultimodal": "Multimodal",
-    "filterCostSaving": "Ahorro",
+    "filterReasoning": "Reasoning",
+    "filterImage": "Imagen",
+    "filterVideo": "Vídeo",
     "readMoreAbout": "Más sobre {name}",
     "backToAllModels": "Todos los modelos",
     "useModelButton": "Usar {name} en VM0",
@@ -3914,6 +3914,14 @@
     "tierExplanationCore": "VM0 posiciona {name} como modelo principal de agente, recomendado junto a Claude Opus 4.7, Claude Opus 4.6 y Claude Sonnet 4.6 para los pasos que determinan el resultado real de una ejecución. Estos son los modelos que elegimos para el rol de orquestador, para agentes que trabajan con código y para cualquier paso donde una respuesta incorrecta sea costosa.",
     "tierExplanationCostSaving": "VM0 posiciona {name} como una opción de ahorro en lugar de un modelo principal de agente. Úsalo para optimizar el coste unitario en trabajo no principal, como clasificación masiva, prefiltros, respuestas cortas con requisitos de latencia o agentes heredados fijos, manteniendo Claude Opus 4.7, Claude Opus 4.6 o Claude Sonnet 4.6 en los pasos que deciden la ejecución.",
     "availableSince": "Disponible en VM0 desde {date}.",
+    "generationPricingSubtitle": "Precio listado por unidad generada.",
+    "generationPricingDetail": "Detalle",
+    "generationUnitImage": "Por imagen generada",
+    "generationUnitMegapixel": "Por megapíxel de salida",
+    "generationUnitVideoSecond": "Por segundo de vídeo",
+    "generationUnitAudioSecond": "Por segundo de audio",
+    "generationAccessHeading": "Usar {name} en VM0",
+    "generationAccessBody": "Los agentes de VM0 pueden invocar {name} como parte de una ejecución de agente, facturado contra tus créditos VM0. El precio listado arriba es lo que cobra el proveedor upstream; VM0 lo traslada con la conversión estándar de créditos.",
     "content": {
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
@@ -4287,6 +4295,168 @@
         "routingNotes": "Enrutado directamente a la API Messages de Anthropic. Disponible en VM0 Managed y como el modelo predeterminado en los proveedores de clave API de Anthropic y OAuth de Claude Code.",
         "vm0Notes": "Opus 4.6 tiene el precio de lista de proveedor más alto por token de cualquier modelo Built-in, por lo que el caché de prompts importa aquí más que en cualquier otro lugar y está activado por defecto. Sigue siendo el modelo predeterminado en los proveedores de clave API de Anthropic y OAuth de Claude Code, lo que significa que probablemente es el modelo para el que tu equipo ya tiene memoria muscular, aunque Opus 4.7 sea la opción recomendada para nuevo trabajo."
       },
+      "gpt-5-5": {
+        "name": "GPT-5.5",
+        "pageTitle": "GPT-5.5 en VM0. El modelo de razonamiento insignia de OpenAI",
+        "tagline": "El buque insignia de OpenAI de la familia GPT-5. La opción más potente para codificación agéntica, razonamiento profundo y bucles de computer-use en el nivel OpenAI.",
+        "cardIntro": "El modelo de razonamiento insignia de OpenAI. Codificación y Tool-Use de primer nivel, enrutado a través del framework Codex en VM0.",
+        "metaTitle": "GPT-5.5: Benchmarks, Precios y Capacidades",
+        "metaDescription": "Reseña de GPT-5.5. El modelo de razonamiento insignia GPT-5 de OpenAI con contexto de 400K, visión multimodal, precio del proveedor de $5/$30, y liderazgo en benchmarks en SWE-bench Verified, AIME 2025 y GPQA Diamond.",
+        "summary": "GPT-5.5 es el modelo al que recurres cuando el trabajo requiere tanto razonamiento profundo como uso fiable de herramientas: orquestar bucles de agente de múltiples pasos, ediciones de código que deben salir bien al primer intento y flujos de computer-use que abarcan muchas acciones de GUI. Los benchmarks del proveedor (SWE-bench Verified, AIME 2025, GPQA Diamond) ponen cifras concretas a las mejoras sobre GPT-5.4.\n\nEl precio de lista del proveedor es de $5 / $30 por 1M tokens con entrada cacheada a $0,50 / 1M. Es el modelo más caro del catálogo Built-in de VM0 a ×2 créditos, por lo que el patrón rentable es mantener GPT-5.4 o Claude Sonnet 4.6 como predeterminado universal y enrutar solo los pasos más difíciles a GPT-5.5.",
+        "releaseDate": "Abril 2026 (sucediendo a GPT-5.4)",
+        "familyPosition": "Nivel superior de la familia GPT-5. El buque insignia de OpenAI para codificación agéntica y razonamiento.",
+        "background": [
+          "GPT-5.5 es el buque insignia de la generación GPT-5 de OpenAI, lanzado en abril de 2026 como la actualización recomendada desde GPT-5.4. OpenAI lo presenta como una mejora sustancial en uso agéntico de herramientas y tareas de computer-use, no como un simple refresco de la API superficial. La ventana de contexto de 400K tokens y el parámetro reasoning_effort introducidos con GPT-5 se mantienen sin cambios, por lo que los agentes Codex existentes funcionan sin reescrituras.",
+          "En comparación con GPT-5.4 (el caballo de batalla de la misma familia), GPT-5.5 invierte más cómputo por token en razonamiento. El beneficio práctico se manifiesta en tres áreas: parches de código significativamente mejores al primer intento en refactorizaciones multi-archivo, materialmente menos llamadas a herramientas mal enrutadas en bucles de agente largos y mejoras notables en razonamiento científico de nivel posgrado (GPQA Diamond) y matemáticas de competición (AIME 2025). El compromiso es el precio de lista más alto entre las variantes GPT-5 ($5 / $30 por 1M tokens) y un multiplicador de ×2 créditos en VM0, razón por la cual OpenAI mismo posiciona a GPT-5.5 como el planificador o nivel de escalación en lugar del predeterminado universal.",
+          "Los rankings independientes (Artificial Analysis, Vellum) corroboran el orden relativo frente a GPT-5.4 y sitúan a GPT-5.5 a pocos puntos de Claude Opus 4.7 en la mayoría de tareas de codificación agéntica. Las cifras absolutas cambian semanalmente y OpenAI mismo ha señalado contaminación de datos de entrenamiento en SWE-bench Verified en todos los modelos frontera. Trata las puntuaciones públicas como direccionales en lugar de autoritativas; las diferencias estructurales de comportamiento (precisión de llamada a herramientas, fiabilidad de computer-use, calidad de parche al primer intento) son la señal más duradera."
+        ],
+        "architecture": "GPT-5.5 mantiene la ventana de contexto de 400K tokens de GPT-5.4, facturada a precio de entrada estándar en toda la ventana. Soporta el parámetro `reasoning_effort` en cuatro niveles (mínimo, bajo, medio, alto), Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie de la Responses API que usa el codex CLI por defecto. Tool-Use, salidas estructuradas y computer-use no cambian respecto a 5.4. Las entradas son multimodales: texto, visión y código; el modelo no tiene generación nativa de imágenes (usa la Images API para eso).",
+        "specs": [
+          { "label": "Familia", "value": "Generación GPT-5" },
+          { "label": "Modalidades", "value": "Texto, visión, código" },
+          { "label": "Idiomas", "value": "Inglés primero, multilingüe" },
+          { "label": "Prompt Caching", "value": "Soportado (OpenAI)" },
+          { "label": "Ventana de contexto", "value": "400K tokens" },
+          { "label": "Salida máxima", "value": "Hasta 128K tokens" },
+          {
+            "label": "Reasoning effort",
+            "value": "Mínimo / Bajo / Medio / Alto"
+          },
+          {
+            "label": "Precio listado",
+            "value": "$5 entrada / $30 salida por 1M"
+          }
+        ],
+        "benchmarksNote": "Puntuaciones reportadas por el proveedor de los materiales de lanzamiento de GPT-5.5 de OpenAI, con deltas mostrados contra las cifras públicas de GPT-5.4. Las reseñas independientes sitúan a 5.5 a pocos puntos de Claude Opus 4.7 en tareas de codificación agéntica. Trata los porcentajes absolutos como direccionales; OpenAI ha señalado contaminación de datos de entrenamiento en SWE-bench Verified en todos los modelos frontera.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~82%",
+            "note": "reportado por el proveedor; sube desde 74,9% de 5.4"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~69%",
+            "note": "uso de herramientas reportado por el proveedor"
+          },
+          {
+            "name": "AIME 2025 (sin herramientas)",
+            "score": "~96%",
+            "note": "matemáticas de competición reportadas por el proveedor"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~89%",
+            "note": "ciencia de nivel posgrado reportada por el proveedor"
+          },
+          {
+            "name": "OSWorld (computer use)",
+            "score": "~74%",
+            "note": "reportado por el proveedor"
+          },
+          {
+            "name": "MMMU (multimodal)",
+            "score": "Lidera la familia GPT-5",
+            "note": "reportado por el proveedor"
+          },
+          {
+            "name": "Velocidad",
+            "score": "~70 tokens/seg",
+            "note": "Artificial Analysis, esfuerzo medio"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Enrutamiento de herramientas",
+            "body": "La tasa más baja de llamadas a herramientas mal enrutadas en la familia GPT-5. La brecha frente a 5.4 se amplía en casos límite difíciles como selección condicional de herramientas, argumentos profundamente anidados y llamadas a herramientas despachadas después de largos tramos de razonamiento."
+          },
+          {
+            "title": "Ediciones de código al primer intento",
+            "body": "La mejor calidad de parche en la familia GPT-5. La opción correcta cuando un agente debe modificar código que debe seguir compilando y pasando pruebas, especialmente cuando el parche abarca múltiples archivos. SWE-bench Verified reportado por el proveedor refleja esto directamente."
+          },
+          {
+            "title": "Computer use",
+            "body": "Materialmente más fiable que 5.4 en secuencias de GUI de múltiples pasos, que es lo que captura el delta de OSWorld. Recurre a él cuando el agente está manejando un navegador o aplicación de escritorio durante decenas de pasos y el costo de una descarrilamiento a mitad de ejecución es alto."
+          },
+          {
+            "title": "Velocidad",
+            "body": "Más lento que 5.4 y notablemente más lento que 5.4 Mini. Alrededor de 70 tokens/seg en esfuerzo medio según Artificial Analysis. Resérvalo para los pasos que realmente necesitan la profundidad de razonamiento adicional y ejecuta niveles más ligeros en paralelo."
+          },
+          {
+            "title": "Comportamiento de alucinación",
+            "body": "GPT-5.5 lleva la calibración más estricta de OpenAI de la generación GPT-5 y tiende a admitir incertidumbre en lugar de confabular, razón por la cual los equipos de producción siguen pagando la prima por razonamiento de alto riesgo a pesar de que alternativas más baratas como DeepSeek V4 Pro ahora lo igualan en benchmarks."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El orquestador ejecutando un plan multi-herramienta",
+            "body": "Usa GPT-5.5 como el planificador que divide la solicitud de un cliente en diez pasos, despacha cada paso a un sub-agente de nivel GPT-5.4 o 5.4 Mini, y une los resultados. Ejecutar 5.5 solo en la capa de planificación (y los niveles más baratos en el resto) cuesta una fracción de ejecutar 5.5 de principio a fin, conservando la mayor parte de la calidad."
+          },
+          {
+            "title": "Las ediciones de código al primer intento que no desperdician una ejecución de CI",
+            "body": "Pide a GPT-5.5 que migre un código base de 50 archivos de un ORM a otro, refactorice un módulo enredado o aplique una corrección de seguridad en todo el repositorio. El parche se aplica limpiamente al primer intento con más frecuencia que cualquier otro modelo de la familia, y eso es exactamente lo que tu factura de CI reflejará."
+          },
+          {
+            "title": "El agente de computer-use que debe terminar el flujo",
+            "body": "Cuando el agente está manejando un navegador a través de un flujo de reserva de múltiples pasos, una aplicación de escritorio o una interfaz administrativa heredada, la mejor puntuación OSWorld de 5.5 se traduce en menos descarrilamientos a mitad de ejecución y menos intervenciones humanas. La prima se paga por sí sola la primera vez que una sesión larga no debe reiniciarse."
+          },
+          {
+            "title": "El paso de investigación de matemáticas o ciencia difícil",
+            "body": "Suelta un conjunto de problemas de matemáticas de competición o una derivación de física de posgrado y 5.5 lo trabajará sin los errores por uno que ves en 5.4. AIME 2025 y GPQA Diamond capturan exactamente este tipo de comportamiento."
+          }
+        ],
+        "avoidFor": "Evita GPT-5.5 en trabajo rutinario de alto volumen donde GPT-5.4 alcanza la misma calidad a la mitad del costo en créditos, en respuestas de chat sensibles a la latencia donde GPT-5.4 Mini es mucho más rápido, y en trabajos de clasificación o extracción masiva donde DeepSeek V4 Flash es aproximadamente 35× más barato a nivel de proveedor.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "GPT-5.4 es el caballo de batalla predeterminado en la familia GPT-5 y la opción correcta para la mayoría de agentes. Promueve a GPT-5.5 solo cuando 5.4 falla visiblemente en razonamiento difícil, bucles agénticos largos o ediciones de código al primer intento, usualmente como el orquestador que delega hacia abajo a sub-agentes de nivel 5.4 o 5.4 Mini."
+          },
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "Mismo rol en familias diferentes: el orquestador de alto riesgo y el modelo al que escalas cuando el nivel más barato falla. Opus 4.7 tiene la ventana de contexto de 1M tokens y el perfil de seguridad de Anthropic; GPT-5.5 tiene mejores puntuaciones de computer-use y es la opción natural para equipos ya en el framework Codex. Elige según qué framework y ecosistema apuntan tus agentes existentes."
+          },
+          {
+            "vs": "Gemini 3 Pro",
+            "body": "Gemini 3 Pro lidera en razonamiento bruto de contexto largo (ventana de 2M tokens) y en algunos benchmarks multimodales. GPT-5.5 lidera en codificación agéntica (SWE-bench Verified, Terminal-Bench) y computer use. Elige GPT-5.5 cuando el agente edita código o maneja una UI; elige Gemini 3 Pro cuando la carga de trabajo es comprensión pesada de documentos o video."
+          }
+        ],
+        "verdict": "GPT-5.5 es el nivel de escalación del lado OpenAI. Usa GPT-5.4 por defecto; promueve a 5.5 solo en los pasos específicos donde 5.4 falla visiblemente.",
+        "faqs": [
+          {
+            "q": "¿Cuál es la ventana de contexto de GPT-5.5?",
+            "a": "400.000 tokens, con hasta 128K tokens de salida por respuesta. La ventana completa se factura a tarifas estándar."
+          },
+          {
+            "q": "¿Puede GPT-5.5 manejar imágenes?",
+            "a": "Sí. GPT-5.5 es multimodal. Acepta entradas de imagen junto con texto y código, por lo que los agentes basados en capturas de pantalla y visión de documentos funcionan de forma nativa. Para generación de imágenes usa la OpenAI Images API."
+          },
+          {
+            "q": "¿Cuándo debería elegir GPT-5.5 sobre GPT-5.4?",
+            "a": "Cuando (a) el agente es el planificador / orquestador y las decisiones se propagan en cascada, (b) la ejecución es lo suficientemente larga como para que 5.4 empiece a mal enrutar llamadas a herramientas, o (c) la salida debe aplicarse limpiamente al primer intento (ediciones de código, cargas estructuradas, flujos de computer-use)."
+          },
+          {
+            "q": "¿GPT-5.5 soporta Prompt Caching?",
+            "a": "Sí. La entrada cacheada se factura a $0,50 por 1M tokens — un descuento del 10× en la porción cacheada. Vale la pena usarlo cuando tu prompt de sistema o esquema de herramientas es estable entre llamadas."
+          },
+          {
+            "q": "¿Qué framework usa GPT-5.5 en VM0?",
+            "a": "Codex. VM0 enruta GPT-5.5 a través de la superficie Responses API del framework Codex, que es lo que usa codex CLI por defecto. Los agentes del framework Claude Code no son compatibles con modelos GPT-5 en VM0."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-5-4", "reason": "Mitad de créditos, misma familia" },
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Buque insignia par del lado Claude"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Caballo de batalla predeterminado a ×1 créditos"
+          }
+        ],
+        "routingNotes": "Enrutado a través del framework Codex en VM0 mediante la Responses API de OpenAI. Expuesto de cuatro formas: a través del pool de créditos VM0 Managed, a través de una clave API directa de OpenAI, a través de un login OAuth de ChatGPT (Codex), y a través de OpenRouter / Vercel AI Gateway en sus variantes Codex.",
+        "vm0Notes": "GPT-5.5 está en el multiplicador de ×2 créditos — el más alto del catálogo Built-in. Prompt Caching está habilitado por defecto a través de VM0, lo que reduce sustancialmente el costo de prompts de sistema repetidos en agentes que emiten muchos turnos desde el mismo prefijo. El patrón estándar es mantener GPT-5.4 o Claude Sonnet 4.6 ejecutándose en todas partes y escalar solo los pasos que genuinamente necesitan la profundidad de razonamiento de 5.5."
+      },
       "claude-sonnet-4-6": {
         "name": "Claude Sonnet 4.6",
         "pageTitle": "Claude Sonnet 4.6 en VM0. El modelo de agente predeterminado",
@@ -4441,6 +4611,162 @@
         ],
         "routingNotes": "Enrutado directamente a la API Messages de Anthropic. Modelo predeterminado en VM0 Managed.",
         "vm0Notes": "Sonnet 4.6 es la línea base de crédito (×1) contra la que se normaliza el multiplicador de todos los demás modelos Built-in, razón principal por la que sigue siendo la primera opción para nuevos agentes en VM0; escala a Opus solo cuando Sonnet visiblemente rinde por debajo de lo esperado en una tarea específica. El caché de prompts nativo se combina bien con los prompts de sistema y definiciones de herramientas estables de VM0, y mantiene predecible el costo por turno de agentes de larga duración."
+      },
+      "gpt-5-4": {
+        "name": "GPT-5.4",
+        "pageTitle": "GPT-5.4 en VM0. El caballo de batalla de OpenAI",
+        "tagline": "El caballo de batalla de OpenAI de la familia GPT-5. Se sitúa en la línea base de ×1 créditos junto con Claude Sonnet 4.6 y es el predeterminado correcto para la mayoría de agentes del framework Codex.",
+        "cardIntro": "El modelo caballo de batalla de OpenAI. ×1 créditos, visión multimodal, código sólido y uso de herramientas — el GPT-5 predeterminado para la mayoría de agentes.",
+        "metaTitle": "GPT-5.4 en VM0: Benchmarks, Precios y Comparación",
+        "metaDescription": "Reseña de GPT-5.4 en VM0. El modelo caballo de batalla OpenAI GPT-5 con contexto de 400K, visión multimodal, precios de $2,5/$15 y ×1 créditos en VM0 Managed. Especificaciones y comparación con Claude.",
+        "summary": "GPT-5.4 es el caballo de batalla de la familia GPT-5 de OpenAI — el modelo que mantienes ejecutándose en todas partes por defecto. SWE-bench Verified reportado por el proveedor a 74,9% lo sitúa en el mismo rango que Claude Sonnet 4.6 en codificación, y su precisión de uso de herramientas es contra lo que están ajustados la mayoría de agentes de producción del framework Codex.\n\nEl precio de lista del proveedor es de $2,5 / $15 por 1M tokens con entrada cacheada a $0,25 / 1M. Se sitúa en ×1 créditos en VM0 Managed — la misma línea base que Claude Sonnet 4.6 — lo que lo convierte en la opción natural cuando tu agente ya está en el framework Codex y quieres un predeterminado equilibrado en costo/calidad.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "Caballo de batalla de la familia GPT-5. El predeterminado recomendado para la mayoría de agentes del framework Codex.",
+        "background": [
+          "GPT-5.4 es el caballo de batalla de la generación GPT-5 de OpenAI, lanzado en abril de 2026 junto con el buque insignia GPT-5.5 y la variante optimizada en costo GPT-5.4 Mini. OpenAI lo posiciona como el predeterminado universal para agentes en el framework Codex — el modelo que mantienes ejecutándose en cada paso a menos que un paso específico justifique escalar a 5.5.",
+          "Arquitectónicamente GPT-5.4 comparte la ventana de contexto de 400K tokens, el parámetro `reasoning_effort`, Prompt Caching y la superficie Responses API con el resto de la familia GPT-5. La división frente a GPT-5.5 es inversión de cómputo por token: 5.4 corre más rápido y barato, 5.5 invierte más en profundidad de razonamiento. La división frente a GPT-5.4 Mini es la opuesta — 5.4 lleva más calidad para los pasos que realmente deciden la ejecución del agente.",
+          "En VM0 se sitúa en el multiplicador de ×1 créditos, la misma línea base que Claude Sonnet 4.6, lo que hace triviales las comparaciones de costo lado a lado entre los predeterminados de Anthropic y OpenAI. La elección entre los dos usualmente se reduce al framework (Codex vs Claude Code), ecosistema (integraciones existentes, definiciones de herramientas) y para qué modelo tu equipo tiene más memoria muscular de comportamiento."
+        ],
+        "architecture": "GPT-5.4 usa la misma arquitectura que el resto de la familia GPT-5: ventana de contexto de 400K tokens, parámetro `reasoning_effort` en cuatro niveles (mínimo, bajo, medio, alto), Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie Responses API que usa el codex CLI por defecto. Tool-Use, salidas estructuradas y computer-use son soportadas. Las entradas son multimodales: texto, visión y código.",
+        "specs": [
+          { "label": "Familia", "value": "Generación GPT-5" },
+          { "label": "Modalidades", "value": "Texto, visión, código" },
+          { "label": "Idiomas", "value": "Inglés primero, multilingüe" },
+          { "label": "Prompt Caching", "value": "Soportado (OpenAI)" },
+          { "label": "Ventana de contexto", "value": "400K tokens" },
+          { "label": "Salida máxima", "value": "Hasta 128K tokens" },
+          {
+            "label": "Reasoning effort",
+            "value": "Mínimo / Bajo / Medio / Alto"
+          },
+          {
+            "label": "Precio listado",
+            "value": "$2,5 entrada / $15 salida por 1M"
+          }
+        ],
+        "benchmarksNote": "Puntuaciones reportadas por el proveedor de los materiales de lanzamiento de GPT-5 de OpenAI, con deltas mostrados contra la generación OpenAI anterior. Las reseñas independientes sitúan a GPT-5.4 en la misma banda de calidad de codificación que Claude Sonnet 4.6. Trata los porcentajes absolutos como direccionales.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "74,9%",
+            "note": "reportado por el proveedor"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~58%",
+            "note": "uso de herramientas reportado por el proveedor"
+          },
+          {
+            "name": "AIME 2025 (sin herramientas)",
+            "score": "~92%",
+            "note": "matemáticas de competición reportadas por el proveedor"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~85%",
+            "note": "ciencia de nivel posgrado reportada por el proveedor"
+          },
+          {
+            "name": "OSWorld (computer use)",
+            "score": "~62%",
+            "note": "reportado por el proveedor"
+          },
+          {
+            "name": "Velocidad",
+            "score": "~110 tokens/seg",
+            "note": "Artificial Analysis, esfuerzo medio"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Enrutamiento de herramientas",
+            "body": "Precisión sólida de línea base en el catálogo estándar de herramientas del framework Codex. Donde 5.5 se adelanta es en casos límite difíciles (selección condicional de herramientas, argumentos profundamente anidados) — para los casos rutinarios 5.4 enruta correctamente con una latencia significativamente menor."
+          },
+          {
+            "title": "Ediciones de código",
+            "body": "Calidad de parche comparable a Claude Sonnet 4.6 en cargas de trabajo estándar de refactorización y corrección de errores. Donde 5.5 empieza a adelantarse es en cambios multi-archivo donde el parche debe aplicarse limpiamente al primer intento."
+          },
+          {
+            "title": "Velocidad",
+            "body": "Materialmente más rápido que 5.5 — alrededor de 110 tokens/seg en esfuerzo medio según Artificial Analysis. Esto es parte de por qué 5.4 sigue siendo el predeterminado para respuestas de chat interactivo y bucles cortos de agente donde la latencia visible al usuario importa."
+          },
+          {
+            "title": "Eficiencia de costo",
+            "body": "×1 créditos con comportamiento de salida en la banda de calidad de Sonnet 4.6. Para equipos ya en el framework Codex, este es el punto óptimo de costo/calidad — promueve a 5.5 solo en los pasos que visiblemente lo necesitan."
+          },
+          {
+            "title": "Comportamiento de alucinación",
+            "body": "Hereda las mejoras de calibración que OpenAI lanzó con la generación GPT-5. Menos propenso a respuestas erróneas con confianza que la serie GPT-4, especialmente en preguntas fuera de su horizonte de entrenamiento."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El paso de agente predeterminado en el framework Codex",
+            "body": "Si tu agente ya está construido sobre codex CLI o cualquier integración del framework Codex, GPT-5.4 es el predeterminado universal natural. ×1 créditos, lo suficientemente rápido para uso interactivo, lo suficientemente preciso para las llamadas a herramientas rutinarias que dominan la mayoría de ejecuciones de agente."
+          },
+          {
+            "title": "El chat interactivo con visión",
+            "body": "UIs basadas en capturas de pantalla, Q&A de documentos, anotación de imágenes — GPT-5.4 maneja los tres multimodalmente a velocidad de caballo de batalla. El multiplicador ×1 mantiene el costo por turno en la misma banda que Sonnet 4.6, así puedes hacer A/B entre los dos en la misma carga de trabajo."
+          },
+          {
+            "title": "El A/B de costo/calidad contra Claude Sonnet 4.6",
+            "body": "Ambos modelos se sitúan en ×1 créditos en VM0 Managed, lo que los hace directamente comparables en costo. Ejecuta el mismo agente en ambos durante una semana y elige por comportamiento en tu carga de trabajo específica — ninguno es universalmente mejor, y el predeterminado correcto depende de tu catálogo de herramientas y estilo de prompts."
+          }
+        ],
+        "avoidFor": "Evita GPT-5.4 en los pasos más difíciles de razonamiento, computer-use o edición de código multi-archivo donde 5.5 lidera notablemente, y en trabajo de clasificación masiva de alto volumen o prefiltrado donde 5.4 Mini es cuatro veces más barato a nivel de proveedor.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.5",
+            "body": "Misma familia, diferente posicionamiento. 5.5 (×2) te da el razonamiento más fuerte, computer-use y calidad de código al primer intento; 5.4 (×1) te da la misma ventana de contexto y conjunto de características a la mitad del costo en créditos y velocidad notablemente mayor. Usa 5.4 por defecto; escala a 5.5 solo en los pasos que visiblemente lo necesitan."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Las dos líneas base de ×1, una en cada ecosistema. Sonnet 4.6 corre en el framework Claude Code; GPT-5.4 corre en Codex. Elige según qué framework apuntan tus agentes y definiciones de herramientas existentes. En calidad bruta de salida están lo suficientemente cerca como para que hacer A/B en tu carga de trabajo sea la decisión correcta."
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "Misma familia, diferente posicionamiento. 5.4 (×1) lleva más calidad de razonamiento por token; 5.4 Mini (×0,3) te da una opción mucho más barata para trabajo masivo y prefiltrado. Usa 5.4 Mini para clasificación fan-out y 5.4 para los pasos que deciden la ejecución del agente."
+          }
+        ],
+        "verdict": "GPT-5.4 es el predeterminado universal para agentes del framework Codex en VM0. Escala a 5.5 para razonamiento difícil, baja a 5.4 Mini para prefiltrado masivo.",
+        "faqs": [
+          {
+            "q": "¿Cuál es la ventana de contexto de GPT-5.4?",
+            "a": "400.000 tokens, con hasta 128K tokens de salida por respuesta. La ventana completa se factura a tarifas estándar."
+          },
+          {
+            "q": "¿Puede GPT-5.4 manejar imágenes?",
+            "a": "Sí. GPT-5.4 es multimodal. Acepta entradas de imagen junto con texto y código de forma nativa."
+          },
+          {
+            "q": "¿Cuándo debería elegir GPT-5.4 sobre Claude Sonnet 4.6?",
+            "a": "Cuando tu agente ya está construido en el framework Codex o necesitas el ecosistema OpenAI (catálogo de herramientas, salidas estructuradas, Responses API). Ambos se sitúan en ×1 créditos, así que el costo es idéntico y la elección se reduce al framework y ajuste de comportamiento."
+          },
+          {
+            "q": "¿GPT-5.4 soporta Prompt Caching?",
+            "a": "Sí. La entrada cacheada se factura a $0,25 por 1M tokens — un descuento del 10× en la porción cacheada."
+          },
+          {
+            "q": "¿Qué framework usa GPT-5.4 en VM0?",
+            "a": "Codex. VM0 enruta todos los modelos GPT-5 a través de la superficie Responses API del framework Codex."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-5",
+            "reason": "Nivel de escalación para los pasos más difíciles"
+          },
+          {
+            "slug": "gpt-5-4-mini",
+            "reason": "Opción más barata para trabajo masivo"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Par ×1 en el framework Claude Code"
+          }
+        ],
+        "routingNotes": "Enrutado a través del framework Codex en VM0 mediante la Responses API de OpenAI. Disponible en VM0 Managed y mediante clave API directa de OpenAI, OAuth de ChatGPT (Codex), OpenRouter (Codex) y Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 se sitúa en la línea base de ×1, igual que Claude Sonnet 4.6, lo que hace los dos equivalentes en costo en VM0 Managed y fáciles de hacer A/B entre sí. Prompt Caching está habilitado por defecto. Empareja con GPT-5.4 Mini para trabajo de prefiltrado de alto volumen, y escala a GPT-5.5 solo para los pasos que genuinamente necesitan la profundidad de razonamiento adicional."
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -4735,6 +5061,157 @@
         ],
         "routingNotes": "Enrutado directamente a la API Messages de Anthropic. Disponible en VM0 Managed y los proveedores OAuth de Anthropic / Claude Code.",
         "vm0Notes": "Haiku 4.5 tiene el multiplicador Claude más bajo (×0,3) y es la opción correcta para cargas de trabajo de enrutamiento de alto volumen, con el caché de prompts manteniendo bajo el costo de prompts cortos repetidos. No tiene la calidad de agente multi-paso de Sonnet, así que diseña cualquier agente basado en Haiku para mantener los bucles cortos y la superficie de herramientas reducida."
+      },
+      "gpt-5-4-mini": {
+        "name": "GPT-5.4 Mini",
+        "pageTitle": "GPT-5.4 Mini en VM0. El GPT-5 que ahorra costos",
+        "tagline": "El miembro optimizado en costo de OpenAI de la familia GPT-5. ×0,3 créditos, visión multimodal, y lo suficientemente rápido para enrutamiento, clasificación y prefiltrado de alto volumen.",
+        "cardIntro": "El GPT-5 de OpenAI que ahorra costos. ×0,3 créditos, rápido y multimodal — la opción correcta para trabajo de prefiltrado masivo en el framework Codex.",
+        "metaTitle": "GPT-5.4 Mini en VM0: Benchmarks, Precios y Comparación",
+        "metaDescription": "Reseña de GPT-5.4 Mini en VM0. El modelo OpenAI GPT-5 que ahorra costos a precios de proveedor de $0,75/$4,5, ×0,3 créditos, contexto de 400K y visión multimodal. Especificaciones, comportamiento y comparación con Claude Haiku 4.5.",
+        "summary": "GPT-5.4 Mini es el miembro que ahorra costos de la familia GPT-5 de OpenAI — al que recurres cuando el costo unitario importa más que la calidad de razonamiento máxima. Mantiene la ventana de contexto de 400K y las entradas multimodales del resto de la familia pero recorta el cómputo por token, lo que se traduce en menor precio ($0,75 / $4,5 por 1M) y velocidad notablemente mayor.\n\nEn VM0 se sitúa en ×0,3 créditos, el mismo multiplicador que Claude Haiku 4.5 y Kimi K2.6, lo que lo convierte en la opción natural del lado OpenAI para clasificación masiva, enrutamiento fan-out, prefiltrado, y cualquier paso de agente donde bajar a un tercio del costo de GPT-5.4 es el factor decisivo.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "Variante que ahorra costos de la familia GPT-5. El par del lado OpenAI de Claude Haiku 4.5.",
+        "background": [
+          "GPT-5.4 Mini es el miembro optimizado en costo de la generación GPT-5 de OpenAI, lanzado en abril de 2026 junto con GPT-5.5 y GPT-5.4. OpenAI lo posiciona como el nivel de alto rendimiento — el modelo que mantienes ejecutándose en pasos de clasificación, enrutamiento y prefiltrado donde 5.4 o 5.5 más grandes se desperdiciarían en decisiones rutinarias.",
+          "Arquitectónicamente comparte la ventana de contexto de 400K tokens de la familia GPT-5, el parámetro `reasoning_effort`, Prompt Caching, y la superficie Responses API que usa el codex CLI por defecto. El compromiso frente a 5.4 es la profundidad de razonamiento: Mini maneja bien llamadas a herramientas estándar, resúmenes cortos y cargas de salida estructurada, pero empieza a derivar en los planes multi-paso más difíciles donde 5.4 todavía aguanta. El compromiso frente a competidores al mismo precio es el ecosistema — si ya estás en Codex, quedarte dentro de la superficie OpenAI mantiene definiciones de herramientas y esquemas de salida estructurada consistentes.",
+          "En VM0 Mini se sitúa en el multiplicador de ×0,3 créditos, el mismo que Claude Haiku 4.5, Kimi K2.6 y DeepSeek V4 Pro. Dentro del nivel que ahorra costos la elección depende principalmente del framework y ajuste de comportamiento en tu carga de trabajo específica."
+        ],
+        "architecture": "GPT-5.4 Mini usa la misma arquitectura que el resto de la familia GPT-5: ventana de contexto de 400K tokens, el parámetro `reasoning_effort` en cuatro niveles, Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie Responses API. Tool-Use, salidas estructuradas y entradas de visión multimodal son soportadas. El modelo es un hermano menor más rápido — menos parámetros por token, más rendimiento por dólar.",
+        "specs": [
+          { "label": "Familia", "value": "Generación GPT-5" },
+          { "label": "Modalidades", "value": "Texto, visión, código" },
+          { "label": "Idiomas", "value": "Inglés primero, multilingüe" },
+          { "label": "Prompt Caching", "value": "Soportado (OpenAI)" },
+          { "label": "Ventana de contexto", "value": "400K tokens" },
+          { "label": "Salida máxima", "value": "Hasta 128K tokens" },
+          {
+            "label": "Reasoning effort",
+            "value": "Mínimo / Bajo / Medio / Alto"
+          },
+          {
+            "label": "Precio listado",
+            "value": "$0,75 entrada / $4,5 salida por 1M"
+          }
+        ],
+        "benchmarksNote": "Puntuaciones reportadas por el proveedor de los materiales de lanzamiento de GPT-5 Mini de OpenAI. Las reseñas independientes sitúan a 5.4 Mini en la misma banda que ahorra costos que Claude Haiku 4.5 en la mayoría de benchmarks de agente. Trata los porcentajes absolutos como direccionales.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~60%",
+            "note": "reportado por el proveedor"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~42%",
+            "note": "uso de herramientas reportado por el proveedor"
+          },
+          {
+            "name": "AIME 2025 (sin herramientas)",
+            "score": "~84%",
+            "note": "matemáticas de competición reportadas por el proveedor"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~74%",
+            "note": "ciencia de nivel posgrado reportada por el proveedor"
+          },
+          {
+            "name": "Velocidad",
+            "score": "~165 tokens/seg",
+            "note": "Artificial Analysis, esfuerzo medio"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Velocidad",
+            "body": "El modelo más rápido de la familia GPT-5 — alrededor de 165 tokens/seg en esfuerzo medio según Artificial Analysis. Esta es la propiedad que lo hace viable para respuestas de chat interactivo y llamadas a herramientas fan-out cortas donde la latencia visible al usuario domina."
+          },
+          {
+            "title": "Llamadas a herramientas rutinarias",
+            "body": "Preciso en el catálogo estándar de herramientas del framework Codex. Donde 5.4 se adelanta es en casos límite difíciles (selección condicional de herramientas, argumentos profundamente anidados) — para los casos rutinarios Mini maneja el enrutamiento de herramientas limpiamente a un tercio del costo."
+          },
+          {
+            "title": "Clasificación masiva y prefiltrado",
+            "body": "La posición de costo/calidad más fuerte de la familia GPT-5 para trabajo fan-out. Triaje masivo de PRs, categorización de tickets de soporte, clasificación por nivel de documentos — todas las cargas de trabajo donde antes habrías hecho regex a mano ahora son asequibles en una llamada real de modelo."
+          },
+          {
+            "title": "Eficiencia de costo",
+            "body": "×0,3 créditos con visión multimodal incluida. A este precio Mini, Claude Haiku 4.5 y Kimi K2.6 se sitúan todos en la misma banda — la elección usualmente se reduce al ajuste de framework y comportamiento en tu carga de trabajo específica."
+          },
+          {
+            "title": "Cuándo escalar",
+            "body": "Mini deriva en planes largos multi-paso, razonamiento difícil y ediciones de código multi-archivo al primer intento. Construye el agente para que el orquestador decida cuándo escalar a 5.4 o 5.5, no para que Mini intente llevar todo el bucle."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El clasificador fan-out que se ejecuta en cada evento",
+            "body": "Ticket de soporte entrante, comentario de PR, transcripción de llamada de ventas, carga de documento — Mini lee cada uno y lo enruta al agente o revisor humano correcto. ×0,3 créditos y 165 tokens/seg significan que el costo por evento es lo suficientemente pequeño como para que ejecutarlo en cada evento (no solo en lotes muestreados) sea realmente viable."
+          },
+          {
+            "title": "El paso de prefiltrado antes del modelo caro",
+            "body": "Fija Mini en lo alto de la llamada a herramienta del agente para que decida si la solicitud siquiera necesita escalarse. La mayoría de solicitudes obtienen una respuesta rápida y barata; solo la minoría residual paga el costo completo de GPT-5.4 o 5.5. Aquí es donde apilar niveles que ahorran costos y de núcleo genuinamente cambia lo que es asequible."
+          },
+          {
+            "title": "La respuesta de chat interactivo",
+            "body": "Turnos multimodales cortos donde la latencia visible al usuario domina la experiencia. Mini responde lo suficientemente rápido como para que el streaming se sienta instantáneo, y el soporte multimodal significa que una captura de pantalla en la conversación simplemente funciona."
+          }
+        ],
+        "avoidFor": "Evita GPT-5.4 Mini en los pasos más difíciles de razonamiento, orquestación de agente multi-paso, secuencias de computer-use y ediciones de código multi-archivo al primer intento — escala a 5.4 para versiones rutinarias de esas tareas y a 5.5 para las más difíciles.",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "Misma familia, diferente posicionamiento. 5.4 Mini (×0,3) gana en costo y velocidad; 5.4 (×1) gana en calidad de razonamiento y precisión de enrutamiento de herramientas en casos difíciles. El patrón estándar es prefiltrar con Mini y escalar los casos residuales a 5.4."
+          },
+          {
+            "vs": "Claude Haiku 4.5",
+            "body": "Mismo multiplicador (×0,3). Mini corre en el framework Codex; Haiku 4.5 corre en Claude Code. Ambos son multimodales y ambos apuntan al mismo espacio que ahorra costos. Elige según qué framework apuntan tus agentes y definiciones de herramientas existentes."
+          },
+          {
+            "vs": "DeepSeek V4 Flash",
+            "body": "DeepSeek V4 Flash (×0,02) es dramáticamente más barato a nivel de proveedor y es la opción correcta para trabajo masivo puro de un solo paso. GPT-5.4 Mini (×0,3) lleva más calidad de razonamiento y se queda dentro del ecosistema OpenAI, lo que importa cuando tus definiciones de herramientas y esquemas de salida estructurada ya están ajustados para Codex."
+          }
+        ],
+        "verdict": "GPT-5.4 Mini es el predeterminado que ahorra costos del lado OpenAI. Prefiltra con Mini, escala a GPT-5.4 para pasos rutinarios, escala a GPT-5.5 solo para el razonamiento más difícil.",
+        "faqs": [
+          {
+            "q": "¿Cuál es la ventana de contexto de GPT-5.4 Mini?",
+            "a": "400.000 tokens, con hasta 128K tokens de salida por respuesta — la misma que el resto de la familia GPT-5."
+          },
+          {
+            "q": "¿Puede GPT-5.4 Mini manejar imágenes?",
+            "a": "Sí. Como el resto de la familia GPT-5 acepta entradas de imagen junto con texto y código."
+          },
+          {
+            "q": "¿Cuándo debería elegir GPT-5.4 Mini sobre Claude Haiku 4.5?",
+            "a": "Cuando tu agente ya está construido en el framework Codex o necesitas el ecosistema de salidas estructuradas / llamadas a herramientas de OpenAI. Ambos se sitúan en ×0,3 créditos, así que el costo es idéntico y la elección se reduce al framework y comportamiento."
+          },
+          {
+            "q": "¿GPT-5.4 Mini soporta Prompt Caching?",
+            "a": "Sí. La entrada cacheada se factura a $0,075 por 1M tokens — un descuento del 10× en la porción cacheada."
+          },
+          {
+            "q": "¿Qué framework usa GPT-5.4 Mini en VM0?",
+            "a": "Codex. VM0 enruta todos los modelos GPT-5 a través de la superficie Responses API del framework Codex."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-4",
+            "reason": "Sube para pasos más difíciles, misma familia"
+          },
+          {
+            "slug": "claude-haiku-4-5",
+            "reason": "Par ×0,3 en el framework Claude Code"
+          },
+          {
+            "slug": "deepseek-v4-flash",
+            "reason": "Dramáticamente más barato para trabajo masivo puro"
+          }
+        ],
+        "routingNotes": "Enrutado a través del framework Codex en VM0 mediante la Responses API de OpenAI. Disponible en VM0 Managed y mediante clave API directa de OpenAI, OAuth de ChatGPT (Codex), OpenRouter (Codex) y Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 Mini se sitúa en el multiplicador de ×0,3 que ahorra costos junto a Claude Haiku 4.5, Kimi K2.6 y DeepSeek V4 Pro. Prompt Caching está habilitado por defecto y el alto rendimiento hace de Mini un paso natural de prefiltrado en diseños de agente apilados que escalan a 5.4 o 5.5 solo en los casos difíciles residuales."
       },
       "kimi-k2-6": {
         "name": "Kimi K2.6",
@@ -5500,6 +5977,750 @@
         ],
         "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de DeepSeek en `api.deepseek.com`. Modelo predeterminado en el proveedor DeepSeek; también disponible en VM0 Managed.",
         "vm0Notes": "V4 Flash tiene el multiplicador de crédito más bajo de cualquier modelo Built-in (×0,02), aproximadamente 50× menos que Sonnet 4.6. Las lecturas de caché facturan mientras que las escrituras de caché son gratuitas, y VM0 establece un timeout de API de 10 minutos para el proveedor DeepSeek que se empareja naturalmente con el trabajo corto de un solo paso de Flash."
+      },
+      "gemini-2-5-flash-image": {
+        "name": "Gemini 2.5 Flash Image",
+        "pageTitle": "Gemini 2.5 Flash Image en VM0. El predeterminado rápido de texto a imagen",
+        "tagline": "El modelo rápido de texto a imagen y edición de imagen de Google. Fuerte seguimiento de instrucciones, consistencia de personajes y el costo de crédito por imagen más barato de la línea curada de imágenes.",
+        "cardIntro": "El modelo rápido de texto a imagen de Google. Barato, preciso siguiendo prompts largos y bueno preservando sujetos a través de ediciones.",
+        "metaTitle": "Gemini 2.5 Flash Image en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "Gemini 2.5 Flash Image en VM0. El modelo de texto a imagen y edición de imagen de Google con alta adherencia a instrucciones, consistencia de personajes y ~$0,04 por imagen. Comparado con GPT Image 1, Flux Pro 1.1 Ultra y SeedDream 4.",
+        "summary": "Gemini 2.5 Flash Image es el modelo predeterminado universal de texto a imagen y edición de imagen de Google. Funciona bien en las dos propiedades que más importan para cargas de trabajo de agente: sigue prompts largos y estructurados (para que puedas entregarle el brief completo sin perder instrucciones en el camino) y mantiene los sujetos consistentes a través de ediciones de múltiples turnos (para que un agente pueda iterar sobre el mismo personaje o toma de producto sin que derive entre llamadas).\n\nEl precio de lista es de alrededor de $0,04 por imagen de 1024×1024, lo que lo convierte en el modelo más barato de la línea curada de imágenes. El patrón natural es usar Gemini 2.5 Flash Image por defecto y escalar a Flux Pro 1.1 Ultra o SeedDream 4 solo cuando necesitas una estética específica que el predeterminado no alcanza.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "El caballo de batalla de texto a imagen de Google para cargas de trabajo de agente.",
+        "background": [
+          "Gemini 2.5 Flash Image es el modelo de texto a imagen y edición de imagen de Google en la familia Gemini 2.5. El planteamiento de Google es el mismo que para la variante Flash del lado de texto: un modelo ajustado para alto rendimiento a bajo costo por llamada, optimizado para cargas de trabajo de producción donde la siguiente solicitud se encola antes de que termine de hacer streaming la anterior.",
+          "Dos propiedades de comportamiento destacan para uso de agente. Primero, la adherencia a instrucciones en prompts largos y estructurados es materialmente mejor que en la mayoría de líneas base de texto a imagen de peso abierto, lo que importa cuando un agente está componiendo el prompt programáticamente y no puede acortarlo. Segundo, la consistencia de personajes y sujetos a través de ediciones de múltiples turnos aguanta bien, que es lo que hace al modelo viable como predeterminado del bucle de edición en flujos de trabajo de agente que iteran sobre un solo activo."
+        ],
+        "architecture": "Modelo de texto a imagen basado en Diffusion con soporte nativo de edición. La facturación es por imagen generada en el nivel estándar. Las entradas aceptan prompts de texto más imágenes de referencia opcionales para flujos tipo edición. Las salidas son PNG en la resolución solicitada.",
+        "specs": [
+          { "label": "Familia", "value": "Generación Gemini 2.5" },
+          {
+            "label": "Modalidades",
+            "value": "Texto a imagen, edición imagen a imagen"
+          },
+          { "label": "Resoluciones", "value": "1024×1024 nivel estándar" },
+          { "label": "Precio listado", "value": "~$0,04 por imagen" },
+          { "label": "Idiomas", "value": "Prompts multilingües" },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Adherencia a instrucciones",
+            "body": "Aguanta en prompts largos y estructurados donde muchos modelos de peso abierto empiezan a soltar cláusulas. Útil cuando un agente compone el brief programáticamente y el prompt es innegociable."
+          },
+          {
+            "title": "Consistencia de personajes",
+            "body": "Mantiene a los sujetos reconocibles a través de ediciones de múltiples turnos, que es la propiedad que hace al modelo viable para bucles iterativos de agente sobre un solo activo."
+          },
+          {
+            "title": "Costo",
+            "body": "Alrededor de $0,04 por imagen — el más barato de los modelos curados de texto a imagen en VM0. La generación masiva fan-out se mantiene asequible."
+          },
+          {
+            "title": "Techo estético",
+            "body": "Se inclina hacia salida limpia y precisa en lugar del look hiper-estilizado de Flux Pro 1.1 Ultra o el look fotorrealista de SeedDream 4. Escala cuando la estética es el entregable."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El agente que redacta visuales de marketing desde un brief",
+            "body": "Entrega al agente la voz de marca, descripción del producto y audiencia objetivo; Gemini 2.5 Flash Image renderiza visuales borrador en segundos. Lo suficientemente barato para hacer fan-out de una docena de variaciones y elegir la mejor."
+          },
+          {
+            "title": "El bucle de edición que itera sobre un solo activo",
+            "body": "Genera una vez, luego itera sobre iluminación, encuadre o fondo manteniendo el sujeto consistente entre turnos. La consistencia de personajes significa que el humano en el bucle está editando la misma imagen, no eligiendo de un conjunto fresco cada turno."
+          },
+          {
+            "title": "El prefiltrado de ilustración antes del modelo premium",
+            "body": "Usa Gemini 2.5 Flash Image para fijar la composición de forma barata, luego re-renderiza el elegido final en Flux Pro 1.1 Ultra para la estética. Reduce el costo del paso premium a una llamada en lugar de un fan-out."
+          }
+        ],
+        "avoidFor": "Evita Gemini 2.5 Flash Image cuando el entregable es la estética — Flux Pro 1.1 Ultra y SeedDream 4 llevan más techo estilístico en looks fotorrealistas y editoriales.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 1 es más fuerte en ilustración estilizada y trabajo de personajes; Gemini 2.5 Flash Image es más barato por llamada y más fuerte en seguimiento de instrucciones en prompts largos. Para cargas de trabajo de agente con prompts estructurados, Gemini 2.5 Flash Image es el predeterminado más seguro."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 lleva un techo fotorrealista más alto; Gemini 2.5 Flash Image es más barato, más rápido y sigue prompts largos de forma más fiable. Usa Gemini por defecto, escala a SeedDream 4 cuando el brief es específicamente una estética de foto."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultra tiene el techo estilístico más alto de la línea curada; Gemini 2.5 Flash Image gana en costo y en seguimiento de instrucciones. Prefiltra con Gemini, entrega finales en Flux cuando la estética es el punto."
+          }
+        ],
+        "verdict": "Usa Gemini 2.5 Flash Image por defecto para cargas de trabajo de agente de texto a imagen. Escala a Flux Pro 1.1 Ultra o SeedDream 4 solo cuando la estética es el entregable.",
+        "faqs": [
+          {
+            "q": "¿Puede Gemini 2.5 Flash Image editar imágenes existentes?",
+            "a": "Sí. Acepta una imagen de referencia junto al prompt de texto y soporta flujos de inpainting y outpainting para ediciones iterativas."
+          },
+          {
+            "q": "¿Qué resolución de salida produce?",
+            "a": "1024×1024 en el nivel estándar. Resoluciones más altas están disponibles a costo proporcional."
+          },
+          {
+            "q": "¿Cuánto cuesta por imagen?",
+            "a": "Alrededor de $0,04 por imagen generada de 1024×1024 — el más barato de los modelos curados de texto a imagen en VM0."
+          },
+          {
+            "q": "¿Es bueno el modelo con texto dentro de imágenes?",
+            "a": "Sí — significativamente más fuerte que la mayoría de líneas base de peso abierto al renderizar cadenas cortas de texto dentro de la imagen generada."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-image-1",
+            "reason": "Ilustración estilizada más fuerte"
+          },
+          { "slug": "flux-pro-1-1-ultra", "reason": "Techo estético más alto" },
+          {
+            "slug": "seedream-4",
+            "reason": "Resultados fotorrealistas más fuertes"
+          }
+        ],
+        "routingNotes": "Enrutado al endpoint Gemini 2.5 Flash Image de Google y facturado por imagen generada.",
+        "vm0Notes": "Gemini 2.5 Flash Image es el predeterminado precio/calidad para cargas de trabajo de agente de texto a imagen en VM0. Úsalo como el predeterminado universal y reserva los modelos de imagen más caros para los pasos donde su techo estilístico realmente importa."
+      },
+      "gpt-image-1": {
+        "name": "GPT Image 1",
+        "pageTitle": "GPT Image 1 en VM0. El modelo de texto a imagen de OpenAI",
+        "tagline": "El modelo de texto a imagen de OpenAI con fuerte ilustración estilizada y edición. La opción natural cuando quieres la estética y estilo de seguimiento de prompts de OpenAI.",
+        "cardIntro": "El modelo de texto a imagen de OpenAI. Fuerte en ilustración estilizada, trabajo de personajes y edición — la contraparte del lado OpenAI de Gemini 2.5 Flash Image.",
+        "metaTitle": "GPT Image 1 en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "GPT Image 1 en VM0. El modelo de texto a imagen y edición de imagen de OpenAI con fortaleza en ilustración estilizada, precios multi-nivel y comparación con Gemini 2.5 Flash Image, Flux Pro 1.1 Ultra y SeedDream 4.",
+        "summary": "GPT Image 1 es el modelo de texto a imagen de OpenAI — el que la mayoría de equipos conoce como el modelo detrás de la generación de imágenes de ChatGPT. Sus fortalezas son la ilustración estilizada, el trabajo de personajes y la edición de imagen con enmascaramiento basado en texto, con un estilo de seguimiento de prompts que se mapea cercanamente a lo que los modelos de texto de OpenAI esperan.\n\nEl precio de lista es basado en niveles, desde alrededor de $0,011 por imagen en el nivel bajo/estándar hasta $0,25 en el nivel alto/grande. El nivel medio-estándar (alrededor de $0,05 por 1024×1024) es el predeterminado sensato para la mayoría de cargas de trabajo de agente.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "El modelo primario de texto a imagen de OpenAI. Precios por nivel a través de configuraciones de resolución y calidad.",
+        "background": [
+          "GPT Image 1 es el modelo de texto a imagen de producción de OpenAI. Se empareja de forma nativa con los modelos de texto de OpenAI, así que cuando un agente ya corre en GPT-5.4 o GPT-5.5 el estilo de prompt se transfiere limpiamente y el flujo del bucle de edición se queda dentro de la superficie OpenAI.",
+          "Las fortalezas estilísticas del modelo se sitúan en ilustración, trabajo de personajes y ediciones que preservan la composición original mientras cambian un elemento específico. La salida fotorrealista es sólida pero se inclina hacia el estilo de la casa OpenAI; los equipos que quieren un techo estético diferente a menudo recurren a Flux Pro 1.1 Ultra o SeedDream 4 junto con él."
+        ],
+        "architecture": "Modelo de texto a imagen basado en Diffusion con soporte nativo de edición. Los precios por nivel escalan según resolución de salida (estándar / grande) y calidad (bajo / medio / alto), con el nivel medio/estándar como el predeterminado típico. Las entradas aceptan texto más imágenes de referencia opcionales para ediciones y máscaras.",
+        "specs": [
+          { "label": "Familia", "value": "OpenAI Images" },
+          {
+            "label": "Modalidades",
+            "value": "Texto a imagen, edición imagen a imagen"
+          },
+          {
+            "label": "Resoluciones",
+            "value": "Estándar / Grande × Bajo / Medio / Alto"
+          },
+          {
+            "label": "Precio listado",
+            "value": "De $0,011 a $0,25 por imagen"
+          },
+          { "label": "Idiomas", "value": "Prompts multilingües" },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Ilustración estilizada",
+            "body": "Uno de los modelos más fuertes para salida no fotorrealista — ilustración, estilo cómic, pictórico. Buen ajuste cuando el entregable es una ilustración en lugar de una foto."
+          },
+          {
+            "title": "Flujos de edición",
+            "body": "Soporte nativo para ediciones enmascaradas y cambios locales basados en texto. Útil cuando un agente debe iterar sobre una región específica de una imagen en lugar de regenerarla entera."
+          },
+          {
+            "title": "Estilo de prompt",
+            "body": "Se mapea cercanamente a las expectativas de los modelos de texto de OpenAI. Cuando el agente que llama ya está en GPT-5.4 o GPT-5.5, los prompts escritos por ese agente se transfieren con poco ajuste."
+          },
+          {
+            "title": "Costo",
+            "body": "Basado en niveles — el nivel medio/estándar (~$0,05 por 1024×1024) es el predeterminado típico. El nivel alto/grande llega a $0,25 y vale la pena solo para salida de calidad de entrega."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El agente de ilustración que entrega estilo cómic o dibujado a mano",
+            "body": "La salida estilizada es donde GPT Image 1 lleva una ventaja real. Paneles de cómic, ilustraciones pictóricas, íconos con apariencia dibujada a mano — todos aterrizan de forma más fiable aquí que en las alternativas inclinadas al fotorrealismo."
+          },
+          {
+            "title": "El agente de bucle de edición en el stack OpenAI",
+            "body": "Si el agente orquestador ya está en GPT-5.4 o GPT-5.5, mantener la generación de imágenes dentro de la superficie OpenAI (GPT Image 1) significa que el estilo de prompt, semántica de edición y salidas estructuradas permanecen consistentes a través de la ejecución."
+          }
+        ],
+        "avoidFor": "Evita GPT Image 1 cuando el costo domina (Gemini 2.5 Flash Image es aproximadamente la mitad del precio para el mismo nivel predeterminado) o cuando el entregable es específicamente fotorrealista (SeedDream 4 lleva un techo fotorrealista más alto).",
+        "comparisons": [
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Image es más barato y más fuerte en prompts largos estructurados; GPT Image 1 es más fuerte en ilustración estilizada y se integra de forma más natural con agentes del stack OpenAI."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 lidera en estética fotorrealista a un precio ligeramente más bajo; GPT Image 1 lidera en ilustración estilizada y flujos de edición."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultra lleva el techo estético más alto para entregables de toma hero; GPT Image 1 es el predeterminado natural del stack OpenAI para todo lo demás."
+          }
+        ],
+        "verdict": "Elige GPT Image 1 cuando tu agente ya está en el stack OpenAI y quieres ilustración estilizada o flujos de edición nativos. Escala a Flux Pro 1.1 Ultra para tomas hero fotorrealistas; baja a Gemini 2.5 Flash Image cuando el costo domina.",
+        "faqs": [
+          {
+            "q": "¿Cómo se cobra GPT Image 1?",
+            "a": "Basado en niveles — combinaciones de tamaño (estándar / grande) y calidad (bajo / medio / alto). El nivel medio/estándar a ~$0,05 por imagen de 1024×1024 es el predeterminado típico."
+          },
+          {
+            "q": "¿GPT Image 1 soporta edición de imagen?",
+            "a": "Sí. Acepta una imagen de referencia más una máscara opcional y soporta ediciones locales basadas en texto así como outpainting."
+          },
+          {
+            "q": "¿Puede GPT Image 1 renderizar texto dentro de imágenes?",
+            "a": "Sí — cadenas cortas de texto se renderizan de forma fiable; los pasajes largos de texto aún tienen dificultades como con la mayoría de modelos de Diffusion."
+          },
+          {
+            "q": "¿Es multimodal como entrada?",
+            "a": "Las ediciones imagen a imagen aceptan imágenes de referencia. El modelo es solo de salida de imagen."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Más barato, adherencia más fuerte a prompts largos"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Techo estético fotorrealista más alto"
+          },
+          {
+            "slug": "seedream-4",
+            "reason": "Mejor predeterminado fotorrealista"
+          }
+        ],
+        "routingNotes": "Enrutado a la superficie Images de OpenAI y facturado por imagen generada en el nivel seleccionado.",
+        "vm0Notes": "GPT Image 1 es el predeterminado del stack OpenAI para flujos de trabajo de agente de ilustración estilizada y bucle de edición. El nivel medio/estándar es el predeterminado universal sensato; reserva el nivel alto/grande para salida de calidad de entrega."
+      },
+      "flux-pro-1-1-ultra": {
+        "name": "Flux Pro 1.1 Ultra",
+        "pageTitle": "Flux Pro 1.1 Ultra en VM0. El techo estético para tomas hero",
+        "tagline": "El modelo de texto a imagen de techo alto de Black Forest Labs. La opción cuando la imagen es el entregable y necesitas salida de grado editorial o fotorrealista.",
+        "cardIntro": "El modelo de imagen de primer nivel de Black Forest Labs. El techo estético más alto de la línea curada — úsalo para tomas hero y salida de grado editorial.",
+        "metaTitle": "Flux Pro 1.1 Ultra en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "Flux Pro 1.1 Ultra en VM0. El modelo de texto a imagen de primer nivel de Black Forest Labs con techo estético de grado editorial, $0,072 por imagen y comparación con GPT Image 1, SeedDream 4 y Gemini 2.5 Flash Image.",
+        "summary": "Flux Pro 1.1 Ultra es el modelo de texto a imagen de primer nivel de Black Forest Labs — al que recurrir cuando la imagen en sí es el entregable, no un paso en un bucle de agente. La calidad de salida en estéticas editoriales, fotorrealistas y dirigidas al diseño es la más alta de la línea curada, y la adherencia a prompts en briefs compositivos detallados aguanta bien.\n\nEl precio de lista es de $0,072 por imagen, lo que lo hace caro en relación con Gemini 2.5 Flash Image ($0,04) o SeedDream 4 ($0,036), pero el aumento de calidad por imagen es lo suficientemente grande como para que la mayoría de equipos lo usen como el paso de renderizado final después de prefiltrar con un modelo más barato.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "Nivel premium de Black Forest Labs de la generación Flux 1.1.",
+        "background": [
+          "Flux Pro 1.1 Ultra es el modelo premium de texto a imagen de Black Forest Labs. La familia Flux es conocida por el techo estético más alto en la frontera de peso abierto, y la variante Ultra es el nivel de grado producción con la calidad compositiva más consistente.",
+          "La fortaleza del modelo se sitúa en estéticas editoriales y fotorrealistas — tomas hero estilo revista, fotografía de producto, ilustraciones dirigidas al diseño. La adherencia a prompts en briefs compositivos detallados (\"una toma en ángulo bajo de X bajo iluminación Y contra fondo Z\") es materialmente mejor que en la mayoría de alternativas más baratas, que es parte de por qué los equipos siguen pagando la prima por salida de calidad de entrega."
+        ],
+        "architecture": "Modelo de Diffusion de alta resolución con seguimiento de prompts ajustado para fidelidad compositiva. Facturado por imagen generada. Las entradas aceptan prompts de texto; produce salida de alta resolución adecuada para entrega.",
+        "specs": [
+          { "label": "Familia", "value": "Flux 1.1 Pro" },
+          { "label": "Modalidades", "value": "Texto a imagen" },
+          { "label": "Precio listado", "value": "$0,072 por imagen" },
+          { "label": "Idiomas", "value": "Prompts multilingües" },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Techo estético",
+            "body": "El más alto de la línea curada de imágenes. Las estéticas de toma hero, editoriales y fotorrealistas aterrizan de forma más fiable aquí que en Gemini 2.5 Flash Image o GPT Image 1."
+          },
+          {
+            "title": "Fidelidad compositiva",
+            "body": "Fuerte en briefs compositivos detallados que especifican ángulo, iluminación, encuadre y posición del sujeto. Útil cuando el prompt es innegociable."
+          },
+          {
+            "title": "Costo",
+            "body": "$0,072 por imagen — aproximadamente 2× Gemini 2.5 Flash Image y SeedDream 4. El patrón estándar es prefiltrar con un modelo más barato y renderizar finales en Flux."
+          },
+          {
+            "title": "Velocidad",
+            "body": "Más lento que las alternativas del nivel Flash. Resérvalo para los pasos que justifican el costo; no lo uses en bucles interactivos ajustados."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "La toma hero de marketing que debe enviarse",
+            "body": "Cuando la imagen es el entregable final para una campaña, una landing page o un anuncio de lanzamiento, el techo estético de Flux Pro 1.1 Ultra justifica la prima."
+          },
+          {
+            "title": "El agente de fotografía de producto para listados de ecommerce",
+            "body": "Fotografía de producto de grado catálogo desde un brief de texto más imágenes de referencia. La fidelidad compositiva marca la diferencia entre una imagen que se envía y una que se re-renderiza."
+          },
+          {
+            "title": "La ilustración editorial para contenido de formato largo",
+            "body": "Ilustraciones hero estilo revista para artículos, posts de blog e informes. El techo estilístico de Flux lo separa de los predeterminados caballo de batalla."
+          }
+        ],
+        "avoidFor": "Evita Flux Pro 1.1 Ultra en bucles fan-out donde el costo domina — Gemini 2.5 Flash Image es aproximadamente 2× más barato por llamada. Úsalo como el paso de renderizado final en lugar del paso de iteración.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "Flux Pro 1.1 Ultra tiene el techo fotorrealista y editorial más alto; GPT Image 1 tiene salida más fuerte de ilustración estilizada y soporte nativo de flujo de edición. Elige según el entregable."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "Ambos inclinados al fotorrealismo. SeedDream 4 es la mitad del precio y competitivo en trabajo de retrato y producto; Flux Pro 1.1 Ultra gana en fidelidad compositiva de toma hero a mayor costo."
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Roles diferentes. Gemini 2.5 Flash Image es el caballo de batalla barato para iteración; Flux Pro 1.1 Ultra es el paso premium de renderizado final. Apílalos, no elijas uno."
+          }
+        ],
+        "verdict": "Usa Flux Pro 1.1 Ultra como el paso de renderizado final después de prefiltrar con un modelo más barato. El techo estético justifica la prima cuando la imagen es el entregable.",
+        "faqs": [
+          {
+            "q": "¿Cuánto cuesta Flux Pro 1.1 Ultra?",
+            "a": "$0,072 por imagen generada. Aproximadamente 2× Gemini 2.5 Flash Image y SeedDream 4."
+          },
+          {
+            "q": "¿Soporta edición de imagen?",
+            "a": "El nivel Ultra es texto a imagen primero. Para flujos nativos de edición enmascarada en la misma familia, el nivel base Flux Pro 1.1 lleva soporte de edición más amplio a un techo estético más bajo."
+          },
+          {
+            "q": "¿Qué proporciones de aspecto se soportan?",
+            "a": "Proporciones de aspecto fotográficas y de diseño estándar hasta salidas de alta resolución adecuadas para entrega."
+          },
+          {
+            "q": "¿Es bueno para ilustración estilizada?",
+            "a": "Posible pero no su fuerte — GPT Image 1 lleva un techo estilizado más alto. Flux Pro 1.1 Ultra brilla en trabajo fotorrealista y editorial."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Predeterminado barato para iteración"
+          },
+          {
+            "slug": "gpt-image-1",
+            "reason": "Ilustración estilizada más fuerte"
+          },
+          {
+            "slug": "seedream-4",
+            "reason": "Alternativa fotorrealista más barata"
+          }
+        ],
+        "routingNotes": "Enrutado al endpoint Flux Pro 1.1 Ultra de Black Forest Labs y facturado por imagen generada.",
+        "vm0Notes": "Flux Pro 1.1 Ultra es el nivel premium de la línea curada de imágenes. Úsalo para el paso de renderizado final en lugar de para iteración; empareja con Gemini 2.5 Flash Image o SeedDream 4 para el prefiltrado barato."
+      },
+      "seedream-4": {
+        "name": "SeedDream 4",
+        "pageTitle": "SeedDream 4 en VM0. El predeterminado fotorrealista de texto a imagen",
+        "tagline": "El modelo de texto a imagen SeedDream 4 de ByteDance. Fuerte estética fotorrealista a un costo comparable a las opciones más baratas de la línea.",
+        "cardIntro": "SeedDream 4 de ByteDance. Estética fotorrealista a bajo costo por imagen — el predeterminado natural cuando el brief es una foto.",
+        "metaTitle": "SeedDream 4 en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "SeedDream 4 en VM0. El modelo de texto a imagen de ByteDance con fuerte salida fotorrealista, ~$0,036 por imagen y comparación con Gemini 2.5 Flash Image, GPT Image 1 y Flux Pro 1.1 Ultra.",
+        "summary": "SeedDream 4 es el modelo de texto a imagen de ByteDance en la generación Seedream V4. Su propiedad destacada es la estética fotorrealista — retratos, tomas de producto, fotografía de estilo de vida — a un precio de lista ($0,036 por imagen) que es competitivo con la opción más barata de la línea curada.\n\nEs el predeterminado natural cuando el brief es específicamente una foto. Para ilustración estilizada o diseño editorial elige GPT Image 1 o Flux Pro 1.1 Ultra; para cargas de trabajo iterativas generales de agente en prompts largos estructurados elige Gemini 2.5 Flash Image.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "El predeterminado fotorrealista de texto a imagen de ByteDance en la generación Seedream V4.",
+        "background": [
+          "SeedDream 4 es la cuarta generación de la familia de texto a imagen de ByteDance. La estética se inclina hacia salida fotorrealista, con retratos, tomas de producto y de estilo de vida como las categorías destacadas. La adherencia a prompts en briefs descriptivos estándar (sujeto, escenario, iluminación) es sólida.",
+          "A $0,036 por imagen se sitúa cerca del fondo de la línea curada en precio, que es lo que lo hace viable como el predeterminado para cargas de trabajo de agente inclinadas a fotos. Cambia a Flux Pro 1.1 Ultra cuando el brief compositivo es específicamente una toma hero que justifica la prima."
+        ],
+        "architecture": "Modelo de texto a imagen basado en Diffusion. Facturado por imagen generada. Las entradas aceptan prompts de texto; produce salida inclinada al fotorrealismo adecuada para retratos, productos e imágenes de estilo de vida.",
+        "specs": [
+          { "label": "Familia", "value": "Seedream V4" },
+          { "label": "Modalidades", "value": "Texto a imagen" },
+          { "label": "Precio listado", "value": "$0,036 por imagen" },
+          {
+            "label": "Idiomas",
+            "value": "Prompts multilingües (inglés + chino fuerte)"
+          },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Estética fotorrealista",
+            "body": "Retratos, tomas de producto y fotografía de estilo de vida son las categorías destacadas. La salida es competitiva con Flux Pro 1.1 Ultra en una proporción significativa de briefs fotorrealistas y dramáticamente más barata por llamada."
+          },
+          {
+            "title": "Costo",
+            "body": "$0,036 por imagen — cerca del fondo de la línea curada. El predeterminado natural para cargas de trabajo fan-out inclinadas a fotos."
+          },
+          {
+            "title": "Prompts en chino",
+            "body": "Fuerte manejo de prompts en chino y sujetos culturalmente anclados, lo cual es una ventaja real para agentes que sirven a usuarios chino-parlantes."
+          },
+          {
+            "title": "Techo estético",
+            "body": "Sólido para todo en el carril fotorrealista; menos ajuste para ilustración hiper-estilizada donde GPT Image 1 lidera."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El agente de retrato o toma de producto a escala",
+            "body": "Sujetos fotorrealistas a bajo costo por imagen hacen viable SeedDream 4 para cargas de trabajo fan-out — cien fotos de producto para un catálogo, generación masiva de retratos para una herramienta de creador."
+          },
+          {
+            "title": "El agente de marketing en chino",
+            "body": "Fuerte manejo de prompts en chino y sujetos culturalmente anclados. El predeterminado correcto para agentes que sirven a mercados chino-parlantes."
+          },
+          {
+            "title": "La alternativa más barata a Flux Pro 1.1 Ultra",
+            "body": "Cuando el brief es fotorrealista pero el entregable no justifica la prima de Flux, SeedDream 4 lleva la mayor parte de la calidad a la mitad del precio."
+          }
+        ],
+        "avoidFor": "Evita SeedDream 4 para ilustración estilizada (GPT Image 1 lidera), iteración en prompts largos estructurados (Gemini 2.5 Flash Image lidera) o trabajo editorial de toma hero donde la prima de Flux está justificada.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "SeedDream 4 lidera en estética fotorrealista a menor costo; GPT Image 1 lidera en ilustración estilizada y flujos nativos de edición."
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Ambos inclinados al fotorrealismo. SeedDream 4 es la mitad del precio y competitivo en trabajo de retrato y producto; Flux Pro 1.1 Ultra gana en fidelidad compositiva de toma hero."
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Image es el predeterminado barato de propósito general con seguimiento de instrucciones más fuerte en prompts largos; SeedDream 4 es el predeterminado específico fotorrealista con un techo más alto en briefs de foto."
+          }
+        ],
+        "verdict": "Usa SeedDream 4 por defecto cuando el brief es específicamente una foto y el costo importa. Escala a Flux Pro 1.1 Ultra solo cuando la toma hero justifica la prima.",
+        "faqs": [
+          {
+            "q": "¿Cuánto cuesta SeedDream 4?",
+            "a": "$0,036 por imagen generada — cerca del fondo de la línea curada en precio."
+          },
+          {
+            "q": "¿Es bueno con prompts en chino?",
+            "a": "Sí — significativamente más fuerte que la mayoría de líneas base entrenadas en Occidente en prompts en chino y sujetos culturalmente anclados."
+          },
+          {
+            "q": "¿Cuál es su estética más fuerte?",
+            "a": "Fotorrealista: retratos, tomas de producto, fotografía de estilo de vida. Menos ajuste para ilustración estilizada."
+          },
+          {
+            "q": "¿Soporta edición de imagen?",
+            "a": "La entrada curada en VM0 cubre texto a imagen. Los flujos de edición no son la fortaleza primaria del modelo."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "Predeterminado de propósito general más barato"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Calidad premium de toma hero"
+          },
+          {
+            "slug": "gpt-image-1",
+            "reason": "Ilustración estilizada más fuerte"
+          }
+        ],
+        "routingNotes": "Enrutado al endpoint de texto a imagen SeedDream V4 de ByteDance y facturado por imagen generada.",
+        "vm0Notes": "SeedDream 4 es el predeterminado específico fotorrealista en la línea curada de imágenes. Empareja con Flux Pro 1.1 Ultra para tomas hero y con Gemini 2.5 Flash Image para iteración no fotográfica."
+      },
+      "veo-3-1-fast": {
+        "name": "Veo 3.1 Fast",
+        "pageTitle": "Veo 3.1 Fast en VM0. El modelo rápido de texto a video de Google",
+        "tagline": "El modelo rápido de texto a video de Google con audio nativo. La opción para clips cortos sociales y de producto donde la calidad cinematográfica y el audio en una sola pasada importan.",
+        "cardIntro": "El modelo de texto a video de Google con audio nativo. Generación rápida, estilo cinematográfico y banda sonora sincronizada en una sola pasada.",
+        "metaTitle": "Veo 3.1 Fast en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "Veo 3.1 Fast en VM0. El modelo rápido de texto a video de Google con audio nativo, clips de 4–8 segundos hasta 4K, y comparación con Kling V3 4K y Dreamina Seedance 2.0.",
+        "summary": "Veo 3.1 Fast es el nivel rápido de la familia de generación de video Veo 3 de Google. Genera clips cortos (4 / 6 / 8 segundos) a 720p, 1080p o 4K, y renderiza audio nativo sincronizado — voz, sonido ambiental y efectos — en la misma pasada que los visuales. Ese audio en una sola pasada es la propiedad que lo distingue de la mayoría de alternativas en la línea curada.\n\nEl precio de lista es del orden de $0,15 por segundo de salida 720p con audio, lo que lo sitúa en el medio de la línea en costo. El patrón natural es usar Veo 3.1 Fast por defecto para clips sociales y de producto donde el audio importa, cambiar a Dreamina Seedance 2.0 cuando el costo domina, y cambiar a Kling V3 4K cuando necesitas una toma más larga o de mayor resolución.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "Nivel rápido de la familia Veo 3 de Google. Optimizado para salida de formato corto con audio nativo.",
+        "background": [
+          "Veo 3.1 es la familia de generación de video de Google en la generación Veo 3, y el nivel Fast es la variante optimizada para rendimiento — generación más rápida, menor costo por clip, pero limitado a duraciones cortas de clip. El soporte de audio nativo es la propiedad distintiva: voz, sonido ambiental y efectos se renderizan en la misma pasada que los visuales en lugar de añadirse como un paso de post separado.",
+          "La salida de Veo se inclina hacia un look cinematográfico — movimiento limpio, encuadre considerado, iluminación precisa. Es fuerte en briefs de texto a video que describen una sola toma en detalle (ángulo de cámara, acción del sujeto, escenario, iluminación), menos ajuste para estéticas altamente estilizadas o estilo anime donde el techo estilístico de Kling V3 4K se adelanta."
+        ],
+        "architecture": "Modelo de Diffusion de texto a video e imagen a video con síntesis de audio nativa en la misma pasada. Las duraciones de salida son 4, 6 u 8 segundos a 720p, 1080p o 4K. Facturado por video-segundo generado con modificadores de nivel de calidad.",
+        "specs": [
+          { "label": "Familia", "value": "Google Veo 3" },
+          {
+            "label": "Modalidades",
+            "value": "Texto a video, imagen a video, audio nativo"
+          },
+          { "label": "Duraciones", "value": "4s / 6s / 8s" },
+          { "label": "Resoluciones", "value": "720p / 1080p / 4K" },
+          {
+            "label": "Precio listado",
+            "value": "~$0,15 por segundo (720p + audio)"
+          },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Audio nativo",
+            "body": "La propiedad distintiva. Voz, sonido ambiental y efectos se renderizan en la misma pasada que los visuales — no se necesita paso de post separado. El predeterminado correcto para clips sociales y de producto donde el audio importa."
+          },
+          {
+            "title": "Movimiento cinematográfico",
+            "body": "La salida se inclina hacia movimiento limpio, encuadre considerado e iluminación precisa. Fuerte en briefs de texto a video que describen una sola toma en detalle."
+          },
+          {
+            "title": "Velocidad",
+            "body": "Nivel Fast — la generación es materialmente más rápida que el nivel Veo 3 estándar a costa de fidelidad ligeramente menor en los briefs más exigentes."
+          },
+          {
+            "title": "Techo estético",
+            "body": "El carril cinematográfico / fotorrealista es el punto óptimo. Para salida estilizada o estilo anime el techo estilístico de Kling V3 4K es más alto."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El agente de clip social que envía en una sola pasada",
+            "body": "Video social de formato corto con voz y sonido ambiental generados en una sola llamada. Sin paso separado de TTS o post de audio, sin sincronización — el clip aterriza listo para publicar."
+          },
+          {
+            "title": "El video de demo de producto para una landing page",
+            "body": "Clip de producto de 8 segundos a 1080p con una voz en off describiendo la característica. El movimiento cinematográfico y el audio sincronizado hacen que el resultado se sienta producido en lugar de generado."
+          },
+          {
+            "title": "El paso de imagen a video en una campaña",
+            "body": "Comienza desde una imagen hero estática renderizada en Flux Pro 1.1 Ultra o SeedDream 4 y extiende a un clip corto de movimiento. El condicionamiento por imagen mantiene el look consistente."
+          }
+        ],
+        "avoidFor": "Evita Veo 3.1 Fast cuando el brief es estilizado o estilo anime (el techo de Kling V3 4K es más alto), cuando necesitas un clip más largo de 8 segundos, o cuando el costo domina y la propiedad de audio no importa (Dreamina Seedance 2.0 es aproximadamente 3× más barato).",
+        "comparisons": [
+          {
+            "vs": "Kling V3 4K",
+            "body": "Veo 3.1 Fast lidera en audio nativo y estéticas cinematográficas / fotorrealistas; Kling V3 4K lidera en salida estilizada / anime y en duraciones de clip más largas a 4K. Elige según la estética."
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "Posicionamiento diferente. Dreamina Seedance 2.0 es aproximadamente 3× más barato por segundo y es la opción correcta cuando el costo domina; Veo 3.1 Fast lleva la ventaja en audio nativo y movimiento cinematográfico."
+          }
+        ],
+        "verdict": "Usa Veo 3.1 Fast por defecto para clips sociales y de producto de formato corto donde el audio importa. Cambia a Kling V3 4K para salida estilizada o duraciones más largas; cambia a Dreamina Seedance 2.0 cuando el costo domina.",
+        "faqs": [
+          {
+            "q": "¿Veo 3.1 Fast genera audio?",
+            "a": "Sí. Audio nativo — voz, sonido ambiental, efectos — se renderiza en la misma pasada que los visuales."
+          },
+          {
+            "q": "¿Qué duraciones de clip se soportan?",
+            "a": "4, 6 u 8 segundos. Para tomas más largas, cambia a Kling V3 4K."
+          },
+          {
+            "q": "¿Qué resoluciones soporta?",
+            "a": "720p, 1080p y 4K. El costo escala con resolución y duración."
+          },
+          {
+            "q": "¿Acepta condicionamiento por imagen?",
+            "a": "Sí — los flujos imagen a video te dejan comenzar desde una estática y extender a un clip corto de movimiento."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "kling-v3-4k",
+            "reason": "Techo estilizado / anime, clips más largos"
+          },
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "Más barato por segundo"
+          }
+        ],
+        "routingNotes": "Enrutado al endpoint de generación de video Veo 3.1 Fast de Google y facturado por video-segundo generado con modificadores de nivel de calidad.",
+        "vm0Notes": "Veo 3.1 Fast es el predeterminado cinematográfico / con audio en la línea curada de video en VM0. Empareja con Dreamina Seedance 2.0 para iteración barata y con Kling V3 4K para clips estilizados o de formato más largo."
+      },
+      "kling-v3-4k": {
+        "name": "Kling V3 4K",
+        "pageTitle": "Kling V3 4K en VM0. El techo 4K de texto a video",
+        "tagline": "El modelo de texto a video Kling V3 4K de Kuaishou. La opción cuando necesitas clips largos, resolución 4K o una estética estilizada que los otros modelos no alcanzan.",
+        "cardIntro": "Kling V3 4K de Kuaishou. Estética estilizada, clips largos hasta 15 segundos, salida 4K — el techo para video editorial y estilo anime.",
+        "metaTitle": "Kling V3 4K en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "Kling V3 4K en VM0. El modelo de texto a video de Kuaishou con resolución 4K, clips de 3–15 segundos, techo estético estilizado y comparación con Veo 3.1 Fast y Dreamina Seedance 2.0.",
+        "summary": "Kling V3 4K es el modelo de texto a video de primer nivel de Kuaishou. Las propiedades destacadas son la duración de clip (hasta 15 segundos, frente al límite de 8 segundos de Veo 3.1 Fast), resolución 4K como el nivel estándar, y un techo estilístico en estéticas estilo anime y editoriales que las alternativas inclinadas a lo cinematográfico no alcanzan.\n\nEl precio de lista es del orden de $0,28 por segundo de salida 4K, lo que lo convierte en la opción más cara de la línea curada de video. El patrón natural es recurrir a él cuando necesitas tomas largas o 4K, o cuando el brief es específicamente estilizado y el techo estético de las alternativas no acierta.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "Nivel superior de la generación Kling V3 de Kuaishou. Techo 4K y de clip largo.",
+        "background": [
+          "Kling V3 4K es la variante de gama alta de la familia de generación de video Kling V3 de Kuaishou. Lleva las duraciones de clip estándar más largas de la línea curada (3 a 15 segundos), salida 4K nativa en el nivel estándar, y un techo estilístico en estéticas anime y editoriales que las alternativas inclinadas a lo cinematográfico no alcanzan.",
+          "La fortaleza del modelo está en briefs estilizados y editoriales — secuencias estilo anime, clips pesados en danza y movimiento, estéticas de video musical. Para salida cinematográfica fotorrealista Veo 3.1 Fast es comparable a menor costo y con audio nativo; para generación masiva impulsada por costo Dreamina Seedance 2.0 es dramáticamente más barato. El rol de Kling V3 4K es el paso de techo alto y clip largo en lugar del predeterminado universal."
+        ],
+        "architecture": "Modelo de Diffusion de texto a video e imagen a video. El nivel estándar renderiza a 4K con duraciones de clip de 3 a 15 segundos. Facturado por video-segundo generado.",
+        "specs": [
+          { "label": "Familia", "value": "Kling V3" },
+          { "label": "Modalidades", "value": "Texto a video, imagen a video" },
+          { "label": "Duraciones", "value": "3 a 15 segundos" },
+          { "label": "Resoluciones", "value": "4K (nivel estándar)" },
+          { "label": "Precio listado", "value": "~$0,28 por segundo (4K)" },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Duración de clip",
+            "body": "Hasta 15 segundos en el nivel estándar — el más largo de la línea curada. La opción correcta cuando una sola toma ininterrumpida más larga de 8 segundos importa."
+          },
+          {
+            "title": "Resolución 4K",
+            "body": "4K nativo en el nivel estándar en lugar de un cargo adicional de nivel alto. Útil cuando el entregable es pantalla de gran formato o salida de calidad cinematográfica."
+          },
+          {
+            "title": "Techo estético estilizado",
+            "body": "Fuerte en estéticas anime, danza, pesadas en movimiento y editoriales. Aquí es donde Kling se adelanta a las alternativas inclinadas a lo cinematográfico."
+          },
+          {
+            "title": "Costo",
+            "body": "~$0,28 por segundo — la opción más cara de la línea curada. Resérvalo para los pasos donde su techo justifica la prima."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El clip social estilo anime o estilizado",
+            "body": "Las estéticas estilizadas — anime, dirigidas por motion-design, estilo video musical — son donde Kling lleva una ventaja real de techo. Las alternativas inclinadas a lo cinematográfico no alcanzan el mismo look."
+          },
+          {
+            "title": "La toma larga ininterrumpida",
+            "body": "Cuando el brief pide una sola toma de 12 a 15 segundos en lugar de un corte entre clips más cortos, Kling V3 4K es la única opción de la línea curada que alcanza el tope de duración."
+          },
+          {
+            "title": "El entregable 4K para pantalla de gran formato",
+            "body": "4K nativo en el nivel estándar hace de Kling la opción correcta cuando la salida está destinada a una valla publicitaria, cine o campaña social de gran formato."
+          }
+        ],
+        "avoidFor": "Evita Kling V3 4K cuando el brief es cinematográfico fotorrealista con audio (Veo 3.1 Fast es más natural a menor costo) o cuando el costo domina (Dreamina Seedance 2.0 es aproximadamente 5× más barato por segundo).",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Veo 3.1 Fast lidera en audio nativo y estéticas cinematográficas / fotorrealistas; Kling V3 4K lidera en salida estilizada / anime, en duraciones de clip más largas y en salida 4K nativa. Elige según estética y duración."
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "Niveles de costo diferentes. Dreamina Seedance 2.0 es dramáticamente más barato y la opción correcta cuando el costo domina; Kling V3 4K lleva el techo en duración, 4K y estética estilizada."
+          }
+        ],
+        "verdict": "Elige Kling V3 4K para entregables de video estilizados, largos o 4K. Cambia a Veo 3.1 Fast para clips cinematográficos con audio; cambia a Dreamina Seedance 2.0 para fan-out impulsado por costo.",
+        "faqs": [
+          {
+            "q": "¿Cuál es el clip más largo que puede generar Kling V3 4K?",
+            "a": "15 segundos en el nivel estándar — la toma más larga de la línea curada de video en VM0."
+          },
+          {
+            "q": "¿Kling V3 4K soporta audio?",
+            "a": "No de forma nativa en la misma pasada. Para video con audio sincronizado en una sola llamada, usa Veo 3.1 Fast."
+          },
+          {
+            "q": "¿Qué resolución produce Kling?",
+            "a": "4K en el nivel estándar. Variantes de menor resolución están disponibles en la misma familia a menor costo."
+          },
+          {
+            "q": "¿Acepta condicionamiento por imagen?",
+            "a": "Sí — los flujos imagen a video te dejan comenzar desde una estática de referencia y extender a un clip más largo de movimiento."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "Cinematográfico / audio nativo"
+          },
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "Generación masiva más barata"
+          }
+        ],
+        "routingNotes": "Enrutado al endpoint Kling V3 4K de Kuaishou y facturado por video-segundo generado.",
+        "vm0Notes": "Kling V3 4K es la opción de techo alto en la línea curada de video en VM0. Resérvalo para entregables estilizados, de formato largo o 4K — para el predeterminado universal recurre a Veo 3.1 Fast o Dreamina Seedance 2.0."
+      },
+      "dreamina-seedance-2-0": {
+        "name": "Dreamina Seedance 2.0",
+        "pageTitle": "Dreamina Seedance 2.0 en VM0. El modelo de video optimizado en costo",
+        "tagline": "El modelo de video Dreamina Seedance 2.0 de ByteDance. El predeterminado correcto cuando el costo domina — dramáticamente más barato por segundo que las alternativas.",
+        "cardIntro": "Dreamina Seedance 2.0 de ByteDance. El video más barato por segundo en la línea curada — la opción correcta para generación masiva e impulsada por costo.",
+        "metaTitle": "Dreamina Seedance 2.0 en VM0: Precios, Especificaciones y Comparación",
+        "metaDescription": "Dreamina Seedance 2.0 en VM0. El modelo de texto a video de ByteDance con el costo por segundo más barato de la línea curada, clips de 4–15 segundos hasta 1080p y comparación con Veo 3.1 Fast y Kling V3 4K.",
+        "summary": "Dreamina Seedance 2.0 es el miembro optimizado en costo de la familia de video Seedance de ByteDance. Las duraciones de salida van de 4 a 15 segundos a 480p, 720p o 1080p, con flujos de texto a video e imagen a video. La propiedad destacada es el costo — aproximadamente $0,05 por segundo de salida 1080p con condicionamiento por imagen, dramáticamente más barato que Veo 3.1 Fast o Kling V3 4K.\n\nEs el predeterminado natural cuando el costo domina: generación masiva fan-out, variantes de clip social, pasadas borrador antes de un renderizado final premium. Para audio nativo recurre a Veo 3.1 Fast; para salida estilizada de formato largo recurre a Kling V3 4K.",
+        "releaseDate": "Abril 2026",
+        "familyPosition": "Nivel optimizado en costo de la familia de video Seedance de ByteDance.",
+        "background": [
+          "Dreamina Seedance 2.0 es el modelo de video Seedance de segunda generación de ByteDance, emparejado con una variante Fast y una variante Pro en la misma familia. La entrada Standard 2.0 en la línea curada es el punto óptimo de costo/calidad — más barato que el nivel Pro, materialmente más alta calidad que el nivel Fast.",
+          "El modelo maneja flujos de texto a video e imagen a video en duraciones de 4 a 15 segundos a 480p, 720p o 1080p. La salida se inclina hacia estéticas amigables para consumidor: formato corto social, estilo de vida, clips de producto. No es el techo para trabajo cinematográfico o estilizado, pero es la opción viable más barata de la línea curada."
+        ],
+        "architecture": "Modelo de Diffusion de texto a video e imagen a video con tres niveles de calidad (Fast, Standard, Pro). La entrada curada cubre el nivel Standard 2.0. Facturado por video-segundo generado con modificadores por resolución y si se usa condicionamiento por imagen.",
+        "specs": [
+          { "label": "Familia", "value": "Seedance 2.0" },
+          { "label": "Modalidades", "value": "Texto a video, imagen a video" },
+          { "label": "Duraciones", "value": "4 a 15 segundos" },
+          { "label": "Resoluciones", "value": "480p / 720p / 1080p" },
+          {
+            "label": "Precio listado",
+            "value": "~$0,05 por segundo (1080p + imagen)"
+          },
+          { "label": "Disponible en VM0", "value": "Abril 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Costo",
+            "body": "El modelo de video más barato por segundo de la línea curada. Aproximadamente 3× más barato que Veo 3.1 Fast y 5× más barato que Kling V3 4K."
+          },
+          {
+            "title": "Velocidad",
+            "body": "Generación rápida en el nivel Standard — comparable a la variante Fast más barata de la misma familia con calidad materialmente mejor."
+          },
+          {
+            "title": "Imagen a video",
+            "body": "Fuerte manejo de flujos de condicionamiento por imagen. Útil cuando un agente quiere extender una imagen estática (generada de forma barata en Gemini 2.5 Flash Image o SeedDream 4) a un clip corto de movimiento."
+          },
+          {
+            "title": "Techo estético",
+            "body": "Más bajo que Veo 3.1 Fast en movimiento cinematográfico y más bajo que Kling V3 4K en estéticas estilizadas. La opción correcta cuando el costo es el factor decisivo, no el techo."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "El paso de generación masiva fan-out de video",
+            "body": "Costo por segundo lo suficientemente bajo como para hacer viable generar una docena de variantes del mismo clip. Prefiltra de forma barata, luego escala la variante elegida a Veo 3.1 Fast o Kling V3 4K para el renderizado final si la calidad lo justifica."
+          },
+          {
+            "title": "La extensión imagen a video en una campaña",
+            "body": "Comienza desde una imagen hero estática y extiende a un clip corto de movimiento sin pagar el precio del nivel premium. El condicionamiento por imagen mantiene el look consistente."
+          },
+          {
+            "title": "La pasada borrador antes del renderizado premium",
+            "body": "Fija el movimiento, encuadre y ritmo de forma barata en Dreamina Seedance 2.0, luego re-renderiza el final en Veo 3.1 Fast o Kling V3 4K solo en la variante elegida."
+          }
+        ],
+        "avoidFor": "Evita Dreamina Seedance 2.0 cuando el audio nativo importa (Veo 3.1 Fast), cuando las estéticas estilizadas o anime importan (Kling V3 4K), o cuando el brief es cinematográfico de calidad de entrega donde el techo de las alternativas justifica su prima.",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Posicionamiento diferente. Veo 3.1 Fast lleva audio nativo y movimiento cinematográfico; Dreamina Seedance 2.0 es dramáticamente más barato y la opción correcta cuando el costo domina. Apílalos — borrador en Dreamina, final en Veo."
+          },
+          {
+            "vs": "Kling V3 4K",
+            "body": "Niveles completamente diferentes. Kling V3 4K es el techo en duración, 4K y estética estilizada; Dreamina Seedance 2.0 es el predeterminado barato para todo lo demás."
+          }
+        ],
+        "verdict": "Usa Dreamina Seedance 2.0 por defecto cuando el costo domina el paso de generación de video. Apila con Veo 3.1 Fast para finales con audio y Kling V3 4K para salida hero estilizada o 4K.",
+        "faqs": [
+          {
+            "q": "¿Cuánto cuesta Dreamina Seedance 2.0 por segundo?",
+            "a": "Alrededor de $0,05 por segundo de salida 1080p con condicionamiento por imagen — el más barato de la línea curada de video."
+          },
+          {
+            "q": "¿Soporta audio?",
+            "a": "No de forma nativa en la misma pasada. Para video con audio sincronizado en una sola llamada, usa Veo 3.1 Fast."
+          },
+          {
+            "q": "¿Qué duraciones de clip y resoluciones se soportan?",
+            "a": "Clips de 4 a 15 segundos a 480p, 720p o 1080p."
+          },
+          {
+            "q": "¿Hay un nivel de calidad superior de Seedance en VM0?",
+            "a": "La familia Seedance incluye variantes Fast y Pro junto con la entrada Standard 2.0. El precio escala con el nivel; el nivel Standard es el punto óptimo de costo/calidad."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "Audio nativo, movimiento cinematográfico"
+          },
+          { "slug": "kling-v3-4k", "reason": "Estilizado, más largo, 4K" }
+        ],
+        "routingNotes": "Enrutado al endpoint Dreamina Seedance 2.0 de ByteDance y facturado por video-segundo generado con modificadores de resolución y condicionamiento por imagen.",
+        "vm0Notes": "Dreamina Seedance 2.0 es el predeterminado optimizado en costo en la línea curada de video en VM0. El patrón estándar es usarlo para iteración y fan-out, luego escalar la variante elegida a Veo 3.1 Fast o Kling V3 4K solo cuando el renderizado final justifica la prima."
       }
     }
   },

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -3862,10 +3862,10 @@
     "back": "← 戻る"
   },
   "models": {
-    "listingPageTitle": "Models — Claudeなどのエージェントを実行",
-    "listingPageDescription": "VM0エージェントで利用可能なすべてのAIモデル — Claude Opus 4.7、Sonnet 4.6、Haiku 4.5など。各モデルの概要とVM0での最適な用途。",
+    "listingPageTitle": "モデル — VM0 の推論・画像・動画モデル",
+    "listingPageDescription": "VM0 エージェントで利用可能なすべての AI モデル — Anthropic、OpenAI、DeepSeek、Moonshot などの推論モデルに加え、画像・動画生成モデルも。各モデルの概要と VM0 での最適な用途。",
     "jsonLdListName": "VM0で利用可能なAIモデル",
-    "jsonLdListDescription": "VM0エージェントで利用可能なすべてのAIモデル — Claudeなど。",
+    "jsonLdListDescription": "VM0 エージェントで利用可能なすべての AI モデル — 推論・画像・動画。",
     "breadcrumbHome": "ホーム",
     "breadcrumbModels": "Models",
     "notFound": "見つかりません",
@@ -3873,9 +3873,9 @@
     "heroDescription": "エージェントが利用できるすべてのモデル。各モデルの得意分野と選択のタイミング。",
     "filterAriaLabel": "モデルを絞り込む",
     "filterAll": "すべて",
-    "filterRecommended": "推奨",
-    "filterMultimodal": "マルチモーダル",
-    "filterCostSaving": "コスト削減",
+    "filterReasoning": "推論",
+    "filterImage": "画像",
+    "filterVideo": "動画",
     "readMoreAbout": "{name}の詳細を見る",
     "backToAllModels": "すべてのモデル",
     "useModelButton": "VM0で{name}を使う",
@@ -3914,6 +3914,14 @@
     "tierExplanationCore": "VM0は{name}をコアエージェントモデルとして位置付けており、Claude Opus 4.7、Claude Opus 4.6、Claude Sonnet 4.6と並んで、エージェント実行の実際の成果を左右するステップに推奨されます。これらは、オーケストレーター役、コードを扱うエージェント、誤った回答のコストが高いステップに選ぶモデルです。",
     "tierExplanationCostSaving": "VM0は{name}をコアエージェントモデルではなく、コスト削減オプションとして位置付けています。一括分類、プレフィルター、レイテンシが重要な短い返信、固定のレガシーエージェントなど、非コア作業の単価最適化に使用し、実行を左右するステップにはClaude Opus 4.7、Claude Opus 4.6、またはClaude Sonnet 4.6を維持します。",
     "availableSince": "VM0で{date}から利用可能。",
+    "generationPricingSubtitle": "生成単位ごとのベンダー定価。",
+    "generationPricingDetail": "詳細",
+    "generationUnitImage": "生成画像 1 枚あたり",
+    "generationUnitMegapixel": "出力メガピクセルあたり",
+    "generationUnitVideoSecond": "動画 1 秒あたり",
+    "generationUnitAudioSecond": "音声 1 秒あたり",
+    "generationAccessHeading": "VM0 で {name} を使う",
+    "generationAccessBody": "VM0 のエージェントはエージェント実行の一部として {name} を呼び出すことができ、VM0 クレジットで請求されます。上記の定価はアップストリーム・プロバイダーが課金する金額で、VM0 は標準のクレジット換算で透過的に転送します。",
     "content": {
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
@@ -4283,6 +4291,165 @@
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and as the default model on the Anthropic API-key and Claude Code OAuth providers.",
         "vm0Notes": "Opus 4.6 carries the highest vendor list price per token of any Built-in model, so prompt caching matters here more than anywhere else and is on by default. It's still the default model on the Anthropic API-key and Claude Code OAuth providers, which means it's likely the model your team already has muscle memory for, even though Opus 4.7 is the recommended choice for new work."
       },
+      "gpt-5-5": {
+        "name": "GPT-5.5",
+        "pageTitle": "GPT-5.5 on VM0. OpenAIのフラッグシップ推論モデル",
+        "tagline": "OpenAIのGPT-5ファミリーのフラッグシップ。OpenAIティアにおけるエージェントコーディング、深い推論、コンピュータ使用ループに最強の選択肢。",
+        "cardIntro": "OpenAIのフラッグシップ推論モデル。トップクラスのコーディングとツール使用、VM0上のCodexフレームワーク経由でルーティング。",
+        "metaTitle": "GPT-5.5: ベンチマーク、価格、性能",
+        "metaDescription": "GPT-5.5のレビュー。OpenAIのフラッグシップGPT-5推論モデル。400Kコンテキスト、マルチモーダルビジョン、$5/$30ベンダー価格、SWE-bench Verified、AIME 2025、GPQA Diamondでベンチマークリード。",
+        "summary": "GPT-5.5は、深い推論と信頼性の高いツール使用の両方が必要な作業に手を伸ばすモデルです。マルチステップのエージェントループのオーケストレーション、一発で着地しなければならないコード編集、多数のGUIアクションにまたがるコンピュータ使用ワークフローに対応します。ベンダーベンチマーク（SWE-bench Verified、AIME 2025、GPQA Diamond）がGPT-5.4からの向上を具体的な数字で示しています。\n\nベンダー定価は$5/$30/1Mトークン、キャッシュ入力は$0.50/1M。VM0のBuilt-inカタログで最も高額な×2クレジットのモデルであるため、コスト効率の良いパターンは、GPT-5.4またはClaude Sonnet 4.6をどこでもデフォルトに保ち、最も難しいステップのみGPT-5.5にルーティングすることです。",
+        "releaseDate": "2026年4月（GPT-5.4の後継）",
+        "familyPosition": "GPT-5ファミリーの最上位ティア。OpenAIのエージェントコーディングと推論のフラッグシップ。",
+        "background": [
+          "GPT-5.5はOpenAIのGPT-5世代のフラッグシップで、2026年4月にGPT-5.4からの推奨アップグレードとしてリリースされました。OpenAIは、表面APIのリフレッシュではなく、エージェントツール使用とコンピュータ使用タスクにおける段階的な改善として位置付けています。GPT-5で導入された400Kトークンコンテキストウィンドウとreasoning_effortパラメーターは変更なしで引き継がれているため、既存のCodexエージェントは書き換えなしで導入できます。",
+          "GPT-5.4（同ファミリーのワークホース）と比較して、GPT-5.5はトークンあたりにより多くの計算を推論に投資します。その行動的な見返りは3点に現れます：マルチファイルリファクタリングでの初回コードパッチの強化、長いエージェントループでのツール呼び出しの誤ルーティングの大幅な減少、大学院レベルの科学的推論（GPQA Diamond）と競技数学（AIME 2025）での顕著な向上です。トレードオフはGPT-5バリアント中で最高額の定価（$5/$30/1Mトークン）とVM0上の×2クレジット乗数で、これがOpenAI自身がGPT-5.5をどこでもデフォルトではなくプランナーまたはエスカレーションティアとして位置付けている理由です。",
+          "独立系リーダーボード（Artificial Analysis、Vellum）はGPT-5.4に対する相対的な順位を裏付け、GPT-5.5を多くのエージェントコーディングタスクでClaude Opus 4.7の数ポイント以内に位置付けています。絶対値は週ごとに変動し、OpenAI自身がフロンティアモデル全体でSWE-bench Verifiedのトレーニングデータ汚染を指摘しています。公開スコアを権威ではなく方向性として捉え、構造化された行動の違い（ツール呼び出しの正確性、コンピュータ使用の信頼性、初回パッチ品質）こそがより持続的なシグナルです。"
+        ],
+        "architecture": "GPT-5.5はGPT-5.4から400Kトークンコンテキストウィンドウを継承し、ウィンドウ全体が標準入力価格で課金されます。`reasoning_effort`パラメーターを4レベル（minimal、low、medium、high）でサポートし、プロンプトキャッシュではキャッシュ入力が入力レートの10分の1で課金され、codex CLIがデフォルトで使用するResponses APIサーフェスを使用します。ツール使用、構造化出力、コンピュータ使用は5.4から変更ありません。入力はテキスト、ビジョン、コードにわたってマルチモーダル。モデルにはネイティブな画像生成はありません（それにはImages APIを使用）。",
+        "specs": [
+          { "label": "ファミリー", "value": "GPT-5世代" },
+          { "label": "モダリティ", "value": "テキスト、ビジョン、コード" },
+          { "label": "言語", "value": "英語中心、多言語対応" },
+          { "label": "プロンプトキャッシュ", "value": "サポート（OpenAI）" },
+          { "label": "コンテキストウィンドウ", "value": "400Kトークン" },
+          { "label": "最大出力", "value": "最大128Kトークン" },
+          {
+            "label": "推論努力レベル",
+            "value": "Minimal / Low / Medium / High"
+          },
+          { "label": "ベンダー定価", "value": "入力$5 / 出力$30 /1M" }
+        ],
+        "benchmarksNote": "OpenAIのGPT-5.5リリース資料からのベンダー報告スコア、公開されているGPT-5.4の数字に対するデルタを示しています。独立レビューは、エージェントコーディングタスクで5.5をClaude Opus 4.7の数ポイント以内に位置付けています。絶対パーセンテージは方向性として捉えてください。OpenAIは全フロンティアモデルでSWE-bench Verifiedのトレーニングデータ汚染を指摘しています。",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~82%",
+            "note": "ベンダー報告。5.4の74.9%から向上"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~69%",
+            "note": "ベンダー報告のツール使用"
+          },
+          {
+            "name": "AIME 2025（ツールなし）",
+            "score": "~96%",
+            "note": "ベンダー報告の競技数学"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~89%",
+            "note": "ベンダー報告の大学院科学"
+          },
+          {
+            "name": "OSWorld（コンピュータ使用）",
+            "score": "~74%",
+            "note": "ベンダー報告"
+          },
+          {
+            "name": "MMMU（マルチモーダル）",
+            "score": "GPT-5ファミリーをリード",
+            "note": "ベンダー報告"
+          },
+          {
+            "name": "速度",
+            "score": "~70トークン/秒",
+            "note": "Artificial Analysis、中努力"
+          }
+        ],
+        "performance": [
+          {
+            "title": "ツールルーティング",
+            "body": "GPT-5ファミリーで最も低いツール呼び出しの誤ルーティング率。5.4との差は、条件付きツール選択、深くネストされた引数、長い推論の後に発行されるツール呼び出しなど、難しいエッジケースで広がります。"
+          },
+          {
+            "title": "初回コード編集",
+            "body": "GPT-5ファミリーで最強のパッチ品質。エージェントがコンパイルとテストを通り続ける必要があるコードを修正する場合、特にパッチが複数ファイルにまたがる場合の正しい選択肢です。ベンダー報告のSWE-bench Verifiedがこれを直接反映しています。"
+          },
+          {
+            "title": "コンピュータ使用",
+            "body": "マルチステップGUIシーケンスにおいて5.4よりも大幅に信頼性が高く、OSWorldのデルタが捉えているのはこれです。エージェントがブラウザやデスクトップアプリを数十ステップにわたって駆動し、途中での脱線コストが高い場合に手を伸ばしてください。"
+          },
+          {
+            "title": "速度",
+            "body": "5.4より遅く、5.4 Miniよりも顕著に遅い。Artificial Analysisによれば中努力で約70トークン/秒。実際に追加の推論深度を必要とするステップのために予約し、より軽いティアを並列で実行してください。"
+          },
+          {
+            "title": "ハルシネーション挙動",
+            "body": "GPT-5.5はGPT-5世代からのOpenAIのより厳格なキャリブレーションを引き継ぎ、作話するよりも不確実性を認める傾向があります。これが、DeepSeek V4 Proのようなより安価な代替がベンチマークで同等になった現在でも、プロダクションチームが高リスクの推論にプレミアムを払い続ける理由です。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "マルチツールプランを実行するオーケストレーター",
+            "body": "GPT-5.5を、顧客のリクエストを10ステップに分割し、各ステップをGPT-5.4または5.4 Miniティアのサブエージェントにディスパッチし、結果を再びつなぎ合わせるプランナーとして使用してください。プランナーレイヤーのみ5.5を実行する（その他はすべてより安価なティア）と、5.5をエンドツーエンドで実行するよりも一部のコストで済み、ほとんどの品質が保持されます。"
+          },
+          {
+            "title": "CI実行を無駄にしない初回コード編集",
+            "body": "GPT-5.5に、50ファイルのコードベースをあるORMから別のORMに移行する、絡まったモジュールをリファクタリングする、またはリポジトリ全体にセキュリティ修正を適用するよう依頼してください。パッチは他のどのファミリーモデルよりも初回でクリーンに適用されることが多く、それこそがあなたのCI請求書に反映されます。"
+          },
+          {
+            "title": "ワークフローを完了しなければならないコンピュータ使用エージェント",
+            "body": "エージェントがマルチステップ予約フロー、デスクトップアプリ、レガシー管理UIをブラウザで駆動している場合、5.5のより強力なOSWorldスコアが、途中での脱線の減少と人間による引き継ぎの減少に翻訳されます。長いセッションを再起動する必要がなくなった最初の一回でプレミアムは元が取れます。"
+          },
+          {
+            "title": "難しい数学または難しい科学のリサーチステップ",
+            "body": "競技グレードの数学問題セットや大学院物理学の導出を投げ込むと、5.5は5.4で見られる1つずれのミスなしで作業を進めます。AIME 2025とGPQA Diamondがまさにこの種の挙動を捉えています。"
+          }
+        ],
+        "avoidFor": "GPT-5.4が半分のクレジットコストで同じ品質バーに達する高ボリュームのルーティン作業、GPT-5.4 Miniがはるかに高速なレイテンシ感応型チャット返信、DeepSeek V4 Flashがベンダーレベルで約35倍安価な大量分類または抽出ジョブではGPT-5.5をスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "GPT-5.4はGPT-5ファミリーのワークホースデフォルトであり、ほとんどのエージェントに対する正しい選択です。GPT-5.5への昇格は、5.4が難しい推論、長いエージェントループ、初回コード編集で目に見えて失敗する場合のみ、通常は5.4または5.4 Miniティアのサブエージェントに下方委任するオーケストレーターとして行ってください。"
+          },
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "異なるファミリーで同じ役割：高リスクオーケストレーター、より安価なティアが失敗したときにエスカレートするモデル。Opus 4.7は1MトークンコンテキストウィンドウとAnthropicの安全性プロファイルを持ち、GPT-5.5はより強力なコンピュータ使用スコアを持ち、既にCodexフレームワークを使用しているチームの自然な選択です。既存のエージェントが対象とするフレームワークとエコシステムで選択してください。"
+          },
+          {
+            "vs": "Gemini 3 Pro",
+            "body": "Gemini 3 Proは生の長文コンテキスト推論（2Mトークンウィンドウ）と一部のマルチモーダルベンチマークでリードします。GPT-5.5はエージェントコーディング（SWE-bench Verified、Terminal-Bench）とコンピュータ使用でリードします。エージェントがコードを編集したりUIを駆動したりするときはGPT-5.5を選び、ワークロードが重いドキュメントまたは動画理解の場合はGemini 3 Proを選んでください。"
+          }
+        ],
+        "verdict": "GPT-5.5はOpenAI側のエスカレーションティアです。GPT-5.4をデフォルトにし、5.4が目に見えて失敗する特定のステップにのみ5.5に昇格してください。",
+        "faqs": [
+          {
+            "q": "GPT-5.5のコンテキストウィンドウは？",
+            "a": "400,000トークン、レスポンスあたり最大128Kトークンの出力。ウィンドウ全体が標準レートで課金されます。"
+          },
+          {
+            "q": "GPT-5.5は画像を処理できますか？",
+            "a": "はい。GPT-5.5はマルチモーダルです。テキストとコードと並んで画像入力を受け付けるため、スクリーンショット駆動およびドキュメントビジョンエージェントがネイティブに動作します。画像生成にはOpenAI Images APIを使用してください。"
+          },
+          {
+            "q": "GPT-5.5とGPT-5.4のどちらを選ぶべき？",
+            "a": "（a）エージェントがプランナー/オーケストレーターで意思決定が連鎖する場合、（b）実行が十分に長く5.4がツール呼び出しの誤ルーティングを始める場合、または（c）出力が初回でクリーンに適用される必要がある場合（コード編集、構造化ペイロード、コンピュータ使用ワークフロー）。"
+          },
+          {
+            "q": "GPT-5.5はプロンプトキャッシュをサポートしていますか？",
+            "a": "はい。キャッシュ入力は$0.50/1Mトークン — キャッシュ部分で10倍の割引。システムプロンプトまたはツールスキーマが呼び出し間で安定している場合に使う価値があります。"
+          },
+          {
+            "q": "GPT-5.5はVM0上でどのフレームワークを使用しますか？",
+            "a": "Codex。VM0はGPT-5.5をCodexフレームワークのResponses APIサーフェス経由でルーティングし、これはcodex CLIがデフォルトで使用するものです。Claude Codeフレームワークエージェントは、VM0上でGPT-5モデルと互換性がありません。"
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-5-4", "reason": "半分のクレジット、同じファミリー" },
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Claude側の同等フラッグシップ"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "×1クレジットでのワークホースデフォルト"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Exposed four ways: through the VM0 Managed credit pool, through a direct OpenAI API key, through a ChatGPT (Codex) OAuth login, and through OpenRouter / Vercel AI Gateway in their Codex variants.",
+        "vm0Notes": "GPT-5.5 sits at the ×2 credit multiplier — the highest in the Built-in catalogue. Prompt caching is enabled by default through VM0, which substantially cuts the cost of repeated system prompts on agents that issue many turns from the same prefix. The standard pattern is to keep GPT-5.4 or Claude Sonnet 4.6 running everywhere and escalate only the steps that genuinely need 5.5's reasoning depth."
+      },
       "claude-sonnet-4-6": {
         "name": "Claude Sonnet 4.6",
         "pageTitle": "Claude Sonnet 4.6 on VM0. The default agent model",
@@ -4437,6 +4604,159 @@
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Default model on VM0 Managed.",
         "vm0Notes": "Sonnet 4.6 is the credit baseline (×1) that every other Built-in model's multiplier is normalised against, which is the main reason it stays the first choice for new agents on VM0; escalate to Opus only when Sonnet visibly underperforms on a specific task. Native prompt caching pairs well with VM0's stable system prompts and tool definitions, and keeps the per-turn cost of long-running agents predictable."
+      },
+      "gpt-5-4": {
+        "name": "GPT-5.4",
+        "pageTitle": "GPT-5.4 on VM0. OpenAIのワークホース",
+        "tagline": "OpenAIのGPT-5ファミリーのワークホース。Claude Sonnet 4.6と並んで×1クレジット基準に位置し、ほとんどのCodexフレームワークエージェントに対する正しいデフォルトです。",
+        "cardIntro": "OpenAIのワークホースモデル。×1クレジット、マルチモーダルビジョン、強力なコードとツール使用 — ほとんどのエージェントに対するデフォルトGPT-5。",
+        "metaTitle": "GPT-5.4 on VM0: ベンチマーク、価格、比較",
+        "metaDescription": "VM0上のGPT-5.4レビュー。OpenAIのワークホースGPT-5モデル、400Kコンテキスト、マルチモーダルビジョン、$2.5/$15価格、VM0 Managedで×1クレジット。仕様とClaudeとの比較。",
+        "summary": "GPT-5.4はOpenAIのGPT-5ファミリーのワークホース — デフォルトでどこでも実行し続けるモデルです。ベンダー報告のSWE-bench Verifiedは74.9%で、コーディングではClaude Sonnet 4.6と同じ範囲に位置し、そのツール使用の正確性は、ほとんどのプロダクションCodexフレームワークエージェントが調整される対象です。\n\nベンダー定価は$2.5/$15/1Mトークン、キャッシュ入力は$0.25/1M。VM0 Managedでは×1クレジット — Claude Sonnet 4.6と同じ基準 — に位置し、エージェントが既にCodexフレームワーク上にあり、バランスの取れたコスト/品質デフォルトが欲しい場合の自然な選択です。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "GPT-5ファミリーのワークホース。ほとんどのCodexフレームワークエージェントに対する推奨デフォルト。",
+        "background": [
+          "GPT-5.4はOpenAIのGPT-5世代のワークホースで、2026年4月にフラッグシップGPT-5.5とコスト最適化されたGPT-5.4 Miniと一緒にリリースされました。OpenAIは、Codexフレームワーク上のエージェントに対するどこでもデフォルトとして位置付けています — 特定のステップが5.5へのエスカレーションを正当化しない限り、すべてのステップで実行し続けるモデルです。",
+          "アーキテクチャ的にGPT-5.4は、GPT-5ファミリーの残りと400Kトークンコンテキストウィンドウ、`reasoning_effort`パラメーター、プロンプトキャッシュ、Responses APIサーフェスを共有しています。GPT-5.5との分岐は、トークンあたりの計算投資です：5.4はより高速かつ安価に実行され、5.5は推論深度により多く投資します。GPT-5.4 Miniとの分岐はその逆 — 5.4はエージェント実行を実際に決定するステップに対してより多くの品質を運びます。",
+          "VM0上では×1クレジット乗数に位置し、Claude Sonnet 4.6と同じ基準なので、AnthropicとOpenAIのデフォルト間の横並びのコスト比較が簡単になります。両者の選択は通常、フレームワーク（Codex対Claude Code）、エコシステム（既存の統合、ツール定義）、およびチームがどちらのモデルにより多くの行動的筋肉記憶を持っているかに帰着します。"
+        ],
+        "architecture": "GPT-5.4はGPT-5ファミリーの残りと同じアーキテクチャを使用します：400Kトークンコンテキストウィンドウ、4レベル（minimal、low、medium、high）の`reasoning_effort`パラメーター、キャッシュ入力が入力レートの10分の1で課金されるプロンプトキャッシュ、codex CLIがデフォルトで使用するResponses APIサーフェス。ツール使用、構造化出力、コンピュータ使用がサポートされています。入力はテキスト、ビジョン、コードにわたってマルチモーダル。",
+        "specs": [
+          { "label": "ファミリー", "value": "GPT-5世代" },
+          { "label": "モダリティ", "value": "テキスト、ビジョン、コード" },
+          { "label": "言語", "value": "英語中心、多言語対応" },
+          { "label": "プロンプトキャッシュ", "value": "サポート（OpenAI）" },
+          { "label": "コンテキストウィンドウ", "value": "400Kトークン" },
+          { "label": "最大出力", "value": "最大128Kトークン" },
+          {
+            "label": "推論努力レベル",
+            "value": "Minimal / Low / Medium / High"
+          },
+          { "label": "ベンダー定価", "value": "入力$2.5 / 出力$15 /1M" }
+        ],
+        "benchmarksNote": "OpenAIのGPT-5リリース資料からのベンダー報告スコア、前世代のOpenAIに対するデルタを示しています。独立レビューはGPT-5.4をClaude Sonnet 4.6と同じコーディング品質帯に位置付けています。絶対パーセンテージは方向性として捉えてください。",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "74.9%",
+            "note": "ベンダー報告"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~58%",
+            "note": "ベンダー報告のツール使用"
+          },
+          {
+            "name": "AIME 2025（ツールなし）",
+            "score": "~92%",
+            "note": "ベンダー報告の競技数学"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~85%",
+            "note": "ベンダー報告の大学院科学"
+          },
+          {
+            "name": "OSWorld（コンピュータ使用）",
+            "score": "~62%",
+            "note": "ベンダー報告"
+          },
+          {
+            "name": "速度",
+            "score": "~110トークン/秒",
+            "note": "Artificial Analysis、中努力"
+          }
+        ],
+        "performance": [
+          {
+            "title": "ツールルーティング",
+            "body": "標準的なCodexフレームワークのツールカタログ全体で確実な基準精度。5.5が先んじるのは難しいエッジケース（条件付きツール選択、深くネストされた引数）であり、ルーチンケースでは5.4は大幅に低いレイテンシで正しくルーティングします。"
+          },
+          {
+            "title": "コード編集",
+            "body": "標準的なリファクタリングとバグ修正ワークロードにおいて、Claude Sonnet 4.6と同等のパッチ品質。5.5が先んじ始めるのは、パッチが初回でクリーンに適用される必要があるマルチファイル変更です。"
+          },
+          {
+            "title": "速度",
+            "body": "5.5よりも大幅に高速 — Artificial Analysisによれば中努力で約110トークン/秒。これが、ユーザーに見えるレイテンシが重要なインタラクティブチャット返信と短いエージェントループに対して5.4がデフォルトのままである理由の一部です。"
+          },
+          {
+            "title": "コスト効率",
+            "body": "Sonnet 4.6品質帯の出力挙動で×1クレジット。既にCodexフレームワーク上にあるチームにとって、これがコスト/品質のスイートスポット — 目に見えて必要なステップのみ5.5に昇格してください。"
+          },
+          {
+            "title": "ハルシネーション挙動",
+            "body": "OpenAIがGPT-5世代で出荷したキャリブレーション改善を継承。特にトレーニング範囲外の質問について、GPT-4シリーズよりも自信のある誤答に陥りにくくなっています。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Codexフレームワーク上のデフォルトエージェントステップ",
+            "body": "エージェントが既にcodex CLIまたは任意のCodexフレームワーク統合上に構築されている場合、GPT-5.4は自然などこでもデフォルトです。×1クレジット、インタラクティブな使用に十分な速度、ほとんどのエージェント実行を支配するルーチンツール呼び出しに十分な正確性。"
+          },
+          {
+            "title": "ビジョン付きインタラクティブチャット",
+            "body": "スクリーンショット駆動UI、ドキュメントQ&A、画像アノテーション — GPT-5.4は3つすべてをワークホース速度でマルチモーダルに処理します。×1乗数によりターンあたりのコストがSonnet 4.6と同じ帯に保たれるため、同じワークロードで両者をA/Bテストできます。"
+          },
+          {
+            "title": "Claude Sonnet 4.6に対するコスト/品質A/B",
+            "body": "両モデルともVM0 Managedで×1クレジットに位置し、コストで直接比較可能です。同じエージェントを両方で1週間実行し、特定のワークロードでの挙動で選んでください — どちらも普遍的に優れているわけではなく、正しいデフォルトはツールカタログとプロンプトスタイルに依存します。"
+          }
+        ],
+        "avoidFor": "5.5が顕著にリードする最も難しい推論、コンピュータ使用、マルチファイルコード編集ステップ、および5.4 Miniがベンダーレベルで4倍安価な大量分類または事前フィルタ作業ではGPT-5.4をスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "GPT-5.5",
+            "body": "同じファミリー、異なるポジショニング。5.5（×2）は最強の推論、コンピュータ使用、初回コード品質を提供。5.4（×1）は同じコンテキストウィンドウと機能セットを半分のクレジットコストと顕著に高い速度で提供。5.4をデフォルトにし、目に見えて必要なステップのみ5.5にエスカレートしてください。"
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "各エコシステムに1つずつの×1基準。Sonnet 4.6はClaude Codeフレームワーク上で実行、GPT-5.4はCodex上で実行。既存のエージェントとツール定義が対象とするフレームワークで選んでください。生の出力品質では両者は十分に近く、ワークロードでA/Bテストすることが正しい判断です。"
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "同じファミリー、異なるポジショニング。5.4（×1）はトークンあたりにより多くの推論品質を運び、5.4 Mini（×0.3）はバルクと事前フィルタ作業のためのはるかに安価なオプションを提供します。ファンアウト分類には5.4 Mini、エージェント実行を決定するステップには5.4を使用してください。"
+          }
+        ],
+        "verdict": "GPT-5.4はVM0上のCodexフレームワークエージェントに対するどこでもデフォルト。難しい推論には5.5にエスカレート、バルク事前フィルタリングには5.4 Miniに降格してください。",
+        "faqs": [
+          {
+            "q": "GPT-5.4のコンテキストウィンドウは？",
+            "a": "400,000トークン、レスポンスあたり最大128Kトークンの出力。ウィンドウ全体が標準レートで課金されます。"
+          },
+          {
+            "q": "GPT-5.4は画像を処理できますか？",
+            "a": "はい。GPT-5.4はマルチモーダルです。テキストとコードと並んで画像入力をネイティブに受け付けます。"
+          },
+          {
+            "q": "GPT-5.4とClaude Sonnet 4.6のどちらを選ぶべき？",
+            "a": "エージェントが既にCodexフレームワーク上に構築されている場合、またはOpenAIエコシステム（ツールカタログ、構造化出力、Responses API）が必要な場合。両者とも×1クレジットなのでコストは同一で、選択はフレームワークと挙動の適合性に帰着します。"
+          },
+          {
+            "q": "GPT-5.4はプロンプトキャッシュをサポートしていますか？",
+            "a": "はい。キャッシュ入力は$0.25/1Mトークン — キャッシュ部分で10倍の割引。"
+          },
+          {
+            "q": "GPT-5.4はVM0上でどのフレームワークを使用しますか？",
+            "a": "Codex。VM0はすべてのGPT-5モデルをCodexフレームワークのResponses APIサーフェス経由でルーティングします。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-5",
+            "reason": "最も難しいステップのためのエスカレーションティア"
+          },
+          {
+            "slug": "gpt-5-4-mini",
+            "reason": "バルク作業のためのより安価なオプション"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Claude Codeフレームワーク上の×1同等"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 sits at the ×1 baseline, same as Claude Sonnet 4.6, which makes the two cost-equivalent on VM0 Managed and easy to A/B against each other. Prompt caching is enabled by default. Pair with GPT-5.4 Mini for high-volume pre-filter work, and escalate to GPT-5.5 only for the steps that genuinely need the extra reasoning depth."
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -4731,6 +5051,154 @@
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and the Anthropic / Claude Code OAuth providers.",
         "vm0Notes": "Haiku 4.5 carries the lowest Claude multiplier (×0.3) and is the right pick for high-volume routing workloads, with prompt caching keeping the cost of repeated short prompts down. It doesn't carry Sonnet's multi-step agent quality, so design any Haiku-based agent to keep loops short and the tool surface narrow."
+      },
+      "gpt-5-4-mini": {
+        "name": "GPT-5.4 Mini",
+        "pageTitle": "GPT-5.4 Mini on VM0. コスト削減型GPT-5",
+        "tagline": "OpenAIのGPT-5ファミリーのコスト最適化メンバー。×0.3クレジット、マルチモーダルビジョン、大量のルーティング、分類、事前フィルタ作業に十分な速度。",
+        "cardIntro": "OpenAIのコスト削減型GPT-5。×0.3クレジット、高速かつマルチモーダル — Codexフレームワーク上のバルク事前フィルタ作業に対する正しい選択。",
+        "metaTitle": "GPT-5.4 Mini on VM0: ベンチマーク、価格、比較",
+        "metaDescription": "VM0上のGPT-5.4 Miniレビュー。コスト削減型OpenAI GPT-5モデル、$0.75/$4.5ベンダー価格、×0.3クレジット、400Kコンテキスト、マルチモーダルビジョン。仕様、挙動、Claude Haiku 4.5との比較。",
+        "summary": "GPT-5.4 MiniはOpenAIのGPT-5ファミリーのコスト削減メンバー — ピーク推論品質よりもユニットコストが重要な場合に手を伸ばすモデルです。ファミリーの残りと同じ400Kコンテキストウィンドウとマルチモーダル入力を維持しますが、トークンあたりの計算を削減しており、それがより低い価格（$0.75/$4.5/1M）と顕著に高い速度に翻訳されます。\n\nVM0では×0.3クレジット — Claude Haiku 4.5やKimi K2.6と同じ乗数 — に位置し、バルク分類、ファンアウトルーティング、事前フィルタ、およびGPT-5.4のコストの3分の1に落とすことが決定要因となるエージェントステップに対する自然なOpenAI側の選択です。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "GPT-5ファミリーのコスト削減バリアント。Claude Haiku 4.5のOpenAI側の同等。",
+        "background": [
+          "GPT-5.4 MiniはOpenAIのGPT-5世代のコスト最適化メンバーで、2026年4月にGPT-5.5とGPT-5.4と一緒にリリースされました。OpenAIは、高スループットティアとして位置付けています — より大きな5.4や5.5がルーチンな決定では無駄になる、分類、ルーティング、事前フィルタステップで実行し続けるモデルです。",
+          "アーキテクチャ的にはGPT-5ファミリーの400Kトークンコンテキストウィンドウ、`reasoning_effort`パラメーター、プロンプトキャッシュ、codex CLIがデフォルトで使用するResponses APIサーフェスを共有しています。5.4とのトレードオフは推論深度です：Miniは標準的なツール呼び出し、短い要約、構造化出力ワークロードを十分に処理しますが、5.4がまだ持ちこたえるより難しいマルチステッププランでドリフトし始めます。同じ価格帯の競合とのトレードオフはエコシステム — 既にCodex上にいる場合、OpenAIサーフェス内に留まることでツール定義と構造化出力スキーマが一貫したまま保たれます。",
+          "VM0上ではMiniは×0.3クレジット乗数に位置し、Claude Haiku 4.5、Kimi K2.6、DeepSeek V4 Proと同じです。コスト削減ティア内では、選択は主にフレームワークと特定のワークロードでの挙動の適合性に依存します。"
+        ],
+        "architecture": "GPT-5.4 MiniはGPT-5ファミリーの残りと同じアーキテクチャを使用します：400Kトークンコンテキストウィンドウ、4レベルの`reasoning_effort`パラメーター、キャッシュ入力が入力レートの10分の1で課金されるプロンプトキャッシュ、Responses APIサーフェス。ツール使用、構造化出力、マルチモーダルビジョン入力がサポートされています。モデルはより小さく高速な兄弟 — トークンあたり少ないパラメーター、ドルあたりより多くのスループット。",
+        "specs": [
+          { "label": "ファミリー", "value": "GPT-5世代" },
+          { "label": "モダリティ", "value": "テキスト、ビジョン、コード" },
+          { "label": "言語", "value": "英語中心、多言語対応" },
+          { "label": "プロンプトキャッシュ", "value": "サポート（OpenAI）" },
+          { "label": "コンテキストウィンドウ", "value": "400Kトークン" },
+          { "label": "最大出力", "value": "最大128Kトークン" },
+          {
+            "label": "推論努力レベル",
+            "value": "Minimal / Low / Medium / High"
+          },
+          { "label": "ベンダー定価", "value": "入力$0.75 / 出力$4.5 /1M" }
+        ],
+        "benchmarksNote": "OpenAIのGPT-5 Miniリリース資料からのベンダー報告スコア。独立レビューはほとんどのエージェントベンチマークで5.4 MiniをClaude Haiku 4.5と同じコスト削減帯に位置付けています。絶対パーセンテージは方向性として捉えてください。",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "~60%",
+            "note": "ベンダー報告"
+          },
+          {
+            "name": "Terminal-Bench 2.0",
+            "score": "~42%",
+            "note": "ベンダー報告のツール使用"
+          },
+          {
+            "name": "AIME 2025（ツールなし）",
+            "score": "~84%",
+            "note": "ベンダー報告の競技数学"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~74%",
+            "note": "ベンダー報告の大学院科学"
+          },
+          {
+            "name": "速度",
+            "score": "~165トークン/秒",
+            "note": "Artificial Analysis、中努力"
+          }
+        ],
+        "performance": [
+          {
+            "title": "速度",
+            "body": "GPT-5ファミリーで最速のモデル — Artificial Analysisによれば中努力で約165トークン/秒。これが、ユーザーに見えるレイテンシが支配的なインタラクティブチャット返信と短いファンアウトツール呼び出しに対して実行可能にする性質です。"
+          },
+          {
+            "title": "ルーチンツール呼び出し",
+            "body": "標準的なCodexフレームワークのツールカタログで正確。5.4が先んじるのは難しいエッジケース（条件付きツール選択、深くネストされた引数）。ルーチンケースではMiniはコストの3分の1でツールルーティングをクリーンに処理します。"
+          },
+          {
+            "title": "バルク分類と事前フィルタ",
+            "body": "GPT-5ファミリーでファンアウト作業に対する最強のコスト/品質ポジション。バルクPRトリアージ、サポートチケット分類、ドキュメントティア分類 — 以前は手書きの正規表現を使っていたすべてのワークロードが、今では実際のモデル呼び出しで手頃な価格になります。"
+          },
+          {
+            "title": "コスト効率",
+            "body": "マルチモーダルビジョンを含む×0.3クレジット。この価格帯では、Mini、Claude Haiku 4.5、Kimi K2.6はすべて同じ帯にあり、選択は通常フレームワークの適合性と特定のワークロードでの挙動に帰着します。"
+          },
+          {
+            "title": "エスカレートするタイミング",
+            "body": "Miniは長いマルチステッププラン、難しい推論、初回マルチファイルコード編集でドリフトします。Miniがループ全体を運ぼうとするのではなく、オーケストレーターが5.4や5.5にエスカレートするタイミングを決定するようにエージェントを設計してください。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "すべてのイベントで実行されるファンアウト分類器",
+            "body": "受信サポートチケット、PRコメント、セールスコール文字起こし、ドキュメントアップロード — Miniは各々を読み取り、正しいダウンストリームエージェントまたはレビューアにルーティングします。×0.3クレジットと165トークン/秒はイベントあたりのコストを十分に小さくし、サンプルバッチだけでなくすべてのイベントで実行することが実際に実行可能にします。"
+          },
+          {
+            "title": "高価なモデルの前の事前フィルタステップ",
+            "body": "Miniをエージェントのツール呼び出しの先頭に固定して、リクエストがエスカレートする必要があるかどうかを決定させます。ほとんどのリクエストは高速で安価な回答を得て、残りの少数のみがフルGPT-5.4または5.5のコストを支払います。これが、コスト削減ティアとコアティアをスタックすることが、実際に手頃な価格を変える場所です。"
+          },
+          {
+            "title": "インタラクティブチャット返信",
+            "body": "ユーザーに見えるレイテンシが体験を支配する短いマルチモーダルターン。Miniはストリーミングを瞬時に感じさせるほど高速に答え、マルチモーダルサポートによって会話中のスクリーンショットがそのまま動作します。"
+          }
+        ],
+        "avoidFor": "最も難しい推論、マルチステップエージェントオーケストレーション、コンピュータ使用シーケンス、初回マルチファイルコード編集ではGPT-5.4 Miniをスキップしてください — それらのタスクのルーチンバージョンには5.4にエスカレート、最も難しいものには5.5にエスカレートしてください。",
+        "comparisons": [
+          {
+            "vs": "GPT-5.4",
+            "body": "同じファミリー、異なるポジショニング。5.4 Mini（×0.3）はコストと速度で勝ち、5.4（×1）は難しいケースでの推論品質とツールルーティング精度で勝ちます。標準パターンはMiniで事前フィルタし、残りのケースを5.4にエスカレートすることです。"
+          },
+          {
+            "vs": "Claude Haiku 4.5",
+            "body": "同じ乗数（×0.3）。MiniはCodexフレームワーク上で実行、Haiku 4.5はClaude Code上で実行。両方ともマルチモーダルで、両方とも同じコスト削減スロットを対象としています。既存のエージェントとツール定義が対象とするフレームワークで選んでください。"
+          },
+          {
+            "vs": "DeepSeek V4 Flash",
+            "body": "DeepSeek V4 Flash（×0.02）はベンダーレベルで劇的に安価で、純粋なバルク単発作業に対する正しい選択です。GPT-5.4 Mini（×0.3）はより多くの推論品質を運び、OpenAIエコシステム内に留まるため、ツール定義と構造化出力スキーマが既にCodex向けに調整されている場合に重要です。"
+          }
+        ],
+        "verdict": "GPT-5.4 MiniはOpenAI側のコスト削減デフォルト。Miniで事前フィルタし、ルーチンステップにはGPT-5.4にエスカレート、最も難しい推論にのみGPT-5.5にエスカレートしてください。",
+        "faqs": [
+          {
+            "q": "GPT-5.4 Miniのコンテキストウィンドウは？",
+            "a": "400,000トークン、レスポンスあたり最大128Kトークンの出力 — GPT-5ファミリーの残りと同じ。"
+          },
+          {
+            "q": "GPT-5.4 Miniは画像を処理できますか？",
+            "a": "はい。GPT-5ファミリーの残りと同様にテキストとコードと並んで画像入力を受け付けます。"
+          },
+          {
+            "q": "GPT-5.4 MiniとClaude Haiku 4.5のどちらを選ぶべき？",
+            "a": "エージェントが既にCodexフレームワーク上に構築されている場合、またはOpenAI構造化出力/ツール呼び出しエコシステムが必要な場合。両者とも×0.3クレジットなのでコストは同一で、選択はフレームワークと挙動に帰着します。"
+          },
+          {
+            "q": "GPT-5.4 Miniはプロンプトキャッシュをサポートしていますか？",
+            "a": "はい。キャッシュ入力は$0.075/1Mトークン — キャッシュ部分で10倍の割引。"
+          },
+          {
+            "q": "GPT-5.4 MiniはVM0上でどのフレームワークを使用しますか？",
+            "a": "Codex。VM0はすべてのGPT-5モデルをCodexフレームワークのResponses APIサーフェス経由でルーティングします。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-5-4",
+            "reason": "より難しいステップへのステップアップ、同じファミリー"
+          },
+          {
+            "slug": "claude-haiku-4-5",
+            "reason": "Claude Codeフレームワーク上の×0.3同等"
+          },
+          {
+            "slug": "deepseek-v4-flash",
+            "reason": "純粋なバルク作業に劇的に安価"
+          }
+        ],
+        "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
+        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Claude Haiku 4.5, Kimi K2.6 and DeepSeek V4 Pro. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
       },
       "kimi-k2-6": {
         "name": "Kimi K2.6",
@@ -5496,6 +5964,735 @@
         ],
         "routingNotes": "DeepSeekのAnthropic互換エンドポイント`api.deepseek.com`経由でルーティング。DeepSeekプロバイダーのデフォルトモデル。VM0 Managedでも利用可能。",
         "vm0Notes": "V4 FlashはBuilt-inモデル中最低のクレジットマルチプライヤー（×0.02）を持ち、Sonnet 4.6の約50分の1です。キャッシュ読み取りは課金、キャッシュ書き込みは無料。VM0はDeepSeekプロバイダーに10分のAPIタイムアウトを設定しており、Flashの短い単発作業と自然に適合します。"
+      },
+      "gemini-2-5-flash-image": {
+        "name": "Gemini 2.5 Flash Image",
+        "pageTitle": "Gemini 2.5 Flash Image on VM0. 高速テキストツーイメージのデフォルト",
+        "tagline": "Googleの高速テキストツーイメージおよび画像編集モデル。強力な指示追従、キャラクター一貫性、キュレーション済み画像ラインナップで画像あたり最も安いクレジットコスト。",
+        "cardIntro": "Googleの高速テキストツーイメージモデル。安価で、長いプロンプトの追従が正確、編集にわたって被写体を保持するのが得意。",
+        "metaTitle": "Gemini 2.5 Flash Image on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のGemini 2.5 Flash Image。Googleのテキストツーイメージおよび画像編集モデル、高い指示遵守、キャラクター一貫性、画像あたり約$0.04。GPT Image 1、Flux Pro 1.1 Ultra、SeedDream 4と比較。",
+        "summary": "Gemini 2.5 Flash ImageはGoogleのどこでもデフォルトのテキストツーイメージおよび画像編集モデルです。エージェントワークロードに最も重要な2つの特性で優れています：長く構造化されたプロンプトに従う（途中で指示を失うことなくフルブリーフを渡せます）、そしてマルチターン編集にわたって被写体を一貫させる（呼び出し間でドリフトすることなく、エージェントが同じキャラクターまたは製品ショットを反復できます）。\n\n定価は1024×1024画像あたり約$0.04で、キュレーション済み画像ラインナップで最も安いモデルです。自然なパターンは、Gemini 2.5 Flash Imageをデフォルトにし、デフォルトが届かない特定のアスペクトレシオまたはアスペクトが必要なときのみFlux Pro 1.1 UltraまたはSeedDream 4にエスカレートすることです。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "エージェントワークロードのためのGoogleのテキストツーイメージワークホース。",
+        "background": [
+          "Gemini 2.5 Flash ImageはGemini 2.5ファミリーにおけるGoogleのテキストツーイメージおよび画像編集モデルです。Googleのフレーミングはテキスト側のFlashバリアントと同じです：低いコールあたりコストで高スループットに調整され、最後のリクエストがストリーミングを終える前に次のリクエストがキューに入るプロダクションワークロード向けに最適化されたモデル。",
+          "エージェント使用において2つの行動的特性が際立ちます。第一に、長く構造化されたプロンプトに対する指示遵守が、ほとんどのオープンウェイトテキストツーイメージのベースラインよりも大幅に優れています。これはエージェントがプログラム的にプロンプトを構成し、短縮できない場合に重要です。第二に、マルチターン編集にわたるキャラクターと被写体の一貫性がよく保たれます。これが、単一のアセットを反復するエージェントワークフローにおける編集ループのデフォルトとしてモデルを実行可能にしているものです。"
+        ],
+        "architecture": "ネイティブ編集サポート付きのディフュージョンベースのテキストツーイメージモデル。標準ティアで生成画像あたり課金。入力はテキストプロンプトと、編集スタイルフロー用のオプションのリファレンス画像を受け付けます。出力は要求された解像度のPNG。",
+        "specs": [
+          { "label": "ファミリー", "value": "Gemini 2.5世代" },
+          {
+            "label": "モダリティ",
+            "value": "テキストツーイメージ、イメージツーイメージ編集"
+          },
+          { "label": "出力解像度", "value": "1024×1024標準ティア" },
+          { "label": "ベンダー定価", "value": "画像あたり約$0.04" },
+          { "label": "言語", "value": "多言語プロンプト" },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "指示遵守",
+            "body": "多くのオープンウェイトモデルが節を脱落させ始める長く構造化されたプロンプトで持ちこたえます。エージェントがブリーフをプログラム的に構成し、プロンプトが交渉不可能な場合に有用です。"
+          },
+          {
+            "title": "キャラクター一貫性",
+            "body": "マルチターン編集にわたって被写体を認識可能に保ち、これが単一アセット上の反復的エージェントループに対してモデルを実行可能にしている特性です。"
+          },
+          {
+            "title": "コスト",
+            "body": "画像あたり約$0.04 — VM0上のキュレーション済みテキストツーイメージモデルで最安。バルクファンアウト生成が手頃なまま。"
+          },
+          {
+            "title": "アスペクト天井",
+            "body": "Flux Pro 1.1 Ultraのハイパースタイライズドな見た目やSeedDream 4のフォトリアルな見た目ではなく、クリーンで正確な出力に偏っています。アスペクトが成果物の場合はエスカレートしてください。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "ブリーフからマーケティングビジュアルをドラフトするエージェント",
+            "body": "ブランドボイス、製品説明、ターゲットオーディエンスをエージェントに渡してください。Gemini 2.5 Flash Imageは数秒でドラフトビジュアルをレンダリングします。十数のバリエーションをファンアウトして最良を選ぶのに十分安価。"
+          },
+          {
+            "title": "単一アセットを反復する編集ループ",
+            "body": "一度生成して、ターン間で被写体を一貫させながら照明、フレーミング、または背景を反復します。キャラクター一貫性は、ループ内の人間が同じ画像を編集していることを意味し、毎ターン新しいセットから選ぶわけではありません。"
+          },
+          {
+            "title": "プレミアムモデルの前のイラスト事前フィルタ",
+            "body": "Gemini 2.5 Flash Imageを使って構図を安価にロックし、最終選択をFlux Pro 1.1 Ultraでアスペクトのために再レンダリングします。プレミアムステップのコストをファンアウトではなく1回の呼び出しに削減します。"
+          }
+        ],
+        "avoidFor": "成果物がアスペクトの場合はGemini 2.5 Flash Imageをスキップしてください — Flux Pro 1.1 UltraとSeedDream 4はフォトリアルおよびエディトリアルな見た目でより多くのスタイリスティック天井を運びます。",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 1はスタイライズドイラストとキャラクター作業でより強く、Gemini 2.5 Flash Imageはコールあたり安価で長いプロンプトの指示追従でより強い。構造化プロンプトを持つエージェントワークロードには、Gemini 2.5 Flash Imageがより安全なデフォルトです。"
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4はより高いフォトリアル天井を運び、Gemini 2.5 Flash Imageはより安価、高速、長いプロンプトをより信頼性高く追従します。Geminiをデフォルトに、ブリーフが特にフォト的アスペクトの場合のみSeedDream 4にエスカレートしてください。"
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultraはキュレーション済みラインナップで最高のスタイリスティック天井を持ち、Gemini 2.5 Flash Imageはコストと指示追従で勝ちます。Geminiで事前フィルタし、アスペクトがポイントのときFluxで最終を提供してください。"
+          }
+        ],
+        "verdict": "テキストツーイメージエージェントワークロードにはGemini 2.5 Flash Imageをデフォルトに。アスペクトが成果物の場合のみFlux Pro 1.1 UltraまたはSeedDream 4にエスカレートしてください。",
+        "faqs": [
+          {
+            "q": "Gemini 2.5 Flash Imageは既存の画像を編集できますか？",
+            "a": "はい。テキストプロンプトと並んでリファレンス画像を受け付け、反復編集のためのインペインティングとアウトペインティングフローをサポートしています。"
+          },
+          {
+            "q": "どの出力解像度を生成しますか？",
+            "a": "標準ティアで1024×1024。より高い解像度は比例コストで利用可能。"
+          },
+          {
+            "q": "画像あたりのコストは？",
+            "a": "生成された1024×1024画像あたり約$0.04 — VM0上のキュレーション済みテキストツーイメージモデルで最安。"
+          },
+          {
+            "q": "モデルは画像内のテキストが得意ですか？",
+            "a": "はい — 生成された画像内に短いテキスト文字列をレンダリングする点で、ほとんどのオープンウェイトベースラインよりも大幅に強力です。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gpt-image-1",
+            "reason": "より強力なスタイライズドイラスト"
+          },
+          { "slug": "flux-pro-1-1-ultra", "reason": "より高いアスペクト天井" },
+          { "slug": "seedream-4", "reason": "より強力なフォトリアル結果" }
+        ],
+        "routingNotes": "Routed to Google's Gemini 2.5 Flash Image endpoint and billed per generated image.",
+        "vm0Notes": "Gemini 2.5 Flash Image is the price/quality default for text-to-image agent workloads on VM0. Use it as the everywhere-default and reserve the more expensive image models for the steps where their stylistic ceiling actually matters."
+      },
+      "gpt-image-1": {
+        "name": "GPT Image 1",
+        "pageTitle": "GPT Image 1 on VM0. OpenAIのテキストツーイメージモデル",
+        "tagline": "強力なスタイライズドイラストと編集を持つOpenAIのテキストツーイメージモデル。OpenAIのアスペクトとプロンプト追従スタイルが欲しいときの自然な選択。",
+        "cardIntro": "OpenAIのテキストツーイメージモデル。スタイライズドイラスト、キャラクター作業、編集に強い — Gemini 2.5 Flash ImageのOpenAI側の対応物。",
+        "metaTitle": "GPT Image 1 on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のGPT Image 1。OpenAIのテキストツーイメージおよび画像編集モデル、スタイライズドイラストの強み、マルチティア価格、Gemini 2.5 Flash Image、Flux Pro 1.1 Ultra、SeedDream 4との比較。",
+        "summary": "GPT Image 1はOpenAIのテキストツーイメージモデル — ほとんどのチームがChatGPTの画像生成の背後にあるモデルとして知っているものです。その強みは、テキスト駆動マスキングによるスタイライズドイラスト、キャラクター作業、画像編集であり、OpenAIのテキストモデルが期待するものに密接にマッピングするプロンプト追従スタイルです。\n\n定価はティアベースで、低/標準ティアで画像あたり約$0.011から、高/大ティアで$0.25まで。中標準ティア（1024×1024で約$0.05）はほとんどのエージェントワークロードに対する賢明なデフォルトです。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "OpenAIの主要なテキストツーイメージモデル。解像度と品質設定にわたるティア価格。",
+        "background": [
+          "GPT Image 1はOpenAIのプロダクションテキストツーイメージモデルです。OpenAIのテキストモデルとネイティブにペアリングするため、エージェントが既にGPT-5.4またはGPT-5.5上で実行されている場合、プロンプトスタイルがクリーンに転送され、編集ループフローがOpenAIサーフェス内に留まります。",
+          "モデルのスタイリスティックな強みはイラスト、キャラクター作業、特定の要素を変更しながら元の構図を保持する編集にあります。フォトリアル出力はしっかりしていますが、OpenAIハウススタイルに偏っています。異なるアスペクト天井が欲しいチームは、しばしばFlux Pro 1.1 UltraまたはSeedDream 4を一緒に手を伸ばします。"
+        ],
+        "architecture": "ネイティブ編集サポート付きのディフュージョンベースのテキストツーイメージ。ティア価格は出力解像度（標準/大）と品質（低/中/高）でスケールし、中/標準ティアが典型的なデフォルト。入力は編集とマスク用のテキストとオプションのリファレンス画像を受け付けます。",
+        "specs": [
+          { "label": "ファミリー", "value": "OpenAI Images" },
+          {
+            "label": "モダリティ",
+            "value": "テキストツーイメージ、イメージツーイメージ編集"
+          },
+          { "label": "出力ティア", "value": "標準/大 × 低/中/高" },
+          { "label": "ベンダー定価", "value": "画像あたり$0.011から$0.25" },
+          { "label": "言語", "value": "多言語プロンプト" },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "スタイライズドイラスト",
+            "body": "非フォトリアル出力 — イラスト、コミックスタイル、絵画調 — に対する最強のモデルの一つ。成果物が写真ではなくイラストの場合に適合します。"
+          },
+          {
+            "title": "編集フロー",
+            "body": "マスク編集とテキスト駆動の局所変更のネイティブサポート。エージェントが全体を再生成するのではなく、画像の特定領域を反復する必要がある場合に有用です。"
+          },
+          {
+            "title": "プロンプトスタイル",
+            "body": "OpenAIのテキストモデルの期待に密接にマッピング。呼び出し側のエージェントが既にGPT-5.4またはGPT-5.5上にある場合、そのエージェントが書いたプロンプトはほとんど調整なしで転送されます。"
+          },
+          {
+            "title": "コスト",
+            "body": "ティアベース — 中/標準ティア（1024×1024あたり約$0.05）が典型的なデフォルト。高/大ティアは$0.25に達し、配信グレードの出力にのみ価値があります。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "コミックまたは手描きスタイルを配信するイラストエージェント",
+            "body": "スタイライズド出力はGPT Image 1が真のエッジを運ぶ場所です。コミックパネル、絵画調イラスト、手描き風アイコン — すべてフォトリアル傾向の代替よりもここでより信頼性高く着地します。"
+          },
+          {
+            "title": "OpenAIスタック上の編集ループエージェント",
+            "body": "オーケストレーションエージェントが既にGPT-5.4またはGPT-5.5上にある場合、画像生成をOpenAIサーフェス内（GPT Image 1）に保つことで、プロンプトスタイル、編集セマンティクス、構造化出力が実行全体で一貫したまま保たれます。"
+          }
+        ],
+        "avoidFor": "コストが支配的な場合（Gemini 2.5 Flash Imageは同じデフォルトティアで約半分の価格）、または成果物が特にフォトリアルな場合（SeedDream 4はより高いフォトリアル天井を運びます）はGPT Image 1をスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Imageはより安価で長い構造化プロンプトで強く、GPT Image 1はスタイライズドイラストで強く、OpenAIスタックエージェントとより自然に統合します。"
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4はわずかに低い価格でフォトリアルアスペクトでリードし、GPT Image 1はスタイライズドイラストと編集フローでリードします。"
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "Flux Pro 1.1 Ultraはヒーローショット成果物で最高のアスペクト天井を運び、GPT Image 1はその他すべての自然なOpenAIスタックデフォルトです。"
+          }
+        ],
+        "verdict": "エージェントが既にOpenAIスタック上にあり、スタイライズドイラストまたはネイティブ編集フローが欲しい場合はGPT Image 1を選んでください。フォトリアルヒーローショットにはFlux Pro 1.1 Ultraにエスカレート、コストが支配する場合はGemini 2.5 Flash Imageに降格してください。",
+        "faqs": [
+          {
+            "q": "GPT Image 1の価格は？",
+            "a": "ティアベース — サイズ（標準/大）と品質（低/中/高）の組み合わせ。1024×1024画像あたり約$0.05の中/標準ティアが典型的なデフォルト。"
+          },
+          {
+            "q": "GPT Image 1は画像編集をサポートしていますか？",
+            "a": "はい。リファレンス画像とオプションのマスクを受け付け、テキスト駆動の局所編集とアウトペインティングをサポートしています。"
+          },
+          {
+            "q": "GPT Image 1は画像内にテキストをレンダリングできますか？",
+            "a": "はい — 短いテキスト文字列は信頼性高くレンダリングされます。長いテキスト箇所はほとんどのディフュージョンモデルと同様にまだ困難です。"
+          },
+          {
+            "q": "入力としてマルチモーダルですか？",
+            "a": "イメージツーイメージ編集はリファレンス画像を受け付けます。モデルは画像出力のみ。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "より安価、より強力な長プロンプト遵守"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "より高いフォトリアルアスペクト天井"
+          },
+          { "slug": "seedream-4", "reason": "より良いフォトリアルデフォルト" }
+        ],
+        "routingNotes": "Routed to OpenAI's Images surface and billed per generated image at the selected tier.",
+        "vm0Notes": "GPT Image 1 is the OpenAI-stack default for stylised illustration and edit-loop agent workflows. The medium/standard tier is the sensible everywhere-default; reserve the high/large tier for delivery-grade output."
+      },
+      "flux-pro-1-1-ultra": {
+        "name": "Flux Pro 1.1 Ultra",
+        "pageTitle": "Flux Pro 1.1 Ultra on VM0. ヒーローショットのアスペクト天井",
+        "tagline": "Black Forest Labsのハイ天井テキストツーイメージモデル。画像が成果物で、エディトリアルまたはフォトリアルグレードの出力が必要なときの選択。",
+        "cardIntro": "Black Forest Labsのトップティア画像モデル。キュレーション済みラインナップで最高のアスペクト天井 — ヒーローショットとエディトリアルグレードの出力に使用。",
+        "metaTitle": "Flux Pro 1.1 Ultra on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のFlux Pro 1.1 Ultra。Black Forest Labsのトップティアテキストツーイメージモデル、エディトリアルグレードのアスペクト天井、画像あたり$0.072、GPT Image 1、SeedDream 4、Gemini 2.5 Flash Imageとの比較。",
+        "summary": "Flux Pro 1.1 UltraはBlack Forest Labsのトップティアテキストツーイメージモデル — 画像自体がエージェントループのステップではなく成果物のときに手を伸ばすものです。エディトリアル、フォトリアル、デザイン主導のアスペクトでの出力品質はキュレーション済みラインナップで最高であり、詳細な構図ブリーフでのプロンプト遵守がよく保たれます。\n\n定価は画像あたり$0.072で、Gemini 2.5 Flash Image（$0.04）やSeedDream 4（$0.036）に対して高価ですが、画像あたりの品質リフトは十分に大きく、ほとんどのチームは安価なモデルで事前フィルタした後の最終レンダリングステップとして使用します。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "Black Forest LabsのFlux 1.1世代のプレミアムティア。",
+        "background": [
+          "Flux Pro 1.1 UltraはBlack Forest Labsのプレミアムテキストツーイメージモデルです。Fluxファミリーはオープンウェイトフロンティアで最高のアスペクト天井で知られ、Ultraバリアントは最も一貫した構図品質を持つプロダクショングレードのティアです。",
+          "モデルの強みはエディトリアルとフォトリアルのアスペクト — マガジンスタイルのヒーローショット、製品写真、デザイン主導のイラスト — にあります。詳細な構図ブリーフ（「X のローアングルショット、Y の光で Z の背景に対して」）に対するプロンプト遵守は、ほとんどの安価な代替よりも大幅に優れています。これが、チームが配信グレードの出力にプレミアムを払い続ける理由の一部です。"
+        ],
+        "architecture": "構図忠実度に調整されたプロンプト追従を持つ高解像度ディフュージョンモデル。生成画像あたり課金。入力はテキストプロンプトを受け付け、配信に適した高解像度出力を生成します。",
+        "specs": [
+          { "label": "ファミリー", "value": "Flux 1.1 Pro" },
+          { "label": "モダリティ", "value": "テキストツーイメージ" },
+          { "label": "ベンダー定価", "value": "画像あたり$0.072" },
+          { "label": "言語", "value": "多言語プロンプト" },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "アスペクト天井",
+            "body": "キュレーション済み画像ラインナップで最高。ヒーローショット、エディトリアル、フォトリアルなアスペクトがGemini 2.5 Flash ImageやGPT Image 1よりもここで信頼性高く着地します。"
+          },
+          {
+            "title": "構図忠実度",
+            "body": "角度、照明、フレーミング、被写体の配置を指定する詳細な構図ブリーフで強い。プロンプトが交渉不可能な場合に有用です。"
+          },
+          {
+            "title": "コスト",
+            "body": "画像あたり$0.072 — Gemini 2.5 Flash ImageとSeedDream 4の約2倍。標準パターンは安価なモデルで事前フィルタし、Fluxで最終をレンダリングすることです。"
+          },
+          {
+            "title": "速度",
+            "body": "Flashティアの代替より遅い。コストを正当化するステップのために予約してください。タイトなインタラクティブループでは使わないでください。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "出荷しなければならないマーケティングヒーローショット",
+            "body": "画像がキャンペーン、ランディングページ、または発表の最終成果物の場合、Flux Pro 1.1 Ultraのアスペクト天井はプレミアムを正当化します。"
+          },
+          {
+            "title": "eコマースリスティング用の製品撮影エージェント",
+            "body": "テキストブリーフとリファレンス画像からのカタロググレードの製品撮影。構図忠実度が、出荷される画像と再レンダリングされる画像の違いを生みます。"
+          },
+          {
+            "title": "長文コンテンツ用エディトリアルイラスト",
+            "body": "記事、ブログ投稿、レポート用のマガジンスタイルのヒーローイラスト。Fluxのスタイリスティック天井がワークホースデフォルトと一線を画します。"
+          }
+        ],
+        "avoidFor": "コストが支配的なファンアウトループではFlux Pro 1.1 Ultraをスキップしてください — Gemini 2.5 Flash Imageはコールあたり約2倍安価です。反復ステップではなく、最終レンダリングステップとして使用してください。",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "Flux Pro 1.1 Ultraはより高いフォトリアルとエディトリアル天井を持ち、GPT Image 1はより強力なスタイライズドイラスト出力とネイティブ編集フローサポートを持ちます。成果物で選んでください。"
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "両方ともフォトリアル傾向。SeedDream 4はより安価でポートレートと製品作業で競争力があり、Flux Pro 1.1 Ultraはより高いコストでヒーローショットの構図忠実度で勝ちます。"
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "異なる役割。Gemini 2.5 Flash Imageは反復用の安価なワークホースで、Flux Pro 1.1 Ultraはプレミアム最終レンダリングステップ。スタックしてください、1つを選ばないで。"
+          }
+        ],
+        "verdict": "Flux Pro 1.1 Ultraを安価なモデルで事前フィルタした後の最終レンダリングステップとして使用してください。画像が成果物のとき、アスペクト天井がプレミアムを正当化します。",
+        "faqs": [
+          {
+            "q": "Flux Pro 1.1 Ultraのコストは？",
+            "a": "生成画像あたり$0.072。Gemini 2.5 Flash ImageとSeedDream 4の約2倍。"
+          },
+          {
+            "q": "画像編集をサポートしていますか？",
+            "a": "Ultraティアはテキストツーイメージ優先。同ファミリーでのネイティブマスク編集フローには、ベースのFlux Pro 1.1ティアがより低いアスペクト天井でより広い編集サポートを運びます。"
+          },
+          {
+            "q": "どのアスペクトレシオがサポートされていますか？",
+            "a": "配信に適した高解像度出力までの標準的な写真とデザインのアスペクトレシオ。"
+          },
+          {
+            "q": "スタイライズドイラストに適していますか？",
+            "a": "可能ですが、その最強の強みではありません — GPT Image 1がより高いスタイライズド天井を運びます。Flux Pro 1.1 Ultraはフォトリアルとエディトリアルの作業で輝きます。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "安価な反復デフォルト"
+          },
+          {
+            "slug": "gpt-image-1",
+            "reason": "より強力なスタイライズドイラスト"
+          },
+          { "slug": "seedream-4", "reason": "より安価なフォトリアル代替" }
+        ],
+        "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
+        "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with Gemini 2.5 Flash Image or SeedDream 4 for the cheap pre-filter."
+      },
+      "seedream-4": {
+        "name": "SeedDream 4",
+        "pageTitle": "SeedDream 4 on VM0. フォトリアルテキストツーイメージのデフォルト",
+        "tagline": "ByteDanceのSeedDream 4テキストツーイメージモデル。ラインナップで最も安いオプションに匹敵するコストで強力なフォトリアルアスペクト。",
+        "cardIntro": "ByteDanceのSeedDream 4。低い画像あたりコストでのフォトリアルアスペクト — ブリーフが写真のときの自然なデフォルト。",
+        "metaTitle": "SeedDream 4 on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のSeedDream 4。ByteDanceのテキストツーイメージモデル、強力なフォトリアル出力、画像あたり約$0.036、Gemini 2.5 Flash Image、GPT Image 1、Flux Pro 1.1 Ultraとの比較。",
+        "summary": "SeedDream 4はByteDanceのSeedream V4世代のテキストツーイメージモデルです。その際立った特性はフォトリアルアスペクト — ポートレート、製品ショット、ライフスタイル写真 — であり、定価（画像あたり$0.036）はキュレーション済みラインナップで最も安いオプションと競争力があります。\n\nブリーフが特に写真の場合の自然なデフォルトです。スタイライズドイラストやエディトリアルデザインにはGPT Image 1またはFlux Pro 1.1 Ultraを、長く構造化されたプロンプトでの一般的な反復エージェントワークロードにはGemini 2.5 Flash Imageを選んでください。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "ByteDanceのSeedream V4世代のフォトリアルテキストツーイメージデフォルト。",
+        "background": [
+          "SeedDream 4はByteDanceのテキストツーイメージファミリーの第4世代です。アスペクトはフォトリアル出力に偏り、ポートレート、製品、ライフスタイルショットが際立ったカテゴリです。標準的な記述ブリーフ（被写体、設定、照明）でのプロンプト遵守はしっかりしています。",
+          "画像あたり$0.036でキュレーション済みラインナップの価格の底近くに位置し、これが写真傾向のエージェントワークロードのデフォルトとして実行可能にしているものです。構図ブリーフが特にプレミアムを正当化するヒーローショットの場合はFlux Pro 1.1 Ultraに切り替えてください。"
+        ],
+        "architecture": "ディフュージョンベースのテキストツーイメージモデル。生成画像あたり課金。入力はテキストプロンプトを受け付け、ポートレート、製品、ライフスタイル画像に適したフォトリアル傾向の出力を生成します。",
+        "specs": [
+          { "label": "ファミリー", "value": "Seedream V4" },
+          { "label": "モダリティ", "value": "テキストツーイメージ" },
+          { "label": "ベンダー定価", "value": "画像あたり$0.036" },
+          {
+            "label": "言語",
+            "value": "多言語プロンプト（英語＋中国語が強い）"
+          },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "フォトリアルアスペクト",
+            "body": "ポートレート、製品ショット、ライフスタイル写真が際立ったカテゴリ。出力はフォトリアルブリーフの意味のあるシェアでFlux Pro 1.1 Ultraと競争力があり、コールあたり劇的に安価です。"
+          },
+          {
+            "title": "コスト",
+            "body": "画像あたり$0.036 — キュレーション済みラインナップの底近く。写真傾向のファンアウトワークロードに対する自然なデフォルト。"
+          },
+          {
+            "title": "中国語プロンプト",
+            "body": "中国語プロンプトと文化的に根ざした被写体の強力な処理。これは中国語を話すユーザーにサービスを提供するエージェントにとって本当のアドバンテージです。"
+          },
+          {
+            "title": "アスペクト天井",
+            "body": "フォトリアルレーン内のすべてに対してしっかりしている。GPT Image 1がリードするハイパースタイライズドイラストには適合性が低い。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "大規模なポートレートまたは製品ショットエージェント",
+            "body": "低い画像あたりコストのフォトリアル被写体は、SeedDream 4をファンアウトワークロードに対して実行可能にします — カタログ用の100枚の製品写真、クリエイターツールのバッチポートレート生成。"
+          },
+          {
+            "title": "中国語マーケティングエージェント",
+            "body": "中国語プロンプトと文化的に根ざした被写体の強力な処理。中国語を話す市場にサービスを提供するエージェントに対する正しいデフォルト。"
+          },
+          {
+            "title": "Flux Pro 1.1 Ultraのより安価な代替",
+            "body": "ブリーフがフォトリアルだが成果物がFluxプレミアムを正当化しない場合、SeedDream 4は半分の価格でほとんどの品質を運びます。"
+          }
+        ],
+        "avoidFor": "スタイライズドイラスト（GPT Image 1がリード）、長い構造化プロンプト反復（Gemini 2.5 Flash Imageがリード）、またはFluxプレミアムが正当化されるヒーローショットエディトリアル作業ではSeedDream 4をスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "SeedDream 4はより低いコストでフォトリアルアスペクトでリードし、GPT Image 1はスタイライズドイラストとネイティブ編集フローでリードします。"
+          },
+          {
+            "vs": "Flux Pro 1.1 Ultra",
+            "body": "両方ともフォトリアル傾向。SeedDream 4は半分の価格でポートレートと製品作業で競争力があり、Flux Pro 1.1 Ultraはヒーローショットの構図忠実度で勝ちます。"
+          },
+          {
+            "vs": "Gemini 2.5 Flash Image",
+            "body": "Gemini 2.5 Flash Imageは長プロンプトの指示追従がより強い安価な汎用デフォルトで、SeedDream 4は写真ブリーフでより高い天井を持つフォトリアル特化デフォルトです。"
+          }
+        ],
+        "verdict": "ブリーフが特に写真でコストが重要なときはSeedDream 4をデフォルトに。ヒーローショットがプレミアムを正当化する場合のみFlux Pro 1.1 Ultraにエスカレートしてください。",
+        "faqs": [
+          {
+            "q": "SeedDream 4のコストは？",
+            "a": "生成画像あたり$0.036 — 価格でキュレーション済みラインナップの底近く。"
+          },
+          {
+            "q": "中国語プロンプトに適していますか？",
+            "a": "はい — 中国語プロンプトと文化的に根ざした被写体において、ほとんどの西洋トレーニングのベースラインよりも大幅に強力です。"
+          },
+          {
+            "q": "最強のアスペクトは？",
+            "a": "フォトリアル：ポートレート、製品ショット、ライフスタイル写真。スタイライズドイラストには適合性が低い。"
+          },
+          {
+            "q": "画像編集をサポートしていますか？",
+            "a": "VM0上のキュレーション済みエントリはテキストツーイメージをカバーします。編集フローはモデルの主要な強みではありません。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "gemini-2-5-flash-image",
+            "reason": "より安価な汎用デフォルト"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "プレミアムヒーローショット品質"
+          },
+          {
+            "slug": "gpt-image-1",
+            "reason": "より強力なスタイライズドイラスト"
+          }
+        ],
+        "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
+        "vm0Notes": "SeedDream 4 is the photoreal-specific default in the curated image lineup. Pair it with Flux Pro 1.1 Ultra for hero shots and with Gemini 2.5 Flash Image for non-photo iteration."
+      },
+      "veo-3-1-fast": {
+        "name": "Veo 3.1 Fast",
+        "pageTitle": "Veo 3.1 Fast on VM0. Googleの高速テキストツービデオモデル",
+        "tagline": "ネイティブオーディオ付きGoogleの高速テキストツービデオモデル。シネマティック品質とオーディオを1パスで重要にする短尺ソーシャルおよび製品クリップの選択。",
+        "cardIntro": "ネイティブオーディオ付きGoogleのテキストツービデオモデル。1回のパスで高速生成、シネマティックスタイル、同期サウンドトラック。",
+        "metaTitle": "Veo 3.1 Fast on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のVeo 3.1 Fast。ネイティブオーディオ付きGoogleの高速テキストツービデオモデル、4Kまで4〜8秒クリップ、Kling V3 4KとDreamina Seedance 2.0との比較。",
+        "summary": "Veo 3.1 FastはGoogleのVeo 3ビデオ生成ファミリーの高速ティアです。720p、1080p、または4Kで短いクリップ（4/6/8秒）を生成し、ビジュアルと同じパスで同期ネイティブオーディオ — 声、環境音、エフェクト — をレンダリングします。その単一パスオーディオが、キュレーション済みラインナップでほとんどの代替と一線を画す特性です。\n\n定価は720pオーディオ付き出力1秒あたり約$0.15のオーダーで、コストでラインナップの中程度に位置付けられます。自然なパターンは、オーディオが重要なソーシャルおよび製品クリップに対してVeo 3.1 Fastをデフォルトにし、コストが支配する場合はDreamina Seedance 2.0に切り替え、より長いまたは高解像度のショットが必要な場合はKling V3 4Kに切り替えることです。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "GoogleのVeo 3ファミリーの高速ティア。ネイティブオーディオ付き短尺出力に最適化。",
+        "background": [
+          "Veo 3.1はGoogleのVeo 3世代のビデオ生成ファミリーで、Fastティアはスループット最適化バリアントです — より高速な生成、クリップあたりより低いコスト、ただし短いクリップ時間でキャップされます。ネイティブオーディオサポートは特徴的な特性です：声、環境音、エフェクトがビジュアルと同じパスでレンダリングされ、別のポストステップとして追加されることはありません。",
+          "Veoの出力はシネマティックな見た目に偏ります — クリーンなモーション、考慮されたフレーミング、正確な照明。詳細な単一ショットを記述するテキストツービデオブリーフ（カメラアングル、被写体のアクション、設定、照明）で強く、Kling V3 4Kのスタイリスティック天井が先んじるハイスタイライズドまたはアニメスタイルのアスペクトには適合性が低い。"
+        ],
+        "architecture": "同じパスでネイティブオーディオ合成を持つテキストツービデオおよびイメージツービデオディフュージョンモデル。出力時間は720p、1080p、または4Kで4、6、または8秒。品質ティアモディファイア付きで生成ビデオ秒あたり課金。",
+        "specs": [
+          { "label": "ファミリー", "value": "Google Veo 3" },
+          {
+            "label": "モダリティ",
+            "value": "テキストツービデオ、イメージツービデオ、ネイティブオーディオ"
+          },
+          { "label": "クリップ長", "value": "4秒 / 6秒 / 8秒" },
+          { "label": "出力解像度", "value": "720p / 1080p / 4K" },
+          {
+            "label": "ベンダー定価",
+            "value": "秒あたり約$0.15（720p＋オーディオ）"
+          },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "ネイティブオーディオ",
+            "body": "特徴的な特性。声、環境音、エフェクトがビジュアルと同じパスでレンダリングされる — 別のポストステップは必要ありません。オーディオが重要なソーシャルおよび製品クリップに対する正しいデフォルト。"
+          },
+          {
+            "title": "シネマティックモーション",
+            "body": "出力はクリーンなモーション、考慮されたフレーミング、正確な照明に偏ります。詳細な単一ショットを記述するテキストツービデオブリーフで強い。"
+          },
+          {
+            "title": "速度",
+            "body": "高速ティア — 最も要求の厳しいブリーフでわずかに低い忠実度のコストで、生成は標準Veo 3ティアよりも大幅に高速。"
+          },
+          {
+            "title": "アスペクト天井",
+            "body": "シネマティック/フォトリアルレーンがスイートスポット。スタイライズドまたはアニメスタイルの出力にはKling V3 4Kのスタイリスティック天井がより高い。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "1パスで出荷するソーシャルクリップエージェント",
+            "body": "1回の呼び出しで生成される声と環境音を持つ短尺ソーシャルビデオ。別のTTSやオーディオポストステップ、同期は不要 — クリップは公開準備完了で着地します。"
+          },
+          {
+            "title": "ランディングページの製品デモビデオ",
+            "body": "機能を説明する声優付き1080pの8秒製品クリップ。シネマティックモーションと同期オーディオが、結果を生成されたものではなく制作されたものに感じさせます。"
+          },
+          {
+            "title": "キャンペーンでのイメージツービデオステップ",
+            "body": "Flux Pro 1.1 UltraまたはSeedDream 4でレンダリングされた静止ヒーロー画像から始めて、短いモーションクリップに拡張します。画像条件付けが見た目を一貫させ続けます。"
+          }
+        ],
+        "avoidFor": "ブリーフがスタイライズドまたはアニメスタイル（Kling V3 4Kの天井がより高い）、8秒より長いクリップが必要、またはコストが支配しオーディオ特性が重要でない場合（Dreamina Seedance 2.0は約3倍安価）はVeo 3.1 Fastをスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "Kling V3 4K",
+            "body": "Veo 3.1 Fastはネイティブオーディオとシネマティック/フォトリアルアスペクトでリードし、Kling V3 4Kはスタイライズド/アニメ出力と4Kでのより長いクリップ時間でリードします。アスペクトで選んでください。"
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "異なるポジショニング。Dreamina Seedance 2.0は秒あたり約3倍安価で、コストが支配する場合の正しい選択です。Veo 3.1 Fastはネイティブオーディオとシネマティックモーションのリードを運びます。"
+          }
+        ],
+        "verdict": "オーディオが重要な短尺ソーシャルおよび製品クリップにはVeo 3.1 Fastをデフォルトに。スタイライズド出力またはより長い時間にはKling V3 4Kに切り替え、コストが支配する場合はDreamina Seedance 2.0に切り替えてください。",
+        "faqs": [
+          {
+            "q": "Veo 3.1 Fastはオーディオを生成しますか？",
+            "a": "はい。ネイティブオーディオ — 声、環境音、エフェクト — がビジュアルと同じパスでレンダリングされます。"
+          },
+          {
+            "q": "サポートされているクリップ長は？",
+            "a": "4、6、または8秒。より長いショットにはKling V3 4Kに切り替えてください。"
+          },
+          {
+            "q": "どの解像度をサポートしていますか？",
+            "a": "720p、1080p、4K。コストは解像度と時間に応じてスケールします。"
+          },
+          {
+            "q": "画像条件付けを受け付けますか？",
+            "a": "はい — イメージツービデオフローにより、静止から始めて短いモーションクリップに拡張できます。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "kling-v3-4k",
+            "reason": "スタイライズド/アニメ天井、より長いクリップ"
+          },
+          { "slug": "dreamina-seedance-2-0", "reason": "秒あたりより安価" }
+        ],
+        "routingNotes": "Routed to Google's Veo 3.1 Fast video generation endpoint and billed per generated video-second with quality-tier modifiers.",
+        "vm0Notes": "Veo 3.1 Fast is the cinematic / audio-bearing default in the curated video lineup on VM0. Pair it with Dreamina Seedance 2.0 for cheap iteration and with Kling V3 4K for stylised or longer-form clips."
+      },
+      "kling-v3-4k": {
+        "name": "Kling V3 4K",
+        "pageTitle": "Kling V3 4K on VM0. 4Kテキストツービデオの天井",
+        "tagline": "KuaishouのKling V3 4Kテキストツービデオモデル。長いクリップ、4K解像度、または他のモデルが届かないスタイライズドアスペクトが必要なときの選択。",
+        "cardIntro": "KuaishouのKling V3 4K。スタイライズドアスペクト、15秒までの長いクリップ、4K出力 — エディトリアルとアニメスタイルビデオの天井。",
+        "metaTitle": "Kling V3 4K on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のKling V3 4K。Kuaishouのテキストツービデオモデル、4K解像度、3〜15秒クリップ、スタイライズドアスペクト天井、Veo 3.1 FastとDreamina Seedance 2.0との比較。",
+        "summary": "Kling V3 4KはKuaishouのトップティアテキストツービデオモデルです。際立った特性は、クリップ時間（Veo 3.1 Fastの8秒キャップに対して最大15秒）、標準ティアとしての4K解像度、そしてシネマティック傾向の代替が届かないアニメスタイルとエディトリアルアスペクトのスタイリスティック天井です。\n\n定価は4K出力1秒あたり約$0.28のオーダーで、これがキュレーション済みビデオラインナップで最も高価なオプションにしています。自然なパターンは、長いまたは4Kショットが必要なとき、またはブリーフが特にスタイライズドで代替のアスペクト天井が届かないときに手を伸ばすことです。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "KuaishouのKling V3世代のトップティア。4Kと長クリップ天井。",
+        "background": [
+          "Kling V3 4KはKuaishouのKling V3ビデオ生成ファミリーのハイエンドバリアントです。キュレーション済みラインナップで最も長い標準クリップ時間（3〜15秒）、標準ティアでのネイティブ4K出力、シネマティック傾向の代替が届かないアニメとエディトリアルアスペクトのスタイリスティック天井を運びます。",
+          "モデルの強みはスタイライズドおよびエディトリアルブリーフ — アニメスタイルシーケンス、ダンスとモーション重視のクリップ、ミュージックビデオアスペクト — にあります。シネマティックフォトリアル出力にはVeo 3.1 Fastがより低いコストとネイティブオーディオで匹敵し、バルクコスト駆動生成にはDreamina Seedance 2.0が劇的に安価です。Kling V3 4Kの役割はどこでもデフォルトではなく、ハイ天井、長クリップステップです。"
+        ],
+        "architecture": "テキストツービデオおよびイメージツービデオディフュージョンモデル。標準ティアは3〜15秒のクリップ時間で4Kでレンダリング。生成ビデオ秒あたり課金。",
+        "specs": [
+          { "label": "ファミリー", "value": "Kling V3" },
+          {
+            "label": "モダリティ",
+            "value": "テキストツービデオ、イメージツービデオ"
+          },
+          { "label": "クリップ長", "value": "3〜15秒" },
+          { "label": "出力解像度", "value": "4K（標準ティア）" },
+          { "label": "ベンダー定価", "value": "秒あたり約$0.28（4K）" },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "クリップ長",
+            "body": "標準ティアで最大15秒 — キュレーション済みラインナップで最長。8秒より長い単一の中断されないショットが重要なときの正しい選択。"
+          },
+          {
+            "title": "4K解像度",
+            "body": "高ティアの追加料金ではなく、標準ティアでネイティブ4K。成果物が大判ディスプレイまたは映画品質出力の場合に有用。"
+          },
+          {
+            "title": "スタイライズドアスペクト天井",
+            "body": "アニメ、ダンス、モーション重視、エディトリアルアスペクトで強い。これがKlingがシネマティック傾向の代替より先んじる場所です。"
+          },
+          {
+            "title": "コスト",
+            "body": "秒あたり約$0.28 — キュレーション済みラインナップで最も高価なオプション。その天井がプレミアムを正当化するステップのために予約してください。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "アニメスタイルまたはスタイライズドソーシャルクリップ",
+            "body": "スタイライズドアスペクト — アニメ、モーションデザイン主導、ミュージックビデオスタイル — はKlingが真の天井アドバンテージを運ぶ場所です。シネマティック傾向の代替は同じ見た目に届きません。"
+          },
+          {
+            "title": "長い中断されないショット",
+            "body": "ブリーフがより短いクリップ間のカットではなく、単一の12〜15秒のショットを要求する場合、Kling V3 4Kはキュレーション済みラインナップで時間キャップに達する唯一のオプションです。"
+          },
+          {
+            "title": "大判ディスプレイ用の4K成果物",
+            "body": "標準ティアでのネイティブ4Kは、出力が広告板、シネマ、または大判ソーシャルキャンペーン向けのときKlingを正しい選択にします。"
+          }
+        ],
+        "avoidFor": "ブリーフがオーディオ付きシネマティックフォトリアル（Veo 3.1 Fastがより低いコストでより自然）またはコストが支配する場合（Dreamina Seedance 2.0は秒あたり約5倍安価）はKling V3 4Kをスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "Veo 3.1 Fastはネイティブオーディオとシネマティック/フォトリアルアスペクトでリードし、Kling V3 4Kはスタイライズド/アニメ出力、より長いクリップ時間、ネイティブ4K出力でリードします。アスペクトと時間で選んでください。"
+          },
+          {
+            "vs": "Dreamina Seedance 2.0",
+            "body": "異なるコストティア。Dreamina Seedance 2.0は劇的に安価で、コストが支配する場合の正しい選択です。Kling V3 4Kは時間、4K、スタイライズドアスペクトの天井を運びます。"
+          }
+        ],
+        "verdict": "スタイライズド、長い、または4Kビデオ成果物にはKling V3 4Kを選んでください。オーディオ付きシネマティッククリップにはVeo 3.1 Fastに切り替え、コスト駆動ファンアウトにはDreamina Seedance 2.0に切り替えてください。",
+        "faqs": [
+          {
+            "q": "Kling V3 4Kが生成できる最長クリップは？",
+            "a": "標準ティアで15秒 — VM0上のキュレーション済みビデオラインナップで最長の単一ショット。"
+          },
+          {
+            "q": "Kling V3 4Kはオーディオをサポートしていますか？",
+            "a": "同じパスではネイティブではありません。1回の呼び出しで同期オーディオ付きビデオには、Veo 3.1 Fastを使用してください。"
+          },
+          {
+            "q": "Klingが生成する解像度は？",
+            "a": "標準ティアで4K。より低い解像度バリアントは同ファミリーでより低いコストで利用可能。"
+          },
+          {
+            "q": "画像条件付けを受け付けますか？",
+            "a": "はい — イメージツービデオフローにより、リファレンス静止から始めて、より長いモーションクリップに拡張できます。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "シネマティック/ネイティブオーディオ"
+          },
+          { "slug": "dreamina-seedance-2-0", "reason": "より安価なバルク生成" }
+        ],
+        "routingNotes": "Routed to Kuaishou's Kling V3 4K endpoint and billed per generated video-second.",
+        "vm0Notes": "Kling V3 4K is the high-ceiling option in the curated video lineup on VM0. Reserve it for stylised, long-form or 4K deliverables — for the everywhere-default reach for Veo 3.1 Fast or Dreamina Seedance 2.0."
+      },
+      "dreamina-seedance-2-0": {
+        "name": "Dreamina Seedance 2.0",
+        "pageTitle": "Dreamina Seedance 2.0 on VM0. コスト最適化されたビデオモデル",
+        "tagline": "ByteDanceのDreamina Seedance 2.0ビデオモデル。コストが支配するときの正しいデフォルト — 代替よりも秒あたり劇的に安価。",
+        "cardIntro": "ByteDanceのDreamina Seedance 2.0。キュレーション済みラインナップで秒あたり最安のビデオ — バルクおよびコスト駆動生成に対する正しい選択。",
+        "metaTitle": "Dreamina Seedance 2.0 on VM0: 価格、仕様、比較",
+        "metaDescription": "VM0上のDreamina Seedance 2.0。ByteDanceのテキストツービデオモデル、キュレーション済みラインナップで秒あたり最安コスト、1080pまで4〜15秒クリップ、Veo 3.1 FastとKling V3 4Kとの比較。",
+        "summary": "Dreamina Seedance 2.0はByteDanceのSeedanceビデオファミリーのコスト最適化メンバーです。出力時間は480p、720p、または1080pで4〜15秒で、テキストツービデオとイメージツービデオフローを持ちます。際立った特性はコスト — 画像条件付き1080p出力1秒あたり約$0.05で、Veo 3.1 FastまたはKling V3 4Kよりも劇的に安価です。\n\nコストが支配するときの自然なデフォルト：バルクファンアウト生成、ソーシャルクリップバリアント、プレミアム最終レンダリング前のドラフトパス。ネイティブオーディオにはVeo 3.1 Fastに、スタイライズド長尺出力にはKling V3 4Kに手を伸ばしてください。",
+        "releaseDate": "2026年4月",
+        "familyPosition": "ByteDanceのSeedanceビデオファミリーのコスト最適化ティア。",
+        "background": [
+          "Dreamina Seedance 2.0はByteDanceからの第2世代Seedanceビデオモデルで、同ファミリーのFastバリアントとProバリアントとペアになっています。キュレーション済みラインナップのStandard 2.0エントリはコスト/品質のスイートスポット — Proティアよりも安く、Fastティアよりも大幅に高品質。",
+          "モデルは480p、720p、または1080pで4〜15秒の時間でテキストツービデオとイメージツービデオフローを処理します。出力はコンシューマーフレンドリーなアスペクトに偏ります：短尺ソーシャル、ライフスタイル、製品クリップ。シネマティックまたはスタイライズド作業の天井ではありませんが、キュレーション済みラインナップで最も安い実行可能なオプション。"
+        ],
+        "architecture": "3つの品質ティア（Fast、Standard、Pro）を持つテキストツービデオおよびイメージツービデオディフュージョンモデル。キュレーション済みエントリはStandard 2.0ティアをカバーします。解像度と画像条件付けが使用されているかどうかのモディファイア付きで生成ビデオ秒あたり課金。",
+        "specs": [
+          { "label": "ファミリー", "value": "Seedance 2.0" },
+          {
+            "label": "モダリティ",
+            "value": "テキストツービデオ、イメージツービデオ"
+          },
+          { "label": "クリップ長", "value": "4〜15秒" },
+          { "label": "出力解像度", "value": "480p / 720p / 1080p" },
+          {
+            "label": "ベンダー定価",
+            "value": "秒あたり約$0.05（1080p＋画像）"
+          },
+          { "label": "VM0 提供開始", "value": "2026年4月" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "コスト",
+            "body": "キュレーション済みラインナップで秒あたり最安のビデオモデル。Veo 3.1 Fastより約3倍安価、Kling V3 4Kより約5倍安価。"
+          },
+          {
+            "title": "速度",
+            "body": "Standardティアでの高速生成 — 同ファミリーのより安価なFastバリアントと同等で、大幅に優れた品質。"
+          },
+          {
+            "title": "イメージツービデオ",
+            "body": "画像条件付けフローの強力な処理。エージェントが静止画像（Gemini 2.5 Flash ImageまたはSeedDream 4で安価に生成）を短いモーションクリップに拡張したい場合に有用。"
+          },
+          {
+            "title": "アスペクト天井",
+            "body": "シネマティックモーションではVeo 3.1 Fastよりも低く、スタイライズドアスペクトではKling V3 4Kよりも低い。天井ではなくコストが決定要因のときの正しい選択。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "バルクファンアウトビデオ生成ステップ",
+            "body": "秒あたりコストが十分に低く、同じクリップの十数のバリアントを生成することを実行可能にします。安価に事前フィルタし、品質が正当化する場合は最終レンダリングのために選択したバリアントをVeo 3.1 FastまたはKling V3 4Kにエスカレートしてください。"
+          },
+          {
+            "title": "キャンペーンでのイメージツービデオ拡張",
+            "body": "プレミアムティア価格を支払うことなく、静止ヒーロー画像から始めて短いモーションクリップに拡張します。画像条件付けが見た目を一貫させ続けます。"
+          },
+          {
+            "title": "プレミアムレンダリング前のドラフトパス",
+            "body": "Dreamina Seedance 2.0でモーション、フレーミング、ペーシングを安価にロックし、選択したバリアントでのみVeo 3.1 FastまたはKling V3 4Kで最終を再レンダリングします。"
+          }
+        ],
+        "avoidFor": "ネイティブオーディオが重要（Veo 3.1 Fast）、スタイライズドまたはアニメアスペクトが重要（Kling V3 4K）、またはブリーフが代替の天井がプレミアムを正当化する配信グレードシネマティックな場合はDreamina Seedance 2.0をスキップしてください。",
+        "comparisons": [
+          {
+            "vs": "Veo 3.1 Fast",
+            "body": "異なるポジショニング。Veo 3.1 Fastはネイティブオーディオとシネマティックモーションを運び、Dreamina Seedance 2.0は劇的に安価で、コストが支配する場合の正しい選択です。スタックしてください — Dreaminaでドラフト、Veoで最終。"
+          },
+          {
+            "vs": "Kling V3 4K",
+            "body": "全く異なるティア。Kling V3 4Kは時間、4K、スタイライズドアスペクトの天井で、Dreamina Seedance 2.0はその他すべての安価なデフォルトです。"
+          }
+        ],
+        "verdict": "ビデオ生成ステップでコストが支配するときはDreamina Seedance 2.0をデフォルトに。オーディオ最終にはVeo 3.1 Fast、スタイライズドまたは4Kヒーロー出力にはKling V3 4Kとスタックしてください。",
+        "faqs": [
+          {
+            "q": "Dreamina Seedance 2.0の秒あたりコストは？",
+            "a": "画像条件付き1080p出力1秒あたり約$0.05 — キュレーション済みビデオラインナップで最安。"
+          },
+          {
+            "q": "オーディオをサポートしていますか？",
+            "a": "同じパスではネイティブではありません。1回の呼び出しで同期オーディオ付きビデオには、Veo 3.1 Fastを使用してください。"
+          },
+          {
+            "q": "サポートされているクリップ長と解像度は？",
+            "a": "480p、720p、または1080pで4〜15秒のクリップ。"
+          },
+          {
+            "q": "VM0上にSeedanceの高品質ティアはありますか？",
+            "a": "SeedanceファミリーにはStandard 2.0エントリと並んでFastとProバリアントが含まれます。価格はティアに応じてスケールします。Standardティアがコスト/品質のスイートスポットです。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "ネイティブオーディオ、シネマティックモーション"
+          },
+          { "slug": "kling-v3-4k", "reason": "スタイライズド、より長い、4K" }
+        ],
+        "routingNotes": "Routed to ByteDance's Dreamina Seedance 2.0 endpoint and billed per generated video-second with resolution and image-conditioning modifiers.",
+        "vm0Notes": "Dreamina Seedance 2.0 is the cost-optimised default in the curated video lineup on VM0. The standard pattern is to use it for iteration and fan-out, then escalate the chosen variant to Veo 3.1 Fast or Kling V3 4K only when the final render justifies the premium."
       }
     }
   },


### PR DESCRIPTION
## Summary

Extends the `/models` marketing page beyond the reasoning-only catalog.

**New reasoning models** (already in `SUPPORTED_RUN_MODELS` but missing from the marketing page):
- GPT-5.5 (×2)
- GPT-5.4 (×1)
- GPT-5.4 Mini (×0.3)

**New image models:**
- Gemini 2.5 Flash Image
- GPT Image 1
- Flux Pro 1.1 Ultra
- SeedDream 4

**New video models:**
- Veo 3.1 Fast
- Kling V3 4K
- Dreamina Seedance 2.0

## Schema changes

- `ModelEntry` is now a union of `ReasoningModelEntry` and `GenerationModelEntry`. Generation models carry a simplified `GenerationPricing` (`unit` + `priceUsd`) instead of per-token pricing, and skip multiplier / BYOK / Vm0 tier fields that don't apply.
- New `category` discriminator (`reasoning` / `image` / `video` / `audio`).
- Filter pills changed from `all / recommended / multimodal / cost-saving` to `all / reasoning / image / video`.
- `ModelDetailClient` conditionally renders the credit-multiplier and BYOK / two-ways-to-access sections only for reasoning models.
- `data.test.ts` now validates uniqueness of slugs+modelIds and restricts the `VM0_MODEL_TO_PROVIDER` membership check to reasoning entries.

## i18n

Full content blocks added in all four locales (en / de / es / ja) for every new model — name, page title, summary, background, architecture, specs, performance notes, best-for examples, avoid-for, comparisons, verdict, FAQs, alternatives. Generation-model FAQs and comparison copy avoid mentioning specific platforms or connectors, focusing on the models themselves.

## Out of scope

- Audio models (ElevenLabs etc.) — can be added in a follow-up; the schema already accommodates `category: "audio"`.
- Image previews / sample outputs on the detail page — kept the same card layout for now; a richer generation-model layout would be a follow-up design pass.

## Test plan

- [x] `pnpm -F web run lint` — 0 warnings, 0 errors
- [x] `pnpm -F web run check-types` — clean
- [x] `pnpm -F web exec vitest run app/[locale]/models` — 2/2 tests pass
- [x] `pnpm knip --workspace apps/web` — clean
- [x] `pnpm format` — applied
- [x] JSON validates for en, de, es, ja
- [ ] Visual QA on staging — verify the new filter pills, the generation-model detail-page layout (no multiplier card), and that all four locales render the new pages