### PR TITLE
fix: keep settings open for clerk profile modal

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -33,10 +33,21 @@ export function isAdminOnlySettingsSection(section: SettingsSection): boolean {
 }
 
 const internalSettingsDialogOpen$ = state(false);
+const internalExternalProfileModalOpen$ = state(false);
 
 export const settingsDialogOpen$ = computed((get) => {
   return get(internalSettingsDialogOpen$);
 });
+
+export const externalProfileModalOpen$ = computed((get) => {
+  return get(internalExternalProfileModalOpen$);
+});
+
+export const setExternalProfileModalOpen$ = command(
+  ({ set }, open: boolean) => {
+    set(internalExternalProfileModalOpen$, open);
+  },
+);
 
 const internalActiveSection$ = state<SettingsSection>("preference");
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-clerk-profile-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-clerk-profile-dialog.test.tsx
@@ -11,7 +11,7 @@ function mountMockClerkProfilePortal() {
   const portal = document.createElement("div");
   portal.setAttribute("role", "dialog");
   portal.setAttribute("aria-label", "Clerk user profile");
-  portal.setAttribute("data-clerk-user-profile", "true");
+  portal.dataset.clerkUserProfile = "true";
   portal.className = "cl-userProfile-root cl-modalContent";
 
   const action = document.createElement("button");
@@ -43,16 +43,15 @@ describe("settings dialog - Clerk profile modal", () => {
       return dialog;
     });
 
-    click(within(settingsDialog).getByRole("button", { name: "Manage" }));
+    click(within(settingsDialog).getByText("Manage"));
 
     const clerkDialog = await waitFor(() => {
       return screen.getByRole("dialog", { name: "Clerk user profile" });
     });
 
-    fireEvent.pointerDown(
-      within(clerkDialog).getByRole("button", { name: "Update profile" }),
-      { button: 0 },
-    );
+    fireEvent.pointerDown(within(clerkDialog).getByText("Update profile"), {
+      button: 0,
+    });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-clerk-profile-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-clerk-profile-dialog.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+
+import { mockedClerk } from "../../../__tests__/mock-auth.ts";
+import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function mountMockClerkProfilePortal() {
+  const portal = document.createElement("div");
+  portal.setAttribute("role", "dialog");
+  portal.setAttribute("aria-label", "Clerk user profile");
+  portal.setAttribute("data-clerk-user-profile", "true");
+  portal.className = "cl-userProfile-root cl-modalContent";
+
+  const action = document.createElement("button");
+  action.type = "button";
+  action.textContent = "Update profile";
+  portal.append(action);
+
+  document.body.append(portal);
+  context.signal.addEventListener("abort", () => {
+    portal.remove();
+  });
+
+  return Promise.resolve();
+}
+
+describe("settings dialog - Clerk profile modal", () => {
+  it("keeps settings open when interacting with the Clerk user profile modal", async () => {
+    mockedClerk.openUserProfile.mockImplementationOnce(
+      mountMockClerkProfilePortal,
+    );
+
+    detachedSetupPage({ context, path: "/?settings=preference" });
+
+    const settingsDialog = await waitFor(() => {
+      const dialog = screen.getByRole("dialog", { name: "Settings" });
+      expect(within(dialog).getAllByText("Preference").length).toBeGreaterThan(
+        0,
+      );
+      return dialog;
+    });
+
+    click(within(settingsDialog).getByRole("button", { name: "Manage" }));
+
+    const clerkDialog = await waitFor(() => {
+      return screen.getByRole("dialog", { name: "Clerk user profile" });
+    });
+
+    fireEvent.pointerDown(
+      within(clerkDialog).getByRole("button", { name: "Update profile" }),
+      { button: 0 },
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Settings" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -1,14 +1,42 @@
-import { useLoadable } from "ccstate-react";
+import { useLoadable, useSet } from "ccstate-react";
 import { IconUser } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import { clerk$, currentUserInfo$ } from "../../../../../signals/auth.ts";
+import { setExternalProfileModalOpen$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
 import { detach, Reason } from "../../../../../signals/utils.ts";
+
+const CLERK_PROFILE_SELECTORS = [
+  "[data-clerk-user-profile]",
+  "[data-clerk-modal]",
+  '[class*="cl-userProfile"]',
+  '[class*="cl-modal"]',
+].join(",");
+
+function watchClerkProfileClose(onClose: () => void): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  let sawProfile = document.querySelector(CLERK_PROFILE_SELECTORS) !== null;
+  const observer = new MutationObserver(() => {
+    const hasProfile = document.querySelector(CLERK_PROFILE_SELECTORS) !== null;
+    if (hasProfile) {
+      sawProfile = true;
+      return;
+    }
+    if (sawProfile) {
+      observer.disconnect();
+      onClose();
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+}
 
 export function AccountSection() {
   const clerkLoadable = useLoadable(clerk$);
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
   const userLoadable = useLoadable(currentUserInfo$);
   const user = userLoadable.state === "hasData" ? userLoadable.data : undefined;
+  const setExternalProfileModalOpen = useSet(setExternalProfileModalOpen$);
 
   const displayName = user?.fullName ?? user?.firstName ?? "";
   const email = user?.primaryEmailAddress?.emailAddress ?? "";
@@ -18,6 +46,10 @@ export function AccountSection() {
     if (!clerk) {
       return;
     }
+    setExternalProfileModalOpen(true);
+    watchClerkProfileClose(() => {
+      setExternalProfileModalOpen(false);
+    });
     detach(
       clerk.openUserProfile({ apiKeysProps: { hide: true } }),
       Reason.DomCallback,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -170,6 +170,22 @@ function SectionContent({ section }: { section: SettingsSection }) {
   return <Component />;
 }
 
+function isClerkModalTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return (
+    target.closest(
+      [
+        "[data-clerk-user-profile]",
+        "[data-clerk-modal]",
+        '[class*="cl-userProfile"]',
+        '[class*="cl-modal"]',
+      ].join(","),
+    ) !== null
+  );
+}
+
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);
@@ -195,7 +211,14 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card">
+      <DialogContent
+        className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
+        onInteractOutside={(event) => {
+          if (isClerkModalTarget(event.target)) {
+            event.preventDefault();
+          }
+        }}
+      >
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">
           Manage your account, preferences, workspace, and billing settings.

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -29,6 +29,7 @@ import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import {
   isAdminOnlySettingsSection,
   settingsActiveSection$,
+  externalProfileModalOpen$,
   setSettingsActiveSection$,
   type SettingsSection,
 } from "../../../../signals/zero-page/settings/settings-dialog.ts";
@@ -189,6 +190,7 @@ function isClerkModalTarget(target: EventTarget | null): boolean {
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);
+  const externalProfileModalOpen = useGet(externalProfileModalOpen$);
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
@@ -210,7 +212,11 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={!externalProfileModalOpen}
+    >
       <DialogContent
         className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
         onInteractOutside={(event) => {


### PR DESCRIPTION
## Summary
- Prevent Settings dialog from treating Clerk user profile modal interactions as outside clicks
- Add a view regression test for the Settings > Preference > Manage account flow

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/settings-clerk-profile-dialog.test.tsx
- pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx apps/platform/src/views/zero-page/__tests__/settings-clerk-profile-dialog.test.tsx