### PR TITLE
fix(mitm-addon): use streamed byte count for response size

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -352,6 +352,17 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     response_streaming.feed_model_websocket_usage(flow, message.content)
 
 
+def _response_size(flow: http.HTTPFlow) -> int:
+    if flow.response is None:
+        return 0
+
+    streamed_size = response_streaming.streamed_response_size(flow)
+    if streamed_size is not None:
+        return streamed_size
+
+    return int(flow.response.headers.get("content-length", 0))
+
+
 def _track_usage_flow(fn):
     """Decorator ensuring decrement_in_flight_flows runs after response/error handlers.
 
@@ -400,19 +411,9 @@ def response(flow: http.HTTPFlow) -> None:
     original_url = flow.metadata["original_url"]
     firewall_action = flow.metadata.get("firewall_action", "ALLOW")
 
-    # Calculate sizes
     request_size = len(flow.request.raw_content or b"")
-    # Use buffered body length when complete; fall back to Content-Length header.
+    response_size = _response_size(flow)
     stream_buf = flow.metadata.get("stream_buffer")
-    stream_state = flow.metadata.get("stream_buffer_state")
-    if stream_buf is not None and stream_state and "total_bytes" in stream_state:
-        response_size = int(stream_state["total_bytes"])
-    elif stream_buf is not None and stream_state and not stream_state["truncated"]:
-        response_size = len(stream_buf)
-    elif flow.response:
-        response_size = int(flow.response.headers.get("content-length", 0))
-    else:
-        response_size = 0
     status_code = flow.response.status_code if flow.response else 0
 
     # Parse URL for host

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -168,6 +168,13 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
     flow.metadata[_RESPONSE_STREAM_CALLBACK] = stream_and_buffer
 
 
+def streamed_response_size(flow: http.HTTPFlow) -> int | None:
+    state = flow.metadata.get("stream_buffer_state")
+    if state is None:
+        return None
+    return int(state["total_bytes"])
+
+
 def finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
     finish = flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
     if finish is None:

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -152,6 +152,31 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == 50000
 
+    def test_response_size_keeps_zero_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
+        """response_size should not treat a streamed byte count of 0 as missing."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-length": "50000", "content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 0
+
     def test_response_size_tracks_streamed_bytes_when_buffer_truncated_without_length(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -152,6 +152,31 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == 50000
 
+    def test_response_size_is_zero_without_stream_state_or_content_length(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """response_size should be 0 when no streamed size or Content-Length exists."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200, headers=_header_map({"content-type": "application/json"})
+        )
+
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 0
+
     def test_response_size_keeps_zero_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
         """response_size should not treat a streamed byte count of 0 as missing."""
         flow = real_flow(with_response=False, host="api.example.com")

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -68,10 +68,8 @@ class TestResponseHandler:
         assert entry["response_size"] == 256
         assert_utc_millisecond_timestamp(entry["timestamp"])
 
-    def test_response_size_from_stream_buffer(
-        self, registry_file, tmp_path, real_flow, mitm_ctx, headers
-    ):
-        """response_size should use stream_buffer length when not truncated."""
+    def test_response_size_tracks_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
+        """response_size should use cumulative streamed bytes."""
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
@@ -80,14 +78,14 @@ class TestResponseHandler:
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
-        # Buffer has 100 bytes, not truncated
-        flow.metadata["stream_buffer"] = bytearray(b"x" * 100)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
-
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-length": "999"})
+            status_code=200,
+            headers=_header_map({"content-length": "999", "content-type": "application/json"}),
         )
 
+        mitm_addon.responseheaders(flow)
+        _response_stream(flow)(b"x" * 40)
+        _response_stream(flow)(b"y" * 60)
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
@@ -95,12 +93,44 @@ class TestResponseHandler:
 
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
-        assert entry["response_size"] == 100  # from buffer, not Content-Length
+        assert entry["response_size"] == 100
 
-    def test_response_size_falls_back_when_truncated(
-        self, registry_file, tmp_path, real_flow, mitm_ctx, headers
+    def test_response_size_tracks_streamed_bytes_when_buffer_truncated(
+        self, tmp_path, real_flow, mitm_ctx
     ):
-        """response_size should fall back to Content-Length when buffer is truncated."""
+        """response_size should ignore Content-Length when stream metadata exists."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+        body = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096)
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-length": "12", "content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        _response_stream(flow)(body[:123])
+        _response_stream(flow)(body[123:])
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == len(body)
+
+    def test_response_size_uses_content_length_without_stream_state(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """response_size should fall back to Content-Length without stream metadata."""
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
@@ -109,9 +139,6 @@ class TestResponseHandler:
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
-        flow.metadata["stream_buffer"] = bytearray(b"x" * 100)
-        flow.metadata["stream_buffer_state"] = {"truncated": True}
-
         flow.response = tutils.tresp(
             status_code=200, headers=_header_map({"content-length": "50000"})
         )
@@ -123,7 +150,7 @@ class TestResponseHandler:
 
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
-        assert entry["response_size"] == 50000  # from Content-Length header
+        assert entry["response_size"] == 50000
 
     def test_response_size_tracks_streamed_bytes_when_buffer_truncated_without_length(
         self, tmp_path, real_flow, mitm_ctx

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -93,7 +93,6 @@ class TestResponseUsageReporting:
             }
         ).encode()
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -145,7 +144,6 @@ class TestResponseUsageReporting:
             }
         ).encode()
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -203,7 +201,6 @@ class TestResponseUsageReporting:
             }
         ).encode()
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map(
@@ -254,7 +251,6 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = False
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=200,
             headers=_header_map({"content-type": "application/json"}),


### PR DESCRIPTION
## Summary

- Move streamed response-size lookup behind `response_streaming.streamed_response_size()`.
- Make `mitm_addon.response()` use cumulative streamed bytes when stream metadata exists, with `Content-Length` only as the non-streaming fallback.
- Rewrite response-size tests to use production-shaped `responseheaders()` + stream callback setup, and remove partial stream state from legacy usage fallback fixtures.

Closes #14699

## Tests

- `pytest tests/test_response_handler.py`
- `pytest tests/test_response_headers_handler.py tests/test_body_capture.py`
- `pytest tests/test_usage_reporting.py`
- `pytest tests/`
- `ruff format --check .`
- `ruff check .`
- `basedpyright`
