### PR TITLE
refactor(sandbox-fc): share prepare park resolution

### DIFF
--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -72,33 +72,13 @@ impl ParkCoordinator {
     ) -> Result<(), PrepareParkError> {
         let PrepareParkEvidence::AgentQuiesced = evidence;
 
-        let mut inner = self.inner();
-        match inner.state.clone() {
-            CoordinatorState::ClosingForPark { attempt_id } if attempt_id == attempt.id => {
-                inner.state = CoordinatorState::ReadyForPark { attempt_id };
-                Ok(())
-            }
-            CoordinatorState::Dirty { reason } => Err(PrepareParkError::Dirty { reason }),
-            state => Err(PrepareParkError::StaleAttempt {
-                attempt_id: attempt.id,
-                state,
-            }),
-        }
+        self.inner()
+            .resolve_prepare_park(attempt, PrepareParkResolution::Complete)
     }
 
     pub(crate) fn abort_prepare_park(&self, attempt: &ParkAttempt) -> Result<(), PrepareParkError> {
-        let mut inner = self.inner();
-        match inner.state.clone() {
-            CoordinatorState::ClosingForPark { attempt_id } if attempt_id == attempt.id => {
-                inner.state = CoordinatorState::Open;
-                Ok(())
-            }
-            CoordinatorState::Dirty { reason } => Err(PrepareParkError::Dirty { reason }),
-            state => Err(PrepareParkError::StaleAttempt {
-                attempt_id: attempt.id,
-                state,
-            }),
-        }
+        self.inner()
+            .resolve_prepare_park(attempt, PrepareParkResolution::Abort)
     }
 
     pub(crate) fn mark_parked(&self, attempt: &ParkAttempt) -> Result<(), PrepareParkError> {
@@ -194,6 +174,20 @@ pub(crate) enum PrepareParkError {
     },
 }
 
