### PR TITLE
feat(web): replace marketing model CTA with onboarding prompt deep-link

### DIFF
--- a/turbo/apps/web/app/[locale]/models/[slug]/ModelDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/models/[slug]/ModelDetailClient.tsx
@@ -10,6 +10,7 @@ import {
   MODELS,
   type GenerationPricingUnit,
   type ModelEntry,
+  getModelCtaUrl,
   isReasoningModel,
   vendorIconPath,
 } from "../data";
@@ -145,6 +146,7 @@ interface Props {
 export function ModelDetailClient({ model, related }: Props) {
   const t = useTranslations("models");
   const platformUrl = getAppUrl();
+  const ctaUrl = getModelCtaUrl(model, platformUrl);
   const c = (key: string) => {
     return `content.${model.slug}.${key}`;
   };
@@ -198,7 +200,7 @@ export function ModelDetailClient({ model, related }: Props) {
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <a
-                href={platformUrl}
+                href={ctaUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn-get-access group"

--- a/turbo/apps/web/app/[locale]/models/data.ts
+++ b/turbo/apps/web/app/[locale]/models/data.ts
@@ -427,23 +427,6 @@ export const MODELS: ModelEntry[] = [
   // -------------------------------------------------------------------------
 
   {
-    slug: "gemini-2-5-flash-image",
-    modelId: "gemini-2.5-flash-image",
-    name: "Gemini 2.5 Flash Image",
-    vendor: "Google",
-    category: "image",
-    modalities: ["Image", "Text-to-image", "Image edit"],
-    releasedToVm0: "April 2026",
-    generationPricing: {
-      unit: "image",
-      priceUsd: 0.0387,
-      note: "1024×1024 standard",
-    },
-    comparisonSlugs: ["GPT Image 1", "SeedDream 4", "Flux Pro 1.1 Ultra"],
-    alternativeSlugs: ["gpt-image-1", "seedream-4", "flux-pro-1-1-ultra"],
-  },
-
-  {
     slug: "gpt-image-1",
     modelId: "gpt-image-1",
     name: "GPT Image 1",
@@ -456,16 +439,8 @@ export const MODELS: ModelEntry[] = [
       priceUsd: 0.05,
       note: "Medium standard tier (1024×1024)",
     },
-    comparisonSlugs: [
-      "Gemini 2.5 Flash Image",
-      "SeedDream 4",
-      "Flux Pro 1.1 Ultra",
-    ],
-    alternativeSlugs: [
-      "gemini-2-5-flash-image",
-      "flux-pro-1-1-ultra",
-      "seedream-4",
-    ],
+    comparisonSlugs: ["SeedDream 4", "Flux Pro 1.1 Ultra"],
+    alternativeSlugs: ["flux-pro-1-1-ultra", "seedream-4"],
   },
 
   {
@@ -481,8 +456,8 @@ export const MODELS: ModelEntry[] = [
       priceUsd: 0.072,
       note: "Per generated image",
     },
-    comparisonSlugs: ["GPT Image 1", "SeedDream 4", "Gemini 2.5 Flash Image"],
-    alternativeSlugs: ["gpt-image-1", "seedream-4", "gemini-2-5-flash-image"],
+    comparisonSlugs: ["GPT Image 1", "SeedDream 4"],
+    alternativeSlugs: ["gpt-image-1", "seedream-4"],
   },
 
   {
@@ -498,16 +473,8 @@ export const MODELS: ModelEntry[] = [
       priceUsd: 0.036,
       note: "Per generated image",
     },
-    comparisonSlugs: [
-      "GPT Image 1",
-      "Flux Pro 1.1 Ultra",
-      "Gemini 2.5 Flash Image",
-    ],
-    alternativeSlugs: [
-      "gpt-image-1",
-      "flux-pro-1-1-ultra",
-      "gemini-2-5-flash-image",
-    ],
+    comparisonSlugs: ["GPT Image 1", "Flux Pro 1.1 Ultra"],
+    alternativeSlugs: ["gpt-image-1", "flux-pro-1-1-ultra"],
   },
 
   // -------------------------------------------------------------------------
@@ -574,4 +541,31 @@ export function getModelBySlug(slug: string): ModelEntry | undefined {
   return MODELS.find((m) => {
     return m.slug === slug;
   });
+}
+
+// Per-generation-model onboarding prompts. The CTA on each image/video detail
+// page deep-links into the app's onboarding flow with this prompt prefilled,
+// so a first-time visitor lands on a chat that can immediately run the model
+// without having to write their own prompt. Mentioning the model id in plain
+// English lets the agent reliably pass it as `--model` when it calls the
+// built-in generation tool, while keeping the surface copy natural.
+const GENERATION_CTA_PROMPTS: Readonly<Record<string, string>> = {
+  "gpt-image-1":
+    "Generate an illustration of a cute cat using the gpt-image-1 model.",
+  "flux-pro-1-1-ultra":
+    "Generate a photorealistic studio portrait of a cat using the flux-pro-1.1-ultra model.",
+  "seedream-4":
+    "Generate a photorealistic shot of a cat sitting in a sunny window using the seedream4 model.",
+  "veo-3-1-fast":
+    "Generate a short cinematic video of a cat stretching on a sunlit windowsill using the veo3.1-fast model.",
+  "kling-v3-4k":
+    "Generate a stylized 4K video of a cat walking through a neon-lit alley using the kling-v3-4k model.",
+  "dreamina-seedance-2-0":
+    "Generate a smooth tracking video of a cat exploring a flower garden using the dreamina-seedance-2.0 model.",
+};
+
+export function getModelCtaUrl(model: ModelEntry, appUrl: string): string {
+  const prompt = GENERATION_CTA_PROMPTS[model.slug];
+  if (!prompt) return appUrl;
+  return `${appUrl}/onboarding?prompt=${encodeURIComponent(prompt)}`;
 }

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -5952,118 +5952,13 @@
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Default model on the DeepSeek provider; also available on VM0 Managed.",
         "vm0Notes": "V4 Flash carries the lowest credit multiplier of any Built-in model (×0.02), roughly 50× less than Sonnet 4.6. Cache reads bill while cache writes are free, and VM0 sets a 10-minute API timeout for the DeepSeek provider that pairs naturally with Flash's short single-shot work."
       },
-      "gemini-2-5-flash-image": {
-        "name": "Gemini 2.5 Flash Image",
-        "pageTitle": "Gemini 2.5 Flash Image on VM0. The fast text-to-image default",
-        "tagline": "Googles schnelles Text-zu-Bild- und Bildbearbeitungsmodell. Starke Anweisungstreue, Charakterkonsistenz und die günstigsten Credit-Kosten pro Bild im kuratierten Bild-Lineup.",
-        "cardIntro": "Googles schnelles Text-zu-Bild-Modell. Günstig, präzise bei langen Prompts und gut darin, Subjekte über Edits hinweg beizubehalten.",
-        "metaTitle": "Gemini 2.5 Flash Image auf VM0: Preise, Specs & Vergleich",
-        "metaDescription": "Gemini 2.5 Flash Image auf VM0. Googles Text-zu-Bild- und Bildbearbeitungsmodell mit hoher Anweisungstreue, Charakterkonsistenz und ~$0,04 pro Bild. Verglichen mit GPT Image 1, Flux Pro 1.1 Ultra und SeedDream 4.",
-        "summary": "Gemini 2.5 Flash Image ist Googles Standard-Text-zu-Bild- und Bildbearbeitungsmodell für überall. Es punktet bei den beiden Eigenschaften, die für Agent-Workloads am wichtigsten sind: Es folgt langen, strukturierten Prompts (so kann man ihm das vollständige Briefing übergeben, ohne unterwegs Anweisungen zu verlieren), und es behält Subjekte über mehrstufige Edits hinweg konsistent (so kann ein Agent denselben Charakter oder dieselbe Produktaufnahme iterieren, ohne dass sie zwischen Calls driftet).\n\nDer Listenpreis liegt bei etwa $0,04 pro 1024×1024-Bild, was es zum günstigsten Modell im kuratierten Bild-Lineup macht. Das natürliche Muster ist, standardmäßig Gemini 2.5 Flash Image zu verwenden und nur dann auf Flux Pro 1.1 Ultra oder SeedDream 4 zu eskalieren, wenn eine bestimmte Ästhetik gefragt ist, die der Standard nicht trifft.",
-        "releaseDate": "April 2026",
-        "familyPosition": "Googles Text-zu-Bild-Arbeitspferd für Agent-Workloads.",
-        "background": [
-          "Gemini 2.5 Flash Image ist Googles Text-zu-Bild- und Bildbearbeitungsmodell in der Gemini-2.5-Familie. Googles Rahmen ist derselbe wie für die textseitige Flash-Variante: Ein Modell, das auf hohen Durchsatz bei niedrigen Kosten pro Call abgestimmt ist, optimiert für Produktions-Workloads, in denen die nächste Anfrage in der Warteschlange steht, bevor die letzte fertig gestreamt ist.",
-          "Zwei Verhaltenseigenschaften stechen für Agent-Nutzung heraus. Erstens ist die Anweisungstreue bei langen strukturierten Prompts deutlich besser als bei den meisten Open-Weight-Text-zu-Bild-Baselines, was zählt, wenn ein Agent den Prompt programmatisch zusammenstellt und ihn nicht kürzen kann. Zweitens hält die Charakter- und Subjektkonsistenz über mehrstufige Edits hinweg gut, was das Modell als Edit-Loop-Default in Agent-Workflows, die auf einem einzigen Asset iterieren, brauchbar macht."
-        ],
-        "architecture": "Diffusion-basiertes Text-zu-Bild-Modell mit nativer Edit-Unterstützung. Die Abrechnung erfolgt pro generiertem Bild in der Standardstufe. Eingaben akzeptieren Textprompts plus optionale Referenzbilder für Edit-Flows. Ausgaben sind PNG in der angeforderten Auflösung.",
-        "specs": [
-          { "label": "Familie", "value": "Gemini 2.5 Generation" },
-          {
-            "label": "Modalitäten",
-            "value": "Text-zu-Bild, Bild-zu-Bild-Edit"
-          },
-          { "label": "Ausgabeauflösung", "value": "1024×1024 Standardstufe" },
-          { "label": "Listenpreis", "value": "~$0,04 pro Bild" },
-          { "label": "Sprachen", "value": "Mehrsprachige Prompts" },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
-        ],
-        "benchmarksNote": "",
-        "benchmarks": [],
-        "performance": [
-          {
-            "title": "Anweisungstreue",
-            "body": "Hält sich bei langen strukturierten Prompts, bei denen viele Open-Weight-Modelle Klauseln verlieren. Nützlich, wenn ein Agent das Briefing programmatisch zusammenstellt und der Prompt nicht verhandelbar ist."
-          },
-          {
-            "title": "Charakterkonsistenz",
-            "body": "Hält Subjekte über mehrstufige Edits hinweg erkennbar, die Eigenschaft, die das Modell für iterative Agent-Loops auf einem einzigen Asset brauchbar macht."
-          },
-          {
-            "title": "Kosten",
-            "body": "Etwa $0,04 pro Bild — das günstigste der kuratierten Text-zu-Bild-Modelle auf VM0. Bulk-Fan-out-Generierung bleibt erschwinglich."
-          },
-          {
-            "title": "Ästhetische Obergrenze",
-            "body": "Neigt zu sauberer, präziser Ausgabe statt zum hyperstilisierten Look von Flux Pro 1.1 Ultra oder zum photorealistischen Look von SeedDream 4. Eskalieren, wenn die Ästhetik das Deliverable ist."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "Der Agent, der Marketing-Visuals aus einem Briefing entwirft",
-            "body": "Übergibt dem Agenten Brand Voice, Produktbeschreibung und Zielgruppe; Gemini 2.5 Flash Image rendert Entwurfs-Visuals in Sekunden. Günstig genug, um ein Dutzend Varianten zu fächern und die beste auszuwählen."
-          },
-          {
-            "title": "Der Edit-Loop, der auf einem einzigen Asset iteriert",
-            "body": "Einmal generieren, dann Beleuchtung, Framing oder Hintergrund iterieren und dabei das Subjekt über Runden hinweg konsistent halten. Charakterkonsistenz bedeutet, dass der Mensch im Loop dasselbe Bild bearbeitet und nicht jede Runde aus einem frischen Set wählt."
-          },
-          {
-            "title": "Der Illustrations-Vorfilter vor dem Premium-Modell",
-            "body": "Mit Gemini 2.5 Flash Image die Komposition günstig festlegen, dann die finale Auswahl auf Flux Pro 1.1 Ultra für die Ästhetik rerendern. Reduziert die Kosten des Premium-Schritts auf einen Call statt eines Fan-outs."
-          }
-        ],
-        "avoidFor": "Überspringe Gemini 2.5 Flash Image, wenn das Deliverable die Ästhetik ist — Flux Pro 1.1 Ultra und SeedDream 4 haben eine höhere stilistische Obergrenze für photorealistische und editoriale Looks.",
-        "comparisons": [
-          {
-            "vs": "GPT Image 1",
-            "body": "GPT Image 1 ist stärker bei stilisierter Illustration und Charakterarbeit; Gemini 2.5 Flash Image ist günstiger pro Call und stärker bei Anweisungstreue für lange Prompts. Für Agent-Workloads mit strukturierten Prompts ist Gemini 2.5 Flash Image der sicherere Standard."
-          },
-          {
-            "vs": "SeedDream 4",
-            "body": "SeedDream 4 hat eine höhere photorealistische Obergrenze; Gemini 2.5 Flash Image ist günstiger, schneller und folgt langen Prompts zuverlässiger. Standardmäßig Gemini, eskaliere auf SeedDream 4, wenn das Briefing speziell eine Foto-Ästhetik ist."
-          },
-          {
-            "vs": "Flux Pro 1.1 Ultra",
-            "body": "Flux Pro 1.1 Ultra hat die höchste stilistische Obergrenze im kuratierten Lineup; Gemini 2.5 Flash Image gewinnt bei Kosten und Anweisungstreue. Vorfiltern mit Gemini, Finals auf Flux liefern, wenn die Ästhetik der Punkt ist."
-          }
-        ],
-        "verdict": "Standardmäßig Gemini 2.5 Flash Image für Text-zu-Bild-Agent-Workloads. Eskaliere auf Flux Pro 1.1 Ultra oder SeedDream 4 nur, wenn die Ästhetik das Deliverable ist.",
-        "faqs": [
-          {
-            "q": "Can Gemini 2.5 Flash Image edit existing images?",
-            "a": "Ja. Es akzeptiert ein Referenzbild neben dem Textprompt und unterstützt Inpainting- und Outpainting-Flows für iterative Edits."
-          },
-          {
-            "q": "What output resolution does it produce?",
-            "a": "1024×1024 in der Standardstufe. Höhere Auflösungen sind zu proportionalen Kosten verfügbar."
-          },
-          {
-            "q": "How much does it cost per image?",
-            "a": "Etwa $0,04 pro generiertem 1024×1024-Bild — das günstigste der kuratierten Text-zu-Bild-Modelle auf VM0."
-          },
-          {
-            "q": "Is the model good at text inside images?",
-            "a": "Ja — deutlich stärker als die meisten Open-Weight-Baselines beim Rendern kurzer Textstrings innerhalb des generierten Bildes."
-          }
-        ],
-        "alternatives": [
-          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
-          {
-            "slug": "flux-pro-1-1-ultra",
-            "reason": "Higher aesthetic ceiling"
-          },
-          { "slug": "seedream-4", "reason": "Stronger photoreal results" }
-        ],
-        "routingNotes": "Routed to Google's Gemini 2.5 Flash Image endpoint and billed per generated image.",
-        "vm0Notes": "Gemini 2.5 Flash Image ist der Preis-/Qualitäts-Standard für Text-zu-Bild-Agent-Workloads auf VM0. Verwende es als Überall-Standard und reserviere die teureren Bildmodelle für die Schritte, in denen ihre stilistische Obergrenze tatsächlich zählt."
-      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 on VM0. OpenAI's text-to-image model",
         "tagline": "OpenAIs Text-zu-Bild-Modell mit starker stilisierter Illustration und Bearbeitung. Die natürliche Wahl, wenn man OpenAIs Ästhetik und Prompt-Style möchte.",
-        "cardIntro": "OpenAIs Text-zu-Bild-Modell. Stark bei stilisierter Illustration, Charakterarbeit und Bearbeitung — das OpenAI-seitige Gegenstück zu Gemini 2.5 Flash Image.",
+        "cardIntro": "OpenAIs Text-zu-Bild-Modell. Stark bei stilisierter Illustration, Charakterarbeit und Bearbeitung — das OpenAI-seitige Gegenstück zu SeedDream 4.",
         "metaTitle": "GPT Image 1 auf VM0: Preise, Specs & Vergleich",
-        "metaDescription": "GPT Image 1 auf VM0. OpenAIs Text-zu-Bild- und Bildbearbeitungsmodell mit Stärken in stilisierter Illustration, mehrstufiger Preisgestaltung und Vergleich zu Gemini 2.5 Flash Image, Flux Pro 1.1 Ultra und SeedDream 4.",
+        "metaDescription": "GPT Image 1 auf VM0. OpenAIs Text-zu-Bild- und Bildbearbeitungsmodell mit Stärken in stilisierter Illustration, mehrstufiger Preisgestaltung und Vergleich zu Flux Pro 1.1 Ultra und SeedDream 4.",
         "summary": "GPT Image 1 ist OpenAIs Text-zu-Bild-Modell — dasjenige, das die meisten Teams als das Modell hinter der Bildgenerierung in ChatGPT kennen. Seine Stärken liegen in stilisierter Illustration, Charakterarbeit und Bildbearbeitung mit textgesteuerter Maskierung, mit einem Prompt-Style, der eng dem entspricht, was OpenAIs Text-Modelle erwarten.\n\nDer Listenpreis ist gestaffelt, von etwa $0,011 pro Bild in der niedrigen/Standard-Stufe bis $0,25 in der hohen/großen Stufe. Die Medium-Standard-Stufe (etwa $0,05 pro 1024×1024) ist der sinnvolle Standard für die meisten Agent-Workloads.",
         "releaseDate": "April 2026",
         "familyPosition": "OpenAIs primäres Text-zu-Bild-Modell. Stufenbasierter Preis über Auflösung und Qualitätseinstellungen.",
@@ -6116,12 +6011,8 @@
             "body": "Wenn der orchestrierende Agent bereits auf GPT-5.4 oder GPT-5.5 läuft, hält die Bildgenerierung innerhalb der OpenAI-Oberfläche (GPT Image 1) den Prompt-Style, die Edit-Semantik und strukturierte Ausgaben über den Run hinweg konsistent."
           }
         ],
-        "avoidFor": "Überspringe GPT Image 1, wenn die Kosten dominieren (Gemini 2.5 Flash Image ist für dieselbe Standardstufe etwa halb so teuer) oder wenn das Deliverable speziell photorealistisch ist (SeedDream 4 hat eine höhere photorealistische Obergrenze).",
+        "avoidFor": "Überspringe GPT Image 1, wenn die Kosten dominieren (SeedDream 4 ist für dieselbe Standardstufe etwa halb so teuer) oder wenn das Deliverable speziell photorealistisch ist (SeedDream 4 hat eine höhere photorealistische Obergrenze).",
         "comparisons": [
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Image ist günstiger und stärker bei langen strukturierten Prompts; GPT Image 1 ist stärker bei stilisierter Illustration und integriert sich natürlicher mit OpenAI-Stack-Agenten."
-          },
           {
             "vs": "SeedDream 4",
             "body": "SeedDream 4 führt bei photorealistischer Ästhetik zu leicht niedrigerem Preis; GPT Image 1 führt bei stilisierter Illustration und Edit-Flows."
@@ -6131,7 +6022,7 @@
             "body": "Flux Pro 1.1 Ultra hat die höchste ästhetische Obergrenze für Hero-Shot-Deliverables; GPT Image 1 ist der natürliche OpenAI-Stack-Standard für alles andere."
           }
         ],
-        "verdict": "Wähle GPT Image 1, wenn dein Agent bereits auf dem OpenAI-Stack läuft und du stilisierte Illustration oder native Edit-Flows möchtest. Eskaliere auf Flux Pro 1.1 Ultra für photorealistische Hero-Shots; wechsle zu Gemini 2.5 Flash Image, wenn die Kosten dominieren.",
+        "verdict": "Wähle GPT Image 1, wenn dein Agent bereits auf dem OpenAI-Stack läuft und du stilisierte Illustration oder native Edit-Flows möchtest. Eskaliere auf Flux Pro 1.1 Ultra für photorealistische Hero-Shots; wechsle zu wenn die Kosten dominieren.",
         "faqs": [
           {
             "q": "How is GPT Image 1 priced?",
@@ -6152,10 +6043,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Cheaper, stronger long-prompt adherence"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "Higher photoreal aesthetic ceiling"
           },
@@ -6170,8 +6057,8 @@
         "tagline": "Black Forest Labs' hochauflösendes Text-zu-Bild-Modell. Die Wahl, wenn das Bild das Deliverable ist und editoriale oder photorealistische Qualität gefragt ist.",
         "cardIntro": "Black Forest Labs' Top-Tier-Bildmodell. Höchste ästhetische Obergrenze im kuratierten Lineup — verwende es für Hero-Shots und editoriale Ausgabe.",
         "metaTitle": "Flux Pro 1.1 Ultra auf VM0: Preise, Specs & Vergleich",
-        "metaDescription": "Flux Pro 1.1 Ultra auf VM0. Black Forest Labs' Top-Tier-Text-zu-Bild-Modell mit editorialer Ästhetik, $0,072 pro Bild und Vergleich zu GPT Image 1, SeedDream 4 und Gemini 2.5 Flash Image.",
-        "summary": "Flux Pro 1.1 Ultra ist Black Forest Labs' Top-Tier-Text-zu-Bild-Modell — dasjenige, zu dem man greift, wenn das Bild selbst das Deliverable ist und nicht ein Schritt in einem Agent-Loop. Die Ausgabequalität bei editorialen, photorealistischen und designgeführten Ästhetiken ist die höchste im kuratierten Lineup, und die Prompt-Treue bei detaillierten Kompositionsbriefings hält gut.\n\nDer Listenpreis liegt bei $0,072 pro Bild, was es im Vergleich zu Gemini 2.5 Flash Image ($0,04) oder SeedDream 4 ($0,036) teuer macht, aber der Qualitätssprung pro Bild ist groß genug, dass die meisten Teams es als Final-Render-Schritt nach Vorfilterung mit einem günstigeren Modell verwenden.",
+        "metaDescription": "Flux Pro 1.1 Ultra auf VM0. Black Forest Labs' Top-Tier-Text-zu-Bild-Modell mit editorialer Ästhetik, $0,072 pro Bild und Vergleich zu GPT Image 1, SeedDream 4.",
+        "summary": "Flux Pro 1.1 Ultra ist Black Forest Labs' Top-Tier-Text-zu-Bild-Modell — dasjenige, zu dem man greift, wenn das Bild selbst das Deliverable ist und nicht ein Schritt in einem Agent-Loop. Die Ausgabequalität bei editorialen, photorealistischen und designgeführten Ästhetiken ist die höchste im kuratierten Lineup, und die Prompt-Treue bei detaillierten Kompositionsbriefings hält gut.\n\nDer Listenpreis liegt bei $0,072 pro Bild, was es im Vergleich zu SeedDream 4 ($0,04) oder SeedDream 4 ($0,036) teuer macht, aber der Qualitätssprung pro Bild ist groß genug, dass die meisten Teams es als Final-Render-Schritt nach Vorfilterung mit einem günstigeren Modell verwenden.",
         "releaseDate": "April 2026",
         "familyPosition": "Premium-Stufe der Flux-1.1-Generation von Black Forest Labs.",
         "background": [
@@ -6191,7 +6078,7 @@
         "performance": [
           {
             "title": "Ästhetische Obergrenze",
-            "body": "Höchste im kuratierten Bild-Lineup. Hero-Shot-, editoriale und photorealistische Ästhetiken landen hier zuverlässiger als auf Gemini 2.5 Flash Image oder GPT Image 1."
+            "body": "Höchste im kuratierten Bild-Lineup. Hero-Shot-, editoriale und photorealistische Ästhetiken landen hier zuverlässiger als auf SeedDream 4 oder GPT Image 1."
           },
           {
             "title": "Kompositionstreue",
@@ -6199,7 +6086,7 @@
           },
           {
             "title": "Kosten",
-            "body": "$0,072 pro Bild — etwa 2× Gemini 2.5 Flash Image und SeedDream 4. Das Standardmuster ist, mit einem günstigeren Modell vorzufiltern und Finals auf Flux zu rendern."
+            "body": "$0,072 pro Bild — etwa 2× SeedDream 4. Das Standardmuster ist, mit einem günstigeren Modell vorzufiltern und Finals auf Flux zu rendern."
           },
           {
             "title": "Geschwindigkeit",
@@ -6220,7 +6107,7 @@
             "body": "Magazinhafte Hero-Illustrationen für Artikel, Blogposts und Reports. Flux' stilistische Obergrenze hebt es von den Workhorse-Standards ab."
           }
         ],
-        "avoidFor": "Überspringe Flux Pro 1.1 Ultra in Fan-out-Loops, in denen die Kosten dominieren — Gemini 2.5 Flash Image ist pro Call etwa 2× günstiger. Verwende es als Final-Render-Schritt statt als Iterationsschritt.",
+        "avoidFor": "Überspringe Flux Pro 1.1 Ultra in Fan-out-Loops, in denen die Kosten dominieren — SeedDream 4 ist pro Call etwa 2× günstiger. Verwende es als Final-Render-Schritt statt als Iterationsschritt.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6229,17 +6116,13 @@
           {
             "vs": "SeedDream 4",
             "body": "Beide sind photorealistisch ausgerichtet. SeedDream 4 ist günstiger und konkurrenzfähig bei Porträt- und Produktarbeiten; Flux Pro 1.1 Ultra gewinnt bei Hero-Shot-Kompositionstreue zu höheren Kosten."
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Unterschiedliche Rollen. Gemini 2.5 Flash Image ist das günstige Arbeitspferd für Iteration; Flux Pro 1.1 Ultra ist der Premium-Final-Render-Schritt. Stapeln, nicht eines auswählen."
           }
         ],
         "verdict": "Verwende Flux Pro 1.1 Ultra als Final-Render-Schritt nach Vorfilterung mit einem günstigeren Modell. Die ästhetische Obergrenze rechtfertigt den Aufpreis, wenn das Bild das Deliverable ist.",
         "faqs": [
           {
             "q": "How much does Flux Pro 1.1 Ultra cost?",
-            "a": "$0,072 pro generiertem Bild. Etwa 2× Gemini 2.5 Flash Image und SeedDream 4."
+            "a": "$0,072 pro generiertem Bild. Etwa 2× SeedDream 4."
           },
           {
             "q": "Does it support image editing?",
@@ -6255,15 +6138,11 @@
           }
         ],
         "alternatives": [
-          {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Cheap iteration default"
-          },
           { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
           { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
         ],
         "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
-        "vm0Notes": "Flux Pro 1.1 Ultra ist die Premium-Stufe des kuratierten Bild-Lineups. Verwende es für den Final-Render-Schritt statt für die Iteration; paare es mit Gemini 2.5 Flash Image oder SeedDream 4 als günstigem Vorfilter."
+        "vm0Notes": "Flux Pro 1.1 Ultra ist die Premium-Stufe des kuratierten Bild-Lineups. Verwende es für den Final-Render-Schritt statt für die Iteration; paare es mit SeedDream 4 oder SeedDream 4 als günstigem Vorfilter."
       },
       "seedream-4": {
         "name": "SeedDream 4",
@@ -6271,8 +6150,8 @@
         "tagline": "ByteDance's SeedDream-4-Text-zu-Bild-Modell. Starke photorealistische Ästhetik zu Kosten, die mit den günstigsten Optionen im Lineup vergleichbar sind.",
         "cardIntro": "ByteDance's SeedDream 4. Photorealistische Ästhetik zu niedrigen Kosten pro Bild — der natürliche Standard, wenn das Briefing ein Foto ist.",
         "metaTitle": "SeedDream 4 auf VM0: Preise, Specs & Vergleich",
-        "metaDescription": "SeedDream 4 auf VM0. ByteDance's Text-zu-Bild-Modell mit starker photorealistischer Ausgabe, ~$0,036 pro Bild und Vergleich zu Gemini 2.5 Flash Image, GPT Image 1 und Flux Pro 1.1 Ultra.",
-        "summary": "SeedDream 4 ist ByteDance's Text-zu-Bild-Modell in der Seedream-V4-Generation. Seine herausragende Eigenschaft ist die photorealistische Ästhetik — Porträts, Produktaufnahmen, Lifestyle-Fotografie — zu einem Listenpreis ($0,036 pro Bild), der mit der günstigsten Option im kuratierten Lineup konkurrieren kann.\n\nEs ist der natürliche Standard, wenn das Briefing speziell ein Foto ist. Für stilisierte Illustration oder editoriales Design wähle GPT Image 1 oder Flux Pro 1.1 Ultra; für allgemeine iterative Agent-Workloads mit langen strukturierten Prompts wähle Gemini 2.5 Flash Image.",
+        "metaDescription": "SeedDream 4 auf VM0. ByteDance's Text-zu-Bild-Modell mit starker photorealistischer Ausgabe, ~$0,036 pro Bild und Vergleich zu GPT Image 1 und Flux Pro 1.1 Ultra.",
+        "summary": "SeedDream 4 ist ByteDance's Text-zu-Bild-Modell in der Seedream-V4-Generation. Seine herausragende Eigenschaft ist die photorealistische Ästhetik — Porträts, Produktaufnahmen, Lifestyle-Fotografie — zu einem Listenpreis ($0,036 pro Bild), der mit der günstigsten Option im kuratierten Lineup konkurrieren kann.\n\nEs ist der natürliche Standard, wenn das Briefing speziell ein Foto ist. Für stilisierte Illustration oder editoriales Design wähle GPT Image 1 oder Flux Pro 1.1 Ultra; für allgemeine iterative Agent-Workloads mit langen strukturierten Prompts wähle SeedDream 4.",
         "releaseDate": "April 2026",
         "familyPosition": "ByteDance's photorealistischer Text-zu-Bild-Standard in der Seedream-V4-Generation.",
         "background": [
@@ -6324,7 +6203,7 @@
             "body": "Wenn das Briefing photorealistisch ist, das Deliverable aber den Flux-Aufpreis nicht rechtfertigt, liefert SeedDream 4 den Großteil der Qualität zum halben Preis."
           }
         ],
-        "avoidFor": "Überspringe SeedDream 4 für stilisierte Illustration (GPT Image 1 führt), Iteration bei langen strukturierten Prompts (Gemini 2.5 Flash Image führt) oder Hero-Shot-Editorial-Arbeit, bei der der Flux-Aufpreis gerechtfertigt ist.",
+        "avoidFor": "Überspringe SeedDream 4 für stilisierte Illustration (GPT Image 1 führt), Iteration bei langen strukturierten Prompts (SeedDream 4 führt) oder Hero-Shot-Editorial-Arbeit, bei der der Flux-Aufpreis gerechtfertigt ist.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6333,10 +6212,6 @@
           {
             "vs": "Flux Pro 1.1 Ultra",
             "body": "Beide sind photorealistisch ausgerichtet. SeedDream 4 ist halb so teuer und konkurrenzfähig bei Porträt- und Produktarbeiten; Flux Pro 1.1 Ultra gewinnt bei Hero-Shot-Kompositionstreue."
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Image ist der günstige Allzweck-Standard mit stärkerer Anweisungstreue bei langen Prompts; SeedDream 4 ist der photorealistik-spezifische Standard mit einer höheren Obergrenze bei Foto-Briefings."
           }
         ],
         "verdict": "Standardmäßig SeedDream 4, wenn das Briefing speziell ein Foto ist und Kosten zählen. Eskaliere auf Flux Pro 1.1 Ultra nur, wenn der Hero-Shot den Aufpreis rechtfertigt.",
@@ -6360,17 +6235,13 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Cheaper general-purpose default"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "Premium hero-shot quality"
           },
           { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
-        "vm0Notes": "SeedDream 4 ist der photorealistik-spezifische Standard im kuratierten Bild-Lineup. Paare es mit Flux Pro 1.1 Ultra für Hero-Shots und mit Gemini 2.5 Flash Image für Nicht-Foto-Iteration."
+        "vm0Notes": "SeedDream 4 ist der photorealistik-spezifische Standard im kuratierten Bild-Lineup. Paare es mit Flux Pro 1.1 Ultra für Hero-Shots und mit SeedDream 4 für Nicht-Foto-Iteration."
       },
       "veo-3-1-fast": {
         "name": "Veo 3.1 Fast",
@@ -6611,7 +6482,7 @@
           },
           {
             "title": "Bild-zu-Video",
-            "body": "Starke Handhabung von Bildkonditionierungs-Flows. Nützlich, wenn ein Agent ein Standbild (günstig generiert auf Gemini 2.5 Flash Image oder SeedDream 4) in einen kurzen Bewegungsclip erweitern möchte."
+            "body": "Starke Handhabung von Bildkonditionierungs-Flows. Nützlich, wenn ein Agent ein Standbild (günstig generiert auf SeedDream 4 oder SeedDream 4) in einen kurzen Bewegungsclip erweitern möchte."
           },
           {
             "title": "Ästhetische Obergrenze",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -5976,118 +5976,13 @@
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Default model on the DeepSeek provider; also available on VM0 Managed.",
         "vm0Notes": "V4 Flash carries the lowest credit multiplier of any Built-in model (×0.02), roughly 50× less than Sonnet 4.6. Cache reads bill while cache writes are free, and VM0 sets a 10-minute API timeout for the DeepSeek provider that pairs naturally with Flash's short single-shot work."
       },
-      "gemini-2-5-flash-image": {
-        "name": "Gemini 2.5 Flash Image",
-        "pageTitle": "Gemini 2.5 Flash Image on VM0. The fast text-to-image default",
-        "tagline": "Google's fast text-to-image and image-edit model. Strong instruction following, character consistency, and the cheapest credit cost per image in the curated image lineup.",
-        "cardIntro": "Google's fast text-to-image model. Cheap, accurate at following long prompts, and good at preserving subjects across edits.",
-        "metaTitle": "Gemini 2.5 Flash Image on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "Gemini 2.5 Flash Image on VM0. Google's text-to-image and image-edit model with high instruction adherence, character consistency, and ~$0.04 per image. Compared with GPT Image 1, Flux Pro 1.1 Ultra and SeedDream 4.",
-        "summary": "Gemini 2.5 Flash Image is Google's everywhere-default text-to-image and image-edit model. It does well on the two properties that matter most for agent workloads: it follows long, structured prompts (so you can hand it the full brief without losing instructions on the way through), and it keeps subjects consistent across multi-turn edits (so an agent can iterate on the same character or product shot without it drifting between calls).\n\nList price is around $0.04 per 1024×1024 image, which makes it the cheapest model in the curated image lineup. The natural pattern is to default to Gemini 2.5 Flash Image and escalate to Flux Pro 1.1 Ultra or SeedDream 4 only when you need a specific aesthetic the default doesn't hit.",
-        "releaseDate": "April 2026",
-        "familyPosition": "Google's text-to-image workhorse for agent workloads.",
-        "background": [
-          "Gemini 2.5 Flash Image is Google's text-to-image and image-edit model in the Gemini 2.5 family. Google's framing is the same as for the text-side Flash variant: a model tuned for high throughput at a low per-call cost, optimised for production workloads where the next request is queued before the last one finishes streaming.",
-          "Two behavioural properties stand out for agent use. First, instruction adherence on long structured prompts is materially better than on most open-weight text-to-image baselines, which matters when an agent is composing the prompt programmatically and can't shorten it. Second, character and subject consistency across multi-turn edits holds up well, which is what makes the model viable as the edit-loop default in agent workflows that iterate on a single asset."
-        ],
-        "architecture": "Diffusion-based text-to-image model with native edit support. Pricing bills per generated image at the standard tier. Inputs accept text prompts plus optional reference images for edit-style flows. Outputs are PNG at the requested resolution.",
-        "specs": [
-          { "label": "Family", "value": "Gemini 2.5 generation" },
-          {
-            "label": "Modalities",
-            "value": "Text-to-image, image-to-image edit"
-          },
-          { "label": "Output resolution", "value": "1024×1024 standard tier" },
-          { "label": "Vendor list price", "value": "~$0.04 per image" },
-          { "label": "Languages", "value": "Multilingual prompts" },
-          { "label": "Available on VM0", "value": "April 2026" }
-        ],
-        "benchmarksNote": "",
-        "benchmarks": [],
-        "performance": [
-          {
-            "title": "Instruction adherence",
-            "body": "Holds up on long structured prompts where many open-weight models start dropping clauses. Useful when an agent composes the brief programmatically and the prompt is non-negotiable."
-          },
-          {
-            "title": "Character consistency",
-            "body": "Keeps subjects recognisable across multi-turn edits, which is the property that makes the model viable for iterative agent loops on a single asset."
-          },
-          {
-            "title": "Cost",
-            "body": "Around $0.04 per image — the cheapest of the curated text-to-image models on VM0. Bulk fan-out generation stays affordable."
-          },
-          {
-            "title": "Aesthetic ceiling",
-            "body": "Skews towards clean, accurate output rather than the hyper-stylised look of Flux Pro 1.1 Ultra or the photoreal look of SeedDream 4. Escalate when the aesthetic is the deliverable."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "The agent that drafts marketing visuals from a brief",
-            "body": "Hand the agent the brand voice, product description and target audience; Gemini 2.5 Flash Image renders draft visuals in seconds. Cheap enough to fan-out a dozen variations and pick the best."
-          },
-          {
-            "title": "The edit loop that iterates on a single asset",
-            "body": "Generate once, then iterate on lighting, framing or background while keeping the subject consistent across turns. Character consistency means the human in the loop is editing the same image, not picking from a fresh set every turn."
-          },
-          {
-            "title": "The illustration pre-filter before the premium model",
-            "body": "Use Gemini 2.5 Flash Image to lock the composition cheaply, then re-render the final pick on Flux Pro 1.1 Ultra for the aesthetic. Cuts the cost of the premium step to one call instead of a fan-out."
-          }
-        ],
-        "avoidFor": "Skip Gemini 2.5 Flash Image when the deliverable is the aesthetic — Flux Pro 1.1 Ultra and SeedDream 4 carry more stylistic ceiling on photoreal and editorial looks.",
-        "comparisons": [
-          {
-            "vs": "GPT Image 1",
-            "body": "GPT Image 1 is stronger on stylised illustration and character work; Gemini 2.5 Flash Image is cheaper per call and stronger on long-prompt instruction following. For agent workloads with structured prompts, Gemini 2.5 Flash Image is the safer default."
-          },
-          {
-            "vs": "SeedDream 4",
-            "body": "SeedDream 4 carries a higher photoreal ceiling; Gemini 2.5 Flash Image is cheaper, faster, and follows long prompts more reliably. Default to Gemini, escalate to SeedDream 4 when the brief is specifically a photo aesthetic."
-          },
-          {
-            "vs": "Flux Pro 1.1 Ultra",
-            "body": "Flux Pro 1.1 Ultra has the highest stylistic ceiling in the curated lineup; Gemini 2.5 Flash Image wins on cost and on instruction following. Pre-filter with Gemini, deliver finals on Flux when the aesthetic is the point."
-          }
-        ],
-        "verdict": "Default to Gemini 2.5 Flash Image for text-to-image agent workloads. Escalate to Flux Pro 1.1 Ultra or SeedDream 4 only when the aesthetic is the deliverable.",
-        "faqs": [
-          {
-            "q": "Can Gemini 2.5 Flash Image edit existing images?",
-            "a": "Yes. It accepts a reference image alongside the text prompt and supports inpainting and outpainting flows for iterative edits."
-          },
-          {
-            "q": "What output resolution does it produce?",
-            "a": "1024×1024 at the standard tier. Higher resolutions are available at proportional cost."
-          },
-          {
-            "q": "How much does it cost per image?",
-            "a": "Around $0.04 per generated 1024×1024 image — the cheapest of the curated text-to-image models on VM0."
-          },
-          {
-            "q": "Is the model good at text inside images?",
-            "a": "Yes — significantly stronger than most open-weight baselines on rendering short text strings inside the generated image."
-          }
-        ],
-        "alternatives": [
-          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
-          {
-            "slug": "flux-pro-1-1-ultra",
-            "reason": "Higher aesthetic ceiling"
-          },
-          { "slug": "seedream-4", "reason": "Stronger photoreal results" }
-        ],
-        "routingNotes": "Routed to Google's Gemini 2.5 Flash Image endpoint and billed per generated image.",
-        "vm0Notes": "Gemini 2.5 Flash Image is the price/quality default for text-to-image agent workloads on VM0. Use it as the everywhere-default and reserve the more expensive image models for the steps where their stylistic ceiling actually matters."
-      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 on VM0. OpenAI's text-to-image model",
         "tagline": "OpenAI's text-to-image model with strong stylised illustration and editing. The natural pick when you want OpenAI's aesthetic and prompt-following style.",
-        "cardIntro": "OpenAI's text-to-image model. Strong on stylised illustration, character work and editing — the OpenAI-side counterpart to Gemini 2.5 Flash Image.",
+        "cardIntro": "OpenAI's text-to-image model. Strong on stylised illustration, character work and editing.",
         "metaTitle": "GPT Image 1 on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "GPT Image 1 on VM0. OpenAI's text-to-image and image-edit model with stylised-illustration strength, multi-tier pricing, and comparison to Gemini 2.5 Flash Image, Flux Pro 1.1 Ultra and SeedDream 4.",
+        "metaDescription": "GPT Image 1 on VM0. OpenAI's text-to-image and image-edit model with stylised-illustration strength, multi-tier pricing, and comparison to Flux Pro 1.1 Ultra and SeedDream 4.",
         "summary": "GPT Image 1 is OpenAI's text-to-image model — the one most teams know as the model behind ChatGPT's image generation. Its strengths are stylised illustration, character work and image editing with text-driven masking, with prompt-following style that maps closely to what OpenAI's text models expect.\n\nList price is tier-based, from around $0.011 per image at the low/standard tier to $0.25 at the high/large tier. The medium-standard tier (around $0.05 per 1024×1024) is the sensible default for most agent workloads.",
         "releaseDate": "April 2026",
         "familyPosition": "OpenAI's primary text-to-image model. Tier-priced across resolution and quality settings.",
@@ -6143,12 +6038,8 @@
             "body": "If the orchestrating agent is already on GPT-5.4 or GPT-5.5, keeping image generation inside the OpenAI surface (GPT Image 1) means the prompt style, edit semantics and structured outputs stay consistent across the run."
           }
         ],
-        "avoidFor": "Skip GPT Image 1 when cost dominates (Gemini 2.5 Flash Image is roughly half the price for the same default tier) or when the deliverable is specifically photoreal (SeedDream 4 carries a higher photoreal ceiling).",
+        "avoidFor": "Skip GPT Image 1 when the deliverable is specifically photoreal (SeedDream 4 carries a higher photoreal ceiling).",
         "comparisons": [
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Image is cheaper and stronger on long structured prompts; GPT Image 1 is stronger on stylised illustration and integrates more naturally with OpenAI-stack agents."
-          },
           {
             "vs": "SeedDream 4",
             "body": "SeedDream 4 leads on photoreal aesthetic at a slightly lower price; GPT Image 1 leads on stylised illustration and edit flows."
@@ -6158,7 +6049,7 @@
             "body": "Flux Pro 1.1 Ultra carries the highest aesthetic ceiling for hero-shot deliverables; GPT Image 1 is the natural OpenAI-stack default for everything else."
           }
         ],
