### PR TITLE
fix: log model usage fallback parse errors

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -234,7 +234,7 @@ def _decompress_zlib_json_usage_body(
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return data, None
+            return b"", "invalid compressed body"
 
         out.extend(decoded)
         if not obj.eof:

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -223,6 +223,38 @@ def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
     return body
 
 
+def _decompress_zlib_json_usage_body(
+    data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
+) -> tuple[bytes, str | None]:
+    wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+    remaining_data = data
+    out = bytearray()
+
+    while remaining_data:
+        if len(out) >= max_output:
+            return bytes(out), None
+
+        obj = zlib.decompressobj(wbits)
+        try:
+            decoded = obj.decompress(remaining_data, max_length=max_output - len(out))
+        except zlib.error as exc:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
+                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            return data, None
+
+        out.extend(decoded)
+        if not obj.eof:
+            if data and not out:
+                return bytes(out), "incomplete compressed body"
+            return bytes(out), None
+        if not obj.unused_data:
+            return bytes(out), None
+        remaining_data = obj.unused_data
+
+    return bytes(out), None
+
+
 def decompress_json_usage_body(
     data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
 ) -> tuple[bytes, str | None]:
@@ -236,18 +268,7 @@ def decompress_json_usage_body(
     """
     encoding = headers.get("content-encoding", "").strip().lower()
     if encoding in ("gzip", "deflate"):
-        try:
-            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-            obj = zlib.decompressobj(wbits)
-            body = obj.decompress(data, max_length=max_output)
-        except zlib.error as exc:
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return data, None
-        if data and not body and not obj.eof:
-            return body, "incomplete compressed body"
-        return body, None
+        return _decompress_zlib_json_usage_body(data, encoding, max_output)
     if encoding == "br":
         try:
             body, finished = _decompress_brotli_bounded_with_finished(data, max_output)

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -46,6 +46,13 @@ _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
 
 
+def _brotli_is_finished(dec: object) -> bool:
+    is_finished = getattr(dec, "is_finished", None)
+    if callable(is_finished):
+        return bool(is_finished())
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Body capture helpers (opt-in per run via captureNetworkBodies registry flag)
 # ---------------------------------------------------------------------------
@@ -181,37 +188,9 @@ def decompress_body(
     return data
 
 
-def decompress_json_usage_body(
-    data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
-) -> tuple[bytes, str | None]:
-    """Decompress a JSON usage response body with an observable empty-prefix error.
-
-    ``decompress_body`` intentionally treats truncated gzip/deflate prefixes as
-    an empty body because body capture can still mark those responses truncated
-    from stream metadata. JSON usage fallback only has the final buffer, so it
-    needs to distinguish a valid compressed empty response from an incomplete
-    compressed frame that produced no JSON bytes.
-    """
-    encoding = headers.get("content-encoding", "").strip().lower()
-    if encoding in ("gzip", "deflate"):
-        try:
-            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-            obj = zlib.decompressobj(wbits)
-            body = obj.decompress(data, max_length=max_output)
-        except zlib.error as exc:
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return data, None
-        if data and not body and not obj.eof:
-            return body, "incomplete compressed body"
-        return body, None
-    return decompress_body(data, headers, max_output=max_output), None
-
-
-def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
+def _decompress_brotli_bounded_with_finished(data: bytes, max_output: int) -> tuple[bytes, bool]:
     if max_output <= 0:
-        return b""
+        return b"", False
 
     chunk_size = min(
         _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE,
@@ -233,10 +212,72 @@ def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
         remaining = max_output - len(out)
         if len(decoded) >= remaining:
             out.extend(decoded[:remaining])
-            return bytes(out)
+            return bytes(out), _brotli_is_finished(dec)
         out.extend(decoded)
 
-    return bytes(out)
+    return bytes(out), _brotli_is_finished(dec)
+
+
+def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
+    body, _finished = _decompress_brotli_bounded_with_finished(data, max_output)
+    return body
+
+
+def decompress_json_usage_body(
+    data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
+) -> tuple[bytes, str | None]:
+    """Decompress a JSON usage response body with an observable empty-prefix error.
+
+    ``decompress_body`` intentionally treats truncated compressed prefixes as an
+    empty body because body capture can still mark those responses truncated
+    from stream metadata. JSON usage fallback only has the final buffer, so it
+    needs to distinguish a valid compressed empty response from an incomplete
+    compressed frame that produced no JSON bytes.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if encoding in ("gzip", "deflate"):
+        try:
+            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+            obj = zlib.decompressobj(wbits)
+            body = obj.decompress(data, max_length=max_output)
+        except zlib.error as exc:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
+                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            return data, None
+        if data and not body and not obj.eof:
+            return body, "incomplete compressed body"
+        return body, None
+    if encoding == "br":
+        try:
+            body, finished = _decompress_brotli_bounded_with_finished(data, max_output)
+        except brotli.error as exc:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
+                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            return data, None
+        if data and not body and not finished:
+            return body, "incomplete compressed body"
+        return body, None
+    if encoding == "zstd":
+        try:
+            with zstandard.ZstdDecompressor().stream_reader(data) as reader:
+                body = reader.read(max_output)
+        except zstandard.ZstdError as exc:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
+                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            return data, None
+        if data and not body:
+            try:
+                obj = zstandard.ZstdDecompressor().decompressobj()
+                obj.decompress(data)
+            except zstandard.ZstdError:
+                return body, "incomplete compressed body"
+            if not obj.eof:
+                return body, "incomplete compressed body"
+        return body, None
+    return decompress_body(data, headers, max_output=max_output), None
 
 
 def _is_text_content(content_type: str) -> bool:

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -46,13 +46,6 @@ _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
 
 
-def _brotli_is_finished(dec: object) -> bool:
-    is_finished = getattr(dec, "is_finished", None)
-    if callable(is_finished):
-        return bool(is_finished())
-    return True
-
-
 # ---------------------------------------------------------------------------
 # Body capture helpers (opt-in per run via captureNetworkBodies registry flag)
 # ---------------------------------------------------------------------------
@@ -212,10 +205,10 @@ def _decompress_brotli_bounded_with_finished(data: bytes, max_output: int) -> tu
         remaining = max_output - len(out)
         if len(decoded) >= remaining:
             out.extend(decoded[:remaining])
-            return bytes(out), _brotli_is_finished(dec)
+            return bytes(out), dec.is_finished()
         out.extend(decoded)
 
-    return bytes(out), _brotli_is_finished(dec)
+    return bytes(out), dec.is_finished()
 
 
 def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -181,6 +181,34 @@ def decompress_body(
     return data
 
 
+def decompress_json_usage_body(
+    data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
+) -> tuple[bytes, str | None]:
+    """Decompress a JSON usage response body with an observable empty-prefix error.
+
+    ``decompress_body`` intentionally treats truncated gzip/deflate prefixes as
+    an empty body because body capture can still mark those responses truncated
+    from stream metadata. JSON usage fallback only has the final buffer, so it
+    needs to distinguish a valid compressed empty response from an incomplete
+    compressed frame that produced no JSON bytes.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if encoding in ("gzip", "deflate"):
+        try:
+            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+            obj = zlib.decompressobj(wbits)
+            body = obj.decompress(data, max_length=max_output)
+        except zlib.error as exc:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
+                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            return data, None
+        if data and not body and not obj.eof:
+            return body, "incomplete compressed body"
+        return body, None
+    return decompress_body(data, headers, max_output=max_output), None
+
+
 def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
     if max_output <= 0:
         return b""

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -291,6 +291,8 @@ def decompress_json_usage_body(
             if not obj.eof:
                 return body, "incomplete compressed body"
         return body, None
+    if encoding and encoding != "identity" and data:
+        return b"", "unsupported content encoding"
     return decompress_body(data, headers, max_output=max_output), None
 
 

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -269,7 +269,7 @@ def decompress_json_usage_body(
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return data, None
+            return b"", "invalid compressed body"
         if data and not body and not finished:
             return body, "incomplete compressed body"
         return body, None
@@ -281,7 +281,7 @@ def decompress_json_usage_body(
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return data, None
+            return b"", "invalid compressed body"
         if data and not body:
             try:
                 obj = zstandard.ZstdDecompressor().decompressobj()

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -472,17 +472,27 @@ def response(flow: http.HTTPFlow) -> None:
             "firewall_billable", False
         ):
             if response_streaming.uses_openai_responses_usage_protocol(flow):
-                json_usage = usage.extract_openai_responses_usage_from_json(
+                json_usage, json_error = usage.extract_openai_responses_usage_with_error_from_json(
                     bytes(stream_buf),
                     flow.response.headers if flow.response else None,
                 )
             else:
-                json_usage = usage.extract_anthropic_messages_usage_from_json(
-                    bytes(stream_buf),
-                    flow.response.headers if flow.response else None,
+                json_usage, json_error = (
+                    usage.extract_anthropic_messages_usage_with_error_from_json(
+                        bytes(stream_buf),
+                        flow.response.headers if flow.response else None,
+                    )
                 )
             if json_usage:
                 flow.metadata["model_provider_usage"] = json_usage
+            elif json_error:
+                log_proxy_entry(
+                    proxy_log_path,
+                    "warn",
+                    "Model provider JSON usage extraction failed",
+                    type="usage_event",
+                    error=json_error,
+                )
     _report_model_provider_usage_once(flow, run_id)
 
     # Billable connector usage observation (issue #9504, stage 0).

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -485,7 +485,7 @@ def response(flow: http.HTTPFlow) -> None:
                 )
             if json_usage:
                 flow.metadata["model_provider_usage"] = json_usage
-            elif json_error:
+            elif json_error is not None:
                 log_proxy_entry(
                     proxy_log_path,
                     "warn",

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -23,6 +23,7 @@ from .anthropic_messages import (
     create_anthropic_messages_json_usage_extractor,
     create_anthropic_messages_sse_usage_extractor,
     extract_anthropic_messages_usage_from_json,
+    extract_anthropic_messages_usage_with_error_from_json,
 )
 from .counters import (
     decrement_in_flight_flows,
@@ -34,6 +35,7 @@ from .openai_responses import (
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event_json,
     extract_openai_responses_usage_from_json,
+    extract_openai_responses_usage_with_error_from_json,
     merge_openai_responses_usage_result,
 )
 from .providers.connectors import report_connector_usage, x
@@ -46,8 +48,10 @@ __all__ = [
     "create_openai_responses_sse_usage_extractor",
     "decrement_in_flight_flows",
     "extract_anthropic_messages_usage_from_json",
+    "extract_anthropic_messages_usage_with_error_from_json",
     "extract_openai_responses_usage_from_event_json",
     "extract_openai_responses_usage_from_json",
+    "extract_openai_responses_usage_with_error_from_json",
     "increment_in_flight_flows",
     "merge_openai_responses_usage_result",
     "report_connector_usage",

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -176,7 +176,7 @@ def extract_anthropic_messages_usage_with_error_from_json(
 
     Falls back to decompressing the body if *headers* indicate compression.
     Returns ``(None, error)`` when the body is not valid JSON and
-    ``(None, None)`` when the body contains no usage.
+    ``(None, None)`` when no selected usage or metadata fields are found.
     """
     if headers:
         body = body_utils.decompress_body(
@@ -191,7 +191,8 @@ def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | N
     """Extract usage from a non-streaming Anthropic API JSON response.
 
     Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``None`` when the body is not valid JSON or contains no usage.
+    Returns ``None`` when the body is not valid JSON or no selected usage or
+    metadata fields are found.
     """
     usage, _error = extract_anthropic_messages_usage_with_error_from_json(body, headers)
     return usage

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -176,12 +176,15 @@ def extract_anthropic_messages_usage_with_error_from_json(
 
     Falls back to decompressing the body if *headers* indicate compression.
     Returns ``(None, error)`` when JSON usage parsing fails and
-    ``(None, None)`` when no selected usage or metadata fields are found.
+    ``(None, None)`` when the decoded body is empty or no selected usage or
+    metadata fields are found.
     """
     if headers:
         body = body_utils.decompress_body(
             body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
         )
+    if not body:
+        return None, None
     extractor = create_anthropic_messages_json_usage_extractor()
     extractor.feed(body)
     return extractor.finish()

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -169,11 +169,14 @@ def create_anthropic_messages_json_usage_extractor() -> AnthropicMessagesJsonUsa
     return AnthropicMessagesJsonUsageExtractor()
 
 
-def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | None:
+def extract_anthropic_messages_usage_with_error_from_json(
+    body: bytes, headers
+) -> tuple[dict | None, str | None]:
     """Extract usage from a non-streaming Anthropic API JSON response.
 
     Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``None`` when the body is not valid JSON or contains no usage.
+    Returns ``(None, error)`` when the body is not valid JSON and
+    ``(None, None)`` when the body contains no usage.
     """
     if headers:
         body = body_utils.decompress_body(
@@ -181,5 +184,14 @@ def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | N
         )
     extractor = create_anthropic_messages_json_usage_extractor()
     extractor.feed(body)
-    usage, _error = extractor.finish()
+    return extractor.finish()
+
+
+def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | None:
+    """Extract usage from a non-streaming Anthropic API JSON response.
+
+    Falls back to decompressing the body if *headers* indicate compression.
+    Returns ``None`` when the body is not valid JSON or contains no usage.
+    """
+    usage, _error = extract_anthropic_messages_usage_with_error_from_json(body, headers)
     return usage

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -180,9 +180,11 @@ def extract_anthropic_messages_usage_with_error_from_json(
     metadata fields are found.
     """
     if headers:
-        body = body_utils.decompress_body(
+        body, decompress_error = body_utils.decompress_json_usage_body(
             body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
         )
+        if decompress_error:
+            return None, decompress_error
     if not body:
         return None, None
     extractor = create_anthropic_messages_json_usage_extractor()

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -169,22 +169,9 @@ def create_anthropic_messages_json_usage_extractor() -> AnthropicMessagesJsonUsa
     return AnthropicMessagesJsonUsageExtractor()
 
 
-def extract_anthropic_messages_usage_with_error_from_json(
-    body: bytes, headers
+def _extract_anthropic_messages_usage_from_decoded_json_body(
+    body: bytes,
 ) -> tuple[dict | None, str | None]:
-    """Extract usage from a non-streaming Anthropic API JSON response.
-
-    Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``(None, error)`` when JSON usage parsing fails and
-    ``(None, None)`` when the decoded body is empty or no selected usage or
-    metadata fields are found.
-    """
-    if headers:
-        body, decompress_error = body_utils.decompress_json_usage_body(
-            body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
-        )
-        if decompress_error:
-            return None, decompress_error
     if not body:
         return None, None
     extractor = create_anthropic_messages_json_usage_extractor()
@@ -195,9 +182,31 @@ def extract_anthropic_messages_usage_with_error_from_json(
 def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | None:
     """Extract usage from a non-streaming Anthropic API JSON response.
 
-    Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``None`` when JSON usage parsing fails or no selected usage or
-    metadata fields are found.
+    This is the silent best-effort API: it returns ``None`` when decoding or
+    parsing fails, the decoded body is empty, or no selected usage or metadata
+    fields are found.
     """
-    usage, _error = extract_anthropic_messages_usage_with_error_from_json(body, headers)
+    if headers:
+        body = body_utils.decompress_body(
+            body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
+        )
+    usage, _error = _extract_anthropic_messages_usage_from_decoded_json_body(body)
     return usage
+
+
+def extract_anthropic_messages_usage_with_error_from_json(
+    body: bytes, headers
+) -> tuple[dict | None, str | None]:
+    """Extract usage from a non-streaming Anthropic API JSON response.
+
+    This is the diagnostic API: it returns ``(None, error)`` when decoding or
+    parsing fails, and ``(None, None)`` when the decoded body is empty or no
+    selected usage or metadata fields are found.
+    """
+    if headers:
+        body, decompress_error = body_utils.decompress_json_usage_body(
+            body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
+        )
+        if decompress_error:
+            return None, decompress_error
+    return _extract_anthropic_messages_usage_from_decoded_json_body(body)

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -175,7 +175,7 @@ def extract_anthropic_messages_usage_with_error_from_json(
     """Extract usage from a non-streaming Anthropic API JSON response.
 
     Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``(None, error)`` when the body is not valid JSON and
+    Returns ``(None, error)`` when JSON usage parsing fails and
     ``(None, None)`` when no selected usage or metadata fields are found.
     """
     if headers:
@@ -191,7 +191,7 @@ def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | N
     """Extract usage from a non-streaming Anthropic API JSON response.
 
     Falls back to decompressing the body if *headers* indicate compression.
-    Returns ``None`` when the body is not valid JSON or no selected usage or
+    Returns ``None`` when JSON usage parsing fails or no selected usage or
     metadata fields are found.
     """
     usage, _error = extract_anthropic_messages_usage_with_error_from_json(body, headers)

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -251,18 +251,18 @@ def create_openai_responses_json_usage_extractor() -> OpenAIResponsesJsonUsageEx
     return OpenAIResponsesJsonUsageExtractor()
 
 
-def extract_openai_responses_usage_from_json(
+def extract_openai_responses_usage_with_error_from_json(
     body: bytes, headers: http.Headers | None
-) -> dict | None:
+) -> tuple[dict | None, str | None]:
     """Extract usage from a complete non-streaming Responses JSON body.
 
     ``headers`` may be mitmproxy response headers or ``None``. When headers are
     provided, their content encoding controls one-shot decompression before
     parsing; ``None`` skips decompression.
 
-    Returns ``None`` when no platform usage categories can be extracted,
-    including invalid JSON and valid JSON without usage. Otherwise returns a
-    dict keyed by platform model usage categories such as
+    Returns ``(None, error)`` when parsing fails and ``(None, None)`` when no
+    platform usage categories can be extracted from valid JSON. Otherwise
+    returns a dict keyed by platform model usage categories such as
     ``MODEL_USAGE_CATEGORY_INPUT``, ``MODEL_USAGE_CATEGORY_OUTPUT``, and
     ``MODEL_USAGE_CATEGORY_CACHE_READ``. OpenAI ``input_tokens`` include cached
     tokens, so this extractor splits them into uncached input and cache-read
@@ -275,7 +275,15 @@ def extract_openai_responses_usage_from_json(
         )
     extractor = create_openai_responses_json_usage_extractor()
     extractor.feed(body)
-    usage, _error = extractor.finish()
+    return extractor.finish()
+
+
+def extract_openai_responses_usage_from_json(
+    body: bytes, headers: http.Headers | None
+) -> dict | None:
+    """Extract usage from a complete non-streaming Responses JSON body."""
+
+    usage, _error = extract_openai_responses_usage_with_error_from_json(body, headers)
     return usage
 
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -260,19 +260,21 @@ def extract_openai_responses_usage_with_error_from_json(
     provided, their content encoding controls one-shot decompression before
     parsing; ``None`` skips decompression.
 
-    Returns ``(None, error)`` when parsing fails and ``(None, None)`` when no
-    platform usage categories can be extracted from valid JSON. Otherwise
-    returns a dict keyed by platform model usage categories such as
-    ``MODEL_USAGE_CATEGORY_INPUT``, ``MODEL_USAGE_CATEGORY_OUTPUT``, and
-    ``MODEL_USAGE_CATEGORY_CACHE_READ``. OpenAI ``input_tokens`` include cached
-    tokens, so this extractor splits them into uncached input and cache-read
-    categories before reporting.
+    Returns ``(None, error)`` when parsing fails and ``(None, None)`` when the
+    decoded body is empty or no platform usage categories can be extracted from
+    valid JSON. Otherwise returns a dict keyed by platform model usage
+    categories such as ``MODEL_USAGE_CATEGORY_INPUT``,
+    ``MODEL_USAGE_CATEGORY_OUTPUT``, and ``MODEL_USAGE_CATEGORY_CACHE_READ``.
+    OpenAI ``input_tokens`` include cached tokens, so this extractor splits
+    them into uncached input and cache-read categories before reporting.
     """
 
     if headers:
         body = body_utils.decompress_body(
             body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
         )
+    if not body:
+        return None, None
     extractor = create_openai_responses_json_usage_extractor()
     extractor.feed(body)
     return extractor.finish()

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -270,9 +270,11 @@ def extract_openai_responses_usage_with_error_from_json(
     """
 
     if headers:
-        body = body_utils.decompress_body(
+        body, decompress_error = body_utils.decompress_json_usage_body(
             body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
         )
+        if decompress_error:
+            return None, decompress_error
     if not body:
         return None, None
     extractor = create_openai_responses_json_usage_extractor()

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -281,7 +281,11 @@ def extract_openai_responses_usage_with_error_from_json(
 def extract_openai_responses_usage_from_json(
     body: bytes, headers: http.Headers | None
 ) -> dict | None:
-    """Extract usage from a complete non-streaming Responses JSON body."""
+    """Extract usage from a complete non-streaming Responses JSON body.
+
+    This compatibility wrapper keeps the original best-effort ``dict | None``
+    contract for callers that do not need parser error details.
+    """
 
     usage, _error = extract_openai_responses_usage_with_error_from_json(body, headers)
     return usage

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -7,8 +7,9 @@ model-provider usage billing:
   ``response_streaming.py`` for ``text/event-stream`` responses.
 - Non-streaming JSON bodies via ``create_openai_responses_json_usage_extractor``
   for incremental parsing in ``response_streaming.py`` and
-  ``extract_openai_responses_usage_from_json`` for the ``mitm_addon.py``
-  fallback used by legacy/test flows without response-streaming parser state.
+  ``extract_openai_responses_usage_with_error_from_json`` for the
+  ``mitm_addon.py`` fallback used by legacy/test flows without
+  response-streaming parser state.
 - Single-frame WebSocket event JSON via
   ``extract_openai_responses_usage_from_event_json``, consumed by
   ``response_streaming.py`` for Responses events received over upgrades.
@@ -251,30 +252,9 @@ def create_openai_responses_json_usage_extractor() -> OpenAIResponsesJsonUsageEx
     return OpenAIResponsesJsonUsageExtractor()
 
 
-def extract_openai_responses_usage_with_error_from_json(
-    body: bytes, headers: http.Headers | None
+def _extract_openai_responses_usage_from_decoded_json_body(
+    body: bytes,
 ) -> tuple[dict | None, str | None]:
-    """Extract usage from a complete non-streaming Responses JSON body.
-
-    ``headers`` may be mitmproxy response headers or ``None``. When headers are
-    provided, their content encoding controls one-shot decompression before
-    parsing; ``None`` skips decompression.
-
-    Returns ``(None, error)`` when parsing fails and ``(None, None)`` when the
-    decoded body is empty or no platform usage categories can be extracted from
-    valid JSON. Otherwise returns a dict keyed by platform model usage
-    categories such as ``MODEL_USAGE_CATEGORY_INPUT``,
-    ``MODEL_USAGE_CATEGORY_OUTPUT``, and ``MODEL_USAGE_CATEGORY_CACHE_READ``.
-    OpenAI ``input_tokens`` include cached tokens, so this extractor splits
-    them into uncached input and cache-read categories before reporting.
-    """
-
-    if headers:
-        body, decompress_error = body_utils.decompress_json_usage_body(
-            body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
-        )
-        if decompress_error:
-            return None, decompress_error
     if not body:
         return None, None
     extractor = create_openai_responses_json_usage_extractor()
@@ -287,12 +267,51 @@ def extract_openai_responses_usage_from_json(
 ) -> dict | None:
     """Extract usage from a complete non-streaming Responses JSON body.
 
-    This compatibility wrapper keeps the original best-effort ``dict | None``
-    contract for callers that do not need parser error details.
+    ``headers`` may be mitmproxy response headers or ``None``. When headers are
+    provided, their content encoding controls one-shot decompression before
+    parsing; ``None`` skips decompression.
+
+    This is the silent best-effort API: it returns ``None`` when decoding or
+    parsing fails, the decoded body is empty, or no platform usage categories
+    can be extracted. Otherwise returns a dict keyed by platform model usage
+    categories such as ``MODEL_USAGE_CATEGORY_INPUT``,
+    ``MODEL_USAGE_CATEGORY_OUTPUT``, and ``MODEL_USAGE_CATEGORY_CACHE_READ``.
     """
 
-    usage, _error = extract_openai_responses_usage_with_error_from_json(body, headers)
+    if headers:
+        body = body_utils.decompress_body(
+            body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
+        )
+    usage, _error = _extract_openai_responses_usage_from_decoded_json_body(body)
     return usage
+
+
+def extract_openai_responses_usage_with_error_from_json(
+    body: bytes, headers: http.Headers | None
+) -> tuple[dict | None, str | None]:
+    """Extract usage from a complete non-streaming Responses JSON body.
+
+    ``headers`` may be mitmproxy response headers or ``None``. When headers are
+    provided, their content encoding controls one-shot decompression before
+    parsing; ``None`` skips decompression.
+
+    This is the diagnostic API: it returns ``(None, error)`` when decoding or
+    parsing fails, and ``(None, None)`` when the decoded body is empty or no
+    platform usage categories can be extracted from valid JSON. Otherwise
+    returns a dict keyed by platform model usage categories such as
+    ``MODEL_USAGE_CATEGORY_INPUT``, ``MODEL_USAGE_CATEGORY_OUTPUT``, and
+    ``MODEL_USAGE_CATEGORY_CACHE_READ``. OpenAI ``input_tokens`` include cached
+    tokens, so this extractor splits them into uncached input and cache-read
+    categories before reporting.
+    """
+
+    if headers:
+        body, decompress_error = body_utils.decompress_json_usage_body(
+            body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
+        )
+        if decompress_error:
+            return None, decompress_error
+    return _extract_openai_responses_usage_from_decoded_json_body(body)
 
 
 def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -42,6 +42,9 @@ def _track_brotli_decompressor(monkeypatch):
             stats["max_output"] = max(stats["max_output"], len(out))
             return out
 
+        def is_finished(self) -> bool:
+            return self._inner.is_finished()
+
     monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
     return stats
 

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -23,7 +23,9 @@ from body_utils import (
 )
 from usage import (
     extract_anthropic_messages_usage_from_json,
+    extract_anthropic_messages_usage_with_error_from_json,
     extract_openai_responses_usage_from_json,
+    extract_openai_responses_usage_with_error_from_json,
 )
 
 
@@ -1075,6 +1077,16 @@ class TestExtractAnthropicUsageFromJson:
         assert result["model"] == "test"
         assert result["tokens.input"] == 42
 
+    def test_truncated_gzip_stays_silent_but_diagnostic_returns_error(self, headers):
+        original = b'{"model":"test","usage":{"input_tokens":42}}'
+        truncated = gzip.compress(original)[:10]
+        headers = headers(("Content-Encoding", "gzip"))
+
+        assert extract_anthropic_messages_usage_from_json(truncated, headers) is None
+        usage, error = extract_anthropic_messages_usage_with_error_from_json(truncated, headers)
+        assert usage is None
+        assert error == "incomplete compressed body"
+
     def test_invalid_json_returns_none(self):
         assert extract_anthropic_messages_usage_from_json(b"not json", None) is None
 
@@ -1211,6 +1223,19 @@ class TestExtractOpenAIResponsesUsageFromJson:
             "tokens.input": 35,
             "tokens.cache_read": 7,
         }
+
+    def test_truncated_gzip_stays_silent_but_diagnostic_returns_error(self, headers):
+        original = (
+            b'{"model":"gpt-5.3-codex","usage":{"input_tokens":42,'
+            b'"input_tokens_details":{"cached_tokens":7}}}'
+        )
+        truncated = gzip.compress(original)[:10]
+        headers = headers(("Content-Encoding", "gzip"))
+
+        assert extract_openai_responses_usage_from_json(truncated, headers) is None
+        usage, error = extract_openai_responses_usage_with_error_from_json(truncated, headers)
+        assert usage is None
+        assert error == "incomplete compressed body"
 
     def test_cached_input_tokens_are_clamped_to_total_input(self):
         body = (

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -126,6 +126,14 @@ def _assert_single_model_sse_parse_warning(
     assert warning["error"]
 
 
+def _set_stream_buffer(flow: http.HTTPFlow, body: bytes) -> None:
+    flow.metadata["stream_buffer"] = bytearray(body)
+    flow.metadata["stream_buffer_state"] = {
+        "truncated": False,
+        "total_bytes": len(body),
+    }
+
+
 class TestResponseUsageReporting:
     """Tests for usage extraction and reporting in response() hook."""
 
@@ -250,11 +258,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -301,11 +305,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -347,11 +347,7 @@ class TestResponseUsageReporting:
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -466,11 +462,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -541,11 +533,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -633,11 +621,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -697,11 +681,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -737,11 +717,7 @@ class TestResponseUsageReporting:
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -805,11 +781,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(status_code=200, headers=_header_map(response_headers))
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -841,11 +813,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -912,11 +880,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -1045,11 +1009,7 @@ class TestResponseUsageReporting:
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = False
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -1911,11 +1871,7 @@ class TestResponseUsageReporting:
             "tokens.output": 20,
         }
         body = b'{"id":"resp_1","usage":{"input_tokens":'
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -2503,11 +2459,7 @@ class TestResponseUsageReporting:
         flow.metadata["original_url"] = "https://api.github.com/repos"
         flow.metadata["firewall_name"] = "github"
         body = b'{"incomplete":'
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200, headers=_header_map({"content-type": "application/json"})
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -368,16 +368,28 @@ class TestResponseUsageReporting:
     @pytest.mark.parametrize(
         "encoding_case", ["chained-gzip", "raw-deflate", "truncated-gzip-prefix"]
     )
+    @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_compressed_body_parse_failure_logs_proxy_warning(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case, provider_case
     ):
         """One-shot decompression failures leave compressed bytes and log parse failure."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        if provider_case == "openai":
+            flow = real_flow(with_response=False, host="api.openai.com")
+            flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+            flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+            flow.metadata["cli_agent_type"] = "codex"
+            payload = (
+                b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50,"output_tokens":200}}'
+            )
+        else:
+            flow = real_flow(with_response=False, host="api.anthropic.com")
+            flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            payload = (
+                b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+                b'"usage":{"input_tokens":50,"output_tokens":200}}'
+            )
         proxy_log_path = tmp_path / "proxy.jsonl"
-        payload = (
-            b'{"id":"msg_1","model":"claude-sonnet-4-6",'
-            b'"usage":{"input_tokens":50,"output_tokens":200}}'
-        )
         if encoding_case == "chained-gzip":
             body = gzip.compress(payload)
             content_encoding = "gzip, identity"
@@ -397,8 +409,6 @@ class TestResponseUsageReporting:
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
@@ -504,27 +514,39 @@ class TestResponseUsageReporting:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
-    @pytest.mark.parametrize("encoding_case", ["identity", "gzip"])
+    @pytest.mark.parametrize("encoding_case", ["identity", "gzip", "deflate"])
+    @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_empty_body_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case, provider_case
     ):
         """Empty model-provider bodies are not JSON parser failures."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        if provider_case == "openai":
+            flow = real_flow(with_response=False, host="api.openai.com")
+            flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+            flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+            flow.metadata["cli_agent_type"] = "codex"
+        else:
+            flow = real_flow(with_response=False, host="api.anthropic.com")
+            flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         proxy_log_path = tmp_path / "proxy.jsonl"
-        body = gzip.compress(b"") if encoding_case == "gzip" else b""
+        if encoding_case == "gzip":
+            body = gzip.compress(b"")
+        elif encoding_case == "deflate":
+            body = zlib.compress(b"")
+        else:
+            body = b""
         response_headers = {
             "content-type": "application/json",
             "content-length": str(len(body)),
         }
-        if encoding_case == "gzip":
-            response_headers["content-encoding"] = "gzip"
+        if encoding_case != "identity":
+            response_headers["content-encoding"] = encoding_case
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -251,7 +251,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -299,7 +302,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -342,7 +348,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -458,7 +467,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -530,7 +542,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -619,7 +634,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -680,7 +698,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -717,7 +738,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -782,7 +806,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(status_code=200, headers=_header_map(response_headers))
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -815,7 +842,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -883,7 +913,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -1013,7 +1046,10 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = False
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -1874,8 +1910,12 @@ class TestResponseUsageReporting:
             "model": "gpt-5.5",
             "tokens.output": 20,
         }
-        flow.metadata["stream_buffer"] = bytearray(b'{"id":"resp_1","usage":{"input_tokens":')
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        body = b'{"id":"resp_1","usage":{"input_tokens":'
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -2462,8 +2502,12 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.github.com/repos"
         flow.metadata["firewall_name"] = "github"
-        flow.metadata["stream_buffer"] = bytearray(b'{"incomplete":')
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        body = b'{"incomplete":'
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
         flow.response = tutils.tresp(
             status_code=200, headers=_header_map({"content-type": "application/json"})
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -1,5 +1,6 @@
 """Tests for response usage reporting flows."""
 
+import gzip
 import json
 import time
 from collections.abc import Callable
@@ -312,6 +313,55 @@ class TestResponseUsageReporting:
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == "incomplete json"
+
+    def test_json_fallback_chained_content_encoding_logs_proxy_warning(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Unsupported one-shot encoding leaves compressed bytes, then logs parse failure."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = gzip.compress(
+            b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":50,"output_tokens":200}}'
+        )
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map(
+                {
+                    "content-type": "application/json",
+                    "content-encoding": "gzip, identity",
+                }
+            ),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["level"] == "warn"
+        assert entries[0]["message"] == "Model provider JSON usage extraction failed"
+        assert entries[0]["type"] == "usage_event"
+        assert entries[0]["error"] == "expected json value"
 
     def test_json_fallback_valid_body_without_usage_stays_quiet(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -365,7 +365,9 @@ class TestResponseUsageReporting:
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == "incomplete json"
 
-    @pytest.mark.parametrize("encoding_case", ["chained-gzip", "raw-deflate"])
+    @pytest.mark.parametrize(
+        "encoding_case", ["chained-gzip", "raw-deflate", "truncated-gzip-prefix"]
+    )
     def test_json_fallback_compressed_body_parse_failure_logs_proxy_warning(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
     ):
@@ -379,10 +381,16 @@ class TestResponseUsageReporting:
         if encoding_case == "chained-gzip":
             body = gzip.compress(payload)
             content_encoding = "gzip, identity"
+            expected_error = "expected json value"
+        elif encoding_case == "truncated-gzip-prefix":
+            body = gzip.compress(payload)[:10]
+            content_encoding = "gzip"
+            expected_error = "incomplete compressed body"
         else:
             compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
             body = compressor.compress(payload) + compressor.flush()
             content_encoding = "deflate"
+            expected_error = "expected json value"
 
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
@@ -421,7 +429,7 @@ class TestResponseUsageReporting:
         assert entries[0]["level"] == "warn"
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
         assert entries[0]["type"] == "usage_event"
-        assert entries[0]["error"] == "expected json value"
+        assert entries[0]["error"] == expected_error
 
     def test_json_fallback_valid_body_without_usage_stays_quiet(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -486,6 +486,71 @@ class TestResponseUsageReporting:
         }
         assert not proxy_log_path.exists()
 
+    @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
+    def test_json_fallback_zero_token_usage_stays_quiet(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, provider_case
+    ):
+        """Valid zero-token usage is not a parser failure and does not bill."""
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        if provider_case == "anthropic":
+            flow = real_flow(with_response=False, host="api.anthropic.com")
+            body = (
+                b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+                b'"usage":{"input_tokens":0,"output_tokens":0}}'
+            )
+            flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            expected_usage = {
+                "message_id": "msg_1",
+                "model": "claude-sonnet-4-6",
+                "tokens.input": 0,
+                "tokens.output": 0,
+            }
+        else:
+            flow = real_flow(with_response=False, host="api.openai.com")
+            body = (
+                b'{"id":"resp_1","model":"gpt-5.5","usage":'
+                b'{"input_tokens":0,"output_tokens":0,'
+                b'"input_tokens_details":{"cached_tokens":0}}}'
+            )
+            flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+            flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+            flow.metadata["cli_agent_type"] = "codex"
+            expected_usage = {
+                "message_id": "resp_1",
+                "model": "gpt-5.5",
+                "tokens.input": 0,
+                "tokens.output": 0,
+                "tokens.cache_read": 0,
+            }
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert flow.metadata["model_provider_usage"] == expected_usage
+        assert not proxy_log_path.exists()
+
     def test_codex_oauth_non_streaming_json_fallback(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -1862,6 +1862,83 @@ class TestResponseUsageReporting:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"tokens.input": 50, "tokens.output": 200}
 
+    @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
+    def test_full_pipeline_compressed_model_json_reports_usage(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, provider_case
+    ):
+        """responseheaders parser should decompress non-SSE model JSON before extraction."""
+        if provider_case == "openai":
+            flow = real_flow(with_response=False, host="api.openai.com")
+            flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+            flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+            flow.metadata["cli_agent_type"] = "codex"
+            payload = json.dumps(
+                {
+                    "id": "resp_1",
+                    "model": "gpt-5.5",
+                    "usage": {
+                        "input_tokens": 50,
+                        "output_tokens": 200,
+                        "input_tokens_details": {"cached_tokens": 10},
+                    },
+                }
+            ).encode()
+        else:
+            flow = real_flow(with_response=False, host="api.anthropic.com")
+            flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            payload = json.dumps(
+                {
+                    "id": "msg_1",
+                    "model": "claude-sonnet-4-6",
+                    "usage": {"input_tokens": 50, "output_tokens": 200},
+                }
+            ).encode()
+        compressed = gzip.compress(payload)
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json", "content-encoding": "gzip"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        midpoint = len(compressed) // 2
+        _response_stream(flow)(compressed[:midpoint])
+        _response_stream(flow)(compressed[midpoint:])
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        extracted = flow.metadata["model_provider_usage"]
+        assert extracted["model"] == (
+            "gpt-5.5" if provider_case == "openai" else "claude-sonnet-4-6"
+        )
+        assert extracted["tokens.input"] == (40 if provider_case == "openai" else 50)
+        assert extracted["tokens.output"] == 200
+        if provider_case == "openai":
+            assert extracted["tokens.cache_read"] == 10
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        expected = {
+            "tokens.input": 40 if provider_case == "openai" else 50,
+            "tokens.output": 200,
+        }
+        if provider_case == "openai":
+            expected["tokens.cache_read"] = 10
+        assert by_category == expected
+
     def test_full_pipeline_incomplete_model_json_does_not_report_partial_usage(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -370,6 +370,7 @@ class TestResponseUsageReporting:
         "encoding_case",
         [
             "chained-gzip",
+            "raw-json-with-unknown-header",
             "raw-deflate",
             "raw-json-with-gzip-header",
             "raw-json-with-br-header",
@@ -406,7 +407,11 @@ class TestResponseUsageReporting:
         if encoding_case == "chained-gzip":
             body = gzip.compress(payload)
             content_encoding = "gzip, identity"
-            expected_error = "expected json value"
+            expected_error = "unsupported content encoding"
+        elif encoding_case == "raw-json-with-unknown-header":
+            body = payload
+            content_encoding = "x-custom"
+            expected_error = "unsupported content encoding"
         elif encoding_case == "raw-json-with-gzip-header":
             body = payload
             content_encoding = "gzip"

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -372,6 +372,8 @@ class TestResponseUsageReporting:
             "chained-gzip",
             "raw-deflate",
             "raw-json-with-gzip-header",
+            "raw-json-with-br-header",
+            "raw-json-with-zstd-header",
             "truncated-gzip-prefix",
             "empty-gzip-member-before-garbage",
             "empty-deflate-stream-before-garbage",
@@ -408,6 +410,14 @@ class TestResponseUsageReporting:
         elif encoding_case == "raw-json-with-gzip-header":
             body = payload
             content_encoding = "gzip"
+            expected_error = "invalid compressed body"
+        elif encoding_case == "raw-json-with-br-header":
+            body = payload
+            content_encoding = "br"
+            expected_error = "invalid compressed body"
+        elif encoding_case == "raw-json-with-zstd-header":
+            body = payload
+            content_encoding = "zstd"
             expected_error = "invalid compressed body"
         elif encoding_case == "truncated-gzip-prefix":
             body = gzip.compress(payload)[:10]

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -468,16 +468,36 @@ class TestResponseUsageReporting:
         assert entries[0]["error"] == expected_error
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_concatenated_zlib_member_reports_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fresh_usage_executor,
+        encoding_case,
+        provider_case,
     ):
         """Zlib stream concatenation should not let an empty first member hide usage."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
         proxy_log_path = tmp_path / "proxy.jsonl"
-        payload = (
-            b'{"id":"msg_1","model":"claude-sonnet-4-6",'
-            b'"usage":{"input_tokens":50,"output_tokens":200}}'
-        )
+        if provider_case == "openai":
+            flow = real_flow(with_response=False, host="api.openai.com")
+            flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+            flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+            flow.metadata["cli_agent_type"] = "codex"
+            payload = (
+                b'{"id":"resp_1","model":"gpt-5.5",'
+                b'"usage":{"input_tokens":50,"output_tokens":200,'
+                b'"input_tokens_details":{"cached_tokens":10}}}'
+            )
+        else:
+            flow = real_flow(with_response=False, host="api.anthropic.com")
+            flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            payload = (
+                b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+                b'"usage":{"input_tokens":50,"output_tokens":200}}'
+            )
         if encoding_case == "gzip":
             body = gzip.compress(b"") + gzip.compress(payload)
         else:
@@ -487,8 +507,6 @@ class TestResponseUsageReporting:
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
@@ -513,9 +531,13 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
-        assert extracted["model"] == "claude-sonnet-4-6"
-        assert extracted["tokens.input"] == 50
+        assert extracted["model"] == (
+            "gpt-5.5" if provider_case == "openai" else "claude-sonnet-4-6"
+        )
+        assert extracted["tokens.input"] == (40 if provider_case == "openai" else 50)
         assert extracted["tokens.output"] == 200
+        if provider_case == "openai":
+            assert extracted["tokens.cache_read"] == 10
         if proxy_log_path.exists():
             entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
             assert not any(

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -1705,7 +1705,14 @@ class TestResponseUsageReporting:
 
         mock_opener.open.assert_not_called()
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-        assert "Model provider JSON usage extraction failed" in proxy_log.read_text()
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        usage_warnings = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert len(usage_warnings) == 1
+        assert usage_warnings[0]["error"] == "incomplete json"
 
     def test_full_pipeline_corrupt_model_json_encoding_does_not_fallback_to_raw_buffer(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -373,6 +373,7 @@ class TestResponseUsageReporting:
             "raw-deflate",
             "truncated-gzip-prefix",
             "empty-gzip-member-before-garbage",
+            "empty-deflate-stream-before-garbage",
             "truncated-brotli-prefix",
             "truncated-zstd-prefix",
         ],
@@ -410,6 +411,10 @@ class TestResponseUsageReporting:
         elif encoding_case == "empty-gzip-member-before-garbage":
             body = gzip.compress(b"") + b"garbage"
             content_encoding = "gzip"
+            expected_error = "expected json value"
+        elif encoding_case == "empty-deflate-stream-before-garbage":
+            body = zlib.compress(b"") + b"garbage"
+            content_encoding = "deflate"
             expected_error = "expected json value"
         elif encoding_case == "truncated-brotli-prefix":
             body = body_utils.brotli.compress(payload)[:2]
@@ -462,17 +467,21 @@ class TestResponseUsageReporting:
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == expected_error
 
-    def test_json_fallback_concatenated_gzip_member_reports_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_json_fallback_concatenated_zlib_member_reports_usage(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
     ):
-        """Gzip concatenation should not let an empty first member hide usage."""
+        """Zlib stream concatenation should not let an empty first member hide usage."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         proxy_log_path = tmp_path / "proxy.jsonl"
         payload = (
             b'{"id":"msg_1","model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":50,"output_tokens":200}}'
         )
-        body = gzip.compress(b"") + gzip.compress(payload)
+        if encoding_case == "gzip":
+            body = gzip.compress(b"") + gzip.compress(payload)
+        else:
+            body = zlib.compress(b"") + zlib.compress(payload)
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
@@ -489,7 +498,7 @@ class TestResponseUsageReporting:
             headers=_header_map(
                 {
                     "content-type": "application/json",
-                    "content-encoding": "gzip",
+                    "content-encoding": encoding_case,
                 }
             ),
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -371,6 +371,7 @@ class TestResponseUsageReporting:
         [
             "chained-gzip",
             "raw-deflate",
+            "raw-json-with-gzip-header",
             "truncated-gzip-prefix",
             "empty-gzip-member-before-garbage",
             "empty-deflate-stream-before-garbage",
@@ -404,6 +405,10 @@ class TestResponseUsageReporting:
             body = gzip.compress(payload)
             content_encoding = "gzip, identity"
             expected_error = "expected json value"
+        elif encoding_case == "raw-json-with-gzip-header":
+            body = payload
+            content_encoding = "gzip"
+            expected_error = "invalid compressed body"
         elif encoding_case == "truncated-gzip-prefix":
             body = gzip.compress(payload)[:10]
             content_encoding = "gzip"
@@ -411,11 +416,11 @@ class TestResponseUsageReporting:
         elif encoding_case == "empty-gzip-member-before-garbage":
             body = gzip.compress(b"") + b"garbage"
             content_encoding = "gzip"
-            expected_error = "expected json value"
+            expected_error = "invalid compressed body"
         elif encoding_case == "empty-deflate-stream-before-garbage":
             body = zlib.compress(b"") + b"garbage"
             content_encoding = "deflate"
-            expected_error = "expected json value"
+            expected_error = "invalid compressed body"
         elif encoding_case == "truncated-brotli-prefix":
             body = body_utils.brotli.compress(payload)[:2]
             content_encoding = "br"
@@ -428,7 +433,7 @@ class TestResponseUsageReporting:
             compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
             body = compressor.compress(payload) + compressor.flush()
             content_encoding = "deflate"
-            expected_error = "expected json value"
+            expected_error = "invalid compressed body"
 
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -274,6 +274,55 @@ class TestResponseUsageReporting:
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == "incomplete json"
 
+    def test_json_fallback_parser_bound_error_logs_proxy_warning(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Bounded parser failures should be observable without logging body content."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        oversized_model = "x" * 1025
+        body = json.dumps(
+            {
+                "id": "msg_1",
+                "model": oversized_model,
+                "usage": {"input_tokens": 50},
+            }
+        ).encode()
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["level"] == "warn"
+        assert entries[0]["message"] == "Model provider JSON usage extraction failed"
+        assert entries[0]["type"] == "usage_event"
+        assert entries[0]["error"] == "string limit exceeded"
+        assert oversized_model not in proxy_log_path.read_text()
+
     def test_openai_json_fallback_parse_error_logs_proxy_warning(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -372,6 +372,7 @@ class TestResponseUsageReporting:
             "chained-gzip",
             "raw-deflate",
             "truncated-gzip-prefix",
+            "empty-gzip-member-before-garbage",
             "truncated-brotli-prefix",
             "truncated-zstd-prefix",
         ],
@@ -406,6 +407,10 @@ class TestResponseUsageReporting:
             body = gzip.compress(payload)[:10]
             content_encoding = "gzip"
             expected_error = "incomplete compressed body"
+        elif encoding_case == "empty-gzip-member-before-garbage":
+            body = gzip.compress(b"") + b"garbage"
+            content_encoding = "gzip"
+            expected_error = "expected json value"
         elif encoding_case == "truncated-brotli-prefix":
             body = body_utils.brotli.compress(payload)[:2]
             content_encoding = "br"
@@ -456,6 +461,58 @@ class TestResponseUsageReporting:
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == expected_error
+
+    def test_json_fallback_concatenated_gzip_member_reports_usage(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Gzip concatenation should not let an empty first member hide usage."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        payload = (
+            b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":50,"output_tokens":200}}'
+        )
+        body = gzip.compress(b"") + gzip.compress(payload)
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map(
+                {
+                    "content-type": "application/json",
+                    "content-encoding": "gzip",
+                }
+            ),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        extracted = flow.metadata["model_provider_usage"]
+        assert extracted["model"] == "claude-sonnet-4-6"
+        assert extracted["tokens.input"] == 50
+        assert extracted["tokens.output"] == 200
+        if proxy_log_path.exists():
+            entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+            assert not any(
+                entry.get("message") == "Model provider JSON usage extraction failed"
+                for entry in entries
+            )
 
     def test_json_fallback_valid_body_without_usage_stays_quiet(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2066,12 +2066,16 @@ class TestResponseUsageReporting:
         """Non-model-provider requests should not trigger usage reporting."""
         flow = real_flow(with_response=False, host="api.github.com")
         log_path = str(tmp_path / "network.jsonl")
+        proxy_log_path = tmp_path / "proxy.jsonl"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.github.com/repos"
         flow.metadata["firewall_name"] = "github"
+        flow.metadata["stream_buffer"] = bytearray(b'{"incomplete":')
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=200, headers=_header_map({"content-type": "application/json"})
         )
@@ -2087,6 +2091,8 @@ class TestResponseUsageReporting:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 0  # urllib external boundary (#9991)
+        assert "model_provider_usage" not in flow.metadata
+        assert not proxy_log_path.exists()
 
     def test_full_path_response_to_opener(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -316,7 +316,7 @@ class TestResponseUsageReporting:
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == "incomplete json"
 
-    @pytest.mark.parametrize("encoding_case", [("chained-gzip",), ("raw-deflate",)])
+    @pytest.mark.parametrize("encoding_case", ["chained-gzip", "raw-deflate"])
     def test_json_fallback_compressed_body_parse_failure_logs_proxy_warning(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import zstandard
 from mitmproxy import http, websocket
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
@@ -366,7 +367,14 @@ class TestResponseUsageReporting:
         assert entries[0]["error"] == "incomplete json"
 
     @pytest.mark.parametrize(
-        "encoding_case", ["chained-gzip", "raw-deflate", "truncated-gzip-prefix"]
+        "encoding_case",
+        [
+            "chained-gzip",
+            "raw-deflate",
+            "truncated-gzip-prefix",
+            "truncated-brotli-prefix",
+            "truncated-zstd-prefix",
+        ],
     )
     @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_compressed_body_parse_failure_logs_proxy_warning(
@@ -397,6 +405,14 @@ class TestResponseUsageReporting:
         elif encoding_case == "truncated-gzip-prefix":
             body = gzip.compress(payload)[:10]
             content_encoding = "gzip"
+            expected_error = "incomplete compressed body"
+        elif encoding_case == "truncated-brotli-prefix":
+            body = body_utils.brotli.compress(payload)[:2]
+            content_encoding = "br"
+            expected_error = "incomplete compressed body"
+        elif encoding_case == "truncated-zstd-prefix":
+            body = zstandard.ZstdCompressor().compress(payload)[:5]
+            content_encoding = "zstd"
             expected_error = "incomplete compressed body"
         else:
             compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
@@ -514,7 +530,9 @@ class TestResponseUsageReporting:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
-    @pytest.mark.parametrize("encoding_case", ["identity", "gzip", "deflate"])
+    @pytest.mark.parametrize(
+        "encoding_case", ["identity", "gzip", "deflate", "br", "zstd", "zstd-no-size"]
+    )
     @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_empty_body_stays_quiet(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case, provider_case
@@ -534,6 +552,12 @@ class TestResponseUsageReporting:
             body = gzip.compress(b"")
         elif encoding_case == "deflate":
             body = zlib.compress(b"")
+        elif encoding_case == "br":
+            body = body_utils.brotli.compress(b"")
+        elif encoding_case == "zstd":
+            body = zstandard.ZstdCompressor().compress(b"")
+        elif encoding_case == "zstd-no-size":
+            body = zstandard.ZstdCompressor(write_content_size=False).compress(b"")
         else:
             body = b""
         response_headers = {
@@ -541,7 +565,9 @@ class TestResponseUsageReporting:
             "content-length": str(len(body)),
         }
         if encoding_case != "identity":
-            response_headers["content-encoding"] = encoding_case
+            response_headers["content-encoding"] = (
+                "zstd" if encoding_case == "zstd-no-size" else encoding_case
+            )
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -496,6 +496,41 @@ class TestResponseUsageReporting:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
+    def test_json_fallback_empty_body_stays_quiet(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Empty model-provider bodies are not JSON parser failures."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray()
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json", "content-length": "0"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        assert not proxy_log_path.exists()
+
     def test_anthropic_json_fallback_metadata_only_usage_stays_quiet(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -496,12 +496,20 @@ class TestResponseUsageReporting:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
+    @pytest.mark.parametrize("encoding_case", ["identity", "gzip"])
     def test_json_fallback_empty_body_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
     ):
         """Empty model-provider bodies are not JSON parser failures."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         proxy_log_path = tmp_path / "proxy.jsonl"
+        body = gzip.compress(b"") if encoding_case == "gzip" else b""
+        response_headers = {
+            "content-type": "application/json",
+            "content-length": str(len(body)),
+        }
+        if encoding_case == "gzip":
+            response_headers["content-encoding"] = "gzip"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
@@ -511,12 +519,9 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["stream_buffer"] = bytearray()
+        flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"truncated": False}
-        flow.response = tutils.tresp(
-            status_code=200,
-            headers=_header_map({"content-type": "application/json", "content-length": "0"}),
-        )
+        flow.response = tutils.tresp(status_code=200, headers=_header_map(response_headers))
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -410,6 +410,43 @@ class TestResponseUsageReporting:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
+    def test_openai_json_fallback_valid_body_without_usage_stays_quiet(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """OpenAI fallback should also keep valid no-usage JSON quiet."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = b'{"id":"resp_1","model":"gpt-5.5"}'
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        assert not proxy_log_path.exists()
+
     def test_codex_oauth_non_streaming_json_fallback(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -230,6 +230,125 @@ class TestResponseUsageReporting:
             "tokens.cache_read": 10,
         }
 
+    def test_anthropic_json_fallback_parse_error_logs_proxy_warning(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Legacy JSON fallback parse failures should be observable."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = b'{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":50'
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["level"] == "warn"
+        assert entries[0]["message"] == "Model provider JSON usage extraction failed"
+        assert entries[0]["type"] == "usage_event"
+        assert entries[0]["error"] == "incomplete json"
+
+    def test_openai_json_fallback_parse_error_logs_proxy_warning(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """OpenAI fallback parse failures should use the same proxy warning."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50'
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["level"] == "warn"
+        assert entries[0]["message"] == "Model provider JSON usage extraction failed"
+        assert entries[0]["type"] == "usage_event"
+        assert entries[0]["error"] == "incomplete json"
+
+    def test_json_fallback_valid_body_without_usage_stays_quiet(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Valid JSON without usage is not a parser failure."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = b'{"id":"msg_1"}'
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        assert not proxy_log_path.exists()
+
     def test_codex_oauth_non_streaming_json_fallback(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -1572,6 +1572,8 @@ class TestResponseUsageReporting:
             "model": "gpt-5.5",
             "tokens.output": 20,
         }
+        flow.metadata["stream_buffer"] = bytearray(b'{"id":"resp_1","usage":{"input_tokens":')
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),
@@ -1590,6 +1592,13 @@ class TestResponseUsageReporting:
 
         events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert [event["category"] for event in events] == ["tokens.output"]
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        if proxy_log.exists():
+            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+            assert not any(
+                entry.get("message") == "Model provider JSON usage extraction failed"
+                for entry in entries
+            )
 
     def test_empty_model_usage_does_not_block_later_error_usage(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -3,10 +3,12 @@
 import gzip
 import json
 import time
+import zlib
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from mitmproxy import http, websocket
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
@@ -314,16 +316,25 @@ class TestResponseUsageReporting:
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == "incomplete json"
 
-    def test_json_fallback_chained_content_encoding_logs_proxy_warning(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    @pytest.mark.parametrize("encoding_case", [("chained-gzip",), ("raw-deflate",)])
+    def test_json_fallback_compressed_body_parse_failure_logs_proxy_warning(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case
     ):
-        """Unsupported one-shot encoding leaves compressed bytes, then logs parse failure."""
+        """One-shot decompression failures leave compressed bytes and log parse failure."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         proxy_log_path = tmp_path / "proxy.jsonl"
-        body = gzip.compress(
+        payload = (
             b'{"id":"msg_1","model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":50,"output_tokens":200}}'
         )
+        if encoding_case == "chained-gzip":
+            body = gzip.compress(payload)
+            content_encoding = "gzip, identity"
+        else:
+            compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+            body = compressor.compress(payload) + compressor.flush()
+            content_encoding = "deflate"
+
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
@@ -340,7 +351,7 @@ class TestResponseUsageReporting:
             headers=_header_map(
                 {
                     "content-type": "application/json",
-                    "content-encoding": "gzip, identity",
+                    "content-encoding": content_encoding,
                 }
             ),
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -560,6 +560,104 @@ class TestResponseUsageReporting:
                 for entry in entries
             )
 
+    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
+    @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
+    def test_json_fallback_brotli_and_zstd_report_usage(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fresh_usage_executor,
+        encoding_case,
+        provider_case,
+    ):
+        """Diagnostic fallback should handle complete br/zstd JSON bodies."""
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        if provider_case == "openai":
+            flow = real_flow(with_response=False, host="api.openai.com")
+            flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+            flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+            flow.metadata["cli_agent_type"] = "codex"
+            payload = json.dumps(
+                {
+                    "id": "resp_1",
+                    "model": "gpt-5.5",
+                    "usage": {
+                        "input_tokens": 50,
+                        "output_tokens": 200,
+                        "input_tokens_details": {"cached_tokens": 10},
+                    },
+                }
+            ).encode()
+        else:
+            flow = real_flow(with_response=False, host="api.anthropic.com")
+            flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            payload = json.dumps(
+                {
+                    "id": "msg_1",
+                    "model": "claude-sonnet-4-6",
+                    "usage": {"input_tokens": 50, "output_tokens": 200},
+                }
+            ).encode()
+
+        if encoding_case == "br":
+            body = body_utils.brotli.compress(payload)
+        else:
+            body = zstandard.ZstdCompressor().compress(payload)
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map(
+                {
+                    "content-type": "application/json",
+                    "content-encoding": encoding_case,
+                }
+            ),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        extracted = flow.metadata["model_provider_usage"]
+        assert extracted["model"] == (
+            "gpt-5.5" if provider_case == "openai" else "claude-sonnet-4-6"
+        )
+        assert extracted["tokens.input"] == (40 if provider_case == "openai" else 50)
+        assert extracted["tokens.output"] == 200
+        if provider_case == "openai":
+            assert extracted["tokens.cache_read"] == 10
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        expected = {
+            "tokens.input": 40 if provider_case == "openai" else 50,
+            "tokens.output": 200,
+        }
+        if provider_case == "openai":
+            expected["tokens.cache_read"] = 10
+        assert by_category == expected
+        if proxy_log_path.exists():
+            entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+            assert not any(
+                entry.get("message") == "Model provider JSON usage extraction failed"
+                for entry in entries
+            )
+
     def test_json_fallback_valid_body_without_usage_stays_quiet(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -447,6 +447,45 @@ class TestResponseUsageReporting:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
+    def test_anthropic_json_fallback_metadata_only_usage_stays_quiet(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Anthropic metadata without positive token usage is not a parser failure."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = b'{"id":"msg_1","model":"claude-sonnet-4-6"}'
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "msg_1",
+            "model": "claude-sonnet-4-6",
+        }
+        assert not proxy_log_path.exists()
+
     def test_codex_oauth_non_streaming_json_fallback(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -694,6 +694,42 @@ class TestResponseUsageReporting:
         mock_opener.open.assert_not_called()
         assert "model_provider_usage" not in flow.metadata
 
+    def test_non_billable_json_fallback_parse_error_stays_quiet(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Non-billable model-provider fallback must not emit usage warnings."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        body = b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50'
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = False
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        assert not proxy_log_path.exists()
+
     def test_full_pipeline_model_sse_finalizes_trailing_event(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):


### PR DESCRIPTION
## Summary

- Add error-returning one-shot JSON usage helpers for Anthropic Messages and OpenAI Responses.
- Keep the existing best-effort `dict | None` helpers as compatibility wrappers.
- Log fallback parser failures from `mitm_addon.response()` using the existing model-provider JSON usage warning shape.
- Cover Anthropic/OpenAI fallback parse failures and valid no-usage JSON quiet behavior.

## Testing

- `pytest tests/test_usage_reporting.py`
- `pytest tests/test_body_capture.py`
- `ruff check src tests`
- `basedpyright src tests`
- `ruff format --check src tests`
- `pytest tests/`
- `git diff --check`

Fixes #14700
