### PR TITLE
feat(models): rename Reasoning filter tab to LLM

### DIFF
--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -3873,7 +3873,7 @@
     "heroDescription": "Jedes Modell, das deinen Agents zur Verfügung steht. Was es gut kann und wann du es wählen solltest.",
     "filterAriaLabel": "Modelle filtern",
     "filterAll": "Alle",
-    "filterReasoning": "Reasoning",
+    "filterReasoning": "LLM",
     "filterImage": "Bilder",
     "filterVideo": "Video",
     "readMoreAbout": "Mehr über {name}",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -3874,7 +3874,7 @@
     "heroDescription": "Every model available to your agents. What it's good at, and when to pick it.",
     "filterAriaLabel": "Filter models",
     "filterAll": "All",
-    "filterReasoning": "Reasoning",
+    "filterReasoning": "LLM",
     "filterImage": "Image",
     "filterVideo": "Video",
     "readMoreAbout": "Read more about {name}",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -3873,7 +3873,7 @@
     "heroDescription": "Cada modelo disponible para tus agentes. En qué destaca y cuándo elegirlo.",
     "filterAriaLabel": "Filtrar modelos",
     "filterAll": "Todos",
-    "filterReasoning": "Reasoning",
+    "filterReasoning": "LLM",
     "filterImage": "Imagen",
     "filterVideo": "Vídeo",
     "readMoreAbout": "Más sobre {name}",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -3873,7 +3873,7 @@
     "heroDescription": "エージェントが利用できるすべてのモデル。各モデルの得意分野と選択のタイミング。",
     "filterAriaLabel": "モデルを絞り込む",
     "filterAll": "すべて",
-    "filterReasoning": "推論",
+    "filterReasoning": "LLM",
     "filterImage": "画像",
     "filterVideo": "動画",
     "readMoreAbout": "{name}の詳細を見る",


### PR DESCRIPTION
## Summary
- On the public `/models` page, rename the filter tab from **Reasoning** to **LLM** across en/ja/de/es.
- Label-only change: internal `"reasoning"` category key and filter routing in `ModelsClient.tsx` / `data.ts` are unchanged.

## Test plan
- [ ] Visit `/models` in each locale (en, ja, de, es) and confirm the tab reads **LLM**
- [ ] Click the LLM tab and confirm the same set of models is shown as before