-        "verdict": "Pick GPT Image 1 when your agent is already on the OpenAI stack and you want stylised illustration or native edit flows. Escalate to Flux Pro 1.1 Ultra for photoreal hero shots; drop to Gemini 2.5 Flash Image when cost dominates.",
+        "verdict": "Pick GPT Image 1 when your agent is already on the OpenAI stack and you want stylised illustration or native edit flows. Escalate to Flux Pro 1.1 Ultra for photoreal hero shots; drop to SeedDream 4 when cost dominates.",
         "faqs": [
           {
             "q": "How is GPT Image 1 priced?",
@@ -6179,10 +6070,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Cheaper, stronger long-prompt adherence"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "Higher photoreal aesthetic ceiling"
           },
@@ -6197,8 +6084,8 @@
         "tagline": "Black Forest Labs' high-ceiling text-to-image model. The pick when the image is the deliverable and you need editorial- or photoreal-grade output.",
         "cardIntro": "Black Forest Labs' top-tier image model. Highest aesthetic ceiling in the curated lineup — use it for hero shots and editorial-grade output.",
         "metaTitle": "Flux Pro 1.1 Ultra on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "Flux Pro 1.1 Ultra on VM0. Black Forest Labs' top-tier text-to-image model with editorial-grade aesthetic ceiling, $0.072 per image, and comparison to GPT Image 1, SeedDream 4 and Gemini 2.5 Flash Image.",
-        "summary": "Flux Pro 1.1 Ultra is Black Forest Labs' top-tier text-to-image model — the one to reach for when the image itself is the deliverable, not a step in an agent loop. Output quality on editorial, photoreal and design-led aesthetics is the highest in the curated lineup, and prompt adherence on detailed compositional briefs holds up well.\n\nList price is $0.072 per image, which makes it expensive relative to Gemini 2.5 Flash Image ($0.04) or SeedDream 4 ($0.036), but the per-image quality lift is large enough that most teams use it as the final-render step after pre-filtering with a cheaper model.",
+        "metaDescription": "Flux Pro 1.1 Ultra on VM0. Black Forest Labs' top-tier text-to-image model with editorial-grade aesthetic ceiling, $0.072 per image, and comparison to GPT Image 1, SeedDream 4.",
+        "summary": "Flux Pro 1.1 Ultra is Black Forest Labs' top-tier text-to-image model — the one to reach for when the image itself is the deliverable, not a step in an agent loop. Output quality on editorial, photoreal and design-led aesthetics is the highest in the curated lineup, and prompt adherence on detailed compositional briefs holds up well.\n\nList price is $0.072 per image, which makes it expensive relative to SeedDream 4 ($0.036), but the per-image quality lift is large enough that most teams use it as the final-render step after pre-filtering with a cheaper model.",
         "releaseDate": "April 2026",
         "familyPosition": "Black Forest Labs' premium tier of the Flux 1.1 generation.",
         "background": [
@@ -6218,7 +6105,7 @@
         "performance": [
           {
             "title": "Aesthetic ceiling",
-            "body": "Highest in the curated image lineup. Hero-shot, editorial and photoreal aesthetics land more reliably here than on Gemini 2.5 Flash Image or GPT Image 1."
+            "body": "Highest in the curated image lineup. Hero-shot, editorial and photoreal aesthetics land more reliably here than on GPT Image 1 or SeedDream 4."
           },
           {
             "title": "Compositional fidelity",
@@ -6226,7 +6113,7 @@
           },
           {
             "title": "Cost",
-            "body": "$0.072 per image — roughly 2× Gemini 2.5 Flash Image and SeedDream 4. The standard pattern is to pre-filter with a cheaper model and render finals on Flux."
+            "body": "$0.072 per image — roughly 2× SeedDream 4. The standard pattern is to pre-filter with a cheaper model and render finals on Flux."
           },
           {
             "title": "Speed",
@@ -6247,7 +6134,7 @@
             "body": "Magazine-style hero illustrations for articles, blog posts and reports. Flux's stylistic ceiling sets it apart from the workhorse defaults."
           }
         ],
-        "avoidFor": "Skip Flux Pro 1.1 Ultra in fan-out loops where cost dominates — Gemini 2.5 Flash Image is roughly 2× cheaper per call. Use it as the final-render step rather than the iteration step.",
+        "avoidFor": "Skip Flux Pro 1.1 Ultra in fan-out loops where cost dominates — SeedDream 4 is roughly 2× cheaper per call. Use it as the final-render step rather than the iteration step.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6256,17 +6143,13 @@
           {
             "vs": "SeedDream 4",
             "body": "Both are photoreal-leaning. SeedDream 4 is cheaper and competitive on portrait and product work; Flux Pro 1.1 Ultra wins on hero-shot compositional fidelity at higher cost."
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Different roles. Gemini 2.5 Flash Image is the cheap workhorse for iteration; Flux Pro 1.1 Ultra is the premium final-render step. Stack them, don't pick one."
           }
         ],
         "verdict": "Use Flux Pro 1.1 Ultra as the final-render step after pre-filtering with a cheaper model. The aesthetic ceiling justifies the premium when the image is the deliverable.",
         "faqs": [
           {
             "q": "How much does Flux Pro 1.1 Ultra cost?",
-            "a": "$0.072 per generated image. Roughly 2× Gemini 2.5 Flash Image and SeedDream 4."
+            "a": "$0.072 per generated image. Roughly 2× SeedDream 4."
           },
           {
             "q": "Does it support image editing?",
@@ -6282,15 +6165,11 @@
           }
         ],
         "alternatives": [
-          {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Cheap iteration default"
-          },
           { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
           { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
         ],
         "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
-        "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with Gemini 2.5 Flash Image or SeedDream 4 for the cheap pre-filter."
+        "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with SeedDream 4 for the cheap pre-filter."
       },
       "seedream-4": {
         "name": "SeedDream 4",
@@ -6298,8 +6177,8 @@
         "tagline": "ByteDance's SeedDream 4 text-to-image model. Strong photoreal aesthetic at a cost comparable to the cheapest options in the lineup.",
         "cardIntro": "ByteDance's SeedDream 4. Photoreal aesthetic at a low per-image cost — the natural default when the brief is a photo.",
         "metaTitle": "SeedDream 4 on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "SeedDream 4 on VM0. ByteDance's text-to-image model with strong photoreal output, ~$0.036 per image, and comparison to Gemini 2.5 Flash Image, GPT Image 1 and Flux Pro 1.1 Ultra.",
-        "summary": "SeedDream 4 is ByteDance's text-to-image model in the Seedream V4 generation. Its standout property is the photoreal aesthetic — portraits, product shots, lifestyle photography — at a list price ($0.036 per image) that's competitive with the cheapest option in the curated lineup.\n\nIt's the natural default when the brief is specifically a photo. For stylised illustration or editorial design pick GPT Image 1 or Flux Pro 1.1 Ultra; for general iterative agent workloads on long structured prompts pick Gemini 2.5 Flash Image.",
+        "metaDescription": "SeedDream 4 on VM0. ByteDance's text-to-image model with strong photoreal output, ~$0.036 per image, and comparison to GPT Image 1 and Flux Pro 1.1 Ultra.",
+        "summary": "SeedDream 4 is ByteDance's text-to-image model in the Seedream V4 generation. Its standout property is the photoreal aesthetic — portraits, product shots, lifestyle photography — at a list price ($0.036 per image) that's competitive with the cheapest option in the curated lineup.\n\nIt's the natural default when the brief is specifically a photo. For stylised illustration or editorial design pick GPT Image 1 or Flux Pro 1.1 Ultra.",
         "releaseDate": "April 2026",
         "familyPosition": "ByteDance's photoreal text-to-image default in the Seedream V4 generation.",
         "background": [
@@ -6351,7 +6230,7 @@
             "body": "When the brief is photoreal but the deliverable doesn't justify the Flux premium, SeedDream 4 carries most of the quality at half the price."
           }
         ],
-        "avoidFor": "Skip SeedDream 4 for stylised illustration (GPT Image 1 leads), long structured-prompt iteration (Gemini 2.5 Flash Image leads), or hero-shot editorial work where the Flux premium is justified.",
+        "avoidFor": "Skip SeedDream 4 for stylised illustration (GPT Image 1 leads) or hero-shot editorial work where the Flux premium is justified.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6360,10 +6239,6 @@
           {
             "vs": "Flux Pro 1.1 Ultra",
             "body": "Both photoreal-leaning. SeedDream 4 is half the price and competitive on portrait and product work; Flux Pro 1.1 Ultra wins on hero-shot compositional fidelity."
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Image is the cheap general-purpose default with stronger long-prompt instruction following; SeedDream 4 is the photoreal-specific default with a higher ceiling on photo briefs."
           }
         ],
         "verdict": "Default to SeedDream 4 when the brief is specifically a photo and cost matters. Escalate to Flux Pro 1.1 Ultra only when the hero shot justifies the premium.",
@@ -6387,17 +6262,13 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Cheaper general-purpose default"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "Premium hero-shot quality"
           },
           { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
-        "vm0Notes": "SeedDream 4 is the photoreal-specific default in the curated image lineup. Pair it with Flux Pro 1.1 Ultra for hero shots and with Gemini 2.5 Flash Image for non-photo iteration."
+        "vm0Notes": "SeedDream 4 is the photoreal-specific default in the curated image lineup. Pair it with Flux Pro 1.1 Ultra for hero shots and with GPT Image 1 for non-photo iteration."
       },
       "veo-3-1-fast": {
         "name": "Veo 3.1 Fast",
@@ -6638,7 +6509,7 @@
           },
           {
             "title": "Image-to-video",
-            "body": "Strong handling of image-conditioning flows. Useful when an agent wants to extend a still image (generated cheaply on Gemini 2.5 Flash Image or SeedDream 4) into a short motion clip."
+            "body": "Strong handling of image-conditioning flows. Useful when an agent wants to extend a still image (generated cheaply on SeedDream 4) into a short motion clip."
           },
           {
             "title": "Aesthetic ceiling",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -5978,121 +5978,13 @@
         "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de DeepSeek en `api.deepseek.com`. Modelo predeterminado en el proveedor DeepSeek; también disponible en VM0 Managed.",
         "vm0Notes": "V4 Flash tiene el multiplicador de crédito más bajo de cualquier modelo Built-in (×0,02), aproximadamente 50× menos que Sonnet 4.6. Las lecturas de caché facturan mientras que las escrituras de caché son gratuitas, y VM0 establece un timeout de API de 10 minutos para el proveedor DeepSeek que se empareja naturalmente con el trabajo corto de un solo paso de Flash."
       },
