### PR TITLE
feat: add GPT Image 2 to web models

### DIFF
--- a/turbo/apps/web/app/[locale]/models/data.ts
+++ b/turbo/apps/web/app/[locale]/models/data.ts
@@ -427,6 +427,23 @@ export const MODELS: ModelEntry[] = [
   // -------------------------------------------------------------------------
 
   {
+    slug: "gpt-image-2",
+    modelId: "gpt-image-2",
+    name: "GPT Image 2",
+    vendor: "OpenAI",
+    category: "image",
+    modalities: ["Image", "Text-to-image", "Image edit"],
+    releasedToVm0: "April 2026",
+    generationPricing: {
+      unit: "image",
+      priceUsd: 0.064,
+      note: "Medium standard tier (1024x1024)",
+    },
+    comparisonSlugs: ["GPT Image 1", "SeedDream 4"],
+    alternativeSlugs: ["gpt-image-1", "seedream-4"],
+  },
+
+  {
     slug: "gpt-image-1",
     modelId: "gpt-image-1",
     name: "GPT Image 1",
@@ -550,6 +567,8 @@ export function getModelBySlug(slug: string): ModelEntry | undefined {
 // English lets the agent reliably pass it as `--model` when it calls the
 // built-in generation tool, while keeping the surface copy natural.
 const GENERATION_CTA_PROMPTS: Readonly<Record<string, string>> = {
+  "gpt-image-2":
+    "Generate an illustration of a cute cat using the gpt-image-2 model.",
   "gpt-image-1":
     "Generate an illustration of a cute cat using the gpt-image-1 model.",
   "flux-pro-1-1-ultra":

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -4308,17 +4308,38 @@
         ],
         "architecture": "GPT-5.5 behält das 400K-Token-Kontextfenster von GPT-5.4 und berechnet über das gesamte Fenster den Standard-Input-Preis. Es unterstützt den `reasoning_effort`-Parameter auf vier Stufen (minimal, niedrig, mittel, hoch), Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses API, die codex CLI standardmäßig nutzt. Tool-Use, Structured Outputs und Computer-Use sind gegenüber 5.4 unverändert. Eingaben sind multimodal über Text, Vision und Code; das Modell hat keine native Bildgenerierung (nutze dafür die Images API).",
         "specs": [
-          { "label": "Familie", "value": "GPT-5 Generation" },
-          { "label": "Modalitäten", "value": "Text, Vision, Code" },
-          { "label": "Sprachen", "value": "Englisch-zentriert, mehrsprachig" },
-          { "label": "Prompt Caching", "value": "Unterstützt (OpenAI)" },
-          { "label": "Kontextfenster", "value": "400K Token" },
-          { "label": "Max Output", "value": "Bis zu 128K Token" },
+          {
+            "label": "Familie",
+            "value": "GPT-5 Generation"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text, Vision, Code"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Englisch-zentriert, mehrsprachig"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Unterstützt (OpenAI)"
+          },
+          {
+            "label": "Kontextfenster",
+            "value": "400K Token"
+          },
+          {
+            "label": "Max Output",
+            "value": "Bis zu 128K Token"
+          },
           {
             "label": "Reasoning Effort",
             "value": "Minimal / Niedrig / Mittel / Hoch"
           },
-          { "label": "Listenpreis", "value": "$5 Input / $30 Output pro 1M" }
+          {
+            "label": "Listenpreis",
+            "value": "$5 Input / $30 Output pro 1M"
+          }
         ],
         "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5.5-Release-Materialien, mit Deltas gegenüber den öffentlichen GPT-5.4-Zahlen. Unabhängige Reviews platzieren 5.5 bei agentischen Coding-Aufgaben innerhalb weniger Punkte von Claude Opus 4.7. Behandle absolute Prozente als richtungsweisend; OpenAI hat Trainingsdaten-Kontamination bei SWE-bench Verified über alle Frontier-Modelle gemeldet.",
         "benchmarks": [
@@ -4437,7 +4458,10 @@
           }
         ],
         "alternatives": [
-          { "slug": "gpt-5-4", "reason": "Halbe Credits, gleiche Familie" },
+          {
+            "slug": "gpt-5-4",
+            "reason": "Halbe Credits, gleiche Familie"
+          },
           {
             "slug": "claude-opus-4-7",
             "reason": "Peer-Flaggschiff auf der Claude-Seite"
@@ -4614,17 +4638,38 @@
         ],
         "architecture": "GPT-5.4 nutzt dieselbe Architektur wie der Rest der GPT-5-Familie: 400K-Token-Kontextfenster, `reasoning_effort`-Parameter auf vier Stufen (minimal, niedrig, mittel, hoch), Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses API, die codex CLI standardmäßig nutzt. Tool-Use, Structured Outputs und Computer-Use werden unterstützt. Eingaben sind multimodal über Text, Vision und Code.",
         "specs": [
-          { "label": "Familie", "value": "GPT-5 Generation" },
-          { "label": "Modalitäten", "value": "Text, Vision, Code" },
-          { "label": "Sprachen", "value": "Englisch-zentriert, mehrsprachig" },
-          { "label": "Prompt Caching", "value": "Unterstützt (OpenAI)" },
-          { "label": "Kontextfenster", "value": "400K Token" },
-          { "label": "Max Output", "value": "Bis zu 128K Token" },
+          {
+            "label": "Familie",
+            "value": "GPT-5 Generation"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text, Vision, Code"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Englisch-zentriert, mehrsprachig"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Unterstützt (OpenAI)"
+          },
+          {
+            "label": "Kontextfenster",
+            "value": "400K Token"
+          },
+          {
+            "label": "Max Output",
+            "value": "Bis zu 128K Token"
+          },
           {
             "label": "Reasoning Effort",
             "value": "Minimal / Niedrig / Mittel / Hoch"
           },
-          { "label": "Listenpreis", "value": "$2,5 Input / $15 Output pro 1M" }
+          {
+            "label": "Listenpreis",
+            "value": "$2,5 Input / $15 Output pro 1M"
+          }
         ],
         "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5-Release-Materialien, mit Deltas gegenüber der vorherigen OpenAI-Generation. Unabhängige Reviews platzieren GPT-5.4 im selben Coding-Qualitätsband wie Claude Sonnet 4.6. Behandle absolute Prozente als richtungsweisend.",
         "benchmarks": [
@@ -5053,12 +5098,30 @@
         ],
         "architecture": "GPT-5.4 Mini nutzt dieselbe Architektur wie der Rest der GPT-5-Familie: 400K-Token-Kontextfenster, `reasoning_effort`-Parameter auf vier Stufen, Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses-API-Oberfläche. Tool-Use, Structured Outputs und multimodale Vision-Eingaben werden unterstützt. Das Modell ist ein kleinerer, schnellerer Verwandter — weniger Parameter pro Token, mehr Durchsatz pro Dollar.",
         "specs": [
-          { "label": "Familie", "value": "GPT-5 Generation" },
-          { "label": "Modalitäten", "value": "Text, Vision, Code" },
-          { "label": "Sprachen", "value": "Englisch-zentriert, mehrsprachig" },
-          { "label": "Prompt Caching", "value": "Unterstützt (OpenAI)" },
-          { "label": "Kontextfenster", "value": "400K Token" },
-          { "label": "Max Output", "value": "Bis zu 128K Token" },
+          {
+            "label": "Familie",
+            "value": "GPT-5 Generation"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text, Vision, Code"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Englisch-zentriert, mehrsprachig"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Unterstützt (OpenAI)"
+          },
+          {
+            "label": "Kontextfenster",
+            "value": "400K Token"
+          },
+          {
+            "label": "Max Output",
+            "value": "Bis zu 128K Token"
+          },
           {
             "label": "Reasoning Effort",
             "value": "Minimal / Niedrig / Mittel / Hoch"
@@ -5954,106 +6017,121 @@
       },
       "gpt-image-2": {
         "name": "GPT Image 2",
-        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
-        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
-        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
-        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
-        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "pageTitle": "GPT Image 2 auf VM0. OpenAIs neueres Bildgenerierungsmodell",
+        "tagline": "OpenAIs neueres Bildmodell fuer Text-zu-Bild-Generierung und Bearbeitungen. Nutze es, wenn du den GPT-Image-Workflow mit staerkerer Prompt-Treue und flexiblen Groessen willst.",
+        "cardIntro": "OpenAIs neueres Bildmodell fuer Generierung und Bearbeitung, mit flexiblen Groessen und staerkerer Prompt-Treue als GPT Image 1.",
+        "metaTitle": "GPT Image 2 auf VM0: Preise, Spezifikationen & Vergleich",
+        "metaDescription": "GPT Image 2 auf VM0. OpenAIs neueres Modell fuer Bildgenerierung und Bearbeitung mit flexiblen Groessen, Qualitaetsstufen und Vergleich mit GPT Image 1 und SeedDream 4.",
+        "summary": "GPT Image 2 ist OpenAIs neueres Bildgenerierungsmodell auf VM0. Es behaelt den GPT-Image-Workflow fuer Text-zu-Bild und Bearbeitung bei und ergaenzt flexible Groessen sowie staerkere Prompt-Treue fuer produktive Bildaufgaben.\n\nDie VM0-Abrechnung ist stufenbasiert: von etwa $0.007 pro Bild in der Low/Standard-Stufe bis $0.481 in der High/Large-Stufe. Die Medium-Standard-Stufe (etwa $0.064 pro 1024x1024-Bild auf VM0) ist der sinnvolle Standard fuer die meisten Built-in-Generierungsaufrufe.",
         "releaseDate": "April 2026",
-        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "familyPosition": "OpenAIs neueres GPT-Image-Modell, oberhalb von GPT Image 1 fuer Prompt-Treue und flexible Ausgabegroessen positioniert.",
         "background": [
-          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
-          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+          "GPT Image 2 ist das neuere OpenAI-Bildmodell, das ueber VM0s Built-in-Bildgenerierung verfuegbar ist. Es unterstuetzt Text-zu-Bild-Generierung und Bildbearbeitungen im selben agentenorientierten Workflow wie GPT Image 1.",
+          "Das Modell ist eine gute Standardwahl, wenn der Aufrufer OpenAI-artige Prompt-Befolgung moechte, aber flexiblere Ausgabegroessen als die Standardstufen von GPT Image 1 benoetigt. Die Abrechnung erfolgt nach Qualitaet und Groesse, sodass Agenten Entwurfsrunden guenstiger halten und hohe Qualitaet fuer finale Renderings reservieren koennen."
         ],
-        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "architecture": "Text-zu-Bild- und Bildbearbeitungsmodell, das ueber OpenAIs GPT-Image-2-Endpunkt auf fal verfuegbar ist. Unterstuetzt Qualitaetsstufen und flexible Bildgroessen; transparente Hintergruende werden fuer dieses Modell auf VM0 nicht unterstuetzt.",
         "specs": [
-          { "label": "Family", "value": "OpenAI Images" },
           {
-            "label": "Modalities",
-            "value": "Text-to-image, image-to-image edit"
+            "label": "Familie",
+            "value": "OpenAI Images"
           },
           {
-            "label": "Output tiers",
-            "value": "Standard / Large × Low / Medium / High"
+            "label": "Modalitaeten",
+            "value": "Text-zu-Bild, Bild-zu-Bild-Bearbeitung"
           },
           {
-            "label": "VM0 billed price",
-            "value": "From $0.007 to $0.481 per image"
+            "label": "Ausgabestufen",
+            "value": "Standard / Large x Low / Medium / High"
           },
-          { "label": "Languages", "value": "Multilingual prompts" },
-          { "label": "Available on VM0", "value": "April 2026" }
+          {
+            "label": "VM0-abgerechneter Preis",
+            "value": "Von $0.007 bis $0.481 pro Bild"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Mehrsprachige Prompts"
+          },
+          {
+            "label": "Auf VM0 verfuegbar",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
         "performance": [
           {
-            "title": "Prompt adherence",
-            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+            "title": "Prompt-Treue",
+            "body": "Der wichtigste Grund, GPT Image 2 statt GPT Image 1 zu waehlen, ist die genauere Umsetzung detaillierter Prompts, besonders wenn der Auftrag Komposition, Seitenverhaeltnis und Stilvorgaben enthaelt."
           },
           {
-            "title": "Flexible sizing",
-            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+            "title": "Flexible Groessen",
+            "body": "Unterstuetzt VM0s flexiblen Bildgroessenpfad, sodass Agenten quadratische, Hochformat-, Querformat- und groessere Ausgaben anfordern koennen, ohne die Modellfamilie zu wechseln."
           },
           {
-            "title": "Edit flows",
-            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+            "title": "Bearbeitungsablaeufe",
+            "body": "Unterstuetzt Bild-zu-Bild-Bearbeitungen und Masken. Nutze es, wenn ein Workflow ein Quellbild erhalten und zugleich einen beschriebenen Bereich veraendern muss."
           },
           {
-            "title": "Cost",
-            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+            "title": "Kosten",
+            "body": "Teurer als GPT Image 1 in Medium- und High-Stufen. Halte Entwurfsrunden auf niedrigerer Qualitaet und reserviere hohe Qualitaet fuer finale Ausgaben."
           }
         ],
         "bestForExamples": [
           {
-            "title": "The agent that needs exact prompt following",
-            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+            "title": "Der Agent, der exakte Prompt-Befolgung braucht",
+            "body": "Wenn der Prompt konkrete Vorgaben zu Bildausschnitt, Stil oder Groesse enthaelt, ist GPT Image 2 die sicherere OpenAI-Bildwahl als GPT Image 1."
           },
           {
-            "title": "The image workflow that needs multiple aspect ratios",
-            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+            "title": "Der Bildworkflow, der mehrere Seitenverhaeltnisse braucht",
+            "body": "Marketing-, Social- und Website-Assets brauchen oft quadratische, Hochformat- und Querformat-Ausgaben. GPT Image 2 passt zu diesen Workflows, ohne den Prompt-Stil zu wechseln."
           },
           {
-            "title": "The OpenAI-stack edit loop",
-            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+            "title": "Die Bearbeitungsschleife im OpenAI-Stack",
+            "body": "Wenn ein Agent bereits OpenAI-Modelle fuer Planung und Text nutzt, haelt GPT Image 2 die Bildgenerierung in derselben Prompt-Following-Familie."
           }
         ],
-        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "avoidFor": "Ueberspringe GPT Image 2, wenn Kosten dominieren oder echte transparente Hintergruende erforderlich sind. GPT Image 1, GPT Image 1.5 oder SeedDream 4 koennen je nach Constraint besser passen.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
-            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+            "body": "GPT Image 2 ist das neuere, flexiblere Modell mit staerkerer Prompt-Treue. GPT Image 1 bleibt bei gaengigen Medium-Standard-Einstellungen guenstiger und ist weiterhin stark fuer stilisierte Illustration."
           },
           {
             "vs": "SeedDream 4",
-            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+            "body": "SeedDream 4 ist guenstiger und tendiert zu Fotorealismus. GPT Image 2 ist die bessere OpenAI-Stack-Wahl, wenn Prompt-Treue, Bearbeitungsworkflow und flexible Groessen wichtiger sind als niedrigste Kosten."
           }
         ],
-        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "verdict": "Waehle GPT Image 2, wenn du OpenAI-Bildgenerierung mit staerkerer Prompt-Treue und flexiblen Groessen willst. Nutze GPT Image 1 oder SeedDream 4, wenn Kosten der wichtigste Faktor sind.",
         "faqs": [
           {
-            "q": "How is GPT Image 2 priced?",
-            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+            "q": "Wie wird GPT Image 2 abgerechnet?",
+            "a": "Es wird nach Qualitaet und Groesse abgerechnet. Auf VM0 kostet die Medium-Standard-Stufe etwa $0.064 pro Bild und die High/Large-Stufe etwa $0.481 pro Bild."
           },
           {
-            "q": "Does GPT Image 2 support image editing?",
-            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+            "q": "Unterstuetzt GPT Image 2 Bildbearbeitung?",
+            "a": "Ja. VM0 stellt Bild-zu-Bild-Bearbeitung und Maskenunterstuetzung fuer GPT Image 2 bereit."
           },
           {
-            "q": "Does GPT Image 2 support transparent backgrounds?",
-            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+            "q": "Unterstuetzt GPT Image 2 transparente Hintergruende?",
+            "a": "Nein. VM0s GPT-Image-2-Pfad unterstuetzt keine Ausgabe mit transparentem Hintergrund."
           },
           {
-            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
-            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+            "q": "Wann sollte ich GPT Image 2 statt GPT Image 1 nutzen?",
+            "a": "Nutze GPT Image 2 fuer genauere Prompt-Befolgung und flexible Groessen. Nutze GPT Image 1, wenn der Auftrag einfacher ist oder Kosten wichtiger sind."
           }
         ],
         "alternatives": [
-          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
-          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+          {
+            "slug": "gpt-image-1",
+            "reason": "Guenstiger OpenAI-Bildstandard"
+          },
+          {
+            "slug": "seedream-4",
+            "reason": "Guenstigere fotorealistische Alternative"
+          }
         ],
-        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
-        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+        "routingNotes": "Wird ueber VM0s Built-in-Generierungspfad an OpenAIs GPT-Image-2-Endpunkt geroutet und pro Ausgabebildstufe abgerechnet.",
+        "vm0Notes": "GPT Image 2 ist ueber VM0 Managed Generation mit Qualitaets- und Groesseneinstellungen verfuegbar. Nutze mittlere Qualitaet fuer normale Agentenarbeit und hohe Qualitaet, wenn das generierte Bild das Lieferergebnis ist."
       },
       "gpt-image-1": {
         "name": "GPT Image 1",
@@ -6071,7 +6149,10 @@
         ],
         "architecture": "Diffusion-basiertes Text-zu-Bild mit nativer Edit-Unterstützung. Der Stufenpreis skaliert nach Ausgabeauflösung (Standard / Groß) und Qualität (Niedrig / Mittel / Hoch), wobei die Stufe Mittel/Standard der typische Standard ist. Eingaben akzeptieren Text plus optionale Referenzbilder für Edits und Masken.",
         "specs": [
-          { "label": "Familie", "value": "OpenAI Images" },
+          {
+            "label": "Familie",
+            "value": "OpenAI Images"
+          },
           {
             "label": "Modalitäten",
             "value": "Text-zu-Bild, Bild-zu-Bild-Edit"
@@ -6080,9 +6161,18 @@
             "label": "Ausgabestufen",
             "value": "Standard / Groß × Niedrig / Mittel / Hoch"
           },
-          { "label": "Listenpreis", "value": "Von $0,011 bis $0,25 pro Bild" },
-          { "label": "Sprachen", "value": "Mehrsprachige Prompts" },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+          {
+            "label": "Listenpreis",
+            "value": "Von $0,011 bis $0,25 pro Bild"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Mehrsprachige Prompts"
+          },
+          {
+            "label": "Verfügbar auf VM0",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6149,7 +6239,10 @@
             "slug": "flux-pro-1-1-ultra",
             "reason": "Higher photoreal aesthetic ceiling"
           },
-          { "slug": "seedream-4", "reason": "Better photoreal default" }
+          {
+            "slug": "seedream-4",
+            "reason": "Better photoreal default"
+          }
         ],
         "routingNotes": "Routed to OpenAI's Images surface and billed per generated image at the selected tier.",
         "vm0Notes": "GPT Image 1 ist der OpenAI-Stack-Standard für stilisierte Illustration und Edit-Loop-Agent-Workflows. Die Stufe Mittel/Standard ist der sinnvolle Überall-Standard; reserviere die Stufe Hoch/Groß für Deliverable-Grade-Ausgabe."
@@ -6170,11 +6263,26 @@
         ],
         "architecture": "Hochauflösendes Diffusion-Modell mit auf Kompositionstreue abgestimmtem Prompt-Following. Abrechnung pro generiertem Bild. Eingaben akzeptieren Textprompts; erzeugt hochauflösende Ausgabe, die für die Lieferung geeignet ist.",
         "specs": [
-          { "label": "Familie", "value": "Flux 1.1 Pro" },
-          { "label": "Modalitäten", "value": "Text-zu-Bild" },
-          { "label": "Listenpreis", "value": "$0,072 pro Bild" },
-          { "label": "Sprachen", "value": "Mehrsprachige Prompts" },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+          {
+            "label": "Familie",
+            "value": "Flux 1.1 Pro"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Bild"
+          },
+          {
+            "label": "Listenpreis",
+            "value": "$0,072 pro Bild"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Mehrsprachige Prompts"
+          },
+          {
+            "label": "Verfügbar auf VM0",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6241,8 +6349,14 @@
           }
         ],
         "alternatives": [
-          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" },
-          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+          {
+            "slug": "gpt-image-1",
+            "reason": "Stronger stylised illustration"
+          },
+          {
+            "slug": "seedream-4",
+            "reason": "Cheaper photoreal alternative"
+          }
         ],
         "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
         "vm0Notes": "Flux Pro 1.1 Ultra ist die Premium-Stufe des kuratierten Bild-Lineups. Verwende es für den Final-Render-Schritt statt für die Iteration; paare es mit SeedDream 4 oder SeedDream 4 als günstigem Vorfilter."
@@ -6263,14 +6377,26 @@
         ],
         "architecture": "Diffusion-basiertes Text-zu-Bild-Modell. Abrechnung pro generiertem Bild. Eingaben akzeptieren Textprompts; erzeugt photorealistisch ausgerichtete Ausgabe, die für Porträts, Produkte und Lifestyle-Bilder geeignet ist.",
         "specs": [
-          { "label": "Familie", "value": "Seedream V4" },
-          { "label": "Modalitäten", "value": "Text-zu-Bild" },
-          { "label": "Listenpreis", "value": "$0,036 pro Bild" },
+          {
+            "label": "Familie",
+            "value": "Seedream V4"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Bild"
+          },
+          {
+            "label": "Listenpreis",
+            "value": "$0,036 pro Bild"
+          },
           {
             "label": "Sprachen",
             "value": "Mehrsprachige Prompts (Englisch + Chinesisch stark)"
           },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+          {
+            "label": "Verfügbar auf VM0",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6341,7 +6467,10 @@
             "slug": "flux-pro-1-1-ultra",
             "reason": "Premium hero-shot quality"
           },
-          { "slug": "gpt-image-1", "reason": "Stronger stylised illustration" }
+          {
+            "slug": "gpt-image-1",
+            "reason": "Stronger stylised illustration"
+          }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",
         "vm0Notes": "SeedDream 4 ist der photorealistik-spezifische Standard im kuratierten Bild-Lineup. Paare es mit Flux Pro 1.1 Ultra für Hero-Shots und mit SeedDream 4 für Nicht-Foto-Iteration."
@@ -6362,18 +6491,30 @@
         ],
         "architecture": "Text-zu-Video- und Bild-zu-Video-Diffusion-Modell mit nativer Audio-Synthese im selben Durchgang. Ausgabedauern sind 4, 6 oder 8 Sekunden bei 720p, 1080p oder 4K. Abrechnung pro generierter Videosekunde mit Qualitätsstufen-Modifikatoren.",
         "specs": [
-          { "label": "Familie", "value": "Google Veo 3" },
+          {
+            "label": "Familie",
+            "value": "Google Veo 3"
+          },
           {
             "label": "Modalitäten",
             "value": "Text-zu-Video, Bild-zu-Video, natives Audio"
           },
-          { "label": "Cliplängen", "value": "4s / 6s / 8s" },
-          { "label": "Ausgabeauflösungen", "value": "720p / 1080p / 4K" },
+          {
+            "label": "Cliplängen",
+            "value": "4s / 6s / 8s"
+          },
+          {
+            "label": "Ausgabeauflösungen",
+            "value": "720p / 1080p / 4K"
+          },
           {
             "label": "Listenpreis",
             "value": "~$0,15 pro Sekunde (720p + Audio)"
           },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+          {
+            "label": "Verfügbar auf VM0",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6444,7 +6585,10 @@
             "slug": "kling-v3-4k",
             "reason": "Stylised / anime ceiling, longer clips"
           },
-          { "slug": "dreamina-seedance-2-0", "reason": "Cheaper per second" }
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "Cheaper per second"
+          }
         ],
         "routingNotes": "Routed to Google's Veo 3.1 Fast video generation endpoint and billed per generated video-second with quality-tier modifiers.",
         "vm0Notes": "Veo 3.1 Fast ist der kinoreife/Audio-tragende Standard im kuratierten Video-Lineup auf VM0. Paare es mit Dreamina Seedance 2.0 für günstige Iteration und mit Kling V3 4K für stilisierte oder Long-Form-Clips."
@@ -6465,12 +6609,30 @@
         ],
         "architecture": "Text-zu-Video- und Bild-zu-Video-Diffusion-Modell. Die Standardstufe rendert in 4K mit Cliplängen von 3 bis 15 Sekunden. Abrechnung pro generierter Videosekunde.",
         "specs": [
-          { "label": "Familie", "value": "Kling V3" },
-          { "label": "Modalitäten", "value": "Text-zu-Video, Bild-zu-Video" },
-          { "label": "Cliplängen", "value": "3 bis 15 Sekunden" },
-          { "label": "Ausgabeauflösung", "value": "4K (Standardstufe)" },
-          { "label": "Listenpreis", "value": "~$0,28 pro Sekunde (4K)" },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+          {
+            "label": "Familie",
+            "value": "Kling V3"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Video, Bild-zu-Video"
+          },
+          {
+            "label": "Cliplängen",
+            "value": "3 bis 15 Sekunden"
+          },
+          {
+            "label": "Ausgabeauflösung",
+            "value": "4K (Standardstufe)"
+          },
+          {
+            "label": "Listenpreis",
+            "value": "~$0,28 pro Sekunde (4K)"
+          },
+          {
+            "label": "Verfügbar auf VM0",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6537,7 +6699,10 @@
           }
         ],
         "alternatives": [
-          { "slug": "veo-3-1-fast", "reason": "Cinematic / native audio" },
+          {
+            "slug": "veo-3-1-fast",
+            "reason": "Cinematic / native audio"
+          },
           {
             "slug": "dreamina-seedance-2-0",
             "reason": "Cheaper bulk generation"
@@ -6562,15 +6727,30 @@
         ],
         "architecture": "Text-zu-Video- und Bild-zu-Video-Diffusion-Modell mit drei Qualitätsstufen (Fast, Standard, Pro). Der kuratierte Eintrag deckt die Standard-2.0-Stufe ab. Abrechnung pro generierter Videosekunde mit Modifikatoren für Auflösung und ob Bildkonditionierung verwendet wird.",
         "specs": [
-          { "label": "Familie", "value": "Seedance 2.0" },
-          { "label": "Modalitäten", "value": "Text-zu-Video, Bild-zu-Video" },
-          { "label": "Cliplängen", "value": "4 bis 15 Sekunden" },
-          { "label": "Ausgabeauflösungen", "value": "480p / 720p / 1080p" },
+          {
+            "label": "Familie",
+            "value": "Seedance 2.0"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text-zu-Video, Bild-zu-Video"
+          },
+          {
+            "label": "Cliplängen",
+            "value": "4 bis 15 Sekunden"
+          },
+          {
+            "label": "Ausgabeauflösungen",
+            "value": "480p / 720p / 1080p"
+          },
           {
             "label": "Listenpreis",
             "value": "~$0,05 pro Sekunde (1080p + Bild)"
           },
-          { "label": "Verfügbar auf VM0", "value": "April 2026" }
+          {
+            "label": "Verfügbar auf VM0",
+            "value": "April 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6641,7 +6821,10 @@
             "slug": "veo-3-1-fast",
             "reason": "Native audio, cinematic motion"
           },
-          { "slug": "kling-v3-4k", "reason": "Stylised, longer, 4K" }
+          {
+            "slug": "kling-v3-4k",
+            "reason": "Stylised, longer, 4K"
+          }
         ],
         "routingNotes": "Routed to ByteDance's Dreamina Seedance 2.0 endpoint and billed per generated video-second with resolution and image-conditioning modifiers.",
         "vm0Notes": "Dreamina Seedance 2.0 ist der kostenoptimierte Standard im kuratierten Video-Lineup auf VM0. Das Standardmuster ist, es für Iteration und Fan-out zu verwenden und dann die gewählte Variante nur auf Veo 3.1 Fast oder Kling V3 4K zu eskalieren, wenn der Final-Render den Aufpreis rechtfertigt."

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -5952,6 +5952,109 @@
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Default model on the DeepSeek provider; also available on VM0 Managed.",
         "vm0Notes": "V4 Flash carries the lowest credit multiplier of any Built-in model (×0.02), roughly 50× less than Sonnet 4.6. Cache reads bill while cache writes are free, and VM0 sets a 10-minute API timeout for the DeepSeek provider that pairs naturally with Flash's short single-shot work."
       },
