### PR TITLE
refactor: migrate model-provider oauth to auth provider

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -35,11 +35,8 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
-import {
-  getConnectorOAuthSecretMetadata,
-  isOAuthRefreshProvider,
-} from "@vm0/connectors/oauth-providers";
-import { getModelProviderOAuthProvider } from "@vm0/connectors/oauth-providers/model-provider-registry";
+import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/oauth-providers";
+import { getModelProviderOAuthSecretMetadata } from "@vm0/connectors/oauth-providers/model-provider-registry";
 import {
   expandHostWildcardsInBaseUrl,
   extractSecretNamesFromApis,
@@ -854,12 +851,12 @@ function modelProviderRefreshMaps(
       >;
     }
   | undefined {
-  const provider = getModelProviderOAuthProvider(providerType);
-  if (!provider || !isOAuthRefreshProvider(provider)) {
+  const metadata = getModelProviderOAuthSecretMetadata(providerType);
+  if (!metadata?.isRefreshable) {
     return undefined;
   }
 
-  const accessSecretName = provider.getSecretName();
+  const accessSecretName = metadata.accessSecretName;
   const secretConnectorMap: Record<string, string> = {
     [accessSecretName]: providerType,
   };

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -11,14 +11,15 @@ import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
   getConnectorOAuthSecretMetadata,
   isOAuthConnectorType,
-  isOAuthRefreshProvider,
   refreshConnectorOAuthToken,
   type ProviderEnv,
 } from "@vm0/connectors/oauth-providers";
-import type { OAuthRefreshProvider } from "@vm0/connectors/oauth-providers/provider-types";
 import {
-  getModelProviderOAuthProvider,
+  getModelProviderOAuthSecretMetadata,
+  isModelProviderOAuthRefreshConfigured,
+  refreshModelProviderOAuthToken,
   isModelProviderOAuthProviderKey,
+  type ModelProviderOAuthProviderKey,
 } from "@vm0/connectors/oauth-providers/model-provider-registry";
 import { isChatgptRefreshError } from "@vm0/connectors/oauth-providers/providers/codex-oauth";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -160,8 +161,6 @@ interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
 interface RefreshTokenContext {
   readonly refreshTokenSecret: string;
   readonly currentRefreshToken: string;
-  readonly clientId?: string;
-  readonly clientSecret?: string;
   readonly accessTokenSecret: string;
   readonly secretUserId: string;
 }
@@ -175,7 +174,8 @@ type PreparedRefreshTokenContext =
     }
   | {
       readonly sourceType: "model-provider";
-      readonly provider: OAuthRefreshProvider;
+      readonly providerKey: ModelProviderOAuthProviderKey;
+      readonly currentEnv: ProviderEnv;
       readonly context: RefreshTokenContext;
     };
 
@@ -353,10 +353,8 @@ function getRefreshSecretNameForSource(
   sourceType: OAuthSecretSource,
 ): string | undefined {
   if (sourceType === "model-provider") {
-    const provider = getModelProviderOAuthProvider(connectorType);
-    return provider && isOAuthRefreshProvider(provider)
-      ? provider.getRefreshSecretName()
-      : undefined;
+    const metadata = getModelProviderOAuthSecretMetadata(connectorType);
+    return metadata?.isRefreshable ? metadata.refreshSecretName : undefined;
   }
 
   const metadata = getConnectorOAuthSecretMetadata(connectorType);
@@ -368,7 +366,7 @@ function getAccessSecretNameForSource(
   sourceType: OAuthSecretSource,
 ): string | undefined {
   if (sourceType === "model-provider") {
-    return getModelProviderOAuthProvider(connectorType)?.getSecretName();
+    return getModelProviderOAuthSecretMetadata(connectorType)?.accessSecretName;
   }
 
   return getConnectorOAuthSecretMetadata(connectorType)?.accessSecretName;
@@ -580,8 +578,13 @@ function prepareRefreshTokenContext(
   args: RefreshAccessTokenArgs,
 ): PreparedRefreshTokenContext | null {
   if (args.sourceType === "model-provider") {
-    const provider = getModelProviderOAuthProvider(args.connectorType);
-    if (!provider || !isOAuthRefreshProvider(provider)) {
+    if (!isModelProviderOAuthProviderKey(args.connectorType)) {
+      return null;
+    }
+    const secretMetadata = getModelProviderOAuthSecretMetadata(
+      args.connectorType,
+    );
+    if (!secretMetadata.isRefreshable) {
       return null;
     }
     if (!args.metadataKey) {
@@ -590,7 +593,7 @@ function prepareRefreshTokenContext(
       );
     }
 
-    const refreshTokenSecret = provider.getRefreshSecretName();
+    const refreshTokenSecret = secretMetadata.refreshSecretName;
     const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
     if (!currentRefreshToken) {
       L.debug(`No ${args.connectorType} refresh token available, skipping`);
@@ -598,8 +601,12 @@ function prepareRefreshTokenContext(
     }
 
     const env = currentProviderEnv();
-    const clientId = provider.getClientId(env);
-    if (!clientId) {
+    if (
+      !isModelProviderOAuthRefreshConfigured({
+        providerKey: args.connectorType,
+        currentEnv: env,
+      })
+    ) {
       L.debug(
         `${args.connectorType} OAuth client ID not configured, skipping token refresh`,
       );
@@ -609,9 +616,7 @@ function prepareRefreshTokenContext(
     const context: RefreshTokenContext = {
       refreshTokenSecret,
       currentRefreshToken,
-      clientId,
-      clientSecret: provider.getClientSecret(env),
-      accessTokenSecret: provider.getSecretName(),
+      accessTokenSecret: secretMetadata.accessSecretName,
       secretUserId: resolveSecretUserId(
         args.sourceType,
         args.userId,
@@ -621,7 +626,8 @@ function prepareRefreshTokenContext(
 
     return {
       sourceType: args.sourceType,
-      provider,
+      providerKey: args.connectorType,
+      currentEnv: env,
       context,
     };
   }
@@ -792,9 +798,9 @@ async function refreshConnectorAccessToken(
           credentials: prepared.credentials,
           refreshToken: prepared.context.currentRefreshToken,
         })
-      : prepared.provider.refreshToken({
-          clientId: prepared.context.clientId,
-          clientSecret: prepared.context.clientSecret,
+      : refreshModelProviderOAuthToken({
+          providerKey: prepared.providerKey,
+          currentEnv: prepared.currentEnv,
           refreshToken: prepared.context.currentRefreshToken,
         });
   const refreshResult = await settle(refreshPromise);

--- a/turbo/apps/web/src/lib/zero/__tests__/oauth-provider-key-bridge.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/oauth-provider-key-bridge.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
-  MODEL_PROVIDER_OAUTH_PROVIDERS,
-  getModelProviderOAuthProvider,
+  MODEL_PROVIDER_OAUTH_PROVIDER_KEYS,
+  getModelProviderOAuthSecretMetadata,
 } from "@vm0/connectors/oauth-providers/model-provider-registry";
-import { isOAuthRefreshProvider } from "@vm0/connectors/oauth-providers";
 import {
   OAUTH_PROVIDER_KEY_SOURCE_TYPE,
   MODEL_PROVIDER_OAUTH_PROVIDER_KEY,
@@ -54,14 +53,13 @@ describe("provider-key bridge tables stay in sync", () => {
     for (const providerKey of Object.values(
       MODEL_PROVIDER_OAUTH_PROVIDER_KEY,
     )) {
-      const provider = getModelProviderOAuthProvider(providerKey!);
-      expect(provider).toBeDefined();
-      expect(provider && isOAuthRefreshProvider(provider)).toBe(true);
+      const metadata = getModelProviderOAuthSecretMetadata(providerKey!);
+      expect(metadata?.isRefreshable).toBe(true);
     }
   });
 
   it("every registered model-provider OAuth provider is bridged", () => {
-    for (const providerKey of Object.keys(MODEL_PROVIDER_OAUTH_PROVIDERS)) {
+    for (const providerKey of MODEL_PROVIDER_OAUTH_PROVIDER_KEYS) {
       expect(OAUTH_PROVIDER_KEY_SOURCE_TYPE[providerKey]).toBe(
         "model-provider",
       );

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts
@@ -3,7 +3,7 @@ import { HttpResponse } from "msw";
 import { server } from "../../../../../mocks/server";
 import { http } from "../../../../../__tests__/msw";
 import { testContext } from "../../../../../__tests__/test-helpers";
-import { getModelProviderOAuthProvider } from "@vm0/connectors/oauth-providers/model-provider-registry";
+import { getModelProviderOAuthSecretMetadata } from "@vm0/connectors/oauth-providers/model-provider-registry";
 import {
   refreshChatgptToken,
   getChatgptSecretName,
@@ -17,6 +17,14 @@ const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const CODEX_PUBLIC_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 
 const context = testContext();
+
+function getCodexRefreshAccess() {
+  const access = codexOauthProvider.access;
+  if (access.kind !== "refresh-token") {
+    throw new Error("codexOauthProvider must expose refresh-token access");
+  }
+  return access;
+}
 
 describe("connector/providers/codex-oauth", () => {
   beforeEach(() => {
@@ -166,27 +174,28 @@ describe("connector/providers/codex-oauth", () => {
   });
 
   describe("codexOauthProvider", () => {
-    it("is registered as a model-provider refresh provider", () => {
-      expect(getModelProviderOAuthProvider("codex-oauth-token")).toBe(
-        codexOauthProvider,
-      );
+    it("is registered with model-provider refresh metadata", () => {
+      expect(
+        getModelProviderOAuthSecretMetadata("codex-oauth-token"),
+      ).toStrictEqual({
+        accessSecretName: "CHATGPT_ACCESS_TOKEN",
+        refreshSecretName: "CHATGPT_REFRESH_TOKEN",
+        isRefreshable: true,
+      });
     });
 
     it("does not expose browser authorize or code exchange helpers", () => {
-      expect("buildAuthUrl" in codexOauthProvider).toBe(false);
-      expect("exchangeCode" in codexOauthProvider).toBe(false);
+      expect(codexOauthProvider.grant.kind).toBe("none");
     });
 
     it("getClientId returns the Codex public client_id (used by refresh)", () => {
-      const env = {} as Parameters<typeof codexOauthProvider.getClientId>[0];
-      expect(codexOauthProvider.getClientId(env)).toBe(CODEX_PUBLIC_CLIENT_ID);
+      expect(getCodexRefreshAccess().getClientId({})).toBe(
+        CODEX_PUBLIC_CLIENT_ID,
+      );
     });
 
     it("getClientSecret returns undefined (PKCE-only)", () => {
-      const env = {} as Parameters<
-        typeof codexOauthProvider.getClientSecret
-      >[0];
-      expect(codexOauthProvider.getClientSecret(env)).toBeUndefined();
+      expect(getCodexRefreshAccess().getClientSecret({})).toBeUndefined();
     });
 
     it("returns documented secret names", () => {

--- a/turbo/apps/web/src/lib/zero/oauth-provider-key-bridge.ts
+++ b/turbo/apps/web/src/lib/zero/oauth-provider-key-bridge.ts
@@ -5,9 +5,8 @@ import { type ModelProviderType } from "@vm0/api-contracts/contracts/model-provi
  *
  * The model-provider type and OAuth provider key are intentionally distinct:
  * the model-provider type names the user-facing provider (e.g., the row in
- * `model_providers.type`), while the OAuth provider key names the OAuth
- * implementation in `MODEL_PROVIDER_OAUTH_PROVIDERS` that knows how to refresh
- * its tokens.
+ * `model_providers.type`), while the OAuth provider key names the registered
+ * model-provider OAuth implementation that knows how to refresh its tokens.
  *
  * Add an entry when a new model-provider OAuth type ships its provider.
  *

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -1,7 +1,22 @@
 import type { ConnectorType } from "../connectors";
 import type { ConnectorAuthProvider } from "./provider-types";
 
-export type ConnectorAuthSecretMetadata =
+type AuthProviderSecretAccess =
+  | {
+      readonly kind: "none";
+      getAccessSecretName(): string;
+    }
+  | {
+      readonly kind: "refresh-token";
+      getAccessSecretName(): string;
+      getRefreshSecretName(): string;
+    };
+
+type AuthProviderWithSecretMetadata = {
+  readonly access: AuthProviderSecretAccess;
+};
+
+export type AuthProviderSecretMetadata =
   | {
       readonly accessSecretName: string;
       readonly isRefreshable: false;
@@ -12,9 +27,11 @@ export type ConnectorAuthSecretMetadata =
       readonly isRefreshable: true;
     };
 
-export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
-  provider: ConnectorAuthProvider<T>,
-): ConnectorAuthSecretMetadata {
+export type ConnectorAuthSecretMetadata = AuthProviderSecretMetadata;
+
+export function getAuthProviderSecretMetadata(
+  provider: AuthProviderWithSecretMetadata,
+): AuthProviderSecretMetadata {
   const access = provider.access;
 
   switch (access.kind) {
@@ -31,4 +48,10 @@ export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
         isRefreshable: true,
       };
   }
+}
+
+export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
+  provider: ConnectorAuthProvider<T>,
+): ConnectorAuthSecretMetadata {
+  return getAuthProviderSecretMetadata(provider);
 }

--- a/turbo/packages/connectors/src/auth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-registry.ts
@@ -1,6 +1,3 @@
-import type { ConnectorType } from "../connectors";
-import type { ConnectorAuthProvider } from "./provider-types";
-
 type AuthProviderSecretAccess =
   | {
       readonly kind: "none";
@@ -27,8 +24,6 @@ export type AuthProviderSecretMetadata =
       readonly isRefreshable: true;
     };
 
-export type ConnectorAuthSecretMetadata = AuthProviderSecretMetadata;
-
 export function getAuthProviderSecretMetadata(
   provider: AuthProviderWithSecretMetadata,
 ): AuthProviderSecretMetadata {
@@ -48,10 +43,4 @@ export function getAuthProviderSecretMetadata(
         isRefreshable: true,
       };
   }
-}
-
-export function getConnectorAuthSecretMetadata<T extends ConnectorType>(
-  provider: ConnectorAuthProvider<T>,
-): ConnectorAuthSecretMetadata {
-  return getAuthProviderSecretMetadata(provider);
 }

--- a/turbo/packages/connectors/src/auth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-types.ts
@@ -1,5 +1,4 @@
 import type {
-  ConnectorType,
   OAuthAuthCodeConnectorType,
   OAuthConnectorType,
   OAuthDeviceAuthConnectorType,
@@ -43,13 +42,6 @@ export interface DeviceAuthGrantProvider<
   ): Promise<OAuthDeviceAuthPollResult>;
 }
 
-export type ConnectorGrantProvider<T extends ConnectorType> =
-  T extends OAuthAuthCodeConnectorType
-    ? AuthCodeGrantProvider<T>
-    : T extends OAuthDeviceAuthConnectorType
-      ? DeviceAuthGrantProvider<T>
-      : NoneGrantProvider;
-
 export interface NoneAccessProvider {
   readonly kind: "none";
   getAccessSecretName(): string;
@@ -66,11 +58,6 @@ export type OAuthConnectorAccessProvider<T extends OAuthConnectorType> =
   | NoneAccessProvider
   | RefreshTokenAccessProvider<T>;
 
-export type ConnectorAccessProvider<T extends ConnectorType> =
-  T extends OAuthConnectorType
-    ? OAuthConnectorAccessProvider<T>
-    : NoneAccessProvider;
-
 interface NoneRevokeProvider {
   readonly kind: "none";
 }
@@ -83,11 +70,6 @@ interface TokenRevokeProvider<T extends OAuthConnectorType> {
 export type OAuthConnectorRevokeProvider<T extends OAuthConnectorType> =
   | NoneRevokeProvider
   | TokenRevokeProvider<T>;
-
-export type ConnectorRevokeProvider<T extends ConnectorType> =
-  T extends OAuthConnectorType
-    ? OAuthConnectorRevokeProvider<T>
-    : NoneRevokeProvider;
 
 export interface AuthProvider<TGrant, TAccess, TRevoke> {
   readonly grant: TGrant;
@@ -109,12 +91,6 @@ export type DeviceAuthConnectorAuthProvider<
   DeviceAuthGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,
   OAuthConnectorRevokeProvider<T>
->;
-
-export type ConnectorAuthProvider<T extends ConnectorType> = AuthProvider<
-  ConnectorGrantProvider<T>,
-  ConnectorAccessProvider<T>,
-  ConnectorRevokeProvider<T>
 >;
 
 export type ModelProviderGrantProvider = NoneGrantProvider;

--- a/turbo/packages/connectors/src/auth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-types.ts
@@ -16,6 +16,7 @@ import type {
   OAuthDeviceAuthStartResult,
   OAuthRefreshResult,
   OAuthTokenResult,
+  ProviderEnv,
 } from "../oauth-providers/provider-types";
 
 interface NoneGrantProvider {
@@ -114,4 +115,35 @@ export type ConnectorAuthProvider<T extends ConnectorType> = AuthProvider<
   ConnectorGrantProvider<T>,
   ConnectorAccessProvider<T>,
   ConnectorRevokeProvider<T>
+>;
+
+export type ModelProviderGrantProvider = NoneGrantProvider;
+
+interface ModelProviderOAuthRefreshArgs {
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly refreshToken: string;
+}
+
+interface ModelProviderRefreshTokenAccessProvider {
+  readonly kind: "refresh-token";
+  getAccessSecretName(): string;
+  getRefreshSecretName(): string;
+  getClientId(currentEnv: ProviderEnv): string | undefined;
+  getClientSecret(currentEnv: ProviderEnv): string | undefined;
+  refreshToken(
+    args: ModelProviderOAuthRefreshArgs,
+  ): Promise<OAuthRefreshResult>;
+}
+
+export type ModelProviderAccessProvider =
+  | NoneAccessProvider
+  | ModelProviderRefreshTokenAccessProvider;
+
+export type ModelProviderRevokeProvider = NoneRevokeProvider;
+
+export type ModelProviderAuthProvider = AuthProvider<
+  ModelProviderGrantProvider,
+  ModelProviderAccessProvider,
+  ModelProviderRevokeProvider
 >;

--- a/turbo/packages/connectors/src/oauth-providers/model-provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/model-provider-registry.ts
@@ -1,21 +1,27 @@
-import type {
-  OAuthAuthCodeProvider,
-  OAuthRefreshProvider,
-} from "./provider-types";
+import {
+  getAuthProviderSecretMetadata,
+  type AuthProviderSecretMetadata,
+} from "../auth-providers/provider-registry";
+import type { ModelProviderAuthProvider } from "../auth-providers/provider-types";
+import type { OAuthRefreshResult, ProviderEnv } from "./provider-types";
 import { codexOauthProvider } from "./providers/codex-oauth-provider";
 
-export const MODEL_PROVIDER_OAUTH_PROVIDERS = {
-  "codex-oauth-token": codexOauthProvider,
-} as const satisfies Record<
-  string,
-  OAuthAuthCodeProvider | OAuthRefreshProvider
->;
+export const MODEL_PROVIDER_OAUTH_PROVIDER_KEYS = [
+  "codex-oauth-token",
+] as const;
 
 export type ModelProviderOAuthProviderKey =
-  keyof typeof MODEL_PROVIDER_OAUTH_PROVIDERS;
+  (typeof MODEL_PROVIDER_OAUTH_PROVIDER_KEYS)[number];
 
-export type ModelProviderOAuthProvider =
-  (typeof MODEL_PROVIDER_OAUTH_PROVIDERS)[ModelProviderOAuthProviderKey];
+type ModelProviderOAuthProviderMap = {
+  readonly [Key in ModelProviderOAuthProviderKey]: ModelProviderAuthProvider;
+};
+
+const MODEL_PROVIDER_OAUTH_PROVIDERS = {
+  "codex-oauth-token": codexOauthProvider,
+} as const satisfies ModelProviderOAuthProviderMap;
+
+export type ModelProviderOAuthSecretMetadata = AuthProviderSecretMetadata;
 
 export function isModelProviderOAuthProviderKey(
   providerKey: string,
@@ -23,11 +29,69 @@ export function isModelProviderOAuthProviderKey(
   return Object.hasOwn(MODEL_PROVIDER_OAUTH_PROVIDERS, providerKey);
 }
 
-export function getModelProviderOAuthProvider(
+function modelProviderOAuthProviderFor(
+  providerKey: ModelProviderOAuthProviderKey,
+): ModelProviderAuthProvider {
+  return MODEL_PROVIDER_OAUTH_PROVIDERS[providerKey];
+}
+
+export function getModelProviderOAuthSecretMetadata(
+  providerKey: ModelProviderOAuthProviderKey,
+): ModelProviderOAuthSecretMetadata;
+export function getModelProviderOAuthSecretMetadata(
   providerKey: string,
-): ModelProviderOAuthProvider | undefined {
+): ModelProviderOAuthSecretMetadata | undefined;
+export function getModelProviderOAuthSecretMetadata(
+  providerKey: string,
+): ModelProviderOAuthSecretMetadata | undefined {
   if (!isModelProviderOAuthProviderKey(providerKey)) {
     return undefined;
   }
-  return MODEL_PROVIDER_OAUTH_PROVIDERS[providerKey];
+
+  return getAuthProviderSecretMetadata(
+    modelProviderOAuthProviderFor(providerKey),
+  );
+}
+
+export function isModelProviderOAuthRefreshConfigured(args: {
+  readonly providerKey: ModelProviderOAuthProviderKey;
+  readonly currentEnv: ProviderEnv;
+}): boolean {
+  const access = modelProviderOAuthProviderFor(args.providerKey).access;
+
+  switch (access.kind) {
+    case "none":
+      return false;
+
+    case "refresh-token":
+      return Boolean(access.getClientId(args.currentEnv));
+  }
+}
+
+export async function refreshModelProviderOAuthToken(args: {
+  readonly providerKey: ModelProviderOAuthProviderKey;
+  readonly currentEnv: ProviderEnv;
+  readonly refreshToken: string;
+}): Promise<OAuthRefreshResult> {
+  const access = modelProviderOAuthProviderFor(args.providerKey).access;
+
+  switch (access.kind) {
+    case "none":
+      throw new Error(
+        `${args.providerKey} OAuth provider does not support refresh`,
+      );
+
+    case "refresh-token": {
+      const clientId = access.getClientId(args.currentEnv);
+      if (!clientId) {
+        throw new Error(`${args.providerKey} OAuth client ID not configured`);
+      }
+
+      return await access.refreshToken({
+        clientId,
+        clientSecret: access.getClientSecret(args.currentEnv),
+        refreshToken: args.refreshToken,
+      });
+    }
+  }
 }

--- a/turbo/packages/connectors/src/oauth-providers/model-provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/model-provider-registry.ts
@@ -29,12 +29,6 @@ export function isModelProviderOAuthProviderKey(
   return Object.hasOwn(MODEL_PROVIDER_OAUTH_PROVIDERS, providerKey);
 }
 
-function modelProviderOAuthProviderFor(
-  providerKey: ModelProviderOAuthProviderKey,
-): ModelProviderAuthProvider {
-  return MODEL_PROVIDER_OAUTH_PROVIDERS[providerKey];
-}
-
 export function getModelProviderOAuthSecretMetadata(
   providerKey: ModelProviderOAuthProviderKey,
 ): ModelProviderOAuthSecretMetadata;
@@ -49,7 +43,7 @@ export function getModelProviderOAuthSecretMetadata(
   }
 
   return getAuthProviderSecretMetadata(
-    modelProviderOAuthProviderFor(providerKey),
+    MODEL_PROVIDER_OAUTH_PROVIDERS[providerKey],
   );
 }
 
@@ -57,7 +51,7 @@ export function isModelProviderOAuthRefreshConfigured(args: {
   readonly providerKey: ModelProviderOAuthProviderKey;
   readonly currentEnv: ProviderEnv;
 }): boolean {
-  const access = modelProviderOAuthProviderFor(args.providerKey).access;
+  const access = MODEL_PROVIDER_OAUTH_PROVIDERS[args.providerKey].access;
 
   switch (access.kind) {
     case "none":
@@ -73,7 +67,7 @@ export async function refreshModelProviderOAuthToken(args: {
   readonly currentEnv: ProviderEnv;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  const access = modelProviderOAuthProviderFor(args.providerKey).access;
+  const access = MODEL_PROVIDER_OAUTH_PROVIDERS[args.providerKey].access;
 
   switch (access.kind) {
     case "none":

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -37,7 +37,6 @@ import {
   type OAuthRefreshArgs,
   type OAuthRefreshResult,
   providerEnvFromObject,
-  isOAuthRefreshProvider,
   type OAuthTokenResult,
   type ProviderEnv,
 } from "./provider-types";
@@ -102,7 +101,7 @@ export type {
   OAuthTokenResult,
 };
 export type { ProviderEnv };
-export { providerEnvFromObject, isOAuthRefreshProvider };
+export { providerEnvFromObject };
 
 type AuthCodeConnectorOAuthProviderMap = {
   readonly [Type in OAuthAuthCodeConnectorType]: AuthCodeConnectorAuthProvider<Type>;

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -13,8 +13,8 @@ import {
   type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import {
-  getConnectorAuthSecretMetadata,
-  type ConnectorAuthSecretMetadata,
+  getAuthProviderSecretMetadata,
+  type AuthProviderSecretMetadata,
 } from "../auth-providers/provider-registry";
 import type {
   AuthCodeConnectorAuthProvider,
@@ -111,7 +111,7 @@ type DeviceAuthConnectorOAuthProviderMap = {
   readonly [Type in OAuthDeviceAuthConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
-export type ConnectorOAuthSecretMetadata = ConnectorAuthSecretMetadata;
+export type ConnectorOAuthSecretMetadata = AuthProviderSecretMetadata;
 
 function deviceAuthConnectorProviderFor<T extends OAuthDeviceAuthConnectorType>(
   type: T,
@@ -230,12 +230,12 @@ export function getConnectorOAuthSecretMetadata(
   }
 
   if (isOAuthAuthCodeConnectorType(type)) {
-    return getConnectorAuthSecretMetadata(
+    return getAuthProviderSecretMetadata(
       AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type],
     );
   }
 
-  return getConnectorAuthSecretMetadata(
+  return getAuthProviderSecretMetadata(
     DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type],
   );
 }

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -85,9 +85,6 @@ export type OAuthExchangeArgs = OAuthExchangeFlowArgs &
 export type OAuthRefreshArgs = OAuthRefreshFlowArgs &
   OptionalClientCredentialArgs;
 
-export type OAuthRevokeArgs = OAuthRevokeFlowArgs &
-  OptionalClientCredentialArgs;
-
 export type OAuthDeviceAuthStartArgs = OAuthDeviceAuthStartFlowArgs &
   OptionalClientCredentialArgs;
 
@@ -149,28 +146,6 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-export type BuildAuthUrlFn = (
-  args: OAuthAuthorizeArgs,
-) => string | AuthUrlResult | Promise<string | AuthUrlResult>;
-
-export type ExchangeCodeFn = (
-  args: OAuthExchangeArgs,
-) => Promise<OAuthTokenResult>;
-
-export type RefreshTokenFn = (
-  args: OAuthRefreshArgs,
-) => Promise<OAuthRefreshResult>;
-
-export type RevokeTokenFn = (args: OAuthRevokeArgs) => Promise<void>;
-
-export type StartDeviceAuthFn = (
-  args: OAuthDeviceAuthStartArgs,
-) => Promise<OAuthDeviceAuthStartResult>;
-
-export type PollDeviceAuthFn = (
-  args: OAuthDeviceAuthPollArgs,
-) => Promise<OAuthDeviceAuthPollResult>;
-
 type ConnectorOAuthClientFor<T extends OAuthConnectorType> =
   (typeof CONNECTOR_TYPES)[T]["oauth"]["client"];
 
@@ -215,45 +190,3 @@ export type ConnectorOAuthDeviceAuthPollArgs<
   T extends OAuthDeviceAuthConnectorType,
 > = OAuthDeviceAuthPollFlowArgs &
   TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
-
-export interface OAuthProviderMetadata {
-  getSecretName(): string;
-}
-
-export interface OAuthProvider extends OAuthProviderMetadata {
-  getClientId(currentEnv: ProviderEnv): string | undefined;
-  getClientSecret(currentEnv: ProviderEnv): string | undefined;
-}
-
-export type OAuthAuthCodeProvider = OAuthProvider & {
-  buildAuthUrl: BuildAuthUrlFn;
-  exchangeCode: ExchangeCodeFn;
-};
-
-export type OAuthDeviceAuthProvider = OAuthProvider & {
-  startDeviceAuth: StartDeviceAuthFn;
-  pollDeviceAuth: PollDeviceAuthFn;
-};
-
-export type OAuthRefreshProvider = OAuthProvider & {
-  getRefreshSecretName(): string;
-  refreshToken: RefreshTokenFn;
-};
-
-export type OAuthRevocationProvider = OAuthProvider & {
-  revokeToken: RevokeTokenFn;
-};
-
-export function isOAuthRefreshProvider(
-  provider: OAuthProviderMetadata,
-): provider is OAuthProviderMetadata & {
-  getRefreshSecretName(): string;
-  refreshToken: RefreshTokenFn;
-} {
-  return (
-    "getRefreshSecretName" in provider &&
-    typeof provider.getRefreshSecretName === "function" &&
-    "refreshToken" in provider &&
-    typeof provider.refreshToken === "function"
-  );
-}

--- a/turbo/packages/connectors/src/oauth-providers/providers/codex-oauth-provider.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/codex-oauth-provider.ts
@@ -1,4 +1,4 @@
-import { type OAuthRefreshProvider } from "../provider-types";
+import { type ModelProviderAuthProvider } from "../../auth-providers/provider-types";
 import {
   CHATGPT_OAUTH_CLIENT_ID,
   getChatgptRefreshSecretName,
@@ -12,20 +12,29 @@ import {
  * Browser OAuth setup is not supported. Users connect by pasting auth.json;
  * this provider only keeps the derived ChatGPT access token fresh server-side.
  */
-export const codexOauthProvider: OAuthRefreshProvider = {
-  refreshToken: (args) => {
-    return refreshChatgptToken(
-      args.clientId ?? CHATGPT_OAUTH_CLIENT_ID,
-      args.clientSecret ?? "",
-      args.refreshToken,
-    );
+export const codexOauthProvider: ModelProviderAuthProvider = {
+  grant: {
+    kind: "none",
   },
-  getClientId: () => {
-    return CHATGPT_OAUTH_CLIENT_ID;
+  access: {
+    kind: "refresh-token",
+    getAccessSecretName: getChatgptSecretName,
+    getRefreshSecretName: getChatgptRefreshSecretName,
+    getClientId: () => {
+      return CHATGPT_OAUTH_CLIENT_ID;
+    },
+    getClientSecret: () => {
+      return undefined;
+    },
+    refreshToken: (args) => {
+      return refreshChatgptToken(
+        args.clientId ?? CHATGPT_OAUTH_CLIENT_ID,
+        args.clientSecret ?? "",
+        args.refreshToken,
+      );
+    },
   },
-  getClientSecret: () => {
-    return undefined;
+  revoke: {
+    kind: "none",
   },
-  getSecretName: getChatgptSecretName,
-  getRefreshSecretName: getChatgptRefreshSecretName,
 };


### PR DESCRIPTION
## Summary
- Convert model-provider OAuth providers to the shared AuthProvider grant/access/revoke shape
- Add model-provider OAuth metadata and refresh wrappers, and route API refresh code through them
- Remove the old flat OAuthProvider/OAuthRefreshProvider model-provider types and update Codex OAuth tests

Closes #14651

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors test
- pnpm -F web exec vitest run src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts src/lib/zero/__tests__/oauth-provider-key-bridge.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm check-types
- pnpm turbo run lint --concurrency=1
- pnpm knip