-      "gemini-2-5-flash-image": {
-        "name": "Gemini 2.5 Flash Image",
-        "pageTitle": "Gemini 2.5 Flash Image en VM0. El predeterminado rápido de texto a imagen",
-        "tagline": "El modelo rápido de texto a imagen y edición de imagen de Google. Fuerte seguimiento de instrucciones, consistencia de personajes y el costo de crédito por imagen más barato de la línea curada de imágenes.",
-        "cardIntro": "El modelo rápido de texto a imagen de Google. Barato, preciso siguiendo prompts largos y bueno preservando sujetos a través de ediciones.",
-        "metaTitle": "Gemini 2.5 Flash Image en VM0: Precios, Especificaciones y Comparación",
-        "metaDescription": "Gemini 2.5 Flash Image en VM0. El modelo de texto a imagen y edición de imagen de Google con alta adherencia a instrucciones, consistencia de personajes y ~$0,04 por imagen. Comparado con GPT Image 1, Flux Pro 1.1 Ultra y SeedDream 4.",
-        "summary": "Gemini 2.5 Flash Image es el modelo predeterminado universal de texto a imagen y edición de imagen de Google. Funciona bien en las dos propiedades que más importan para cargas de trabajo de agente: sigue prompts largos y estructurados (para que puedas entregarle el brief completo sin perder instrucciones en el camino) y mantiene los sujetos consistentes a través de ediciones de múltiples turnos (para que un agente pueda iterar sobre el mismo personaje o toma de producto sin que derive entre llamadas).\n\nEl precio de lista es de alrededor de $0,04 por imagen de 1024×1024, lo que lo convierte en el modelo más barato de la línea curada de imágenes. El patrón natural es usar Gemini 2.5 Flash Image por defecto y escalar a Flux Pro 1.1 Ultra o SeedDream 4 solo cuando necesitas una estética específica que el predeterminado no alcanza.",
-        "releaseDate": "Abril 2026",
-        "familyPosition": "El caballo de batalla de texto a imagen de Google para cargas de trabajo de agente.",
-        "background": [
-          "Gemini 2.5 Flash Image es el modelo de texto a imagen y edición de imagen de Google en la familia Gemini 2.5. El planteamiento de Google es el mismo que para la variante Flash del lado de texto: un modelo ajustado para alto rendimiento a bajo costo por llamada, optimizado para cargas de trabajo de producción donde la siguiente solicitud se encola antes de que termine de hacer streaming la anterior.",
-          "Dos propiedades de comportamiento destacan para uso de agente. Primero, la adherencia a instrucciones en prompts largos y estructurados es materialmente mejor que en la mayoría de líneas base de texto a imagen de peso abierto, lo que importa cuando un agente está componiendo el prompt programáticamente y no puede acortarlo. Segundo, la consistencia de personajes y sujetos a través de ediciones de múltiples turnos aguanta bien, que es lo que hace al modelo viable como predeterminado del bucle de edición en flujos de trabajo de agente que iteran sobre un solo activo."
-        ],
-        "architecture": "Modelo de texto a imagen basado en Diffusion con soporte nativo de edición. La facturación es por imagen generada en el nivel estándar. Las entradas aceptan prompts de texto más imágenes de referencia opcionales para flujos tipo edición. Las salidas son PNG en la resolución solicitada.",
-        "specs": [
-          { "label": "Familia", "value": "Generación Gemini 2.5" },
-          {
-            "label": "Modalidades",
-            "value": "Texto a imagen, edición imagen a imagen"
-          },
-          { "label": "Resoluciones", "value": "1024×1024 nivel estándar" },
-          { "label": "Precio listado", "value": "~$0,04 por imagen" },
-          { "label": "Idiomas", "value": "Prompts multilingües" },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
-        ],
-        "benchmarksNote": "",
-        "benchmarks": [],
-        "performance": [
-          {
-            "title": "Adherencia a instrucciones",
-            "body": "Aguanta en prompts largos y estructurados donde muchos modelos de peso abierto empiezan a soltar cláusulas. Útil cuando un agente compone el brief programáticamente y el prompt es innegociable."
-          },
-          {
-            "title": "Consistencia de personajes",
-            "body": "Mantiene a los sujetos reconocibles a través de ediciones de múltiples turnos, que es la propiedad que hace al modelo viable para bucles iterativos de agente sobre un solo activo."
-          },
-          {
-            "title": "Costo",
-            "body": "Alrededor de $0,04 por imagen — el más barato de los modelos curados de texto a imagen en VM0. La generación masiva fan-out se mantiene asequible."
-          },
-          {
-            "title": "Techo estético",
-            "body": "Se inclina hacia salida limpia y precisa en lugar del look hiper-estilizado de Flux Pro 1.1 Ultra o el look fotorrealista de SeedDream 4. Escala cuando la estética es el entregable."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "El agente que redacta visuales de marketing desde un brief",
-            "body": "Entrega al agente la voz de marca, descripción del producto y audiencia objetivo; Gemini 2.5 Flash Image renderiza visuales borrador en segundos. Lo suficientemente barato para hacer fan-out de una docena de variaciones y elegir la mejor."
-          },
-          {
-            "title": "El bucle de edición que itera sobre un solo activo",
-            "body": "Genera una vez, luego itera sobre iluminación, encuadre o fondo manteniendo el sujeto consistente entre turnos. La consistencia de personajes significa que el humano en el bucle está editando la misma imagen, no eligiendo de un conjunto fresco cada turno."
-          },
-          {
-            "title": "El prefiltrado de ilustración antes del modelo premium",
-            "body": "Usa Gemini 2.5 Flash Image para fijar la composición de forma barata, luego re-renderiza el elegido final en Flux Pro 1.1 Ultra para la estética. Reduce el costo del paso premium a una llamada en lugar de un fan-out."
-          }
-        ],
-        "avoidFor": "Evita Gemini 2.5 Flash Image cuando el entregable es la estética — Flux Pro 1.1 Ultra y SeedDream 4 llevan más techo estilístico en looks fotorrealistas y editoriales.",
-        "comparisons": [
-          {
-            "vs": "GPT Image 1",
-            "body": "GPT Image 1 es más fuerte en ilustración estilizada y trabajo de personajes; Gemini 2.5 Flash Image es más barato por llamada y más fuerte en seguimiento de instrucciones en prompts largos. Para cargas de trabajo de agente con prompts estructurados, Gemini 2.5 Flash Image es el predeterminado más seguro."
-          },
-          {
-            "vs": "SeedDream 4",
-            "body": "SeedDream 4 lleva un techo fotorrealista más alto; Gemini 2.5 Flash Image es más barato, más rápido y sigue prompts largos de forma más fiable. Usa Gemini por defecto, escala a SeedDream 4 cuando el brief es específicamente una estética de foto."
-          },
-          {
-            "vs": "Flux Pro 1.1 Ultra",
-            "body": "Flux Pro 1.1 Ultra tiene el techo estilístico más alto de la línea curada; Gemini 2.5 Flash Image gana en costo y en seguimiento de instrucciones. Prefiltra con Gemini, entrega finales en Flux cuando la estética es el punto."
-          }
-        ],
-        "verdict": "Usa Gemini 2.5 Flash Image por defecto para cargas de trabajo de agente de texto a imagen. Escala a Flux Pro 1.1 Ultra o SeedDream 4 solo cuando la estética es el entregable.",
-        "faqs": [
-          {
-            "q": "¿Puede Gemini 2.5 Flash Image editar imágenes existentes?",
-            "a": "Sí. Acepta una imagen de referencia junto al prompt de texto y soporta flujos de inpainting y outpainting para ediciones iterativas."
-          },
-          {
-            "q": "¿Qué resolución de salida produce?",
-            "a": "1024×1024 en el nivel estándar. Resoluciones más altas están disponibles a costo proporcional."
-          },
-          {
-            "q": "¿Cuánto cuesta por imagen?",
-            "a": "Alrededor de $0,04 por imagen generada de 1024×1024 — el más barato de los modelos curados de texto a imagen en VM0."
-          },
-          {
-            "q": "¿Es bueno el modelo con texto dentro de imágenes?",
-            "a": "Sí — significativamente más fuerte que la mayoría de líneas base de peso abierto al renderizar cadenas cortas de texto dentro de la imagen generada."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "gpt-image-1",
-            "reason": "Ilustración estilizada más fuerte"
-          },
-          { "slug": "flux-pro-1-1-ultra", "reason": "Techo estético más alto" },
-          {
-            "slug": "seedream-4",
-            "reason": "Resultados fotorrealistas más fuertes"
-          }
-        ],
-        "routingNotes": "Enrutado al endpoint Gemini 2.5 Flash Image de Google y facturado por imagen generada.",
-        "vm0Notes": "Gemini 2.5 Flash Image es el predeterminado precio/calidad para cargas de trabajo de agente de texto a imagen en VM0. Úsalo como el predeterminado universal y reserva los modelos de imagen más caros para los pasos donde su techo estilístico realmente importa."
-      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 en VM0. El modelo de texto a imagen de OpenAI",
         "tagline": "El modelo de texto a imagen de OpenAI con fuerte ilustración estilizada y edición. La opción natural cuando quieres la estética y estilo de seguimiento de prompts de OpenAI.",
-        "cardIntro": "El modelo de texto a imagen de OpenAI. Fuerte en ilustración estilizada, trabajo de personajes y edición — la contraparte del lado OpenAI de Gemini 2.5 Flash Image.",
+        "cardIntro": "El modelo de texto a imagen de OpenAI. Fuerte en ilustración estilizada, trabajo de personajes y edición — la contraparte del lado OpenAI de SeedDream 4.",
         "metaTitle": "GPT Image 1 en VM0: Precios, Especificaciones y Comparación",
-        "metaDescription": "GPT Image 1 en VM0. El modelo de texto a imagen y edición de imagen de OpenAI con fortaleza en ilustración estilizada, precios multi-nivel y comparación con Gemini 2.5 Flash Image, Flux Pro 1.1 Ultra y SeedDream 4.",
+        "metaDescription": "GPT Image 1 en VM0. El modelo de texto a imagen y edición de imagen de OpenAI con fortaleza en ilustración estilizada, precios multi-nivel y comparación con Flux Pro 1.1 Ultra y SeedDream 4.",
         "summary": "GPT Image 1 es el modelo de texto a imagen de OpenAI — el que la mayoría de equipos conoce como el modelo detrás de la generación de imágenes de ChatGPT. Sus fortalezas son la ilustración estilizada, el trabajo de personajes y la edición de imagen con enmascaramiento basado en texto, con un estilo de seguimiento de prompts que se mapea cercanamente a lo que los modelos de texto de OpenAI esperan.\n\nEl precio de lista es basado en niveles, desde alrededor de $0,011 por imagen en el nivel bajo/estándar hasta $0,25 en el nivel alto/grande. El nivel medio-estándar (alrededor de $0,05 por 1024×1024) es el predeterminado sensato para la mayoría de cargas de trabajo de agente.",
         "releaseDate": "Abril 2026",
         "familyPosition": "El modelo primario de texto a imagen de OpenAI. Precios por nivel a través de configuraciones de resolución y calidad.",
@@ -6148,12 +6040,8 @@
             "body": "Si el agente orquestador ya está en GPT-5.4 o GPT-5.5, mantener la generación de imágenes dentro de la superficie OpenAI (GPT Image 1) significa que el estilo de prompt, semántica de edición y salidas estructuradas permanecen consistentes a través de la ejecución."
           }
         ],
