### PR TITLE
chore: include web routes in knip production entries

### DIFF
--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -5,7 +5,7 @@
       "entry": [
         "app/**/page.{ts,tsx}",
         "app/**/layout.{ts,tsx}",
-        "app/api/**/route.{ts,tsx}",
+        "app/**/route.{ts,tsx}!",
         "proxy.{ts,tsx}",
         "proxy.cors.ts",
         "i18n.ts",
@@ -16,7 +16,14 @@
         "src/__tests__/api-test-helpers/index.ts",
         "src/__tests__/webhook-simulators/index.ts"
       ],
-      "project": ["**/*.{ts,tsx}", "scripts/**/*.ts"],
+      "project": [
+        "**/*.{ts,tsx}!",
+        "!**/__tests__/**!",
+        "!**/*.{test,spec}.{ts,tsx}!",
+        "!src/lib/test-endpoints/**!",
+        "!src/mocks/**!",
+        "scripts/**/*.ts"
+      ],
       "ignoreDependencies": [
         "@vm0/ui",
         "e2b",


### PR DESCRIPTION
## Summary
- include every `apps/web/app/**/route.{ts,tsx}` file as a production Knip entry
- mark the web project source glob as production-visible so route import graphs are analyzed
- exclude test, mock, and test-endpoint trees from the production project pass

Closes #14742

## Validation
- `pnpm format`
- `pnpm knip --workspace web`
- `pnpm exec knip --workspace web --production --reporter json --no-exit-code`
  - confirmed `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner` are no longer reported as unused
  - remaining dependency signals are real #14401 cleanup candidates: `@aws-sdk/client-kms`, `@axiomhq/js`, `@axiomhq/logging`, `@clerk/backend`, `@slack/web-api`, `@vm0/api-services`, `@vm0/connectors`, `ably`, `server-only`
- `pnpm turbo run lint --filter=web`