### PR TITLE
ci: update ghcr image pins

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260419",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260525",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -82,7 +82,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -58,7 +58,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
@@ -244,7 +244,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     needs: [detect]
     if: needs.detect.outputs.any-changed == 'true'
     steps:
@@ -300,7 +300,7 @@ jobs:
   api-contracts-rust-bindings:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||
@@ -360,7 +360,7 @@ jobs:
   nbd-cow-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     needs: [detect]
     if: |
       needs.detect.outputs.metal-job-ref != '' && (

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,7 +82,7 @@ jobs:
       needs.builds-complete.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
     environment: production
@@ -280,7 +280,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -400,7 +400,7 @@ jobs:
     if: ${{ needs.release-please.outputs.api_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -578,7 +578,7 @@ jobs:
       group: deploy-host-worker-production
       cancel-in-progress: false
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
     environment: production
@@ -724,7 +724,7 @@ jobs:
       needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       deployment_url: ${{ needs.build-web-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -851,7 +851,7 @@ jobs:
       needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       deployment_url: ${{ needs.build-api-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -969,7 +969,7 @@ jobs:
     if: ${{ needs.release-please.outputs.app_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -1084,7 +1084,7 @@ jobs:
       needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       deployment_url: ${{ needs.build-app-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -1605,7 +1605,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:
       contents: write
     environment: production
@@ -1841,7 +1841,7 @@ jobs:
       needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:
       contents: read
     environment: production
@@ -2008,7 +2008,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
     environment: production
@@ -2032,7 +2032,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
     steps:

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -50,7 +50,7 @@ jobs:
   rollback:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260416
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:
       contents: read
     environment: production

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -197,7 +197,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:
       contents: read
     needs: [prepare]

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -105,7 +105,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
         with:
@@ -376,7 +376,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -389,7 +389,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -402,7 +402,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -419,7 +419,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     services:
       postgres:
         image: postgres:17-alpine
@@ -470,7 +470,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main')
       )
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     services:
       postgres:
         image: postgres:17-alpine
@@ -512,7 +512,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     services:
       postgres:
         image: postgres:17-alpine
@@ -569,7 +569,7 @@ jobs:
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -600,7 +600,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -628,7 +628,7 @@ jobs:
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
     steps:
@@ -650,7 +650,7 @@ jobs:
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     services:
       postgres:
         image: postgres:17-alpine
@@ -697,7 +697,7 @@ jobs:
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -728,7 +728,7 @@ jobs:
       group: deploy-web-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, API, CLI, runner, or platform changed.
     # Web API-backend proxy changes also deploy API because the web preview points VM0_API_BACKEND_URL at the PR API alias.
@@ -1146,7 +1146,7 @@ jobs:
       group: deploy-app-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
     if: >-
@@ -1301,7 +1301,7 @@ jobs:
   build-api:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1320,7 +1320,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1981,7 +1981,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary
- update vm0-toolchain and vm0-toolchain-rust workflow container pins to 20260525
- update the devcontainer vm0-dev image pin to 20260525
- keep date-pinned images instead of using latest for reproducibility

## Verification
- parsed .github/workflows/*.yml with PyYAML
- ran jq empty .devcontainer/devcontainer.json
- ran git diff --check
- ran actionlint
- confirmed no ghcr.io/vm0-ai/vm0-{toolchain,toolchain-rust,dev}:20260416 or :20260419 references remain