-        "avoidFor": "Evita GPT Image 1 cuando el costo domina (Gemini 2.5 Flash Image es aproximadamente la mitad del precio para el mismo nivel predeterminado) o cuando el entregable es específicamente fotorrealista (SeedDream 4 lleva un techo fotorrealista más alto).",
+        "avoidFor": "Evita GPT Image 1 cuando el costo domina (SeedDream 4 es aproximadamente la mitad del precio para el mismo nivel predeterminado) o cuando el entregable es específicamente fotorrealista (SeedDream 4 lleva un techo fotorrealista más alto).",
         "comparisons": [
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Image es más barato y más fuerte en prompts largos estructurados; GPT Image 1 es más fuerte en ilustración estilizada y se integra de forma más natural con agentes del stack OpenAI."
-          },
           {
             "vs": "SeedDream 4",
             "body": "SeedDream 4 lidera en estética fotorrealista a un precio ligeramente más bajo; GPT Image 1 lidera en ilustración estilizada y flujos de edición."
@@ -6163,7 +6051,7 @@
             "body": "Flux Pro 1.1 Ultra lleva el techo estético más alto para entregables de toma hero; GPT Image 1 es el predeterminado natural del stack OpenAI para todo lo demás."
           }
         ],
-        "verdict": "Elige GPT Image 1 cuando tu agente ya está en el stack OpenAI y quieres ilustración estilizada o flujos de edición nativos. Escala a Flux Pro 1.1 Ultra para tomas hero fotorrealistas; baja a Gemini 2.5 Flash Image cuando el costo domina.",
+        "verdict": "Elige GPT Image 1 cuando tu agente ya está en el stack OpenAI y quieres ilustración estilizada o flujos de edición nativos. Escala a Flux Pro 1.1 Ultra para tomas hero fotorrealistas; baja a SeedDream 4 cuando el costo domina.",
         "faqs": [
           {
             "q": "¿Cómo se cobra GPT Image 1?",
@@ -6184,10 +6072,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Más barato, adherencia más fuerte a prompts largos"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "Techo estético fotorrealista más alto"
           },
@@ -6205,8 +6089,8 @@
         "tagline": "El modelo de texto a imagen de techo alto de Black Forest Labs. La opción cuando la imagen es el entregable y necesitas salida de grado editorial o fotorrealista.",
         "cardIntro": "El modelo de imagen de primer nivel de Black Forest Labs. El techo estético más alto de la línea curada — úsalo para tomas hero y salida de grado editorial.",
         "metaTitle": "Flux Pro 1.1 Ultra en VM0: Precios, Especificaciones y Comparación",
-        "metaDescription": "Flux Pro 1.1 Ultra en VM0. El modelo de texto a imagen de primer nivel de Black Forest Labs con techo estético de grado editorial, $0,072 por imagen y comparación con GPT Image 1, SeedDream 4 y Gemini 2.5 Flash Image.",
-        "summary": "Flux Pro 1.1 Ultra es el modelo de texto a imagen de primer nivel de Black Forest Labs — al que recurrir cuando la imagen en sí es el entregable, no un paso en un bucle de agente. La calidad de salida en estéticas editoriales, fotorrealistas y dirigidas al diseño es la más alta de la línea curada, y la adherencia a prompts en briefs compositivos detallados aguanta bien.\n\nEl precio de lista es de $0,072 por imagen, lo que lo hace caro en relación con Gemini 2.5 Flash Image ($0,04) o SeedDream 4 ($0,036), pero el aumento de calidad por imagen es lo suficientemente grande como para que la mayoría de equipos lo usen como el paso de renderizado final después de prefiltrar con un modelo más barato.",
+        "metaDescription": "Flux Pro 1.1 Ultra en VM0. El modelo de texto a imagen de primer nivel de Black Forest Labs con techo estético de grado editorial, $0,072 por imagen y comparación con GPT Image 1, SeedDream 4.",
+        "summary": "Flux Pro 1.1 Ultra es el modelo de texto a imagen de primer nivel de Black Forest Labs — al que recurrir cuando la imagen en sí es el entregable, no un paso en un bucle de agente. La calidad de salida en estéticas editoriales, fotorrealistas y dirigidas al diseño es la más alta de la línea curada, y la adherencia a prompts en briefs compositivos detallados aguanta bien.\n\nEl precio de lista es de $0,072 por imagen, lo que lo hace caro en relación con SeedDream 4 ($0,04) o SeedDream 4 ($0,036), pero el aumento de calidad por imagen es lo suficientemente grande como para que la mayoría de equipos lo usen como el paso de renderizado final después de prefiltrar con un modelo más barato.",
         "releaseDate": "Abril 2026",
         "familyPosition": "Nivel premium de Black Forest Labs de la generación Flux 1.1.",
         "background": [
@@ -6226,7 +6110,7 @@
         "performance": [
           {
             "title": "Techo estético",
-            "body": "El más alto de la línea curada de imágenes. Las estéticas de toma hero, editoriales y fotorrealistas aterrizan de forma más fiable aquí que en Gemini 2.5 Flash Image o GPT Image 1."
+            "body": "El más alto de la línea curada de imágenes. Las estéticas de toma hero, editoriales y fotorrealistas aterrizan de forma más fiable aquí que en SeedDream 4 o GPT Image 1."
           },
           {
             "title": "Fidelidad compositiva",
@@ -6234,7 +6118,7 @@
           },
           {
             "title": "Costo",
-            "body": "$0,072 por imagen — aproximadamente 2× Gemini 2.5 Flash Image y SeedDream 4. El patrón estándar es prefiltrar con un modelo más barato y renderizar finales en Flux."
+            "body": "$0,072 por imagen — aproximadamente 2× SeedDream 4. El patrón estándar es prefiltrar con un modelo más barato y renderizar finales en Flux."
           },
           {
             "title": "Velocidad",
@@ -6255,7 +6139,7 @@
             "body": "Ilustraciones hero estilo revista para artículos, posts de blog e informes. El techo estilístico de Flux lo separa de los predeterminados caballo de batalla."
           }
         ],
-        "avoidFor": "Evita Flux Pro 1.1 Ultra en bucles fan-out donde el costo domina — Gemini 2.5 Flash Image es aproximadamente 2× más barato por llamada. Úsalo como el paso de renderizado final en lugar del paso de iteración.",
+        "avoidFor": "Evita Flux Pro 1.1 Ultra en bucles fan-out donde el costo domina — SeedDream 4 es aproximadamente 2× más barato por llamada. Úsalo como el paso de renderizado final en lugar del paso de iteración.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6264,17 +6148,13 @@
           {
             "vs": "SeedDream 4",
             "body": "Ambos inclinados al fotorrealismo. SeedDream 4 es la mitad del precio y competitivo en trabajo de retrato y producto; Flux Pro 1.1 Ultra gana en fidelidad compositiva de toma hero a mayor costo."
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Roles diferentes. Gemini 2.5 Flash Image es el caballo de batalla barato para iteración; Flux Pro 1.1 Ultra es el paso premium de renderizado final. Apílalos, no elijas uno."
           }
         ],
         "verdict": "Usa Flux Pro 1.1 Ultra como el paso de renderizado final después de prefiltrar con un modelo más barato. El techo estético justifica la prima cuando la imagen es el entregable.",
         "faqs": [
           {
             "q": "¿Cuánto cuesta Flux Pro 1.1 Ultra?",
-            "a": "$0,072 por imagen generada. Aproximadamente 2× Gemini 2.5 Flash Image y SeedDream 4."
+            "a": "$0,072 por imagen generada. Aproximadamente 2× SeedDream 4."
           },
           {
             "q": "¿Soporta edición de imagen?",
@@ -6291,10 +6171,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Predeterminado barato para iteración"
-          },
-          {
             "slug": "gpt-image-1",
             "reason": "Ilustración estilizada más fuerte"
           },
@@ -6304,7 +6180,7 @@
           }
         ],
         "routingNotes": "Enrutado al endpoint Flux Pro 1.1 Ultra de Black Forest Labs y facturado por imagen generada.",
