### PR TITLE
fix(connectors): gate lark connector behind feature switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -376,3 +376,35 @@ describe("ideation page - ZapierConnector feature switch", () => {
     });
   });
 });
+
+describe("ideation page - LarkConnector feature switch", () => {
+  it("should hide the Lark use case card when LarkConnector switch is off (default)", async () => {
+    mockChatAPI();
+    detachedSetupPage({ context, path: IDEAS_PATH });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Ideas & Use Cases" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Lark \u2194 Slack message relay"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the Lark use case card when LarkConnector switch is on", async () => {
+    mockChatAPI();
+    detachedSetupPage({
+      context,
+      path: IDEAS_PATH,
+      featureSwitches: { [FeatureSwitchKey.LarkConnector]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Lark \u2194 Slack message relay"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -235,6 +235,7 @@ const categories: readonly Category[] = [
         prompt:
           "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
         connectors: ["lark", "slack"],
+        featureFlag: FeatureSwitchKey.LarkConnector,
       },
       {
         title: "Google Drive file organizer",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -24,6 +24,7 @@ import {
   getConnectorOAuthConfig,
   getConnectorOAuthConfigIfSupported,
   getConnectorOAuthFlow,
+  getEligibleConnectorTypes,
   getRuntimeAvailableConnectorTypes,
   isOAuthAuthCodeConnectorType,
   isOAuthDeviceAuthConnectorType,
@@ -828,6 +829,15 @@ describe("getAvailableConnectorAuthMethods", () => {
     ).toStrictEqual(["oauth"]);
   });
 
+  it("exposes Lark API-token auth only when its switch is enabled", () => {
+    expect(getAvailableConnectorAuthMethods("lark", {})).toStrictEqual([]);
+    expect(
+      getAvailableConnectorAuthMethods("lark", {
+        [FeatureSwitchKey.LarkConnector]: true,
+      }),
+    ).toStrictEqual(["api-token"]);
+  });
+
   it("exposes Doubao API-token auth without a feature switch", () => {
     expect(getAvailableConnectorAuthMethods("doubao", {})).toStrictEqual([
       "api-token",
@@ -838,6 +848,12 @@ describe("getAvailableConnectorAuthMethods", () => {
     expect(getAvailableConnectorAuthMethods("weread", {})).toStrictEqual([
       "api-token",
     ]);
+  });
+});
+
+describe("getEligibleConnectorTypes", () => {
+  it("excludes Lark while every auth method is feature-gated", () => {
+    expect(getEligibleConnectorTypes()).not.toContain("lark");
   });
 });
 

--- a/turbo/packages/connectors/src/connectors/lark.ts
+++ b/turbo/packages/connectors/src/connectors/lark.ts
@@ -1,4 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const lark = {
   lark: {
@@ -12,6 +13,7 @@ export const lark = {
       "Connect your Lark app to manage messages, documents, calendars, and workflows",
     authMethods: {
       "api-token": {
+        featureFlag: FeatureSwitchKey.LarkConnector,
         label: "App Credentials",
         helpText:
           "1. Log in to the [Lark Developer Console](https://open.larksuite.com/app/)\n2. Select your app from the list (or create a new one)\n3. Go to the **Credentials & Basic Info** page\n4. Copy your **App ID** and **App Secret**\n5. Use these credentials to call the tenant_access_token API to obtain an access token",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -36,6 +36,7 @@ export enum FeatureSwitchKey {
   GitHubIntegration = "githubIntegration",
   ZeroDebug = "zeroDebug",
   ComputerUse = "computerUse",
+  LarkConnector = "larkConnector",
   LocalBrowserUse = "localBrowserUse",
   LocalAgentConnector = "localAgentConnector",
   Lab = "lab",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -202,6 +202,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable remote desktop host registration",
     enabled: false,
   },
+  [FeatureSwitchKey.LarkConnector]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Enable the Lark connector while tenant access-token exchange is being repaired.",
+    enabled: false,
+  },
   [FeatureSwitchKey.LocalBrowserUse]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Add a `LarkConnector` feature switch and keep it disabled by default.
- Gate the Lark API-token connection flow behind that switch.
- Hide the Lark ideation use case behind the same switch.
- Add coverage for connector auth-method gating, compose eligibility, and ideation visibility.

Refs #13542
Refs #14607

## Tests

- `pnpm i`
- `pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts`
- `pnpm -F @vm0/core test -- src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-ideation-page.test.tsx`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/app lint`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`
