### PR TITLE
fix(ui): render running indicator with real elements so animation starts on first mobile sidebar open

### DIFF
--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -15,7 +15,10 @@ function RunningIndicator({
       aria-label={label}
       className={cn("running-indicator", className)}
       {...rest}
-    />
+    >
+      <span className="running-indicator-center" aria-hidden />
+      <span className="running-indicator-ripple" aria-hidden />
+    </span>
   );
 }
 

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -405,32 +405,21 @@
     border-radius: 9999px;
     color: var(--color-sky-600, #0284c7);
   }
-  .running-indicator::before {
-    content: "";
+  .running-indicator-center {
     position: absolute;
     inset: 2.5px;
     border-radius: inherit;
     background: currentColor;
     transform-origin: center;
-    /* Match the 0% keyframe as the resting state. Without this, iOS Safari
-       paints the pseudo-element at scale(1)/opacity(1) on first display
-       while the animation has not started ticking yet — that looks
-       identical to the static Unread dot until the next paint, which
-       happens to coincide with closing and reopening the mobile sidebar. */
-    transform: scale(0.64);
-    opacity: 0.34;
     animation: running-indicator-center 2400ms cubic-bezier(0.33, 0, 0.66, 1)
       infinite;
   }
-  .running-indicator::after {
-    content: "";
+  .running-indicator-ripple {
     position: absolute;
     inset: 1.5px;
     border-radius: inherit;
     border: 1px solid currentColor;
     transform-origin: center;
-    transform: scale(0.8);
-    opacity: 0;
     animation: running-indicator-ripple 2400ms ease-out infinite;
   }
 }


### PR DESCRIPTION
## Summary

- PR #14662 fixed the **visual symptom** of the mobile sidebar running indicator looking like an Unread dot on first open (by pinning the pseudo-element resting transform/opacity to the 0% keyframe values), but it did not fix the **underlying bug**: on iOS Safari, the infinite CSS animation on `.running-indicator::before` / `::after` does not start ticking after a `display:none → display:flex` transition. The dot now correctly renders as a small dot on first open — but it stays static and never breathes until the sidebar is closed and reopened.
- Move the breathing-dot and ripple from `::before` / `::after` to two real child `<span>` elements (`.running-indicator-center` and `.running-indicator-ripple`). iOS Safari schedules CSS animations on real DOM nodes immediately after a `display:none → display:flex` transition, so the animation ticks on the very first open.
- The defensive resting transform/opacity values added in #14662 — and their iOS-specific comment — are gone, because they are no longer needed once the animation actually ticks.

Files:

- `turbo/packages/ui/src/components/ui/running-indicator.tsx` — renders two child spans
- `turbo/packages/ui/src/styles/globals.css` — `::before` → `.running-indicator-center`, `::after` → `.running-indicator-ripple`, keyframes unchanged

## Test plan

- [ ] On iOS Safari (real device), enter a chat thread that has at least one non-terminal run, open the mobile sidebar from the menu button on the very first open, and verify the running rows show the small dot **breathing/pulsing** — not a static small dot.
- [ ] Repeat the close/reopen cycle a few times to confirm the animation stays in sync.
- [ ] Chrome desktop at a narrow viewport (DevTools mobile emulation, ≤768px) — no regression in existing animation.
- [ ] `prefers-reduced-motion: reduce` still renders a static small dot (covered by the existing media query, unchanged).
- [ ] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx src/views/zero-page/__tests__/sidebar-mobile-indicator-stale.test.tsx` — should still pass (data-layer tests, unaffected by markup change).
- [ ] `pnpm -F @vm0/ui lint`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types` — clean.