### PR TITLE
feat(platform): show filename in zero attachment chips

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -148,6 +148,8 @@ describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
         within(link).getByTestId("attachment-chip-file-icon"),
       ).toBeInTheDocument();
       expect(within(link).getByText("ZIP")).toBeInTheDocument();
+      // Filename must be rendered in the chip body, not only in the title tooltip.
+      expect(within(link).getByText("archive.zip")).toBeInTheDocument();
     });
   });
 });
@@ -700,8 +702,8 @@ describe("chat-d-063: preview button renders for previewable file attachment", (
 // Covers the video branch added to AttachmentChip in #9662.
 // ---------------------------------------------------------------------------
 
-describe("chat-d-064: video attachment chip shows neither image thumbnail nor file-type icon", () => {
-  it("renders composer chip without image preview or file-type icon for an mp4 upload", async () => {
+describe("chat-d-064: video attachment chip shows filename next to a file-type icon", () => {
+  it("renders composer chip with filename text and no image thumbnail for an mp4 upload", async () => {
     const user = userEvent.setup();
     const videoUrl = "https://example.com/demo.mp4";
 
@@ -729,28 +731,26 @@ describe("chat-d-064: video attachment chip shows neither image thumbnail nor fi
       new File(["v"], "demo.mp4", { type: "video/mp4" }),
     );
 
-    // Wait for the chip's Remove button, which appears only after the
-    // attachment has been added to the draft.
     await waitFor(() => {
       expect(screen.getByLabelText("Remove demo.mp4")).toBeInTheDocument();
     });
 
     const chipDiv = document.querySelector<HTMLElement>('[title="demo.mp4"]');
     expect(chipDiv).toBeInTheDocument();
-
-    // Image branch would render an <img> with src=videoUrl; video branch must not.
+    // Image branch would render an <img> with src=videoUrl; video must not.
     expect(
       document.querySelector(`img[src="${videoUrl}"]`),
     ).not.toBeInTheDocument();
-    // File branch would render an aria-hidden file-type icon <img>; video must not.
+    // Filename must be visible in the chip body (not just in the title tooltip).
+    expect(within(chipDiv!).getByText("demo.mp4")).toBeInTheDocument();
     expect(
-      chipDiv?.querySelector('img[aria-hidden="true"]'),
-    ).not.toBeInTheDocument();
+      within(chipDiv!).getByTestId("composer-attachment-file-icon"),
+    ).toBeInTheDocument();
   });
 });
 
-describe("chat-d-064: audio attachment chip shows audio file icon", () => {
-  it("renders composer chip without image preview or file-type icon for an mp3 upload", async () => {
+describe("chat-d-064: audio attachment chip shows filename next to a file-type icon", () => {
+  it("renders composer chip with filename text and no image thumbnail for an mp3 upload", async () => {
     const user = userEvent.setup();
     const audioUrl = "https://example.com/clip.mp3";
 
@@ -787,10 +787,10 @@ describe("chat-d-064: audio attachment chip shows audio file icon", () => {
     expect(
       document.querySelector(`img[src="${audioUrl}"]`),
     ).not.toBeInTheDocument();
+    expect(within(chipDiv!).getByText("clip.mp3")).toBeInTheDocument();
     expect(
-      chipDiv?.querySelector('img[aria-hidden="true"]'),
-    ).not.toBeInTheDocument();
-    expect(chipDiv?.querySelector("svg")).toBeInTheDocument();
+      within(chipDiv!).getByTestId("composer-attachment-file-icon"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -3,10 +3,8 @@ import { useGet, useSet, useLoadable } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
   IconDownload,
-  IconFileMusic,
   IconLink,
   IconPhoto,
-  IconVideo,
   IconLoader2,
   IconZoomIn,
   IconZoomOut,
@@ -899,6 +897,35 @@ function CsvLightboxBody({
 // FileAttachmentChip — compact chip shown inside sent message bubbles
 // ---------------------------------------------------------------------------
 
+// Shared visual shape for file attachment chips. Keeps a fixed h-7 (28px)
+// height regardless of upload state, with the filename always visible and
+// truncated with an ellipsis past max-w-[240px].
+const FILE_CHIP_CLASSES =
+  "inline-flex h-7 max-w-[240px] items-center gap-1.5 rounded-md border border-foreground/15 bg-background/80 px-1.5 transition-colors";
+
+function FileChipBody({
+  filename,
+  contentType,
+  testId,
+}: {
+  filename: string;
+  contentType?: string;
+  testId: string;
+}) {
+  return (
+    <>
+      <FilePreviewIcon
+        filename={filename}
+        contentType={contentType}
+        size="sm"
+        className="shrink-0"
+        testId={testId}
+      />
+      <span className="min-w-0 truncate text-xs font-medium">{filename}</span>
+    </>
+  );
+}
+
 export function FileAttachmentChip({
   contentType,
   filename,
@@ -920,12 +947,11 @@ export function FileAttachmentChip({
       }}
       title={filename}
       aria-label={`Download ${filename}`}
-      className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"
+      className={`${FILE_CHIP_CLASSES} hover:bg-foreground/10`}
     >
-      <FilePreviewIcon
+      <FileChipBody
         filename={filename}
         contentType={contentType}
-        className="h-9 w-9"
         testId="attachment-chip-file-icon"
       />
     </button>
@@ -951,12 +977,11 @@ export function PreviewableFileAttachmentChip({
       }}
       title={filename}
       aria-label={`Open ${kind} preview for ${filename}`}
-      className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"
+      className={`${FILE_CHIP_CLASSES} hover:bg-foreground/10`}
     >
-      <FilePreviewIcon
+      <FileChipBody
         filename={filename}
         contentType={contentTypeForDocumentAttachmentPreviewKind(kind)}
-        className="h-9 w-9"
         testId="attachment-chip-file-icon"
       />
     </button>
@@ -1065,58 +1090,47 @@ function AttachmentChip({
     infoLoadable.state === "hasData" ? infoLoadable.data?.url : undefined;
   const openImageLightbox = useSet(openImageLightbox$);
   const isImage = attachment.contentType.startsWith("image/");
-  const isVideo = attachment.contentType.startsWith("video/");
-  const isAudio = attachment.contentType.startsWith("audio/");
   return (
-    <>
-      <div
-        className="relative inline-flex items-center justify-center"
-        title={attachment.filename}
-      >
-        {isImage ? (
-          <ComposerImagePreviewButton
-            filename={attachment.filename}
-            openImageLightbox={openImageLightbox}
-            url={url}
-          />
-        ) : isVideo ? (
-          <IconVideo size={28} stroke={1.5} className="text-muted-foreground" />
-        ) : isAudio ? (
-          <IconFileMusic
-            size={28}
-            stroke={1.5}
-            className="text-muted-foreground"
-          />
-        ) : (
-          <FilePreviewIcon
+    <div
+      className="relative inline-flex items-center"
+      title={attachment.filename}
+    >
+      {isImage ? (
+        <ComposerImagePreviewButton
+          filename={attachment.filename}
+          openImageLightbox={openImageLightbox}
+          url={url}
+        />
+      ) : (
+        <span className={FILE_CHIP_CLASSES}>
+          <FileChipBody
             filename={attachment.filename}
             contentType={attachment.contentType}
-            className="h-9 w-9"
             testId="composer-attachment-file-icon"
           />
-        )}
-        {uploading && (
-          <span className="absolute -top-1 -left-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
-            <IconLoader2
-              size={10}
-              className="animate-spin text-muted-foreground"
-            />
-          </span>
-        )}
-        <button
-          type="button"
-          onClick={onRemove}
-          className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
-          aria-label={
-            uploading
-              ? `Cancel upload ${attachment.filename}`
-              : `Remove ${attachment.filename}`
-          }
-        >
-          <IconX size={9} stroke={2.5} />
-        </button>
-      </div>
-    </>
+        </span>
+      )}
+      {uploading && (
+        <span className="absolute -top-1 -left-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
+          <IconLoader2
+            size={10}
+            className="animate-spin text-muted-foreground"
+          />
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
+        aria-label={
+          uploading
+            ? `Cancel upload ${attachment.filename}`
+            : `Remove ${attachment.filename}`
+        }
+      >
+        <IconX size={9} stroke={2.5} />
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

The current attachment chip in both the chat composer and sent message bubbles renders only a 36px file-type icon (`FilePreviewIcon`), and stashes the filename in a `title` tooltip. From the UI, you can only tell that a file is "a ZIP" or "a PDF" — the actual filename is invisible unless you hover and wait.

This PR makes every non-image attachment chip render the filename next to the file-type icon, using a Notion-style inline pill:

- `FileAttachmentChip` (sent messages, generic files)
- `PreviewableFileAttachmentChip` (sent messages, markdown / text / json / csv / pdf / html)
- `AttachmentChip` (composer, non-image files — incl. video / audio, which previously also rendered as bare icons)

Each pill is locked at `h-7` (28px) with the file-type icon at `size="sm"` and the filename truncated by `max-w-[240px] truncate`. The height stays constant across the entire upload lifecycle: the uploading spinner and the remove button continue to be absolutely-positioned overlays, so they never change layout. Long filenames get a CSS ellipsis.

Composer image chips keep their existing 36x36 thumbnail behaviour, since the image itself is its own visual cue.

## Render exploration

A visual exploration of the 8 alternatives I considered (and why I landed on the Notion-style pill) is at https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d88cf64b-22e7-4165-8f91-9b2d5ecc1245/attachment-render-explorations.html

## Test plan
- [ ] CI passes (lint + types + vitest)
- [ ] Updated test \`chat-d-056\` asserts \`archive.zip\` text is visible inside the chip
- [ ] Updated tests \`chat-d-064\` (video / audio) assert filename text + \`composer-attachment-file-icon\` testid are present
- [ ] Manually drop a long-named ZIP in the composer, confirm ellipsis + remove button + uploading spinner all behave during and after upload
- [ ] Send the message and confirm the sent bubble renders the same pill with a download click target

Generated with [Claude Code](https://claude.com/claude-code)