+      "gpt-image-2": {
+        "name": "GPT Image 2",
+        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
+        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
+        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
+        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
+        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "releaseDate": "April 2026",
+        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "background": [
+          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
+          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+        ],
+        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "specs": [
+          { "label": "Family", "value": "OpenAI Images" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-image, image-to-image edit"
+          },
+          {
+            "label": "Output tiers",
+            "value": "Standard / Large × Low / Medium / High"
+          },
+          {
+            "label": "VM0 billed price",
+            "value": "From $0.007 to $0.481 per image"
+          },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Prompt adherence",
+            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+          },
+          {
+            "title": "Flexible sizing",
+            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+          },
+          {
+            "title": "Edit flows",
+            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+          },
+          {
+            "title": "Cost",
+            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The agent that needs exact prompt following",
+            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+          },
+          {
+            "title": "The image workflow that needs multiple aspect ratios",
+            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+          },
+          {
+            "title": "The OpenAI-stack edit loop",
+            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+          }
+        ],
+        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+          }
+        ],
+        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "faqs": [
+          {
+            "q": "How is GPT Image 2 priced?",
+            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+          },
+          {
+            "q": "Does GPT Image 2 support image editing?",
+            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+          },
+          {
+            "q": "Does GPT Image 2 support transparent backgrounds?",
+            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+          },
+          {
+            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
+            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
+          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+        ],
+        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
+        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 on VM0. OpenAI's text-to-image model",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -5976,6 +5976,109 @@
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Default model on the DeepSeek provider; also available on VM0 Managed.",
         "vm0Notes": "V4 Flash carries the lowest credit multiplier of any Built-in model (×0.02), roughly 50× less than Sonnet 4.6. Cache reads bill while cache writes are free, and VM0 sets a 10-minute API timeout for the DeepSeek provider that pairs naturally with Flash's short single-shot work."
       },
