### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -116,7 +116,7 @@ CODEX_CLI_VERSION="0.133.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.0"
-PNPM_VERSION="11.2.2"
+PNPM_VERSION="11.3.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Bump pnpm to its latest stable release in `crates/runner/scripts/build-template.sh`.

## Updates

| Package | Old | New |
|---|---|---|
| pnpm | 11.2.2 | 11.3.0 |

All other pinned versions (Go 1.26.3, claude-code 2.1.150, @openai/codex 0.133.0, @googleworkspace/cli 0.22.5, @xdevplatform/xurl 1.0.3, agent-browser 0.27.0) are already at their latest upstream releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)