### PR TITLE
refactor(mitm-addon): centralize authority validation error context

### DIFF
--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -147,7 +147,6 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
 
     raw_sni = getattr(flow.client_conn, "sni", None)
     sni = raw_sni.strip() if isinstance(raw_sni, str) else None
-    raw_fallback_url = _build_url(scheme, request_host, port, path)
 
     def _authority_validation_error(
         reason: AuthorityValidationReason,
@@ -169,7 +168,7 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         raise _authority_validation_error(
             "missing_sni",
             message="Request blocked: HTTPS request is missing TLS SNI",
-            fallback_url=raw_fallback_url,
+            fallback_url=_build_url(scheme, request_host, port, path),
         )
 
     try:
@@ -178,7 +177,7 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         raise _authority_validation_error(
             "invalid_sni",
             message="Request blocked: HTTPS request has invalid TLS SNI",
-            fallback_url=raw_fallback_url,
+            fallback_url=_build_url(scheme, request_host, port, path),
         ) from None
 
     trusted_url = _build_url(scheme, normalized_sni, port, path)

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -147,39 +147,45 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
 
     raw_sni = getattr(flow.client_conn, "sni", None)
     sni = raw_sni.strip() if isinstance(raw_sni, str) else None
-    if not sni:
-        raise AuthorityValidationError(
-            "missing_sni",
-            message="Request blocked: HTTPS request is missing TLS SNI",
+    raw_fallback_url = _build_url(scheme, request_host, port, path)
+
+    def _authority_validation_error(
+        reason: AuthorityValidationReason,
+        *,
+        message: str,
+        fallback_url: str,
+    ) -> AuthorityValidationError:
+        return AuthorityValidationError(
+            reason,
+            message=message,
             sni=sni,
             request_host=request_host,
             host_header=host_header,
             request_port=port,
-            fallback_url=_build_url(scheme, request_host, port, path),
+            fallback_url=fallback_url,
+        )
+
+    if not sni:
+        raise _authority_validation_error(
+            "missing_sni",
+            message="Request blocked: HTTPS request is missing TLS SNI",
+            fallback_url=raw_fallback_url,
         )
 
     try:
         normalized_sni = _normalize_hostname(sni)
     except (UnicodeError, ValueError):
-        raise AuthorityValidationError(
+        raise _authority_validation_error(
             "invalid_sni",
             message="Request blocked: HTTPS request has invalid TLS SNI",
-            sni=sni,
-            request_host=request_host,
-            host_header=host_header,
-            request_port=port,
-            fallback_url=_build_url(scheme, request_host, port, path),
+            fallback_url=raw_fallback_url,
         ) from None
 
     trusted_url = _build_url(scheme, normalized_sni, port, path)
     if not host_header:
-        raise AuthorityValidationError(
+        raise _authority_validation_error(
             "missing_authority",
             message="Request blocked: HTTPS request is missing Host authority",
-            sni=sni,
-            request_host=request_host,
-            host_header=host_header,
-            request_port=port,
             fallback_url=trusted_url,
         )
 
@@ -187,35 +193,23 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         header_host, header_port = _parse_host_authority(host_header)
         normalized_header_host = _normalize_hostname(header_host)
     except (UnicodeError, ValueError):
-        raise AuthorityValidationError(
+        raise _authority_validation_error(
             "invalid_authority",
             message="Request blocked: HTTPS request has invalid Host authority",
-            sni=sni,
-            request_host=request_host,
-            host_header=host_header,
-            request_port=port,
             fallback_url=trusted_url,
         ) from None
 
     if normalized_header_host != normalized_sni:
-        raise AuthorityValidationError(
+        raise _authority_validation_error(
             "authority_mismatch",
             message="Request blocked: Host authority does not match TLS SNI",
-            sni=sni,
-            request_host=request_host,
-            host_header=host_header,
-            request_port=port,
             fallback_url=trusted_url,
         )
 
     if header_port is not None and header_port != port:
-        raise AuthorityValidationError(
+        raise _authority_validation_error(
             "authority_port_mismatch",
             message="Request blocked: Host authority port does not match destination port",
-            sni=sni,
-            request_host=request_host,
-            host_header=host_header,
-            request_port=port,
             fallback_url=trusted_url,
         )
 

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -367,10 +367,29 @@ class TestRequestHandler:
         auth_fetch.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("sni", "host_header"),
+        ("base", "sni", "host_header", "expected_firewall_base", "expected_original_url"),
         [
-            ("api.github.com", "API.GITHUB.COM"),
-            ("API.GITHUB.COM.", "api.github.com."),
+            (
+                "https://api.github.com",
+                "api.github.com",
+                "API.GITHUB.COM",
+                "https://api.github.com",
+                "https://api.github.com/repos",
+            ),
+            (
+                "https://api.github.com",
+                "API.GITHUB.COM.",
+                "api.github.com.",
+                "https://api.github.com",
+                "https://api.github.com/repos",
+            ),
+            (
+                "https://xn--bcher-kva.example",
+                "bücher.example",
+                "xn--bcher-kva.example",
+                "https://xn--bcher-kva.example",
+                "https://xn--bcher-kva.example/repos",
+            ),
         ],
     )
     async def test_accepts_authority_host_normalization_equivalence(
@@ -380,10 +399,13 @@ class TestRequestHandler:
         mitm_ctx,
         fake_firewall_headers,
         headers,
+        base,
         sni,
         host_header,
+        expected_firewall_base,
+        expected_original_url,
     ):
-        reg_path = _write_github_firewall_registry(tmp_path)
+        reg_path = _write_github_firewall_registry(tmp_path, base=base)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -400,7 +422,8 @@ class TestRequestHandler:
             await mitm_addon.request(flow)
 
         assert flow.response is None
-        assert flow.metadata["firewall_base"] == "https://api.github.com"
+        assert flow.metadata["firewall_base"] == expected_firewall_base
+        assert flow.metadata["original_url"] == expected_original_url
         assert flow.request.headers["Authorization"] == "Bearer x"
 
     @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -244,6 +244,32 @@ class TestRequestHandler:
         assert flow.request.headers["Authorization"] == "Bearer x"
         assert flow.metadata["original_url"] == "https://api.github.com/repos"
 
+    async def test_http2_authority_without_host_allows_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(),
+        )
+        flow.request.http_version = "HTTP/2.0"
+        flow.request.authority = "api.github.com"
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "https://api.github.com"
+        assert flow.metadata["original_url"] == "https://api.github.com/repos"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+
     async def test_rejects_spoofed_host_before_vm0_api_auto_allow(
         self, registry_file, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -453,14 +453,29 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == expected_original_url
         auth_fetch.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("request_port", "expected_original_url"),
+        [
+            (443, "https://203.0.113.10/repos"),
+            (8443, "https://203.0.113.10:8443/repos"),
+        ],
+    )
     async def test_rejects_invalid_https_sni_before_firewall_auth(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        request_port,
+        expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
             host="203.0.113.10",
+            port=request_port,
             sni="...",
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
@@ -479,17 +494,17 @@ class TestRequestHandler:
         assert body["sni"] == "..."
         assert body["request_host"] == "203.0.113.10"
         assert body["host_header"] == "api.github.com"
-        assert body["request_port"] == 443
+        assert body["request_port"] == request_port
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == "invalid_sni"
-        assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
+        assert flow.metadata["original_url"] == expected_original_url
         proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
         assert proxy_log_entry["type"] == "authority_validation"
         assert proxy_log_entry["reason"] == "invalid_sni"
         assert proxy_log_entry["sni"] == "..."
         assert proxy_log_entry["request_host"] == "203.0.113.10"
         assert proxy_log_entry["host_header"] == "api.github.com"
-        assert proxy_log_entry["request_port"] == 443
+        assert proxy_log_entry["request_port"] == request_port
         auth_fetch.assert_not_called()
         assert "Authorization" not in flow.request.headers
 

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -322,6 +322,34 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://api.github.com:8443/repos"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    async def test_accepts_matching_ipv6_host_authority(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(
+            tmp_path,
+            base="https://[2001:db8::1]:8443",
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="2001:db8::1",
+            port=8443,
+            sni="2001:db8::1",
+            path="/repos",
+            request_headers=headers(("Host", "[2001:db8::1]:8443")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_base"] == "https://[2001:db8::1]:8443"
+        assert flow.metadata["original_url"] == "https://[2001:db8::1]:8443/repos"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+
     @pytest.mark.parametrize(
         ("request_port", "host_header", "expected_original_url"),
         [

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -385,6 +385,7 @@ class TestRequestHandler:
     @pytest.mark.parametrize(
         ("request_port", "host_header", "expected_error", "expected_original_url"),
         [
+            (443, None, "missing_authority", "https://api.github.com/repos"),
             (443, "", "missing_authority", "https://api.github.com/repos"),
             (8443, "", "missing_authority", "https://api.github.com:8443/repos"),
             (443, "api.github.com:bad", "invalid_authority", "https://api.github.com/repos"),
@@ -409,6 +410,7 @@ class TestRequestHandler:
         expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
+        request_headers = headers() if host_header is None else headers(("Host", host_header))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -416,7 +418,7 @@ class TestRequestHandler:
             port=request_port,
             sni="api.github.com",
             path="/repos",
-            request_headers=headers(("Host", host_header)),
+            request_headers=request_headers,
         )
 
         with (
@@ -429,6 +431,10 @@ class TestRequestHandler:
         assert flow.response.status_code == 403
         body = json.loads(flow.response.content)
         assert body["error"] == expected_error
+        assert body["sni"] == "api.github.com"
+        assert body["request_host"] == "203.0.113.10"
+        assert body["host_header"] == host_header
+        assert body["request_port"] == request_port
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == expected_error
         assert flow.metadata["original_url"] == expected_original_url

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -300,17 +300,33 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://api.github.com:8443/repos"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    @pytest.mark.parametrize(
+        ("request_port", "host_header", "expected_original_url"),
+        [
+            (443, "api.github.com:444", "https://api.github.com/repos"),
+            (8443, "api.github.com:443", "https://api.github.com:8443/repos"),
+        ],
+    )
     async def test_rejects_host_authority_port_mismatch(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        request_port,
+        host_header,
+        expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
             host="203.0.113.10",
+            port=request_port,
             sni="api.github.com",
             path="/repos",
-            request_headers=headers(("Host", "api.github.com:444")),
+            request_headers=headers(("Host", host_header)),
         )
 
         with (
@@ -325,7 +341,7 @@ class TestRequestHandler:
         assert body["error"] == "authority_port_mismatch"
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == "authority_port_mismatch"
-        assert flow.metadata["original_url"] == "https://api.github.com/repos"
+        assert flow.metadata["original_url"] == expected_original_url
         auth_fetch.assert_not_called()
 
     async def test_accepts_authority_host_case_differences(

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -198,6 +198,8 @@ class TestRequestHandler:
         body = json.loads(flow.response.content)
         assert body["error"] == "authority_mismatch"
         assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "authority_mismatch"
+        assert flow.metadata["original_url"] == "https://attacker.example.com/repos"
         auth_fetch.assert_not_called()
         assert "Authorization" not in flow.request.headers
 
@@ -322,6 +324,8 @@ class TestRequestHandler:
         body = json.loads(flow.response.content)
         assert body["error"] == "authority_port_mismatch"
         assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "authority_port_mismatch"
+        assert flow.metadata["original_url"] == "https://api.github.com/repos"
         auth_fetch.assert_not_called()
 
     async def test_accepts_authority_host_case_differences(
@@ -385,6 +389,8 @@ class TestRequestHandler:
         body = json.loads(flow.response.content)
         assert body["error"] == expected_error
         assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == expected_error
+        assert flow.metadata["original_url"] == "https://api.github.com/repos"
         auth_fetch.assert_not_called()
 
     async def test_rejects_missing_https_sni_before_firewall_auth(
@@ -410,7 +416,10 @@ class TestRequestHandler:
         assert flow.response.status_code == 403
         body = json.loads(flow.response.content)
         assert body["error"] == "missing_sni"
+        assert body["sni"] is None
         assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "missing_sni"
+        assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
         auth_fetch.assert_not_called()
 
     async def test_rejects_invalid_https_sni_before_firewall_auth(

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -539,10 +539,11 @@ class TestRequestHandler:
         auth_fetch.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("request_port", "expected_original_url"),
+        ("request_port", "raw_sni", "expected_sni", "expected_original_url"),
         [
-            (443, "https://203.0.113.10/repos"),
-            (8443, "https://203.0.113.10:8443/repos"),
+            (443, "...", "...", "https://203.0.113.10/repos"),
+            (8443, "...", "...", "https://203.0.113.10:8443/repos"),
+            (443, "\ud800", "\ud800", "https://203.0.113.10/repos"),
         ],
     )
     async def test_rejects_invalid_https_sni_before_firewall_auth(
@@ -553,6 +554,8 @@ class TestRequestHandler:
         fake_firewall_headers,
         headers,
         request_port,
+        raw_sni,
+        expected_sni,
         expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
@@ -561,7 +564,7 @@ class TestRequestHandler:
             client_ip="10.200.0.5",
             host="203.0.113.10",
             port=request_port,
-            sni="...",
+            sni=raw_sni,
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
         )
@@ -576,7 +579,7 @@ class TestRequestHandler:
         assert flow.response.status_code == 403
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_sni"
-        assert body["sni"] == "..."
+        assert body["sni"] == expected_sni
         assert body["request_host"] == "203.0.113.10"
         assert body["host_header"] == "api.github.com"
         assert body["request_port"] == request_port
@@ -586,7 +589,7 @@ class TestRequestHandler:
         proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
         assert proxy_log_entry["type"] == "authority_validation"
         assert proxy_log_entry["reason"] == "invalid_sni"
-        assert proxy_log_entry["sni"] == "..."
+        assert proxy_log_entry["sni"] == expected_sni
         assert proxy_log_entry["request_host"] == "203.0.113.10"
         assert proxy_log_entry["host_header"] == "api.github.com"
         assert proxy_log_entry["request_port"] == request_port

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -448,10 +448,11 @@ class TestRequestHandler:
         auth_fetch.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("request_port", "expected_original_url"),
+        ("request_port", "raw_sni", "expected_sni", "expected_original_url"),
         [
-            (443, "https://203.0.113.10/repos"),
-            (8443, "https://203.0.113.10:8443/repos"),
+            (443, None, None, "https://203.0.113.10/repos"),
+            (443, "   ", "", "https://203.0.113.10/repos"),
+            (8443, None, None, "https://203.0.113.10:8443/repos"),
         ],
     )
     async def test_rejects_missing_https_sni_before_firewall_auth(
@@ -462,6 +463,8 @@ class TestRequestHandler:
         fake_firewall_headers,
         headers,
         request_port,
+        raw_sni,
+        expected_sni,
         expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
@@ -473,7 +476,7 @@ class TestRequestHandler:
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
         )
-        flow.client_conn.sni = None
+        flow.client_conn.sni = raw_sni
 
         with (
             mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -485,7 +488,7 @@ class TestRequestHandler:
         assert flow.response.status_code == 403
         body = json.loads(flow.response.content)
         assert body["error"] == "missing_sni"
-        assert body["sni"] is None
+        assert body["sni"] == expected_sni
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == "missing_sni"
         assert flow.metadata["original_url"] == expected_original_url

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -325,6 +325,40 @@ class TestRequestHandler:
         assert body["error"] == "authority_mismatch"
         assert flow.metadata["firewall_action"] == "DENY"
 
+    async def test_rejects_duplicate_host_authority_before_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(
+                ("Host", "api.github.com"),
+                ("Host", "attacker.example.com"),
+            ),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "invalid_authority"
+        assert body["sni"] == "api.github.com"
+        assert body["host_header"] == "api.github.com, attacker.example.com"
+        assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "invalid_authority"
+        assert flow.metadata["original_url"] == "https://api.github.com/repos"
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+
     async def test_accepts_equivalent_host_authority_default_https_port(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -436,7 +436,12 @@ class TestRequestHandler:
         assert flow.response.status_code == 403
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_sni"
+        assert body["sni"] == "..."
+        assert body["request_host"] == "203.0.113.10"
+        assert body["host_header"] == "api.github.com"
+        assert body["request_port"] == 443
         assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "invalid_sni"
         assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
         auth_fetch.assert_not_called()
         assert "Authorization" not in flow.request.headers

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -322,8 +322,9 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://api.github.com:8443/repos"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    @pytest.mark.parametrize("host_header", ["[2001:db8::1]", "[2001:db8::1]:8443"])
     async def test_accepts_matching_ipv6_host_authority(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, host_header
     ):
         reg_path = _write_github_firewall_registry(
             tmp_path,
@@ -336,7 +337,7 @@ class TestRequestHandler:
             port=8443,
             sni="2001:db8::1",
             path="/repos",
-            request_headers=headers(("Host", "[2001:db8::1]:8443")),
+            request_headers=headers(("Host", host_header)),
         )
 
         with (

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -390,6 +390,13 @@ class TestRequestHandler:
                 "https://xn--bcher-kva.example",
                 "https://xn--bcher-kva.example/repos",
             ),
+            (
+                "https://xn--bcher-kva.example",
+                "xn--bcher-kva.example",
+                "bücher.example",
+                "https://xn--bcher-kva.example",
+                "https://xn--bcher-kva.example/repos",
+            ),
         ],
     )
     async def test_accepts_authority_host_normalization_equivalence(

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -483,6 +483,13 @@ class TestRequestHandler:
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == "invalid_sni"
         assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
+        proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        assert proxy_log_entry["type"] == "authority_validation"
+        assert proxy_log_entry["reason"] == "invalid_sni"
+        assert proxy_log_entry["sni"] == "..."
+        assert proxy_log_entry["request_host"] == "203.0.113.10"
+        assert proxy_log_entry["host_header"] == "api.github.com"
+        assert proxy_log_entry["request_port"] == 443
         auth_fetch.assert_not_called()
         assert "Authorization" not in flow.request.headers
 

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -270,6 +270,39 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://api.github.com/repos"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    async def test_http2_authority_takes_precedence_over_host_header(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+        flow.request.http_version = "HTTP/2.0"
+        flow.request.authority = "attacker.example.com"
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "authority_mismatch"
+        assert body["sni"] == "api.github.com"
+        assert body["host_header"] == "attacker.example.com"
+        assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "authority_mismatch"
+        assert flow.metadata["original_url"] == "https://api.github.com/repos"
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+
     async def test_rejects_spoofed_host_before_vm0_api_auto_allow(
         self, registry_file, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -368,10 +368,17 @@ class TestRequestHandler:
         assert flow.request.headers["Authorization"] == "Bearer x"
 
     @pytest.mark.parametrize(
-        ("host_header", "expected_error"),
+        ("request_port", "host_header", "expected_error", "expected_original_url"),
         [
-            ("", "missing_authority"),
-            ("api.github.com:bad", "invalid_authority"),
+            (443, "", "missing_authority", "https://api.github.com/repos"),
+            (8443, "", "missing_authority", "https://api.github.com:8443/repos"),
+            (443, "api.github.com:bad", "invalid_authority", "https://api.github.com/repos"),
+            (
+                8443,
+                "api.github.com:bad",
+                "invalid_authority",
+                "https://api.github.com:8443/repos",
+            ),
         ],
     )
     async def test_rejects_invalid_host_authority_before_firewall_auth(
@@ -381,14 +388,17 @@ class TestRequestHandler:
         mitm_ctx,
         fake_firewall_headers,
         headers,
+        request_port,
         host_header,
         expected_error,
+        expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
             host="203.0.113.10",
+            port=request_port,
             sni="api.github.com",
             path="/repos",
             request_headers=headers(("Host", host_header)),
@@ -406,7 +416,7 @@ class TestRequestHandler:
         assert body["error"] == expected_error
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == expected_error
-        assert flow.metadata["original_url"] == "https://api.github.com/repos"
+        assert flow.metadata["original_url"] == expected_original_url
         auth_fetch.assert_not_called()
 
     @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -287,8 +287,15 @@ class TestRequestHandler:
         assert flow.metadata["firewall_base"] == "https://api.github.com"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    @pytest.mark.parametrize("host_header", ["api.github.com", "api.github.com:8443"])
     async def test_accepts_matching_non_default_host_authority_port(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        host_header,
     ):
         reg_path = _write_github_firewall_registry(
             tmp_path,
@@ -301,7 +308,7 @@ class TestRequestHandler:
             port=8443,
             sni="api.github.com",
             path="/repos",
-            request_headers=headers(("Host", "api.github.com:8443")),
+            request_headers=headers(("Host", host_header)),
         )
 
         with (

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -244,8 +244,9 @@ class TestRequestHandler:
         assert flow.request.headers["Authorization"] == "Bearer x"
         assert flow.metadata["original_url"] == "https://api.github.com/repos"
 
-    async def test_http2_authority_without_host_allows_firewall_auth(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    @pytest.mark.parametrize("http_version", ["HTTP/2.0", "HTTP/3"])
+    async def test_pseudo_authority_without_host_allows_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, http_version
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
@@ -256,7 +257,7 @@ class TestRequestHandler:
             path="/repos",
             request_headers=headers(),
         )
-        flow.request.http_version = "HTTP/2.0"
+        flow.request.http_version = http_version
         flow.request.authority = "api.github.com"
 
         with (
@@ -270,8 +271,9 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://api.github.com/repos"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
-    async def test_http2_authority_takes_precedence_over_host_header(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    @pytest.mark.parametrize("http_version", ["HTTP/2.0", "HTTP/3"])
+    async def test_pseudo_authority_takes_precedence_over_host_header(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, http_version
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
@@ -282,7 +284,7 @@ class TestRequestHandler:
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
         )
-        flow.request.http_version = "HTTP/2.0"
+        flow.request.http_version = http_version
         flow.request.authority = "attacker.example.com"
 
         with (

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -492,11 +492,12 @@ class TestRequestHandler:
         auth_fetch.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("request_port", "raw_sni", "expected_sni", "expected_original_url"),
+        ("request_host", "request_port", "raw_sni", "expected_sni", "expected_original_url"),
         [
-            (443, None, None, "https://203.0.113.10/repos"),
-            (443, "   ", "", "https://203.0.113.10/repos"),
-            (8443, None, None, "https://203.0.113.10:8443/repos"),
+            ("203.0.113.10", 443, None, None, "https://203.0.113.10/repos"),
+            ("203.0.113.10", 443, "   ", "", "https://203.0.113.10/repos"),
+            ("203.0.113.10", 8443, None, None, "https://203.0.113.10:8443/repos"),
+            ("2001:db8::1", 8443, None, None, "https://[2001:db8::1]:8443/repos"),
         ],
     )
     async def test_rejects_missing_https_sni_before_firewall_auth(
@@ -506,6 +507,7 @@ class TestRequestHandler:
         mitm_ctx,
         fake_firewall_headers,
         headers,
+        request_host,
         request_port,
         raw_sni,
         expected_sni,
@@ -515,7 +517,7 @@ class TestRequestHandler:
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
-            host="203.0.113.10",
+            host=request_host,
             port=request_port,
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -541,11 +541,12 @@ class TestRequestHandler:
         auth_fetch.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("request_port", "raw_sni", "expected_sni", "expected_original_url"),
+        ("request_host", "request_port", "raw_sni", "expected_sni", "expected_original_url"),
         [
-            (443, "...", "...", "https://203.0.113.10/repos"),
-            (8443, "...", "...", "https://203.0.113.10:8443/repos"),
-            (443, "\ud800", "\ud800", "https://203.0.113.10/repos"),
+            ("203.0.113.10", 443, "...", "...", "https://203.0.113.10/repos"),
+            ("203.0.113.10", 8443, "...", "...", "https://203.0.113.10:8443/repos"),
+            ("203.0.113.10", 443, "\ud800", "\ud800", "https://203.0.113.10/repos"),
+            ("2001:db8::1", 8443, "...", "...", "https://[2001:db8::1]:8443/repos"),
         ],
     )
     async def test_rejects_invalid_https_sni_before_firewall_auth(
@@ -555,6 +556,7 @@ class TestRequestHandler:
         mitm_ctx,
         fake_firewall_headers,
         headers,
+        request_host,
         request_port,
         raw_sni,
         expected_sni,
@@ -564,7 +566,7 @@ class TestRequestHandler:
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
-            host="203.0.113.10",
+            host=request_host,
             port=request_port,
             sni=raw_sni,
             path="/repos",
@@ -582,7 +584,7 @@ class TestRequestHandler:
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_sni"
         assert body["sni"] == expected_sni
-        assert body["request_host"] == "203.0.113.10"
+        assert body["request_host"] == request_host
         assert body["host_header"] == "api.github.com"
         assert body["request_port"] == request_port
         assert flow.metadata["firewall_action"] == "DENY"
@@ -592,7 +594,7 @@ class TestRequestHandler:
         assert proxy_log_entry["type"] == "authority_validation"
         assert proxy_log_entry["reason"] == "invalid_sni"
         assert proxy_log_entry["sni"] == expected_sni
-        assert proxy_log_entry["request_host"] == "203.0.113.10"
+        assert proxy_log_entry["request_host"] == request_host
         assert proxy_log_entry["host_header"] == "api.github.com"
         assert proxy_log_entry["request_port"] == request_port
         auth_fetch.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -437,6 +437,7 @@ class TestRequestHandler:
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_sni"
         assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
         auth_fetch.assert_not_called()
         assert "Authorization" not in flow.request.headers
 

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -350,6 +350,43 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://[2001:db8::1]:8443/repos"
         assert flow.request.headers["Authorization"] == "Bearer x"
 
+    async def test_rejects_unbracketed_ipv6_host_authority(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(
+            tmp_path,
+            base="https://[2001:db8::1]:8443",
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="2001:db8::1",
+            port=8443,
+            sni="2001:db8::1",
+            path="/repos",
+            request_headers=headers(("Host", "2001:db8::1")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "invalid_authority"
+        assert body["sni"] == "2001:db8::1"
+        assert body["request_host"] == "2001:db8::1"
+        assert body["host_header"] == "2001:db8::1"
+        assert body["request_port"] == 8443
+        assert flow.metadata["firewall_action"] == "DENY"
+        assert flow.metadata["firewall_error"] == "invalid_authority"
+        assert flow.metadata["original_url"] == "https://[2001:db8::1]:8443/repos"
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+
     @pytest.mark.parametrize(
         ("request_port", "host_header", "expected_original_url"),
         [

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -366,17 +366,31 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == expected_original_url
         auth_fetch.assert_not_called()
 
-    async def test_accepts_authority_host_case_differences(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    @pytest.mark.parametrize(
+        ("sni", "host_header"),
+        [
+            ("api.github.com", "API.GITHUB.COM"),
+            ("API.GITHUB.COM.", "api.github.com."),
+        ],
+    )
+    async def test_accepts_authority_host_normalization_equivalence(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        sni,
+        host_header,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
             host="203.0.113.10",
-            sni="api.github.com",
+            sni=sni,
             path="/repos",
-            request_headers=headers(("Host", "API.GITHUB.COM")),
+            request_headers=headers(("Host", host_header)),
         )
 
         with (

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -413,6 +413,33 @@ class TestRequestHandler:
         assert flow.metadata["firewall_action"] == "DENY"
         auth_fetch.assert_not_called()
 
+    async def test_rejects_invalid_https_sni_before_firewall_auth(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_github_firewall_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="...",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers() as auth_fetch,
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["error"] == "invalid_sni"
+        assert flow.metadata["firewall_action"] == "DENY"
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+
     async def test_http_host_spoof_does_not_match_domain_firewall(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -409,14 +409,29 @@ class TestRequestHandler:
         assert flow.metadata["original_url"] == "https://api.github.com/repos"
         auth_fetch.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("request_port", "expected_original_url"),
+        [
+            (443, "https://203.0.113.10/repos"),
+            (8443, "https://203.0.113.10:8443/repos"),
+        ],
+    )
     async def test_rejects_missing_https_sni_before_firewall_auth(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        request_port,
+        expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
             host="203.0.113.10",
+            port=request_port,
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
         )
@@ -435,7 +450,7 @@ class TestRequestHandler:
         assert body["sni"] is None
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == "missing_sni"
-        assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
+        assert flow.metadata["original_url"] == expected_original_url
         auth_fetch.assert_not_called()
 
     async def test_rejects_invalid_https_sni_before_firewall_auth(

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -174,14 +174,29 @@ class TestRequestHandler:
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata.get("original_url") == "https://api.anthropic.com/v1/messages"
 
+    @pytest.mark.parametrize(
+        ("request_port", "expected_original_url"),
+        [
+            (443, "https://attacker.example.com/repos"),
+            (8443, "https://attacker.example.com:8443/repos"),
+        ],
+    )
     async def test_rejects_spoofed_host_before_firewall_auth(
-        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        headers,
+        request_port,
+        expected_original_url,
     ):
         reg_path = _write_github_firewall_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
             host="203.0.113.10",
+            port=request_port,
             sni="attacker.example.com",
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
@@ -199,7 +214,7 @@ class TestRequestHandler:
         assert body["error"] == "authority_mismatch"
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_error"] == "authority_mismatch"
-        assert flow.metadata["original_url"] == "https://attacker.example.com/repos"
+        assert flow.metadata["original_url"] == expected_original_url
         auth_fetch.assert_not_called()
         assert "Authorization" not in flow.request.headers
 


### PR DESCRIPTION
## Summary

- centralize repeated `AuthorityValidationError` context construction in `get_trusted_authority`
- preserve the existing pre-SNI raw fallback URL and post-SNI trusted fallback URL split
- add request-handler integration coverage for invalid HTTPS SNI rejection before firewall auth

Closes #14694

## Tests

- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_request_handler.py -v`
- `python3 -m pytest tests/ -v`
