### PR TITLE
refactor(mitm-addon): structure firewall allow results

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 
 from mitmproxy import ctx, http
 
+import matching
 from auth_base_forwarder import (
     forward_request,
     forwarded_request_header_pairs,
@@ -82,30 +83,30 @@ def _get_auth_state(cache_key: tuple[str, str]) -> _FirewallAuthState:
     return state
 
 
-def is_billable_firewall(match_info: dict, vm_info: dict) -> bool:
+def is_billable_firewall(firewall_name: str, vm_info: dict) -> bool:
     """Return whether this firewall should emit connector/model usage."""
-    return match_info.get("name", "") in (vm_info.get("billableFirewalls") or [])
+    return firewall_name in (vm_info.get("billableFirewalls") or [])
 
 
 def _prepare_firewall_metadata(
     flow: http.HTTPFlow,
-    api_entry: dict,
+    allow: matching.FirewallAllow,
     vm_info: dict,
-    match_info: dict,
 ) -> None:
     """Store firewall match metadata once before auth resolution starts."""
+    api_entry = allow.api_entry
     firewall_base = api_entry["base"]
     api_id = api_entry.get("id", firewall_base)
     # billableFirewalls is optional in the TS schema; runner may omit the
     # field entirely for non-vm0 / no-billable-connector runs.
-    firewall_billable = is_billable_firewall(match_info, vm_info)
+    firewall_billable = is_billable_firewall(allow.name, vm_info)
 
     flow.metadata["firewall_base"] = firewall_base
     flow.metadata["firewall_api_id"] = api_id
-    flow.metadata["firewall_name"] = match_info.get("name", "")
-    flow.metadata["firewall_permission"] = match_info.get("permission", "")
-    flow.metadata["firewall_rule_match"] = match_info.get("rule", "")
-    flow.metadata["firewall_params"] = match_info.get("params", {})
+    flow.metadata["firewall_name"] = allow.name
+    flow.metadata["firewall_permission"] = allow.permission or ""
+    flow.metadata["firewall_rule_match"] = allow.rule or ""
+    flow.metadata["firewall_params"] = allow.params
     flow.metadata["firewall_billable"] = firewall_billable
     flow.metadata["model_usage_provider"] = vm_info.get("modelUsageProvider")
 
@@ -475,10 +476,11 @@ async def get_firewall_headers(
 
 
 async def handle_firewall_request(
-    flow: http.HTTPFlow, api_entry: dict, vm_info: dict, match_info: dict
+    flow: http.HTTPFlow, allow: matching.FirewallAllow, vm_info: dict
 ) -> None:
     """Handle a firewall-matched request: fetch resolved headers, inject into request."""
-    _prepare_firewall_metadata(flow, api_entry, vm_info, match_info)
+    _prepare_firewall_metadata(flow, allow, vm_info)
+    api_entry = allow.api_entry
     firewall_base = flow.metadata["firewall_base"]
     api_id = flow.metadata["firewall_api_id"]
     run_id = flow.metadata.get("vm_run_id", "")
@@ -508,7 +510,7 @@ async def handle_firewall_request(
             action="ALLOW",
             error_code="auth_unavailable",
             message="Auth secrets not configured",
-            permission=match_info.get("name", ""),
+            permission=allow.name,
         )
         return
 
@@ -527,7 +529,6 @@ async def handle_firewall_request(
             firewall_billable,
         )
     except ConnectorNotConfiguredError as e:
-        fw_name = match_info.get("name", "")
         log_proxy_entry(
             proxy_log_path,
             "info",
@@ -541,8 +542,8 @@ async def handle_firewall_request(
             action="BLOCK",
             error_code="connector_not_configured",
             message=str(e),
-            permission=fw_name,
-            connectors=[fw_name] if fw_name else None,
+            permission=allow.name,
+            connectors=[allow.name] if allow.name else None,
         )
         return
     except InsufficientCreditsError as e:
@@ -559,7 +560,7 @@ async def handle_firewall_request(
             action="BLOCK",
             error_code="insufficient_credits",
             message=str(e),
-            permission=match_info.get("name", ""),
+            permission=allow.name,
         )
         return
     except Exception as e:
@@ -576,7 +577,7 @@ async def handle_firewall_request(
             action="ALLOW",
             error_code="auth_failed",
             message=f"Failed to resolve auth headers: {e}",
-            permission=match_info.get("name", ""),
+            permission=allow.name,
         )
         return
 
@@ -592,7 +593,7 @@ async def handle_firewall_request(
     resolved_base = token_meta.get("base")
     if resolved_base:
         orig_query = urllib.parse.urlparse(flow.request.path).query
-        new_url = build_rewrite_url(resolved_base, match_info, orig_query, resolved_query)
+        new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
 
         # Filter client-controlled hop-by-hop headers before adding trusted
         # auth headers, so Connection tokens cannot suppress injected auth.
@@ -626,7 +627,7 @@ async def handle_firewall_request(
                 action="ALLOW",
                 error_code="url_rewrite_forward_failed",
                 message="Failed to forward request to upstream",
-                permission=match_info.get("name", ""),
+                permission=allow.name,
             )
             return
 

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -732,10 +732,41 @@ def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
 
 
 class FirewallAllow(NamedTuple):
-    """Permission matched — inject auth headers."""
+    """Base URL matched and auth headers should be injected.
+
+    ``permission`` and ``rule`` are present for a matched permission. They are
+    ``None`` for unknown-endpoint allow, where the firewall base matched but no
+    permission rule did and ``unknownPolicy`` allowed the request.
+    """
 
     api_entry: dict
-    match_info: dict
+    name: str
+    permission: str | None
+    params: dict[str, str]
+    rule: str | None
+    rel_path: str
+
+
+def _permission_allow(
+    api_entry: dict,
+    *,
+    name: str,
+    permission: str,
+    params: dict[str, str],
+    rule: str,
+    rel_path: str,
+) -> FirewallAllow:
+    return FirewallAllow(api_entry, name, permission, params, rule, rel_path)
+
+
+def _unknown_allow(
+    api_entry: dict,
+    *,
+    name: str,
+    params: dict[str, str],
+    rel_path: str,
+) -> FirewallAllow:
+    return FirewallAllow(api_entry, name, None, params, None, rel_path)
 
 
 FirewallBlockReason = Literal[
@@ -802,6 +833,8 @@ def match_compiled_firewall_request(
       FirewallBlock — permission denied, unknown endpoint blocked, or matched
         malformed firewall config failed closed
       None — no base URL match (not a firewall request)
+
+    ``unknownPolicy="ask"`` is treated as block at the proxy layer.
     """
     if not compiled_firewalls:
         return None
@@ -856,15 +889,13 @@ def match_compiled_firewall_request(
                         all_params = {**base_params, **params}
 
                         if perm.name not in block_set:
-                            return FirewallAllow(
+                            return _permission_allow(
                                 api_entry.raw_api_entry,
-                                {
-                                    "name": fw_entry.name,
-                                    "permission": perm.name,
-                                    "params": all_params,
-                                    "rule": rule.raw,
-                                    "rel_path": rel_path,
-                                },
+                                name=fw_entry.name,
+                                permission=perm.name,
+                                params=all_params,
+                                rule=rule.raw,
+                                rel_path=rel_path,
                             )
                         if perm.name not in denied_perm_names:
                             denied_perm_names.append(perm.name)
@@ -889,15 +920,11 @@ def match_compiled_firewall_request(
         if malformed_match is not None:
             return FirewallBlock(*malformed_match, (), "malformed_firewall_config")
         if _get_unknown_policy(blocked_name, network_policies) == "allow":
-            return FirewallAllow(
+            return _unknown_allow(
                 first_matched_api_entry,
-                {
-                    "name": blocked_name,
-                    "permission": "",
-                    "params": base_params,
-                    "rule": "",
-                    "rel_path": blocked_rel_path,
-                },
+                name=blocked_name,
+                params=base_params,
+                rel_path=blocked_rel_path,
             )
         return FirewallBlock(
             blocked_base,
@@ -986,15 +1013,13 @@ def match_firewall_request(
 
                         # Three-level: not in deny/ask → allowed
                         if perm_name not in block_set:
-                            return FirewallAllow(
+                            return _permission_allow(
                                 api_entry,
-                                {
-                                    "name": fw_name,
-                                    "permission": perm_name,
-                                    "params": all_params,
-                                    "rule": rule_str,
-                                    "rel_path": rel_path,
-                                },
+                                name=fw_name,
+                                permission=perm_name,
+                                params=all_params,
+                                rule=rule_str,
+                                rel_path=rel_path,
                             )
                         # Permission exists but not granted — record for
                         # DENY but keep checking other permissions.
@@ -1017,15 +1042,11 @@ def match_firewall_request(
         # No permission rule matched — this is an "unknown" endpoint.
         # "ask" is treated as "deny" at the proxy level (same as ask permissions).
         if _get_unknown_policy(blocked_name, network_policies) == "allow":
-            return FirewallAllow(
+            return _unknown_allow(
                 first_matched_api_entry,
-                {
-                    "name": blocked_name,
-                    "permission": "",
-                    "params": base_params,
-                    "rule": "",
-                    "rel_path": blocked_rel_path,
-                },
+                name=blocked_name,
+                params=base_params,
+                rel_path=blocked_rel_path,
             )
         return FirewallBlock(
             blocked_base,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -283,9 +283,9 @@ async def request(flow: http.HTTPFlow) -> None:
             if isinstance(result, matching.FirewallAllow):
                 _maybe_track_usage_flow(
                     flow,
-                    is_billable_firewall(result.match_info, vm_info),
+                    is_billable_firewall(result.name, vm_info),
                 )
-                await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
+                await handle_firewall_request(flow, result, vm_info)
                 if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
                     # Local firewall/auth errors never reach a provider. They only
                     # need pre-tracking to keep shutdown from racing while auth is

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -335,7 +335,7 @@ def _merge_rewrite_query(
 
 def build_rewrite_url(
     resolved_base: str,
-    match_info: dict,
+    rel_path: str,
     orig_query: str,
     resolved_query: dict[str, str] | None = None,
 ) -> str:
@@ -350,7 +350,6 @@ def build_rewrite_url(
     base_parsed = urllib.parse.urlsplit(resolved_base)
 
     # Append rel_path to the base path portion
-    rel_path = match_info.get("rel_path", "/")
     base_path = base_parsed.path.rstrip("/") + rel_path if rel_path != "/" else base_parsed.path
 
     merged_qs = _merge_rewrite_query(base_parsed.query, orig_query, resolved_query)

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -4,6 +4,19 @@ from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import auth
+import matching
+
+
+def _allow(
+    api_entry: dict,
+    *,
+    name: str = "test",
+    permission: str | None = "send",
+    params: dict[str, str] | None = None,
+    rule: str | None = "POST /",
+    rel_path: str = "/",
+) -> matching.FirewallAllow:
+    return matching.FirewallAllow(api_entry, name, permission, params or {}, rule, rel_path)
 
 
 def make_query_inputs(
@@ -34,14 +47,15 @@ def make_query_inputs(
         "encryptedSecrets": "iv:tag:data",
         "billableFirewalls": [],
     }
-    match_info = {
+    allow_kwargs = {
         "name": "serpapi",
         "permission": "search",
         "rule": "GET /search",
         "params": {},
     }
     if match_overrides:
-        match_info.update(match_overrides)
+        allow_kwargs.update(match_overrides)
+    allow = _allow(api_entry, **allow_kwargs)
     token_meta = {
         "headers": {},
         "resolved_secrets": ["SERPAPI_TOKEN"],
@@ -52,7 +66,7 @@ def make_query_inputs(
     }
     if token_overrides:
         token_meta.update(token_overrides)
-    return flow, api_entry, vm_info, match_info, token_meta
+    return flow, allow, vm_info, token_meta
 
 
 # =========================================================================
@@ -65,7 +79,7 @@ class TestAuthQueryInjection:
 
     async def test_query_params_injected_on_standard_path(self, real_flow, mitm_ctx):
         """Resolved auth.query params are injected into flow.request.query."""
-        flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
+        flow, allow, vm_info, token_meta = make_query_inputs(
             real_flow,
             auth_overrides={
                 "query": {
@@ -86,7 +100,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.request.query["api_key"] == "resolved-key-123"
         assert flow.request.query["empty_auth"] == ""
@@ -94,7 +108,7 @@ class TestAuthQueryInjection:
 
     async def test_query_param_overwrites_existing_key(self, real_flow, mitm_ctx):
         """auth.query overwrites a query param already present in the original request."""
-        flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
+        flow, allow, vm_info, token_meta = make_query_inputs(
             real_flow,
             host="serpapi.com",
             path=(
@@ -107,7 +121,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         # auth.query overwrites the agent's api_key
         assert flow.request.query["api_key"] == "real-secret-key"
         assert list(flow.request.query.get_all("api_key")) == ["real-secret-key"]
@@ -120,7 +134,7 @@ class TestAuthQueryInjection:
 
     async def test_query_params_with_headers_simultaneously(self, real_flow, mitm_ctx):
         """auth.query and auth.headers can coexist on the standard path."""
-        flow, api_entry, vm_info, match_info, token_meta = make_query_inputs(
+        flow, allow, vm_info, token_meta = make_query_inputs(
             real_flow,
             api_base="https://example.com",
             auth_overrides={
@@ -138,7 +152,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.request.headers["Authorization"] == "Bearer real-token"
         assert flow.request.query["key"] == "resolved-query-value"
 
@@ -160,13 +174,7 @@ class TestAuthQueryInjection:
             "encryptedSecrets": "iv:tag:data",
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
+        allow = _allow(api_entry)
         token_meta = {
             "headers": {},
             "base": "https://real-api.com/webhook/secret",
@@ -180,7 +188,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.metadata["auth_url_rewrite"] is True
         # Verify the forwarded URL contains the auth.query params
         call_args = mock_forward.call_args
@@ -214,13 +222,7 @@ class TestAuthQueryInjection:
             "encryptedSecrets": "iv:tag:data",
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/",
-        }
+        allow = _allow(api_entry)
         token_meta = {
             "headers": {},
             "base": "https://real-api.com/webhook/secret?api_key=base-key&mode=fast&base_empty=",
@@ -238,7 +240,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         forwarded = urlparse(mock_forward.call_args[0][0])
         query = parse_qs(forwarded.query, keep_blank_values=True)
@@ -276,13 +278,7 @@ class TestAuthQueryInjection:
             "encryptedSecrets": "iv:tag:data",
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "test",
-            "permission": "send",
-            "rule": "POST /",
-            "params": {},
-            "rel_path": "/callback;matrix=1",
-        }
+        allow = _allow(api_entry, rel_path="/callback;matrix=1")
         token_meta = {
             "headers": {},
             "base": "https://real-api.com/webhook/secret;v=1?mode=fast",
@@ -296,7 +292,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         forwarded = urlparse(mock_forward.call_args[0][0])
         assert forwarded.path == "/webhook/secret;v=1/callback"
@@ -322,12 +318,7 @@ class TestAuthQueryInjection:
             "encryptedSecrets": "iv:tag:data",
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "gh",
-            "permission": "read",
-            "rule": "GET /repos/{owner}/{repo}",
-            "params": {},
-        }
+        allow = _allow(api_entry, name="gh", permission="read", rule="GET /repos/{owner}/{repo}")
         token_meta = {
             "headers": {"Authorization": "Bearer real"},
             "resolved_secrets": ["TOKEN"],
@@ -337,7 +328,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.request.headers["Authorization"] == "Bearer real"
         # No query params should have been added
         assert len(flow.request.query) == 0

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -17,7 +17,11 @@ class TestCompiledFirewallMatching:
         if isinstance(raw, matching.FirewallAllow):
             assert isinstance(compiled, matching.FirewallAllow)
             assert compiled.api_entry is raw.api_entry
-            assert compiled.match_info == raw.match_info
+            assert compiled.name == raw.name
+            assert compiled.permission == raw.permission
+            assert compiled.params == raw.params
+            assert compiled.rule == raw.rule
+            assert compiled.rel_path == raw.rel_path
             return
         if isinstance(raw, matching.FirewallBlock):
             assert compiled == raw
@@ -50,7 +54,7 @@ class TestCompiledFirewallMatching:
 
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["params"] == {
+        assert compiled.params == {
             "region": "us",
             "org": "acme",
             "path": "a/b/c",
@@ -95,7 +99,7 @@ class TestCompiledFirewallMatching:
         )
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["params"] == {"sub": "a.b", "id": "123"}
+        assert compiled.params == {"sub": "a.b", "id": "123"}
 
         url = "https://example.org/items/123"
         raw = matching.match_firewall_request(url, "GET", fws, policies)
@@ -107,7 +111,7 @@ class TestCompiledFirewallMatching:
         )
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["params"] == {"sub": "", "id": "123"}
+        assert compiled.params == {"sub": "", "id": "123"}
 
     def test_matches_raw_for_static_base_boundary_and_query(self):
         fws = _wrap_firewalls(
@@ -135,7 +139,7 @@ class TestCompiledFirewallMatching:
         )
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["rel_path"] == "/"
+        assert compiled.rel_path == "/"
 
         url = "https://api.anthropic.com/v1/messages_fake"
         raw = matching.match_firewall_request(url, "GET", fws, policies)
@@ -199,7 +203,7 @@ class TestCompiledFirewallMatching:
         )
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["permission"] == ""
+        assert compiled.permission is None
 
         ask_policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "ask"}}
         raw = matching.match_firewall_request(url, "GET", fws, ask_policies)
@@ -290,8 +294,8 @@ class TestCompiledFirewallMatching:
 
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["name"] == "specific"
-        assert compiled.match_info["permission"] == "items-read"
+        assert compiled.name == "specific"
+        assert compiled.permission == "items-read"
 
     def test_preserves_raw_rule_order_for_any_before_exact_method(self):
         api_entry = {
@@ -319,7 +323,7 @@ class TestCompiledFirewallMatching:
 
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry is api_entry
-        assert result.match_info["rule"] == "ANY /repos/{owner}/{repo}"
+        assert result.rule == "ANY /repos/{owner}/{repo}"
 
     def test_later_allowed_permission_still_wins_after_earlier_denied_match(self):
         fws = _wrap_firewalls(
@@ -354,7 +358,7 @@ class TestCompiledFirewallMatching:
 
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, matching.FirewallAllow)
-        assert compiled.match_info["permission"] == "repo-admin"
+        assert compiled.permission == "repo-admin"
 
     def test_denied_permission_names_keep_encounter_order_and_deduplicate(self):
         fws = _wrap_firewalls(
@@ -513,7 +517,7 @@ class TestCompiledFirewallMatching:
         )
 
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "repo-read"
+        assert result.permission == "repo-read"
 
     def test_malformed_rules_shape_fails_closed_without_compile_error(self):
         fws = _wrap_firewalls(

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import auth
+import matching
 from tests.auth_state_helpers import (
     cached_headers,
     force_refresh_pending,
@@ -32,6 +33,18 @@ def _upstream_headers(*pairs: tuple[str, str]) -> Message:
 
 def _http_error(url: str, status: int, reason: str, body: bytes) -> urllib.error.HTTPError:
     return urllib.error.HTTPError(url, status, reason, Message(), io.BytesIO(body))
+
+
+def _allow(
+    api_entry: dict,
+    *,
+    name: str = "github",
+    permission: str | None = "repo-read",
+    params: dict[str, str] | None = None,
+    rule: str | None = "GET /repos/{owner}/{repo}",
+    rel_path: str = "/",
+) -> matching.FirewallAllow:
+    return matching.FirewallAllow(api_entry, name, permission, params or {}, rule, rel_path)
 
 
 class _UnreadableHttpErrorBody(io.BytesIO):
@@ -554,12 +567,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "github",
-            "permission": "repo-read",
-            "rule": "GET /repos/{owner}/{repo}",
-            "params": {"owner": "octocat", "repo": "hello"},
-        }
+        allow = _allow(api_entry, params={"owner": "octocat", "repo": "hello"})
         token_meta = {
             "headers": {"Authorization": "Bearer real-token", "X-Custom": "value"},
             "resolved_secrets": ["GITHUB_TOKEN"],
@@ -572,7 +580,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         # Headers injected
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -614,12 +622,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             # intentionally no "billableFirewalls" key
         }
-        match_info = {
-            "name": "github",
-            "permission": "repo-read",
-            "rule": "GET /repos",
-            "params": {},
-        }
+        allow = _allow(api_entry, rule="GET /repos")
         token_meta = {
             "headers": {},
             "resolved_secrets": [],
@@ -632,7 +635,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.metadata["firewall_billable"] is False
 
@@ -647,7 +650,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {"name": "github"}
+        allow = _allow(api_entry)
 
         with (
             patch.object(
@@ -658,7 +661,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -683,7 +686,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": "",
             "billableFirewalls": [],
         }
-        match_info = {"name": "github"}
+        allow = _allow(api_entry)
 
         with (
             patch.object(
@@ -701,7 +704,7 @@ class TestHandleFirewallRequest:
             ),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is None
 
@@ -719,7 +722,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {"name": "github"}
+        allow = _allow(api_entry)
 
         with (
             patch.object(
@@ -734,7 +737,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 424
@@ -759,7 +762,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": ["github"],
         }
-        match_info = {"name": "github"}
+        allow = _allow(api_entry)
 
         with (
             patch.object(
@@ -770,7 +773,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 402
@@ -797,7 +800,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {}
+        allow = _allow(api_entry, name="", permission=None, rule=None)
 
         with (
             patch.object(
@@ -812,7 +815,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 424
@@ -837,7 +840,7 @@ class TestHandleFirewallRequest:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {"name": "htmlcsstoimage"}
+        allow = _allow(api_entry, name="htmlcsstoimage")
 
         with (
             patch.object(
@@ -852,7 +855,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 424
@@ -872,10 +875,10 @@ class TestHandleFirewallRequest:
             "networkLogPath": "",
             "billableFirewalls": [],
         }
-        match_info = {"name": "github"}
+        allow = _allow(api_entry)
 
         with mitm_ctx():
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -47,10 +47,10 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["name"] == "github"
-        assert result.match_info["permission"] == "repo-read"
-        assert result.match_info["params"] == {"owner": "octocat", "repo": "hello"}
-        assert result.match_info["rule"] == "GET /repos/{owner}/{repo}"
+        assert result.name == "github"
+        assert result.permission == "repo-read"
+        assert result.params == {"owner": "octocat", "repo": "hello"}
+        assert result.rule == "GET /repos/{owner}/{repo}"
 
     def test_any_method_matches(self, headers):
         fw_configs = _wrap_firewalls(
@@ -69,7 +69,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "full-access"
+        assert result.permission == "full-access"
 
     def test_method_case_insensitive(self, headers):
         fw_configs = _wrap_firewalls(
@@ -174,7 +174,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com", "GET", fw_configs, network_policies=_grant_all(fw_configs)
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "root"
+        assert result.permission == "root"
 
     def test_trailing_slash_on_url(self, headers):
         """URL trailing slash doesn't affect matching (split filters empty segments)."""
@@ -271,7 +271,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "messages-send"
+        assert result.permission == "messages-send"
 
     def test_malformed_rules_skipped(self, headers):
         """Rules without 'METHOD /path' format are silently skipped, not crash or false-allow."""
@@ -352,7 +352,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(gh, matching.FirewallAllow)
-        assert gh.match_info["name"] == "github"
+        assert gh.name == "github"
 
         sl = matching.match_firewall_request(
             "https://slack.com/api/chat.postMessage",
@@ -361,7 +361,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(sl, matching.FirewallAllow)
-        assert sl.match_info["name"] == "slack"
+        assert sl.name == "slack"
 
     def test_query_string_stripped_for_matching(self, headers):
         fw_configs = _wrap_firewalls(
@@ -443,7 +443,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer api-token"
-        assert result.match_info["permission"] == "full-access"
+        assert result.permission == "full-access"
 
         # Request to second base
         result = matching.match_firewall_request(
@@ -454,7 +454,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer files-token"
-        assert result.match_info["permission"] == "full-access"
+        assert result.permission == "full-access"
 
     def test_same_base_different_permissions(self, headers):
         """Same base URL with different permissions/auth — second api_entry can match."""
@@ -480,7 +480,7 @@ class TestMatchFirewallRequest:
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer user"
-        assert result.match_info["permission"] == "send"
+        assert result.permission == "send"
 
     def test_parameterized_host_allows(self, headers):
         """Base URL with {subdomain} in host matches dynamically."""
@@ -501,9 +501,9 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["name"] == "zendesk"
-        assert result.match_info["permission"] == "tickets"
-        assert result.match_info["params"] == {"subdomain": "acme"}
+        assert result.name == "zendesk"
+        assert result.permission == "tickets"
+        assert result.params == {"subdomain": "acme"}
 
     def test_parameterized_host_blocks_no_permission(self, headers):
         """Base URL with host param matches but no rule → block."""
@@ -563,7 +563,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["params"] == {"org": "acme", "id": "123"}
+        assert result.params == {"org": "acme", "id": "123"}
 
     def test_parameterized_host_and_path(self, headers):
         """Both host and path params extracted."""
@@ -583,7 +583,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["params"] == {"tenant": "us", "org": "acme"}
+        assert result.params == {"tenant": "us", "org": "acme"}
 
     def test_greedy_host_param_matches_multi_level(self, headers):
         """Greedy {sub+} in host matches multiple subdomain levels."""
@@ -603,7 +603,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["params"]["sub"] == "a.b.c"
+        assert result.params["sub"] == "a.b.c"
 
     def test_greedy_star_host_param_matches_zero(self, headers):
         """Greedy {sub*} in host matches zero subdomains."""
@@ -620,7 +620,7 @@ class TestMatchFirewallRequest:
             "https://example.com/api", "GET", fw_configs, network_policies=_grant_all(fw_configs)
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["params"]["sub"] == ""
+        assert result.params["sub"] == ""
 
     def test_mixed_static_and_parameterized_bases(self, headers):
         """Static and parameterized bases in same config both work."""
@@ -653,7 +653,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(gh, matching.FirewallAllow)
-        assert gh.match_info["name"] == "github"
+        assert gh.name == "github"
 
         zd = matching.match_firewall_request(
             "https://acme.zendesk.com/api/v2/tickets",
@@ -662,8 +662,8 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(zd, matching.FirewallAllow)
-        assert zd.match_info["name"] == "zendesk"
-        assert zd.match_info["params"]["sub"] == "acme"
+        assert zd.name == "zendesk"
+        assert zd.params["sub"] == "acme"
 
     def test_parameterized_host_with_query_string(self, headers):
         """Parameterized base URL + query string in request."""
@@ -683,7 +683,7 @@ class TestMatchFirewallRequest:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["params"]["sub"] == "acme"
+        assert result.params["sub"] == "acme"
 
     def test_parameterized_host_rejects_nonstandard_port(self, headers):
         """Non-standard port must NOT match — prevents auth header leaking to rogue server."""
@@ -725,15 +725,15 @@ class TestMatchFirewallRequestMixedSegments:
             _grant_all(firewalls),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["params"] == {"owner": "octocat", "repo": "hello"}
-        assert result.match_info["rel_path"] == "/info/refs"
-        assert result.match_info["permission"] == "git|fetch"
+        assert result.params == {"owner": "octocat", "repo": "hello"}
+        assert result.rel_path == "/info/refs"
+        assert result.permission == "git|fetch"
 
 
 class TestMatchFirewallRequestRelPath:
-    """Tests that match_firewall_request includes rel_path in match_info."""
+    """Tests that match_firewall_request includes rel_path in allow result."""
 
-    def test_rel_path_included_in_match_info(self, headers):
+    def test_rel_path_included_in_allow_result(self, headers):
         fw_configs = _wrap_firewalls(
             [
                 {
@@ -751,7 +751,7 @@ class TestMatchFirewallRequestRelPath:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["rel_path"] == "/"
+        assert result.rel_path == "/"
 
     def test_rel_path_with_remaining_segments(self, headers):
         fw_configs = _wrap_firewalls(
@@ -771,7 +771,7 @@ class TestMatchFirewallRequestRelPath:
             network_policies=_grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["rel_path"] == "/crm.deal.list"
+        assert result.rel_path == "/crm.deal.list"
 
 
 class TestThreeLevelMatching:
@@ -803,7 +803,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "repo-read"
+        assert result.permission == "repo-read"
 
     def test_denied_permission_blocked(self):
         policies = {
@@ -842,7 +842,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "repo-read"
+        assert result.permission == "repo-read"
 
     def test_ask_permission_blocked(self):
         """Permission in ask list is treated as denied at proxy level."""
@@ -897,7 +897,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == ""
+        assert result.permission is None
 
     def test_permission_in_both_allow_and_deny_is_blocked(self):
         """deny takes precedence when permission appears in both allow and deny."""
@@ -924,8 +924,8 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == ""
-        assert result.match_info["rule"] == ""
+        assert result.permission is None
+        assert result.rule is None
 
     def test_unknown_endpoint_blocked_when_unknown_policy_deny(self):
         policies = {
@@ -1013,7 +1013,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == ""
+        assert result.permission is None
 
     def test_overlapping_permissions_allows_if_any_not_blocked(self, headers):
         """Same endpoint in two permissions — one denied, one allowed → ALLOW."""
@@ -1040,7 +1040,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "repo-admin"
+        assert result.permission == "repo-admin"
 
     def test_overlapping_permissions_denies_if_all_blocked(self, headers):
         """Same endpoint in two permissions — both denied → DENY."""
@@ -1114,7 +1114,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["name"] == "github"
+        assert result.name == "github"
 
         # Slack: channels:read explicitly denied → DENY
         result = matching.match_firewall_request(
@@ -1134,8 +1134,8 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["name"] == "slack"
-        assert result.match_info["permission"] == ""
+        assert result.name == "slack"
+        assert result.permission is None
 
     def test_different_unknown_policy_per_name(self, headers):
         """unknownPolicy differs per firewall name — github strict, slack permissive."""
@@ -1317,7 +1317,7 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == "repo-read"
+        assert result.permission == "repo-read"
 
         # Second API: no permissions defined, base matches → unknown
         # → ALLOW (unknownPolicy: allow)
@@ -1328,4 +1328,4 @@ class TestThreeLevelMatching:
             network_policies=policies,
         )
         assert isinstance(result, matching.FirewallAllow)
-        assert result.match_info["permission"] == ""
+        assert result.permission is None

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -9,6 +9,19 @@ from urllib.parse import urlparse
 from mitmproxy import http
 
 import auth
+import matching
+
+
+def _allow(
+    api_entry: dict,
+    *,
+    name: str = "test",
+    permission: str | None = "send",
+    params: dict[str, str] | None = None,
+    rule: str | None = "POST /",
+    rel_path: str = "/",
+) -> matching.FirewallAllow:
+    return matching.FirewallAllow(api_entry, name, permission, params or {}, rule, rel_path)
 
 
 def make_rewrite_inputs(
@@ -68,7 +81,7 @@ def make_rewrite_inputs(
         "networkLogPath": str(tmp_path / "net.jsonl"),
         "billableFirewalls": [],
     }
-    match_info = {
+    allow_kwargs = {
         "name": "test",
         "permission": "send",
         "rule": "POST /",
@@ -76,7 +89,8 @@ def make_rewrite_inputs(
         "rel_path": rel_path,
     }
     if match_overrides:
-        match_info.update(match_overrides)
+        allow_kwargs.update(match_overrides)
+    allow = _allow(api_entry, **allow_kwargs)
     token_meta = {
         "headers": {},
         "base": resolved_base,
@@ -87,7 +101,7 @@ def make_rewrite_inputs(
     }
     if token_overrides:
         token_meta.update(token_overrides)
-    return flow, api_entry, vm_info, match_info, token_meta
+    return flow, allow, vm_info, token_meta
 
 
 class TestAuthBaseUrlRewrite:
@@ -95,7 +109,7 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_with_rel_path_root(self, real_flow, mitm_ctx, tmp_path):
         """When rel_path is '/', resolved base URL is forwarded as-is."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             auth_overrides={"base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
@@ -108,7 +122,7 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.response.status_code == 200
@@ -117,7 +131,7 @@ class TestAuthBaseUrlRewrite:
         self, real_flow, mitm_ctx, tmp_path
     ):
         """Duplicate upstream response headers survive response construction."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             auth_overrides={"base": "${{ secrets.DISCORD_WEBHOOK_URL }}"},
@@ -139,7 +153,7 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response.status_code == 200
         assert flow.response.headers.get_all("Set-Cookie") == ["a=1", "b=2"]
@@ -147,7 +161,7 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_with_remaining_path(self, real_flow, mitm_ctx, tmp_path):
         """When rel_path has content, it's appended to resolved base in forwarded URL."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             seed_url="https://bitrix.internal/rest/0/placeholder/crm.deal.list.json",
@@ -169,7 +183,7 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert (
             mock_forward.call_args[0][0]
             == "https://mycompany.bitrix24.com/rest/1/real-token/crm.deal.list.json"
@@ -178,7 +192,7 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_preserves_query_string(self, real_flow, mitm_ctx, tmp_path):
         """Query string from original request is preserved in forwarded URL."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             path="/discord-webhook/hook?wait=true",
@@ -192,14 +206,14 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert mock_forward.call_args[0][0] == "https://discord.com/api/webhooks/123/abc?wait=true"
 
     async def test_url_rewrite_resolved_base_with_trailing_slash(
         self, real_flow, mitm_ctx, tmp_path
     ):
         """Trailing slash on resolved base is stripped before appending rel_path."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             path="/bitrix/rest/0/placeholder/crm.deal.list",
@@ -220,7 +234,7 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert (
             mock_forward.call_args[0][0]
             == "https://mycompany.bitrix24.com/rest/1/token/crm.deal.list"
@@ -228,7 +242,7 @@ class TestAuthBaseUrlRewrite:
 
     async def test_url_rewrite_merges_query_strings(self, real_flow, mitm_ctx, tmp_path):
         """When resolved base has query string and original request also has one, merge with &."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             path="/discord-webhook/hook?wait=true",
@@ -242,14 +256,14 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert mock_forward.call_args[0][0] == "https://example.com/hook?token=abc&wait=true"
 
     async def test_url_rewrite_auth_query_overrides_base_and_original_query(
         self, real_flow, mitm_ctx, tmp_path
     ):
         """auth.query is the highest-priority trusted query source for URL rewrites."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             path="/discord-webhook/hook?api_key=agent&q=test",
@@ -269,7 +283,7 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert (
             mock_forward.call_args[0][0]
             == "https://example.com/hook?region=us&q=test&api_key=trusted+key"
@@ -291,12 +305,12 @@ class TestAuthBaseUrlRewrite:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "github",
-            "permission": "repo-read",
-            "rule": "GET /repos/{owner}/{repo}",
-            "params": {},
-        }
+        allow = _allow(
+            api_entry,
+            name="github",
+            permission="repo-read",
+            rule="GET /repos/{owner}/{repo}",
+        )
         token_meta = {
             "headers": {"Authorization": "Bearer real-token"},
             "resolved_secrets": ["GITHUB_TOKEN"],
@@ -308,7 +322,7 @@ class TestAuthBaseUrlRewrite:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         # URL should not be modified
         assert flow.request.url == original_url
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -319,7 +333,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     async def test_sets_auth_url_rewrite_metadata_and_response(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is set and flow.response is populated via forward_request."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
         mock_forward = AsyncMock(
             return_value=(200, b'{"ok":true}', {"Content-Type": "application/json"})
         )
@@ -328,7 +342,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.metadata["auth_url_rewrite"] is True
         assert flow.response is not None
         assert flow.response.status_code == 200
@@ -351,12 +365,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "billableFirewalls": [],
         }
-        match_info = {
-            "name": "gh",
-            "permission": "read",
-            "rule": "GET /repos/{owner}/{repo}",
-            "params": {},
-        }
+        allow = _allow(api_entry, name="gh", permission="read", rule="GET /repos/{owner}/{repo}")
         token_meta = {
             "headers": {"Authorization": "Bearer real"},
             "resolved_secrets": ["TOKEN"],
@@ -366,14 +375,14 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert "auth_url_rewrite" not in flow.metadata
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"
 
     async def test_forward_request_includes_auth_headers(self, real_flow, mitm_ctx, tmp_path):
         """auth.headers are included in the forwarded request to the real URL."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             resolved_base="https://discord.com/api/webhooks/123/abc",
@@ -385,7 +394,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.metadata["auth_url_rewrite"] is True
         # Auth headers passed to forward_request.
         call_args = mock_forward.call_args
@@ -396,7 +405,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
         """auth.base forwarding keeps repeated headers unless auth overrides that name."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             request_headers=headers(
@@ -418,7 +427,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         req_headers = mock_forward.call_args[0][2]
         assert ("Connection", "Authorization, X-Remove") not in req_headers
@@ -435,7 +444,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
         """Unsafe client and injected headers are stripped without suppressing auth."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             request_headers=headers(
@@ -475,7 +484,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         req_headers = mock_forward.call_args[0][2]
         header_names = [name.lower() for name, _value in req_headers]
@@ -502,7 +511,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, real_flow, mitm_ctx, tmp_path
     ):
         """auth.base forwarding does not drop bodies for non-POST methods."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             method="DELETE",
@@ -514,14 +523,14 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert mock_forward.call_args[0][1] == "DELETE"
         assert mock_forward.call_args[0][3] == b"delete-body"
 
     async def test_forward_request_preserves_empty_raw_body(self, real_flow, mitm_ctx, tmp_path):
         """An explicit empty body is distinct from no body for Content-Length."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             method="POST",
@@ -533,13 +542,13 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert mock_forward.call_args[0][3] == b""
 
     async def test_forward_request_preserves_absent_body(self, real_flow, mitm_ctx, tmp_path):
         """A request with no raw body remains distinct from an explicit empty body."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             method="GET",
@@ -551,7 +560,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert mock_forward.call_args[0][3] is None
 
@@ -564,22 +573,22 @@ class TestAuthBaseUrlRewriteEdgeCases:
         log were emitted on failure, and ``firewall_error`` was left unset —
         making failed rewrites indistinguishable from successful ones in
         dashboards."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.response.headers["Content-Type"] == "application/json"
         body = json.loads(flow.response.content)
         assert body["error"] == "url_rewrite_forward_failed"
         assert body["message"] == "Failed to forward request to upstream"
-        assert body["permission"] == match_info["name"]
-        assert body["base"] == api_entry["base"]
+        assert body["permission"] == allow.name
+        assert body["base"] == allow.api_entry["base"]
         assert "connectors" not in body
         # Failure must not masquerade as a successful rewrite.
         assert "auth_url_rewrite" not in flow.metadata
@@ -596,7 +605,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         self, real_flow, mitm_ctx, tmp_path
     ):
         """Forward errors must not leak secret-bearing resolved auth.base URLs."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             resolved_base="https://real.example.com/webhook/super-secret-token",
@@ -611,7 +620,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert flow.response is not None
         assert b"super-secret-token" not in flow.response.content
@@ -622,13 +631,13 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
         """Empty string base from server is treated as absent — no URL rewrite."""
-        flow, api_entry, vm_info, match_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
         token_meta["base"] = ""
         original_url = flow.request.url
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.request.url == original_url
         assert "auth_url_rewrite" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -684,6 +684,56 @@ class TestRequestHandler:
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
 
+    async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        """Unknown-endpoint allow keeps legacy empty permission metadata."""
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                firewall_name="example",
+                api_entry={
+                    "base": "https://api-{region}.example.com/v1",
+                    "auth": {"headers": {"Authorization": "Bearer ${{ secrets.EXAMPLE_TOKEN }}"}},
+                    "permissions": [
+                        {
+                            "name": "read-items",
+                            "rules": ["GET /items/{id}"],
+                        },
+                    ],
+                },
+                network_policy={
+                    "allow": ["read-items"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+            ),
+        )
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api-us.example.com",
+            path="/v1/users/octocat",
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+
+        assert flow.response is None
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_base"] == "https://api-{region}.example.com/v1"
+        assert flow.metadata["firewall_name"] == "example"
+        assert flow.metadata["firewall_permission"] == ""
+        assert flow.metadata["firewall_rule_match"] == ""
+        assert flow.metadata["firewall_params"] == {"region": "us"}
+        assert flow.request.headers["Authorization"] == "Bearer x"
+
     async def test_billable_flow_is_tracked_before_responseheaders(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -485,7 +485,7 @@ class TestRequestHandler:
             await mitm_addon.request(flow)
 
         # Dispatcher routed to the real handle_firewall_request, which writes
-        # match-info into flow.metadata at auth.py:327–333 up-front.
+        # firewall allow metadata into flow.metadata up front.
         assert flow.metadata["firewall_base"] == "https://api.github.com"
         assert flow.metadata["firewall_name"] == "github"
         assert flow.metadata["firewall_permission"] == "full-access"
@@ -639,7 +639,7 @@ class TestRequestHandler:
     async def test_firewall_permission_allows_matched(
         self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
     ):
-        """Firewall with permissions and matching rule calls handler with match_info."""
+        """Firewall with permissions and matching rule calls handler with allow result."""
         reg_path = _write_registry(
             tmp_path,
             vm_info=_single_firewall_vm(
@@ -677,7 +677,7 @@ class TestRequestHandler:
             await mitm_addon.request(flow)
 
         # Dispatcher routed to the real handle_firewall_request, which writes
-        # match-info into flow.metadata at auth.py:327–333 up-front.
+        # firewall allow metadata into flow.metadata up front.
         assert flow.metadata["firewall_base"] == "https://api.github.com"
         assert flow.metadata["firewall_name"] == "github"
         assert flow.metadata["firewall_permission"] == "read-repos"

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -9,7 +9,7 @@ class TestBuildRewriteUrl:
     def test_simple_base_no_rel_path(self):
         url = url_utils.build_rewrite_url(
             "https://discord.com/api/webhooks/123/abc",
-            {"rel_path": "/"},
+            "/",
             "",
         )
         assert url == "https://discord.com/api/webhooks/123/abc"
@@ -17,7 +17,7 @@ class TestBuildRewriteUrl:
     def test_multi_segment_rel_path(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/base",
-            {"rel_path": "/a/b/c"},
+            "/a/b/c",
             "",
         )
         assert url == "https://example.com/base/a/b/c"
@@ -25,7 +25,7 @@ class TestBuildRewriteUrl:
     def test_base_with_query_no_orig_query(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "",
         )
         assert url == "https://example.com/hook?token=secret"
@@ -33,7 +33,7 @@ class TestBuildRewriteUrl:
     def test_empty_orig_query_ignored(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook",
-            {"rel_path": "/"},
+            "/",
             "",
         )
         assert url == "https://example.com/hook"
@@ -41,7 +41,7 @@ class TestBuildRewriteUrl:
     def test_rel_path_with_both_queries_merged(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=abc",
-            {"rel_path": "/sub"},
+            "/sub",
             "extra=1",
         )
         assert url == "https://example.com/hook/sub?token=abc&extra=1"
@@ -49,7 +49,7 @@ class TestBuildRewriteUrl:
     def test_original_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
@@ -57,7 +57,7 @@ class TestBuildRewriteUrl:
     def test_original_duplicate_query_key_followed_by_empty_segment_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&&wait=true",
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
@@ -65,7 +65,7 @@ class TestBuildRewriteUrl:
     def test_original_duplicate_query_key_preceded_by_empty_segment_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "wait=true&&token=attacker",
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
@@ -73,7 +73,7 @@ class TestBuildRewriteUrl:
     def test_all_original_duplicate_query_keys_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "token=first&token=second",
         )
         assert url == "https://example.com/hook?token=secret"
@@ -81,7 +81,7 @@ class TestBuildRewriteUrl:
     def test_original_encoded_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "to%6ben=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
@@ -89,7 +89,7 @@ class TestBuildRewriteUrl:
     def test_original_duplicate_of_encoded_trusted_base_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?to%6ben=secret",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?to%6ben=secret&wait=true"
@@ -97,7 +97,7 @@ class TestBuildRewriteUrl:
     def test_original_plus_encoded_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api+key=secret",
-            {"rel_path": "/"},
+            "/",
             "api%20key=attacker&wait=true",
         )
         assert url == "https://example.com/hook?api+key=secret&wait=true"
@@ -105,7 +105,7 @@ class TestBuildRewriteUrl:
     def test_original_semicolon_duplicate_query_key_dropped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "wait=true;token=attacker",
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
@@ -113,7 +113,7 @@ class TestBuildRewriteUrl:
     def test_original_semicolon_duplicate_before_kept_pair_uses_source_separator(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "token=attacker;wait=true",
         )
         assert url == "https://example.com/hook?token=secret&wait=true"
@@ -121,7 +121,7 @@ class TestBuildRewriteUrl:
     def test_original_semicolon_duplicate_between_kept_pairs_uses_safe_separator(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=secret",
-            {"rel_path": "/"},
+            "/",
             "keep=1;token=attacker;wait=true",
         )
         assert url == "https://example.com/hook?token=secret&keep=1&wait=true"
@@ -129,7 +129,7 @@ class TestBuildRewriteUrl:
     def test_duplicate_trusted_base_query_keys_preserved(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=first&token=second",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token=first&token=second&wait=true"
@@ -137,7 +137,7 @@ class TestBuildRewriteUrl:
     def test_duplicate_trusted_base_query_keys_with_semicolon_preserved(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=first;token=second",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token=first;token=second&wait=true"
@@ -145,7 +145,7 @@ class TestBuildRewriteUrl:
     def test_blank_trusted_base_query_value_is_authoritative(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token=",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token=&wait=true"
@@ -153,7 +153,7 @@ class TestBuildRewriteUrl:
     def test_valueless_trusted_base_query_key_is_authoritative(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?token",
-            {"rel_path": "/"},
+            "/",
             "token=attacker&wait=true",
         )
         assert url == "https://example.com/hook?token&wait=true"
@@ -161,7 +161,7 @@ class TestBuildRewriteUrl:
     def test_empty_trusted_base_query_key_is_authoritative(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?=secret",
-            {"rel_path": "/"},
+            "/",
             "=attacker&wait=true",
         )
         assert url == "https://example.com/hook?=secret&wait=true"
@@ -169,7 +169,7 @@ class TestBuildRewriteUrl:
     def test_empty_trusted_base_query_segments_do_not_block_empty_original_key(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?&&region=us",
-            {"rel_path": "/"},
+            "/",
             "=agent&q=test",
         )
         assert url == "https://example.com/hook?&&region=us&=agent&q=test"
@@ -177,7 +177,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_base_and_original_query(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&region=us",
-            {"rel_path": "/"},
+            "/",
             "api_key=agent&q=test",
             {"api_key": "trusted key"},
         )
@@ -186,7 +186,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_empty_key_overrides_base_and_original_empty_keys(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?=base&region=us",
-            {"rel_path": "/"},
+            "/",
             "=agent&q=test",
             {"": "trusted"},
         )
@@ -195,7 +195,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_base_query_without_leading_empty_segment(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base&&region=us",
-            {"rel_path": "/"},
+            "/",
             "q=test",
             {"api_key": "trusted key"},
         )
@@ -204,7 +204,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_base_query_without_trailing_empty_segment(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?region=us&&api_key=base",
-            {"rel_path": "/"},
+            "/",
             "q=test",
             {"api_key": "trusted key"},
         )
@@ -213,7 +213,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_all_lower_priority_duplicates(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base",
-            {"rel_path": "/"},
+            "/",
             "api_key=agent",
             {"api_key": "trusted key"},
         )
@@ -222,7 +222,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_duplicate_trusted_base_query_keys(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=first&api_key=second&region=us",
-            {"rel_path": "/"},
+            "/",
             "api_key=agent&q=test",
             {"api_key": "trusted key"},
         )
@@ -231,7 +231,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_encoded_base_and_original_query_keys(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api%5Fkey=base&region=us",
-            {"rel_path": "/"},
+            "/",
             "api%5fkey=agent&q=test",
             {"api_key": "trusted key"},
         )
@@ -240,7 +240,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_plus_encoded_lower_priority_keys(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api+key=base&region=us",
-            {"rel_path": "/"},
+            "/",
             "api%20key=agent&q=test",
             {"api key": "trusted key"},
         )
@@ -249,7 +249,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_semicolon_base_without_prefixing_kept_pair(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?api_key=base;region=us",
-            {"rel_path": "/"},
+            "/",
             "q=test",
             {"api_key": "trusted key"},
         )
@@ -258,7 +258,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_overrides_semicolon_base_between_kept_pairs(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?tenant=one;api_key=base;region=us",
-            {"rel_path": "/"},
+            "/",
             "q=test",
             {"api_key": "trusted key"},
         )
@@ -267,7 +267,7 @@ class TestBuildRewriteUrl:
     def test_auth_query_filter_preserves_existing_semicolon_value(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook?redirect=a;b&api_key=base&region=us",
-            {"rel_path": "/"},
+            "/",
             "q=test",
             {"api_key": "trusted key"},
         )
@@ -276,7 +276,7 @@ class TestBuildRewriteUrl:
     def test_base_path_params_are_preserved(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook;v=1?token=abc",
-            {"rel_path": "/sub;mode=fast"},
+            "/sub;mode=fast",
             "extra=1",
         )
         assert url == "https://example.com/hook;v=1/sub;mode=fast?token=abc&extra=1"
@@ -284,15 +284,15 @@ class TestBuildRewriteUrl:
     def test_trailing_slash_on_base_deduped(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook/",
-            {"rel_path": "/sub"},
+            "/sub",
             "",
         )
         assert url == "https://example.com/hook/sub"
 
-    def test_no_rel_path_key_defaults_to_root(self):
+    def test_root_rel_path_keeps_base_path(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook",
-            {},
+            "/",
             "",
         )
         assert url == "https://example.com/hook"


### PR DESCRIPTION
## Summary

- Replace `FirewallAllow.match_info` with structured allow fields.
- Represent unknown endpoint allow with `permission=None` and `rule=None` internally.
- Preserve existing metadata/log compatibility by writing empty strings at output boundaries.
- Narrow URL rewrite helpers to accept `rel_path` directly.

Fixes #14693

## Tests

- `pytest tests/test_firewall_matching.py tests/test_compiled_firewall_matching.py tests/test_url_utils.py`
- `pytest tests/test_registry.py tests/test_request_handler.py tests/test_firewall_auth.py tests/test_firewall_rewrite.py tests/test_auth_query_injection.py`
- `ruff check .`
- `basedpyright`
- `ruff format . --check`
- `pytest tests/`
