### PR TITLE
refactor: route connector oauth revocation through registry

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -625,6 +625,48 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     );
     expect(revokeBody).toContain('"access_token":"gh-access-token"');
   });
+
+  it("skips provider revoke for OAuth connectors without revoke support", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    const db = store.set(writeDb$);
+    const [connector] = await db
+      .insert(connectors)
+      .values({ orgId, userId, type: "notion", authMethod: "oauth" })
+      .returning({ id: connectors.id });
+    expect(connector).toBeDefined();
+    await db.insert(secrets).values({
+      orgId,
+      userId,
+      name: "NOTION_ACCESS_TOKEN",
+      type: "connector",
+      encryptedValue: "invalid-encrypted-token",
+    });
+
+    let revokeCalled = false;
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/revoke", () => {
+        revokeCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    mocks.clerk.session(userId, orgId);
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(authorizeUrl("notion"), {
+      method: "GET",
+      headers: sessionHeaders(),
+    });
+
+    expect(response.status).toBe(307);
+    expect(revokeCalled).toBeFalsy();
+    const survivors = await db
+      .select()
+      .from(connectors)
+      .where(eq(connectors.id, connector!.id));
+    expect(survivors).toHaveLength(0);
+  });
 });
 
 describe("POST /api/zero/connectors/:type/oauth/start", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -9,7 +9,7 @@ import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -666,6 +666,18 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
       .from(connectors)
       .where(eq(connectors.id, connector!.id));
     expect(survivors).toHaveLength(0);
+    const secretSurvivors = await db
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, orgId),
+          eq(secrets.userId, userId),
+          eq(secrets.name, "NOTION_ACCESS_TOKEN"),
+          eq(secrets.type, "connector"),
+        ),
+      );
+    expect(secretSurvivors).toHaveLength(0);
   });
 });
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -448,17 +448,16 @@ async function revokeExistingConnectorToken(args: {
 
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
-    (async (): Promise<void> => {
-      const accessToken = await decryptStoredSecretValue(
-        accessTokenSecret.encryptedValue,
-        args.featureSwitchContext,
-      );
-      await revokeConnectorOAuthToken({
-        type: connectorType,
-        credentials,
-        accessToken,
-      });
-    })(),
+    revokeConnectorOAuthToken({
+      type: connectorType,
+      credentials,
+      loadAccessToken: () => {
+        return decryptStoredSecretValue(
+          accessTokenSecret.encryptedValue,
+          args.featureSwitchContext,
+        );
+      },
+    }),
   );
   args.signal.throwIfAborted();
 }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -9,14 +9,18 @@ import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
   getAvailableConnectorAuthMethods,
-  getConnectorOAuthEnvKeys,
+  getConnectorOAuthCredentials,
   getConnectorProvidedSecretNames,
   getConnectorSecretNames,
   getRuntimeAvailableConnectorTypes,
   getScopeDiff,
   isConnectorAuthMethodAvailable,
 } from "@vm0/connectors/connector-utils";
-import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/oauth-providers";
+import {
+  getConnectorOAuthSecretMetadata,
+  isOAuthConnectorType,
+  revokeConnectorOAuthToken,
+} from "@vm0/connectors/oauth-providers";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -403,99 +407,6 @@ export function zeroConnectorByType(args: {
   });
 }
 
