### PR TITLE
refactor: share storage request file dto

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -40,15 +40,15 @@ pub mod runners {
 pub mod webhooks {
     pub mod agent {
         pub mod storages {
-            pub mod commit {
-                #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-                #[serde(rename_all = "camelCase")]
-                pub struct RequestFile {
-                    pub path: String,
-                    pub hash: String,
-                    pub size: u64,
-                }
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct FileEntryWithHash {
+                pub path: String,
+                pub hash: String,
+                pub size: u64,
+            }
 
+            pub mod commit {
                 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
                 #[serde(rename_all = "camelCase")]
                 pub struct Request {
@@ -58,7 +58,7 @@ pub mod webhooks {
                     pub version_id: String,
                     #[serde(default, skip_serializing_if = "Option::is_none")]
                     pub parent_version_id: Option<String>,
-                    pub files: Vec<RequestFile>,
+                    pub files: Vec<super::FileEntryWithHash>,
                     #[serde(default, skip_serializing_if = "Option::is_none")]
                     pub message: Option<String>,
                 }
@@ -79,14 +79,6 @@ pub mod webhooks {
             pub mod prepare {
                 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
                 #[serde(rename_all = "camelCase")]
-                pub struct RequestFile {
-                    pub path: String,
-                    pub hash: String,
-                    pub size: u64,
-                }
-
-                #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-                #[serde(rename_all = "camelCase")]
                 pub struct RequestChanges {
                     pub added: Vec<String>,
                     pub modified: Vec<String>,
@@ -99,7 +91,7 @@ pub mod webhooks {
                     pub run_id: String,
                     pub storage_name: String,
                     pub storage_type: String,
-                    pub files: Vec<RequestFile>,
+                    pub files: Vec<super::FileEntryWithHash>,
                     #[serde(default, skip_serializing_if = "Option::is_none")]
                     pub parent_version_id: Option<String>,
                     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -1,6 +1,6 @@
 use api_contracts::generated::types::{
     runners::storage as runner_storage,
-    webhooks::agent::storages::{commit, prepare},
+    webhooks::agent::storages::{FileEntryWithHash, commit, prepare},
 };
 use serde_json::json;
 
@@ -11,7 +11,7 @@ fn generated_prepare_request_serializes_wire_shape() {
         run_id: "run-1".to_string(),
         storage_name: "memory".to_string(),
         storage_type: "artifact".to_string(),
-        files: vec![prepare::RequestFile {
+        files: vec![FileEntryWithHash {
             path: "file.txt".to_string(),
             hash: hash.clone(),
             size: 12,
@@ -119,7 +119,7 @@ fn generated_commit_request_serializes_wire_shape() {
         storage_type: "artifact".to_string(),
         version_id: "version-1".to_string(),
         parent_version_id: None,
-        files: vec![commit::RequestFile {
+        files: vec![FileEntryWithHash {
             path: "file.txt".to_string(),
             hash: hash.clone(),
             size: 34,

--- a/crates/guest-agent/src/artifact/api.rs
+++ b/crates/guest-agent/src/artifact/api.rs
@@ -4,7 +4,7 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::urls;
 use api_contracts::generated::types::webhooks::agent::storages::{
-    commit as storage_commit, prepare as storage_prepare,
+    FileEntryWithHash, commit as storage_commit, prepare as storage_prepare,
 };
 use guest_common::log_warn;
 
@@ -58,7 +58,7 @@ pub(super) async fn prepare_snapshot(
         run_id: request.run_id.to_string(),
         storage_name: request.storage_name.to_string(),
         storage_type: request.storage_type.to_string(),
-        files: to_prepare_files(request.files),
+        files: to_request_files(request.files),
         parent_version_id: non_empty_string(request.parent_version_id),
         force: None,
         base_version: None,
@@ -118,7 +118,7 @@ pub(super) async fn commit_snapshot(
         storage_type: request.storage_type.to_string(),
         version_id: request.version_id.to_string(),
         parent_version_id: non_empty_string(request.parent_version_id),
-        files: to_commit_files(request.files),
+        files: to_request_files(request.files),
         message: request.message.map(str::to_string),
     };
 
@@ -150,21 +150,10 @@ fn non_empty_string(value: &str) -> Option<String> {
     }
 }
 
-fn to_prepare_files(files: &[FileEntry]) -> Vec<storage_prepare::RequestFile> {
+fn to_request_files(files: &[FileEntry]) -> Vec<FileEntryWithHash> {
     files
         .iter()
-        .map(|file| storage_prepare::RequestFile {
-            path: file.path.clone(),
-            hash: file.hash.clone(),
-            size: file.size,
-        })
-        .collect()
-}
-
-fn to_commit_files(files: &[FileEntry]) -> Vec<storage_commit::RequestFile> {
-    files
-        .iter()
-        .map(|file| storage_commit::RequestFile {
+        .map(|file| FileEntryWithHash {
             path: file.path.clone(),
             hash: file.hash.clone(),
             size: file.size,

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -306,15 +306,21 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
+        std::fs::write(root.join("alpha.txt"), "alpha").unwrap();
         std::fs::write(root.join("target.txt"), "content").unwrap();
-        let files = archive::collect_file_metadata(root.to_str().unwrap());
-        let file = files.iter().find(|file| file.path == "target.txt").unwrap();
-
-        let expected_file = serde_json::json!({
-            "path": file.path.clone(),
-            "hash": file.hash.clone(),
-            "size": file.size,
-        });
+        let mut files = archive::collect_file_metadata(root.to_str().unwrap());
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        let expected_files: Vec<serde_json::Value> = files
+            .iter()
+            .map(|file| {
+                serde_json::json!({
+                    "path": file.path,
+                    "hash": file.hash,
+                    "size": file.size,
+                })
+            })
+            .collect();
+        let total_size: u64 = files.iter().map(|file| file.size).sum();
 
         let prepare = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
@@ -323,7 +329,7 @@ mod tests {
                     "runId": "run-id",
                     "storageName": "storage",
                     "storageType": "artifact",
-                    "files": [expected_file.clone()],
+                    "files": expected_files,
                     "parentVersionId": "parent-v1",
                 }));
             then.status(200).json_body(serde_json::json!({
@@ -340,14 +346,14 @@ mod tests {
                     "storageType": "artifact",
                     "versionId": "v-existing",
                     "parentVersionId": "parent-v1",
-                    "files": [expected_file.clone()],
+                    "files": expected_files,
                 }));
             then.status(200).json_body(serde_json::json!({
                 "success": true,
                 "versionId": "v-existing",
                 "storageName": "storage",
-                "size": file.size,
-                "fileCount": 1,
+                "size": total_size,
+                "fileCount": expected_files.len(),
             }));
         });
 
@@ -381,7 +387,7 @@ mod tests {
                     "runId": "run-id",
                     "storageName": "storage",
                     "storageType": "artifact",
-                    "files": [expected_file],
+                    "files": expected_files,
                 }));
             then.status(200).json_body(serde_json::json!({
                 "versionId": "v-existing",

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -340,7 +340,7 @@ mod tests {
                     "storageType": "artifact",
                     "versionId": "v-existing",
                     "parentVersionId": "parent-v1",
-                    "files": [expected_file],
+                    "files": [expected_file.clone()],
                 }));
             then.status(200).json_body(serde_json::json!({
                 "success": true,
@@ -376,7 +376,13 @@ mod tests {
         std::fs::write(root.join("target.txt"), "changed").unwrap();
         let prepare = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
-                .path("/api/webhooks/agent/storages/prepare");
+                .path("/api/webhooks/agent/storages/prepare")
+                .json_body(serde_json::json!({
+                    "runId": "run-id",
+                    "storageName": "storage",
+                    "storageType": "artifact",
+                    "files": [expected_file],
+                }));
             then.status(200).json_body(serde_json::json!({
                 "versionId": "v-existing",
                 "existing": true

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -300,16 +300,80 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dedup_snapshot_validation_failure_does_not_commit() {
+    async fn dedup_snapshot_posts_file_payloads_before_validation_failure_blocks_commit() {
         disable_system_log();
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        std::fs::write(root.join("target.txt"), "before").unwrap();
-        let files = archive::collect_file_metadata(root.to_str().unwrap());
-        std::fs::write(root.join("target.txt"), "after!").unwrap();
-
         let server = &*SNAPSHOT_MOCK_SERVER;
 
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("target.txt"), "content").unwrap();
+        let files = archive::collect_file_metadata(root.to_str().unwrap());
+        let file = files.iter().find(|file| file.path == "target.txt").unwrap();
+
+        let expected_file = serde_json::json!({
+            "path": file.path.clone(),
+            "hash": file.hash.clone(),
+            "size": file.size,
+        });
+
+        let prepare = server.mock(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/api/webhooks/agent/storages/prepare")
+                .json_body(serde_json::json!({
+                    "runId": "run-id",
+                    "storageName": "storage",
+                    "storageType": "artifact",
+                    "files": [expected_file.clone()],
+                    "parentVersionId": "parent-v1",
+                }));
+            then.status(200).json_body(serde_json::json!({
+                "versionId": "v-existing",
+                "existing": true
+            }));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/api/webhooks/agent/storages/commit")
+                .json_body(serde_json::json!({
+                    "runId": "run-id",
+                    "storageName": "storage",
+                    "storageType": "artifact",
+                    "versionId": "v-existing",
+                    "parentVersionId": "parent-v1",
+                    "files": [expected_file],
+                }));
+            then.status(200).json_body(serde_json::json!({
+                "success": true,
+                "versionId": "v-existing",
+                "storageName": "storage",
+                "size": file.size,
+                "fileCount": 1,
+            }));
+        });
+
+        let http = HttpClient::new().unwrap();
+        let result = create_snapshot(
+            &http,
+            CreateSnapshotRequest {
+                mount_path: root.to_str().unwrap(),
+                files: files.clone(),
+                storage_name: "storage",
+                storage_type: "artifact",
+                run_id: "run-id",
+                message: "message",
+                parent_version_id: "parent-v1",
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.version_id, "v-existing");
+        prepare.assert_calls(1);
+        commit.assert_calls(1);
+        prepare.delete_async().await;
+        commit.delete_async().await;
+
+        std::fs::write(root.join("target.txt"), "changed").unwrap();
         let prepare = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/api/webhooks/agent/storages/prepare");
@@ -349,5 +413,7 @@ mod tests {
         );
         prepare.assert_calls(1);
         commit.assert_calls(0);
+        prepare.delete_async().await;
+        commit.delete_async().await;
     }
 }

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -10,6 +10,11 @@ import {
   storageEntrySchema,
   storageManifestSchema,
 } from "../../contracts/runners";
+import { fileEntryWithHashSchema } from "../../contracts/storages";
+import {
+  webhookStoragesCommitContract,
+  webhookStoragesPrepareContract,
+} from "../../contracts/webhooks";
 
 const expectedBindings = [
   {
@@ -26,6 +31,11 @@ const expectedBindings = [
     rustModulePath: ["runners", "storage"],
     rustTypeName: "StorageManifest",
     direction: "response",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "storages"],
+    rustTypeName: "FileEntryWithHash",
+    direction: "request",
   },
   {
     rustModulePath: ["webhooks", "agent", "storages", "prepare"],
@@ -71,6 +81,21 @@ function summarizeBinding(binding: NormalizedTypeBinding) {
   };
 }
 
+function compareBindingName(
+  left: (typeof expectedBindings)[number],
+  right: (typeof expectedBindings)[number],
+): number {
+  const leftName = [...left.rustModulePath, left.rustTypeName].join("::");
+  const rightName = [...right.rustModulePath, right.rustTypeName].join("::");
+  if (leftName < rightName) {
+    return -1;
+  }
+  if (leftName > rightName) {
+    return 1;
+  }
+  return 0;
+}
+
 describe("Rust type bindings", () => {
   it("contains exactly the supported Rust DTO set", () => {
     const actualBindings = normalizeTypeBindings(rustTypeBindings).map(
@@ -80,13 +105,7 @@ describe("Rust type bindings", () => {
     );
 
     expect(actualBindings).toEqual(
-      [...expectedBindings].sort((left, right) => {
-        return [...left.rustModulePath, left.rustTypeName]
-          .join("::")
-          .localeCompare(
-            [...right.rustModulePath, right.rustTypeName].join("::"),
-          );
-      }),
+      [...expectedBindings].sort(compareBindingName),
     );
   });
 
@@ -97,9 +116,13 @@ describe("Rust type bindings", () => {
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod webhooks {");
     expect(firstRender).toContain("pub mod prepare {");
+    expect(firstRender).toContain("pub struct FileEntryWithHash {");
     expect(firstRender).toContain("pub struct Request {");
     expect(firstRender).toContain("pub struct Response {");
-    expect(firstRender).toContain("pub files: Vec<RequestFile>,");
+    expect(
+      firstRender.match(/pub files: Vec<super::FileEntryWithHash>,/g),
+    ).toHaveLength(2);
+    expect(firstRender).not.toContain("pub struct RequestFile {");
     expect(firstRender).toContain("pub uploads: Option<ResponseUploads>,");
     expect(firstRender).toContain("pub struct StorageManifest {");
     expect(firstRender).toContain("pub storages: Vec<StorageEntry>,");
@@ -123,6 +146,32 @@ describe("Rust type bindings", () => {
         artifacts: {
           type: "array",
           items: artifactSchema,
+        },
+      },
+    });
+  });
+
+  it("keeps webhook storage file overrides aligned with shared file schema", () => {
+    const requestFileSchema = { ...z.toJSONSchema(fileEntryWithHashSchema) };
+    delete requestFileSchema.$schema;
+
+    expect(
+      z.toJSONSchema(webhookStoragesPrepareContract.prepare.body),
+    ).toMatchObject({
+      properties: {
+        files: {
+          type: "array",
+          items: requestFileSchema,
+        },
+      },
+    });
+    expect(
+      z.toJSONSchema(webhookStoragesCommitContract.commit.body),
+    ).toMatchObject({
+      properties: {
+        files: {
+          type: "array",
+          items: requestFileSchema,
         },
       },
     });

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -153,28 +153,23 @@ describe("Rust type bindings", () => {
 
   it("keeps webhook storage file overrides aligned with shared file schema", () => {
     const requestFileSchema = { ...z.toJSONSchema(fileEntryWithHashSchema) };
-    delete requestFileSchema.$schema;
+    const prepareFileSchema = {
+      ...z.toJSONSchema(
+        webhookStoragesPrepareContract.prepare.body.shape.files.element,
+      ),
+    };
+    const commitFileSchema = {
+      ...z.toJSONSchema(
+        webhookStoragesCommitContract.commit.body.shape.files.element,
+      ),
+    };
 
-    expect(
-      z.toJSONSchema(webhookStoragesPrepareContract.prepare.body),
-    ).toMatchObject({
-      properties: {
-        files: {
-          type: "array",
-          items: requestFileSchema,
-        },
-      },
-    });
-    expect(
-      z.toJSONSchema(webhookStoragesCommitContract.commit.body),
-    ).toMatchObject({
-      properties: {
-        files: {
-          type: "array",
-          items: requestFileSchema,
-        },
-      },
-    });
+    delete requestFileSchema.$schema;
+    delete prepareFileSchema.$schema;
+    delete commitFileSchema.$schema;
+
+    expect(prepareFileSchema).toEqual(requestFileSchema);
+    expect(commitFileSchema).toEqual(requestFileSchema);
   });
 
   it("renders common JSON schema shapes", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -4,6 +4,7 @@ import {
   storageEntrySchema,
   storageManifestSchema,
 } from "../contracts/runners";
+import { fileEntryWithHashSchema } from "../contracts/storages";
 import {
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
@@ -41,12 +42,19 @@ export const rustTypeBindings = [
     },
   },
   {
+    schema: fileEntryWithHashSchema,
+    rustModulePath: ["webhooks", "agent", "storages"],
+    rustTypeName: "FileEntryWithHash",
+    direction: "request",
+  },
+  {
     schema: webhookStoragesPrepareContract.prepare.body,
     rustModulePath: ["webhooks", "agent", "storages", "prepare"],
     rustTypeName: "Request",
     direction: "request",
     fieldTypeOverrides: {
       storageType: "String",
+      files: "Vec<super::FileEntryWithHash>",
     },
   },
   {
@@ -62,6 +70,7 @@ export const rustTypeBindings = [
     direction: "request",
     fieldTypeOverrides: {
       storageType: "String",
+      files: "Vec<super::FileEntryWithHash>",
     },
   },
   {


### PR DESCRIPTION
## Summary
- generate a shared webhook storage FileEntryWithHash Rust DTO from fileEntryWithHashSchema
- use the shared DTO for prepare/commit request files and keep guest-agent artifact::FileEntry internal
- collapse guest-agent prepare/commit file mapping into one HTTP boundary conversion helper

Fixes #14696

## Testing
- pnpm -F @vm0/api-contracts test
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts generate:rust
- cargo test --manifest-path crates/Cargo.toml -p api-contracts
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --jobs 1
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check
- ./scripts/check-file-size.sh turbo/packages/api-contracts/src/rust-bindings/types.ts turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts crates/api-contracts/tests/types.rs crates/guest-agent/src/artifact/api.rs
- ./scripts/block-generated-firewalls.sh turbo/packages/api-contracts/src/rust-bindings/types.ts turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts crates/api-contracts/src/generated/types.rs crates/api-contracts/tests/types.rs crates/guest-agent/src/artifact/api.rs

Note: the normal pre-commit hook was attempted and failed only on all-workspace @vm0/desktop#check-types because the local desktop workspace dependencies/typescript config were unavailable. The touched package check-types passed after generating ignored firewall files.