### PR TITLE
test(mitm-addon): split firewall rewrite tests

### DIFF
--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -1,0 +1,345 @@
+"""Tests for firewall auth query injection."""
+
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import auth
+
+
+def make_query_inputs(
+    real_flow,
+    *,
+    host="api.github.com",
+    path="/repos",
+    api_base="https://serpapi.com",
+    auth_overrides=None,
+    token_overrides=None,
+    match_overrides=None,
+):
+    flow = real_flow(with_response=False, host=host, path=path)
+    flow.metadata["vm_run_id"] = "test-run"
+    auth_config = {
+        "headers": {},
+        "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"},
+    }
+    if auth_overrides:
+        auth_config.update(auth_overrides)
+    api_entry = {
+        "base": api_base,
+        "auth": auth_config,
+    }
+    vm_info = {
+        "runId": "run-1",
+        "sandboxToken": "tok",
+        "encryptedSecrets": "iv:tag:data",
+        "billableFirewalls": [],
+    }
+    match_info = {
+        "name": "serpapi",
+        "permission": "search",
+        "rule": "GET /search",
+        "params": {},
+    }
+    if match_overrides:
+        match_info.update(match_overrides)
+    token_meta = {
+        "headers": {},
+        "resolved_secrets": ["SERPAPI_TOKEN"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+        "query": {"api_key": "resolved-key-123"},
+    }
+    if token_overrides:
+        token_meta.update(token_overrides)
+    return flow, api_entry, vm_info, match_info, token_meta
+
+
+# =========================================================================
+# auth.query injection
+# =========================================================================
+
+
+class TestAuthQueryInjection:
+    """Tests for query parameter injection via auth.query."""
+
+    async def test_query_params_injected_on_standard_path(self, real_flow, headers, mitm_ctx):
+        """Resolved auth.query params are injected into flow.request.query."""
+        flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
+            real_flow,
+            auth_overrides={
+                "query": {
+                    "api_key": "${{ secrets.SERPAPI_TOKEN }}",
+                    "empty_auth": "${{ vars.EMPTY }}",
+                    "space": "${{ vars.SPACE }}",
+                },
+            },
+            token_overrides={
+                "query": {
+                    "api_key": "resolved-key-123",
+                    "empty_auth": "",
+                    "space": "a b",
+                }
+            },
+        )
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.request.query["api_key"] == "resolved-key-123"
+        assert flow.request.query["empty_auth"] == ""
+        assert flow.request.query["space"] == "a b"
+
+    async def test_query_param_overwrites_existing_key(self, real_flow, headers, mitm_ctx):
+        """auth.query overwrites a query param already present in the original request."""
+        flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
+            real_flow,
+            host="serpapi.com",
+            path=(
+                "/search?api_key=agent-value&api_key=stale-value"
+                "&q=test&empty=&repeat=one&repeat=two"
+            ),
+            token_overrides={"query": {"api_key": "real-secret-key"}},
+        )
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        # auth.query overwrites the agent's api_key
+        assert flow.request.query["api_key"] == "real-secret-key"
+        assert list(flow.request.query.get_all("api_key")) == ["real-secret-key"]
+        # Other query params are preserved
+        assert flow.request.query["q"] == "test"
+        assert flow.request.query["empty"] == ""
+        query_items = list(flow.request.query.items(multi=True))
+        assert query_items.count(("repeat", "one")) == 1
+        assert query_items.count(("repeat", "two")) == 1
+
+    async def test_query_params_with_headers_simultaneously(self, real_flow, headers, mitm_ctx):
+        """auth.query and auth.headers can coexist on the standard path."""
+        flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
+            real_flow,
+            api_base="https://example.com",
+            auth_overrides={
+                "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+                "query": {"key": "${{ secrets.QUERY_KEY }}"},
+            },
+            token_overrides={
+                "headers": {"Authorization": "Bearer real-token"},
+                "resolved_secrets": ["TOKEN", "QUERY_KEY"],
+                "query": {"key": "resolved-query-value"},
+            },
+            match_overrides={"name": "ex", "permission": "read", "rule": "GET /data"},
+        )
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert flow.request.headers["Authorization"] == "Bearer real-token"
+        assert flow.request.query["key"] == "resolved-query-value"
+
+    async def test_query_params_merged_into_rewrite_url(self, real_flow, headers, mitm_ctx):
+        """auth.query params are appended to the forwarded URL in the URL rewrite path."""
+        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
+            "auth": {
+                "headers": {},
+                "base": "${{ secrets.WEBHOOK }}",
+                "query": {"api_key": "${{ secrets.KEY }}"},
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+            "billableFirewalls": [],
+        }
+        match_info = {
+            "name": "test",
+            "permission": "send",
+            "rule": "POST /",
+            "params": {},
+            "rel_path": "/",
+        }
+        token_meta = {
+            "headers": {},
+            "base": "https://real-api.com/webhook/secret",
+            "resolved_secrets": ["WEBHOOK", "KEY"],
+            "cache_hit": False,
+            "query": {"api_key": "resolved-key-456"},
+        }
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert flow.metadata["auth_url_rewrite"] is True
+        # Verify the forwarded URL contains the auth.query params
+        call_args = mock_forward.call_args
+        forwarded_url = call_args[0][0]
+        assert "api_key=resolved-key-456" in forwarded_url
+        assert forwarded_url.startswith("https://real-api.com/webhook/secret")
+
+    async def test_query_params_overwrite_existing_rewrite_url_keys(
+        self, real_flow, headers, mitm_ctx
+    ):
+        """auth.query overwrites duplicate keys while preserving other query values."""
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/hook?api_key=agent-key&q=test&empty=&repeat=one&repeat=two",
+        )
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
+            "auth": {
+                "headers": {},
+                "base": "${{ secrets.WEBHOOK }}",
+                "query": {
+                    "api_key": "${{ secrets.KEY }}",
+                    "empty_auth": "${{ vars.EMPTY }}",
+                    "space": "${{ vars.SPACE }}",
+                },
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+            "billableFirewalls": [],
+        }
+        match_info = {
+            "name": "test",
+            "permission": "send",
+            "rule": "POST /",
+            "params": {},
+            "rel_path": "/",
+        }
+        token_meta = {
+            "headers": {},
+            "base": "https://real-api.com/webhook/secret?api_key=base-key&mode=fast&base_empty=",
+            "resolved_secrets": ["WEBHOOK", "KEY"],
+            "cache_hit": False,
+            "query": {
+                "api_key": "resolved-key-456",
+                "empty_auth": "",
+                "space": "a b",
+            },
+        }
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+
+        forwarded = urlparse(mock_forward.call_args[0][0])
+        query = parse_qs(forwarded.query, keep_blank_values=True)
+        assert forwarded.scheme == "https"
+        assert forwarded.netloc == "real-api.com"
+        assert forwarded.path == "/webhook/secret"
+        assert query["api_key"] == ["resolved-key-456"]
+        assert query["mode"] == ["fast"]
+        assert query["base_empty"] == [""]
+        assert query["q"] == ["test"]
+        assert query["empty"] == [""]
+        assert query["empty_auth"] == [""]
+        assert query["space"] == ["a b"]
+        assert query["repeat"] == ["one", "two"]
+
+    async def test_query_params_preserve_rewrite_path_params(self, real_flow, headers, mitm_ctx):
+        """auth.query merging must not strip URL path params from the rewrite target."""
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/hook/callback;matrix=1?q=test",
+        )
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
+            "auth": {
+                "headers": {},
+                "base": "${{ secrets.WEBHOOK }}",
+                "query": {"api_key": "${{ secrets.KEY }}"},
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+            "billableFirewalls": [],
+        }
+        match_info = {
+            "name": "test",
+            "permission": "send",
+            "rule": "POST /",
+            "params": {},
+            "rel_path": "/callback;matrix=1",
+        }
+        token_meta = {
+            "headers": {},
+            "base": "https://real-api.com/webhook/secret;v=1?mode=fast",
+            "resolved_secrets": ["WEBHOOK", "KEY"],
+            "cache_hit": False,
+            "query": {"api_key": "resolved-key"},
+        }
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+
+        forwarded = urlparse(mock_forward.call_args[0][0])
+        assert forwarded.path == "/webhook/secret;v=1/callback"
+        assert forwarded.params == "matrix=1"
+        query = parse_qs(forwarded.query, keep_blank_values=True)
+        assert query == {
+            "mode": ["fast"],
+            "q": ["test"],
+            "api_key": ["resolved-key"],
+        }
+
+    async def test_no_query_injection_when_absent(self, real_flow, headers, mitm_ctx):
+        """No query modification when auth.query is not present."""
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok",
+            "encryptedSecrets": "iv:tag:data",
+            "billableFirewalls": [],
+        }
+        match_info = {
+            "name": "gh",
+            "permission": "read",
+            "rule": "GET /repos/{owner}/{repo}",
+            "params": {},
+        }
+        token_meta = {
+            "headers": {"Authorization": "Bearer real"},
+            "resolved_secrets": ["TOKEN"],
+            "cache_hit": False,
+        }
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+        assert flow.request.headers["Authorization"] == "Bearer real"
+        # No query params should have been added
+        assert len(flow.request.query) == 0

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -63,7 +63,7 @@ def make_query_inputs(
 class TestAuthQueryInjection:
     """Tests for query parameter injection via auth.query."""
 
-    async def test_query_params_injected_on_standard_path(self, real_flow, headers, mitm_ctx):
+    async def test_query_params_injected_on_standard_path(self, real_flow, mitm_ctx):
         """Resolved auth.query params are injected into flow.request.query."""
         flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
             real_flow,
@@ -92,7 +92,7 @@ class TestAuthQueryInjection:
         assert flow.request.query["empty_auth"] == ""
         assert flow.request.query["space"] == "a b"
 
-    async def test_query_param_overwrites_existing_key(self, real_flow, headers, mitm_ctx):
+    async def test_query_param_overwrites_existing_key(self, real_flow, mitm_ctx):
         """auth.query overwrites a query param already present in the original request."""
         flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
             real_flow,
@@ -118,7 +118,7 @@ class TestAuthQueryInjection:
         assert query_items.count(("repeat", "one")) == 1
         assert query_items.count(("repeat", "two")) == 1
 
-    async def test_query_params_with_headers_simultaneously(self, real_flow, headers, mitm_ctx):
+    async def test_query_params_with_headers_simultaneously(self, real_flow, mitm_ctx):
         """auth.query and auth.headers can coexist on the standard path."""
         flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
             real_flow,
@@ -142,7 +142,7 @@ class TestAuthQueryInjection:
         assert flow.request.headers["Authorization"] == "Bearer real-token"
         assert flow.request.query["key"] == "resolved-query-value"
 
-    async def test_query_params_merged_into_rewrite_url(self, real_flow, headers, mitm_ctx):
+    async def test_query_params_merged_into_rewrite_url(self, real_flow, mitm_ctx):
         """auth.query params are appended to the forwarded URL in the URL rewrite path."""
         flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
         flow.metadata["vm_run_id"] = "test-run"
@@ -188,9 +188,7 @@ class TestAuthQueryInjection:
         assert "api_key=resolved-key-456" in forwarded_url
         assert forwarded_url.startswith("https://real-api.com/webhook/secret")
 
-    async def test_query_params_overwrite_existing_rewrite_url_keys(
-        self, real_flow, headers, mitm_ctx
-    ):
+    async def test_query_params_overwrite_existing_rewrite_url_keys(self, real_flow, mitm_ctx):
         """auth.query overwrites duplicate keys while preserving other query values."""
         flow = real_flow(
             with_response=False,
@@ -256,7 +254,7 @@ class TestAuthQueryInjection:
         assert query["space"] == ["a b"]
         assert query["repeat"] == ["one", "two"]
 
-    async def test_query_params_preserve_rewrite_path_params(self, real_flow, headers, mitm_ctx):
+    async def test_query_params_preserve_rewrite_path_params(self, real_flow, mitm_ctx):
         """auth.query merging must not strip URL path params from the rewrite target."""
         flow = real_flow(
             with_response=False,
@@ -310,7 +308,7 @@ class TestAuthQueryInjection:
             "api_key": ["resolved-key"],
         }
 
-    async def test_no_query_injection_when_absent(self, real_flow, headers, mitm_ctx):
+    async def test_no_query_injection_when_absent(self, real_flow, mitm_ctx):
         """No query modification when auth.query is not present."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -4,12 +4,90 @@ import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 from mitmproxy import http
 
 import auth
-import url_utils
+
+
+def make_rewrite_inputs(
+    real_flow,
+    tmp_path,
+    *,
+    path="/hook",
+    seed_url=None,
+    resolved_base="https://discord.com/api/webhooks/123/abc",
+    rel_path="/",
+    method="GET",
+    request_body=None,
+    request_headers=None,
+    api_base="https://firewall-placeholder.vm3.ai/discord-webhook/hook",
+    auth_overrides=None,
+    token_overrides=None,
+    match_overrides=None,
+):
+    # ``seed_url`` lets callers specify a scheme://host/path?query to seed
+    # the request without mutating read-only mitmproxy Request properties.
+    if seed_url:
+        parsed = urlparse(seed_url)
+        host = parsed.hostname or "firewall-placeholder.vm3.ai"
+        real_path = parsed.path or "/"
+        if parsed.query:
+            real_path = f"{real_path}?{parsed.query}"
+        flow = real_flow(
+            with_response=False,
+            host=host,
+            path=real_path,
+            method=method,
+            request_body=request_body,
+            request_headers=request_headers,
+        )
+    else:
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path=path,
+            method=method,
+            request_body=request_body,
+            request_headers=request_headers,
+        )
+    flow.metadata["vm_run_id"] = "test-run"
+
+    auth_config = {"headers": {}, "base": "${{ secrets.WEBHOOK }}"}
+    if auth_overrides:
+        auth_config.update(auth_overrides)
+    api_entry = {
+        "base": api_base,
+        "auth": auth_config,
+    }
+    vm_info = {
+        "runId": "run-1",
+        "sandboxToken": "tok",
+        "encryptedSecrets": "iv:tag:data",
+        "networkLogPath": str(tmp_path / "net.jsonl"),
+        "billableFirewalls": [],
+    }
+    match_info = {
+        "name": "test",
+        "permission": "send",
+        "rule": "POST /",
+        "params": {},
+        "rel_path": rel_path,
+    }
+    if match_overrides:
+        match_info.update(match_overrides)
+    token_meta = {
+        "headers": {},
+        "base": resolved_base,
+        "resolved_secrets": ["WEBHOOK"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+    if token_overrides:
+        token_meta.update(token_overrides)
+    return flow, api_entry, vm_info, match_info, token_meta
 
 
 class TestAuthBaseUrlRewrite:
@@ -17,34 +95,13 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_with_rel_path_root(self, real_flow, headers, mitm_ctx, tmp_path):
         """When rel_path is '/', resolved base URL is forwarded as-is."""
-        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
-            "auth": {"headers": {}, "base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "discord-webhook",
-            "permission": "send-message",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://discord.com/api/webhooks/123/abc",
-            "resolved_secrets": ["DISCORD_WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            auth_overrides={"base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
+            token_overrides={"resolved_secrets": ["DISCORD_WEBHOOK_URL"]},
+            match_overrides={"name": "discord-webhook", "permission": "send-message"},
+        )
         mock_forward = AsyncMock(return_value=(200, b'{"ok":true}', {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -60,34 +117,13 @@ class TestAuthBaseUrlRewrite:
         self, real_flow, headers, mitm_ctx, tmp_path
     ):
         """Duplicate upstream response headers survive response construction."""
-        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
-            "auth": {"headers": {}, "base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "discord-webhook",
-            "permission": "send-message",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://discord.com/api/webhooks/123/abc",
-            "resolved_secrets": ["DISCORD_WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            auth_overrides={"base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
+            token_overrides={"resolved_secrets": ["DISCORD_WEBHOOK_URL"]},
+            match_overrides={"name": "discord-webhook", "permission": "send-message"},
+        )
         response_headers = http.Headers(
             [
                 (b"Set-Cookie", b"a=1"),
@@ -111,38 +147,22 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_with_remaining_path(self, real_flow, headers, mitm_ctx, tmp_path):
         """When rel_path has content, it's appended to resolved base in forwarded URL."""
-        flow = real_flow(
-            with_response=False,
-            host="bitrix.internal",
-            path="/rest/0/placeholder/crm.deal.list.json",
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            seed_url="https://bitrix.internal/rest/0/placeholder/crm.deal.list.json",
+            resolved_base="https://mycompany.bitrix24.com/rest/1/real-token",
+            rel_path="/crm.deal.list.json",
+            api_base="https://bitrix.internal/rest/{uid}/{code}",
+            auth_overrides={"base": "${{ secrets.BITRIX_WEBHOOK_URL }}"},
+            token_overrides={"resolved_secrets": ["BITRIX_WEBHOOK_URL"]},
+            match_overrides={
+                "name": "bitrix",
+                "permission": "crm",
+                "rule": "ANY /crm.{method}",
+                "params": {"uid": "0", "code": "placeholder", "method": "deal.list.json"},
+            },
         )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://bitrix.internal/rest/{uid}/{code}",
-            "auth": {"headers": {}, "base": "${{ secrets.BITRIX_WEBHOOK_URL }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "bitrix",
-            "permission": "crm",
-            "rule": "ANY /crm.{method}",
-            "params": {"uid": "0", "code": "placeholder", "method": "deal.list.json"},
-            "rel_path": "/crm.deal.list.json",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://mycompany.bitrix24.com/rest/1/real-token",
-            "resolved_secrets": ["BITRIX_WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -158,38 +178,14 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_preserves_query_string(self, real_flow, headers, mitm_ctx, tmp_path):
         """Query string from original request is preserved in forwarded URL."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/discord-webhook/hook?wait=true",
+            auth_overrides={"base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
+            token_overrides={"resolved_secrets": ["DISCORD_WEBHOOK_URL"]},
+            match_overrides={"name": "discord-webhook", "permission": "send-message"},
         )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
-            "auth": {"headers": {}, "base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "discord-webhook",
-            "permission": "send-message",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://discord.com/api/webhooks/123/abc",
-            "resolved_secrets": ["DISCORD_WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -203,38 +199,21 @@ class TestAuthBaseUrlRewrite:
         self, real_flow, headers, mitm_ctx, tmp_path
     ):
         """Trailing slash on resolved base is stripped before appending rel_path."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/bitrix/rest/0/placeholder/crm.deal.list",
+            resolved_base="https://mycompany.bitrix24.com/rest/1/token/",
+            rel_path="/crm.deal.list",
+            api_base="https://firewall-placeholder.vm3.ai/bitrix/rest/{uid}/{code}",
+            auth_overrides={"base": "${{ secrets.BITRIX_WEBHOOK_URL }}"},
+            token_overrides={"resolved_secrets": ["BITRIX_WEBHOOK_URL"]},
+            match_overrides={
+                "name": "bitrix",
+                "permission": "crm",
+                "rule": "ANY /crm.{method}",
+            },
         )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/bitrix/rest/{uid}/{code}",
-            "auth": {"headers": {}, "base": "${{ secrets.BITRIX_WEBHOOK_URL }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "bitrix",
-            "permission": "crm",
-            "rule": "ANY /crm.{method}",
-            "params": {},
-            "rel_path": "/crm.deal.list",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://mycompany.bitrix24.com/rest/1/token/",
-            "resolved_secrets": ["BITRIX_WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -249,38 +228,14 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_merges_query_strings(self, real_flow, headers, mitm_ctx, tmp_path):
         """When resolved base has query string and original request also has one, merge with &."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/discord-webhook/hook?wait=true",
+            resolved_base="https://example.com/hook?token=abc",
+            auth_overrides={"base": "${{ secrets.WEBHOOK_URL }}"},
+            token_overrides={"resolved_secrets": ["WEBHOOK_URL"]},
         )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
-            "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://example.com/hook?token=abc",
-            "resolved_secrets": ["WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -294,43 +249,20 @@ class TestAuthBaseUrlRewrite:
         self, real_flow, headers, mitm_ctx, tmp_path
     ):
         """auth.query is the highest-priority trusted query source for URL rewrites."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/discord-webhook/hook?api_key=agent&q=test",
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
-            "auth": {
-                "headers": {},
+            resolved_base="https://example.com/hook?api_key=base&region=us",
+            auth_overrides={
                 "base": "${{ secrets.WEBHOOK_URL }}",
                 "query": {"api_key": "${{ secrets.API_KEY }}"},
             },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok-xyz",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://example.com/hook?api_key=base&region=us",
-            "query": {"api_key": "trusted key"},
-            "resolved_secrets": ["WEBHOOK_URL", "API_KEY"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
+            token_overrides={
+                "query": {"api_key": "trusted key"},
+                "resolved_secrets": ["WEBHOOK_URL", "API_KEY"],
+            },
+        )
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -384,375 +316,12 @@ class TestAuthBaseUrlRewrite:
         assert flow.request.headers["Authorization"] == "Bearer real-token"
 
 
-class TestBuildRewriteUrl:
-    """Unit tests for _build_rewrite_url (pure URL construction)."""
-
-    def test_simple_base_no_rel_path(self):
-        url = url_utils.build_rewrite_url(
-            "https://discord.com/api/webhooks/123/abc",
-            {"rel_path": "/"},
-            "",
-        )
-        assert url == "https://discord.com/api/webhooks/123/abc"
-
-    def test_multi_segment_rel_path(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/base",
-            {"rel_path": "/a/b/c"},
-            "",
-        )
-        assert url == "https://example.com/base/a/b/c"
-
-    def test_base_with_query_no_orig_query(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "",
-        )
-        assert url == "https://example.com/hook?token=secret"
-
-    def test_empty_orig_query_ignored(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook",
-            {"rel_path": "/"},
-            "",
-        )
-        assert url == "https://example.com/hook"
-
-    def test_rel_path_with_both_queries_merged(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=abc",
-            {"rel_path": "/sub"},
-            "extra=1",
-        )
-        assert url == "https://example.com/hook/sub?token=abc&extra=1"
-
-    def test_original_duplicate_query_key_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "token=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?token=secret&wait=true"
-
-    def test_original_duplicate_query_key_followed_by_empty_segment_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "token=attacker&&wait=true",
-        )
-        assert url == "https://example.com/hook?token=secret&wait=true"
-
-    def test_original_duplicate_query_key_preceded_by_empty_segment_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "wait=true&&token=attacker",
-        )
-        assert url == "https://example.com/hook?token=secret&wait=true"
-
-    def test_all_original_duplicate_query_keys_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "token=first&token=second",
-        )
-        assert url == "https://example.com/hook?token=secret"
-
-    def test_original_encoded_duplicate_query_key_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "to%6ben=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?token=secret&wait=true"
-
-    def test_original_duplicate_of_encoded_trusted_base_query_key_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?to%6ben=secret",
-            {"rel_path": "/"},
-            "token=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?to%6ben=secret&wait=true"
-
-    def test_original_plus_encoded_duplicate_query_key_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api+key=secret",
-            {"rel_path": "/"},
-            "api%20key=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?api+key=secret&wait=true"
-
-    def test_original_semicolon_duplicate_query_key_dropped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "wait=true;token=attacker",
-        )
-        assert url == "https://example.com/hook?token=secret&wait=true"
-
-    def test_original_semicolon_duplicate_before_kept_pair_uses_source_separator(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "token=attacker;wait=true",
-        )
-        assert url == "https://example.com/hook?token=secret&wait=true"
-
-    def test_original_semicolon_duplicate_between_kept_pairs_uses_safe_separator(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
-            "keep=1;token=attacker;wait=true",
-        )
-        assert url == "https://example.com/hook?token=secret&keep=1&wait=true"
-
-    def test_duplicate_trusted_base_query_keys_preserved(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=first&token=second",
-            {"rel_path": "/"},
-            "token=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?token=first&token=second&wait=true"
-
-    def test_duplicate_trusted_base_query_keys_with_semicolon_preserved(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=first;token=second",
-            {"rel_path": "/"},
-            "token=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?token=first;token=second&wait=true"
-
-    def test_blank_trusted_base_query_value_is_authoritative(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token=",
-            {"rel_path": "/"},
-            "token=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?token=&wait=true"
-
-    def test_valueless_trusted_base_query_key_is_authoritative(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?token",
-            {"rel_path": "/"},
-            "token=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?token&wait=true"
-
-    def test_empty_trusted_base_query_key_is_authoritative(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?=secret",
-            {"rel_path": "/"},
-            "=attacker&wait=true",
-        )
-        assert url == "https://example.com/hook?=secret&wait=true"
-
-    def test_empty_trusted_base_query_segments_do_not_block_empty_original_key(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?&&region=us",
-            {"rel_path": "/"},
-            "=agent&q=test",
-        )
-        assert url == "https://example.com/hook?&&region=us&=agent&q=test"
-
-    def test_auth_query_overrides_base_and_original_query(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api_key=base&region=us",
-            {"rel_path": "/"},
-            "api_key=agent&q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_empty_key_overrides_base_and_original_empty_keys(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?=base&region=us",
-            {"rel_path": "/"},
-            "=agent&q=test",
-            {"": "trusted"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&=trusted"
-
-    def test_auth_query_overrides_base_query_without_leading_empty_segment(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api_key=base&&region=us",
-            {"rel_path": "/"},
-            "q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_overrides_base_query_without_trailing_empty_segment(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?region=us&&api_key=base",
-            {"rel_path": "/"},
-            "q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_overrides_all_lower_priority_duplicates(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api_key=base",
-            {"rel_path": "/"},
-            "api_key=agent",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?api_key=trusted+key"
-
-    def test_auth_query_overrides_duplicate_trusted_base_query_keys(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api_key=first&api_key=second&region=us",
-            {"rel_path": "/"},
-            "api_key=agent&q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_overrides_encoded_base_and_original_query_keys(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api%5Fkey=base&region=us",
-            {"rel_path": "/"},
-            "api%5fkey=agent&q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_overrides_plus_encoded_lower_priority_keys(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api+key=base&region=us",
-            {"rel_path": "/"},
-            "api%20key=agent&q=test",
-            {"api key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api+key=trusted+key"
-
-    def test_auth_query_overrides_semicolon_base_without_prefixing_kept_pair(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?api_key=base;region=us",
-            {"rel_path": "/"},
-            "q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_overrides_semicolon_base_between_kept_pairs(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?tenant=one;api_key=base;region=us",
-            {"rel_path": "/"},
-            "q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?tenant=one&region=us&q=test&api_key=trusted+key"
-
-    def test_auth_query_filter_preserves_existing_semicolon_value(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook?redirect=a;b&api_key=base&region=us",
-            {"rel_path": "/"},
-            "q=test",
-            {"api_key": "trusted key"},
-        )
-        assert url == "https://example.com/hook?redirect=a;b&region=us&q=test&api_key=trusted+key"
-
-    def test_base_path_params_are_preserved(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook;v=1?token=abc",
-            {"rel_path": "/sub;mode=fast"},
-            "extra=1",
-        )
-        assert url == "https://example.com/hook;v=1/sub;mode=fast?token=abc&extra=1"
-
-    def test_trailing_slash_on_base_deduped(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook/",
-            {"rel_path": "/sub"},
-            "",
-        )
-        assert url == "https://example.com/hook/sub"
-
-    def test_no_rel_path_key_defaults_to_root(self):
-        url = url_utils.build_rewrite_url(
-            "https://example.com/hook",
-            {},
-            "",
-        )
-        assert url == "https://example.com/hook"
-
-
 class TestAuthBaseUrlRewriteEdgeCases:
     """Integration tests for auth.base URL rewriting via forward_request."""
 
-    def _make_rewrite_inputs(
-        self,
-        real_flow,
-        tmp_path,
-        *,
-        path="/hook",
-        seed_url=None,
-        resolved_base="https://discord.com/api/webhooks/123/abc",
-        rel_path="/",
-        method="GET",
-        request_body=None,
-        request_headers=None,
-    ):
-        # ``seed_url`` lets callers specify a scheme://host/path?query to
-        # seed the request. We parse it back into ``real_flow`` kwargs
-        # rather than mutating the read-only ``Request`` properties.
-        if seed_url:
-            parsed = urlparse(seed_url)
-            host = parsed.hostname or "firewall-placeholder.vm3.ai"
-            real_path = parsed.path or "/"
-            if parsed.query:
-                real_path = f"{real_path}?{parsed.query}"
-            flow = real_flow(
-                with_response=False,
-                host=host,
-                path=real_path,
-                method=method,
-                request_body=request_body,
-                request_headers=request_headers,
-            )
-        else:
-            flow = real_flow(
-                with_response=False,
-                host="firewall-placeholder.vm3.ai",
-                path=path,
-                method=method,
-                request_body=request_body,
-                request_headers=request_headers,
-            )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
-            "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK }}"},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "networkLogPath": str(tmp_path / "net.jsonl"),
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": rel_path,
-        }
-        token_meta = {
-            "headers": {},
-            "base": resolved_base,
-            "resolved_secrets": ["WEBHOOK"],
-            "cache_hit": False,
-        }
-        return flow, api_entry, vm_info, match_info, token_meta
-
     async def test_sets_auth_url_rewrite_metadata_and_response(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is set and flow.response is populated via forward_request."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
-            real_flow, tmp_path
-        )
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
         mock_forward = AsyncMock(
             return_value=(200, b'{"ok":true}', {"Content-Type": "application/json"})
         )
@@ -810,7 +379,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
         """auth.headers are included in the forwarded request to the real URL."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             resolved_base="https://discord.com/api/webhooks/123/abc",
@@ -833,7 +402,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
         """auth.base forwarding keeps repeated headers unless auth overrides that name."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             request_headers=headers(
@@ -872,7 +441,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
         """Unsafe client and injected headers are stripped without suppressing auth."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             request_headers=headers(
@@ -939,7 +508,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, real_flow, mitm_ctx, tmp_path
     ):
         """auth.base forwarding does not drop bodies for non-POST methods."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             method="DELETE",
@@ -958,7 +527,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     async def test_forward_request_preserves_empty_raw_body(self, real_flow, mitm_ctx, tmp_path):
         """An explicit empty body is distinct from no body for Content-Length."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             method="POST",
@@ -976,7 +545,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     async def test_forward_request_preserves_absent_body(self, real_flow, mitm_ctx, tmp_path):
         """A request with no raw body remains distinct from an explicit empty body."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             method="GET",
@@ -1001,9 +570,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         log were emitted on failure, and ``firewall_error`` was left unset —
         making failed rewrites indistinguishable from successful ones in
         dashboards."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
-            real_flow, tmp_path
-        )
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -1035,7 +602,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, real_flow, mitm_ctx, tmp_path
     ):
         """Forward errors must not leak secret-bearing resolved auth.base URLs."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             resolved_base="https://real.example.com/webhook/super-secret-token",
@@ -1061,9 +628,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
         """Empty string base from server is treated as absent — no URL rewrite."""
-        flow, api_entry, vm_info, match_info, token_meta = self._make_rewrite_inputs(
-            real_flow, tmp_path
-        )
+        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
         token_meta["base"] = ""
         original_url = flow.request.url
         with (
@@ -1073,346 +638,3 @@ class TestAuthBaseUrlRewriteEdgeCases:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.request.url == original_url
         assert "auth_url_rewrite" not in flow.metadata
-
-
-# =========================================================================
-# auth.query injection
-# =========================================================================
-
-
-class TestAuthQueryInjection:
-    """Tests for query parameter injection via auth.query."""
-
-    async def test_query_params_injected_on_standard_path(self, real_flow, headers, mitm_ctx):
-        """Resolved auth.query params are injected into flow.request.query."""
-        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://serpapi.com",
-            "auth": {
-                "headers": {},
-                "query": {
-                    "api_key": "${{ secrets.SERPAPI_TOKEN }}",
-                    "empty_auth": "${{ vars.EMPTY }}",
-                    "space": "${{ vars.SPACE }}",
-                },
-            },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "serpapi",
-            "permission": "search",
-            "rule": "GET /search",
-            "params": {},
-        }
-        token_meta = {
-            "headers": {},
-            "resolved_secrets": ["SERPAPI_TOKEN"],
-            "cache_hit": False,
-            "query": {
-                "api_key": "resolved-key-123",
-                "empty_auth": "",
-                "space": "a b",
-            },
-        }
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-        assert "auth_url_rewrite" not in flow.metadata
-        assert flow.request.query["api_key"] == "resolved-key-123"
-        assert flow.request.query["empty_auth"] == ""
-        assert flow.request.query["space"] == "a b"
-
-    async def test_query_param_overwrites_existing_key(self, real_flow, headers, mitm_ctx):
-        """auth.query overwrites a query param already present in the original request."""
-        flow = real_flow(
-            with_response=False,
-            host="serpapi.com",
-            path=(
-                "/search?api_key=agent-value&api_key=stale-value"
-                "&q=test&empty=&repeat=one&repeat=two"
-            ),
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://serpapi.com",
-            "auth": {"headers": {}, "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"}},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "serpapi",
-            "permission": "search",
-            "rule": "GET /search",
-            "params": {},
-        }
-        token_meta = {
-            "headers": {},
-            "resolved_secrets": ["SERPAPI_TOKEN"],
-            "cache_hit": False,
-            "query": {"api_key": "real-secret-key"},
-        }
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-        # auth.query overwrites the agent's api_key
-        assert flow.request.query["api_key"] == "real-secret-key"
-        assert list(flow.request.query.get_all("api_key")) == ["real-secret-key"]
-        # Other query params are preserved
-        assert flow.request.query["q"] == "test"
-        assert flow.request.query["empty"] == ""
-        query_items = list(flow.request.query.items(multi=True))
-        assert query_items.count(("repeat", "one")) == 1
-        assert query_items.count(("repeat", "two")) == 1
-
-    async def test_query_params_with_headers_simultaneously(self, real_flow, headers, mitm_ctx):
-        """auth.query and auth.headers can coexist on the standard path."""
-        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://example.com",
-            "auth": {
-                "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
-                "query": {"key": "${{ secrets.QUERY_KEY }}"},
-            },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "ex",
-            "permission": "read",
-            "rule": "GET /data",
-            "params": {},
-        }
-        token_meta = {
-            "headers": {"Authorization": "Bearer real-token"},
-            "resolved_secrets": ["TOKEN", "QUERY_KEY"],
-            "cache_hit": False,
-            "query": {"key": "resolved-query-value"},
-        }
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-        assert flow.request.headers["Authorization"] == "Bearer real-token"
-        assert flow.request.query["key"] == "resolved-query-value"
-
-    async def test_query_params_merged_into_rewrite_url(self, real_flow, headers, mitm_ctx):
-        """auth.query params are appended to the forwarded URL in the URL rewrite path."""
-        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
-            "auth": {
-                "headers": {},
-                "base": "${{ secrets.WEBHOOK }}",
-                "query": {"api_key": "${{ secrets.KEY }}"},
-            },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://real-api.com/webhook/secret",
-            "resolved_secrets": ["WEBHOOK", "KEY"],
-            "cache_hit": False,
-            "query": {"api_key": "resolved-key-456"},
-        }
-        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth, "forward_request", mock_forward),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-        assert flow.metadata["auth_url_rewrite"] is True
-        # Verify the forwarded URL contains the auth.query params
-        call_args = mock_forward.call_args
-        forwarded_url = call_args[0][0]
-        assert "api_key=resolved-key-456" in forwarded_url
-        assert forwarded_url.startswith("https://real-api.com/webhook/secret")
-
-    async def test_query_params_overwrite_existing_rewrite_url_keys(
-        self, real_flow, headers, mitm_ctx
-    ):
-        """auth.query overwrites duplicate keys while preserving other query values."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
-            path="/hook?api_key=agent-key&q=test&empty=&repeat=one&repeat=two",
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
-            "auth": {
-                "headers": {},
-                "base": "${{ secrets.WEBHOOK }}",
-                "query": {
-                    "api_key": "${{ secrets.KEY }}",
-                    "empty_auth": "${{ vars.EMPTY }}",
-                    "space": "${{ vars.SPACE }}",
-                },
-            },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://real-api.com/webhook/secret?api_key=base-key&mode=fast&base_empty=",
-            "resolved_secrets": ["WEBHOOK", "KEY"],
-            "cache_hit": False,
-            "query": {
-                "api_key": "resolved-key-456",
-                "empty_auth": "",
-                "space": "a b",
-            },
-        }
-        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth, "forward_request", mock_forward),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-
-        forwarded = urlparse(mock_forward.call_args[0][0])
-        query = parse_qs(forwarded.query, keep_blank_values=True)
-        assert forwarded.scheme == "https"
-        assert forwarded.netloc == "real-api.com"
-        assert forwarded.path == "/webhook/secret"
-        assert query["api_key"] == ["resolved-key-456"]
-        assert query["mode"] == ["fast"]
-        assert query["base_empty"] == [""]
-        assert query["q"] == ["test"]
-        assert query["empty"] == [""]
-        assert query["empty_auth"] == [""]
-        assert query["space"] == ["a b"]
-        assert query["repeat"] == ["one", "two"]
-
-    async def test_query_params_preserve_rewrite_path_params(self, real_flow, headers, mitm_ctx):
-        """auth.query merging must not strip URL path params from the rewrite target."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
-            path="/hook/callback;matrix=1?q=test",
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
-            "auth": {
-                "headers": {},
-                "base": "${{ secrets.WEBHOOK }}",
-                "query": {"api_key": "${{ secrets.KEY }}"},
-            },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/callback;matrix=1",
-        }
-        token_meta = {
-            "headers": {},
-            "base": "https://real-api.com/webhook/secret;v=1?mode=fast",
-            "resolved_secrets": ["WEBHOOK", "KEY"],
-            "cache_hit": False,
-            "query": {"api_key": "resolved-key"},
-        }
-        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            patch.object(auth, "forward_request", mock_forward),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-
-        forwarded = urlparse(mock_forward.call_args[0][0])
-        assert forwarded.path == "/webhook/secret;v=1/callback"
-        assert forwarded.params == "matrix=1"
-        query = parse_qs(forwarded.query, keep_blank_values=True)
-        assert query == {
-            "mode": ["fast"],
-            "q": ["test"],
-            "api_key": ["resolved-key"],
-        }
-
-    async def test_no_query_injection_when_absent(self, real_flow, headers, mitm_ctx):
-        """No query modification when auth.query is not present."""
-        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://api.github.com",
-            "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        match_info = {
-            "name": "gh",
-            "permission": "read",
-            "rule": "GET /repos/{owner}/{repo}",
-            "params": {},
-        }
-        token_meta = {
-            "headers": {"Authorization": "Bearer real"},
-            "resolved_secrets": ["TOKEN"],
-            "cache_hit": False,
-        }
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
-        assert flow.request.headers["Authorization"] == "Bearer real"
-        # No query params should have been added
-        assert len(flow.request.query) == 0

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -1,4 +1,4 @@
-"""Tests for firewall auth URL rewrite and query injection."""
+"""Tests for firewall auth URL rewrite."""
 
 import asyncio
 import json
@@ -93,7 +93,7 @@ def make_rewrite_inputs(
 class TestAuthBaseUrlRewrite:
     """Tests for auth.base URL rewriting via forward_request in handle_firewall_request."""
 
-    async def test_url_rewrite_with_rel_path_root(self, real_flow, headers, mitm_ctx, tmp_path):
+    async def test_url_rewrite_with_rel_path_root(self, real_flow, mitm_ctx, tmp_path):
         """When rel_path is '/', resolved base URL is forwarded as-is."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
@@ -114,7 +114,7 @@ class TestAuthBaseUrlRewrite:
         assert flow.response.status_code == 200
 
     async def test_url_rewrite_response_preserves_duplicate_headers(
-        self, real_flow, headers, mitm_ctx, tmp_path
+        self, real_flow, mitm_ctx, tmp_path
     ):
         """Duplicate upstream response headers survive response construction."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
@@ -145,7 +145,7 @@ class TestAuthBaseUrlRewrite:
         assert flow.response.headers.get_all("Set-Cookie") == ["a=1", "b=2"]
         assert flow.response.headers.get_all("Link") == ["<next>; rel=next", "<prev>; rel=prev"]
 
-    async def test_url_rewrite_with_remaining_path(self, real_flow, headers, mitm_ctx, tmp_path):
+    async def test_url_rewrite_with_remaining_path(self, real_flow, mitm_ctx, tmp_path):
         """When rel_path has content, it's appended to resolved base in forwarded URL."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
@@ -176,7 +176,7 @@ class TestAuthBaseUrlRewrite:
         )
         assert flow.metadata["firewall_action"] == "ALLOW"
 
-    async def test_url_rewrite_preserves_query_string(self, real_flow, headers, mitm_ctx, tmp_path):
+    async def test_url_rewrite_preserves_query_string(self, real_flow, mitm_ctx, tmp_path):
         """Query string from original request is preserved in forwarded URL."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
@@ -196,7 +196,7 @@ class TestAuthBaseUrlRewrite:
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc?wait=true"
 
     async def test_url_rewrite_resolved_base_with_trailing_slash(
-        self, real_flow, headers, mitm_ctx, tmp_path
+        self, real_flow, mitm_ctx, tmp_path
     ):
         """Trailing slash on resolved base is stripped before appending rel_path."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
@@ -226,7 +226,7 @@ class TestAuthBaseUrlRewrite:
             == "https://mycompany.bitrix24.com/rest/1/token/crm.deal.list"
         )
 
-    async def test_url_rewrite_merges_query_strings(self, real_flow, headers, mitm_ctx, tmp_path):
+    async def test_url_rewrite_merges_query_strings(self, real_flow, mitm_ctx, tmp_path):
         """When resolved base has query string and original request also has one, merge with &."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,
@@ -246,7 +246,7 @@ class TestAuthBaseUrlRewrite:
         assert mock_forward.call_args[0][0] == "https://example.com/hook?token=abc&wait=true"
 
     async def test_url_rewrite_auth_query_overrides_base_and_original_query(
-        self, real_flow, headers, mitm_ctx, tmp_path
+        self, real_flow, mitm_ctx, tmp_path
     ):
         """auth.query is the highest-priority trusted query source for URL rewrites."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
@@ -275,9 +275,7 @@ class TestAuthBaseUrlRewrite:
             == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
         )
 
-    async def test_no_url_rewrite_when_auth_base_absent(
-        self, real_flow, headers, mitm_ctx, tmp_path
-    ):
+    async def test_no_url_rewrite_when_auth_base_absent(self, real_flow, mitm_ctx, tmp_path):
         """Without auth.base, no URL rewriting happens (existing behavior)."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -338,9 +336,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         call_args = mock_forward.call_args
         assert call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
 
-    async def test_no_auth_url_rewrite_metadata_when_no_base(
-        self, real_flow, headers, mitm_ctx, tmp_path
-    ):
+    async def test_no_auth_url_rewrite_metadata_when_no_base(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is absent when no URL rewrite happens."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
@@ -375,9 +371,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"
 
-    async def test_forward_request_includes_auth_headers(
-        self, headers, real_flow, mitm_ctx, tmp_path
-    ):
+    async def test_forward_request_includes_auth_headers(self, real_flow, mitm_ctx, tmp_path):
         """auth.headers are included in the forwarded request to the real URL."""
         flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
             real_flow,

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -1,0 +1,298 @@
+"""Tests for URL reconstruction and rewrite utilities."""
+
+import url_utils
+
+
+class TestBuildRewriteUrl:
+    """Unit tests for _build_rewrite_url (pure URL construction)."""
+
+    def test_simple_base_no_rel_path(self):
+        url = url_utils.build_rewrite_url(
+            "https://discord.com/api/webhooks/123/abc",
+            {"rel_path": "/"},
+            "",
+        )
+        assert url == "https://discord.com/api/webhooks/123/abc"
+
+    def test_multi_segment_rel_path(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/base",
+            {"rel_path": "/a/b/c"},
+            "",
+        )
+        assert url == "https://example.com/base/a/b/c"
+
+    def test_base_with_query_no_orig_query(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "",
+        )
+        assert url == "https://example.com/hook?token=secret"
+
+    def test_empty_orig_query_ignored(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook",
+            {"rel_path": "/"},
+            "",
+        )
+        assert url == "https://example.com/hook"
+
+    def test_rel_path_with_both_queries_merged(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=abc",
+            {"rel_path": "/sub"},
+            "extra=1",
+        )
+        assert url == "https://example.com/hook/sub?token=abc&extra=1"
+
+    def test_original_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_original_duplicate_query_key_followed_by_empty_segment_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=attacker&&wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_original_duplicate_query_key_preceded_by_empty_segment_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "wait=true&&token=attacker",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_all_original_duplicate_query_keys_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=first&token=second",
+        )
+        assert url == "https://example.com/hook?token=secret"
+
+    def test_original_encoded_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "to%6ben=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_original_duplicate_of_encoded_trusted_base_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?to%6ben=secret",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?to%6ben=secret&wait=true"
+
+    def test_original_plus_encoded_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api+key=secret",
+            {"rel_path": "/"},
+            "api%20key=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?api+key=secret&wait=true"
+
+    def test_original_semicolon_duplicate_query_key_dropped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "wait=true;token=attacker",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_original_semicolon_duplicate_before_kept_pair_uses_source_separator(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "token=attacker;wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&wait=true"
+
+    def test_original_semicolon_duplicate_between_kept_pairs_uses_safe_separator(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=secret",
+            {"rel_path": "/"},
+            "keep=1;token=attacker;wait=true",
+        )
+        assert url == "https://example.com/hook?token=secret&keep=1&wait=true"
+
+    def test_duplicate_trusted_base_query_keys_preserved(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=first&token=second",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=first&token=second&wait=true"
+
+    def test_duplicate_trusted_base_query_keys_with_semicolon_preserved(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=first;token=second",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=first;token=second&wait=true"
+
+    def test_blank_trusted_base_query_value_is_authoritative(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token=",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token=&wait=true"
+
+    def test_valueless_trusted_base_query_key_is_authoritative(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?token",
+            {"rel_path": "/"},
+            "token=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?token&wait=true"
+
+    def test_empty_trusted_base_query_key_is_authoritative(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?=secret",
+            {"rel_path": "/"},
+            "=attacker&wait=true",
+        )
+        assert url == "https://example.com/hook?=secret&wait=true"
+
+    def test_empty_trusted_base_query_segments_do_not_block_empty_original_key(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?&&region=us",
+            {"rel_path": "/"},
+            "=agent&q=test",
+        )
+        assert url == "https://example.com/hook?&&region=us&=agent&q=test"
+
+    def test_auth_query_overrides_base_and_original_query(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base&region=us",
+            {"rel_path": "/"},
+            "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_empty_key_overrides_base_and_original_empty_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?=base&region=us",
+            {"rel_path": "/"},
+            "=agent&q=test",
+            {"": "trusted"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&=trusted"
+
+    def test_auth_query_overrides_base_query_without_leading_empty_segment(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base&&region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_base_query_without_trailing_empty_segment(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?region=us&&api_key=base",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_all_lower_priority_duplicates(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base",
+            {"rel_path": "/"},
+            "api_key=agent",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?api_key=trusted+key"
+
+    def test_auth_query_overrides_duplicate_trusted_base_query_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=first&api_key=second&region=us",
+            {"rel_path": "/"},
+            "api_key=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_encoded_base_and_original_query_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api%5Fkey=base&region=us",
+            {"rel_path": "/"},
+            "api%5fkey=agent&q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_plus_encoded_lower_priority_keys(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api+key=base&region=us",
+            {"rel_path": "/"},
+            "api%20key=agent&q=test",
+            {"api key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api+key=trusted+key"
+
+    def test_auth_query_overrides_semicolon_base_without_prefixing_kept_pair(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?api_key=base;region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_overrides_semicolon_base_between_kept_pairs(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?tenant=one;api_key=base;region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?tenant=one&region=us&q=test&api_key=trusted+key"
+
+    def test_auth_query_filter_preserves_existing_semicolon_value(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook?redirect=a;b&api_key=base&region=us",
+            {"rel_path": "/"},
+            "q=test",
+            {"api_key": "trusted key"},
+        )
+        assert url == "https://example.com/hook?redirect=a;b&region=us&q=test&api_key=trusted+key"
+
+    def test_base_path_params_are_preserved(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook;v=1?token=abc",
+            {"rel_path": "/sub;mode=fast"},
+            "extra=1",
+        )
+        assert url == "https://example.com/hook;v=1/sub;mode=fast?token=abc&extra=1"
+
+    def test_trailing_slash_on_base_deduped(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook/",
+            {"rel_path": "/sub"},
+            "",
+        )
+        assert url == "https://example.com/hook/sub"
+
+    def test_no_rel_path_key_defaults_to_root(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook",
+            {},
+            "",
+        )
+        assert url == "https://example.com/hook"

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -4,7 +4,7 @@ import url_utils
 
 
 class TestBuildRewriteUrl:
-    """Unit tests for _build_rewrite_url (pure URL construction)."""
+    """Tests for build_rewrite_url pure URL construction."""
 
     def test_simple_base_no_rel_path(self):
         url = url_utils.build_rewrite_url(

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -40,7 +40,9 @@ Pre-commit hooks run `pytest` on staged Python files in the addon.
 | `test_compiled_firewall_matching.py` | Compiled firewall matcher parity and edge cases |
 | `test_firewall_auth.py` | Firewall auth header resolution, fetching, forwarding, and cleanup |
 | `test_auth_base_forwarder.py` | Low-level auth.base forwarding, header filtering, and cleanup |
-| `test_firewall_rewrite.py` | Firewall auth URL rewrite and query injection |
+| `test_firewall_rewrite.py` | Firewall auth URL rewrite and forwarding behavior |
+| `test_auth_query_injection.py` | Firewall auth query injection and query rewrite behavior |
+| `test_url_utils.py` | URL reconstruction and rewrite utility cases |
 | `test_auth_cache.py` | Firewall auth cache behavior |
 | `test_anthropic_messages.py` | Anthropic Messages usage extraction |
 | `test_openai_responses_sse.py` | OpenAI Responses SSE usage extraction |


### PR DESCRIPTION
## Summary

- split pure `url_utils.build_rewrite_url` coverage into `test_url_utils.py`
- split auth.query injection coverage into `test_auth_query_injection.py`
- promote a narrow rewrite-path input helper and add a separate query-only helper

Closes #14643

## Tests

- `pytest tests/test_firewall_rewrite.py tests/test_auth_query_injection.py tests/test_url_utils.py`
- `ruff check tests/test_firewall_rewrite.py tests/test_auth_query_injection.py tests/test_url_utils.py`
- `ruff format --check tests/test_firewall_rewrite.py tests/test_auth_query_injection.py tests/test_url_utils.py`
- `basedpyright tests/test_firewall_rewrite.py tests/test_auth_query_injection.py tests/test_url_utils.py`