### PR TITLE
feat(onboarding): make connector optional on use-case deep links

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -25,13 +25,12 @@ export const setupOnboardingPage$ = command(
     set(resetOnboardingStep$);
     signal.throwIfAborted();
 
-    // Detect use-case deep link early — `?prompt=...&connector=...` lets even
-    // already-onboarded users (including non-admins) land here intentionally
-    // to try a suggested task, so we must NOT auto-redirect them home then.
+    // Detect use-case deep link early — `?prompt=...` (optionally with
+    // `&connector=...`) lets even already-onboarded users (including
+    // non-admins) land here intentionally to try a suggested task, so we
+    // must NOT auto-redirect them home then.
     const earlyParams = get(searchParams$);
-    const hasUseCaseLink =
-      (earlyParams.get("prompt")?.length ?? 0) > 0 &&
-      earlyParams.get("connector") !== null;
+    const hasUseCaseLink = (earlyParams.get("prompt")?.length ?? 0) > 0;
 
     // Onboarding is purely admin workspace setup. If onboarding is not needed
     // (non-admins, or admins whose workspace is already set up) and there's no
@@ -78,17 +77,13 @@ export const setupOnboardingPage$ = command(
       }
     }
 
-    // "Use case" deep link: ?prompt=... + ?connector=... together signal that
-    // the user came in from a specific suggested task. We seed an editable
-    // prompt draft and switch onboarding into condensed mode where the flow
-    // collapses to step 3, which grows a composer + "Try It" CTA that goes
-    // straight to the web chat.
+    // "Use case" deep link: ?prompt=... (optionally with ?connector=...)
+    // signals that the user came in from a specific suggested task. We seed
+    // an editable prompt draft and switch onboarding into condensed mode
+    // where the flow collapses to step 3, which grows a composer + "Try It"
+    // CTA that goes straight to the web chat.
     const promptParam = params.get("prompt");
-    if (
-      promptParam !== null &&
-      promptParam.length > 0 &&
-      connectorParam !== null
-    ) {
+    if (promptParam !== null && promptParam.length > 0) {
       set(markUseCaseMode$, promptParam);
     }
   },

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts
@@ -81,7 +81,7 @@ describe("onboarding use-case mode (?prompt=...&connector=...)", () => {
     expect(context.store.get(zeroSelectedConnectors$)).toContain("github");
   });
 
