### PR TITLE
fix(mitm-addon): filter empty X fallback id segments

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -9,7 +9,7 @@ import json
 import urllib.parse
 import uuid
 import zlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TypedDict
 
 from mitmproxy import http
@@ -241,15 +241,21 @@ def create_json_response_extractor() -> XJsonResponseExtractor:
     return XJsonResponseExtractor()
 
 
+def _count_non_empty_comma_segments(values: Iterable[str]) -> int | None:
+    count = sum(1 for value in values for segment in value.split(",") if segment.strip())
+    return count or None
+
+
 def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
     """Extract billing-relevant query params from an X API request.
 
     Returns a dict with:
       - ``request_ids_count``: int | None — total comma-separated count
         across all ``?ids=`` and ``?usernames=`` params (None when both
-        are absent).  ``usernames`` is folded in because ``GET /2/users/by``
-        uses it instead of ``ids`` for batch user lookup; both signal the
-        same "this many resources" billing dimension.
+        are absent or contain no non-empty segments).  ``usernames`` is
+        folded in because ``GET /2/users/by`` uses it instead of ``ids`` for
+        batch user lookup; both signal the same "this many resources" billing
+        dimension.
       - ``has_expansions``: bool — whether ``?expansions=`` is present.
       - ``max_results``: int | None — value of ``?max_results=``, used
         as an upper-bound fallback when the response body cannot be parsed.
@@ -263,7 +269,7 @@ def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
     parsed = urllib.parse.urlparse(flow.metadata.get("original_url", ""))
     qs = urllib.parse.parse_qs(parsed.query)
     id_like_values = qs.get("ids", []) + qs.get("usernames", [])
-    ids_count = sum(len(v.split(",")) for v in id_like_values) if id_like_values else None
+    ids_count = _count_non_empty_comma_segments(id_like_values)
     max_values = qs.get("max_results", [])
     max_results: int | None = None
     if max_values:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -904,6 +904,48 @@ class TestReportConnectorUsage:
         assert p["category"] == "posts.read"
         assert p["quantity"] == 3
 
+    @pytest.mark.parametrize(
+        ("query", "expected_quantity"),
+        [
+            ("ids=1,,2", 2),
+            ("ids=,1,2,", 2),
+            ("ids=1,+,2", 2),
+        ],
+    )
+    def test_billable_counts_fallback_filters_empty_id_segments(
+        self, tmp_path, real_flow, query, expected_quantity
+    ):
+        """body unparseable but ?ids= present -> uses non-empty id segment count."""
+        flow = self._make_x_flow(real_flow, tmp_path, query=query, body=b"not json")
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "posts.read"
+        assert p["quantity"] == expected_quantity
+
+    def test_billable_counts_fallback_filters_empty_username_segments(self, tmp_path, real_flow):
+        """body unparseable but ?usernames= present -> uses non-empty username count."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/users/by",
+            query="usernames=a,,b",
+            body=b"not json",
+            permission="users.read",
+            rule="GET /2/users/by",
+        )
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "user.read"
+        assert p["quantity"] == 2
+
+    def test_billable_counts_fallback_empty_id_segments_are_no_hint(self, tmp_path, real_flow):
+        """body unparseable and only empty ?ids= segments -> no billing, with audit log."""
+        flow = self._make_x_flow(real_flow, tmp_path, query="ids=,,", body=b"not json")
+        proxy_log = tmp_path / "proxy.jsonl"
+        assert self._call_and_get_billing(flow) == []
+        assert proxy_log.exists()
+        content = proxy_log.read_text()
+        assert "unparseable" in content.lower()
+        assert '"level":"error"' in content or '"level": "error"' in content
+
     def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path, real_flow):
         """body unparseable but ?max_results=50 present -> uses max_results."""
         flow = self._make_x_flow(real_flow, tmp_path, query="max_results=50", body=b"not json")


### PR DESCRIPTION
## Summary

- Count only non-empty comma segments for X `ids` / `usernames` fallback hints
- Treat all-empty `ids` / `usernames` hints as absent so the existing no-count-hints audit log path still runs
- Add connector usage regression coverage for empty ID and username segments

## Tests

- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_connector_usage.py -v`

Closes #14646