### PR TITLE
fix: return BytePlus video errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { providerFailureDetailsForLog } from "../webhooks-built-in-generations";
+import { bytePlusBuiltInGenerationError } from "../../services/zero-video-io-generate.service";
 
 describe("providerFailureDetailsForLog", () => {
   it("extracts common top-level provider failure fields", () => {
@@ -46,6 +47,44 @@ describe("providerFailureDetailsForLog", () => {
     ).toStrictEqual({
       errorMessage: "model capacity exceeded",
       statusMessage: "no worker available",
+    });
+  });
+});
+
+describe("bytePlusBuiltInGenerationError", () => {
+  it("maps BytePlus invalid parameter errors to a specific built-in generation error", () => {
+    expect(
+      bytePlusBuiltInGenerationError({
+        error: {
+          code: "InvalidParameter",
+          message:
+            "The parameter `content[1].image_url` specified in the request is not valid.",
+          param: "content[1].image_url",
+          type: "BadRequest",
+        },
+      }),
+    ).toStrictEqual({
+      message:
+        "BytePlus video generation failed: The parameter `content[1].image_url` specified in the request is not valid. (content[1].image_url)",
+      code: "BYTEPLUS_INVALID_PARAMETER",
+    });
+  });
+
+  it("maps BytePlus content safety errors to a specific built-in generation error", () => {
+    expect(
+      bytePlusBuiltInGenerationError({
+        status: "failed",
+        error: {
+          code: "InputImageSensitiveContentDetected.PrivacyInformation",
+          message:
+            "The request failed because the input image may contain real person.",
+          type: "BadRequest",
+        },
+      }),
+    ).toStrictEqual({
+      message:
+        "BytePlus video generation failed: The request failed because the input image may contain real person.",
+      code: "BYTEPLUS_INPUT_IMAGE_SENSITIVE_CONTENT_DETECTED_PRIVACY_INFORMATION",
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -1331,8 +1331,16 @@ describe("POST /api/zero/video-io/generate", () => {
     server.use(
       http.post(BYTEPLUS_VIDEO_TASKS_URL, () => {
         return HttpResponse.json(
-          { error: { message: "rate limit exceeded" } },
-          { status: 429 },
+          {
+            error: {
+              code: "InvalidParameter",
+              message:
+                "The parameter `content[1].image_url` specified in the request is not valid.",
+              param: "content[1].image_url",
+              type: "BadRequest",
+            },
+          },
+          { status: 400 },
         );
       }),
     );
@@ -1344,11 +1352,12 @@ describe("POST /api/zero/video-io/generate", () => {
       body: JSON.stringify({ prompt: "a city" }),
     });
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "Video generation failed",
-        code: "INTERNAL_SERVER_ERROR",
+        message:
+          "BytePlus video generation failed: The parameter `content[1].image_url` specified in the request is not valid. (content[1].image_url)",
+        code: "BYTEPLUS_INVALID_PARAMETER",
       },
     });
     const jobRows = await store
@@ -1361,8 +1370,9 @@ describe("POST /api/zero/video-io/generate", () => {
       type: "video",
       status: "failed",
       error: {
-        message: "Video generation failed",
-        code: "INTERNAL_SERVER_ERROR",
+        message:
+          "BytePlus video generation failed: The parameter `content[1].image_url` specified in the request is not valid. (content[1].image_url)",
+        code: "BYTEPLUS_INVALID_PARAMETER",
       },
     });
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
@@ -1374,5 +1384,80 @@ describe("POST /api/zero/video-io/generate", () => {
       }),
     );
     expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+
+  it("records specific BytePlus webhook failure details on async failure", async () => {
+    const fixture = await track(
+      seedVideoFixture({ credits: 1000, withPricing: true }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedBody: unknown = null;
+    server.use(
+      http.post(BYTEPLUS_VIDEO_TASKS_URL, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          id: "byteplus-video-task",
+          status: "queued",
+        });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/video-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "a city" }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "video",
+      fixture.userId,
+    );
+    const callbackUrl = readCallbackUrl(observedBody);
+
+    await postBytePlusWebhook(app, callbackUrl, {
+      id: "byteplus-video-task",
+      status: "failed",
+      error: {
+        code: "InputImageSensitiveContentDetected.PrivacyInformation",
+        message:
+          "The request failed because the input image may contain real person.",
+        type: "BadRequest",
+      },
+    });
+
+    const statusResponse = await app.request(
+      `/api/zero/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    await expect(statusResponse.json()).resolves.toMatchObject({
+      generationId,
+      type: "video",
+      status: "failed",
+      error: {
+        message:
+          "BytePlus video generation failed: The request failed because the input image may contain real person.",
+        code: "BYTEPLUS_INPUT_IMAGE_SENSITIVE_CONTENT_DETECTED_PRIVACY_INFORMATION",
+      },
+    });
+
+    const jobRows = await store
+      .set(writeDb$)
+      .select()
+      .from(builtInGenerationJobs)
+      .where(eq(builtInGenerationJobs.id, generationId));
+    expect(jobRows[0]).toMatchObject({
+      type: "video",
+      status: "failed",
+      error: {
+        message:
+          "BytePlus video generation failed: The request failed because the input image may contain real person.",
+        code: "BYTEPLUS_INPUT_IMAGE_SENSITIVE_CONTENT_DETECTED_PRIVACY_INFORMATION",
+      },
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -31,6 +31,7 @@ import {
 } from "../services/zero-run-built-in-admission.service";
 import { verifyBuiltInGenerationProviderWebhookToken } from "../services/built-in-generation-provider-webhooks.service";
 import {
+  bytePlusBuiltInGenerationError,
   downloadFalVideo,
   downloadBytePlusVideo,
   parseFalVideoResult,
@@ -765,7 +766,7 @@ const postBytePlusBuiltInGenerationWebhook$ = command(
         failBuiltInGenerationJob$,
         {
           generationId: job.id,
-          error: failError("Generation failed"),
+          error: bytePlusBuiltInGenerationError(parsed),
         },
         signal,
       );

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -11,7 +11,7 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { putS3Object } from "../external/s3";
-import { settle } from "../utils";
+import { safeJsonParse, safeSync, settle } from "../utils";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 import {
@@ -557,19 +557,10 @@ function stringifyCompact(value: unknown): string | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
-  try {
+  const serialized = safeSync(() => {
     return JSON.stringify(value);
-  } catch {
-    return undefined;
-  }
-}
-
-function parseJsonSafely(text: string): unknown {
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return undefined;
-  }
+  });
+  return "ok" in serialized ? serialized.ok : undefined;
 }
 
 function readBytePlusProviderError(
@@ -618,7 +609,7 @@ function bytePlusProviderErrorFromText(
   status: number,
   statusText: string,
 ): BytePlusProviderError {
-  const parsed = text ? parseJsonSafely(text) : undefined;
+  const parsed = text ? safeJsonParse(text) : undefined;
   const providerError = readBytePlusProviderError(parsed);
   if (providerError) {
     return providerError;
@@ -631,9 +622,7 @@ function bytePlusProviderErrorFromText(
   };
 }
 
-export function bytePlusProviderFailureError(
-  payload: unknown,
-): BytePlusProviderError {
+function bytePlusProviderFailureError(payload: unknown): BytePlusProviderError {
   return (
     readBytePlusProviderError(payload) ?? {
       message: "Generation failed",

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -394,6 +394,11 @@ interface BytePlusVideoResult {
   readonly completionTokens: number | undefined;
 }
 
+interface BytePlusProviderError {
+  readonly message: string;
+  readonly code: string;
+}
+
 interface ParsedVideoGeneration {
   readonly model: VideoModel;
   readonly videoBytes: Buffer;
@@ -479,6 +484,38 @@ function badGateway(message: string, code: string) {
   return { status: 502 as const, body: errorBody(message, code) };
 }
 
+function bytePlusErrorStatus(status: number): ErrorStatus {
+  if (status === 400 || status === 503 || status === 504) {
+    return status;
+  }
+  return 502;
+}
+
+function normalizeBytePlusErrorCode(value: string | undefined): string {
+  const normalized = value
+    ?.trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+  return normalized
+    ? `BYTEPLUS_${normalized}`
+    : "BYTEPLUS_VIDEO_GENERATION_FAILED";
+}
+
+function bytePlusProviderErrorResponse(
+  providerError: BytePlusProviderError,
+  providerStatus: number,
+): VideoErrorResponse {
+  return {
+    status: bytePlusErrorStatus(providerStatus),
+    body: errorBody(
+      `BytePlus video generation failed: ${providerError.message}`,
+      normalizeBytePlusErrorCode(providerError.code),
+    ),
+  };
+}
+
 export function videoServiceUnavailable(message: string, code: string) {
   return { status: 503 as const, body: errorBody(message, code) };
 }
@@ -495,6 +532,125 @@ export function videoInsufficientCredits() {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readProviderString(
+  body: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = body[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function stringifyCompact(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() || undefined;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJsonSafely(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function readBytePlusProviderError(
+  value: unknown,
+): BytePlusProviderError | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const sources = [value.error, value.data, value.response, value].filter(
+    isRecord,
+  );
+  for (const source of sources) {
+    const message =
+      readProviderString(source, [
+        "message",
+        "error_message",
+        "errorMessage",
+        "detail",
+        "description",
+        "reason",
+        "failure_reason",
+        "failureReason",
+        "status_message",
+        "statusMessage",
+        "err_msg",
+      ]) ?? stringifyCompact(source.error);
+    if (!message) {
+      continue;
+    }
+    const code =
+      readProviderString(source, ["code", "error_code", "errorCode", "type"]) ??
+      readProviderString(value, ["code", "error_code", "errorCode", "type"]);
+    const param = readProviderString(source, ["param", "parameter"]);
+    return {
+      message: param ? `${message} (${param})` : message,
+      code: code ?? "VIDEO_GENERATION_FAILED",
+    };
+  }
+
+  return null;
+}
+
+function bytePlusProviderErrorFromText(
+  text: string | undefined,
+  status: number,
+  statusText: string,
+): BytePlusProviderError {
+  const parsed = text ? parseJsonSafely(text) : undefined;
+  const providerError = readBytePlusProviderError(parsed);
+  if (providerError) {
+    return providerError;
+  }
+  return {
+    message: statusText
+      ? `${statusText} (HTTP ${status})`
+      : `provider returned HTTP ${status}`,
+    code: "VIDEO_GENERATION_FAILED",
+  };
+}
+
+export function bytePlusProviderFailureError(
+  payload: unknown,
+): BytePlusProviderError {
+  return (
+    readBytePlusProviderError(payload) ?? {
+      message: "Generation failed",
+      code: "VIDEO_GENERATION_FAILED",
+    }
+  );
+}
+
+export function bytePlusBuiltInGenerationError(payload: unknown): {
+  readonly message: string;
+  readonly code: string;
+} {
+  const providerError = bytePlusProviderFailureError(payload);
+  return {
+    message: `BytePlus video generation failed: ${providerError.message}`,
+    code: normalizeBytePlusErrorCode(providerError.code),
+  };
 }
 
 function readString(
@@ -1169,11 +1325,18 @@ export async function submitBytePlusVideoGeneration(
 
   if (!response.ok) {
     const responseBody = await readBytePlusErrorBodyForLog(response);
+    const providerError = bytePlusProviderErrorFromText(
+      responseBody,
+      response.status,
+      response.statusText,
+    );
     L.warn("BytePlus video generation task creation failed", {
       provider: "byteplus",
       model: options.model,
       status: response.status,
       statusText: response.statusText,
+      providerErrorCode: providerError.code,
+      providerErrorMessage: providerError.message,
       responseBody,
       hasFirstFrameImage: Boolean(options.firstFrameImageUrl),
       hasLastFrameImage: Boolean(options.lastFrameImageUrl),
@@ -1181,7 +1344,7 @@ export async function submitBytePlusVideoGeneration(
       referenceVideoCount: options.inputVideoUrls.length,
       referenceAudioCount: options.referenceAudioUrls.length,
     });
-    return videoInternalError("Video generation failed");
+    return bytePlusProviderErrorResponse(providerError, response.status);
   }
 
   const body: unknown = await response.json();

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -642,6 +642,15 @@ function statusForBuiltInGenerationError(code: string): number {
   if (code === "GENERATION_TIMEOUT") {
     return 504;
   }
+  if (
+    code.startsWith("BYTEPLUS_INVALID_PARAMETER") ||
+    code.startsWith("BYTEPLUS_INPUT_")
+  ) {
+    return 400;
+  }
+  if (code.startsWith("BYTEPLUS_")) {
+    return 502;
+  }
   if (code.startsWith("NO_") || code.endsWith("_FAILED")) {
     return 502;
   }


### PR DESCRIPTION
## Summary
- parse BytePlus video task creation error bodies and return specific provider messages/codes to callers
- store specific BytePlus failure details when async BytePlus webhooks report failed/expired jobs
- map BytePlus input errors to 400 in CLI async generation status handling

## Tests
- pnpm -C turbo --filter api exec vitest run src/signals/routes/__tests__/webhooks-built-in-generations.test.ts
- pnpm -C turbo --filter @vm0/cli check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -C turbo --filter api check-types

## Notes
- Full zero-video route test file requires local Postgres on localhost:5432; in this environment it fails during fixture DB insert with ECONNREFUSED before exercising route assertions.