-function revocableConnectorAccessTokenName(
-  type: ConnectorType,
-): string | undefined {
-  switch (type) {
-    case "github": {
-      return "GITHUB_ACCESS_TOKEN";
-    }
-    case "linear": {
-      return "LINEAR_ACCESS_TOKEN";
-    }
-    case "slack": {
-      return "SLACK_ACCESS_TOKEN";
-    }
-    default: {
-      return undefined;
-    }
-  }
-}
-
-async function revokeConnectorToken(args: {
-  readonly type: ConnectorType;
-  readonly accessToken: string;
-}): Promise<void> {
-  const envKeys = getConnectorOAuthEnvKeys(args.type);
-  const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
-  const clientSecret = envKeys?.clientSecret
-    ? optionalEnv(envKeys.clientSecret)
-    : undefined;
-  if (!clientId || !clientSecret) {
-    return;
-  }
-
-  if (args.type === "github") {
-    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
-      "base64",
-    );
-    const response = await fetch(
-      `https://api.github.com/applications/${clientId}/grant`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${credentials}`,
-          Accept: "application/vnd.github+json",
-          "Content-Type": "application/json",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-        body: JSON.stringify({ access_token: args.accessToken }),
-      },
-    );
-    if (!response.ok) {
-      throw new Error(`GitHub grant revocation failed: ${response.status}`);
-    }
-    return;
-  }
-
-  if (args.type === "slack") {
-    const response = await fetch("https://slack.com/api/auth.revoke", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${args.accessToken}`,
-      },
-    });
-    if (!response.ok) {
-      throw new Error(`Slack token revocation failed: ${response.status}`);
-    }
-    const data = (await response.json()) as { ok: boolean; error?: string };
-    if (!data.ok) {
-      throw new Error(data.error ?? "Slack token revocation returned ok=false");
-    }
-    return;
-  }
-
-  if (args.type === "linear") {
-    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
-      "base64",
-    );
-    const response = await fetch("https://api.linear.app/oauth/revoke", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: `Basic ${credentials}`,
-      },
-      body: new URLSearchParams({
-        token: args.accessToken,
-        token_type_hint: "access_token",
-      }),
-    });
-    if (!response.ok) {
-      throw new Error(`Linear token revocation failed: ${response.status}`);
-    }
-  }
-}
-
 async function revokeExistingConnectorToken(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -504,10 +415,13 @@ async function revokeExistingConnectorToken(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<void> {
-  const accessTokenName = revocableConnectorAccessTokenName(args.type);
-  if (!accessTokenName) {
+  if (!isOAuthConnectorType(args.type)) {
     return;
   }
+
+  const connectorType = args.type;
+  const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
+  const accessTokenName = secretMetadata.accessSecretName;
 
   const [accessTokenSecret] = await args.db
     .select({ encryptedValue: secrets.encryptedValue })
@@ -527,15 +441,24 @@ async function revokeExistingConnectorToken(args: {
     return;
   }
 
+  const credentials = getConnectorOAuthCredentials(connectorType, optionalEnv);
+  if (!credentials) {
+    return;
+  }
+
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
-    revokeConnectorToken({
-      type: args.type,
-      accessToken: await decryptStoredSecretValue(
+    (async (): Promise<void> => {
+      const accessToken = await decryptStoredSecretValue(
         accessTokenSecret.encryptedValue,
         args.featureSwitchContext,
-      ),
-    }),
+      );
+      await revokeConnectorOAuthToken({
+        type: connectorType,
+        credentials,
+        accessToken,
+      });
+    })(),
   );
   args.signal.throwIfAborted();
 }

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -39,6 +39,7 @@ import {
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
   refreshConnectorOAuthToken,
+  revokeConnectorOAuthToken,
   startConnectorOAuthDeviceAuth,
 } from "../oauth-providers/provider-registry";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../oauth-providers/google-oauth-connectors";
@@ -257,6 +258,92 @@ describe("isOAuthConnectorType", () => {
         refreshToken: "refresh-token",
       }),
     ).rejects.toThrow("github OAuth provider does not support refresh");
+  });
+
+  it("revokes OAuth tokens through the provider registry", async () => {
+    const credentials = getConnectorOAuthCredentials("github", (name) => {
+      if (name === "GH_OAUTH_CLIENT_ID") {
+        return "test-github-client";
+      }
+      if (name === "GH_OAUTH_CLIENT_SECRET") {
+        return "test-github-secret";
+      }
+      return undefined;
+    });
+    expect(credentials?.configured).toBe(true);
+
+    if (!credentials?.configured) {
+      throw new Error("Expected github OAuth credentials");
+    }
+
+    let authorization: string | null = null;
+    let body = "";
+    server.use(
+      http.delete(
+        "https://api.github.com/applications/test-github-client/grant",
+        async ({ request }) => {
+          authorization = request.headers.get("authorization");
+          body = await request.text();
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await expect(
+      revokeConnectorOAuthToken({
+        type: "github",
+        credentials,
+        accessToken: "gh-access-token",
+      }),
+    ).resolves.toStrictEqual({ status: "revoked" });
+    expect(authorization).toBe(
+      `Basic ${btoa("test-github-client:test-github-secret")}`,
+    );
+    expect(body).toBe(JSON.stringify({ access_token: "gh-access-token" }));
+  });
+
+  it("returns unsupported for OAuth connectors without revoke support", async () => {
+    const credentials = getConnectorOAuthCredentials("notion", (name) => {
+      if (name === "NOTION_OAUTH_CLIENT_ID") {
+        return "test-notion-client";
+      }
+      if (name === "NOTION_OAUTH_CLIENT_SECRET") {
+        return "test-notion-secret";
+      }
+      return undefined;
+    });
+    expect(credentials?.configured).toBe(true);
+
+    if (!credentials?.configured) {
+      throw new Error("Expected notion OAuth credentials");
+    }
+
+    await expect(
+      revokeConnectorOAuthToken({
+        type: "notion",
+        credentials,
+        accessToken: "notion-access-token",
+      }),
+    ).resolves.toStrictEqual({ status: "unsupported" });
+  });
+
+  it("returns unconfigured when OAuth credentials are unavailable for revoke", async () => {
+    const credentials = getConnectorOAuthCredentials("github", () => {
+      return undefined;
+    });
+    expect(credentials?.configured).toBe(false);
+
+    if (!credentials) {
+      throw new Error("Expected github OAuth credentials shape");
+    }
+
+    await expect(
+      revokeConnectorOAuthToken({
+        type: "github",
+        credentials,
+        accessToken: "gh-access-token",
+      }),
+    ).resolves.toStrictEqual({ status: "unconfigured" });
   });
 
   it("builds the expected authorization URL base for every OAuth provider", async () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -293,7 +293,9 @@ describe("isOAuthConnectorType", () => {
       revokeConnectorOAuthToken({
         type: "github",
         credentials,
-        accessToken: "gh-access-token",
+        loadAccessToken: () => {
+          return "gh-access-token";
+        },
       }),
     ).resolves.toStrictEqual({ status: "revoked" });
     expect(authorization).toBe(
@@ -318,13 +320,19 @@ describe("isOAuthConnectorType", () => {
       throw new Error("Expected notion OAuth credentials");
     }
 
+    let loadedAccessToken = false;
+
     await expect(
       revokeConnectorOAuthToken({
         type: "notion",
         credentials,
-        accessToken: "notion-access-token",
+        loadAccessToken: () => {
+          loadedAccessToken = true;
+          return "notion-access-token";
+        },
       }),
     ).resolves.toStrictEqual({ status: "unsupported" });
+    expect(loadedAccessToken).toBe(false);
   });
 
   it("returns unconfigured when OAuth credentials are unavailable for revoke", async () => {
@@ -337,13 +345,19 @@ describe("isOAuthConnectorType", () => {
       throw new Error("Expected github OAuth credentials shape");
     }
 
+    let loadedAccessToken = false;
+
     await expect(
       revokeConnectorOAuthToken({
         type: "github",
         credentials,
-        accessToken: "gh-access-token",
+        loadAccessToken: () => {
+          loadedAccessToken = true;
+          return "gh-access-token";
+        },
       }),
     ).resolves.toStrictEqual({ status: "unconfigured" });
+    expect(loadedAccessToken).toBe(false);
   });
 
   it("builds the expected authorization URL base for every OAuth provider", async () => {

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -20,6 +20,7 @@ import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
   OAuthConnectorAccessProvider,
+  OAuthConnectorRevokeProvider,
 } from "../auth-providers/provider-types";
 import {
   type AuthUrlResult,
@@ -28,6 +29,7 @@ import {
   type ConnectorOAuthDeviceAuthStartArgs,
   type ConnectorOAuthExchangeArgs,
   type ConnectorOAuthRefreshArgs,
+  type ConnectorOAuthRevokeArgs,
   type OAuthAuthorizeArgs,
   type OAuthDeviceAuthPollArgs,
   type OAuthDeviceAuthPollResult,
@@ -103,6 +105,11 @@ export type {
 export type { ProviderEnv };
 export { providerEnvFromObject };
 
+export type ConnectorOAuthRevokeResult =
+  | { readonly status: "revoked" }
+  | { readonly status: "unsupported" }
+  | { readonly status: "unconfigured" };
+
 type AuthCodeConnectorOAuthProviderMap = {
   readonly [Type in OAuthAuthCodeConnectorType]: AuthCodeConnectorAuthProvider<Type>;
 };
@@ -127,6 +134,16 @@ function connectorAccessProviderFor<T extends OAuthConnectorType>(
   }
 
   return deviceAuthConnectorProviderFor(type).access;
+}
+
+function connectorRevokeProviderFor<T extends OAuthConnectorType>(
+  type: T,
+): OAuthConnectorRevokeProvider<T> {
+  if (isOAuthAuthCodeConnectorType(type)) {
+    return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type].revoke;
+  }
+
+  return deviceAuthConnectorProviderFor(type).revoke;
 }
 
 function connectorCredentialArgs(
@@ -333,6 +350,32 @@ export async function refreshConnectorOAuthToken<
         ...connectorCredentialArgs(args.credentials),
         refreshToken: args.refreshToken,
       } as ConnectorOAuthRefreshArgs<T>);
+  }
+}
+
+export async function revokeConnectorOAuthToken<
+  T extends OAuthConnectorType,
+>(args: {
+  readonly type: T;
+  readonly credentials: ConnectorOAuthCredentials;
+  readonly accessToken: string;
+}): Promise<ConnectorOAuthRevokeResult> {
+  if (!args.credentials.configured) {
+    return { status: "unconfigured" };
+  }
+
+  const revoke = connectorRevokeProviderFor(args.type);
+
+  switch (revoke.kind) {
+    case "none":
+      return { status: "unsupported" };
+
+    case "token-revoke":
+      await revoke.revokeToken({
+        ...connectorCredentialArgs(args.credentials),
+        accessToken: args.accessToken,
+      } as ConnectorOAuthRevokeArgs<T>);
+      return { status: "revoked" };
   }
 }
 

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -358,7 +358,7 @@ export async function revokeConnectorOAuthToken<
 >(args: {
   readonly type: T;
   readonly credentials: ConnectorOAuthCredentials;
-  readonly accessToken: string;
+  readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorOAuthRevokeResult> {
   if (!args.credentials.configured) {
     return { status: "unconfigured" };
@@ -373,7 +373,7 @@ export async function revokeConnectorOAuthToken<
     case "token-revoke":
       await revoke.revokeToken({
         ...connectorCredentialArgs(args.credentials),
-        accessToken: args.accessToken,
+        accessToken: await args.loadAccessToken(),
       } as ConnectorOAuthRevokeArgs<T>);
       return { status: "revoked" };
   }


### PR DESCRIPTION
## Summary

- Add `revokeConnectorOAuthToken` as the connector OAuth provider-registry revoke boundary with `revoked`, `unsupported`, and `unconfigured` outcomes.
- Route connector cleanup through the registry wrapper and remove duplicated GitHub/Slack/Linear revoke HTTP logic from the API service.
- Add provider-registry revoke coverage plus route-level coverage for non-revocable OAuth cleanup.

## Tests

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm turbo run lint --concurrency=1`
- `pnpm knip`

`pnpm vitest` was also run and failed in unrelated app timezone coverage: `src/views/zero-page/__tests__/schedule-dialog.test.tsx > renders timezone select and reflects selection change` expected `Eastern Time (ET)` but received `(GMT+09:00) Korea Standard Time (KST)`. The same targeted test failed when run alone.

Closes #14661
