### PR TITLE
fix(mitm-addon): log truncated model sse usage events

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -23,6 +23,7 @@ _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 _X_JSON_RESPONSE_FINISH = "x_json_response_finish"
 
 _ResponseChunkParser = Callable[[bytes], None]
+_SseUsageParseErrorLogger = Callable[[str, str], None]
 
 
 def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
@@ -41,6 +42,27 @@ def _make_response_chunk_parser(
         feed(decompressor(chunk))
 
     return parse_chunk
+
+
+def _make_model_sse_parse_error_logger(
+    flow: http.HTTPFlow,
+    *,
+    usage_protocol: str,
+) -> _SseUsageParseErrorLogger:
+    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+
+    def log_parse_error(event: str, error: str) -> None:
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            "Model provider SSE usage extraction failed",
+            type="usage_event",
+            usage_protocol=usage_protocol,
+            event=event,
+            error=error,
+        )
+
+    return log_parse_error
 
 
 def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParser | None:
@@ -94,9 +116,19 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         content_type = flow.response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
             if uses_openai_responses_usage_protocol(flow):
-                parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor()
+                parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor(
+                    on_parse_error=_make_model_sse_parse_error_logger(
+                        flow,
+                        usage_protocol="openai_responses_sse",
+                    )
+                )
             else:
-                parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor()
+                parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor(
+                    on_parse_error=_make_model_sse_parse_error_logger(
+                        flow,
+                        usage_protocol="anthropic_messages_sse",
+                    )
+                )
             flow.metadata["model_provider_usage"] = usage_dict
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = parser_fn.finish
             return _make_response_chunk_parser(parser_fn, flow.response.headers)

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -4,6 +4,7 @@ Pure parsers shared by both the SSE streaming path and the non-streaming
 JSON fallback.
 """
 
+from collections.abc import Callable
 from typing import TypeGuard
 
 import body_utils
@@ -13,6 +14,7 @@ from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
 from .sse import SseUsageParser
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
+_SseUsageParseErrorCallback = Callable[[str, str], None]
 
 _MODEL_JSON_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
@@ -49,7 +51,9 @@ def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, 
             target[category] = value
 
 
-def create_anthropic_messages_sse_usage_extractor() -> tuple[SseUsageParser, dict]:
+def create_anthropic_messages_sse_usage_extractor(
+    on_parse_error: _SseUsageParseErrorCallback | None = None,
+) -> tuple[SseUsageParser, dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
     Anthropic-shaped model providers use the Anthropic Messages API streaming
@@ -64,16 +68,22 @@ def create_anthropic_messages_sse_usage_extractor() -> tuple[SseUsageParser, dic
     """
     usage: dict = {}
     parser = SseUsageParser(
-        _AnthropicMessagesSseUsageHandler(usage),
+        _AnthropicMessagesSseUsageHandler(usage, on_parse_error=on_parse_error),
         capture_data_without_event=True,
     )
     return parser, usage
 
 
 class _AnthropicMessagesSseUsageHandler:
