### PR TITLE
refactor: remove chat thread search from sidebar and chat list

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -2,30 +2,6 @@ import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
 
 // ---------------------------------------------------------------------------
-// Sidebar search state
-// ---------------------------------------------------------------------------
-const internalThreadSearchOpen$ = state(false);
-export const threadSearchOpen$ = computed((get) => {
-  return get(internalThreadSearchOpen$);
-});
-
-const internalThreadSearchTerm$ = state("");
-export const sidebarSearchTerm$ = computed((get) => {
-  return get(internalThreadSearchTerm$);
-});
-
-export const setThreadSearchOpen$ = command(({ set }, open: boolean) => {
-  set(internalThreadSearchOpen$, open);
-  if (!open) {
-    set(internalThreadSearchTerm$, "");
-  }
-});
-
-export const setThreadSearchTerm$ = command(({ set }, term: string) => {
-  set(internalThreadSearchTerm$, term);
-});
-
-// ---------------------------------------------------------------------------
 // Manage pinned agents dialog state
 // ---------------------------------------------------------------------------
 const internalManagePinnedOpen$ = state(false);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
@@ -7,7 +7,6 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
@@ -68,17 +67,6 @@ describe("zero chat list page - header and title", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("heading", { name: "Chats with Zero" }),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("should show agent-scoped 'Search chat with Zero' placeholder (CHAT-LIST-002)", async () => {
-    mockChatThreads(createMockThreads());
-    setupPage();
-
-    await waitFor(() => {
-      expect(
-        screen.getByPlaceholderText("Search chat with Zero"),
       ).toBeInTheDocument();
     });
   });
@@ -179,88 +167,6 @@ describe("zero chat list page - chat list rendering (continued)", () => {
       expect(
         screen.getByText(/failed to load chats|server error/i),
       ).toBeInTheDocument();
-    });
-  });
-});
-
-describe("zero chat list page - search", () => {
-  it("should filter threads by search term (CHAT-LIST-006)", async () => {
-    mockChatThreads(createMockThreads());
-    setupPage();
-
-    await waitFor(() => {
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
-    });
-
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await userEvent.type(searchInput, "First");
-
-    await waitFor(() => {
-      // After filtering, matching results should remain visible
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
-      // "No chats match your search" should not appear when results exist
-      expect(
-        screen.queryByText("No chats match your search"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("should show 'No chats match your search' when no results (CHAT-LIST-007)", async () => {
-    mockChatThreads(createMockThreads());
-    setupPage();
-
-    await waitFor(() => {
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
-    });
-
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await userEvent.type(searchInput, "nonexistent");
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("No chats match your search"),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("should clear search when X button is clicked (CHAT-LIST-008)", async () => {
-    mockChatThreads(createMockThreads());
-    setupPage();
-
-    await waitFor(() => {
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
-    });
-
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await userEvent.type(searchInput, "First");
-
-    await waitFor(() => {
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
-    });
-
-    const clearButton = screen.getAllByRole("button").find((el) => {
-      return /Clear search/.test(el.getAttribute("aria-label") ?? "");
-    })!;
-    fireEvent.click(clearButton);
-
-    await waitFor(() => {
-      expect(searchInput).toHaveValue("");
-    });
-  });
-
-  it("should be case-insensitive when filtering (CHAT-LIST-009)", async () => {
-    mockChatThreads(createMockThreads());
-    setupPage();
-
-    await waitFor(() => {
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
-    });
-
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await userEvent.type(searchInput, "first");
-
-    await waitFor(() => {
-      expect(screen.getAllByText("First chat thread")[0]).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -13,7 +13,6 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
@@ -140,97 +139,6 @@ describe("zero sidebar - loading state (SIDEBAR-D-002)", () => {
     });
 
     deferred.resolve();
-  });
-});
-
-describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
-  it("shows only matching thread after typing a search term", async () => {
-    const user = userEvent.setup();
-    mockBaseAPIs({
-      threads: [
-        {
-          id: "thread-1",
-          title: "Deploy to production",
-          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
-          createdAt: "2026-03-10T00:00:00Z",
-          updatedAt: "2026-03-10T00:00:00Z",
-          isRead: false,
-          isArchived: false,
-          running: false,
-        },
-        {
-          id: "thread-2",
-          title: "Fix the bug",
-          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
-          createdAt: "2026-03-09T00:00:00Z",
-          updatedAt: "2026-03-09T00:00:00Z",
-          isRead: false,
-          isArchived: false,
-          running: false,
-        },
-      ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/",
-    });
-
-    await waitFor(() => {
-      expect(
-        within(getSidebar()).getByText("Deploy to production"),
-      ).toBeInTheDocument();
-    });
-
-    const searchChatsBtn1 = screen.getByLabelText("Search chats");
-    click(searchChatsBtn1);
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await user.type(searchInput, "deploy");
-
-    expect(
-      within(getSidebar()).getByText("Deploy to production"),
-    ).toBeInTheDocument();
-    expect(
-      within(getSidebar()).queryByText("Fix the bug"),
-    ).not.toBeInTheDocument();
-  });
-});
-
-describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
-  it("shows the typed search term in the search input", async () => {
-    const user = userEvent.setup();
-    mockBaseAPIs({
-      threads: [
-        {
-          id: "thread-1",
-          title: "Deploy to production",
-          agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
-          createdAt: "2026-03-10T00:00:00Z",
-          updatedAt: "2026-03-10T00:00:00Z",
-          isRead: false,
-          isArchived: false,
-          running: false,
-        },
-      ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/",
-    });
-
-    await waitFor(() => {
-      expect(
-        within(getSidebar()).getByText("Deploy to production"),
-      ).toBeInTheDocument();
-    });
-
-    const searchChatsBtn2 = screen.getByLabelText("Search chats");
-    click(searchChatsBtn2);
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await user.type(searchInput, "deploy");
-
-    expect(searchInput).toHaveValue("deploy");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -322,68 +322,6 @@ describe("zero sidebar - sign-out option works (SIDEBAR-D-014)", () => {
   });
 });
 
-describe("zero sidebar - search input accepts text (SIDEBAR-D-015)", () => {
-  it("receives focus and accepts typed text in the search input", async () => {
-    const user = userEvent.setup();
-    mockBaseAPIs({
-      threads: [makeThread("thread-1", "First chat", "2026-03-10T00:00:00Z")],
-    });
-    detachedSetupPage({
-      context,
-      path: "/",
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("First chat")).toBeInTheDocument();
-    });
-
-    const searchChatsBtn1 = screen.getByLabelText("Search chats");
-    click(searchChatsBtn1);
-
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await user.type(searchInput, "hello");
-
-    expect(searchInput).toHaveValue("hello");
-  });
-});
-
-describe("zero sidebar - clear search button resets search (SIDEBAR-D-016)", () => {
-  it("clears the search field and restores the full thread list", async () => {
-    const user = userEvent.setup();
-    mockBaseAPIs({
-      threads: [
-        makeThread("thread-1", "First chat", "2026-03-10T00:00:00Z"),
-        makeThread("thread-2", "Second chat", "2026-03-09T00:00:00Z"),
-      ],
-    });
-    detachedSetupPage({
-      context,
-      path: "/",
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("First chat")).toBeInTheDocument();
-      expect(screen.getByText("Second chat")).toBeInTheDocument();
-    });
-
-    const searchChatsBtn2 = screen.getByLabelText("Search chats");
-    click(searchChatsBtn2);
-
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await user.type(searchInput, "First");
-
-    expect(screen.queryByText("Second chat")).not.toBeInTheDocument();
-
-    const closeSearchBtn = screen.getByLabelText("Close search");
-    click(closeSearchBtn);
-
-    await waitFor(() => {
-      expect(screen.getByText("First chat")).toBeInTheDocument();
-      expect(screen.getByText("Second chat")).toBeInTheDocument();
-    });
-  });
-});
-
 describe("zero sidebar - new chat button creates session (SIDEBAR-D-017)", () => {
   it("creates a new chat session and navigates to it", async () => {
     mockBaseAPIs();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers";
-import {
-  detachedSetupPage,
-  fill,
-  click,
-} from "../../../__tests__/page-helper.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { screen, waitFor } from "@testing-library/react";
 import { featureSwitch$ } from "../../../signals/external/feature-switch";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -144,64 +140,5 @@ describe("zero sidebar", () => {
       expect(screen.getByText("Agents")).toBeInTheDocument();
     });
     expect(screen.getByText("Activity logs")).toBeInTheDocument();
-  });
-
-  it("should filter chat sessions when searching", async () => {
-    mockAPIs();
-    detachedSetupPage({
-      context,
-      path: "/",
-    });
-
-    // Wait for chat threads to render
-    await waitFor(() => {
-      expect(screen.getByText("First chat")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Second chat")).toBeInTheDocument();
-
-    // Click search button
-    const searchButton = screen.getByLabelText("Search chats");
-    click(searchButton);
-
-    // Type search query
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await fill(searchInput, "First");
-
-    // Only matching thread should be visible
-    expect(screen.getByText("First chat")).toBeInTheDocument();
-    expect(screen.queryByText("Second chat")).not.toBeInTheDocument();
-  });
-
-  it("should close search and reset filter", async () => {
-    mockAPIs();
-    detachedSetupPage({
-      context,
-      path: "/",
-    });
-
-    // Wait for chat threads to render
-    await waitFor(() => {
-      expect(screen.getByText("First chat")).toBeInTheDocument();
-    });
-
-    // Open search
-    const searchButton = screen.getByLabelText("Search chats");
-    click(searchButton);
-
-    // Type search query that filters out one thread
-    const searchInput = screen.getByPlaceholderText("Search chat with Zero");
-    await fill(searchInput, "First");
-
-    expect(screen.queryByText("Second chat")).not.toBeInTheDocument();
-
-    // Close search
-    const closeButton = screen.getByLabelText("Close search");
-    click(closeButton);
-
-    // Both threads should be visible again (search term was reset)
-    await waitFor(() => {
-      expect(screen.getByText("First chat")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Second chat")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -5,8 +5,6 @@ import {
   useLastLoadable,
 } from "ccstate-react";
 import {
-  IconSearch,
-  IconX,
   IconPlus,
   IconChevronRight,
   IconTrash,
@@ -69,10 +67,6 @@ import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import { pathParams$, searchParams$ } from "../../signals/route.ts";
 import { setSidebarExpanded$ } from "../../signals/zero-page/zero-nav.ts";
 import {
-  threadSearchOpen$,
-  sidebarSearchTerm$,
-  setThreadSearchOpen$,
-  setThreadSearchTerm$,
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
   renameDialogThreadId$,
@@ -589,13 +583,6 @@ function ChatThreads() {
   const pageSignal = useGet(pageSignal$);
 
   const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
-  const searchTerm = useGet(sidebarSearchTerm$);
-  const trimmedTerm = searchTerm.trim().toLowerCase();
-  const filteredChatThreads = trimmedTerm
-    ? chatThreads.filter((s) => {
-        return (s.title ?? "").toLowerCase().includes(trimmedTerm);
-      })
-    : chatThreads;
 
   function confirmDelete() {
     if (!pendingDeleteThreadId) {
@@ -606,18 +593,16 @@ function ChatThreads() {
     detach(deleteChatThread(threadId, pageSignal), Reason.DomCallback);
   }
 
-  if (filteredChatThreads.length === 0) {
+  if (chatThreads.length === 0) {
     return (
       <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
-        {trimmedTerm
-          ? "No chats match your search"
-          : "Start a conversation and it'll show up here"}
+        Start a conversation and it&apos;ll show up here
       </p>
     );
   }
   return (
     <>
-      {filteredChatThreads.map((session) => {
+      {chatThreads.map((session) => {
         return <ChatThreadItem key={session.id} session={session} />;
       })}
       <ChatThreadRenameDialog />
@@ -661,8 +646,7 @@ function ChatThreadsTitle() {
   const createNewChat = useSet(createNewChatThreadOptimistically$);
   const setExpanded = useSet(setSidebarExpanded$);
   const rootSignal = useGet(rootSignal$);
-  const { titleLabel, searchPlaceholder, newChatAriaLabel } =
-    useChatThreadsTitleLabels();
+  const { titleLabel, newChatAriaLabel } = useChatThreadsTitleLabels();
   const newChatDisabled = useGet(optimisticChatThread$) !== null;
   const onNewChat = (pane: OptimisticChatPane) => {
     if (!currentChatAgentId) {
@@ -674,45 +658,10 @@ function ChatThreadsTitle() {
     );
     setExpanded(false);
   };
-  const searchOpen = useGet(threadSearchOpen$);
-  const setSearchOpen = useSet(setThreadSearchOpen$);
-  const searchTerm = useGet(sidebarSearchTerm$);
-  const setSearchTerm = useSet(setThreadSearchTerm$);
   const setCollapsed = useSet(setSessionListCollapsed$);
   const collapsed = useGet(sessionListCollapsed$);
 
-  return searchOpen ? (
-    <div className="shrink-0 flex h-8 items-center gap-2 rounded-lg bg-sidebar-accent/60 pl-2 pr-2 zero-border">
-      <IconSearch
-        size={15}
-        stroke={2.5}
-        className="shrink-0 text-sidebar-foreground/50"
-      />
-      <input
-        type="text"
-        value={searchTerm}
-        onChange={(e) => {
-          return setSearchTerm(e.target.value);
-        }}
-        placeholder={searchPlaceholder}
-        autoFocus
-        className="flex-1 min-w-0 bg-transparent text-sm leading-5 text-sidebar-foreground placeholder:text-sidebar-foreground/50 focus:outline-none"
-      />
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            setSearchOpen(false);
-          }}
-          className="shrink-0 flex items-center justify-center h-5 w-5 rounded text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-          aria-label="Close search"
-        >
-          <IconX size={12} stroke={2} />
-        </button>
-      </div>
-    </div>
-  ) : (
+  return (
     <div
       className="zero-nav-recent-label group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent transition-colors"
       onClick={() => {
@@ -730,27 +679,6 @@ function ChatThreadsTitle() {
         </span>
       </span>
       <div className="flex items-center gap-0.5">
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setSearchOpen(true);
-                }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
-                aria-label="Search chats"
-              >
-                <IconSearch size={15} stroke={2.5} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">Search chats</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -6,7 +6,7 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
-import { IconPlus, IconSearch, IconX, IconTrash } from "@tabler/icons-react";
+import { IconPlus, IconTrash } from "@tabler/icons-react";
 import {
   Button,
   Dialog,
@@ -36,8 +36,6 @@ import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
 import {
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
-  chatListQuery$,
-  setChatListQuery$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
@@ -59,23 +57,13 @@ export function ZeroChatListPage() {
       : null;
 
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  const { titleLabel, searchPlaceholder } = useChatThreadsTitleLabels();
+  const { titleLabel } = useChatThreadsTitleLabels();
 
   const selectedRecentId = useGet(currentChatThreadId$);
   const navigateToChat = useSet(navigateToChat$);
   const createNewChat = useSet(createNewChatThreadOptimistically$);
   const creating = useGet(optimisticChatThread$) !== null;
   const rootSignal = useGet(rootSignal$);
-
-  const searchTerm = useGet(chatListQuery$);
-  const setSearchTerm = useSet(setChatListQuery$);
-
-  const trimmedTerm = searchTerm.trim().toLowerCase();
-  const filteredSessions = trimmedTerm
-    ? recentSessions.filter((s) => {
-        return (s.title ?? "").toLowerCase().includes(trimmedTerm);
-      })
-    : recentSessions;
 
   const onNewChat = (pane: OptimisticChatPane) => {
     if (!currentChatAgentId) {
@@ -97,36 +85,6 @@ export function ZeroChatListPage() {
       <div className="shrink-0 px-4 pt-4 pb-2">
         <div className="flex items-center gap-3 mb-3">
           <h1 className="text-lg font-semibold">{titleLabel}</h1>
-        </div>
-
-        {/* Search */}
-        <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 h-10">
-          <IconSearch
-            size={16}
-            stroke={2}
-            className="shrink-0 text-muted-foreground"
-          />
-          <input
-            type="text"
-            value={searchTerm}
-            onChange={(e) => {
-              return setSearchTerm(e.target.value);
-            }}
-            placeholder={searchPlaceholder}
-            className="flex-1 min-w-0 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
-          />
-          {searchTerm && (
-            <button
-              type="button"
-              onClick={() => {
-                return setSearchTerm("");
-              }}
-              className="shrink-0 text-muted-foreground hover:text-foreground"
-              aria-label="Clear search"
-            >
-              <IconX size={14} stroke={2} />
-            </button>
-          )}
         </div>
       </div>
 
@@ -150,8 +108,7 @@ export function ZeroChatListPage() {
         <ChatList
           loading={loading}
           error={error}
-          sessions={filteredSessions}
-          searchTerm={searchTerm}
+          sessions={recentSessions}
           selectedRecentId={selectedRecentId}
           onRecentSelect={onRecentSelect}
         />
@@ -164,14 +121,12 @@ function ChatList({
   loading,
   error,
   sessions,
-  searchTerm,
   selectedRecentId,
   onRecentSelect,
 }: {
   loading: boolean;
   error: string | null;
   sessions: ChatThreadListItem[];
-  searchTerm: string;
   selectedRecentId: string | null;
   onRecentSelect: (id: string) => void;
 }) {
@@ -210,9 +165,7 @@ function ChatList({
   if (sessions.length === 0) {
     return (
       <p className="px-3 py-8 text-sm text-muted-foreground text-center">
-        {searchTerm.trim()
-          ? "No chats match your search"
-          : "Start a conversation and it'll show up here"}
+        Start a conversation and it&apos;ll show up here
       </p>
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
@@ -14,7 +14,6 @@ export function useChatThreadsTitleLabels() {
   const agentName = agentDisplayName ?? "Zero";
   return {
     titleLabel: `Chats with ${agentName}`,
-    searchPlaceholder: `Search chat with ${agentName}`,
     newChatAriaLabel: `New chat with ${agentName}`,
   };
 }


### PR DESCRIPTION
## Summary
- Drop the search button (and its expanded input branch) next to **Chats with {agent}** in the sidebar
- Drop the search input on the chat list page (`/chats`)
- Remove the now-unused `threadSearchOpen$` / `sidebarSearchTerm$` signals and `setThreadSearchOpen$` / `setThreadSearchTerm$` setters; `searchPlaceholder` is no longer returned from `useChatThreadsTitleLabels`
- Remove 7 obsolete search test cases (CHAT-LIST-002, CHAT-LIST-006–009, SIDEBAR-D-003/004/015/016, plus two in `zero-sidebar.test.tsx`)

`chatListQuery$` / `setChatListQuery$` are kept because `AgentListDialog` ("Talk to" dialog) still uses them for agent search — that's a separate feature.

## Test plan
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm -F @vm0/app lint`
- [x] `pnpm knip --workspace apps/platform`
- [x] `pnpm -F @vm0/app exec vitest run` for the 4 touched test files — 37/37 pass
- [ ] Manual: open sidebar → confirm only the "+ New chat" button remains next to **Chats with Zero**
- [ ] Manual: visit `/chats` → confirm the search input is gone and only the **New chat** button + list remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)