### PR TITLE
test(mitm-addon): cover anthropic delta data-level event type

### DIFF
--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -106,6 +106,17 @@ class TestAnthropicSseUsageExtractor:
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 58
 
+    def test_accepts_data_level_type_for_message_delta_without_event_line(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":40,"output_tokens":1}}}\n\n'
+        )
+        parse(b'data: {"type":"message_delta","usage":{"output_tokens":250}}\n\n')
+        assert usage["tokens.input"] == 40
+        assert usage["tokens.output"] == 250
+
     def test_empty_chunks(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()
         parse(b"")


### PR DESCRIPTION
## Summary

- Add coverage for Anthropic `message_delta` SSE frames that omit the `event:` line and rely on `data.type`.
- Keep production parser behavior unchanged.

## Tests

- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_anthropic_messages.py::TestAnthropicSseUsageExtractor::test_accepts_data_level_type_for_message_delta_without_event_line -q`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_anthropic_messages.py -q`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_sse.py tests/test_anthropic_messages.py -q`
- `cd crates/runner/mitm-addon && python3 -m ruff check tests/test_anthropic_messages.py`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check tests/test_anthropic_messages.py`
- `cd crates/runner/mitm-addon && python3 -m basedpyright tests/test_anthropic_messages.py`

Fixes #14647