+      "gpt-image-2": {
+        "name": "GPT Image 2",
+        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
+        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
+        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
+        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
+        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "releaseDate": "April 2026",
+        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "background": [
+          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
+          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+        ],
+        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "specs": [
+          { "label": "Family", "value": "OpenAI Images" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-image, image-to-image edit"
+          },
+          {
+            "label": "Output tiers",
+            "value": "Standard / Large × Low / Medium / High"
+          },
+          {
+            "label": "VM0 billed price",
+            "value": "From $0.007 to $0.481 per image"
+          },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Prompt adherence",
+            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+          },
+          {
+            "title": "Flexible sizing",
+            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+          },
+          {
+            "title": "Edit flows",
+            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+          },
+          {
+            "title": "Cost",
+            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The agent that needs exact prompt following",
+            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+          },
+          {
+            "title": "The image workflow that needs multiple aspect ratios",
+            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+          },
+          {
+            "title": "The OpenAI-stack edit loop",
+            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+          }
+        ],
+        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+          }
+        ],
+        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "faqs": [
+          {
+            "q": "How is GPT Image 2 priced?",
+            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+          },
+          {
+            "q": "Does GPT Image 2 support image editing?",
+            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+          },
+          {
+            "q": "Does GPT Image 2 support transparent backgrounds?",
+            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+          },
+          {
+            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
+            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
+          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+        ],
+        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
+        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 on VM0. OpenAI's text-to-image model",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -5978,6 +5978,109 @@
         "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de DeepSeek en `api.deepseek.com`. Modelo predeterminado en el proveedor DeepSeek; también disponible en VM0 Managed.",
         "vm0Notes": "V4 Flash tiene el multiplicador de crédito más bajo de cualquier modelo Built-in (×0,02), aproximadamente 50× menos que Sonnet 4.6. Las lecturas de caché facturan mientras que las escrituras de caché son gratuitas, y VM0 establece un timeout de API de 10 minutos para el proveedor DeepSeek que se empareja naturalmente con el trabajo corto de un solo paso de Flash."
       },
