### PR TITLE
refactor: add connector auth provider capabilities

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -238,6 +238,27 @@ describe("isOAuthConnectorType", () => {
     expect(getConnectorOAuthSecretMetadata("computer")).toBeUndefined();
   });
 
+  it("rejects refresh for OAuth connectors without refresh-token access", async () => {
+    const credentials = getConnectorOAuthCredentials("github", (name) => {
+      return name === "GITHUB_CLIENT_ID"
+        ? "test-github-client"
+        : "test-github-secret";
+    });
+    expect(credentials?.configured).toBe(true);
+
+    if (!credentials?.configured) {
+      throw new Error("Expected github OAuth credentials");
+    }
+
+    await expect(
+      refreshConnectorOAuthToken({
+        type: "github",
+        credentials,
+        refreshToken: "refresh-token",
+      }),
+    ).rejects.toThrow("github OAuth provider does not support refresh");
+  });
+
   it("builds the expected authorization URL base for every OAuth provider", async () => {
     const previousEnv = {
       VM0_API_URL: process.env.VM0_API_URL,

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -1,0 +1,158 @@
+import type {
+  OAuthAuthCodeConnectorType,
+  OAuthConnectorType,
+  OAuthDeviceAuthConnectorType,
+} from "../connectors";
+import type {
+  AuthUrlResult,
+  ConnectorOAuthAuthorizeArgs,
+  ConnectorOAuthDeviceAuthPollArgs,
+  ConnectorOAuthDeviceAuthStartArgs,
+  ConnectorOAuthExchangeArgs,
+  ConnectorOAuthRefreshArgs,
+  OAuthDeviceAuthPollResult,
+  OAuthDeviceAuthStartResult,
+  OAuthRefreshResult,
+  OAuthTokenResult,
+} from "../oauth-providers/provider-types";
+import type {
+  AuthCodeConnectorAuthProvider,
+  ConnectorAuthProvider,
+  DeviceAuthConnectorAuthProvider,
+} from "./provider-types";
+
+export type ConnectorAuthSecretMetadata =
+  | {
+      readonly accessSecretName: string;
+      readonly isRefreshable: false;
+    }
+  | {
+      readonly accessSecretName: string;
+      readonly refreshSecretName: string;
+      readonly isRefreshable: true;
+    };
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled connector auth provider capability: ${value}`);
+}
+
+export function getConnectorAuthSecretMetadata<T extends OAuthConnectorType>(
+  provider: ConnectorAuthProvider<T>,
+): ConnectorAuthSecretMetadata {
+  const access = provider.access;
+
+  switch (access.kind) {
+    case "none":
+      return {
+        accessSecretName: access.getAccessSecretName(),
+        isRefreshable: false,
+      };
+
+    case "refresh-token":
+      return {
+        accessSecretName: access.getAccessSecretName(),
+        refreshSecretName: access.getRefreshSecretName(),
+        isRefreshable: true,
+      };
+  }
+
+  assertNever(access);
+}
+
+export async function buildAuthCodeGrantAuthUrl<
+  T extends OAuthAuthCodeConnectorType,
+>(args: {
+  readonly type: T;
+  readonly provider: AuthCodeConnectorAuthProvider<T>;
+  readonly authorizeArgs: ConnectorOAuthAuthorizeArgs<T>;
+}): Promise<string | AuthUrlResult> {
+  const grant = args.provider.grant;
+
+  switch (grant.kind) {
+    case "none":
+      throw new Error(`${args.type} does not support auth-code grant`);
+
+    case "auth-code":
+      return await grant.buildAuthUrl(args.authorizeArgs);
+  }
+
+  assertNever(grant);
+}
+
+export async function exchangeAuthCodeGrant<
+  T extends OAuthAuthCodeConnectorType,
+>(args: {
+  readonly type: T;
+  readonly provider: AuthCodeConnectorAuthProvider<T>;
+  readonly exchangeArgs: ConnectorOAuthExchangeArgs<T>;
+}): Promise<OAuthTokenResult> {
+  const grant = args.provider.grant;
+
+  switch (grant.kind) {
+    case "none":
+      throw new Error(`${args.type} does not support auth-code grant`);
+
+    case "auth-code":
+      return await grant.exchangeCode(args.exchangeArgs);
+  }
+
+  assertNever(grant);
+}
+
+export async function startDeviceAuthGrant<
+  T extends OAuthDeviceAuthConnectorType,
+>(args: {
+  readonly type: T;
+  readonly provider: DeviceAuthConnectorAuthProvider<T>;
+  readonly startArgs: ConnectorOAuthDeviceAuthStartArgs<T>;
+}): Promise<OAuthDeviceAuthStartResult> {
+  const grant = args.provider.grant;
+
+  switch (grant.kind) {
+    case "none":
+      throw new Error(`${args.type} does not support device-auth grant`);
+
+    case "device-auth":
+      return await grant.startDeviceAuth(args.startArgs);
+  }
+
+  assertNever(grant);
+}
+
+export async function pollDeviceAuthGrant<
+  T extends OAuthDeviceAuthConnectorType,
+>(args: {
+  readonly type: T;
+  readonly provider: DeviceAuthConnectorAuthProvider<T>;
+  readonly pollArgs: ConnectorOAuthDeviceAuthPollArgs<T>;
+}): Promise<OAuthDeviceAuthPollResult> {
+  const grant = args.provider.grant;
+
+  switch (grant.kind) {
+    case "none":
+      throw new Error(`${args.type} does not support device-auth grant`);
+
+    case "device-auth":
+      return await grant.pollDeviceAuth(args.pollArgs);
+  }
+
+  assertNever(grant);
+}
+
+export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
+  readonly type: T;
+  readonly provider: ConnectorAuthProvider<T>;
+  readonly refreshArgs: ConnectorOAuthRefreshArgs<T>;
+}): Promise<OAuthRefreshResult> {
+  const access = args.provider.access;
+
+  switch (access.kind) {
+    case "none":
+      throw new Error(`${args.type} OAuth provider does not support refresh`);
+
+    case "refresh-token":
+      return await access.refreshToken(args.refreshArgs);
+  }
+
+  assertNever(access);
+}

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -34,10 +34,6 @@ export type ConnectorAuthSecretMetadata =
       readonly isRefreshable: true;
     };
 
-function assertNever(value: never): never {
-  throw new Error(`Unhandled connector auth provider capability: ${value}`);
-}
-
 export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
   provider: ConnectorAuthProvider<T>,
 ): ConnectorAuthSecretMetadata {
@@ -57,8 +53,6 @@ export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
         isRefreshable: true,
       };
   }
-
-  assertNever(access);
 }
 
 export async function buildAuthCodeGrantAuthUrl<
@@ -77,8 +71,6 @@ export async function buildAuthCodeGrantAuthUrl<
     case "auth-code":
       return await grant.buildAuthUrl(args.authorizeArgs);
   }
-
-  assertNever(grant);
 }
 
 export async function exchangeAuthCodeGrant<
@@ -97,8 +89,6 @@ export async function exchangeAuthCodeGrant<
     case "auth-code":
       return await grant.exchangeCode(args.exchangeArgs);
   }
-
-  assertNever(grant);
 }
 
 export async function startDeviceAuthGrant<
@@ -117,8 +107,6 @@ export async function startDeviceAuthGrant<
     case "device-auth":
       return await grant.startDeviceAuth(args.startArgs);
   }
-
-  assertNever(grant);
 }
 
 export async function pollDeviceAuthGrant<
@@ -137,8 +125,6 @@ export async function pollDeviceAuthGrant<
     case "device-auth":
       return await grant.pollDeviceAuth(args.pollArgs);
   }
-
-  assertNever(grant);
 }
 
 export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
@@ -155,6 +141,4 @@ export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
     case "refresh-token":
       return await access.refreshToken(args.refreshArgs);
   }
-
-  assertNever(access);
 }

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -20,7 +20,7 @@ import type {
   AuthCodeConnectorAuthProvider,
   ConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
-  OAuthConnectorAccessProvider,
+  RefreshTokenAccessProvider,
 } from "./provider-types";
 
 export type ConnectorAuthSecretMetadata =
@@ -101,16 +101,8 @@ export async function pollDeviceAuthGrant<
 
 export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
   readonly type: T;
-  readonly access: OAuthConnectorAccessProvider<T>;
+  readonly access: RefreshTokenAccessProvider<T>;
   readonly refreshArgs: ConnectorOAuthRefreshArgs<T>;
 }): Promise<OAuthRefreshResult> {
-  const access = args.access;
-
-  switch (access.kind) {
-    case "none":
-      throw new Error(`${args.type} OAuth provider does not support refresh`);
-
-    case "refresh-token":
-      return await access.refreshToken(args.refreshArgs);
-  }
+  return await args.access.refreshToken(args.refreshArgs);
 }

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorType,
   OAuthAuthCodeConnectorType,
   OAuthConnectorType,
   OAuthDeviceAuthConnectorType,
@@ -19,6 +20,7 @@ import type {
   AuthCodeConnectorAuthProvider,
   ConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
+  OAuthConnectorAccessProvider,
 } from "./provider-types";
 
 export type ConnectorAuthSecretMetadata =
@@ -36,7 +38,7 @@ function assertNever(value: never): never {
   throw new Error(`Unhandled connector auth provider capability: ${value}`);
 }
 
-export function getConnectorAuthSecretMetadata<T extends OAuthConnectorType>(
+export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
   provider: ConnectorAuthProvider<T>,
 ): ConnectorAuthSecretMetadata {
   const access = provider.access;
@@ -141,10 +143,10 @@ export async function pollDeviceAuthGrant<
 
 export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
   readonly type: T;
-  readonly provider: ConnectorAuthProvider<T>;
+  readonly access: OAuthConnectorAccessProvider<T>;
   readonly refreshArgs: ConnectorOAuthRefreshArgs<T>;
 }): Promise<OAuthRefreshResult> {
-  const access = args.provider.access;
+  const access = args.access;
 
   switch (access.kind) {
     case "none":

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -53,12 +53,13 @@ export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
         isRefreshable: true,
       };
   }
+  const exhaustive: never = access;
+  return exhaustive;
 }
 
 export async function buildAuthCodeGrantAuthUrl<
   T extends OAuthAuthCodeConnectorType,
 >(args: {
-  readonly type: T;
   readonly provider: AuthCodeConnectorAuthProvider<T>;
   readonly authorizeArgs: ConnectorOAuthAuthorizeArgs<T>;
 }): Promise<string | AuthUrlResult> {
@@ -69,7 +70,6 @@ export async function buildAuthCodeGrantAuthUrl<
 export async function exchangeAuthCodeGrant<
   T extends OAuthAuthCodeConnectorType,
 >(args: {
-  readonly type: T;
   readonly provider: AuthCodeConnectorAuthProvider<T>;
   readonly exchangeArgs: ConnectorOAuthExchangeArgs<T>;
 }): Promise<OAuthTokenResult> {
@@ -80,7 +80,6 @@ export async function exchangeAuthCodeGrant<
 export async function startDeviceAuthGrant<
   T extends OAuthDeviceAuthConnectorType,
 >(args: {
-  readonly type: T;
   readonly provider: DeviceAuthConnectorAuthProvider<T>;
   readonly startArgs: ConnectorOAuthDeviceAuthStartArgs<T>;
 }): Promise<OAuthDeviceAuthStartResult> {
@@ -91,7 +90,6 @@ export async function startDeviceAuthGrant<
 export async function pollDeviceAuthGrant<
   T extends OAuthDeviceAuthConnectorType,
 >(args: {
-  readonly type: T;
   readonly provider: DeviceAuthConnectorAuthProvider<T>;
   readonly pollArgs: ConnectorOAuthDeviceAuthPollArgs<T>;
 }): Promise<OAuthDeviceAuthPollResult> {
@@ -100,7 +98,6 @@ export async function pollDeviceAuthGrant<
 }
 
 export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
-  readonly type: T;
   readonly access: RefreshTokenAccessProvider<T>;
   readonly refreshArgs: ConnectorOAuthRefreshArgs<T>;
 }): Promise<OAuthRefreshResult> {

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -63,14 +63,7 @@ export async function buildAuthCodeGrantAuthUrl<
   readonly authorizeArgs: ConnectorOAuthAuthorizeArgs<T>;
 }): Promise<string | AuthUrlResult> {
   const grant = args.provider.grant;
-
-  switch (grant.kind) {
-    case "none":
-      throw new Error(`${args.type} does not support auth-code grant`);
-
-    case "auth-code":
-      return await grant.buildAuthUrl(args.authorizeArgs);
-  }
+  return await grant.buildAuthUrl(args.authorizeArgs);
 }
 
 export async function exchangeAuthCodeGrant<
@@ -81,14 +74,7 @@ export async function exchangeAuthCodeGrant<
   readonly exchangeArgs: ConnectorOAuthExchangeArgs<T>;
 }): Promise<OAuthTokenResult> {
   const grant = args.provider.grant;
-
-  switch (grant.kind) {
-    case "none":
-      throw new Error(`${args.type} does not support auth-code grant`);
-
-    case "auth-code":
-      return await grant.exchangeCode(args.exchangeArgs);
-  }
+  return await grant.exchangeCode(args.exchangeArgs);
 }
 
 export async function startDeviceAuthGrant<
@@ -99,14 +85,7 @@ export async function startDeviceAuthGrant<
   readonly startArgs: ConnectorOAuthDeviceAuthStartArgs<T>;
 }): Promise<OAuthDeviceAuthStartResult> {
   const grant = args.provider.grant;
-
-  switch (grant.kind) {
-    case "none":
-      throw new Error(`${args.type} does not support device-auth grant`);
-
-    case "device-auth":
-      return await grant.startDeviceAuth(args.startArgs);
-  }
+  return await grant.startDeviceAuth(args.startArgs);
 }
 
 export async function pollDeviceAuthGrant<
@@ -117,14 +96,7 @@ export async function pollDeviceAuthGrant<
   readonly pollArgs: ConnectorOAuthDeviceAuthPollArgs<T>;
 }): Promise<OAuthDeviceAuthPollResult> {
   const grant = args.provider.grant;
-
-  switch (grant.kind) {
-    case "none":
-      throw new Error(`${args.type} does not support device-auth grant`);
-
-    case "device-auth":
-      return await grant.pollDeviceAuth(args.pollArgs);
-  }
+  return await grant.pollDeviceAuth(args.pollArgs);
 }
 
 export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -53,8 +53,6 @@ export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
         isRefreshable: true,
       };
   }
-  const exhaustive: never = access;
-  return exhaustive;
 }
 
 export async function buildAuthCodeGrantAuthUrl<

--- a/turbo/packages/connectors/src/auth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-types.ts
@@ -18,7 +18,7 @@ import type {
   OAuthTokenResult,
 } from "../oauth-providers/provider-types";
 
-export interface NoneGrantProvider {
+interface NoneGrantProvider {
   readonly kind: "none";
 }
 
@@ -44,9 +44,9 @@ export interface DeviceAuthGrantProvider<
 
 export type ConnectorGrantProvider<T extends ConnectorType> =
   T extends OAuthAuthCodeConnectorType
-    ? NoneGrantProvider | AuthCodeGrantProvider<T>
+    ? AuthCodeGrantProvider<T>
     : T extends OAuthDeviceAuthConnectorType
-      ? NoneGrantProvider | DeviceAuthGrantProvider<T>
+      ? DeviceAuthGrantProvider<T>
       : NoneGrantProvider;
 
 export interface NoneAccessProvider {
@@ -97,7 +97,7 @@ interface BaseConnectorAuthProvider<TGrant, TAccess, TRevoke> {
 export type AuthCodeConnectorAuthProvider<
   T extends OAuthAuthCodeConnectorType,
 > = BaseConnectorAuthProvider<
-  NoneGrantProvider | AuthCodeGrantProvider<T>,
+  AuthCodeGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,
   OAuthConnectorRevokeProvider<T>
 >;
@@ -105,7 +105,7 @@ export type AuthCodeConnectorAuthProvider<
 export type DeviceAuthConnectorAuthProvider<
   T extends OAuthDeviceAuthConnectorType,
 > = BaseConnectorAuthProvider<
-  NoneGrantProvider | DeviceAuthGrantProvider<T>,
+  DeviceAuthGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,
   OAuthConnectorRevokeProvider<T>
 >;

--- a/turbo/packages/connectors/src/auth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-types.ts
@@ -1,0 +1,100 @@
+import type {
+  OAuthAuthCodeConnectorType,
+  OAuthConnectorType,
+  OAuthDeviceAuthConnectorType,
+} from "../connectors";
+import type {
+  AuthUrlResult,
+  ConnectorOAuthAuthorizeArgs,
+  ConnectorOAuthDeviceAuthPollArgs,
+  ConnectorOAuthDeviceAuthStartArgs,
+  ConnectorOAuthExchangeArgs,
+  ConnectorOAuthRefreshArgs,
+  ConnectorOAuthRevokeArgs,
+  OAuthDeviceAuthPollResult,
+  OAuthDeviceAuthStartResult,
+  OAuthRefreshResult,
+  OAuthTokenResult,
+} from "../oauth-providers/provider-types";
+
+export interface NoneGrantProvider {
+  readonly kind: "none";
+}
+
+export interface AuthCodeGrantProvider<T extends OAuthAuthCodeConnectorType> {
+  readonly kind: "auth-code";
+  buildAuthUrl(
+    args: ConnectorOAuthAuthorizeArgs<T>,
+  ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
+  exchangeCode(args: ConnectorOAuthExchangeArgs<T>): Promise<OAuthTokenResult>;
+}
+
+export interface DeviceAuthGrantProvider<
+  T extends OAuthDeviceAuthConnectorType,
+> {
+  readonly kind: "device-auth";
+  startDeviceAuth(
+    args: ConnectorOAuthDeviceAuthStartArgs<T>,
+  ): Promise<OAuthDeviceAuthStartResult>;
+  pollDeviceAuth(
+    args: ConnectorOAuthDeviceAuthPollArgs<T>,
+  ): Promise<OAuthDeviceAuthPollResult>;
+}
+
+export type ConnectorGrantProvider<T extends OAuthConnectorType> =
+  T extends OAuthAuthCodeConnectorType
+    ? NoneGrantProvider | AuthCodeGrantProvider<T>
+    : T extends OAuthDeviceAuthConnectorType
+      ? NoneGrantProvider | DeviceAuthGrantProvider<T>
+      : NoneGrantProvider;
+
+export interface NoneAccessProvider {
+  readonly kind: "none";
+  getAccessSecretName(): string;
+}
+
+export interface RefreshTokenAccessProvider<T extends OAuthConnectorType> {
+  readonly kind: "refresh-token";
+  getAccessSecretName(): string;
+  getRefreshSecretName(): string;
+  refreshToken(args: ConnectorOAuthRefreshArgs<T>): Promise<OAuthRefreshResult>;
+}
+
+export type ConnectorAccessProvider<T extends OAuthConnectorType> =
+  | NoneAccessProvider
+  | RefreshTokenAccessProvider<T>;
+
+export interface NoneRevokeProvider {
+  readonly kind: "none";
+}
+
+export interface TokenRevokeProvider<T extends OAuthConnectorType> {
+  readonly kind: "token-revoke";
+  revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
+}
+
+export type ConnectorRevokeProvider<T extends OAuthConnectorType> =
+  | NoneRevokeProvider
+  | TokenRevokeProvider<T>;
+
+interface BaseConnectorAuthProvider<T extends OAuthConnectorType> {
+  readonly access: ConnectorAccessProvider<T>;
+  readonly revoke: ConnectorRevokeProvider<T>;
+}
+
+export interface AuthCodeConnectorAuthProvider<
+  T extends OAuthAuthCodeConnectorType,
+> extends BaseConnectorAuthProvider<T> {
+  readonly grant: NoneGrantProvider | AuthCodeGrantProvider<T>;
+}
+
+export interface DeviceAuthConnectorAuthProvider<
+  T extends OAuthDeviceAuthConnectorType,
+> extends BaseConnectorAuthProvider<T> {
+  readonly grant: NoneGrantProvider | DeviceAuthGrantProvider<T>;
+}
+
+export type ConnectorAuthProvider<T extends OAuthConnectorType> =
+  BaseConnectorAuthProvider<T> & {
+    readonly grant: ConnectorGrantProvider<T>;
+  };

--- a/turbo/packages/connectors/src/auth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-types.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorType,
   OAuthAuthCodeConnectorType,
   OAuthConnectorType,
   OAuthDeviceAuthConnectorType,
@@ -41,7 +42,7 @@ export interface DeviceAuthGrantProvider<
   ): Promise<OAuthDeviceAuthPollResult>;
 }
 
-export type ConnectorGrantProvider<T extends OAuthConnectorType> =
+export type ConnectorGrantProvider<T extends ConnectorType> =
   T extends OAuthAuthCodeConnectorType
     ? NoneGrantProvider | AuthCodeGrantProvider<T>
     : T extends OAuthDeviceAuthConnectorType
@@ -60,9 +61,14 @@ export interface RefreshTokenAccessProvider<T extends OAuthConnectorType> {
   refreshToken(args: ConnectorOAuthRefreshArgs<T>): Promise<OAuthRefreshResult>;
 }
 
-export type ConnectorAccessProvider<T extends OAuthConnectorType> =
+export type OAuthConnectorAccessProvider<T extends OAuthConnectorType> =
   | NoneAccessProvider
   | RefreshTokenAccessProvider<T>;
+
+export type ConnectorAccessProvider<T extends ConnectorType> =
+  T extends OAuthConnectorType
+    ? OAuthConnectorAccessProvider<T>
+    : NoneAccessProvider;
 
 export interface NoneRevokeProvider {
   readonly kind: "none";
@@ -73,28 +79,40 @@ export interface TokenRevokeProvider<T extends OAuthConnectorType> {
   revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
 }
 
-export type ConnectorRevokeProvider<T extends OAuthConnectorType> =
+export type OAuthConnectorRevokeProvider<T extends OAuthConnectorType> =
   | NoneRevokeProvider
   | TokenRevokeProvider<T>;
 
-interface BaseConnectorAuthProvider<T extends OAuthConnectorType> {
-  readonly access: ConnectorAccessProvider<T>;
-  readonly revoke: ConnectorRevokeProvider<T>;
+export type ConnectorRevokeProvider<T extends ConnectorType> =
+  T extends OAuthConnectorType
+    ? OAuthConnectorRevokeProvider<T>
+    : NoneRevokeProvider;
+
+interface BaseConnectorAuthProvider<TGrant, TAccess, TRevoke> {
+  readonly grant: TGrant;
+  readonly access: TAccess;
+  readonly revoke: TRevoke;
 }
 
-export interface AuthCodeConnectorAuthProvider<
+export type AuthCodeConnectorAuthProvider<
   T extends OAuthAuthCodeConnectorType,
-> extends BaseConnectorAuthProvider<T> {
-  readonly grant: NoneGrantProvider | AuthCodeGrantProvider<T>;
-}
+> = BaseConnectorAuthProvider<
+  NoneGrantProvider | AuthCodeGrantProvider<T>,
+  OAuthConnectorAccessProvider<T>,
+  OAuthConnectorRevokeProvider<T>
+>;
 
-export interface DeviceAuthConnectorAuthProvider<
+export type DeviceAuthConnectorAuthProvider<
   T extends OAuthDeviceAuthConnectorType,
-> extends BaseConnectorAuthProvider<T> {
-  readonly grant: NoneGrantProvider | DeviceAuthGrantProvider<T>;
-}
+> = BaseConnectorAuthProvider<
+  NoneGrantProvider | DeviceAuthGrantProvider<T>,
+  OAuthConnectorAccessProvider<T>,
+  OAuthConnectorRevokeProvider<T>
+>;
 
-export type ConnectorAuthProvider<T extends OAuthConnectorType> =
-  BaseConnectorAuthProvider<T> & {
-    readonly grant: ConnectorGrantProvider<T>;
-  };
+export type ConnectorAuthProvider<T extends ConnectorType> =
+  BaseConnectorAuthProvider<
+    ConnectorGrantProvider<T>,
+    ConnectorAccessProvider<T>,
+    ConnectorRevokeProvider<T>
+  >;

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -23,13 +23,10 @@ import {
   type ConnectorAuthSecretMetadata,
 } from "../auth-providers/provider-registry";
 import type {
-  AuthCodeGrantProvider,
   AuthCodeConnectorAuthProvider,
-  ConnectorAccessProvider,
-  ConnectorAuthProvider,
-  ConnectorRevokeProvider,
   DeviceAuthConnectorAuthProvider,
-  DeviceAuthGrantProvider,
+  OAuthConnectorAccessProvider,
+  OAuthConnectorRevokeProvider,
 } from "../auth-providers/provider-types";
 import {
   type AuthUrlResult,
@@ -153,7 +150,7 @@ function assertConfiguredConnectorOAuthCredentials(
 
 function connectorAccessProviderFor<T extends OAuthConnectorType>(
   provider: ConnectorOAuthProviderFor<T>,
-): ConnectorAccessProvider<T> {
+): OAuthConnectorAccessProvider<T> {
   if (
     "getRefreshSecretName" in provider &&
     typeof provider.getRefreshSecretName === "function" &&
@@ -176,7 +173,7 @@ function connectorAccessProviderFor<T extends OAuthConnectorType>(
 
 function connectorRevokeProviderFor<T extends OAuthConnectorType>(
   provider: ConnectorOAuthProviderFor<T>,
-): ConnectorRevokeProvider<T> {
+): OAuthConnectorRevokeProvider<T> {
   if ("revokeToken" in provider && typeof provider.revokeToken === "function") {
     return {
       kind: "token-revoke",
@@ -196,7 +193,7 @@ function authCodeConnectorAuthProviderFor<T extends OAuthAuthCodeConnectorType>(
       kind: "auth-code",
       buildAuthUrl: provider.buildAuthUrl,
       exchangeCode: provider.exchangeCode,
-    } as AuthCodeGrantProvider<T>,
+    },
     access: connectorAccessProviderFor(provider),
     revoke: connectorRevokeProviderFor(provider),
   };
@@ -211,24 +208,10 @@ function deviceConnectorAuthProviderFor<T extends OAuthDeviceAuthConnectorType>(
       kind: "device-auth",
       startDeviceAuth: provider.startDeviceAuth,
       pollDeviceAuth: provider.pollDeviceAuth,
-    } as DeviceAuthGrantProvider<T>,
+    },
     access: connectorAccessProviderFor(provider),
     revoke: connectorRevokeProviderFor(provider),
   };
-}
-
-function connectorAuthProviderFor<T extends OAuthConnectorType>(
-  type: T,
-): ConnectorAuthProvider<T> {
-  if (isOAuthAuthCodeConnectorType(type)) {
-    return authCodeConnectorAuthProviderFor(type) as ConnectorAuthProvider<T>;
-  }
-
-  if (isOAuthDeviceAuthConnectorType(type)) {
-    return deviceConnectorAuthProviderFor(type) as ConnectorAuthProvider<T>;
-  }
-
-  throw new Error(`${type} OAuth flow is not supported`);
 }
 
 const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
@@ -298,7 +281,17 @@ export function getConnectorOAuthSecretMetadata(
     return undefined;
   }
 
-  return getConnectorAuthSecretMetadata(connectorAuthProviderFor(type));
+  if (isOAuthAuthCodeConnectorType(type)) {
+    return getConnectorAuthSecretMetadata(
+      authCodeConnectorAuthProviderFor(type),
+    );
+  }
+
+  if (isOAuthDeviceAuthConnectorType(type)) {
+    return getConnectorAuthSecretMetadata(deviceConnectorAuthProviderFor(type));
+  }
+
+  throw new Error(`${type} OAuth flow is not supported`);
 }
 
 export async function buildConnectorOAuthAuthUrl<
@@ -393,7 +386,7 @@ export async function refreshConnectorOAuthToken<
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await refreshTokenAccess({
     type: args.type,
-    provider: connectorAuthProviderFor(args.type),
+    access: connectorAccessProviderFor(connectorProviderFor(args.type)),
     refreshArgs: {
       ...connectorCredentialArgs(args.credentials),
       refreshToken: args.refreshToken,

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -291,7 +291,8 @@ export function getConnectorOAuthSecretMetadata(
     return getConnectorAuthSecretMetadata(deviceConnectorAuthProviderFor(type));
   }
 
-  throw new Error(`${type} OAuth flow is not supported`);
+  const exhaustive: never = type;
+  throw new Error(`${exhaustive} OAuth flow is not supported`);
 }
 
 export async function buildConnectorOAuthAuthUrl<
@@ -304,7 +305,6 @@ export async function buildConnectorOAuthAuthUrl<
 }): Promise<string | AuthUrlResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await buildAuthCodeGrantAuthUrl({
-    type: args.type,
     provider: authCodeConnectorAuthProviderFor(args.type),
     authorizeArgs: {
       ...connectorCredentialArgs(args.credentials),
@@ -327,7 +327,6 @@ export async function exchangeConnectorOAuthCode<
 }): Promise<OAuthTokenResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await exchangeAuthCodeGrant({
-    type: args.type,
     provider: authCodeConnectorAuthProviderFor(args.type),
     exchangeArgs: {
       ...connectorCredentialArgs(args.credentials),
@@ -349,7 +348,6 @@ export async function startConnectorOAuthDeviceAuth<
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const oauthConfig = getConnectorOAuthDeviceAuthConfig(args.type);
   return await startDeviceAuthGrant({
-    type: args.type,
     provider: deviceConnectorAuthProviderFor(args.type),
     startArgs: {
       ...connectorCredentialArgs(args.credentials),
@@ -367,7 +365,6 @@ export async function pollConnectorOAuthDeviceAuth<
 }): Promise<OAuthDeviceAuthPollResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await pollDeviceAuthGrant({
-    type: args.type,
     provider: deviceConnectorAuthProviderFor(args.type),
     pollArgs: {
       ...connectorCredentialArgs(args.credentials),
@@ -392,7 +389,6 @@ export async function refreshConnectorOAuthToken<
 
     case "refresh-token":
       return await refreshTokenAccess({
-        type: args.type,
         access,
         refreshArgs: {
           ...connectorCredentialArgs(args.credentials),
@@ -400,6 +396,8 @@ export async function refreshConnectorOAuthToken<
         } as ConnectorOAuthRefreshArgs<T>,
       });
   }
+  const exhaustive: never = access;
+  return exhaustive;
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -7,10 +7,30 @@ import type {
 import {
   getConnectorOAuthDeviceAuthConfig,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
+  isOAuthAuthCodeConnectorType,
+  isOAuthDeviceAuthConnectorType,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
+import {
+  buildAuthCodeGrantAuthUrl,
+  exchangeAuthCodeGrant,
+  getConnectorAuthSecretMetadata,
+  pollDeviceAuthGrant,
+  refreshTokenAccess,
+  startDeviceAuthGrant,
+  type ConnectorAuthSecretMetadata,
+} from "../auth-providers/provider-registry";
+import type {
+  AuthCodeGrantProvider,
+  AuthCodeConnectorAuthProvider,
+  ConnectorAccessProvider,
+  ConnectorAuthProvider,
+  ConnectorRevokeProvider,
+  DeviceAuthConnectorAuthProvider,
+  DeviceAuthGrantProvider,
+} from "../auth-providers/provider-types";
 import {
   type AuthUrlResult,
   type ConnectorOAuthAuthorizeArgs,
@@ -18,6 +38,7 @@ import {
   type ConnectorOAuthDeviceAuthStartArgs,
   type ConnectorOAuthExchangeArgs,
   type ConnectorOAuthProviderFor,
+  type ConnectorOAuthRefreshArgs,
   type OAuthAuthorizeArgs,
   type OAuthDeviceAuthPollArgs,
   type OAuthDeviceAuthPollResult,
@@ -98,20 +119,7 @@ type ConnectorOAuthProviderMap = {
   readonly [Type in OAuthConnectorType]: ConnectorOAuthProviderFor<Type>;
 };
 
-type DispatchRefreshProvider = {
-  refreshToken(args: OAuthRefreshArgs): Promise<OAuthRefreshResult>;
-};
-
-export type ConnectorOAuthSecretMetadata =
-  | {
-      readonly accessSecretName: string;
-      readonly isRefreshable: false;
-    }
-  | {
-      readonly accessSecretName: string;
-      readonly refreshSecretName: string;
-      readonly isRefreshable: true;
-    };
+export type ConnectorOAuthSecretMetadata = ConnectorAuthSecretMetadata;
 
 function connectorProviderFor<T extends OAuthConnectorType>(
   type: T,
@@ -141,6 +149,86 @@ function assertConfiguredConnectorOAuthCredentials(
   if (!credentials.configured) {
     throw new Error(`${type} OAuth not configured`);
   }
+}
+
+function connectorAccessProviderFor<T extends OAuthConnectorType>(
+  provider: ConnectorOAuthProviderFor<T>,
+): ConnectorAccessProvider<T> {
+  if (
+    "getRefreshSecretName" in provider &&
+    typeof provider.getRefreshSecretName === "function" &&
+    "refreshToken" in provider &&
+    typeof provider.refreshToken === "function"
+  ) {
+    return {
+      kind: "refresh-token",
+      getAccessSecretName: provider.getSecretName,
+      getRefreshSecretName: provider.getRefreshSecretName,
+      refreshToken: provider.refreshToken,
+    };
+  }
+
+  return {
+    kind: "none",
+    getAccessSecretName: provider.getSecretName,
+  };
+}
+
+function connectorRevokeProviderFor<T extends OAuthConnectorType>(
+  provider: ConnectorOAuthProviderFor<T>,
+): ConnectorRevokeProvider<T> {
+  if ("revokeToken" in provider && typeof provider.revokeToken === "function") {
+    return {
+      kind: "token-revoke",
+      revokeToken: provider.revokeToken,
+    };
+  }
+
+  return { kind: "none" };
+}
+
+function authCodeConnectorAuthProviderFor<T extends OAuthAuthCodeConnectorType>(
+  type: T,
+): AuthCodeConnectorAuthProvider<T> {
+  const provider = connectorProviderFor(type);
+  return {
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: provider.buildAuthUrl,
+      exchangeCode: provider.exchangeCode,
+    } as AuthCodeGrantProvider<T>,
+    access: connectorAccessProviderFor(provider),
+    revoke: connectorRevokeProviderFor(provider),
+  };
+}
+
+function deviceConnectorAuthProviderFor<T extends OAuthDeviceAuthConnectorType>(
+  type: T,
+): DeviceAuthConnectorAuthProvider<T> {
+  const provider = connectorProviderFor(type);
+  return {
+    grant: {
+      kind: "device-auth",
+      startDeviceAuth: provider.startDeviceAuth,
+      pollDeviceAuth: provider.pollDeviceAuth,
+    } as DeviceAuthGrantProvider<T>,
+    access: connectorAccessProviderFor(provider),
+    revoke: connectorRevokeProviderFor(provider),
+  };
+}
+
+function connectorAuthProviderFor<T extends OAuthConnectorType>(
+  type: T,
+): ConnectorAuthProvider<T> {
+  if (isOAuthAuthCodeConnectorType(type)) {
+    return authCodeConnectorAuthProviderFor(type) as ConnectorAuthProvider<T>;
+  }
+
+  if (isOAuthDeviceAuthConnectorType(type)) {
+    return deviceConnectorAuthProviderFor(type) as ConnectorAuthProvider<T>;
+  }
+
+  throw new Error(`${type} OAuth flow is not supported`);
 }
 
 const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
@@ -210,20 +298,7 @@ export function getConnectorOAuthSecretMetadata(
     return undefined;
   }
 
-  const provider = connectorProviderFor(type);
-  const accessSecretName = provider.getSecretName();
-  if (!isOAuthRefreshProvider(provider)) {
-    return {
-      accessSecretName,
-      isRefreshable: false,
-    };
-  }
-
-  return {
-    accessSecretName,
-    refreshSecretName: provider.getRefreshSecretName(),
-    isRefreshable: true,
-  };
+  return getConnectorAuthSecretMetadata(connectorAuthProviderFor(type));
 }
 
 export async function buildConnectorOAuthAuthUrl<
@@ -235,12 +310,15 @@ export async function buildConnectorOAuthAuthUrl<
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(args.type);
-  return await provider.buildAuthUrl({
-    ...connectorCredentialArgs(args.credentials),
-    redirectUri: args.redirectUri,
-    state: args.state,
-  } as ConnectorOAuthAuthorizeArgs<T>);
+  return await buildAuthCodeGrantAuthUrl({
+    type: args.type,
+    provider: authCodeConnectorAuthProviderFor(args.type),
+    authorizeArgs: {
+      ...connectorCredentialArgs(args.credentials),
+      redirectUri: args.redirectUri,
+      state: args.state,
+    } as ConnectorOAuthAuthorizeArgs<T>,
+  });
 }
 
 export async function exchangeConnectorOAuthCode<
@@ -255,15 +333,18 @@ export async function exchangeConnectorOAuthCode<
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(args.type);
-  return await provider.exchangeCode({
-    ...connectorCredentialArgs(args.credentials),
-    code: args.code,
-    redirectUri: args.redirectUri,
-    state: args.state,
-    codeVerifier: args.codeVerifier,
-    oauthContext: args.oauthContext,
-  } as ConnectorOAuthExchangeArgs<T>);
+  return await exchangeAuthCodeGrant({
+    type: args.type,
+    provider: authCodeConnectorAuthProviderFor(args.type),
+    exchangeArgs: {
+      ...connectorCredentialArgs(args.credentials),
+      code: args.code,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      codeVerifier: args.codeVerifier,
+      oauthContext: args.oauthContext,
+    } as ConnectorOAuthExchangeArgs<T>,
+  });
 }
 
 export async function startConnectorOAuthDeviceAuth<
@@ -273,12 +354,15 @@ export async function startConnectorOAuthDeviceAuth<
   readonly credentials: ConnectorOAuthCredentials;
 }): Promise<OAuthDeviceAuthStartResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(args.type);
   const oauthConfig = getConnectorOAuthDeviceAuthConfig(args.type);
-  return await provider.startDeviceAuth({
-    ...connectorCredentialArgs(args.credentials),
-    scopes: oauthConfig.scopes,
-  } as ConnectorOAuthDeviceAuthStartArgs<T>);
+  return await startDeviceAuthGrant({
+    type: args.type,
+    provider: deviceConnectorAuthProviderFor(args.type),
+    startArgs: {
+      ...connectorCredentialArgs(args.credentials),
+      scopes: oauthConfig.scopes,
+    } as ConnectorOAuthDeviceAuthStartArgs<T>,
+  });
 }
 
 export async function pollConnectorOAuthDeviceAuth<
@@ -289,27 +373,31 @@ export async function pollConnectorOAuthDeviceAuth<
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(args.type);
-  return await provider.pollDeviceAuth({
-    ...connectorCredentialArgs(args.credentials),
-    deviceCode: args.deviceCode,
-  } as ConnectorOAuthDeviceAuthPollArgs<T>);
+  return await pollDeviceAuthGrant({
+    type: args.type,
+    provider: deviceConnectorAuthProviderFor(args.type),
+    pollArgs: {
+      ...connectorCredentialArgs(args.credentials),
+      deviceCode: args.deviceCode,
+    } as ConnectorOAuthDeviceAuthPollArgs<T>,
+  });
 }
 
-export async function refreshConnectorOAuthToken(args: {
-  readonly type: OAuthConnectorType;
+export async function refreshConnectorOAuthToken<
+  T extends OAuthConnectorType,
+>(args: {
+  readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const provider = connectorProviderFor(args.type);
-  if (!isOAuthRefreshProvider(provider)) {
-    throw new Error(`${args.type} OAuth provider does not support refresh`);
-  }
-  const dispatchProvider = provider as unknown as DispatchRefreshProvider;
-  return await dispatchProvider.refreshToken({
-    ...connectorCredentialArgs(args.credentials),
-    refreshToken: args.refreshToken,
+  return await refreshTokenAccess({
+    type: args.type,
+    provider: connectorAuthProviderFor(args.type),
+    refreshArgs: {
+      ...connectorCredentialArgs(args.credentials),
+      refreshToken: args.refreshToken,
+    } as ConnectorOAuthRefreshArgs<T>,
   });
 }
 

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -384,14 +384,22 @@ export async function refreshConnectorOAuthToken<
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  return await refreshTokenAccess({
-    type: args.type,
-    access: connectorAccessProviderFor(connectorProviderFor(args.type)),
-    refreshArgs: {
-      ...connectorCredentialArgs(args.credentials),
-      refreshToken: args.refreshToken,
-    } as ConnectorOAuthRefreshArgs<T>,
-  });
+  const access = connectorAccessProviderFor(connectorProviderFor(args.type));
+
+  switch (access.kind) {
+    case "none":
+      throw new Error(`${args.type} OAuth provider does not support refresh`);
+
+    case "refresh-token":
+      return await refreshTokenAccess({
+        type: args.type,
+        access,
+        refreshArgs: {
+          ...connectorCredentialArgs(args.credentials),
+          refreshToken: args.refreshToken,
+        } as ConnectorOAuthRefreshArgs<T>,
+      });
+  }
 }
 
 /**

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -290,9 +290,6 @@ export function getConnectorOAuthSecretMetadata(
   if (isOAuthDeviceAuthConnectorType(type)) {
     return getConnectorAuthSecretMetadata(deviceConnectorAuthProviderFor(type));
   }
-
-  const exhaustive: never = type;
-  throw new Error(`${exhaustive} OAuth flow is not supported`);
 }
 
 export async function buildConnectorOAuthAuthUrl<
@@ -396,8 +393,6 @@ export async function refreshConnectorOAuthToken<
         } as ConnectorOAuthRefreshArgs<T>,
       });
   }
-  const exhaustive: never = access;
-  return exhaustive;
 }
 
 /**


### PR DESCRIPTION
## Summary

- add an internal connector auth provider capability layer with required grant/access/revoke slots
- adapt existing connector OAuth providers into auth-code, device-auth, refresh-token, token-revoke, and none capabilities
- keep existing OAuth wrapper APIs as the route/service boundary and add a non-refreshable OAuth refresh regression test

Closes #14604

## Tests

- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors test
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm knip --workspace @vm0/connectors
- pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F api check-types
- pre-commit: pnpm knip --cache
- pre-commit: pnpm check-types
