### PR TITLE
build: update toolchain image base

### DIFF
--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -17,7 +17,17 @@ jobs:
   toolchain:
     # Skip for release-please PRs (only version bumps and changelogs)
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -33,7 +43,8 @@ jobs:
           context: ./docker/toolchain
           file: ./docker/toolchain/Dockerfile
           target: development
+          platforms: ${{ matrix.platform }}
           push: false
           tags: vm0-dev:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base toolchain for CI/CD and minimal development
-FROM ubuntu:22.04 AS toolchain
+FROM ubuntu:24.04 AS toolchain
 
 # Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -127,6 +127,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     zsh \
     vim \
+    gawk \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -193,9 +193,15 @@ RUN apt-get update && apt-get install -y unzip \
 
 # Create vscode user with standard UID/GID for devcontainer compatibility
 # Following Microsoft's devcontainer pattern for better feature compatibility
-# Use -f flag to force group creation if GID already exists (1Password CLI creates GID 1000)
-RUN groupadd -f --gid 1000 vscode \
-    && useradd --uid 1000 --gid vscode --shell /usr/bin/zsh --create-home vscode \
+# Ubuntu 24.04 base images already include a UID/GID 1000 user/group, so
+# rename/reuse it instead of creating a duplicate UID.
+RUN existing_group="$(getent group 1000 | cut -d: -f1 || true)" \
+    && if [ -n "$existing_group" ] && [ "$existing_group" != "vscode" ]; then groupmod --new-name vscode "$existing_group"; fi \
+    && if [ -z "$existing_group" ]; then groupadd --gid 1000 vscode; fi \
+    && existing_user="$(getent passwd 1000 | cut -d: -f1 || true)" \
+    && if [ -n "$existing_user" ] && [ "$existing_user" != "vscode" ]; then usermod --login vscode --home /home/vscode --move-home --shell /usr/bin/zsh --gid vscode "$existing_user"; fi \
+    && if [ -z "$existing_user" ]; then useradd --uid 1000 --gid vscode --shell /usr/bin/zsh --create-home vscode; fi \
+    && if [ "$existing_user" = "vscode" ]; then usermod --shell /usr/bin/zsh --gid vscode vscode; fi \
     && echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vscode \
     && chmod 0440 /etc/sudoers.d/vscode \
     && mkdir -p /home/vscode/.local/share /home/vscode/.local/share/agent-browser /home/vscode/.cache /home/vscode/.config \

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -115,8 +115,7 @@ RUN ARCH=$(dpkg --print-architecture) \
 
 # Install Python3 and Ansible for runner deployments via SSH.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-pip \
-    && pip3 install --no-cache-dir ansible-core \
+    ansible-core \
     && rm -rf /var/lib/apt/lists/*
 
 # Stage 3: Development environment with additional tools

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -115,6 +115,7 @@ RUN ARCH=$(dpkg --print-architecture) \
 
 # Install Python3 and Ansible for runner deployments via SSH.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip \
     ansible-core \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Update the toolchain base image from Ubuntu 22.04 to Ubuntu 24.04.
- Keep `python3-pip` installed so the toolchain image continues to provide `pip3`.
- Install `ansible-core` from Ubuntu apt instead of using system `pip3`, which is blocked by PEP 668 on Ubuntu 24.04.
- Reuse/rename an existing UID/GID 1000 user/group as `vscode`, because Ubuntu 24.04 base images already reserve UID 1000.
- Install GNU awk in the development stage so standalone Codex updates use an awk implementation compatible with the installer checksum parser.
- Build the toolchain development image on both amd64 and arm64 in PR CI, matching the publish workflow architecture coverage.

## Validation
- `git diff --check`
- pre-commit hooks for staged files
- Docker Toolchain Build CI: pending latest run

## Notes
- Local Docker image build was not run because docker/podman is not available in this container.