+      "gpt-image-2": {
+        "name": "GPT Image 2",
+        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
+        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
+        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
+        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
+        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "releaseDate": "April 2026",
+        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "background": [
+          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
+          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+        ],
+        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "specs": [
+          { "label": "Family", "value": "OpenAI Images" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-image, image-to-image edit"
+          },
+          {
+            "label": "Output tiers",
+            "value": "Standard / Large × Low / Medium / High"
+          },
+          {
+            "label": "VM0 billed price",
+            "value": "From $0.007 to $0.481 per image"
+          },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Prompt adherence",
+            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+          },
+          {
+            "title": "Flexible sizing",
+            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+          },
+          {
+            "title": "Edit flows",
+            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+          },
+          {
+            "title": "Cost",
+            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The agent that needs exact prompt following",
+            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+          },
+          {
+            "title": "The image workflow that needs multiple aspect ratios",
+            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+          },
+          {
+            "title": "The OpenAI-stack edit loop",
+            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+          }
+        ],
+        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+          }
+        ],
+        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "faqs": [
+          {
+            "q": "How is GPT Image 2 priced?",
+            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+          },
+          {
+            "q": "Does GPT Image 2 support image editing?",
+            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+          },
+          {
+            "q": "Does GPT Image 2 support transparent backgrounds?",
+            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+          },
+          {
+            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
+            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
+          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+        ],
+        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
+        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 en VM0. El modelo de texto a imagen de OpenAI",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -4312,12 +4312,30 @@
         ],
         "architecture": "GPT-5.5 mantiene la ventana de contexto de 400K tokens de GPT-5.4, facturada a precio de entrada estándar en toda la ventana. Soporta el parámetro `reasoning_effort` en cuatro niveles (mínimo, bajo, medio, alto), Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie de la Responses API que usa el codex CLI por defecto. Tool-Use, salidas estructuradas y computer-use no cambian respecto a 5.4. Las entradas son multimodales: texto, visión y código; el modelo no tiene generación nativa de imágenes (usa la Images API para eso).",
         "specs": [
-          { "label": "Familia", "value": "Generación GPT-5" },
-          { "label": "Modalidades", "value": "Texto, visión, código" },
-          { "label": "Idiomas", "value": "Inglés primero, multilingüe" },
-          { "label": "Prompt Caching", "value": "Soportado (OpenAI)" },
-          { "label": "Ventana de contexto", "value": "400K tokens" },
-          { "label": "Salida máxima", "value": "Hasta 128K tokens" },
+          {
+            "label": "Familia",
+            "value": "Generación GPT-5"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto, visión, código"
+          },
+          {
+            "label": "Idiomas",
+            "value": "Inglés primero, multilingüe"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Soportado (OpenAI)"
+          },
+          {
+            "label": "Ventana de contexto",
+            "value": "400K tokens"
+          },
+          {
+            "label": "Salida máxima",
+            "value": "Hasta 128K tokens"
+          },
           {
             "label": "Reasoning effort",
             "value": "Mínimo / Bajo / Medio / Alto"
@@ -4444,7 +4462,10 @@
           }
         ],
         "alternatives": [
-          { "slug": "gpt-5-4", "reason": "Mitad de créditos, misma familia" },
+          {
+            "slug": "gpt-5-4",
+            "reason": "Mitad de créditos, misma familia"
+          },
           {
             "slug": "claude-opus-4-7",
             "reason": "Buque insignia par del lado Claude"
@@ -4629,12 +4650,30 @@
         ],
         "architecture": "GPT-5.4 usa la misma arquitectura que el resto de la familia GPT-5: ventana de contexto de 400K tokens, parámetro `reasoning_effort` en cuatro niveles (mínimo, bajo, medio, alto), Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie Responses API que usa el codex CLI por defecto. Tool-Use, salidas estructuradas y computer-use son soportadas. Las entradas son multimodales: texto, visión y código.",
         "specs": [
-          { "label": "Familia", "value": "Generación GPT-5" },
-          { "label": "Modalidades", "value": "Texto, visión, código" },
-          { "label": "Idiomas", "value": "Inglés primero, multilingüe" },
-          { "label": "Prompt Caching", "value": "Soportado (OpenAI)" },
-          { "label": "Ventana de contexto", "value": "400K tokens" },
-          { "label": "Salida máxima", "value": "Hasta 128K tokens" },
+          {
+            "label": "Familia",
+            "value": "Generación GPT-5"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto, visión, código"
+          },
+          {
+            "label": "Idiomas",
+            "value": "Inglés primero, multilingüe"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Soportado (OpenAI)"
+          },
+          {
+            "label": "Ventana de contexto",
+            "value": "400K tokens"
+          },
+          {
+            "label": "Salida máxima",
+            "value": "Hasta 128K tokens"
+          },
           {
             "label": "Reasoning effort",
             "value": "Mínimo / Bajo / Medio / Alto"
@@ -5079,12 +5118,30 @@
         ],
         "architecture": "GPT-5.4 Mini usa la misma arquitectura que el resto de la familia GPT-5: ventana de contexto de 400K tokens, el parámetro `reasoning_effort` en cuatro niveles, Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie Responses API. Tool-Use, salidas estructuradas y entradas de visión multimodal son soportadas. El modelo es un hermano menor más rápido — menos parámetros por token, más rendimiento por dólar.",
         "specs": [
-          { "label": "Familia", "value": "Generación GPT-5" },
-          { "label": "Modalidades", "value": "Texto, visión, código" },
-          { "label": "Idiomas", "value": "Inglés primero, multilingüe" },
-          { "label": "Prompt Caching", "value": "Soportado (OpenAI)" },
-          { "label": "Ventana de contexto", "value": "400K tokens" },
-          { "label": "Salida máxima", "value": "Hasta 128K tokens" },
+          {
+            "label": "Familia",
+            "value": "Generación GPT-5"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto, visión, código"
+          },
+          {
+            "label": "Idiomas",
+            "value": "Inglés primero, multilingüe"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Soportado (OpenAI)"
+          },
+          {
+            "label": "Ventana de contexto",
+            "value": "400K tokens"
+          },
+          {
+            "label": "Salida máxima",
+            "value": "Hasta 128K tokens"
+          },
           {
             "label": "Reasoning effort",
             "value": "Mínimo / Bajo / Medio / Alto"
@@ -5980,106 +6037,121 @@
       },
       "gpt-image-2": {
         "name": "GPT Image 2",
-        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
-        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
-        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
-        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
-        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "pageTitle": "GPT Image 2 en VM0. El modelo de generacion de imagenes mas reciente de OpenAI",
+        "tagline": "El modelo de imagenes mas reciente de OpenAI para generacion de texto a imagen y ediciones. Usalo cuando quieras el flujo de GPT Image con mejor seguimiento del prompt y tamanos flexibles.",
+        "cardIntro": "El modelo de imagenes mas reciente de OpenAI para generar y editar, con tamanos flexibles y mejor seguimiento del prompt que GPT Image 1.",
+        "metaTitle": "GPT Image 2 en VM0: precios, especificaciones y comparacion",
+        "metaDescription": "GPT Image 2 en VM0. El modelo mas reciente de OpenAI para generacion y edicion de imagenes, con tamanos flexibles, niveles de calidad y comparacion con GPT Image 1 y SeedDream 4.",
+        "summary": "GPT Image 2 es el modelo de generacion de imagenes mas reciente de OpenAI en VM0. Mantiene el flujo de texto a imagen y edicion de GPT Image, y anade tamanos flexibles y mejor seguimiento del prompt para tareas de imagen en produccion.\n\nLa facturacion de VM0 se basa en niveles: desde alrededor de $0.007 por imagen en el nivel low/standard hasta $0.481 en el nivel high/large. El nivel medium-standard (alrededor de $0.064 por 1024x1024 en VM0) es el valor predeterminado razonable para la mayoria de llamadas de generacion Built-in.",
         "releaseDate": "April 2026",
-        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "familyPosition": "El modelo GPT Image mas reciente de OpenAI, situado por encima de GPT Image 1 en seguimiento del prompt y tamanos de salida flexibles.",
         "background": [
-          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
-          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+          "GPT Image 2 es el modelo de imagenes mas reciente de OpenAI expuesto mediante la ruta Built-in de generacion de imagenes de VM0. Admite generacion de texto a imagen y ediciones de imagenes con el mismo flujo orientado a agentes que GPT Image 1.",
+          "El modelo es una buena opcion predeterminada cuando se busca seguimiento de prompts al estilo OpenAI pero se necesitan tamanos de salida mas flexibles que los niveles estandar de GPT Image 1. Se cobra por calidad y tamano, por lo que los agentes pueden mantener mas baratas las iteraciones de borrador y reservar la alta calidad para entregables finales."
         ],
-        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "architecture": "Modelo de texto a imagen y edicion de imagenes expuesto mediante el endpoint GPT Image 2 de OpenAI en fal. Admite niveles de calidad y tamanos de imagen flexibles; los fondos transparentes no estan disponibles en VM0 para este modelo.",
         "specs": [
-          { "label": "Family", "value": "OpenAI Images" },
           {
-            "label": "Modalities",
-            "value": "Text-to-image, image-to-image edit"
+            "label": "Familia",
+            "value": "OpenAI Images"
           },
           {
-            "label": "Output tiers",
-            "value": "Standard / Large × Low / Medium / High"
+            "label": "Modalidades",
+            "value": "Texto a imagen, edicion imagen a imagen"
           },
           {
-            "label": "VM0 billed price",
-            "value": "From $0.007 to $0.481 per image"
+            "label": "Niveles de salida",
+            "value": "Standard / Large x Low / Medium / High"
           },
-          { "label": "Languages", "value": "Multilingual prompts" },
-          { "label": "Available on VM0", "value": "April 2026" }
+          {
+            "label": "Precio facturado por VM0",
+            "value": "De $0.007 a $0.481 por imagen"
+          },
+          {
+            "label": "Idiomas",
+            "value": "Prompts multilingues"
+          },
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril de 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
         "performance": [
           {
-            "title": "Prompt adherence",
-            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+            "title": "Seguimiento del prompt",
+            "body": "La principal razon para elegir GPT Image 2 en lugar de GPT Image 1 es una ejecucion mas estricta de prompts detallados, especialmente cuando el brief incluye composicion, relacion de aspecto y restricciones de estilo."
           },
           {
-            "title": "Flexible sizing",
-            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+            "title": "Tamanos flexibles",
+            "body": "Admite la ruta de tamanos de imagen flexibles de VM0, para que los agentes puedan pedir salidas cuadradas, verticales, horizontales y de mayor tamano sin cambiar de familia de modelos."
           },
           {
-            "title": "Edit flows",
-            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+            "title": "Flujos de edicion",
+            "body": "Admite ediciones imagen a imagen y mascaras. Usalo cuando un flujo necesite preservar una imagen fuente mientras cambia una region descrita."
           },
           {
-            "title": "Cost",
-            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+            "title": "Costo",
+            "body": "Es mas caro que GPT Image 1 en niveles medium y high. Mantén las iteraciones de borrador en menor calidad y reserva la alta calidad para la salida final."
           }
         ],
         "bestForExamples": [
           {
-            "title": "The agent that needs exact prompt following",
-            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+            "title": "El agente que necesita seguir el prompt con precision",
+            "body": "Cuando el prompt tiene requisitos especificos de encuadre, estilo o tamano, GPT Image 2 es la opcion de imagen de OpenAI mas segura que GPT Image 1."
           },
           {
-            "title": "The image workflow that needs multiple aspect ratios",
-            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+            "title": "El flujo de imagenes que necesita multiples relaciones de aspecto",
+            "body": "Los activos de marketing, redes sociales y sitios web suelen necesitar salidas cuadradas, verticales y horizontales. GPT Image 2 encaja en esos flujos sin cambiar el estilo del prompt."
           },
           {
-            "title": "The OpenAI-stack edit loop",
-            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+            "title": "El ciclo de edicion en el stack de OpenAI",
+            "body": "Si un agente ya usa modelos de OpenAI para planificacion y copy, GPT Image 2 mantiene la generacion de imagenes en la misma familia de seguimiento de prompts."
           }
         ],
-        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "avoidFor": "Evita GPT Image 2 cuando el costo sea la restriccion principal o cuando se requiera salida real con fondo transparente. GPT Image 1, GPT Image 1.5 o SeedDream 4 pueden ser mejores segun la restriccion.",
         "comparisons": [
           {
             "vs": "GPT Image 1",
-            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+            "body": "GPT Image 2 es el modelo mas reciente y flexible, con mejor seguimiento del prompt. GPT Image 1 sigue siendo mas barato en configuraciones medium-standard comunes y continua siendo fuerte para ilustracion estilizada."
           },
           {
             "vs": "SeedDream 4",
-            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+            "body": "SeedDream 4 es mas barato y se inclina hacia el fotorrealismo. GPT Image 2 es la mejor opcion dentro del stack de OpenAI cuando importan mas el seguimiento del prompt, el flujo de edicion y los tamanos flexibles que el costo minimo."
           }
         ],
-        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "verdict": "Elige GPT Image 2 cuando quieras generacion de imagenes de OpenAI con mejor seguimiento del prompt y tamanos flexibles. Usa GPT Image 1 o SeedDream 4 cuando el costo sea la restriccion dominante.",
         "faqs": [
           {
-            "q": "How is GPT Image 2 priced?",
-            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+            "q": "Como se cobra GPT Image 2?",
+            "a": "Se cobra por calidad y tamano. En VM0, el nivel medium-standard cuesta alrededor de $0.064 por imagen y el nivel high/large alrededor de $0.481 por imagen."
           },
           {
-            "q": "Does GPT Image 2 support image editing?",
-            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+            "q": "GPT Image 2 admite edicion de imagenes?",
+            "a": "Si. VM0 expone edicion imagen a imagen y soporte de mascaras para GPT Image 2."
           },
           {
-            "q": "Does GPT Image 2 support transparent backgrounds?",
-            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+            "q": "GPT Image 2 admite fondos transparentes?",
+            "a": "No. La ruta GPT Image 2 de VM0 no admite salida con fondo transparente."
           },
           {
-            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
-            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+            "q": "Cuando deberia usar GPT Image 2 en lugar de GPT Image 1?",
+            "a": "Usa GPT Image 2 para un seguimiento del prompt mas estricto y tamanos flexibles. Usa GPT Image 1 cuando el brief sea mas simple o el costo importe mas."
           }
         ],
         "alternatives": [
-          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
-          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+          {
+            "slug": "gpt-image-1",
+            "reason": "Opcion predeterminada de imagen OpenAI mas barata"
+          },
+          {
+            "slug": "seedream-4",
+            "reason": "Alternativa fotorrealista mas barata"
+          }
         ],
-        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
-        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+        "routingNotes": "Se enruta al endpoint GPT Image 2 de OpenAI mediante la ruta Built-in de generacion de VM0 y se cobra por nivel de imagen de salida.",
+        "vm0Notes": "GPT Image 2 esta disponible mediante VM0 Managed generation con controles de calidad y tamano. Usa calidad media para trabajo normal de agentes y alta calidad cuando la imagen generada sea el entregable."
       },
       "gpt-image-1": {
         "name": "GPT Image 1",
@@ -6097,7 +6169,10 @@
         ],
         "architecture": "Modelo de texto a imagen basado en Diffusion con soporte nativo de edición. Los precios por nivel escalan según resolución de salida (estándar / grande) y calidad (bajo / medio / alto), con el nivel medio/estándar como el predeterminado típico. Las entradas aceptan texto más imágenes de referencia opcionales para ediciones y máscaras.",
         "specs": [
-          { "label": "Familia", "value": "OpenAI Images" },
+          {
+            "label": "Familia",
+            "value": "OpenAI Images"
+          },
           {
             "label": "Modalidades",
             "value": "Texto a imagen, edición imagen a imagen"
@@ -6110,8 +6185,14 @@
             "label": "Precio listado",
             "value": "De $0,011 a $0,25 por imagen"
           },
-          { "label": "Idiomas", "value": "Prompts multilingües" },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
+          {
+            "label": "Idiomas",
+            "value": "Prompts multilingües"
+          },
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6202,11 +6283,26 @@
         ],
         "architecture": "Modelo de Diffusion de alta resolución con seguimiento de prompts ajustado para fidelidad compositiva. Facturado por imagen generada. Las entradas aceptan prompts de texto; produce salida de alta resolución adecuada para entrega.",
         "specs": [
-          { "label": "Familia", "value": "Flux 1.1 Pro" },
-          { "label": "Modalidades", "value": "Texto a imagen" },
-          { "label": "Precio listado", "value": "$0,072 por imagen" },
-          { "label": "Idiomas", "value": "Prompts multilingües" },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
+          {
+            "label": "Familia",
+            "value": "Flux 1.1 Pro"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto a imagen"
+          },
+          {
+            "label": "Precio listado",
+            "value": "$0,072 por imagen"
+          },
+          {
+            "label": "Idiomas",
+            "value": "Prompts multilingües"
+          },
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6301,14 +6397,26 @@
         ],
         "architecture": "Modelo de texto a imagen basado en Diffusion. Facturado por imagen generada. Las entradas aceptan prompts de texto; produce salida inclinada al fotorrealismo adecuada para retratos, productos e imágenes de estilo de vida.",
         "specs": [
-          { "label": "Familia", "value": "Seedream V4" },
-          { "label": "Modalidades", "value": "Texto a imagen" },
-          { "label": "Precio listado", "value": "$0,036 por imagen" },
+          {
+            "label": "Familia",
+            "value": "Seedream V4"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto a imagen"
+          },
+          {
+            "label": "Precio listado",
+            "value": "$0,036 por imagen"
+          },
           {
             "label": "Idiomas",
             "value": "Prompts multilingües (inglés + chino fuerte)"
           },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6403,18 +6511,30 @@
         ],
         "architecture": "Modelo de Diffusion de texto a video e imagen a video con síntesis de audio nativa en la misma pasada. Las duraciones de salida son 4, 6 u 8 segundos a 720p, 1080p o 4K. Facturado por video-segundo generado con modificadores de nivel de calidad.",
         "specs": [
-          { "label": "Familia", "value": "Google Veo 3" },
+          {
+            "label": "Familia",
+            "value": "Google Veo 3"
+          },
           {
             "label": "Modalidades",
             "value": "Texto a video, imagen a video, audio nativo"
           },
-          { "label": "Duraciones", "value": "4s / 6s / 8s" },
-          { "label": "Resoluciones", "value": "720p / 1080p / 4K" },
+          {
+            "label": "Duraciones",
+            "value": "4s / 6s / 8s"
+          },
+          {
+            "label": "Resoluciones",
+            "value": "720p / 1080p / 4K"
+          },
           {
             "label": "Precio listado",
             "value": "~$0,15 por segundo (720p + audio)"
           },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6509,12 +6629,30 @@
         ],
         "architecture": "Modelo de Diffusion de texto a video e imagen a video. El nivel estándar renderiza a 4K con duraciones de clip de 3 a 15 segundos. Facturado por video-segundo generado.",
         "specs": [
-          { "label": "Familia", "value": "Kling V3" },
-          { "label": "Modalidades", "value": "Texto a video, imagen a video" },
-          { "label": "Duraciones", "value": "3 a 15 segundos" },
-          { "label": "Resoluciones", "value": "4K (nivel estándar)" },
-          { "label": "Precio listado", "value": "~$0,28 por segundo (4K)" },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
+          {
+            "label": "Familia",
+            "value": "Kling V3"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto a video, imagen a video"
+          },
+          {
+            "label": "Duraciones",
+            "value": "3 a 15 segundos"
+          },
+          {
+            "label": "Resoluciones",
+            "value": "4K (nivel estándar)"
+          },
+          {
+            "label": "Precio listado",
+            "value": "~$0,28 por segundo (4K)"
+          },
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6609,15 +6747,30 @@
         ],
         "architecture": "Modelo de Diffusion de texto a video e imagen a video con tres niveles de calidad (Fast, Standard, Pro). La entrada curada cubre el nivel Standard 2.0. Facturado por video-segundo generado con modificadores por resolución y si se usa condicionamiento por imagen.",
         "specs": [
-          { "label": "Familia", "value": "Seedance 2.0" },
-          { "label": "Modalidades", "value": "Texto a video, imagen a video" },
-          { "label": "Duraciones", "value": "4 a 15 segundos" },
-          { "label": "Resoluciones", "value": "480p / 720p / 1080p" },
+          {
+            "label": "Familia",
+            "value": "Seedance 2.0"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto a video, imagen a video"
+          },
+          {
+            "label": "Duraciones",
+            "value": "4 a 15 segundos"
+          },
+          {
+            "label": "Resoluciones",
+            "value": "480p / 720p / 1080p"
+          },
           {
             "label": "Precio listado",
             "value": "~$0,05 por segundo (1080p + imagen)"
           },
-          { "label": "Disponible en VM0", "value": "Abril 2026" }
+          {
+            "label": "Disponible en VM0",
+            "value": "Abril 2026"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6688,7 +6841,10 @@
             "slug": "veo-3-1-fast",
             "reason": "Audio nativo, movimiento cinematográfico"
           },
-          { "slug": "kling-v3-4k", "reason": "Estilizado, más largo, 4K" }
+          {
+            "slug": "kling-v3-4k",
+            "reason": "Estilizado, más largo, 4K"
+          }
         ],
         "routingNotes": "Enrutado al endpoint Dreamina Seedance 2.0 de ByteDance y facturado por video-segundo generado con modificadores de resolución y condicionamiento por imagen.",
         "vm0Notes": "Dreamina Seedance 2.0 es el predeterminado optimizado en costo en la línea curada de video en VM0. El patrón estándar es usarlo para iteración y fan-out, luego escalar la variante elegida a Veo 3.1 Fast o Kling V3 4K solo cuando el renderizado final justifica la prima."

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -4308,17 +4308,38 @@
         ],
         "architecture": "GPT-5.5はGPT-5.4から400Kトークンコンテキストウィンドウを継承し、ウィンドウ全体が標準入力価格で課金されます。`reasoning_effort`パラメーターを4レベル（minimal、low、medium、high）でサポートし、プロンプトキャッシュではキャッシュ入力が入力レートの10分の1で課金され、codex CLIがデフォルトで使用するResponses APIサーフェスを使用します。ツール使用、構造化出力、コンピュータ使用は5.4から変更ありません。入力はテキスト、ビジョン、コードにわたってマルチモーダル。モデルにはネイティブな画像生成はありません（それにはImages APIを使用）。",
         "specs": [
-          { "label": "ファミリー", "value": "GPT-5世代" },
-          { "label": "モダリティ", "value": "テキスト、ビジョン、コード" },
-          { "label": "言語", "value": "英語中心、多言語対応" },
-          { "label": "プロンプトキャッシュ", "value": "サポート（OpenAI）" },
-          { "label": "コンテキストウィンドウ", "value": "400Kトークン" },
-          { "label": "最大出力", "value": "最大128Kトークン" },
+          {
+            "label": "ファミリー",
+            "value": "GPT-5世代"
+          },
+          {
+            "label": "モダリティ",
+            "value": "テキスト、ビジョン、コード"
+          },
+          {
+            "label": "言語",
+            "value": "英語中心、多言語対応"
+          },
+          {
+            "label": "プロンプトキャッシュ",
+            "value": "サポート（OpenAI）"
+          },
+          {
+            "label": "コンテキストウィンドウ",
+            "value": "400Kトークン"
+          },
+          {
+            "label": "最大出力",
+            "value": "最大128Kトークン"
+          },
           {
             "label": "推論努力レベル",
             "value": "Minimal / Low / Medium / High"
           },
-          { "label": "ベンダー定価", "value": "入力$5 / 出力$30 /1M" }
+          {
+            "label": "ベンダー定価",
+            "value": "入力$5 / 出力$30 /1M"
+          }
         ],
         "benchmarksNote": "OpenAIのGPT-5.5リリース資料からのベンダー報告スコア、公開されているGPT-5.4の数字に対するデルタを示しています。独立レビューは、エージェントコーディングタスクで5.5をClaude Opus 4.7の数ポイント以内に位置付けています。絶対パーセンテージは方向性として捉えてください。OpenAIは全フロンティアモデルでSWE-bench Verifiedのトレーニングデータ汚染を指摘しています。",
         "benchmarks": [
@@ -4437,7 +4458,10 @@
           }
         ],
         "alternatives": [
-          { "slug": "gpt-5-4", "reason": "半分のクレジット、同じファミリー" },
+          {
+            "slug": "gpt-5-4",
+            "reason": "半分のクレジット、同じファミリー"
+          },
           {
             "slug": "claude-opus-4-7",
             "reason": "Claude側の同等フラッグシップ"
@@ -4622,17 +4646,38 @@
         ],
         "architecture": "GPT-5.4はGPT-5ファミリーの残りと同じアーキテクチャを使用します：400Kトークンコンテキストウィンドウ、4レベル（minimal、low、medium、high）の`reasoning_effort`パラメーター、キャッシュ入力が入力レートの10分の1で課金されるプロンプトキャッシュ、codex CLIがデフォルトで使用するResponses APIサーフェス。ツール使用、構造化出力、コンピュータ使用がサポートされています。入力はテキスト、ビジョン、コードにわたってマルチモーダル。",
         "specs": [
-          { "label": "ファミリー", "value": "GPT-5世代" },
-          { "label": "モダリティ", "value": "テキスト、ビジョン、コード" },
-          { "label": "言語", "value": "英語中心、多言語対応" },
-          { "label": "プロンプトキャッシュ", "value": "サポート（OpenAI）" },
-          { "label": "コンテキストウィンドウ", "value": "400Kトークン" },
-          { "label": "最大出力", "value": "最大128Kトークン" },
+          {
+            "label": "ファミリー",
+            "value": "GPT-5世代"
+          },
+          {
+            "label": "モダリティ",
+            "value": "テキスト、ビジョン、コード"
+          },
+          {
+            "label": "言語",
+            "value": "英語中心、多言語対応"
+          },
+          {
+            "label": "プロンプトキャッシュ",
+            "value": "サポート（OpenAI）"
+          },
+          {
+            "label": "コンテキストウィンドウ",
+            "value": "400Kトークン"
+          },
+          {
+            "label": "最大出力",
+            "value": "最大128Kトークン"
+          },
           {
             "label": "推論努力レベル",
             "value": "Minimal / Low / Medium / High"
           },
-          { "label": "ベンダー定価", "value": "入力$2.5 / 出力$15 /1M" }
+          {
+            "label": "ベンダー定価",
+            "value": "入力$2.5 / 出力$15 /1M"
+          }
         ],
         "benchmarksNote": "OpenAIのGPT-5リリース資料からのベンダー報告スコア、前世代のOpenAIに対するデルタを示しています。独立レビューはGPT-5.4をClaude Sonnet 4.6と同じコーディング品質帯に位置付けています。絶対パーセンテージは方向性として捉えてください。",
         "benchmarks": [
@@ -5069,17 +5114,38 @@
         ],
         "architecture": "GPT-5.4 MiniはGPT-5ファミリーの残りと同じアーキテクチャを使用します：400Kトークンコンテキストウィンドウ、4レベルの`reasoning_effort`パラメーター、キャッシュ入力が入力レートの10分の1で課金されるプロンプトキャッシュ、Responses APIサーフェス。ツール使用、構造化出力、マルチモーダルビジョン入力がサポートされています。モデルはより小さく高速な兄弟 — トークンあたり少ないパラメーター、ドルあたりより多くのスループット。",
         "specs": [
-          { "label": "ファミリー", "value": "GPT-5世代" },
-          { "label": "モダリティ", "value": "テキスト、ビジョン、コード" },
-          { "label": "言語", "value": "英語中心、多言語対応" },
-          { "label": "プロンプトキャッシュ", "value": "サポート（OpenAI）" },
-          { "label": "コンテキストウィンドウ", "value": "400Kトークン" },
-          { "label": "最大出力", "value": "最大128Kトークン" },
+          {
+            "label": "ファミリー",
+            "value": "GPT-5世代"
+          },
+          {
+            "label": "モダリティ",
+            "value": "テキスト、ビジョン、コード"
+          },
+          {
+            "label": "言語",
+            "value": "英語中心、多言語対応"
+          },
+          {
+            "label": "プロンプトキャッシュ",
+            "value": "サポート（OpenAI）"
+          },
+          {
+            "label": "コンテキストウィンドウ",
+            "value": "400Kトークン"
+          },
+          {
+            "label": "最大出力",
+            "value": "最大128Kトークン"
+          },
           {
             "label": "推論努力レベル",
             "value": "Minimal / Low / Medium / High"
           },
-          { "label": "ベンダー定価", "value": "入力$0.75 / 出力$4.5 /1M" }
+          {
+            "label": "ベンダー定価",
+            "value": "入力$0.75 / 出力$4.5 /1M"
+          }
         ],
         "benchmarksNote": "OpenAIのGPT-5 Miniリリース資料からのベンダー報告スコア。独立レビューはほとんどのエージェントベンチマークで5.4 MiniをClaude Haiku 4.5と同じコスト削減帯に位置付けています。絶対パーセンテージは方向性として捉えてください。",
         "benchmarks": [
@@ -5967,106 +6033,121 @@
       },
       "gpt-image-2": {
         "name": "GPT Image 2",
-        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
-        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
-        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
-        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
-        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
-        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "pageTitle": "VM0 の GPT Image 2。OpenAI の新しい画像生成モデル",
+        "tagline": "OpenAI の新しい画像モデルで、テキストからの画像生成と編集に対応します。GPT Image のワークフローで、より高いプロンプト追従性と柔軟なサイズ指定が必要なときに使います。",
+        "cardIntro": "生成と編集に対応する OpenAI の新しい画像モデル。GPT Image 1 より柔軟なサイズ指定と高いプロンプト追従性を備えています。",
+        "metaTitle": "VM0 の GPT Image 2: 料金、仕様、比較",
+        "metaDescription": "VM0 の GPT Image 2。柔軟なサイズ、品質ティア、GPT Image 1 や SeedDream 4 との比較を備えた OpenAI の新しい画像生成・編集モデルです。",
+        "summary": "GPT Image 2 は VM0 で利用できる OpenAI の新しい画像生成モデルです。GPT Image のテキストから画像生成と編集のワークフローを維持しつつ、本番向けの画像タスクに必要な柔軟なサイズ指定と高いプロンプト追従性を追加しています。\n\nVM0 の課金はティア制で、low/standard ティアの 1 画像あたり約 $0.007 から high/large ティアの $0.481 までです。medium-standard ティア (VM0 では 1024x1024 あたり約 $0.064) は、ほとんどの Built-in 生成呼び出しに適した標準設定です。",
         "releaseDate": "April 2026",
-        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "familyPosition": "OpenAI の新しい GPT Image モデル。プロンプト追従性と柔軟な出力サイズの面で GPT Image 1 の上位に位置づけられます。",
         "background": [
-          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
-          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+          "GPT Image 2 は、VM0 の Built-in 画像生成パスから利用できる OpenAI の新しい画像モデルです。GPT Image 1 と同じエージェント向けワークフローで、テキストから画像生成と画像編集に対応します。",
+          "OpenAI らしいプロンプト追従性が必要で、GPT Image 1 の標準ティアより柔軟な出力サイズも必要な場合に、よいデフォルトになります。品質とサイズに応じて課金されるため、下書きループは安価に抑え、最終レンダーだけ高品質にできます。"
         ],
-        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "architecture": "fal 上の OpenAI GPT Image 2 エンドポイントを通じて提供される、テキストから画像生成および画像編集モデルです。品質ティアと柔軟な画像サイズに対応します。このモデルでは VM0 の透明背景出力はサポートされません。",
         "specs": [
-          { "label": "Family", "value": "OpenAI Images" },
           {
-            "label": "Modalities",
-            "value": "Text-to-image, image-to-image edit"
+            "label": "ファミリー",
+            "value": "OpenAI Images"
           },
           {
-            "label": "Output tiers",
-            "value": "Standard / Large × Low / Medium / High"
+            "label": "モダリティ",
+            "value": "テキストから画像、画像から画像の編集"
           },
           {
-            "label": "VM0 billed price",
-            "value": "From $0.007 to $0.481 per image"
+            "label": "出力ティア",
+            "value": "Standard / Large x Low / Medium / High"
           },
-          { "label": "Languages", "value": "Multilingual prompts" },
-          { "label": "Available on VM0", "value": "April 2026" }
+          {
+            "label": "VM0 課金価格",
+            "value": "1 画像あたり $0.007 から $0.481"
+          },
+          {
+            "label": "言語",
+            "value": "多言語プロンプト"
+          },
+          {
+            "label": "VM0 での提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
         "performance": [
           {
-            "title": "Prompt adherence",
-            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+            "title": "プロンプト追従性",
+            "body": "GPT Image 1 ではなく GPT Image 2 を選ぶ主な理由は、詳細なプロンプトをより厳密に実行できることです。構図、アスペクト比、スタイル制約を含む指示で特に有効です。"
           },
           {
-            "title": "Flexible sizing",
-            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+            "title": "柔軟なサイズ",
+            "body": "VM0 の柔軟な画像サイズパスに対応しているため、モデルファミリーを切り替えずに正方形、縦長、横長、大きめの出力をエージェントから要求できます。"
           },
           {
-            "title": "Edit flows",
-            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+            "title": "編集フロー",
+            "body": "画像から画像の編集とマスクに対応します。元画像を保ちながら、指定した領域だけを変更するワークフローで使います。"
           },
           {
-            "title": "Cost",
-            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+            "title": "コスト",
+            "body": "medium と high のティアでは GPT Image 1 より高価です。下書きループは低めの品質にし、最終出力だけ高品質にするのが適しています。"
           }
         ],
         "bestForExamples": [
           {
-            "title": "The agent that needs exact prompt following",
-            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+            "title": "正確なプロンプト追従が必要なエージェント",
+            "body": "フレーミング、スタイル、サイズに具体的な要件がある場合、GPT Image 2 は GPT Image 1 より安全な OpenAI 画像モデルの選択肢です。"
           },
           {
-            "title": "The image workflow that needs multiple aspect ratios",
-            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+            "title": "複数のアスペクト比が必要な画像ワークフロー",
+            "body": "マーケティング、SNS、Web サイトのアセットでは、正方形、縦長、横長の出力が必要になることがよくあります。GPT Image 2 は、プロンプトの書き方を変えずにそうしたワークフローに合います。"
           },
           {
-            "title": "The OpenAI-stack edit loop",
-            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+            "title": "OpenAI スタックでの編集ループ",
+            "body": "エージェントがすでに計画やコピーに OpenAI モデルを使っている場合、GPT Image 2 により画像生成も同じプロンプト追従系のファミリーに保てます。"
           }
         ],
-        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "avoidFor": "コストが最優先の場合や、真の透明背景出力が必要な場合は GPT Image 2 を避けてください。制約によっては GPT Image 1、GPT Image 1.5、SeedDream 4 の方が適しています。",
         "comparisons": [
           {
             "vs": "GPT Image 1",
-            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+            "body": "GPT Image 2 は、より新しく柔軟で、プロンプト追従性が高いモデルです。GPT Image 1 は一般的な medium-standard 設定では引き続き安価で、スタイライズされたイラストにも強みがあります。"
           },
           {
             "vs": "SeedDream 4",
-            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+            "body": "SeedDream 4 はより安価で、フォトリアル寄りです。最低コストよりもプロンプト追従性、編集ワークフロー、柔軟なサイズが重要な場合は、GPT Image 2 が OpenAI スタックでのよりよい選択です。"
           }
         ],
-        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "verdict": "より高いプロンプト追従性と柔軟なサイズ指定を備えた OpenAI 画像生成が必要なら GPT Image 2 を選びます。コストが最重要なら GPT Image 1 または SeedDream 4 を使います。",
         "faqs": [
           {
-            "q": "How is GPT Image 2 priced?",
-            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+            "q": "GPT Image 2 はどのように課金されますか?",
+            "a": "品質とサイズに応じて課金されます。VM0 では medium-standard ティアが 1 画像あたり約 $0.064、high/large ティアが約 $0.481 です。"
           },
           {
-            "q": "Does GPT Image 2 support image editing?",
-            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+            "q": "GPT Image 2 は画像編集に対応していますか?",
+            "a": "はい。VM0 では GPT Image 2 の画像から画像の編集とマスク対応を提供しています。"
           },
           {
-            "q": "Does GPT Image 2 support transparent backgrounds?",
-            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+            "q": "GPT Image 2 は透明背景に対応していますか?",
+            "a": "いいえ。VM0 の GPT Image 2 パスは透明背景出力をサポートしていません。"
           },
           {
-            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
-            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+            "q": "GPT Image 1 ではなく GPT Image 2 を使うべきタイミングは?",
+            "a": "より厳密なプロンプト追従と柔軟なサイズが必要な場合は GPT Image 2 を使います。指示が単純な場合やコストを重視する場合は GPT Image 1 を使います。"
           }
         ],
         "alternatives": [
-          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
-          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+          {
+            "slug": "gpt-image-1",
+            "reason": "より安価な OpenAI 画像のデフォルト"
+          },
+          {
+            "slug": "seedream-4",
+            "reason": "より安価なフォトリアル代替"
+          }
         ],
-        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
-        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+        "routingNotes": "VM0 の Built-in 生成パスを通じて OpenAI の GPT Image 2 エンドポイントへルーティングされ、出力画像ティアごとに課金されます。",
+        "vm0Notes": "GPT Image 2 は VM0 Managed generation で利用でき、品質とサイズを制御できます。通常のエージェント作業には medium 品質を使い、生成画像自体が納品物になる場合は high 品質を使います。"
       },
       "gpt-image-1": {
         "name": "GPT Image 1",
@@ -6084,15 +6165,30 @@
         ],
         "architecture": "ネイティブ編集サポート付きのディフュージョンベースのテキストツーイメージ。ティア価格は出力解像度（標準/大）と品質（低/中/高）でスケールし、中/標準ティアが典型的なデフォルト。入力は編集とマスク用のテキストとオプションのリファレンス画像を受け付けます。",
         "specs": [
-          { "label": "ファミリー", "value": "OpenAI Images" },
+          {
+            "label": "ファミリー",
+            "value": "OpenAI Images"
+          },
           {
             "label": "モダリティ",
             "value": "テキストツーイメージ、イメージツーイメージ編集"
           },
-          { "label": "出力ティア", "value": "標準/大 × 低/中/高" },
-          { "label": "ベンダー定価", "value": "画像あたり$0.011から$0.25" },
-          { "label": "言語", "value": "多言語プロンプト" },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
+          {
+            "label": "出力ティア",
+            "value": "標準/大 × 低/中/高"
+          },
+          {
+            "label": "ベンダー定価",
+            "value": "画像あたり$0.011から$0.25"
+          },
+          {
+            "label": "言語",
+            "value": "多言語プロンプト"
+          },
+          {
+            "label": "VM0 提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6159,7 +6255,10 @@
             "slug": "flux-pro-1-1-ultra",
             "reason": "より高いフォトリアルアスペクト天井"
           },
-          { "slug": "seedream-4", "reason": "より良いフォトリアルデフォルト" }
+          {
+            "slug": "seedream-4",
+            "reason": "より良いフォトリアルデフォルト"
+          }
         ],
         "routingNotes": "Routed to OpenAI's Images surface and billed per generated image at the selected tier.",
         "vm0Notes": "GPT Image 1 is the OpenAI-stack default for stylised illustration and edit-loop agent workflows. The medium/standard tier is the sensible everywhere-default; reserve the high/large tier for delivery-grade output."
@@ -6180,11 +6279,26 @@
         ],
         "architecture": "構図忠実度に調整されたプロンプト追従を持つ高解像度ディフュージョンモデル。生成画像あたり課金。入力はテキストプロンプトを受け付け、配信に適した高解像度出力を生成します。",
         "specs": [
-          { "label": "ファミリー", "value": "Flux 1.1 Pro" },
-          { "label": "モダリティ", "value": "テキストツーイメージ" },
-          { "label": "ベンダー定価", "value": "画像あたり$0.072" },
-          { "label": "言語", "value": "多言語プロンプト" },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
+          {
+            "label": "ファミリー",
+            "value": "Flux 1.1 Pro"
+          },
+          {
+            "label": "モダリティ",
+            "value": "テキストツーイメージ"
+          },
+          {
+            "label": "ベンダー定価",
+            "value": "画像あたり$0.072"
+          },
+          {
+            "label": "言語",
+            "value": "多言語プロンプト"
+          },
+          {
+            "label": "VM0 提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6255,7 +6369,10 @@
             "slug": "gpt-image-1",
             "reason": "より強力なスタイライズドイラスト"
           },
-          { "slug": "seedream-4", "reason": "より安価なフォトリアル代替" }
+          {
+            "slug": "seedream-4",
+            "reason": "より安価なフォトリアル代替"
+          }
         ],
         "routingNotes": "Routed to Black Forest Labs' Flux Pro 1.1 Ultra endpoint and billed per generated image.",
         "vm0Notes": "Flux Pro 1.1 Ultra is the premium tier of the curated image lineup. Use it for the final-render step rather than for iteration; pair it with SeedDream 4 for the cheap pre-filter."
@@ -6276,14 +6393,26 @@
         ],
         "architecture": "ディフュージョンベースのテキストツーイメージモデル。生成画像あたり課金。入力はテキストプロンプトを受け付け、ポートレート、製品、ライフスタイル画像に適したフォトリアル傾向の出力を生成します。",
         "specs": [
-          { "label": "ファミリー", "value": "Seedream V4" },
-          { "label": "モダリティ", "value": "テキストツーイメージ" },
-          { "label": "ベンダー定価", "value": "画像あたり$0.036" },
+          {
+            "label": "ファミリー",
+            "value": "Seedream V4"
+          },
+          {
+            "label": "モダリティ",
+            "value": "テキストツーイメージ"
+          },
+          {
+            "label": "ベンダー定価",
+            "value": "画像あたり$0.036"
+          },
           {
             "label": "言語",
             "value": "多言語プロンプト（英語＋中国語が強い）"
           },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
+          {
+            "label": "VM0 提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6378,18 +6507,30 @@
         ],
         "architecture": "同じパスでネイティブオーディオ合成を持つテキストツービデオおよびイメージツービデオディフュージョンモデル。出力時間は720p、1080p、または4Kで4、6、または8秒。品質ティアモディファイア付きで生成ビデオ秒あたり課金。",
         "specs": [
-          { "label": "ファミリー", "value": "Google Veo 3" },
+          {
+            "label": "ファミリー",
+            "value": "Google Veo 3"
+          },
           {
             "label": "モダリティ",
             "value": "テキストツービデオ、イメージツービデオ、ネイティブオーディオ"
           },
-          { "label": "クリップ長", "value": "4秒 / 6秒 / 8秒" },
-          { "label": "出力解像度", "value": "720p / 1080p / 4K" },
+          {
+            "label": "クリップ長",
+            "value": "4秒 / 6秒 / 8秒"
+          },
+          {
+            "label": "出力解像度",
+            "value": "720p / 1080p / 4K"
+          },
           {
             "label": "ベンダー定価",
             "value": "秒あたり約$0.15（720p＋オーディオ）"
           },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
+          {
+            "label": "VM0 提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6460,7 +6601,10 @@
             "slug": "kling-v3-4k",
             "reason": "スタイライズド/アニメ天井、より長いクリップ"
           },
-          { "slug": "dreamina-seedance-2-0", "reason": "秒あたりより安価" }
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "秒あたりより安価"
+          }
         ],
         "routingNotes": "Routed to Google's Veo 3.1 Fast video generation endpoint and billed per generated video-second with quality-tier modifiers.",
         "vm0Notes": "Veo 3.1 Fast is the cinematic / audio-bearing default in the curated video lineup on VM0. Pair it with Dreamina Seedance 2.0 for cheap iteration and with Kling V3 4K for stylised or longer-form clips."
@@ -6481,15 +6625,30 @@
         ],
         "architecture": "テキストツービデオおよびイメージツービデオディフュージョンモデル。標準ティアは3〜15秒のクリップ時間で4Kでレンダリング。生成ビデオ秒あたり課金。",
         "specs": [
-          { "label": "ファミリー", "value": "Kling V3" },
+          {
+            "label": "ファミリー",
+            "value": "Kling V3"
+          },
           {
             "label": "モダリティ",
             "value": "テキストツービデオ、イメージツービデオ"
           },
-          { "label": "クリップ長", "value": "3〜15秒" },
-          { "label": "出力解像度", "value": "4K（標準ティア）" },
-          { "label": "ベンダー定価", "value": "秒あたり約$0.28（4K）" },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
+          {
+            "label": "クリップ長",
+            "value": "3〜15秒"
+          },
+          {
+            "label": "出力解像度",
+            "value": "4K（標準ティア）"
+          },
+          {
+            "label": "ベンダー定価",
+            "value": "秒あたり約$0.28（4K）"
+          },
+          {
+            "label": "VM0 提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6560,7 +6719,10 @@
             "slug": "veo-3-1-fast",
             "reason": "シネマティック/ネイティブオーディオ"
           },
-          { "slug": "dreamina-seedance-2-0", "reason": "より安価なバルク生成" }
+          {
+            "slug": "dreamina-seedance-2-0",
+            "reason": "より安価なバルク生成"
+          }
         ],
         "routingNotes": "Routed to Kuaishou's Kling V3 4K endpoint and billed per generated video-second.",
         "vm0Notes": "Kling V3 4K is the high-ceiling option in the curated video lineup on VM0. Reserve it for stylised, long-form or 4K deliverables — for the everywhere-default reach for Veo 3.1 Fast or Dreamina Seedance 2.0."
@@ -6581,18 +6743,30 @@
         ],
         "architecture": "3つの品質ティア（Fast、Standard、Pro）を持つテキストツービデオおよびイメージツービデオディフュージョンモデル。キュレーション済みエントリはStandard 2.0ティアをカバーします。解像度と画像条件付けが使用されているかどうかのモディファイア付きで生成ビデオ秒あたり課金。",
         "specs": [
-          { "label": "ファミリー", "value": "Seedance 2.0" },
+          {
+            "label": "ファミリー",
+            "value": "Seedance 2.0"
+          },
           {
             "label": "モダリティ",
             "value": "テキストツービデオ、イメージツービデオ"
           },
-          { "label": "クリップ長", "value": "4〜15秒" },
-          { "label": "出力解像度", "value": "480p / 720p / 1080p" },
+          {
+            "label": "クリップ長",
+            "value": "4〜15秒"
+          },
+          {
+            "label": "出力解像度",
+            "value": "480p / 720p / 1080p"
+          },
           {
             "label": "ベンダー定価",
             "value": "秒あたり約$0.05（1080p＋画像）"
           },
-          { "label": "VM0 提供開始", "value": "2026年4月" }
+          {
+            "label": "VM0 提供開始",
+            "value": "2026年4月"
+          }
         ],
         "benchmarksNote": "",
         "benchmarks": [],
@@ -6663,7 +6837,10 @@
             "slug": "veo-3-1-fast",
             "reason": "ネイティブオーディオ、シネマティックモーション"
           },
