### PR TITLE
refactor: remove web seed skills helper

### DIFF
--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -5,11 +5,12 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { eq, sql } from "drizzle-orm";
 import { getEligibleConnectorTypes } from "@vm0/connectors/connector-utils";
 import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-providers";
+import { resolveSkillRef } from "@vm0/core/github-url";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import { schema } from "@vm0/db";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { skills } from "@vm0/db/schema/skill";
-import { SEED_SKILLS, buildSeedSkillValues } from "../src/lib/zero/seed-skills";
 
 /**
  * Dev seed: populate usage_pricing, vm0_api_keys, and skills tables.
@@ -39,6 +40,25 @@ function usageGroup(
 ): (typeof usagePricing.$inferInsert)[] {
   return rows.map(([category, unitPrice, unitSize]) => {
     return { kind, provider, category, unitPrice, unitSize };
+  });
+}
+
+function buildSeedSkillValues(
+  names: readonly string[],
+): (typeof skills.$inferInsert)[] {
+  return names.map((name) => {
+    const url = resolveSkillRef(name);
+    const fullPath = url.replace("https://github.com/", "");
+    return {
+      url,
+      name,
+      fullPath,
+      versionHash: null,
+      frontmatter: {
+        name,
+        description: `${name} skill`,
+      },
+    };
   });
 }
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/seed-skill-values.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/seed-skill-values.ts
@@ -1,12 +1,9 @@
 import { resolveSkillRef } from "@vm0/core/github-url";
-import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import type { skills } from "@vm0/db/schema/skill";
-
-export { SEED_SKILLS };
 
 /**
  * Build skill insert values from a list of skill names.
- * Shared by dev-seed and test helpers to avoid duplicated URL/frontmatter construction.
+ * Shared by web test setup and DB-direct seeders.
  */
 export function buildSeedSkillValues(
   names: readonly string[],

--- a/turbo/apps/web/src/__tests__/db-test-seeders/skills.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/skills.ts
@@ -6,7 +6,7 @@ import { skills } from "@vm0/db/schema/skill";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroSkills } from "@vm0/db/schema/zero-skill";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { buildSeedSkillValues } from "../../lib/zero/seed-skills";
+import { buildSeedSkillValues } from "./seed-skill-values";
 
 // ---------------------------------------------------------------------------
 // DB-direct seeders for skill test setup.

--- a/turbo/apps/web/src/__tests__/global-setup.ts
+++ b/turbo/apps/web/src/__tests__/global-setup.ts
@@ -17,7 +17,8 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { schema } from "@vm0/db";
 import { skills } from "@vm0/db/schema/skill";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { SEED_SKILLS, buildSeedSkillValues } from "../lib/zero/seed-skills";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { buildSeedSkillValues } from "./db-test-seeders/seed-skill-values";
 import { getEligibleConnectorTypes } from "@vm0/connectors/connector-utils";
 import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 


### PR DESCRIPTION
## Summary
- remove the web-local seed-skills helper from production src/lib
- move the shared test seed-row builder into web test seeders
- update web dev seed to import SEED_SKILLS directly from core and build its own rows

Closes #14788

## Validation
- pnpm -F web lint
- pnpm -F web check-types
- pnpm -F web exec vitest run src/lib/zero/credit/__tests__/starter-grant.test.ts
- pnpm exec knip --workspace web --production confirms apps/web/src/lib/zero/seed-skills.ts is gone; it still exits 1 on unrelated existing web production leftovers that are out of scope for #14788
- lefthook pre-commit: prettier, knip --cache, turbo run check-types