### PR TITLE
refactor: remove connector oauth provider adapter

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -237,10 +237,10 @@ function configureDynamicTestOAuthExchange(
   const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
   const originalClient = oauth.client;
   const provider = testOauthProvider;
-  const originalExchangeCode = provider.exchangeCode;
+  const originalExchangeCode = provider.grant.exchangeCode;
 
   mutableOAuth.client = dynamicPublicClient;
-  provider.exchangeCode = (args) => {
+  provider.grant.exchangeCode = (args) => {
     exchanges.push({
       clientId: args.clientId,
       clientSecret: args.clientSecret,
@@ -265,7 +265,7 @@ function configureDynamicTestOAuthExchange(
 
   return () => {
     mutableOAuth.client = originalClient;
-    provider.exchangeCode = originalExchangeCode;
+    provider.grant.exchangeCode = originalExchangeCode;
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -320,11 +320,14 @@ function configureDynamicTestOAuthRefresh(
 
   const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
   const originalClient = oauth.client;
-  const provider = testOauthProvider;
-  const originalRefreshToken = provider.refreshToken;
+  const access = testOauthProvider.access;
+  if (access.kind !== "refresh-token") {
+    throw new Error("test-oauth provider should support refresh");
+  }
+  const originalRefreshToken = access.refreshToken;
 
   mutableOAuth.client = dynamicPublicClient;
-  provider.refreshToken = (args) => {
+  access.refreshToken = (args) => {
     refreshes.push({
       clientId: args.clientId,
       clientSecret: args.clientSecret,
@@ -339,11 +342,7 @@ function configureDynamicTestOAuthRefresh(
 
   return () => {
     mutableOAuth.client = originalClient;
-    if (originalRefreshToken) {
-      provider.refreshToken = originalRefreshToken;
-    } else {
-      delete provider.refreshToken;
-    }
+    access.refreshToken = originalRefreshToken;
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -100,10 +100,10 @@ function useDynamicTestOAuthAuthorize(): () => void {
   const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
   const originalClient = oauth.client;
   const provider = testOauthProvider;
-  const originalBuildAuthUrl = provider.buildAuthUrl;
+  const originalBuildAuthUrl = provider.grant.buildAuthUrl;
 
   mutableOAuth.client = dynamicPublicClient;
-  provider.buildAuthUrl = (args) => {
+  provider.grant.buildAuthUrl = (args) => {
     expect(args.clientId).toBeUndefined();
     return {
       url: `https://dynamic-oauth.test/authorize?state=${args.state}`,
@@ -113,7 +113,7 @@ function useDynamicTestOAuthAuthorize(): () => void {
 
   return () => {
     mutableOAuth.client = originalClient;
-    provider.buildAuthUrl = originalBuildAuthUrl;
+    provider.grant.buildAuthUrl = originalBuildAuthUrl;
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -25,7 +25,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
-const originalPollDeviceAuth = testOauthDeviceProvider.pollDeviceAuth;
+const originalPollDeviceAuth = testOauthDeviceProvider.grant.pollDeviceAuth;
 const TEST_OAUTH_DEVICE_CODE_URL =
   "http://localhost:3000/api/test/oauth-provider/device/code";
 const TEST_OAUTH_TOKEN_URL =
@@ -316,7 +316,7 @@ describe("OAuth device authorization connector routes", () => {
   const users: { readonly userId: string; readonly orgId: string }[] = [];
 
   afterEach(async () => {
-    testOauthDeviceProvider.pollDeviceAuth = originalPollDeviceAuth;
+    testOauthDeviceProvider.grant.pollDeviceAuth = originalPollDeviceAuth;
     while (users.length > 0) {
       const user = users.pop();
       if (user) {
@@ -449,7 +449,7 @@ describe("OAuth device authorization connector routes", () => {
 
     let releaseProviderPoll: (() => void) | undefined;
     const providerPollStarted = new Promise<void>((resolve) => {
-      testOauthDeviceProvider.pollDeviceAuth = async (args) => {
+      testOauthDeviceProvider.grant.pollDeviceAuth = async (args) => {
         resolve();
         await new Promise<void>((resolve) => {
           releaseProviderPoll = resolve;
@@ -601,7 +601,7 @@ describe("OAuth device authorization connector routes", () => {
       }),
       [200],
     );
-    testOauthDeviceProvider.pollDeviceAuth = async (args) => {
+    testOauthDeviceProvider.grant.pollDeviceAuth = async (args) => {
       const result = await originalPollDeviceAuth(args);
       if (result.status !== "complete") {
         return result;
@@ -799,7 +799,7 @@ describe("OAuth device authorization connector routes", () => {
       zeroConnectorOauthDeviceAuthSessionContract,
     );
     let pollCount = 0;
-    testOauthDeviceProvider.pollDeviceAuth = () => {
+    testOauthDeviceProvider.grant.pollDeviceAuth = () => {
       pollCount += 1;
       return originalPollDeviceAuth({
         clientId: "test-oauth-device-client",
@@ -861,7 +861,7 @@ describe("OAuth device authorization connector routes", () => {
     let pollCount = 0;
     let releaseProviderPoll: (() => void) | undefined;
     const providerPollStarted = new Promise<void>((resolve) => {
-      testOauthDeviceProvider.pollDeviceAuth = async () => {
+      testOauthDeviceProvider.grant.pollDeviceAuth = async () => {
         pollCount += 1;
         resolve();
         await new Promise<void>((resolve) => {
@@ -913,7 +913,7 @@ describe("OAuth device authorization connector routes", () => {
       zeroConnectorOauthDeviceAuthSessionContract,
     );
     let pollCount = 0;
-    testOauthDeviceProvider.pollDeviceAuth = () => {
+    testOauthDeviceProvider.grant.pollDeviceAuth = () => {
       pollCount += 1;
       return Promise.resolve({ status: "pending" });
     };
@@ -953,7 +953,7 @@ describe("OAuth device authorization connector routes", () => {
     );
     expect(first.body.status).toBe("complete");
 
-    testOauthDeviceProvider.pollDeviceAuth = () => {
+    testOauthDeviceProvider.grant.pollDeviceAuth = () => {
       return Promise.reject(
         new Error("Provider should not be called for terminal sessions"),
       );

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/google-ads.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/google-ads.test.ts
@@ -22,7 +22,7 @@ describe("connector/providers/google-ads", () => {
     });
 
     it("buildAuthUrl builds Google OAuth URL with Google Ads and userinfo scopes", () => {
-      const url = googleAdsProvider.buildAuthUrl({
+      const url = googleAdsProvider.grant.buildAuthUrl({
         clientId: "test-client",
         redirectUri: "https://example.com/callback",
         state: "test-state",
@@ -66,17 +66,22 @@ describe("connector/providers/google-ads", () => {
     });
 
     it("getSecretName returns GOOGLE_ADS_ACCESS_TOKEN", () => {
-      expect(googleAdsProvider.getSecretName()).toBe("GOOGLE_ADS_ACCESS_TOKEN");
-    });
-
-    it("getRefreshSecretName returns GOOGLE_ADS_REFRESH_TOKEN", () => {
-      expect(googleAdsProvider.getRefreshSecretName?.()).toBe(
-        "GOOGLE_ADS_REFRESH_TOKEN",
+      expect(googleAdsProvider.access.getAccessSecretName()).toBe(
+        "GOOGLE_ADS_ACCESS_TOKEN",
       );
     });
 
+    it("getRefreshSecretName returns GOOGLE_ADS_REFRESH_TOKEN", () => {
+      const { access } = googleAdsProvider;
+      if (access.kind !== "refresh-token") {
+        throw new Error("Expected Google Ads provider to support refresh");
+      }
+
+      expect(access.getRefreshSecretName()).toBe("GOOGLE_ADS_REFRESH_TOKEN");
+    });
+
     it("refreshToken is defined (uses shared Google token refresh)", () => {
-      expect(googleAdsProvider.refreshToken).toBeDefined();
+      expect(googleAdsProvider.access.kind).toBe("refresh-token");
     });
 
     it("exchangeCode maps Google token and user info response", async () => {
@@ -98,7 +103,7 @@ describe("connector/providers/google-ads", () => {
       });
       server.use(tokenHandler, userInfoHandler);
 
-      const result = await googleAdsProvider.exchangeCode({
+      const result = await googleAdsProvider.grant.exchangeCode({
         clientId: "client-id",
         clientSecret: "client-secret",
         code: "auth-code",
@@ -130,12 +135,12 @@ describe("connector/providers/google-ads", () => {
       });
       server.use(handler);
 
-      const refreshToken = googleAdsProvider.refreshToken;
-      if (!refreshToken) {
+      const { access } = googleAdsProvider;
+      if (access.kind !== "refresh-token") {
         throw new Error("Expected Google Ads provider to support refresh");
       }
 
-      const result = await refreshToken({
+      const result = await access.refreshToken({
         clientId: "client-id",
         clientSecret: "client-secret",
         refreshToken: "refresh-token",

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/meta-ads.test.ts
@@ -151,7 +151,7 @@ describe("connector/providers/meta-ads", () => {
     });
 
     it("buildAuthUrl delegates to buildMetaAdsAuthorizationUrl", () => {
-      const url = metaAdsProvider.buildAuthUrl({
+      const url = metaAdsProvider.grant.buildAuthUrl({
         clientId: "test-client",
         redirectUri: "https://example.com/callback",
         state: "test-state",
@@ -179,11 +179,13 @@ describe("connector/providers/meta-ads", () => {
     });
 
     it("getSecretName returns META_ADS_ACCESS_TOKEN", () => {
-      expect(metaAdsProvider.getSecretName()).toBe("META_ADS_ACCESS_TOKEN");
+      expect(metaAdsProvider.access.getAccessSecretName()).toBe(
+        "META_ADS_ACCESS_TOKEN",
+      );
     });
 
     it("refreshToken is not registered (Meta uses long-lived token exchange)", () => {
-      expect("refreshToken" in metaAdsProvider).toBe(false);
+      expect(metaAdsProvider.access.kind).toBe("none");
     });
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -1,27 +1,5 @@
-import type {
-  ConnectorType,
-  OAuthAuthCodeConnectorType,
-  OAuthConnectorType,
-  OAuthDeviceAuthConnectorType,
-} from "../connectors";
-import type {
-  AuthUrlResult,
-  ConnectorOAuthAuthorizeArgs,
-  ConnectorOAuthDeviceAuthPollArgs,
-  ConnectorOAuthDeviceAuthStartArgs,
-  ConnectorOAuthExchangeArgs,
-  ConnectorOAuthRefreshArgs,
-  OAuthDeviceAuthPollResult,
-  OAuthDeviceAuthStartResult,
-  OAuthRefreshResult,
-  OAuthTokenResult,
-} from "../oauth-providers/provider-types";
-import type {
-  AuthCodeConnectorAuthProvider,
-  ConnectorAuthProvider,
-  DeviceAuthConnectorAuthProvider,
-  RefreshTokenAccessProvider,
-} from "./provider-types";
+import type { ConnectorType } from "../connectors";
+import type { ConnectorAuthProvider } from "./provider-types";
 
 export type ConnectorAuthSecretMetadata =
   | {
@@ -53,51 +31,4 @@ export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
         isRefreshable: true,
       };
   }
-}
-
-export async function buildAuthCodeGrantAuthUrl<
-  T extends OAuthAuthCodeConnectorType,
->(args: {
-  readonly provider: AuthCodeConnectorAuthProvider<T>;
-  readonly authorizeArgs: ConnectorOAuthAuthorizeArgs<T>;
-}): Promise<string | AuthUrlResult> {
-  const grant = args.provider.grant;
-  return await grant.buildAuthUrl(args.authorizeArgs);
-}
-
-export async function exchangeAuthCodeGrant<
-  T extends OAuthAuthCodeConnectorType,
->(args: {
-  readonly provider: AuthCodeConnectorAuthProvider<T>;
-  readonly exchangeArgs: ConnectorOAuthExchangeArgs<T>;
-}): Promise<OAuthTokenResult> {
-  const grant = args.provider.grant;
-  return await grant.exchangeCode(args.exchangeArgs);
-}
-
-export async function startDeviceAuthGrant<
-  T extends OAuthDeviceAuthConnectorType,
->(args: {
-  readonly provider: DeviceAuthConnectorAuthProvider<T>;
-  readonly startArgs: ConnectorOAuthDeviceAuthStartArgs<T>;
-}): Promise<OAuthDeviceAuthStartResult> {
-  const grant = args.provider.grant;
-  return await grant.startDeviceAuth(args.startArgs);
-}
-
-export async function pollDeviceAuthGrant<
-  T extends OAuthDeviceAuthConnectorType,
->(args: {
-  readonly provider: DeviceAuthConnectorAuthProvider<T>;
-  readonly pollArgs: ConnectorOAuthDeviceAuthPollArgs<T>;
-}): Promise<OAuthDeviceAuthPollResult> {
-  const grant = args.provider.grant;
-  return await grant.pollDeviceAuth(args.pollArgs);
-}
-
-export async function refreshTokenAccess<T extends OAuthConnectorType>(args: {
-  readonly access: RefreshTokenAccessProvider<T>;
-  readonly refreshArgs: ConnectorOAuthRefreshArgs<T>;
-}): Promise<OAuthRefreshResult> {
-  return await args.access.refreshToken(args.refreshArgs);
 }

--- a/turbo/packages/connectors/src/auth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-types.ts
@@ -70,11 +70,11 @@ export type ConnectorAccessProvider<T extends ConnectorType> =
     ? OAuthConnectorAccessProvider<T>
     : NoneAccessProvider;
 
-export interface NoneRevokeProvider {
+interface NoneRevokeProvider {
   readonly kind: "none";
 }
 
-export interface TokenRevokeProvider<T extends OAuthConnectorType> {
+interface TokenRevokeProvider<T extends OAuthConnectorType> {
   readonly kind: "token-revoke";
   revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
 }
@@ -88,7 +88,7 @@ export type ConnectorRevokeProvider<T extends ConnectorType> =
     ? OAuthConnectorRevokeProvider<T>
     : NoneRevokeProvider;
 
-interface BaseConnectorAuthProvider<TGrant, TAccess, TRevoke> {
+export interface AuthProvider<TGrant, TAccess, TRevoke> {
   readonly grant: TGrant;
   readonly access: TAccess;
   readonly revoke: TRevoke;
@@ -96,7 +96,7 @@ interface BaseConnectorAuthProvider<TGrant, TAccess, TRevoke> {
 
 export type AuthCodeConnectorAuthProvider<
   T extends OAuthAuthCodeConnectorType,
-> = BaseConnectorAuthProvider<
+> = AuthProvider<
   AuthCodeGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,
   OAuthConnectorRevokeProvider<T>
@@ -104,15 +104,14 @@ export type AuthCodeConnectorAuthProvider<
 
 export type DeviceAuthConnectorAuthProvider<
   T extends OAuthDeviceAuthConnectorType,
-> = BaseConnectorAuthProvider<
+> = AuthProvider<
   DeviceAuthGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,
   OAuthConnectorRevokeProvider<T>
 >;
 
-export type ConnectorAuthProvider<T extends ConnectorType> =
-  BaseConnectorAuthProvider<
-    ConnectorGrantProvider<T>,
-    ConnectorAccessProvider<T>,
-    ConnectorRevokeProvider<T>
-  >;
+export type ConnectorAuthProvider<T extends ConnectorType> = AuthProvider<
+  ConnectorGrantProvider<T>,
+  ConnectorAccessProvider<T>,
+  ConnectorRevokeProvider<T>
+>;

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -8,7 +8,6 @@ import {
   getConnectorOAuthDeviceAuthConfig,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isOAuthAuthCodeConnectorType,
-  isOAuthDeviceAuthConnectorType,
   isStaticConfidentialConnectorOAuthCredentials,
   isStaticConnectorOAuthCredentials,
   type ConnectorOAuthCredentials,
@@ -26,7 +25,6 @@ import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
   OAuthConnectorAccessProvider,
-  OAuthConnectorRevokeProvider,
 } from "../auth-providers/provider-types";
 import {
   type AuthUrlResult,
@@ -34,7 +32,6 @@ import {
   type ConnectorOAuthDeviceAuthPollArgs,
   type ConnectorOAuthDeviceAuthStartArgs,
   type ConnectorOAuthExchangeArgs,
-  type ConnectorOAuthProviderFor,
   type ConnectorOAuthRefreshArgs,
   type OAuthAuthorizeArgs,
   type OAuthDeviceAuthPollArgs,
@@ -112,16 +109,36 @@ export type {
 export type { ProviderEnv };
 export { providerEnvFromObject, isOAuthRefreshProvider };
 
-type ConnectorOAuthProviderMap = {
-  readonly [Type in OAuthConnectorType]: ConnectorOAuthProviderFor<Type>;
+type AuthCodeConnectorOAuthProviderMap = {
+  readonly [Type in OAuthAuthCodeConnectorType]: AuthCodeConnectorAuthProvider<Type>;
+};
+
+type DeviceAuthConnectorOAuthProviderMap = {
+  readonly [Type in OAuthDeviceAuthConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
 export type ConnectorOAuthSecretMetadata = ConnectorAuthSecretMetadata;
 
-function connectorProviderFor<T extends OAuthConnectorType>(
+function authCodeConnectorProviderFor<T extends OAuthAuthCodeConnectorType>(
   type: T,
-): ConnectorOAuthProviderFor<T> {
-  return CONNECTOR_OAUTH_PROVIDERS[type];
+): AuthCodeConnectorOAuthProviderMap[T] {
+  return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type];
+}
+
+function deviceAuthConnectorProviderFor<T extends OAuthDeviceAuthConnectorType>(
+  type: T,
+): DeviceAuthConnectorOAuthProviderMap[T] {
+  return DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type];
+}
+
+function connectorAccessProviderFor<T extends OAuthConnectorType>(
+  type: T,
+): OAuthConnectorAccessProvider<T> {
+  if (isOAuthAuthCodeConnectorType(type)) {
+    return authCodeConnectorProviderFor(type).access;
+  }
+
+  return deviceAuthConnectorProviderFor(type).access;
 }
 
 function connectorCredentialArgs(
@@ -148,77 +165,10 @@ function assertConfiguredConnectorOAuthCredentials(
   }
 }
 
-function connectorAccessProviderFor<T extends OAuthConnectorType>(
-  provider: ConnectorOAuthProviderFor<T>,
-): OAuthConnectorAccessProvider<T> {
-  if (
-    "getRefreshSecretName" in provider &&
-    typeof provider.getRefreshSecretName === "function" &&
-    "refreshToken" in provider &&
-    typeof provider.refreshToken === "function"
-  ) {
-    return {
-      kind: "refresh-token",
-      getAccessSecretName: provider.getSecretName,
-      getRefreshSecretName: provider.getRefreshSecretName,
-      refreshToken: provider.refreshToken,
-    };
-  }
-
-  return {
-    kind: "none",
-    getAccessSecretName: provider.getSecretName,
-  };
-}
-
-function connectorRevokeProviderFor<T extends OAuthConnectorType>(
-  provider: ConnectorOAuthProviderFor<T>,
-): OAuthConnectorRevokeProvider<T> {
-  if ("revokeToken" in provider && typeof provider.revokeToken === "function") {
-    return {
-      kind: "token-revoke",
-      revokeToken: provider.revokeToken,
-    };
-  }
-
-  return { kind: "none" };
-}
-
-function authCodeConnectorAuthProviderFor<T extends OAuthAuthCodeConnectorType>(
-  type: T,
-): AuthCodeConnectorAuthProvider<T> {
-  const provider = connectorProviderFor(type);
-  return {
-    grant: {
-      kind: "auth-code",
-      buildAuthUrl: provider.buildAuthUrl,
-      exchangeCode: provider.exchangeCode,
-    },
-    access: connectorAccessProviderFor(provider),
-    revoke: connectorRevokeProviderFor(provider),
-  };
-}
-
-function deviceConnectorAuthProviderFor<T extends OAuthDeviceAuthConnectorType>(
-  type: T,
-): DeviceAuthConnectorAuthProvider<T> {
-  const provider = connectorProviderFor(type);
-  return {
-    grant: {
-      kind: "device-auth",
-      startDeviceAuth: provider.startDeviceAuth,
-      pollDeviceAuth: provider.pollDeviceAuth,
-    },
-    access: connectorAccessProviderFor(provider),
-    revoke: connectorRevokeProviderFor(provider),
-  };
-}
-
-const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
+const AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS: AuthCodeConnectorOAuthProviderMap = {
   ahrefs: ahrefsProvider,
   airtable: airtableProvider,
   asana: asanaProvider,
-  base44: base44Provider,
   canva: canvaProvider,
   close: closeProvider,
   deel: deelProvider,
@@ -261,7 +211,17 @@ const CONNECTOR_OAUTH_PROVIDERS: ConnectorOAuthProviderMap = {
   xero: xeroProvider,
   zoom: zoomProvider,
   "test-oauth": testOauthProvider,
-  "test-oauth-device": testOauthDeviceProvider,
+};
+
+const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap =
+  {
+    base44: base44Provider,
+    "test-oauth-device": testOauthDeviceProvider,
+  };
+
+const CONNECTOR_OAUTH_PROVIDERS = {
+  ...AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS,
+  ...DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS,
 };
 
 export function isOAuthConnectorType(type: string): type is OAuthConnectorType {
@@ -282,14 +242,10 @@ export function getConnectorOAuthSecretMetadata(
   }
 
   if (isOAuthAuthCodeConnectorType(type)) {
-    return getConnectorAuthSecretMetadata(
-      authCodeConnectorAuthProviderFor(type),
-    );
+    return getConnectorAuthSecretMetadata(authCodeConnectorProviderFor(type));
   }
 
-  if (isOAuthDeviceAuthConnectorType(type)) {
-    return getConnectorAuthSecretMetadata(deviceConnectorAuthProviderFor(type));
-  }
+  return getConnectorAuthSecretMetadata(deviceAuthConnectorProviderFor(type));
 }
 
 export async function buildConnectorOAuthAuthUrl<
@@ -302,7 +258,7 @@ export async function buildConnectorOAuthAuthUrl<
 }): Promise<string | AuthUrlResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await buildAuthCodeGrantAuthUrl({
-    provider: authCodeConnectorAuthProviderFor(args.type),
+    provider: authCodeConnectorProviderFor(args.type),
     authorizeArgs: {
       ...connectorCredentialArgs(args.credentials),
       redirectUri: args.redirectUri,
@@ -324,7 +280,7 @@ export async function exchangeConnectorOAuthCode<
 }): Promise<OAuthTokenResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await exchangeAuthCodeGrant({
-    provider: authCodeConnectorAuthProviderFor(args.type),
+    provider: authCodeConnectorProviderFor(args.type),
     exchangeArgs: {
       ...connectorCredentialArgs(args.credentials),
       code: args.code,
@@ -345,7 +301,7 @@ export async function startConnectorOAuthDeviceAuth<
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const oauthConfig = getConnectorOAuthDeviceAuthConfig(args.type);
   return await startDeviceAuthGrant({
-    provider: deviceConnectorAuthProviderFor(args.type),
+    provider: deviceAuthConnectorProviderFor(args.type),
     startArgs: {
       ...connectorCredentialArgs(args.credentials),
       scopes: oauthConfig.scopes,
@@ -362,7 +318,7 @@ export async function pollConnectorOAuthDeviceAuth<
 }): Promise<OAuthDeviceAuthPollResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await pollDeviceAuthGrant({
-    provider: deviceConnectorAuthProviderFor(args.type),
+    provider: deviceAuthConnectorProviderFor(args.type),
     pollArgs: {
       ...connectorCredentialArgs(args.credentials),
       deviceCode: args.deviceCode,
@@ -378,7 +334,7 @@ export async function refreshConnectorOAuthToken<
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const access = connectorAccessProviderFor(connectorProviderFor(args.type));
+  const access = connectorAccessProviderFor(args.type);
 
   switch (access.kind) {
     case "none":

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -13,12 +13,7 @@ import {
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
-  buildAuthCodeGrantAuthUrl,
-  exchangeAuthCodeGrant,
   getConnectorAuthSecretMetadata,
-  pollDeviceAuthGrant,
-  refreshTokenAccess,
-  startDeviceAuthGrant,
   type ConnectorAuthSecretMetadata,
 } from "../auth-providers/provider-registry";
 import type {
@@ -119,12 +114,6 @@ type DeviceAuthConnectorOAuthProviderMap = {
 
 export type ConnectorOAuthSecretMetadata = ConnectorAuthSecretMetadata;
 
-function authCodeConnectorProviderFor<T extends OAuthAuthCodeConnectorType>(
-  type: T,
-): AuthCodeConnectorOAuthProviderMap[T] {
-  return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type];
-}
-
 function deviceAuthConnectorProviderFor<T extends OAuthDeviceAuthConnectorType>(
   type: T,
 ): DeviceAuthConnectorOAuthProviderMap[T] {
@@ -135,7 +124,7 @@ function connectorAccessProviderFor<T extends OAuthConnectorType>(
   type: T,
 ): OAuthConnectorAccessProvider<T> {
   if (isOAuthAuthCodeConnectorType(type)) {
-    return authCodeConnectorProviderFor(type).access;
+    return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type].access;
   }
 
   return deviceAuthConnectorProviderFor(type).access;
@@ -242,10 +231,14 @@ export function getConnectorOAuthSecretMetadata(
   }
 
   if (isOAuthAuthCodeConnectorType(type)) {
-    return getConnectorAuthSecretMetadata(authCodeConnectorProviderFor(type));
+    return getConnectorAuthSecretMetadata(
+      AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type],
+    );
   }
 
-  return getConnectorAuthSecretMetadata(deviceAuthConnectorProviderFor(type));
+  return getConnectorAuthSecretMetadata(
+    DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type],
+  );
 }
 
 export async function buildConnectorOAuthAuthUrl<
@@ -257,14 +250,13 @@ export async function buildConnectorOAuthAuthUrl<
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  return await buildAuthCodeGrantAuthUrl({
-    provider: authCodeConnectorProviderFor(args.type),
-    authorizeArgs: {
-      ...connectorCredentialArgs(args.credentials),
-      redirectUri: args.redirectUri,
-      state: args.state,
-    } as ConnectorOAuthAuthorizeArgs<T>,
-  });
+  return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
+    args.type
+  ].grant.buildAuthUrl({
+    ...connectorCredentialArgs(args.credentials),
+    redirectUri: args.redirectUri,
+    state: args.state,
+  } as ConnectorOAuthAuthorizeArgs<T>);
 }
 
 export async function exchangeConnectorOAuthCode<
@@ -279,17 +271,16 @@ export async function exchangeConnectorOAuthCode<
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  return await exchangeAuthCodeGrant({
-    provider: authCodeConnectorProviderFor(args.type),
-    exchangeArgs: {
-      ...connectorCredentialArgs(args.credentials),
-      code: args.code,
-      redirectUri: args.redirectUri,
-      state: args.state,
-      codeVerifier: args.codeVerifier,
-      oauthContext: args.oauthContext,
-    } as ConnectorOAuthExchangeArgs<T>,
-  });
+  return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
+    args.type
+  ].grant.exchangeCode({
+    ...connectorCredentialArgs(args.credentials),
+    code: args.code,
+    redirectUri: args.redirectUri,
+    state: args.state,
+    codeVerifier: args.codeVerifier,
+    oauthContext: args.oauthContext,
+  } as ConnectorOAuthExchangeArgs<T>);
 }
 
 export async function startConnectorOAuthDeviceAuth<
@@ -300,13 +291,12 @@ export async function startConnectorOAuthDeviceAuth<
 }): Promise<OAuthDeviceAuthStartResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const oauthConfig = getConnectorOAuthDeviceAuthConfig(args.type);
-  return await startDeviceAuthGrant({
-    provider: deviceAuthConnectorProviderFor(args.type),
-    startArgs: {
-      ...connectorCredentialArgs(args.credentials),
-      scopes: oauthConfig.scopes,
-    } as ConnectorOAuthDeviceAuthStartArgs<T>,
-  });
+  return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
+    args.type
+  ].grant.startDeviceAuth({
+    ...connectorCredentialArgs(args.credentials),
+    scopes: oauthConfig.scopes,
+  } as ConnectorOAuthDeviceAuthStartArgs<T>);
 }
 
 export async function pollConnectorOAuthDeviceAuth<
@@ -317,13 +307,12 @@ export async function pollConnectorOAuthDeviceAuth<
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  return await pollDeviceAuthGrant({
-    provider: deviceAuthConnectorProviderFor(args.type),
-    pollArgs: {
-      ...connectorCredentialArgs(args.credentials),
-      deviceCode: args.deviceCode,
-    } as ConnectorOAuthDeviceAuthPollArgs<T>,
-  });
+  return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
+    args.type
+  ].grant.pollDeviceAuth({
+    ...connectorCredentialArgs(args.credentials),
+    deviceCode: args.deviceCode,
+  } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
 
 export async function refreshConnectorOAuthToken<
@@ -341,13 +330,10 @@ export async function refreshConnectorOAuthToken<
       throw new Error(`${args.type} OAuth provider does not support refresh`);
 
     case "refresh-token":
-      return await refreshTokenAccess({
-        access,
-        refreshArgs: {
-          ...connectorCredentialArgs(args.credentials),
-          refreshToken: args.refreshToken,
-        } as ConnectorOAuthRefreshArgs<T>,
-      });
+      return await access.refreshToken({
+        ...connectorCredentialArgs(args.credentials),
+        refreshToken: args.refreshToken,
+      } as ConnectorOAuthRefreshArgs<T>);
   }
 }
 

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -1,7 +1,6 @@
 import type {
   CONNECTOR_TYPES,
   ConnectorOAuthClientConfig,
-  OAuthAuthCodeConnectorType,
   OAuthConnectorType,
   OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
@@ -217,30 +216,6 @@ export type ConnectorOAuthDeviceAuthPollArgs<
 > = OAuthDeviceAuthPollFlowArgs &
   TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-type BuildConnectorAuthUrlFn<T extends OAuthAuthCodeConnectorType> = (
-  args: ConnectorOAuthAuthorizeArgs<T>,
-) => string | AuthUrlResult | Promise<string | AuthUrlResult>;
-
-type ExchangeConnectorCodeFn<T extends OAuthAuthCodeConnectorType> = (
-  args: ConnectorOAuthExchangeArgs<T>,
-) => Promise<OAuthTokenResult>;
-
-type RefreshConnectorTokenFn<T extends OAuthConnectorType> = (
-  args: ConnectorOAuthRefreshArgs<T>,
-) => Promise<OAuthRefreshResult>;
-
-type RevokeConnectorTokenFn<T extends OAuthConnectorType> = (
-  args: ConnectorOAuthRevokeArgs<T>,
-) => Promise<void>;
-
-type StartConnectorDeviceAuthFn<T extends OAuthDeviceAuthConnectorType> = (
-  args: ConnectorOAuthDeviceAuthStartArgs<T>,
-) => Promise<OAuthDeviceAuthStartResult>;
-
-type PollConnectorDeviceAuthFn<T extends OAuthDeviceAuthConnectorType> = (
-  args: ConnectorOAuthDeviceAuthPollArgs<T>,
-) => Promise<OAuthDeviceAuthPollResult>;
-
 export interface OAuthProviderMetadata {
   getSecretName(): string;
 }
@@ -268,57 +243,6 @@ export type OAuthRefreshProvider = OAuthProvider & {
 export type OAuthRevocationProvider = OAuthProvider & {
   revokeToken: RevokeTokenFn;
 };
-
-type OAuthNoRefreshProvider = {
-  getRefreshSecretName?: never;
-  refreshToken?: never;
-};
-
-type OAuthNoRevocationProvider = {
-  revokeToken?: never;
-};
-
-export type ConnectorOAuthAuthCodeProvider<
-  T extends OAuthAuthCodeConnectorType,
-> = OAuthProviderMetadata & {
-  buildAuthUrl: BuildConnectorAuthUrlFn<T>;
-  exchangeCode: ExchangeConnectorCodeFn<T>;
-};
-
-export type ConnectorOAuthDeviceAuthProvider<
-  T extends OAuthDeviceAuthConnectorType,
-> = OAuthProviderMetadata & {
-  startDeviceAuth: StartConnectorDeviceAuthFn<T>;
-  pollDeviceAuth: PollConnectorDeviceAuthFn<T>;
-};
-
-export type ConnectorOAuthRefreshProvider<T extends OAuthConnectorType> = {
-  getRefreshSecretName(): string;
-  refreshToken: RefreshConnectorTokenFn<T>;
-};
-
-export type ConnectorOAuthRevocationProvider<T extends OAuthConnectorType> = {
-  revokeToken: RevokeConnectorTokenFn<T>;
-};
-
-type ConnectorOAuthFlowProvider<T extends OAuthConnectorType> =
-  T extends OAuthAuthCodeConnectorType
-    ? ConnectorOAuthAuthCodeProvider<T>
-    : T extends OAuthDeviceAuthConnectorType
-      ? ConnectorOAuthDeviceAuthProvider<T>
-      : never;
-
-export type ConnectorOAuthProviderFor<T extends OAuthConnectorType> =
-  ConnectorOAuthFlowProvider<T> &
-    (ConnectorOAuthRefreshProvider<T> | OAuthNoRefreshProvider) &
-    (ConnectorOAuthRevocationProvider<T> | OAuthNoRevocationProvider);
-
-export function defineConnectorOAuthProvider<T extends OAuthConnectorType>(
-  _type: T,
-  provider: ConnectorOAuthProviderFor<T>,
-): ConnectorOAuthProviderFor<T> {
-  return provider;
-}
 
 export function isOAuthRefreshProvider(
   provider: OAuthProviderMetadata,

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildAhrefsAuthorizationUrl,
   exchangeAhrefsCode,
   getAhrefsSecretName,
   refreshAhrefsToken,
 } from "./ahrefs";
-export const ahrefsProvider = defineConnectorOAuthProvider("ahrefs", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildAhrefsAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const ahrefsProvider: AuthCodeConnectorAuthProvider<"ahrefs"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildAhrefsAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeAhrefsCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeAhrefsCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getAhrefsSecretName,
+    getRefreshSecretName: () => {
+      return "AHREFS_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshAhrefsToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getAhrefsSecretName,
-  getRefreshSecretName: () => {
-    return "AHREFS_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshAhrefsToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable-provider.ts
@@ -1,49 +1,56 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildAirtableAuthorizationUrl,
   exchangeAirtableCode,
   getAirtableSecretName,
   refreshAirtableToken,
 } from "./airtable";
-export const airtableProvider = defineConnectorOAuthProvider("airtable", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildAirtableAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
+export const airtableProvider: AuthCodeConnectorAuthProvider<"airtable"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildAirtableAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const codeVerifier = args.codeVerifier;
+      const result = await exchangeAirtableCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+        codeVerifier,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const codeVerifier = args.codeVerifier;
-    const result = await exchangeAirtableCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-      codeVerifier,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getAirtableSecretName,
+    getRefreshSecretName: () => {
+      return "AIRTABLE_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshAirtableToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getAirtableSecretName,
-  getRefreshSecretName: () => {
-    return "AIRTABLE_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshAirtableToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana-provider.ts
@@ -1,43 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildAsanaAuthorizationUrl,
   exchangeAsanaCode,
   getAsanaSecretName,
   refreshAsanaToken,
 } from "./asana";
-export const asanaProvider = defineConnectorOAuthProvider("asana", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildAsanaAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const asanaProvider: AuthCodeConnectorAuthProvider<"asana"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildAsanaAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeAsanaCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeAsanaCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getAsanaSecretName,
+    getRefreshSecretName: () => {
+      return "ASANA_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshAsanaToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getAsanaSecretName,
-  getRefreshSecretName: () => {
-    return "ASANA_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshAsanaToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/base44-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/base44-provider.ts
@@ -1,4 +1,4 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { DeviceAuthConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   BASE44_ACCESS_SECRET_NAME,
   BASE44_REFRESH_SECRET_NAME,
@@ -7,32 +7,39 @@ import {
   startBase44DeviceAuth,
 } from "./base44";
 
-export const base44Provider = defineConnectorOAuthProvider("base44", {
-  getSecretName: () => {
-    return BASE44_ACCESS_SECRET_NAME;
+export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
+  grant: {
+    kind: "device-auth",
+    startDeviceAuth: async (args) => {
+      const { clientId } = args;
+      return await startBase44DeviceAuth({
+        clientId,
+        scopes: args.scopes,
+      });
+    },
+    pollDeviceAuth: async (args) => {
+      const { clientId } = args;
+      return await pollBase44DeviceAuth({
+        clientId,
+        deviceCode: args.deviceCode,
+      });
+    },
   },
-  getRefreshSecretName: () => {
-    return BASE44_REFRESH_SECRET_NAME;
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: () => {
+      return BASE44_ACCESS_SECRET_NAME;
+    },
+    getRefreshSecretName: () => {
+      return BASE44_REFRESH_SECRET_NAME;
+    },
+    refreshToken: async (args) => {
+      const { clientId } = args;
+      return await refreshBase44Token({
+        clientId,
+        refreshToken: args.refreshToken,
+      });
+    },
   },
-  startDeviceAuth: async (args) => {
-    const { clientId } = args;
-    return await startBase44DeviceAuth({
-      clientId,
-      scopes: args.scopes,
-    });
-  },
-  pollDeviceAuth: async (args) => {
-    const { clientId } = args;
-    return await pollBase44DeviceAuth({
-      clientId,
-      deviceCode: args.deviceCode,
-    });
-  },
-  refreshToken: async (args) => {
-    const { clientId } = args;
-    return await refreshBase44Token({
-      clientId,
-      refreshToken: args.refreshToken,
-    });
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva-provider.ts
@@ -1,48 +1,57 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildCanvaAuthorizationUrl,
   exchangeCanvaCode,
   getCanvaSecretName,
   refreshCanvaToken,
 } from "./canva";
-export const canvaProvider = defineConnectorOAuthProvider("canva", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildCanvaAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const canvaProvider: AuthCodeConnectorAuthProvider<"canva"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildCanvaAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      if (!state) {
+        throw new Error(
+          "Canva PKCE requires state for code_verifier derivation",
+        );
+      }
+      const result = await exchangeCanvaCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+        state,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    if (!state) {
-      throw new Error("Canva PKCE requires state for code_verifier derivation");
-    }
-    const result = await exchangeCanvaCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-      state,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getCanvaSecretName,
+    getRefreshSecretName: () => {
+      return "CANVA_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshCanvaToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getCanvaSecretName,
-  getRefreshSecretName: () => {
-    return "CANVA_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshCanvaToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/close-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close-provider.ts
@@ -1,43 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildCloseAuthorizationUrl,
   exchangeCloseCode,
   getCloseSecretName,
   refreshCloseToken,
 } from "./close";
-export const closeProvider = defineConnectorOAuthProvider("close", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildCloseAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const closeProvider: AuthCodeConnectorAuthProvider<"close"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildCloseAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeCloseCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.email,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeCloseCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.email,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getCloseSecretName,
+    getRefreshSecretName: () => {
+      return "CLOSE_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshCloseToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getCloseSecretName,
-  getRefreshSecretName: () => {
-    return "CLOSE_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshCloseToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel-provider.ts
@@ -1,48 +1,57 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildDeelAuthorizationUrl,
   exchangeDeelCode,
   getDeelSecretName,
   refreshDeelToken,
 } from "./deel";
-export const deelProvider = defineConnectorOAuthProvider("deel", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildDeelAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const deelProvider: AuthCodeConnectorAuthProvider<"deel"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildDeelAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      if (!state) {
+        throw new Error(
+          "Deel PKCE requires state for code_verifier derivation",
+        );
+      }
+      const result = await exchangeDeelCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+        state,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    if (!state) {
-      throw new Error("Deel PKCE requires state for code_verifier derivation");
-    }
-    const result = await exchangeDeelCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-      state,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getDeelSecretName,
+    getRefreshSecretName: () => {
+      return "DEEL_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshDeelToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getDeelSecretName,
-  getRefreshSecretName: () => {
-    return "DEEL_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshDeelToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign-provider.ts
@@ -1,54 +1,61 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildDocuSignAuthorizationUrl,
   exchangeDocuSignCode,
   getDocuSignSecretName,
   refreshDocuSignToken,
 } from "./docusign";
-export const docusignProvider = defineConnectorOAuthProvider("docusign", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildDocuSignAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
-  },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    if (!state) {
-      throw new Error(
-        "DocuSign PKCE requires state for code_verifier derivation",
+export const docusignProvider: AuthCodeConnectorAuthProvider<"docusign"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildDocuSignAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
       );
-    }
-    const result = await exchangeDocuSignCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-      state,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      if (!state) {
+        throw new Error(
+          "DocuSign PKCE requires state for code_verifier derivation",
+        );
+      }
+      const result = await exchangeDocuSignCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+        state,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  getSecretName: getDocuSignSecretName,
-  getRefreshSecretName: () => {
-    return "DOCUSIGN_REFRESH_TOKEN";
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getDocuSignSecretName,
+    getRefreshSecretName: () => {
+      return "DOCUSIGN_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshDocuSignToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshDocuSignToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildDropboxAuthorizationUrl,
   exchangeDropboxCode,
   getDropboxSecretName,
   refreshDropboxToken,
 } from "./dropbox";
-export const dropboxProvider = defineConnectorOAuthProvider("dropbox", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildDropboxAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const dropboxProvider: AuthCodeConnectorAuthProvider<"dropbox"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildDropboxAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeDropboxCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeDropboxCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getDropboxSecretName,
+    getRefreshSecretName: () => {
+      return "DROPBOX_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshDropboxToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getDropboxSecretName,
-  getRefreshSecretName: () => {
-    return "DROPBOX_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshDropboxToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma-provider.ts
@@ -1,43 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildFigmaAuthorizationUrl,
   exchangeFigmaCode,
   getFigmaSecretName,
   refreshFigmaToken,
 } from "./figma";
-export const figmaProvider = defineConnectorOAuthProvider("figma", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildFigmaAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const figmaProvider: AuthCodeConnectorAuthProvider<"figma"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildFigmaAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeFigmaCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeFigmaCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getFigmaSecretName,
+    getRefreshSecretName: () => {
+      return "FIGMA_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshFigmaToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getFigmaSecretName,
-  getRefreshSecretName: () => {
-    return "FIGMA_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshFigmaToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect-provider.ts
@@ -1,59 +1,64 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGarminConnectAuthorizationUrl,
   exchangeGarminConnectCode,
   getGarminConnectSecretName,
   refreshGarminConnectToken,
 } from "./garmin-connect";
-export const garminConnectProvider = defineConnectorOAuthProvider(
-  "garmin-connect",
+export const garminConnectProvider: AuthCodeConnectorAuthProvider<"garmin-connect"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      return buildGarminConnectAuthorizationUrl(
-        clientId,
-        args.redirectUri,
-        args.state,
-      );
-    },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const state = args.state;
-      if (!state) {
-        throw new Error(
-          "Garmin Connect PKCE requires state for code_verifier derivation",
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        return buildGarminConnectAuthorizationUrl(
+          clientId,
+          args.redirectUri,
+          args.state,
         );
-      }
-      const result = await exchangeGarminConnectCode(
-        clientId,
-        clientSecret,
-        code,
-        state,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const state = args.state;
+        if (!state) {
+          throw new Error(
+            "Garmin Connect PKCE requires state for code_verifier derivation",
+          );
+        }
+        const result = await exchangeGarminConnectCode(
+          clientId,
+          clientSecret,
+          code,
+          state,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.username,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    getSecretName: getGarminConnectSecretName,
-    getRefreshSecretName: () => {
-      return "GARMIN_CONNECT_REFRESH_TOKEN";
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: getGarminConnectSecretName,
+      getRefreshSecretName: () => {
+        return "GARMIN_CONNECT_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        return refreshGarminConnectToken(
+          clientId,
+          clientSecret,
+          args.refreshToken,
+        );
+      },
     },
-    refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
-      return refreshGarminConnectToken(
-        clientId,
-        clientSecret,
-        args.refreshToken,
-      );
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/github-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github-provider.ts
@@ -1,4 +1,4 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGitHubAuthorizationUrl,
   exchangeGitHubCode,
@@ -6,27 +6,40 @@ import {
   getGitHubSecretName,
   revokeGitHubGrant,
 } from "./github";
-export const githubProvider = defineConnectorOAuthProvider("github", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildGitHubAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildGitHubAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const { accessToken, scopes } = await exchangeGitHubCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      const userInfo = await fetchGitHubUserInfo(accessToken);
+      return { accessToken, scopes, userInfo };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const { accessToken, scopes } = await exchangeGitHubCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    const userInfo = await fetchGitHubUserInfo(accessToken);
-    return { accessToken, scopes, userInfo };
+  access: {
+    kind: "none",
+    getAccessSecretName: getGitHubSecretName,
   },
-  getSecretName: getGitHubSecretName,
-  revokeToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return revokeGitHubGrant(clientId, clientSecret, args.accessToken);
+  revoke: {
+    kind: "token-revoke",
+    revokeToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return revokeGitHubGrant(clientId, clientSecret, args.accessToken);
+    },
   },
-});
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail-provider.ts
@@ -1,44 +1,51 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGmailAuthorizationUrl,
   exchangeGmailCode,
   getGmailSecretName,
 } from "./gmail";
 import { refreshGoogleToken } from "./google-oauth";
-export const gmailProvider = defineConnectorOAuthProvider("gmail", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildGmailAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const gmailProvider: AuthCodeConnectorAuthProvider<"gmail"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildGmailAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeGmailCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGmailCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getGmailSecretName,
+    getRefreshSecretName: () => {
+      return "GMAIL_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshGoogleToken("gmail", clientId, clientSecret, refreshToken);
+    },
   },
-  getSecretName: getGmailSecretName,
-  getRefreshSecretName: () => {
-    return "GMAIL_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken("gmail", clientId, clientSecret, refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-ads-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-ads-provider.ts
@@ -1,58 +1,65 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleAdsProvider = defineConnectorOAuthProvider("google-ads", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildGoogleAuthorizationUrl(
-      "google-ads",
-      clientId,
-      redirectUri,
-      state,
-    );
+export const googleAdsProvider: AuthCodeConnectorAuthProvider<"google-ads"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      return buildGoogleAuthorizationUrl(
+        "google-ads",
+        clientId,
+        redirectUri,
+        state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeGoogleOAuthCode(
+        "google-ads",
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGoogleOAuthCode(
-      "google-ads",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: () => {
+      return "GOOGLE_ADS_ACCESS_TOKEN";
+    },
+    getRefreshSecretName: () => {
+      return "GOOGLE_ADS_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      return refreshGoogleToken(
+        "google-ads",
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+    },
   },
-  getSecretName: () => {
-    return "GOOGLE_ADS_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "GOOGLE_ADS_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken(
-      "google-ads",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-calendar-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-calendar-provider.ts
@@ -1,61 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleCalendarProvider = defineConnectorOAuthProvider(
-  "google-calendar",
+export const googleCalendarProvider: AuthCodeConnectorAuthProvider<"google-calendar"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      const redirectUri = args.redirectUri;
-      const state = args.state;
-      return buildGoogleAuthorizationUrl(
-        "google-calendar",
-        clientId,
-        redirectUri,
-        state,
-      );
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildGoogleAuthorizationUrl(
+          "google-calendar",
+          clientId,
+          redirectUri,
+          state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeGoogleOAuthCode(
+          "google-calendar",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const redirectUri = args.redirectUri;
-      const result = await exchangeGoogleOAuthCode(
-        "google-calendar",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "GOOGLE_CALENDAR_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "GOOGLE_CALENDAR_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshGoogleToken(
+          "google-calendar",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
     },
-    getSecretName: () => {
-      return "GOOGLE_CALENDAR_ACCESS_TOKEN";
-    },
-    getRefreshSecretName: () => {
-      return "GOOGLE_CALENDAR_REFRESH_TOKEN";
-    },
-    refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
-      const refreshToken = args.refreshToken;
-      return refreshGoogleToken(
-        "google-calendar",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-docs-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-docs-provider.ts
@@ -1,58 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleDocsProvider = defineConnectorOAuthProvider("google-docs", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildGoogleAuthorizationUrl(
-      "google-docs",
-      clientId,
-      redirectUri,
-      state,
-    );
-  },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGoogleOAuthCode(
-      "google-docs",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
+export const googleDocsProvider: AuthCodeConnectorAuthProvider<"google-docs"> =
+  {
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildGoogleAuthorizationUrl(
+          "google-docs",
+          clientId,
+          redirectUri,
+          state,
+        );
       },
-    };
-  },
-  getSecretName: () => {
-    return "GOOGLE_DOCS_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "GOOGLE_DOCS_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken(
-      "google-docs",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-});
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeGoogleOAuthCode(
+          "google-docs",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "GOOGLE_DOCS_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "GOOGLE_DOCS_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshGoogleToken(
+          "google-docs",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
+    },
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-drive-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-drive-provider.ts
@@ -1,61 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleDriveProvider = defineConnectorOAuthProvider(
-  "google-drive",
+export const googleDriveProvider: AuthCodeConnectorAuthProvider<"google-drive"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      const redirectUri = args.redirectUri;
-      const state = args.state;
-      return buildGoogleAuthorizationUrl(
-        "google-drive",
-        clientId,
-        redirectUri,
-        state,
-      );
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildGoogleAuthorizationUrl(
+          "google-drive",
+          clientId,
+          redirectUri,
+          state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeGoogleOAuthCode(
+          "google-drive",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const redirectUri = args.redirectUri;
-      const result = await exchangeGoogleOAuthCode(
-        "google-drive",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "GOOGLE_DRIVE_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "GOOGLE_DRIVE_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshGoogleToken(
+          "google-drive",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
     },
-    getSecretName: () => {
-      return "GOOGLE_DRIVE_ACCESS_TOKEN";
-    },
-    getRefreshSecretName: () => {
-      return "GOOGLE_DRIVE_REFRESH_TOKEN";
-    },
-    refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
-      const refreshToken = args.refreshToken;
-      return refreshGoogleToken(
-        "google-drive",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-meet-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-meet-provider.ts
@@ -1,58 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleMeetProvider = defineConnectorOAuthProvider("google-meet", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    return buildGoogleAuthorizationUrl(
-      "google-meet",
-      clientId,
-      redirectUri,
-      state,
-    );
-  },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGoogleOAuthCode(
-      "google-meet",
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
+export const googleMeetProvider: AuthCodeConnectorAuthProvider<"google-meet"> =
+  {
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildGoogleAuthorizationUrl(
+          "google-meet",
+          clientId,
+          redirectUri,
+          state,
+        );
       },
-    };
-  },
-  getSecretName: () => {
-    return "GOOGLE_MEET_ACCESS_TOKEN";
-  },
-  getRefreshSecretName: () => {
-    return "GOOGLE_MEET_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    const refreshToken = args.refreshToken;
-    return refreshGoogleToken(
-      "google-meet",
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-  },
-});
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeGoogleOAuthCode(
+          "google-meet",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "GOOGLE_MEET_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "GOOGLE_MEET_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshGoogleToken(
+          "google-meet",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
+    },
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-sheets-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-sheets-provider.ts
@@ -1,61 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
   refreshGoogleToken,
 } from "./google-oauth";
-export const googleSheetsProvider = defineConnectorOAuthProvider(
-  "google-sheets",
+export const googleSheetsProvider: AuthCodeConnectorAuthProvider<"google-sheets"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      const redirectUri = args.redirectUri;
-      const state = args.state;
-      return buildGoogleAuthorizationUrl(
-        "google-sheets",
-        clientId,
-        redirectUri,
-        state,
-      );
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildGoogleAuthorizationUrl(
+          "google-sheets",
+          clientId,
+          redirectUri,
+          state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeGoogleOAuthCode(
+          "google-sheets",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const redirectUri = args.redirectUri;
-      const result = await exchangeGoogleOAuthCode(
-        "google-sheets",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "GOOGLE_SHEETS_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "GOOGLE_SHEETS_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshGoogleToken(
+          "google-sheets",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
     },
-    getSecretName: () => {
-      return "GOOGLE_SHEETS_ACCESS_TOKEN";
-    },
-    getRefreshSecretName: () => {
-      return "GOOGLE_SHEETS_REFRESH_TOKEN";
-    },
-    refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
-      const refreshToken = args.refreshToken;
-      return refreshGoogleToken(
-        "google-sheets",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildGumroadAuthorizationUrl,
   exchangeGumroadCode,
   getGumroadSecretName,
   refreshGumroadToken,
 } from "./gumroad";
-export const gumroadProvider = defineConnectorOAuthProvider("gumroad", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildGumroadAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const gumroadProvider: AuthCodeConnectorAuthProvider<"gumroad"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildGumroadAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeGumroadCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeGumroadCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getGumroadSecretName,
+    getRefreshSecretName: () => {
+      return "GUMROAD_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshGumroadToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getGumroadSecretName,
-  getRefreshSecretName: () => {
-    return "GUMROAD_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshGumroadToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildHubSpotAuthorizationUrl,
   exchangeHubSpotCode,
   getHubSpotSecretName,
   refreshHubSpotToken,
 } from "./hubspot";
-export const hubspotProvider = defineConnectorOAuthProvider("hubspot", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildHubSpotAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const hubspotProvider: AuthCodeConnectorAuthProvider<"hubspot"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildHubSpotAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeHubSpotCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.hubDomain,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeHubSpotCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.hubDomain,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getHubSpotSecretName,
+    getRefreshSecretName: () => {
+      return "HUBSPOT_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshHubSpotToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getHubSpotSecretName,
-  getRefreshSecretName: () => {
-    return "HUBSPOT_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshHubSpotToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu-provider.ts
@@ -1,39 +1,44 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildIntervalsIcuAuthorizationUrl,
   exchangeIntervalsIcuCode,
   getIntervalsIcuSecretName,
 } from "./intervals-icu";
-export const intervalsIcuProvider = defineConnectorOAuthProvider(
-  "intervals-icu",
+export const intervalsIcuProvider: AuthCodeConnectorAuthProvider<"intervals-icu"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      return buildIntervalsIcuAuthorizationUrl(
-        clientId,
-        args.redirectUri,
-        args.state,
-      );
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        return buildIntervalsIcuAuthorizationUrl(
+          clientId,
+          args.redirectUri,
+          args.state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const result = await exchangeIntervalsIcuCode(
+          clientId,
+          clientSecret,
+          code,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: null,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.username,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const result = await exchangeIntervalsIcuCode(
-        clientId,
-        clientSecret,
-        code,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: null,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
+    access: {
+      kind: "none",
+      getAccessSecretName: getIntervalsIcuSecretName,
     },
-    getSecretName: getIntervalsIcuSecretName,
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear-provider.ts
@@ -1,4 +1,4 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildLinearAuthorizationUrl,
   exchangeLinearCode,
@@ -6,43 +6,56 @@ import {
   refreshLinearToken,
   revokeLinearToken,
 } from "./linear";
-export const linearProvider = defineConnectorOAuthProvider("linear", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildLinearAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildLinearAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeLinearCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeLinearCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getLinearSecretName,
+    getRefreshSecretName: () => {
+      return "LINEAR_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshLinearToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getLinearSecretName,
-  getRefreshSecretName: () => {
-    return "LINEAR_REFRESH_TOKEN";
+  revoke: {
+    kind: "token-revoke",
+    revokeToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return revokeLinearToken(clientId, clientSecret, args.accessToken);
+    },
   },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshLinearToken(clientId, clientSecret, args.refreshToken);
-  },
-  revokeToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return revokeLinearToken(clientId, clientSecret, args.accessToken);
-  },
-});
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-provider.ts
@@ -1,38 +1,45 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildMailchimpAuthorizationUrl,
   exchangeMailchimpCode,
   getMailchimpSecretName,
 } from "./mailchimp";
-export const mailchimpProvider = defineConnectorOAuthProvider("mailchimp", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildMailchimpAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
+export const mailchimpProvider: AuthCodeConnectorAuthProvider<"mailchimp"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildMailchimpAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeMailchimpCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: null,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeMailchimpCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: null,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "none",
+    getAccessSecretName: getMailchimpSecretName,
   },
-  getSecretName: getMailchimpSecretName,
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildMercuryAuthorizationUrl,
   exchangeMercuryCode,
   getMercurySecretName,
   refreshMercuryToken,
 } from "./mercury";
-export const mercuryProvider = defineConnectorOAuthProvider("mercury", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildMercuryAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildMercuryAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeMercuryCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeMercuryCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getMercurySecretName,
+    getRefreshSecretName: () => {
+      return "MERCURY_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshMercuryToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getMercurySecretName,
-  getRefreshSecretName: () => {
-    return "MERCURY_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshMercuryToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads-provider.ts
@@ -1,35 +1,46 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
   getMetaAdsSecretName,
 } from "./meta-ads";
-export const metaAdsProvider = defineConnectorOAuthProvider("meta-ads", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildMetaAdsAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const metaAdsProvider: AuthCodeConnectorAuthProvider<"meta-ads"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildMetaAdsAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeMetaAdsCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeMetaAdsCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "none",
+    getAccessSecretName: getMetaAdsSecretName,
   },
-  getSecretName: getMetaAdsSecretName,
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildMondayAuthorizationUrl,
   exchangeMondayCode,
   getMondaySecretName,
   refreshMondayToken,
 } from "./monday";
-export const mondayProvider = defineConnectorOAuthProvider("monday", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildMondayAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const mondayProvider: AuthCodeConnectorAuthProvider<"monday"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildMondayAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeMondayCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeMondayCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getMondaySecretName,
+    getRefreshSecretName: () => {
+      return "MONDAY_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshMondayToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getMondaySecretName,
-  getRefreshSecretName: () => {
-    return "MONDAY_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshMondayToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon-provider.ts
@@ -1,43 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildNeonAuthorizationUrl,
   exchangeNeonCode,
   getNeonSecretName,
   refreshNeonToken,
 } from "./neon";
-export const neonProvider = defineConnectorOAuthProvider("neon", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildNeonAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const neonProvider: AuthCodeConnectorAuthProvider<"neon"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildNeonAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeNeonCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeNeonCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getNeonSecretName,
+    getRefreshSecretName: () => {
+      return "NEON_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshNeonToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getNeonSecretName,
-  getRefreshSecretName: () => {
-    return "NEON_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshNeonToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion-provider.ts
@@ -1,39 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildNotionAuthorizationUrl,
   exchangeNotionCode,
   getNotionSecretName,
   refreshNotionToken,
 } from "./notion";
-export const notionProvider = defineConnectorOAuthProvider("notion", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildNotionAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const notionProvider: AuthCodeConnectorAuthProvider<"notion"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildNotionAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeNotionCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: result.userInfo,
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeNotionCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: result.userInfo,
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getNotionSecretName,
+    getRefreshSecretName: () => {
+      return "NOTION_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshNotionToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getNotionSecretName,
-  getRefreshSecretName: () => {
-    return "NOTION_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshNotionToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/outlook-calendar-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/outlook-calendar-provider.ts
@@ -1,61 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildMicrosoftAuthorizationUrl,
   exchangeMicrosoftOAuthCode,
   refreshMicrosoftToken,
 } from "./microsoft-oauth";
-export const outlookCalendarProvider = defineConnectorOAuthProvider(
-  "outlook-calendar",
+export const outlookCalendarProvider: AuthCodeConnectorAuthProvider<"outlook-calendar"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      const redirectUri = args.redirectUri;
-      const state = args.state;
-      return buildMicrosoftAuthorizationUrl(
-        "outlook-calendar",
-        clientId,
-        redirectUri,
-        state,
-      );
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildMicrosoftAuthorizationUrl(
+          "outlook-calendar",
+          clientId,
+          redirectUri,
+          state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeMicrosoftOAuthCode(
+          "outlook-calendar",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const redirectUri = args.redirectUri;
-      const result = await exchangeMicrosoftOAuthCode(
-        "outlook-calendar",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "OUTLOOK_CALENDAR_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "OUTLOOK_CALENDAR_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshMicrosoftToken(
+          "outlook-calendar",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
     },
-    getSecretName: () => {
-      return "OUTLOOK_CALENDAR_ACCESS_TOKEN";
-    },
-    getRefreshSecretName: () => {
-      return "OUTLOOK_CALENDAR_REFRESH_TOKEN";
-    },
-    refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
-      const refreshToken = args.refreshToken;
-      return refreshMicrosoftToken(
-        "outlook-calendar",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/outlook-mail-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/outlook-mail-provider.ts
@@ -1,61 +1,66 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildMicrosoftAuthorizationUrl,
   exchangeMicrosoftOAuthCode,
   refreshMicrosoftToken,
 } from "./microsoft-oauth";
-export const outlookMailProvider = defineConnectorOAuthProvider(
-  "outlook-mail",
+export const outlookMailProvider: AuthCodeConnectorAuthProvider<"outlook-mail"> =
   {
-    buildAuthUrl: (args) => {
-      const { clientId } = args;
-      const redirectUri = args.redirectUri;
-      const state = args.state;
-      return buildMicrosoftAuthorizationUrl(
-        "outlook-mail",
-        clientId,
-        redirectUri,
-        state,
-      );
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args;
+        const redirectUri = args.redirectUri;
+        const state = args.state;
+        return buildMicrosoftAuthorizationUrl(
+          "outlook-mail",
+          clientId,
+          redirectUri,
+          state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args;
+        const code = args.code;
+        const redirectUri = args.redirectUri;
+        const result = await exchangeMicrosoftOAuthCode(
+          "outlook-mail",
+          clientId,
+          clientSecret,
+          code,
+          redirectUri,
+        );
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: {
+            id: result.userInfo.id,
+            username: result.userInfo.name,
+            email: result.userInfo.email,
+          },
+        };
+      },
     },
-    exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
-      const code = args.code;
-      const redirectUri = args.redirectUri;
-      const result = await exchangeMicrosoftOAuthCode(
-        "outlook-mail",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
+    access: {
+      kind: "refresh-token",
+      getAccessSecretName: () => {
+        return "OUTLOOK_MAIL_ACCESS_TOKEN";
+      },
+      getRefreshSecretName: () => {
+        return "OUTLOOK_MAIL_REFRESH_TOKEN";
+      },
+      refreshToken: (args) => {
+        const { clientId, clientSecret } = args;
+        const refreshToken = args.refreshToken;
+        return refreshMicrosoftToken(
+          "outlook-mail",
+          clientId,
+          clientSecret,
+          refreshToken,
+        );
+      },
     },
-    getSecretName: () => {
-      return "OUTLOOK_MAIL_ACCESS_TOKEN";
-    },
-    getRefreshSecretName: () => {
-      return "OUTLOOK_MAIL_REFRESH_TOKEN";
-    },
-    refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
-      const refreshToken = args.refreshToken;
-      return refreshMicrosoftToken(
-        "outlook-mail",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildPosthogAuthorizationUrl,
   exchangePosthogCode,
   getPosthogSecretName,
   refreshPosthogToken,
 } from "./posthog";
-export const posthogProvider = defineConnectorOAuthProvider("posthog", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildPosthogAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const posthogProvider: AuthCodeConnectorAuthProvider<"posthog"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildPosthogAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangePosthogCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangePosthogCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getPosthogSecretName,
+    getRefreshSecretName: () => {
+      return "POSTHOG_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshPosthogToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getPosthogSecretName,
-  getRefreshSecretName: () => {
-    return "POSTHOG_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshPosthogToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildRedditAuthorizationUrl,
   exchangeRedditCode,
   getRedditSecretName,
   refreshRedditToken,
 } from "./reddit";
-export const redditProvider = defineConnectorOAuthProvider("reddit", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildRedditAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const redditProvider: AuthCodeConnectorAuthProvider<"reddit"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildRedditAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeRedditCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeRedditCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getRedditSecretName,
+    getRefreshSecretName: () => {
+      return "REDDIT_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshRedditToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getRedditSecretName,
-  getRefreshSecretName: () => {
-    return "REDDIT_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshRedditToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildSentryAuthorizationUrl,
   exchangeSentryCode,
   getSentrySecretName,
   refreshSentryToken,
 } from "./sentry";
-export const sentryProvider = defineConnectorOAuthProvider("sentry", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildSentryAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const sentryProvider: AuthCodeConnectorAuthProvider<"sentry"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildSentryAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeSentryCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.name,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeSentryCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.name,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getSentrySecretName,
+    getRefreshSecretName: () => {
+      return "SENTRY_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshSentryToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getSentrySecretName,
-  getRefreshSecretName: () => {
-    return "SENTRY_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshSentryToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack-provider.ts
@@ -1,4 +1,4 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildSlackAuthorizationUrl,
   exchangeSlackCode,
@@ -6,38 +6,47 @@ import {
   getSlackSecretName,
   revokeSlackToken,
 } from "./slack";
-export const slackProvider = defineConnectorOAuthProvider("slack", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildSlackAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildSlackAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const slackResult = await exchangeSlackCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      const slackUser = await fetchSlackUserInfo(
+        slackResult.userId,
+        slackResult.accessToken,
+      );
+      return {
+        accessToken: slackResult.accessToken,
+        scopes: slackResult.scopes,
+        userInfo: {
+          id: slackUser.id,
+          username: slackUser.username,
+          email: slackUser.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const slackResult = await exchangeSlackCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    const slackUser = await fetchSlackUserInfo(
-      slackResult.userId,
-      slackResult.accessToken,
-    );
-    return {
-      accessToken: slackResult.accessToken,
-      scopes: slackResult.scopes,
-      userInfo: {
-        id: slackUser.id,
-        username: slackUser.username,
-        email: slackUser.email,
-      },
-    };
+  access: {
+    kind: "none",
+    getAccessSecretName: getSlackSecretName,
   },
-  getSecretName: getSlackSecretName,
-  revokeToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return revokeSlackToken(clientId, clientSecret, args.accessToken);
+  revoke: {
+    kind: "token-revoke",
+    revokeToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return revokeSlackToken(clientId, clientSecret, args.accessToken);
+    },
   },
-});
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify-provider.ts
@@ -1,43 +1,54 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildSpotifyAuthorizationUrl,
   exchangeSpotifyCode,
   getSpotifySecretName,
   refreshSpotifyToken,
 } from "./spotify";
-export const spotifyProvider = defineConnectorOAuthProvider("spotify", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildSpotifyAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const spotifyProvider: AuthCodeConnectorAuthProvider<"spotify"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildSpotifyAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeSpotifyCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeSpotifyCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getSpotifySecretName,
+    getRefreshSecretName: () => {
+      return "SPOTIFY_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshSpotifyToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getSpotifySecretName,
-  getRefreshSecretName: () => {
-    return "SPOTIFY_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshSpotifyToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava-provider.ts
@@ -1,37 +1,48 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildStravaAuthorizationUrl,
   exchangeStravaCode,
   getStravaSecretName,
   refreshStravaToken,
 } from "./strava";
-export const stravaProvider = defineConnectorOAuthProvider("strava", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildStravaAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const stravaProvider: AuthCodeConnectorAuthProvider<"strava"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildStravaAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const result = await exchangeStravaCode(clientId, clientSecret, code);
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const result = await exchangeStravaCode(clientId, clientSecret, code);
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getStravaSecretName,
+    getRefreshSecretName: () => {
+      return "STRAVA_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshStravaToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getStravaSecretName,
-  getRefreshSecretName: () => {
-    return "STRAVA_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshStravaToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe-provider.ts
@@ -1,36 +1,47 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildStripeAuthorizationUrl,
   exchangeStripeCode,
   getStripeSecretName,
   refreshStripeToken,
 } from "./stripe";
-export const stripeProvider = defineConnectorOAuthProvider("stripe", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildStripeAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildStripeAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const result = await exchangeStripeCode(clientId, clientSecret, code);
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const result = await exchangeStripeCode(clientId, clientSecret, code);
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getStripeSecretName,
+    getRefreshSecretName: () => {
+      return "STRIPE_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshStripeToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getStripeSecretName,
-  getRefreshSecretName: () => {
-    return "STRIPE_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshStripeToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase-provider.ts
@@ -1,54 +1,61 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildSupabaseAuthorizationUrl,
   exchangeSupabaseCode,
   getSupabaseSecretName,
   refreshSupabaseToken,
 } from "./supabase";
-export const supabaseProvider = defineConnectorOAuthProvider("supabase", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildSupabaseAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
-  },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    if (!state) {
-      throw new Error(
-        "Supabase PKCE requires state for code_verifier derivation",
+export const supabaseProvider: AuthCodeConnectorAuthProvider<"supabase"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildSupabaseAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
       );
-    }
-    const result = await exchangeSupabaseCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-      state,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      if (!state) {
+        throw new Error(
+          "Supabase PKCE requires state for code_verifier derivation",
+        );
+      }
+      const result = await exchangeSupabaseCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+        state,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  getSecretName: getSupabaseSecretName,
-  getRefreshSecretName: () => {
-    return "SUPABASE_REFRESH_TOKEN";
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getSupabaseSecretName,
+    getRefreshSecretName: () => {
+      return "SUPABASE_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshSupabaseToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshSupabaseToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-device-provider.ts
@@ -1,29 +1,34 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { DeviceAuthConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   pollTestOAuthDeviceAuth,
   startTestOAuthDeviceAuth,
   TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
 } from "./test-oauth-device";
 
-export const testOauthDeviceProvider = defineConnectorOAuthProvider(
-  "test-oauth-device",
+export const testOauthDeviceProvider: DeviceAuthConnectorAuthProvider<"test-oauth-device"> =
   {
-    getSecretName: () => {
-      return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
+    grant: {
+      kind: "device-auth",
+      startDeviceAuth: async (args) => {
+        const { clientId } = args;
+        return await startTestOAuthDeviceAuth({
+          clientId,
+          scopes: args.scopes,
+        });
+      },
+      pollDeviceAuth: async (args) => {
+        const { clientId } = args;
+        return await pollTestOAuthDeviceAuth({
+          clientId,
+          deviceCode: args.deviceCode,
+        });
+      },
     },
-    startDeviceAuth: async (args) => {
-      const { clientId } = args;
-      return await startTestOAuthDeviceAuth({
-        clientId,
-        scopes: args.scopes,
-      });
+    access: {
+      kind: "none",
+      getAccessSecretName: () => {
+        return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
+      },
     },
-    pollDeviceAuth: async (args) => {
-      const { clientId } = args;
-      return await pollTestOAuthDeviceAuth({
-        clientId,
-        deviceCode: args.deviceCode,
-      });
-    },
-  },
-);
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-provider.ts
@@ -1,4 +1,4 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildTestOAuthAuthorizationUrl,
   exchangeTestOAuthCode,
@@ -7,52 +7,59 @@ import {
   TEST_OAUTH_ACCESS_SECRET_NAME,
   TEST_OAUTH_REFRESH_SECRET_NAME,
 } from "./test-oauth";
-export const testOauthProvider = defineConnectorOAuthProvider("test-oauth", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildTestOAuthAuthorizationUrl(
-      clientId,
-      args.redirectUri,
-      args.state,
-    );
+export const testOauthProvider: AuthCodeConnectorAuthProvider<"test-oauth"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildTestOAuthAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const token = await exchangeTestOAuthCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      const user = await fetchTestOAuthUserInfo(token.accessToken);
+      return {
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken,
+        expiresIn: token.expiresIn,
+        scopes: token.scopes,
+        userInfo: user,
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const token = await exchangeTestOAuthCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    const user = await fetchTestOAuthUserInfo(token.accessToken);
-    return {
-      accessToken: token.accessToken,
-      refreshToken: token.refreshToken,
-      expiresIn: token.expiresIn,
-      scopes: token.scopes,
-      userInfo: user,
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: () => {
+      return TEST_OAUTH_ACCESS_SECRET_NAME;
+    },
+    getRefreshSecretName: () => {
+      return TEST_OAUTH_REFRESH_SECRET_NAME;
+    },
+    refreshToken: async (args) => {
+      const { clientId, clientSecret } = args;
+      const refreshToken = args.refreshToken;
+      const result = await refreshTestOAuthToken(
+        clientId,
+        clientSecret,
+        refreshToken,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+      };
+    },
   },
-  getSecretName: () => {
-    return TEST_OAUTH_ACCESS_SECRET_NAME;
-  },
-  getRefreshSecretName: () => {
-    return TEST_OAUTH_REFRESH_SECRET_NAME;
-  },
-  refreshToken: async (args) => {
-    const { clientId, clientSecret } = args;
-    const refreshToken = args.refreshToken;
-    const result = await refreshTestOAuthToken(
-      clientId,
-      clientSecret,
-      refreshToken,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-    };
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist-provider.ts
@@ -1,34 +1,45 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildTodoistAuthorizationUrl,
   exchangeTodoistCode,
   getTodoistSecretName,
 } from "./todoist";
-export const todoistProvider = defineConnectorOAuthProvider("todoist", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildTodoistAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const todoistProvider: AuthCodeConnectorAuthProvider<"todoist"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildTodoistAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeTodoistCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: null,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeTodoistCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: null,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "none",
+    getAccessSecretName: getTodoistSecretName,
   },
-  getSecretName: getTodoistSecretName,
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/vercel-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/vercel-provider.ts
@@ -1,33 +1,44 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildVercelAuthorizationUrl,
   exchangeVercelCode,
   getVercelSecretName,
 } from "./vercel";
-export const vercelProvider = defineConnectorOAuthProvider("vercel", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildVercelAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const vercelProvider: AuthCodeConnectorAuthProvider<"vercel"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildVercelAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeVercelCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        scopes: [],
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeVercelCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      scopes: [],
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "none",
+    getAccessSecretName: getVercelSecretName,
   },
-  getSecretName: getVercelSecretName,
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow-provider.ts
@@ -1,34 +1,45 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildWebflowAuthorizationUrl,
   exchangeWebflowCode,
   getWebflowSecretName,
 } from "./webflow";
-export const webflowProvider = defineConnectorOAuthProvider("webflow", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildWebflowAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const webflowProvider: AuthCodeConnectorAuthProvider<"webflow"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildWebflowAuthorizationUrl(
+        clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeWebflowCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: null,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeWebflowCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: null,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "none",
+    getAccessSecretName: getWebflowSecretName,
   },
-  getSecretName: getWebflowSecretName,
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/x-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x-provider.ts
@@ -1,48 +1,55 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildXAuthorizationUrl,
   exchangeXCode,
   getXSecretName,
   refreshXToken,
 } from "./x";
-export const xProvider = defineConnectorOAuthProvider("x", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildXAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const xProvider: AuthCodeConnectorAuthProvider<"x"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildXAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const state = args.state;
+      if (!state) {
+        throw new Error("X PKCE requires state for code_verifier derivation");
+      }
+      const result = await exchangeXCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+        state,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const state = args.state;
-    if (!state) {
-      throw new Error("X PKCE requires state for code_verifier derivation");
-    }
-    const result = await exchangeXCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-      state,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getXSecretName,
+    getRefreshSecretName: () => {
+      return "X_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshXToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getXSecretName,
-  getRefreshSecretName: () => {
-    return "X_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshXToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero-provider.ts
@@ -1,43 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildXeroAuthorizationUrl,
   exchangeXeroCode,
   getXeroSecretName,
   refreshXeroToken,
 } from "./xero";
-export const xeroProvider = defineConnectorOAuthProvider("xero", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildXeroAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const xeroProvider: AuthCodeConnectorAuthProvider<"xero"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildXeroAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeXeroCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeXeroCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getXeroSecretName,
+    getRefreshSecretName: () => {
+      return "XERO_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshXeroToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getXeroSecretName,
-  getRefreshSecretName: () => {
-    return "XERO_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshXeroToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom-provider.ts
@@ -1,43 +1,50 @@
-import { defineConnectorOAuthProvider } from "../provider-types";
+import type { AuthCodeConnectorAuthProvider } from "../../auth-providers/provider-types";
 import {
   buildZoomAuthorizationUrl,
   exchangeZoomCode,
   getZoomSecretName,
   refreshZoomToken,
 } from "./zoom";
-export const zoomProvider = defineConnectorOAuthProvider("zoom", {
-  buildAuthUrl: (args) => {
-    const { clientId } = args;
-    return buildZoomAuthorizationUrl(clientId, args.redirectUri, args.state);
+export const zoomProvider: AuthCodeConnectorAuthProvider<"zoom"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      const { clientId } = args;
+      return buildZoomAuthorizationUrl(clientId, args.redirectUri, args.state);
+    },
+    exchangeCode: async (args) => {
+      const { clientId, clientSecret } = args;
+      const code = args.code;
+      const redirectUri = args.redirectUri;
+      const result = await exchangeZoomCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: {
+          id: result.userInfo.id,
+          username: result.userInfo.username,
+          email: result.userInfo.email,
+        },
+      };
+    },
   },
-  exchangeCode: async (args) => {
-    const { clientId, clientSecret } = args;
-    const code = args.code;
-    const redirectUri = args.redirectUri;
-    const result = await exchangeZoomCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresIn: result.expiresIn,
-      scopes: result.scopes,
-      userInfo: {
-        id: result.userInfo.id,
-        username: result.userInfo.username,
-        email: result.userInfo.email,
-      },
-    };
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getZoomSecretName,
+    getRefreshSecretName: () => {
+      return "ZOOM_REFRESH_TOKEN";
+    },
+    refreshToken: (args) => {
+      const { clientId, clientSecret } = args;
+      return refreshZoomToken(clientId, clientSecret, args.refreshToken);
+    },
   },
-  getSecretName: getZoomSecretName,
-  getRefreshSecretName: () => {
-    return "ZOOM_REFRESH_TOKEN";
-  },
-  refreshToken: (args) => {
-    const { clientId, clientSecret } = args;
-    return refreshZoomToken(clientId, clientSecret, args.refreshToken);
-  },
-});
+  revoke: { kind: "none" },
+};


### PR DESCRIPTION
Closes #14634.

## Summary
- Add a generic `AuthProvider<TGrant, TAccess, TRevoke>` base and keep connector-specific provider aliases on top of it.
- Convert connector OAuth providers to declare `grant`, `access`, and `revoke` capabilities directly.
- Remove the connector-only flat OAuth provider adapter layer while keeping public connector OAuth registry APIs stable.
- Update API and web tests to patch/assert provider capabilities through the new slots.

## Tests
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-connectors-authorize.test.ts`
- `pnpm -F web exec vitest run src/lib/zero/connector/providers/__tests__/google-ads.test.ts src/lib/zero/connector/providers/__tests__/meta-ads.test.ts`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm format`
- `pnpm check-types`
- `pnpm turbo run lint`
- `pnpm knip`

Known local unrelated failure:
- `pnpm vitest` fails only in `@vm0/app src/views/zero-page/__tests__/schedule-dialog.test.tsx` because the timezone select renders `(GMT+09:00) Korea Standard Time (KST)` while the test expects `Eastern Time (ET)`; a focused rerun of that single test fails the same way.