### PR TITLE
test(sandbox-fc): cover oversized control frames

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -722,6 +722,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_frame_rejects_frames_larger_than_max_size() {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+
+        writer.write_u32(MAX_FRAME_SIZE + 1).await.unwrap();
+        drop(writer);
+
+        let err = read_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("frame too large"));
+    }
+
+    #[tokio::test]
     async fn protocol_round_trip() {
         let request = ExecRequest {
             command: "echo hello".into(),


### PR DESCRIPTION
## Summary

- Add an inline regression test for `read_frame` rejecting frame lengths above `MAX_FRAME_SIZE`
- Use `UnixStream::pair()` and only write the 4-byte oversized length prefix
- Drop the writer so a broken no-guard implementation fails instead of hanging in `read_exact`

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc read_frame_rejects_frames_larger_than_max_size`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc frame_round_trip`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::tests`
- `cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`

Closes #14639