-        "vm0Notes": "Flux Pro 1.1 Ultra es el nivel premium de la línea curada de imágenes. Úsalo para el paso de renderizado final en lugar de para iteración; empareja con Gemini 2.5 Flash Image o SeedDream 4 para el prefiltrado barato."
+        "vm0Notes": "Flux Pro 1.1 Ultra es el nivel premium de la línea curada de imágenes. Úsalo para el paso de renderizado final en lugar de para iteración; empareja con SeedDream 4 o SeedDream 4 para el prefiltrado barato."
       },
       "seedream-4": {
         "name": "SeedDream 4",
@@ -6312,8 +6188,8 @@
         "tagline": "El modelo de texto a imagen SeedDream 4 de ByteDance. Fuerte estética fotorrealista a un costo comparable a las opciones más baratas de la línea.",
         "cardIntro": "SeedDream 4 de ByteDance. Estética fotorrealista a bajo costo por imagen — el predeterminado natural cuando el brief es una foto.",
         "metaTitle": "SeedDream 4 en VM0: Precios, Especificaciones y Comparación",
-        "metaDescription": "SeedDream 4 en VM0. El modelo de texto a imagen de ByteDance con fuerte salida fotorrealista, ~$0,036 por imagen y comparación con Gemini 2.5 Flash Image, GPT Image 1 y Flux Pro 1.1 Ultra.",
-        "summary": "SeedDream 4 es el modelo de texto a imagen de ByteDance en la generación Seedream V4. Su propiedad destacada es la estética fotorrealista — retratos, tomas de producto, fotografía de estilo de vida — a un precio de lista ($0,036 por imagen) que es competitivo con la opción más barata de la línea curada.\n\nEs el predeterminado natural cuando el brief es específicamente una foto. Para ilustración estilizada o diseño editorial elige GPT Image 1 o Flux Pro 1.1 Ultra; para cargas de trabajo iterativas generales de agente en prompts largos estructurados elige Gemini 2.5 Flash Image.",
+        "metaDescription": "SeedDream 4 en VM0. El modelo de texto a imagen de ByteDance con fuerte salida fotorrealista, ~$0,036 por imagen y comparación con GPT Image 1 y Flux Pro 1.1 Ultra.",
+        "summary": "SeedDream 4 es el modelo de texto a imagen de ByteDance en la generación Seedream V4. Su propiedad destacada es la estética fotorrealista — retratos, tomas de producto, fotografía de estilo de vida — a un precio de lista ($0,036 por imagen) que es competitivo con la opción más barata de la línea curada.\n\nEs el predeterminado natural cuando el brief es específicamente una foto. Para ilustración estilizada o diseño editorial elige GPT Image 1 o Flux Pro 1.1 Ultra; para cargas de trabajo iterativas generales de agente en prompts largos estructurados elige SeedDream 4.",
         "releaseDate": "Abril 2026",
         "familyPosition": "El predeterminado fotorrealista de texto a imagen de ByteDance en la generación Seedream V4.",
         "background": [
@@ -6365,7 +6241,7 @@
             "body": "Cuando el brief es fotorrealista pero el entregable no justifica la prima de Flux, SeedDream 4 lleva la mayor parte de la calidad a la mitad del precio."
           }
         ],
