### PR TITLE
fix: hide mobile sidebar dropdown icon when other indicator present

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -230,11 +230,13 @@ function ChatThreadMenu({
   isPinned,
   isHighlighted,
   renameEnabled,
+  hasOtherIndicator,
 }: {
   threadId: string;
   isPinned: boolean;
   isHighlighted: boolean;
   renameEnabled: boolean;
+  hasOtherIndicator: boolean;
 }) {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const pinChatThread = useSet(pinChatThread$);
@@ -268,7 +270,9 @@ function ChatThreadMenu({
           <button
             type="button"
             onClick={handleMenuTriggerClick}
-            className={`peer pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md visible md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
+            className={`peer pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md ${
+              hasOtherIndicator ? "invisible" : "visible"
+            } md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
               isHighlighted
                 ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
                 : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
@@ -346,6 +350,7 @@ function ChatThreadSideDecorator({
       </div>
     );
   }
+  const hasOtherIndicator = indicatorState !== null || isPinned;
   return (
     <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
       <ChatThreadMenu
@@ -353,6 +358,7 @@ function ChatThreadSideDecorator({
         isPinned={isPinned}
         isHighlighted={isHighlighted}
         renameEnabled={renameEnabled}
+        hasOtherIndicator={hasOtherIndicator}
       />
       {indicatorState !== null ? (
         <span className="flex items-center justify-center group-hover:hidden peer-data-[state=open]:hidden">


### PR DESCRIPTION
## Summary

On mobile, the sidebar chat-row `...` dropdown trigger and the right-side indicators (unread blue dot, pinned pin, running spinner) share the same 8×8 anchor and visually overlap. This change suppresses the `...` icon on mobile whenever any other indicator is rendered, so the indicator stays legible. The icon still shows on rows with no other indicator. Desktop hover / open behavior is unchanged.

- `ChatThreadSideDecorator` computes `hasOtherIndicator = indicatorState !== null || isPinned` and passes it down.
- `ChatThreadMenu`'s trigger button now toggles between `visible` and `invisible` on mobile based on that prop; desktop classes (`md:invisible md:group-hover:visible md:data-[state=open]:visible`) are unchanged.

Display-only — menu actions are untouched.

Closes #14653

## Test plan

- [ ] Resize to mobile width (<768px). Confirm rows with no indicator still show `...`; rows with unread, pinned, or running indicator no longer show `...` overlapping the indicator.
- [ ] Resize to desktop (≥768px). Confirm `...` remains hidden by default and appears on row hover and when the dropdown is open, on both indicator and non-indicator rows.
- [ ] Open the dropdown menu and confirm pin / rename / delete actions still work.