-          { "slug": "kling-v3-4k", "reason": "スタイライズド、より長い、4K" }
+          {
+            "slug": "kling-v3-4k",
+            "reason": "スタイライズド、より長い、4K"
+          }
         ],
         "routingNotes": "Routed to ByteDance's Dreamina Seedance 2.0 endpoint and billed per generated video-second with resolution and image-conditioning modifiers.",
         "vm0Notes": "Dreamina Seedance 2.0 is the cost-optimised default in the curated video lineup on VM0. The standard pattern is to use it for iteration and fan-out, then escalate the chosen variant to Veo 3.1 Fast or Kling V3 4K only when the final render justifies the premium."

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -5965,6 +5965,109 @@
         "routingNotes": "DeepSeekのAnthropic互換エンドポイント`api.deepseek.com`経由でルーティング。DeepSeekプロバイダーのデフォルトモデル。VM0 Managedでも利用可能。",
         "vm0Notes": "V4 FlashはBuilt-inモデル中最低のクレジットマルチプライヤー（×0.02）を持ち、Sonnet 4.6の約50分の1です。キャッシュ読み取りは課金、キャッシュ書き込みは無料。VM0はDeepSeekプロバイダーに10分のAPIタイムアウトを設定しており、Flashの短い単発作業と自然に適合します。"
       },