-        "avoidFor": "Evita SeedDream 4 para ilustración estilizada (GPT Image 1 lidera), iteración en prompts largos estructurados (Gemini 2.5 Flash Image lidera) o trabajo editorial de toma hero donde la prima de Flux está justificada.",
+        "avoidFor": "Evita SeedDream 4 para ilustración estilizada (GPT Image 1 lidera), iteración en prompts largos estructurados (SeedDream 4 lidera) o trabajo editorial de toma hero donde la prima de Flux está justificada.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6374,10 +6250,6 @@
           {
             "vs": "Flux Pro 1.1 Ultra",
             "body": "Ambos inclinados al fotorrealismo. SeedDream 4 es la mitad del precio y competitivo en trabajo de retrato y producto; Flux Pro 1.1 Ultra gana en fidelidad compositiva de toma hero."
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Image es el predeterminado barato de propósito general con seguimiento de instrucciones más fuerte en prompts largos; SeedDream 4 es el predeterminado específico fotorrealista con un techo más alto en briefs de foto."
           }
         ],
         "verdict": "Usa SeedDream 4 por defecto cuando el brief es específicamente una foto y el costo importa. Escala a Flux Pro 1.1 Ultra solo cuando la toma hero justifica la prima.",
@@ -6401,10 +6273,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "Predeterminado de propósito general más barato"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "Calidad premium de toma hero"
           },
@@ -6414,7 +6282,7 @@
           }
         ],
         "routingNotes": "Enrutado al endpoint de texto a imagen SeedDream V4 de ByteDance y facturado por imagen generada.",
-        "vm0Notes": "SeedDream 4 es el predeterminado específico fotorrealista en la línea curada de imágenes. Empareja con Flux Pro 1.1 Ultra para tomas hero y con Gemini 2.5 Flash Image para iteración no fotográfica."
+        "vm0Notes": "SeedDream 4 es el predeterminado específico fotorrealista en la línea curada de imágenes. Empareja con Flux Pro 1.1 Ultra para tomas hero y con SeedDream 4 para iteración no fotográfica."
       },
       "veo-3-1-fast": {
         "name": "Veo 3.1 Fast",
@@ -6661,7 +6529,7 @@
           },
           {
             "title": "Imagen a video",
-            "body": "Fuerte manejo de flujos de condicionamiento por imagen. Útil cuando un agente quiere extender una imagen estática (generada de forma barata en Gemini 2.5 Flash Image o SeedDream 4) a un clip corto de movimiento."
+            "body": "Fuerte manejo de flujos de condicionamiento por imagen. Útil cuando un agente quiere extender una imagen estática (generada de forma barata en SeedDream 4 o SeedDream 4) a un clip corto de movimiento."
           },
           {
             "title": "Techo estético",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -5965,118 +5965,13 @@
         "routingNotes": "DeepSeekのAnthropic互換エンドポイント`api.deepseek.com`経由でルーティング。DeepSeekプロバイダーのデフォルトモデル。VM0 Managedでも利用可能。",
         "vm0Notes": "V4 FlashはBuilt-inモデル中最低のクレジットマルチプライヤー（×0.02）を持ち、Sonnet 4.6の約50分の1です。キャッシュ読み取りは課金、キャッシュ書き込みは無料。VM0はDeepSeekプロバイダーに10分のAPIタイムアウトを設定しており、Flashの短い単発作業と自然に適合します。"
       },
