### PR TITLE
fix: separate queue message strip from page bg in dark mode

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -350,7 +350,7 @@ function QueuedMessagesStrip({
   const count = items.length;
   const label = `${count} ${count === 1 ? "message" : "messages"} waiting to send`;
   return (
-    <div className="relative z-0 mx-5 -mb-6 overflow-hidden rounded-xl bg-gray-50">
+    <div className="relative z-0 mx-5 -mb-6 overflow-hidden rounded-xl bg-gray-50 dark:bg-gray-100">
       <div className="flex items-center gap-2 px-5 pt-3 pb-2">
         <span className="inline-flex items-center gap-[2px]" aria-hidden="true">
           <span className="h-2 w-[3px] rounded-sm bg-emerald-800" />


### PR DESCRIPTION
## Summary
- Queued message strip used `bg-gray-50`, which in dark mode resolves to the page background (`--gray-50: 240 3% 10%` / `#19191B`) — so the strip blended in with no visible container.
- Add `dark:bg-gray-100` so the strip sits on a slightly lighter surface (`#252527`) in dark mode and reads as a distinct layer tucked behind the composer. Light mode is unchanged.

Closes #14680

## Test plan
- [ ] In dark mode, send a message while the agent is still running and confirm the queued message strip is visually separated from the page background.
- [ ] In light mode, confirm the strip still uses `bg-gray-50` and renders identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)