-  it("does not enter use-case mode when only ?prompt= is present", async () => {
+  it("enters use-case mode when only ?prompt= is present (connector is optional)", async () => {
     mockAdminOnboarding();
 
     detachedSetupPage({
@@ -92,8 +92,8 @@ describe("onboarding use-case mode (?prompt=...&connector=...)", () => {
 
     await context.store.set(setupOnboardingPage$, context.signal);
 
-    expect(context.store.get(onboardingIsUseCase$)).toBeFalsy();
-    expect(context.store.get(onboardingPromptDraft$)).toBe("");
+    expect(context.store.get(onboardingIsUseCase$)).toBeTruthy();
+    expect(context.store.get(onboardingPromptDraft$)).toBe("hello");
   });
 
   it("does not enter use-case mode when only ?connector= is present", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -57,8 +57,9 @@ export const onboardingEffectiveConnectors$ = computed((get) => {
 
 /**
  * The resolved step. Onboarding is admin workspace setup (step 1 → step 2).
- * A use-case deep link (`?prompt=&connector=`) collapses the flow to step 3,
- * where the user reviews connectors + edits the prompt before "Try It".
+ * A use-case deep link (`?prompt=`, optionally with `&connector=`) collapses
+ * the flow to step 3, where the user reviews connectors + edits the prompt
+ * before "Try It".
  */
 export const onboardingEffectiveStep$ = computed(async (get) => {
   const step = await get(zeroOnboardingStep$);

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -52,10 +52,11 @@ const internalWorkspaceName$ = state("");
 const internalSelectedConnectors$ = state<ConnectorType[]>([]);
 
 /**
- * True when the user arrived via a "use case" deep link carrying both
- * `?connector=` and `?prompt=`. In this mode the onboarding is condensed to
- * step 3, which grows an editable composer so the user can tweak the prompt
- * before continuing straight into the web chat with their default agent.
+ * True when the user arrived via a "use case" deep link carrying a
+ * `?prompt=` (with or without `?connector=`). In this mode the onboarding
+ * is condensed to step 3, which grows an editable composer so the user can
+ * tweak the prompt before continuing straight into the web chat with their
+ * default agent.
  */
 const internalUseCaseMode$ = state(false);
 const internalPromptDraft$ = state("");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -101,9 +101,9 @@ describe("onboarding connector permission dialog suppression", () => {
     await fill(input, "Test Workspace");
     click(screen.getByText("Next"));
 
-    // Step 3: Connect your apps (github pre-selected from the deep link)
+    // Step 3: Try this prompt (github pre-selected from the deep link)
     await waitFor(() => {
-      expect(screen.getByText("Connect your apps")).toBeInTheDocument();
+      expect(screen.getByText("Try this prompt")).toBeInTheDocument();
     });
 
     // Mock the connectors API to return GitHub as connected (simulates
@@ -182,7 +182,7 @@ describe("onboarding connector permission dialog suppression", () => {
     click(screen.getByText("Next"));
 
     await waitFor(() => {
-      expect(screen.getByText("Connect your apps")).toBeInTheDocument();
+      expect(screen.getByText("Try this prompt")).toBeInTheDocument();
     });
     click(screen.getByText("Connect"));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -110,25 +110,27 @@ describe("onboarding continue in web → agent chat page", () => {
 // ---------------------------------------------------------------------------
 
 describe("prompt param forwarding", () => {
-  it("should forward ?prompt= to chat page via Get Started", async () => {
+  it("?prompt= alone enters use-case mode and seeds the Try It composer", async () => {
     mockAdminOnboarding();
 
     detachedSetupPage({ context, path: "/onboarding?prompt=hello%20world" });
-    await walkAdminToContinue();
 
-    switchToAdminComplete();
-
-    click(screen.getByText(/Get Started/));
+    // Step 1: name workspace. Use-case mode collapses step 2, so the next
+    // screen after Next is the condensed step 3 with the editable composer
+    // and a "Try It" CTA — not the regular "Choose your tools" picker.
+    await waitFor(() => {
+      expect(screen.getByText(/Name your workspace/)).toBeInTheDocument();
+    });
+    await fill(screen.getByPlaceholderText("e.g. Acme Corp"), "Test Workspace");
+    click(screen.getByText("Next"));
 
     await waitFor(() => {
-      expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
+      expect(screen.getByText("Try this prompt")).toBeInTheDocument();
     });
-
-    // The chat page consumes ?prompt= and injects it into the textarea
-    const textarea = await waitFor(() => {
-      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-    });
-    expect(textarea).toHaveValue("hello world");
+    expect(screen.getByTestId("onboarding-prompt-input")).toHaveValue(
+      "hello world",
+    );
+    expect(screen.getByText("Try It")).toBeInTheDocument();
   });
 
   it("should not include prompt param when absent", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -288,21 +288,13 @@ function ConnectStepContent() {
         data-testid="onboarding-step-connect"
         className="text-2xl font-semibold tracking-tight"
       >
-        Connect your apps
+        Try this prompt
       </h2>
       <p className="text-sm text-muted-foreground leading-relaxed mt-2 mb-6">
-        Authorize each app so Zero can work with it. You can always add more
-        later. Credentials are encrypted and never exposed.
+        Tweak it below or run it as-is. Zero takes it from here — your tools
+        stay sandboxed and nothing leaves your workspace.
       </p>
-      {selectedEntries.length === 0 ? (
-        <p
-          data-testid="onboarding-no-connectors"
-          className="text-sm text-muted-foreground py-8"
-        >
-          No connectors selected. You can go back to add some, or skip this
-          step.
-        </p>
-      ) : (
+      {selectedEntries.length > 0 && (
         <div className="w-full flex flex-col gap-3">
           {selectedEntries.map(([type, config]) => {
             const isConnected = connectedSet.has(type);
@@ -378,9 +370,6 @@ function UseCasePromptComposer() {
 
   return (
     <div data-testid="onboarding-prompt-composer" className="w-full mt-6">
-      <p className="text-xs font-medium text-muted-foreground mb-2">
-        Your first prompt
-      </p>
       <textarea
         data-testid="onboarding-prompt-input"
         value={draft}
@@ -702,14 +691,21 @@ function OnboardingFooterNav() {
 function OnboardingOrbitPanel() {
   const effectiveConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
+  const isUseCase = useGet(onboardingIsUseCase$);
+  // Use-case mode without any preselected connectors has no picker to point
+  // the user at, so the "Pick your tools\u2026" hint is misleading. Drop it and
+  // let the orbit + trust badges carry the panel on their own.
+  const hideCopy = isUseCase && effectiveConnectors.length === 0;
   return (
     <>
       <OrbitIllustration />
-      <p className="text-sm text-foreground text-center leading-relaxed mt-6 max-w-[300px]">
-        {effectiveConnectors.length === 0
-          ? "Pick your tools and Zero will handle the rest, securely."
-          : `${effectiveConnectors.length} app${effectiveConnectors.length === 1 ? "" : "s"} selected. Zero will securely manage ${effectiveConnectors.length === 1 ? "it" : "them"} for you so you don\u2019t have to.`}
-      </p>
+      {!hideCopy && (
+        <p className="text-sm text-foreground text-center leading-relaxed mt-6 max-w-[300px]">
+          {effectiveConnectors.length === 0
+            ? "Pick your tools and Zero will handle the rest, securely."
+            : `${effectiveConnectors.length} app${effectiveConnectors.length === 1 ? "" : "s"} selected. Zero will securely manage ${effectiveConnectors.length === 1 ? "it" : "them"} for you so you don\u2019t have to.`}
+        </p>
+      )}
       <p className="text-[11px] text-muted-foreground text-center mt-4">
         Sandboxed VMs&ensp;|&ensp;No credential exposure&ensp;|&ensp;Full audit
         trail&ensp;|&ensp;Open source


### PR DESCRIPTION
## Summary

`/onboarding?prompt=...` now enters the condensed "Try It" flow on its own — the `connector` param is no longer required for the page to stick or for use-case mode to fire. Previously, dropping `connector=` from a shared deep link silently bounced already-onboarded users back to `/` and stripped the prompt.

Copy + layout changes on the prompt deep-link landing (step 3):

- Heading: **Connect your apps → Try this prompt**
- Description rewritten around editing/running the seeded prompt
- Drop the "No connectors selected…" empty-state line when nothing was preselected — the section just stays blank
- Drop the "Your first prompt" label above the composer textarea
- Suppress the "Pick your tools and Zero will handle the rest, securely." sidebar copy when use-case mode launches without any connectors

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/onboarding-page src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts src/views/zero-page/__tests__/onboarding-continue-web.test.tsx src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx` → 30/30 passing
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm -F @vm0/app lint`
- [ ] Manually open `/onboarding?prompt=update+the+daily+triage+schedule...` (no `connector=`) and confirm the "Try this prompt" step + composer renders without the empty-state copy or sidebar tools hint

Note: an unrelated test in `onboarding-continue-web.test.tsx` ("should navigate to /agents/:id/chat after admin completes onboarding") was already flaky on `main` when run together with other onboarding files, and passes in isolation — unrelated to this PR.