-      "gemini-2-5-flash-image": {
-        "name": "Gemini 2.5 Flash Image",
-        "pageTitle": "Gemini 2.5 Flash Image on VM0. 高速テキストツーイメージのデフォルト",
-        "tagline": "Googleの高速テキストツーイメージおよび画像編集モデル。強力な指示追従、キャラクター一貫性、キュレーション済み画像ラインナップで画像あたり最も安いクレジットコスト。",
-        "cardIntro": "Googleの高速テキストツーイメージモデル。安価で、長いプロンプトの追従が正確、編集にわたって被写体を保持するのが得意。",
-        "metaTitle": "Gemini 2.5 Flash Image on VM0: 価格、仕様、比較",
-        "metaDescription": "VM0上のGemini 2.5 Flash Image。Googleのテキストツーイメージおよび画像編集モデル、高い指示遵守、キャラクター一貫性、画像あたり約$0.04。GPT Image 1、Flux Pro 1.1 Ultra、SeedDream 4と比較。",
-        "summary": "Gemini 2.5 Flash ImageはGoogleのどこでもデフォルトのテキストツーイメージおよび画像編集モデルです。エージェントワークロードに最も重要な2つの特性で優れています：長く構造化されたプロンプトに従う（途中で指示を失うことなくフルブリーフを渡せます）、そしてマルチターン編集にわたって被写体を一貫させる（呼び出し間でドリフトすることなく、エージェントが同じキャラクターまたは製品ショットを反復できます）。\n\n定価は1024×1024画像あたり約$0.04で、キュレーション済み画像ラインナップで最も安いモデルです。自然なパターンは、Gemini 2.5 Flash Imageをデフォルトにし、デフォルトが届かない特定のアスペクトレシオまたはアスペクトが必要なときのみFlux Pro 1.1 UltraまたはSeedDream 4にエスカレートすることです。",
-        "releaseDate": "2026年4月",
-        "familyPosition": "エージェントワークロードのためのGoogleのテキストツーイメージワークホース。",
-        "background": [
-          "Gemini 2.5 Flash ImageはGemini 2.5ファミリーにおけるGoogleのテキストツーイメージおよび画像編集モデルです。Googleのフレーミングはテキスト側のFlashバリアントと同じです：低いコールあたりコストで高スループットに調整され、最後のリクエストがストリーミングを終える前に次のリクエストがキューに入るプロダクションワークロード向けに最適化されたモデル。",
-          "エージェント使用において2つの行動的特性が際立ちます。第一に、長く構造化されたプロンプトに対する指示遵守が、ほとんどのオープンウェイトテキストツーイメージのベースラインよりも大幅に優れています。これはエージェントがプログラム的にプロンプトを構成し、短縮できない場合に重要です。第二に、マルチターン編集にわたるキャラクターと被写体の一貫性がよく保たれます。これが、単一のアセットを反復するエージェントワークフローにおける編集ループのデフォルトとしてモデルを実行可能にしているものです。"
-        ],
-        "architecture": "ネイティブ編集サポート付きのディフュージョンベースのテキストツーイメージモデル。標準ティアで生成画像あたり課金。入力はテキストプロンプトと、編集スタイルフロー用のオプションのリファレンス画像を受け付けます。出力は要求された解像度のPNG。",
-        "specs": [
-          { "label": "ファミリー", "value": "Gemini 2.5世代" },
-          {
-            "label": "モダリティ",
-            "value": "テキストツーイメージ、イメージツーイメージ編集"
-          },
-          { "label": "出力解像度", "value": "1024×1024標準ティア" },
-          { "label": "ベンダー定価", "value": "画像あたり約$0.04" },
-          { "label": "言語", "value": "多言語プロンプト" },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
-        ],
-        "benchmarksNote": "",
-        "benchmarks": [],
-        "performance": [
-          {
-            "title": "指示遵守",
-            "body": "多くのオープンウェイトモデルが節を脱落させ始める長く構造化されたプロンプトで持ちこたえます。エージェントがブリーフをプログラム的に構成し、プロンプトが交渉不可能な場合に有用です。"
-          },
-          {
-            "title": "キャラクター一貫性",
-            "body": "マルチターン編集にわたって被写体を認識可能に保ち、これが単一アセット上の反復的エージェントループに対してモデルを実行可能にしている特性です。"
-          },
-          {
-            "title": "コスト",
-            "body": "画像あたり約$0.04 — VM0上のキュレーション済みテキストツーイメージモデルで最安。バルクファンアウト生成が手頃なまま。"
-          },
-          {
-            "title": "アスペクト天井",
-            "body": "Flux Pro 1.1 Ultraのハイパースタイライズドな見た目やSeedDream 4のフォトリアルな見た目ではなく、クリーンで正確な出力に偏っています。アスペクトが成果物の場合はエスカレートしてください。"
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "ブリーフからマーケティングビジュアルをドラフトするエージェント",
-            "body": "ブランドボイス、製品説明、ターゲットオーディエンスをエージェントに渡してください。Gemini 2.5 Flash Imageは数秒でドラフトビジュアルをレンダリングします。十数のバリエーションをファンアウトして最良を選ぶのに十分安価。"
-          },
-          {
-            "title": "単一アセットを反復する編集ループ",
-            "body": "一度生成して、ターン間で被写体を一貫させながら照明、フレーミング、または背景を反復します。キャラクター一貫性は、ループ内の人間が同じ画像を編集していることを意味し、毎ターン新しいセットから選ぶわけではありません。"
-          },
-          {
-            "title": "プレミアムモデルの前のイラスト事前フィルタ",
-            "body": "Gemini 2.5 Flash Imageを使って構図を安価にロックし、最終選択をFlux Pro 1.1 Ultraでアスペクトのために再レンダリングします。プレミアムステップのコストをファンアウトではなく1回の呼び出しに削減します。"
-          }
-        ],
-        "avoidFor": "成果物がアスペクトの場合はGemini 2.5 Flash Imageをスキップしてください — Flux Pro 1.1 UltraとSeedDream 4はフォトリアルおよびエディトリアルな見た目でより多くのスタイリスティック天井を運びます。",
-        "comparisons": [
-          {
-            "vs": "GPT Image 1",
-            "body": "GPT Image 1はスタイライズドイラストとキャラクター作業でより強く、Gemini 2.5 Flash Imageはコールあたり安価で長いプロンプトの指示追従でより強い。構造化プロンプトを持つエージェントワークロードには、Gemini 2.5 Flash Imageがより安全なデフォルトです。"
-          },
-          {
-            "vs": "SeedDream 4",
-            "body": "SeedDream 4はより高いフォトリアル天井を運び、Gemini 2.5 Flash Imageはより安価、高速、長いプロンプトをより信頼性高く追従します。Geminiをデフォルトに、ブリーフが特にフォト的アスペクトの場合のみSeedDream 4にエスカレートしてください。"
-          },
-          {
-            "vs": "Flux Pro 1.1 Ultra",
-            "body": "Flux Pro 1.1 Ultraはキュレーション済みラインナップで最高のスタイリスティック天井を持ち、Gemini 2.5 Flash Imageはコストと指示追従で勝ちます。Geminiで事前フィルタし、アスペクトがポイントのときFluxで最終を提供してください。"
-          }
-        ],
-        "verdict": "テキストツーイメージエージェントワークロードにはGemini 2.5 Flash Imageをデフォルトに。アスペクトが成果物の場合のみFlux Pro 1.1 UltraまたはSeedDream 4にエスカレートしてください。",
-        "faqs": [
-          {
-            "q": "Gemini 2.5 Flash Imageは既存の画像を編集できますか？",
-            "a": "はい。テキストプロンプトと並んでリファレンス画像を受け付け、反復編集のためのインペインティングとアウトペインティングフローをサポートしています。"
-          },
-          {
-            "q": "どの出力解像度を生成しますか？",
-            "a": "標準ティアで1024×1024。より高い解像度は比例コストで利用可能。"
-          },
-          {
-            "q": "画像あたりのコストは？",
-            "a": "生成された1024×1024画像あたり約$0.04 — VM0上のキュレーション済みテキストツーイメージモデルで最安。"
-          },
-          {
-            "q": "モデルは画像内のテキストが得意ですか？",
-            "a": "はい — 生成された画像内に短いテキスト文字列をレンダリングする点で、ほとんどのオープンウェイトベースラインよりも大幅に強力です。"
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "gpt-image-1",
-            "reason": "より強力なスタイライズドイラスト"
-          },
-          { "slug": "flux-pro-1-1-ultra", "reason": "より高いアスペクト天井" },
-          { "slug": "seedream-4", "reason": "より強力なフォトリアル結果" }
-        ],
-        "routingNotes": "Routed to Google's Gemini 2.5 Flash Image endpoint and billed per generated image.",
-        "vm0Notes": "Gemini 2.5 Flash Image is the price/quality default for text-to-image agent workloads on VM0. Use it as the everywhere-default and reserve the more expensive image models for the steps where their stylistic ceiling actually matters."
-      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 on VM0. OpenAIのテキストツーイメージモデル",
         "tagline": "強力なスタイライズドイラストと編集を持つOpenAIのテキストツーイメージモデル。OpenAIのアスペクトとプロンプト追従スタイルが欲しいときの自然な選択。",
-        "cardIntro": "OpenAIのテキストツーイメージモデル。スタイライズドイラスト、キャラクター作業、編集に強い — Gemini 2.5 Flash ImageのOpenAI側の対応物。",
+        "cardIntro": "OpenAIのテキストツーイメージモデル。スタイライズドイラスト、キャラクター作業、編集に強い — SeedDream 4のOpenAI側の対応物。",
         "metaTitle": "GPT Image 1 on VM0: 価格、仕様、比較",
-        "metaDescription": "VM0上のGPT Image 1。OpenAIのテキストツーイメージおよび画像編集モデル、スタイライズドイラストの強み、マルチティア価格、Gemini 2.5 Flash Image、Flux Pro 1.1 Ultra、SeedDream 4との比較。",
+        "metaDescription": "VM0上のGPT Image 1。OpenAIのテキストツーイメージおよび画像編集モデル、スタイライズドイラストの強み、マルチティア価格、Flux Pro 1.1 Ultra、SeedDream 4との比較。",
         "summary": "GPT Image 1はOpenAIのテキストツーイメージモデル — ほとんどのチームがChatGPTの画像生成の背後にあるモデルとして知っているものです。その強みは、テキスト駆動マスキングによるスタイライズドイラスト、キャラクター作業、画像編集であり、OpenAIのテキストモデルが期待するものに密接にマッピングするプロンプト追従スタイルです。\n\n定価はティアベースで、低/標準ティアで画像あたり約$0.011から、高/大ティアで$0.25まで。中標準ティア（1024×1024で約$0.05）はほとんどのエージェントワークロードに対する賢明なデフォルトです。",
         "releaseDate": "2026年4月",
         "familyPosition": "OpenAIの主要なテキストツーイメージモデル。解像度と品質設定にわたるティア価格。",
@@ -6126,12 +6021,8 @@
             "body": "オーケストレーションエージェントが既にGPT-5.4またはGPT-5.5上にある場合、画像生成をOpenAIサーフェス内（GPT Image 1）に保つことで、プロンプトスタイル、編集セマンティクス、構造化出力が実行全体で一貫したまま保たれます。"
           }
         ],
-        "avoidFor": "コストが支配的な場合（Gemini 2.5 Flash Imageは同じデフォルトティアで約半分の価格）、または成果物が特にフォトリアルな場合（SeedDream 4はより高いフォトリアル天井を運びます）はGPT Image 1をスキップしてください。",
+        "avoidFor": "コストが支配的な場合（SeedDream 4は同じデフォルトティアで約半分の価格）、または成果物が特にフォトリアルな場合（SeedDream 4はより高いフォトリアル天井を運びます）はGPT Image 1をスキップしてください。",
         "comparisons": [
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Imageはより安価で長い構造化プロンプトで強く、GPT Image 1はスタイライズドイラストで強く、OpenAIスタックエージェントとより自然に統合します。"
-          },
           {
             "vs": "SeedDream 4",
             "body": "SeedDream 4はわずかに低い価格でフォトリアルアスペクトでリードし、GPT Image 1はスタイライズドイラストと編集フローでリードします。"
@@ -6141,7 +6032,7 @@
             "body": "Flux Pro 1.1 Ultraはヒーローショット成果物で最高のアスペクト天井を運び、GPT Image 1はその他すべての自然なOpenAIスタックデフォルトです。"
           }
         ],