-    def __init__(self, usage: dict) -> None:
+    def __init__(
+        self,
+        usage: dict,
+        *,
+        on_parse_error: _SseUsageParseErrorCallback | None = None,
+    ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
+        self._on_parse_error = on_parse_error
 
     def should_capture_event(self, event_name: str | None) -> bool:
         return event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
@@ -96,6 +106,13 @@ class _AnthropicMessagesSseUsageHandler:
 
         result = extractor.finish()
         if not result.complete:
+            if (
+                event_name is not None
+                and event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
+                and result.error
+                and self._on_parse_error is not None
+            ):
+                self._on_parse_error(event_name, result.error)
             return
 
         event_type = event_name

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -14,6 +14,7 @@ model-provider usage billing:
   ``response_streaming.py`` for Responses events received over upgrades.
 """
 
+from collections.abc import Callable
 from typing import TypeGuard
 
 from mitmproxy import http
@@ -33,6 +34,7 @@ from .sse import SseUsageParser
 _RESPONSES_TERMINAL_USAGE_EVENTS = frozenset(
     ("response.completed", "response.done", "response.incomplete", "response.failed")
 )
+_SseUsageParseErrorCallback = Callable[[str, str], None]
 
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_INPUT,
@@ -163,21 +165,29 @@ def _store_sse_result_values(
     merge_openai_responses_usage_result(target, source)
 
 
-def create_openai_responses_sse_usage_extractor() -> tuple[SseUsageParser, dict]:
+def create_openai_responses_sse_usage_extractor(
+    on_parse_error: _SseUsageParseErrorCallback | None = None,
+) -> tuple[SseUsageParser, dict]:
     """Create an incremental SSE parser for OpenAI Responses streams."""
 
     usage: dict = {}
     parser = SseUsageParser(
-        _OpenAIResponsesSseUsageHandler(usage),
+        _OpenAIResponsesSseUsageHandler(usage, on_parse_error=on_parse_error),
         capture_data_without_event=True,
     )
     return parser, usage
 
 
 class _OpenAIResponsesSseUsageHandler:
-    def __init__(self, usage: dict) -> None:
+    def __init__(
+        self,
+        usage: dict,
+        *,
+        on_parse_error: _SseUsageParseErrorCallback | None = None,
+    ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
+        self._on_parse_error = on_parse_error
 
     def should_capture_event(self, event_name: str | None) -> bool:
         return event_name is None or event_name in _RESPONSES_TERMINAL_USAGE_EVENTS
@@ -200,6 +210,14 @@ class _OpenAIResponsesSseUsageHandler:
         result = extractor.finish()
         if result.complete:
             _store_sse_result_values(result.values, self._usage, event_name=event_name)
+            return
+        if (
+            event_name is not None
+            and event_name in _RESPONSES_TERMINAL_USAGE_EVENTS
+            and result.error
+            and self._on_parse_error is not None
+        ):
+            self._on_parse_error(event_name, result.error)
 
     def on_event_discard(self, event_name: str | None) -> None:
         self._extractor = None

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -539,6 +539,41 @@ class TestResponseUsageReporting:
         assert warning["event"] == "response.completed"
         assert warning["error"]
 
+    def test_full_pipeline_openai_sse_logs_truncated_late_event_name(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.openai.com",
+            original_url="https://api.openai.com/v1/responses",
+            firewall_name="model-provider:openai-api-key",
+            cli_agent_type="codex",
+        )
+        _response_stream(flow)(
+            b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt\n'
+            b"event: response.completed\n\n"
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        usage_warnings = _model_sse_parse_warnings(flow)
+        assert len(usage_warnings) == 1
+        warning = usage_warnings[0]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "openai_responses_sse"
+        assert warning["event"] == "response.completed"
+        assert warning["error"]
+
     def test_full_pipeline_eventless_incomplete_sse_does_not_warn(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -433,6 +433,37 @@ class TestResponseUsageReporting:
         assert warning["event"] == "message_start"
         assert warning["error"]
 
+    def test_full_pipeline_anthropic_sse_logs_malformed_message_start(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+        )
+        _response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        usage_warnings = _model_sse_parse_warnings(flow)
+        assert len(usage_warnings) == 1
+        warning = usage_warnings[0]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "anthropic_messages_sse"
+        assert warning["event"] == "message_start"
+        assert warning["error"]
+
     def test_full_pipeline_anthropic_sse_logs_truncated_message_delta_after_start(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -634,6 +634,33 @@ class TestResponseUsageReporting:
         mock_opener.open.assert_not_called()
         assert _model_sse_parse_warnings(flow) == []
 
+    def test_full_pipeline_anthropic_non_usage_incomplete_sse_does_not_warn(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+        )
+        _response_stream(flow)(
+            b"event: content_block_delta\n"
+            b'data: {"type":"content_block_delta","delta":{"text":"hello'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert _model_sse_parse_warnings(flow) == []
+
     def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -106,6 +106,22 @@ def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
     ]
 
 
+def _assert_single_model_sse_parse_warning(
+    flow: http.HTTPFlow,
+    *,
+    usage_protocol: str,
+    event: str,
+) -> None:
+    usage_warnings = _model_sse_parse_warnings(flow)
+    assert len(usage_warnings) == 1
+    warning = usage_warnings[0]
+    assert warning["level"] == "warn"
+    assert warning["type"] == "usage_event"
+    assert warning["usage_protocol"] == usage_protocol
+    assert warning["event"] == event
+    assert warning["error"]
+
+
 class TestResponseUsageReporting:
     """Tests for usage extraction and reporting in response() hook."""
 
@@ -424,14 +440,11 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
-        usage_warnings = _model_sse_parse_warnings(flow)
-        assert len(usage_warnings) == 1
-        warning = usage_warnings[0]
-        assert warning["level"] == "warn"
-        assert warning["type"] == "usage_event"
-        assert warning["usage_protocol"] == "anthropic_messages_sse"
-        assert warning["event"] == "message_start"
-        assert warning["error"]
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="anthropic_messages_sse",
+            event="message_start",
+        )
 
     def test_full_pipeline_anthropic_sse_error_logs_truncated_message_start(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
@@ -458,14 +471,11 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
-        usage_warnings = _model_sse_parse_warnings(flow)
-        assert len(usage_warnings) == 1
-        warning = usage_warnings[0]
-        assert warning["level"] == "warn"
-        assert warning["type"] == "usage_event"
-        assert warning["usage_protocol"] == "anthropic_messages_sse"
-        assert warning["event"] == "message_start"
-        assert warning["error"]
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="anthropic_messages_sse",
+            event="message_start",
+        )
 
     def test_full_pipeline_anthropic_sse_logs_malformed_message_start(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
@@ -489,14 +499,11 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
-        usage_warnings = _model_sse_parse_warnings(flow)
-        assert len(usage_warnings) == 1
-        warning = usage_warnings[0]
-        assert warning["level"] == "warn"
-        assert warning["type"] == "usage_event"
-        assert warning["usage_protocol"] == "anthropic_messages_sse"
-        assert warning["event"] == "message_start"
-        assert warning["error"]
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="anthropic_messages_sse",
+            event="message_start",
+        )
 
     def test_full_pipeline_anthropic_sse_logs_truncated_message_delta_after_start(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
@@ -529,14 +536,11 @@ class TestResponseUsageReporting:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"tokens.input": 50}
         assert {event["provider"] for event in events} == {"claude-sonnet-4-6"}
-        usage_warnings = _model_sse_parse_warnings(flow)
-        assert len(usage_warnings) == 1
-        warning = usage_warnings[0]
-        assert warning["level"] == "warn"
-        assert warning["type"] == "usage_event"
-        assert warning["usage_protocol"] == "anthropic_messages_sse"
-        assert warning["event"] == "message_delta"
-        assert warning["error"]
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="anthropic_messages_sse",
+            event="message_delta",
+        )
 
     def test_full_pipeline_openai_sse_logs_truncated_terminal_event(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
@@ -564,14 +568,11 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
-        usage_warnings = _model_sse_parse_warnings(flow)
-        assert len(usage_warnings) == 1
-        warning = usage_warnings[0]
-        assert warning["level"] == "warn"
-        assert warning["type"] == "usage_event"
-        assert warning["usage_protocol"] == "openai_responses_sse"
-        assert warning["event"] == "response.completed"
-        assert warning["error"]
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="openai_responses_sse",
+            event="response.completed",
+        )
 
     def test_full_pipeline_openai_sse_logs_truncated_late_event_name(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
@@ -599,14 +600,11 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
-        usage_warnings = _model_sse_parse_warnings(flow)
-        assert len(usage_warnings) == 1
-        warning = usage_warnings[0]
-        assert warning["level"] == "warn"
-        assert warning["type"] == "usage_event"
-        assert warning["usage_protocol"] == "openai_responses_sse"
-        assert warning["event"] == "response.completed"
-        assert warning["error"]
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="openai_responses_sse",
+            event="response.completed",
+        )
 
     def test_full_pipeline_eventless_incomplete_sse_does_not_warn(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -661,6 +661,34 @@ class TestResponseUsageReporting:
         mock_opener.open.assert_not_called()
         assert _model_sse_parse_warnings(flow) == []
 
+    def test_full_pipeline_openai_non_terminal_incomplete_sse_does_not_warn(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.openai.com",
+            original_url="https://api.openai.com/v1/responses",
+            firewall_name="model-provider:openai-api-key",
+            cli_agent_type="codex",
+        )
+        _response_stream(flow)(
+            b"event: response.in_progress\n"
+            b'data: {"type":"response.in_progress","response":{"id":"resp_1","model":"gpt'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert _model_sse_parse_warnings(flow) == []
+
     def test_full_pipeline_model_sse_zero_event_preserves_billed_usage_and_id(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -534,6 +534,33 @@ class TestResponseUsageReporting:
         mock_opener.open.assert_not_called()
         assert _model_sse_parse_warnings(flow) == []
 
+    def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.openai.com",
+            original_url="https://api.openai.com/v1/responses",
+            firewall_name="model-provider:openai-api-key",
+            cli_agent_type="codex",
+        )
+        _response_stream(flow)(
+            b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert _model_sse_parse_warnings(flow) == []
+
     def test_full_pipeline_model_sse_zero_event_preserves_billed_usage_and_id(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -433,6 +433,40 @@ class TestResponseUsageReporting:
         assert warning["event"] == "message_start"
         assert warning["error"]
 
+    def test_full_pipeline_anthropic_sse_error_logs_truncated_message_start(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+        )
+        _response_stream(flow)(
+            b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
+        )
+        flow.error = Error("connection reset by peer")
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.error(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        usage_warnings = _model_sse_parse_warnings(flow)
+        assert len(usage_warnings) == 1
+        warning = usage_warnings[0]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "anthropic_messages_sse"
+        assert warning["event"] == "message_start"
+        assert warning["error"]
+
     def test_full_pipeline_anthropic_sse_logs_malformed_message_start(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -44,6 +44,35 @@ def _openai_model_websocket_flow(
     return flow
 
 
+def _model_provider_sse_flow(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    *,
+    host: str,
+    original_url: str,
+    firewall_name: str,
+    cli_agent_type: str | None = None,
+) -> http.HTTPFlow:
+    flow = real_flow(with_response=False, host=host)
+    flow.metadata["vm_run_id"] = "run-abc-123"
+    flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+    flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+    flow.metadata["firewall_action"] = "ALLOW"
+    flow.metadata["original_url"] = original_url
+    flow.metadata["firewall_name"] = firewall_name
+    flow.metadata["firewall_billable"] = True
+    flow.metadata["vm_sandbox_token"] = "tok-xyz"
+    if cli_agent_type is not None:
+        flow.metadata["cli_agent_type"] = cli_agent_type
+    flow.response = tutils.tresp(
+        status_code=200,
+        headers=_header_map({"content-type": "text/event-stream"}),
+    )
+
+    mitm_addon.responseheaders(flow)
+    return flow
+
+
 def _set_websocket_message(
     flow: http.HTTPFlow,
     *,
@@ -64,6 +93,17 @@ def _set_websocket_message(
 def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
     _set_websocket_message(flow, from_client=False, content=content)
     mitm_addon.websocket_message(flow)
+
+
+def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
+    proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+    if not proxy_log.exists():
+        return []
+    return [
+        entry
+        for entry in (json.loads(line) for line in proxy_log.read_text().splitlines())
+        if entry.get("message") == "Model provider SSE usage extraction failed"
+    ]
 
 
 class TestResponseUsageReporting:
@@ -359,6 +399,140 @@ class TestResponseUsageReporting:
             "tokens.cache_read": 2000,
         }
         assert {event["provider"] for event in events} == {"gpt-5.5"}
+
+    def test_full_pipeline_anthropic_sse_logs_truncated_message_start(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+        )
+        _response_stream(flow)(
+            b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        usage_warnings = _model_sse_parse_warnings(flow)
+        assert len(usage_warnings) == 1
+        warning = usage_warnings[0]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "anthropic_messages_sse"
+        assert warning["event"] == "message_start"
+        assert warning["error"]
+
+    def test_full_pipeline_anthropic_sse_logs_truncated_message_delta_after_start(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+        )
+        _response_stream(flow)(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"id":"msg_1",'
+            b'"model":"claude-sonnet-4-6","usage":{"input_tokens":50}}}\n\n'
+            b"event: message_delta\n"
+            b'data: {"type":"message_delta","usage":{"output_tokens":'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {"tokens.input": 50}
+        assert {event["provider"] for event in events} == {"claude-sonnet-4-6"}
+        usage_warnings = _model_sse_parse_warnings(flow)
+        assert len(usage_warnings) == 1
+        warning = usage_warnings[0]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "anthropic_messages_sse"
+        assert warning["event"] == "message_delta"
+        assert warning["error"]
+
+    def test_full_pipeline_openai_sse_logs_truncated_terminal_event(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.openai.com",
+            original_url="https://api.openai.com/v1/responses",
+            firewall_name="model-provider:openai-api-key",
+            cli_agent_type="codex",
+        )
+        _response_stream(flow)(
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        usage_warnings = _model_sse_parse_warnings(flow)
+        assert len(usage_warnings) == 1
+        warning = usage_warnings[0]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "openai_responses_sse"
+        assert warning["event"] == "response.completed"
+        assert warning["error"]
+
+    def test_full_pipeline_eventless_incomplete_sse_does_not_warn(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+        )
+        _response_stream(flow)(
+            b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert _model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_model_sse_zero_event_preserves_billed_usage_and_id(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor


### PR DESCRIPTION
## Summary

- add optional parse-error callbacks to Anthropic and OpenAI Responses SSE usage parsers
- log incomplete known model-provider SSE usage events as proxy `usage_event` warnings from `response_streaming.py`
- add full-pipeline regression coverage for Anthropic, OpenAI Responses, and event-less incomplete SSE data

Fixes #14701

## Tests

- `python3 -m pytest tests/test_usage_reporting.py -q`
- `python3 -m pytest tests/test_anthropic_messages.py tests/test_openai_responses_sse.py tests/test_response_streaming.py -q`
- `python3 -m pytest tests/ -q`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `basedpyright -p .`