+enum PrepareParkResolution {
+    Complete,
+    Abort,
+}
+
+impl PrepareParkResolution {
+    fn next_state(self, attempt_id: ParkAttemptId) -> CoordinatorState {
+        match self {
+            Self::Complete => CoordinatorState::ReadyForPark { attempt_id },
+            Self::Abort => CoordinatorState::Open,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct Inner {
     state: CoordinatorState,
@@ -201,6 +195,24 @@ struct Inner {
 }
 
 impl Inner {
+    fn resolve_prepare_park(
+        &mut self,
+        attempt: &ParkAttempt,
+        resolution: PrepareParkResolution,
+    ) -> Result<(), PrepareParkError> {
+        match self.state.clone() {
+            CoordinatorState::ClosingForPark { attempt_id } if attempt_id == attempt.id => {
+                self.state = resolution.next_state(attempt_id);
+                Ok(())
+            }
+            CoordinatorState::Dirty { reason } => Err(PrepareParkError::Dirty { reason }),
+            state => Err(PrepareParkError::StaleAttempt {
+                attempt_id: attempt.id,
+                state,
+            }),
+        }
+    }
+
     fn mark_dirty(&mut self, reason: DirtyReason) {
         if matches!(self.state, CoordinatorState::Dirty { .. }) {
             return;

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -422,10 +422,15 @@ mod tests {
         assert!(coordinator.abort_prepare_park(&stale).is_ok());
 
         let current = begin_attempt(&coordinator);
-        assert!(matches!(
+        assert_eq!(
             coordinator.complete_prepare_park(&stale, PrepareParkEvidence::AgentQuiesced),
-            Err(PrepareParkError::StaleAttempt { .. })
-        ));
+            Err(PrepareParkError::StaleAttempt {
+                attempt_id: stale.id,
+                state: CoordinatorState::ClosingForPark {
+                    attempt_id: current.id
+                },
+            })
+        );
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::ClosingForPark { attempt_id } if attempt_id == current.id
@@ -439,10 +444,15 @@ mod tests {
         assert!(coordinator.abort_prepare_park(&stale).is_ok());
 
         let current = begin_attempt(&coordinator);
-        assert!(matches!(
+        assert_eq!(
             coordinator.abort_prepare_park(&stale),
-            Err(PrepareParkError::StaleAttempt { .. })
-        ));
+            Err(PrepareParkError::StaleAttempt {
+                attempt_id: stale.id,
+                state: CoordinatorState::ClosingForPark {
+                    attempt_id: current.id
+                },
+            })
+        );
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::ClosingForPark { attempt_id } if attempt_id == current.id
@@ -455,10 +465,15 @@ mod tests {
         let attempt = begin_attempt(&coordinator);
         complete_attempt(&coordinator, &attempt);
 
-        assert!(matches!(
+        assert_eq!(
             coordinator.abort_prepare_park(&attempt),
-            Err(PrepareParkError::StaleAttempt { .. })
-        ));
+            Err(PrepareParkError::StaleAttempt {
+                attempt_id: attempt.id,
+                state: CoordinatorState::ReadyForPark {
+                    attempt_id: attempt.id
+                },
+            })
+        );
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::ReadyForPark { attempt_id } if attempt_id == attempt.id
@@ -471,10 +486,13 @@ mod tests {
         let attempt = begin_attempt(&coordinator);
         assert!(coordinator.abort_prepare_park(&attempt).is_ok());
 
-        assert!(matches!(
+        assert_eq!(
             coordinator.complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced),
-            Err(PrepareParkError::StaleAttempt { .. })
-        ));
+            Err(PrepareParkError::StaleAttempt {
+                attempt_id: attempt.id,
+                state: CoordinatorState::Open,
+            })
+        );
         assert_eq!(coordinator.state(), CoordinatorState::Open);
     }
 

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -433,6 +433,23 @@ mod tests {
     }
 
     #[test]
+    fn stale_attempt_cannot_abort_current_prepare() {
+        let coordinator = ParkCoordinator::new();
+        let stale = begin_attempt(&coordinator);
+        assert!(coordinator.abort_prepare_park(&stale).is_ok());
+
+        let current = begin_attempt(&coordinator);
+        assert!(matches!(
+            coordinator.abort_prepare_park(&stale),
+            Err(PrepareParkError::StaleAttempt { .. })
+        ));
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::ClosingForPark { attempt_id } if attempt_id == current.id
+        ));
+    }
+
+    #[test]
     fn dirty_during_prepare_blocks_completion_and_abort() {
         let coordinator = ParkCoordinator::new();
         let attempt = begin_attempt(&coordinator);

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -450,6 +450,22 @@ mod tests {
     }
 
     #[test]
+    fn completed_prepare_cannot_be_aborted() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = begin_attempt(&coordinator);
+        complete_attempt(&coordinator, &attempt);
+
+        assert!(matches!(
+            coordinator.abort_prepare_park(&attempt),
+            Err(PrepareParkError::StaleAttempt { .. })
+        ));
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::ReadyForPark { attempt_id } if attempt_id == attempt.id
+        ));
+    }
+
+    #[test]
     fn dirty_during_prepare_blocks_completion_and_abort() {
         let coordinator = ParkCoordinator::new();
         let attempt = begin_attempt(&coordinator);

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -466,6 +466,19 @@ mod tests {
     }
 
     #[test]
+    fn aborted_prepare_cannot_later_complete() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = begin_attempt(&coordinator);
+        assert!(coordinator.abort_prepare_park(&attempt).is_ok());
+
+        assert!(matches!(
+            coordinator.complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced),
+            Err(PrepareParkError::StaleAttempt { .. })
+        ));
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+    }
+
+    #[test]
     fn dirty_during_prepare_blocks_completion_and_abort() {
         let coordinator = ParkCoordinator::new();
         let attempt = begin_attempt(&coordinator);


### PR DESCRIPTION
## Summary
- add a private `PrepareParkResolution` for completing vs aborting prepare-park attempts
- move the shared `ClosingForPark` check-and-set into `Inner::resolve_prepare_park`
- keep `ReadyForPark` tied to the attempt id matched under the coordinator lock

Closes #14697

## Tests
- `cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc park_coordinator`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc ready_for_park_boundary`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- pre-commit hook with `CARGO_BUILD_JOBS=1`