+      "gpt-image-2": {
+        "name": "GPT Image 2",
+        "pageTitle": "GPT Image 2 on VM0. OpenAI's newer image generation model",
+        "tagline": "OpenAI's newer image model for text-to-image generation and edits. Use it when you want the GPT Image workflow with stronger prompt adherence and flexible sizing.",
+        "cardIntro": "OpenAI's newer image model for generation and editing, with flexible sizing and stronger prompt adherence than GPT Image 1.",
+        "metaTitle": "GPT Image 2 on VM0: Pricing, Specs & Comparison",
+        "metaDescription": "GPT Image 2 on VM0. OpenAI's newer image generation and edit model with flexible sizing, quality tiers, and comparison to GPT Image 1 and SeedDream 4.",
+        "summary": "GPT Image 2 is OpenAI's newer image generation model on VM0. It keeps the GPT Image text-to-image and edit workflow while adding flexible sizing and stronger prompt adherence for production image tasks.\n\nVM0 billing is tier-based, from around $0.007 per image at the low/standard tier to $0.481 at the high/large tier. The medium-standard tier (around $0.064 per 1024×1024 on VM0) is the sensible default for most built-in generation calls.",
+        "releaseDate": "April 2026",
+        "familyPosition": "OpenAI's newer GPT Image model, positioned above GPT Image 1 for prompt adherence and flexible output sizing.",
+        "background": [
+          "GPT Image 2 is the newer OpenAI image model exposed through VM0's built-in image generation path. It supports text-to-image generation and image edits through the same agent-facing workflow as GPT Image 1.",
+          "The model is a good default when the caller wants OpenAI-style prompt following but needs more flexible output sizing than the standard GPT Image 1 tiers. It is priced by quality and size, so agents can keep draft loops cheaper and reserve high-quality output for final renders."
+        ],
+        "architecture": "Text-to-image and image-edit model exposed through OpenAI's GPT Image 2 endpoint on fal. Supports quality tiers and flexible image sizes; transparent backgrounds are not supported on VM0 for this model.",
+        "specs": [
+          { "label": "Family", "value": "OpenAI Images" },
+          {
+            "label": "Modalities",
+            "value": "Text-to-image, image-to-image edit"
+          },
+          {
+            "label": "Output tiers",
+            "value": "Standard / Large × Low / Medium / High"
+          },
+          {
+            "label": "VM0 billed price",
+            "value": "From $0.007 to $0.481 per image"
+          },
+          { "label": "Languages", "value": "Multilingual prompts" },
+          { "label": "Available on VM0", "value": "April 2026" }
+        ],
+        "benchmarksNote": "",
+        "benchmarks": [],
+        "performance": [
+          {
+            "title": "Prompt adherence",
+            "body": "The main reason to pick GPT Image 2 over GPT Image 1 is stricter execution of detailed prompts, especially when the brief includes composition, aspect ratio and style constraints."
+          },
+          {
+            "title": "Flexible sizing",
+            "body": "Supports VM0's flexible image-size path, so agents can request square, portrait, landscape and larger delivery sizes without switching model families."
+          },
+          {
+            "title": "Edit flows",
+            "body": "Supports image-to-image edits and masks. Use it when a workflow needs to preserve a source image while changing a described region."
+          },
+          {
+            "title": "Cost",
+            "body": "More expensive than GPT Image 1 at medium and high tiers. Keep draft loops on lower quality and reserve high quality for final output."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The agent that needs exact prompt following",
+            "body": "When the prompt has specific framing, style or size requirements, GPT Image 2 is the safer OpenAI-image choice than GPT Image 1."
+          },
+          {
+            "title": "The image workflow that needs multiple aspect ratios",
+            "body": "Marketing, social and website assets often need square, portrait and landscape outputs. GPT Image 2 fits those workflows without changing the prompt style."
+          },
+          {
+            "title": "The OpenAI-stack edit loop",
+            "body": "If an agent is already using OpenAI models for planning and copy, GPT Image 2 keeps image generation in the same prompt-following family."
+          }
+        ],
+        "avoidFor": "Skip GPT Image 2 when cost dominates or when true transparent-background output is required. GPT Image 1, GPT Image 1.5 or SeedDream 4 may be better depending on the constraint.",
+        "comparisons": [
+          {
+            "vs": "GPT Image 1",
+            "body": "GPT Image 2 is the newer, more flexible model with stronger prompt adherence. GPT Image 1 remains cheaper at common medium-standard settings and is still strong for stylised illustration."
+          },
+          {
+            "vs": "SeedDream 4",
+            "body": "SeedDream 4 is cheaper and photoreal-leaning. GPT Image 2 is the better OpenAI-stack choice when prompt adherence, edit workflow and flexible sizing matter more than lowest cost."
+          }
+        ],
+        "verdict": "Pick GPT Image 2 when you want OpenAI image generation with stronger prompt adherence and flexible sizing. Use GPT Image 1 or SeedDream 4 when cost is the dominant constraint.",
+        "faqs": [
+          {
+            "q": "How is GPT Image 2 priced?",
+            "a": "It is priced by quality and size. On VM0, the medium-standard tier is about $0.064 per image and the high/large tier is about $0.481 per image."
+          },
+          {
+            "q": "Does GPT Image 2 support image editing?",
+            "a": "Yes. VM0 exposes image-to-image editing and mask support for GPT Image 2."
+          },
+          {
+            "q": "Does GPT Image 2 support transparent backgrounds?",
+            "a": "No. VM0's GPT Image 2 path does not support transparent-background output."
+          },
+          {
+            "q": "When should I use GPT Image 2 instead of GPT Image 1?",
+            "a": "Use GPT Image 2 for stricter prompt adherence and flexible sizing. Use GPT Image 1 when the brief is simpler or cost matters more."
+          }
+        ],
+        "alternatives": [
+          { "slug": "gpt-image-1", "reason": "Cheaper OpenAI image default" },
+          { "slug": "seedream-4", "reason": "Cheaper photoreal alternative" }
+        ],
+        "routingNotes": "Routed to OpenAI's GPT Image 2 endpoint through VM0's built-in generation path and billed per output image tier.",
+        "vm0Notes": "GPT Image 2 is available through VM0 Managed generation with quality and size controls. Use medium quality for normal agent work and high quality when the generated image is the deliverable."
+      },
       "gpt-image-1": {
         "name": "GPT Image 1",
         "pageTitle": "GPT Image 1 on VM0. OpenAIのテキストツーイメージモデル",


### PR DESCRIPTION
## Summary
- Add GPT Image 2 to the www /models registry with pricing, modalities, comparisons, and CTA prompt
- Add GPT Image 2 model-detail copy for all supported web locales
- Align GPT Image 2 pricing copy with VM0 billed tiers from `dev-seed.ts` / migration pricing: vendor tier price + 20% markup, rounded to credits

## Pricing Check
- `output_image.low.standard`: `$0.006 * 1.2` → 7 credits / ~$0.007
- `output_image.medium.standard`: `$0.053 * 1.2` → 64 credits / ~$0.064
- `output_image.high.large`: `$0.401 * 1.2` → 481 credits / ~$0.481

## Verification
- Parsed all updated locale JSON files
- Ran Prettier check for updated model files
- Ran web type check: `pnpm --filter web check-types`
- Ran pricing-copy sanity check against the VM0 billed tier values

## Notes
- Targeted Vitest run was blocked by local test environment: web global setup requires Postgres on localhost:5432, which is not running in this workspace.