-        "verdict": "エージェントが既にOpenAIスタック上にあり、スタイライズドイラストまたはネイティブ編集フローが欲しい場合はGPT Image 1を選んでください。フォトリアルヒーローショットにはFlux Pro 1.1 Ultraにエスカレート、コストが支配する場合はGemini 2.5 Flash Imageに降格してください。",
+        "verdict": "エージェントが既にOpenAIスタック上にあり、スタイライズドイラストまたはネイティブ編集フローが欲しい場合はGPT Image 1を選んでください。フォトリアルヒーローショットにはFlux Pro 1.1 Ultraにエスカレート、コストが支配する場合はSeedDream 4に降格してください。",
         "faqs": [
           {
             "q": "GPT Image 1の価格は？",
@@ -6162,10 +6053,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "より安価、より強力な長プロンプト遵守"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "より高いフォトリアルアスペクト天井"
           },
@@ -6180,8 +6067,8 @@
         "tagline": "Black Forest Labsのハイ天井テキストツーイメージモデル。画像が成果物で、エディトリアルまたはフォトリアルグレードの出力が必要なときの選択。",
         "cardIntro": "Black Forest Labsのトップティア画像モデル。キュレーション済みラインナップで最高のアスペクト天井 — ヒーローショットとエディトリアルグレードの出力に使用。",
         "metaTitle": "Flux Pro 1.1 Ultra on VM0: 価格、仕様、比較",
-        "metaDescription": "VM0上のFlux Pro 1.1 Ultra。Black Forest Labsのトップティアテキストツーイメージモデル、エディトリアルグレードのアスペクト天井、画像あたり$0.072、GPT Image 1、SeedDream 4、Gemini 2.5 Flash Imageとの比較。",
-        "summary": "Flux Pro 1.1 UltraはBlack Forest Labsのトップティアテキストツーイメージモデル — 画像自体がエージェントループのステップではなく成果物のときに手を伸ばすものです。エディトリアル、フォトリアル、デザイン主導のアスペクトでの出力品質はキュレーション済みラインナップで最高であり、詳細な構図ブリーフでのプロンプト遵守がよく保たれます。\n\n定価は画像あたり$0.072で、Gemini 2.5 Flash Image（$0.04）やSeedDream 4（$0.036）に対して高価ですが、画像あたりの品質リフトは十分に大きく、ほとんどのチームは安価なモデルで事前フィルタした後の最終レンダリングステップとして使用します。",
+        "metaDescription": "VM0上のFlux Pro 1.1 Ultra。Black Forest Labsのトップティアテキストツーイメージモデル、エディトリアルグレードのアスペクト天井、画像あたり$0.072、GPT Image 1、SeedDream 4との比較。",
+        "summary": "Flux Pro 1.1 UltraはBlack Forest Labsのトップティアテキストツーイメージモデル — 画像自体がエージェントループのステップではなく成果物のときに手を伸ばすものです。エディトリアル、フォトリアル、デザイン主導のアスペクトでの出力品質はキュレーション済みラインナップで最高であり、詳細な構図ブリーフでのプロンプト遵守がよく保たれます。\n\n定価は画像あたり$0.072で（$0.04）やSeedDream 4（$0.036）に対して高価ですが、画像あたりの品質リフトは十分に大きく、ほとんどのチームは安価なモデルで事前フィルタした後の最終レンダリングステップとして使用します。",
         "releaseDate": "2026年4月",
         "familyPosition": "Black Forest LabsのFlux 1.1世代のプレミアムティア。",
         "background": [
@@ -6201,7 +6088,7 @@
         "performance": [
           {
             "title": "アスペクト天井",
-            "body": "キュレーション済み画像ラインナップで最高。ヒーローショット、エディトリアル、フォトリアルなアスペクトがGemini 2.5 Flash ImageやGPT Image 1よりもここで信頼性高く着地します。"
+            "body": "キュレーション済み画像ラインナップで最高。ヒーローショット、エディトリアル、フォトリアルなアスペクトがSeedDream 4やGPT Image 1よりもここで信頼性高く着地します。"
           },
           {
             "title": "構図忠実度",
@@ -6209,7 +6096,7 @@
           },
           {
             "title": "コスト",
-            "body": "画像あたり$0.072 — Gemini 2.5 Flash ImageとSeedDream 4の約2倍。標準パターンは安価なモデルで事前フィルタし、Fluxで最終をレンダリングすることです。"
+            "body": "画像あたり$0.072 — SeedDream 4とSeedDream 4の約2倍。標準パターンは安価なモデルで事前フィルタし、Fluxで最終をレンダリングすることです。"
           },
           {
             "title": "速度",
@@ -6230,7 +6117,7 @@
             "body": "記事、ブログ投稿、レポート用のマガジンスタイルのヒーローイラスト。Fluxのスタイリスティック天井がワークホースデフォルトと一線を画します。"
           }
         ],
-        "avoidFor": "コストが支配的なファンアウトループではFlux Pro 1.1 Ultraをスキップしてください — Gemini 2.5 Flash Imageはコールあたり約2倍安価です。反復ステップではなく、最終レンダリングステップとして使用してください。",
+        "avoidFor": "コストが支配的なファンアウトループではFlux Pro 1.1 Ultraをスキップしてください — SeedDream 4はコールあたり約2倍安価です。反復ステップではなく、最終レンダリングステップとして使用してください。",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6239,17 +6126,13 @@
           {
             "vs": "SeedDream 4",
             "body": "両方ともフォトリアル傾向。SeedDream 4はより安価でポートレートと製品作業で競争力があり、Flux Pro 1.1 Ultraはより高いコストでヒーローショットの構図忠実度で勝ちます。"
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "異なる役割。Gemini 2.5 Flash Imageは反復用の安価なワークホースで、Flux Pro 1.1 Ultraはプレミアム最終レンダリングステップ。スタックしてください、1つを選ばないで。"
           }
         ],
         "verdict": "Flux Pro 1.1 Ultraを安価なモデルで事前フィルタした後の最終レンダリングステップとして使用してください。画像が成果物のとき、アスペクト天井がプレミアムを正当化します。",
         "faqs": [
           {
             "q": "Flux Pro 1.1 Ultraのコストは？",
-            "a": "生成画像あたり$0.072。Gemini 2.5 Flash ImageとSeedDream 4の約2倍。"
+            "a": "生成画像あたり$0.072。SeedDream 4とSeedDream 4の約2倍。"
           },
           {
             "q": "画像編集をサポートしていますか？",
@@ -6266,17 +6149,13 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "安価な反復デフォルト"
-          },
-          {
             "slug": "gpt-image-1",
             "reason": "より強力なスタイライズドイラスト"
           },
           { "slug": "seedream-4", "reason": "より安価なフォトリアル代替" }
         ],
         "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
-        "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with Gemini 2.5 Flash Image or SeedDream 4 for the cheap pre-filter."
+        "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with SeedDream 4 for the cheap pre-filter."
       },
       "seedream-4": {
         "name": "SeedDream 4",
@@ -6284,8 +6163,8 @@
         "tagline": "ByteDanceのSeedDream 4テキストツーイメージモデル。ラインナップで最も安いオプションに匹敵するコストで強力なフォトリアルアスペクト。",
         "cardIntro": "ByteDanceのSeedDream 4。低い画像あたりコストでのフォトリアルアスペクト — ブリーフが写真のときの自然なデフォルト。",
         "metaTitle": "SeedDream 4 on VM0: 価格、仕様、比較",
-        "metaDescription": "VM0上のSeedDream 4。ByteDanceのテキストツーイメージモデル、強力なフォトリアル出力、画像あたり約$0.036、Gemini 2.5 Flash Image、GPT Image 1、Flux Pro 1.1 Ultraとの比較。",
-        "summary": "SeedDream 4はByteDanceのSeedream V4世代のテキストツーイメージモデルです。その際立った特性はフォトリアルアスペクト — ポートレート、製品ショット、ライフスタイル写真 — であり、定価（画像あたり$0.036）はキュレーション済みラインナップで最も安いオプションと競争力があります。\n\nブリーフが特に写真の場合の自然なデフォルトです。スタイライズドイラストやエディトリアルデザインにはGPT Image 1またはFlux Pro 1.1 Ultraを、長く構造化されたプロンプトでの一般的な反復エージェントワークロードにはGemini 2.5 Flash Imageを選んでください。",
+        "metaDescription": "VM0上のSeedDream 4。ByteDanceのテキストツーイメージモデル、強力なフォトリアル出力、画像あたり約$0.036、GPT Image 1、Flux Pro 1.1 Ultraとの比較。",
+        "summary": "SeedDream 4はByteDanceのSeedream V4世代のテキストツーイメージモデルです。その際立った特性はフォトリアルアスペクト — ポートレート、製品ショット、ライフスタイル写真 — であり、定価（画像あたり$0.036）はキュレーション済みラインナップで最も安いオプションと競争力があります。\n\nブリーフが特に写真の場合の自然なデフォルトです。スタイライズドイラストやエディトリアルデザインにはGPT Image 1またはFlux Pro 1.1 Ultraを、長く構造化されたプロンプトでの一般的な反復エージェントワークロードにはSeedDream 4を選んでください。",
         "releaseDate": "2026年4月",
         "familyPosition": "ByteDanceのSeedream V4世代のフォトリアルテキストツーイメージデフォルト。",
         "background": [
@@ -6337,7 +6216,7 @@
             "body": "ブリーフがフォトリアルだが成果物がFluxプレミアムを正当化しない場合、SeedDream 4は半分の価格でほとんどの品質を運びます。"
           }
         ],
-        "avoidFor": "スタイライズドイラスト（GPT Image 1がリード）、長い構造化プロンプト反復（Gemini 2.5 Flash Imageがリード）、またはFluxプレミアムが正当化されるヒーローショットエディトリアル作業ではSeedDream 4をスキップしてください。",
+        "avoidFor": "スタイライズドイラスト（GPT Image 1がリード）、長い構造化プロンプト反復（SeedDream 4がリード）、またはFluxプレミアムが正当化されるヒーローショットエディトリアル作業ではSeedDream 4をスキップしてください。",
         "comparisons": [
           {
             "vs": "GPT Image 1",
@@ -6346,10 +6225,6 @@
           {
             "vs": "Flux Pro 1.1 Ultra",
             "body": "両方ともフォトリアル傾向。SeedDream 4は半分の価格でポートレートと製品作業で競争力があり、Flux Pro 1.1 Ultraはヒーローショットの構図忠実度で勝ちます。"
-          },
-          {
-            "vs": "Gemini 2.5 Flash Image",
-            "body": "Gemini 2.5 Flash Imageは長プロンプトの指示追従がより強い安価な汎用デフォルトで、SeedDream 4は写真ブリーフでより高い天井を持つフォトリアル特化デフォルトです。"
           }
         ],
         "verdict": "ブリーフが特に写真でコストが重要なときはSeedDream 4をデフォルトに。ヒーローショットがプレミアムを正当化する場合のみFlux Pro 1.1 Ultraにエスカレートしてください。",
@@ -6373,10 +6248,6 @@
         ],
         "alternatives": [
           {
-            "slug": "gemini-2-5-flash-image",
-            "reason": "より安価な汎用デフォルト"
-          },
-          {
             "slug": "flux-pro-1-1-ultra",
             "reason": "プレミアムヒーローショット品質"
           },
@@ -6386,7 +6257,7 @@
           }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
-        "vm0Notes": "SeedDream 4 is the photoreal-specific default in the curated image lineup. Pair it with Flux Pro 1.1 Ultra for hero shots and with Gemini 2.5 Flash Image for non-photo iteration."
+        "vm0Notes": "SeedDream 4 is the photoreal-specific default in the curated image lineup. Pair it with Flux Pro 1.1 Ultra for hero shots and with GPT Image 1 for non-photo iteration."
       },
       "veo-3-1-fast": {
         "name": "Veo 3.1 Fast",
@@ -6633,7 +6504,7 @@
           },
           {
             "title": "イメージツービデオ",
-            "body": "画像条件付けフローの強力な処理。エージェントが静止画像（Gemini 2.5 Flash ImageまたはSeedDream 4で安価に生成）を短いモーションクリップに拡張したい場合に有用。"
+            "body": "画像条件付けフローの強力な処理。エージェントが静止画像（SeedDream 4またはSeedDream 4で安価に生成）を短いモーションクリップに拡張したい場合に有用。"
           },
           {
             "title": "アスペクト天井",


### PR DESCRIPTION
## Summary
- Drop **Gemini 2.5 Flash Image** from `/models`: the catalog entry, peer image models' alternative/comparison references, and narrative mentions across en/de/es/ja locales.
- Route the per-model CTA on `/models/[slug]` into `https://app.vm0.ai/onboarding?prompt=<prefilled>` for image/video models. Reasoning model CTAs are unchanged.
- The prefilled prompt names the model id in plain English (e.g. `Generate an illustration of a cute cat using the gpt-image-1 model.`) so the agent reliably passes the model to the built-in generator while the visible copy stays natural.

## Why
Earlier the "Use SeedDream 4 on VM0" CTA dropped users into an empty chat with no way to actually select the named model: the agent would default to `gpt-image-1` regardless of which detail page they arrived from. The marketing page made a promise the product couldn't keep. Deep-linking into `/onboarding?prompt=...` with a model-hinted prompt closes that gap without requiring a new per-message model selector.

Removing Gemini 2.5 Flash Image keeps the surface honest: the model is still wired up via the Gemini connector for users with their own key, but it isn't a curated built-in, so it shouldn't share the same `/models` CTA as the others.

## Prompts (per model)
| Slug | Prompt |
|------|--------|
| `gpt-image-1` | Generate an illustration of a cute cat using the gpt-image-1 model. |
| `flux-pro-1-1-ultra` | Generate a photorealistic studio portrait of a cat using the flux-pro-1.1-ultra model. |
| `seedream-4` | Generate a photorealistic shot of a cat sitting in a sunny window using the seedream4 model. |
| `veo-3-1-fast` | Generate a short cinematic video of a cat stretching on a sunlit windowsill using the veo3.1-fast model. |
| `kling-v3-4k` | Generate a stylized 4K video of a cat walking through a neon-lit alley using the kling-v3-4k model. |
| `dreamina-seedance-2-0` | Generate a smooth tracking video of a cat exploring a flower garden using the dreamina-seedance-2.0 model. |

## Test plan
- [ ] `pnpm -F web tsc --noEmit` clean against models scope
- [ ] `eslint app/[locale]/models` clean
- [ ] Visit `/en/models` and confirm Gemini 2.5 Flash Image no longer listed
- [ ] Visit `/en/models/gemini-2-5-flash-image` → expect 404
- [ ] Click the hero CTA on each remaining image and video detail page → lands on `app.vm0.ai/onboarding` with the prompt prefilled in the chat composer
- [ ] Submit the prefilled prompt and confirm the agent calls the named model via `zero built-in generate {image,video}`
- [ ] Reasoning model CTAs still route to the bare app URL (no prompt param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)