### PR TITLE
fix: show disabled github install for members

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -10,6 +10,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -23,6 +24,7 @@ import {
   zeroIntegrationsSlackContract,
   type SlackOrgStatus,
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
+import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -40,6 +42,7 @@ const context = testContext();
 const mockApi = createMockApi(context);
 const GITHUB_CONNECT_URL =
   "https://github.com/login/oauth/authorize?client_id=github-oauth-client-id";
+const GITHUB_ADMIN_INSTALL_TOOLTIP = "Ask an org admin to install GitHub.";
 
 function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
   const defaults: SlackOrgStatus = {
@@ -198,6 +201,54 @@ describe("works page - GitHub integration card", () => {
         ),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows disabled GitHub install guidance when org members cannot install", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    server.use(
+      mockApi(integrationsGithubContract.getInstallation, ({ respond }) => {
+        return respond(404, {
+          error: {
+            message: "No GitHub installation found",
+            code: "NOT_FOUND",
+          },
+          installUrl: null,
+        });
+      }),
+    );
+    renderWorksPage({
+      featureSwitches: { [FeatureSwitchKey.GitHubIntegration]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    const githubCard = getGithubCard();
+    const installButton = within(githubCard)
+      .getByText("Install GitHub")
+      .closest("button");
+    if (!installButton) {
+      throw new Error("GitHub install button not found");
+    }
+    expect(installButton).toBeDisabled();
+    expect(installButton).toHaveAttribute(
+      "title",
+      GITHUB_ADMIN_INSTALL_TOOLTIP,
+    );
+
+    await userEvent.hover(
+      within(githubCard).getByTestId("github-install-admin-required"),
+    );
+    const tooltip = (
+      await screen.findAllByText(GITHUB_ADMIN_INSTALL_TOOLTIP)
+    ).find((element) => {
+      return element.dataset.state === "delayed-open";
+    });
+    if (!tooltip) {
+      throw new Error("GitHub admin install tooltip not found");
+    }
+    expect(tooltip).toBeVisible();
   });
 
   it("refreshes the GitHub card from the page-level realtime subscription", async () => {

--- a/turbo/apps/platform/src/views/zero-page/github-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/github-card.tsx
@@ -7,6 +7,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@vm0/ui/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui/components/ui/tooltip";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   connectGithubInstallation$,
@@ -19,6 +25,8 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import githubIconImg from "./components/settings/icons/github.svg";
+
+const GITHUB_ADMIN_INSTALL_TOOLTIP = "Ask an org admin to install GitHub.";
 
 function openFreshOAuth(url: string) {
   const fresh = new URL(url, window.location.origin);
@@ -134,35 +142,67 @@ function GithubCardActions({
   const [uninstallLoadable, uninstall] = useLoadableSet(
     uninstallGithubInstallation$,
   );
+
+  if (!data) {
+    return null;
+  }
+
   const connecting = connectLoadable.state === "loading";
   const disconnecting = disconnectLoadable.state === "loading";
   const uninstalling = uninstallLoadable.state === "loading";
   const busy = connecting || disconnecting || uninstalling;
-  const isInstalled = data?.isInstalled ?? false;
-  const isConnected = data?.isConnected ?? false;
-  const installUrl = isInstalled ? null : data?.installUrl;
-  const connectUrl = data?.connectUrl ?? null;
-  const canUninstall = Boolean(data?.isInstalled && data.installation.isAdmin);
-
-  if (installUrl) {
-    return (
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-8 shrink-0 gap-1.5 rounded-lg"
-        disabled={busy}
-        onClick={() => {
-          openFreshOAuth(installUrl);
-        }}
-      >
-        Install GitHub
-      </Button>
-    );
-  }
+  const isInstalled = data.isInstalled;
+  const isConnected = data.isConnected;
+  const installUrl = isInstalled ? null : data.installUrl;
+  const connectUrl = data.connectUrl;
+  const canUninstall = Boolean(data.isInstalled && data.installation.isAdmin);
 
   if (!isInstalled) {
-    return null;
+    if (installUrl) {
+      return (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5 rounded-lg"
+          disabled={busy}
+          onClick={() => {
+            openFreshOAuth(installUrl);
+          }}
+        >
+          Install GitHub
+        </Button>
+      );
+    }
+
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              data-testid="github-install-admin-required"
+              className="inline-flex shrink-0"
+              tabIndex={0}
+              title={GITHUB_ADMIN_INSTALL_TOOLTIP}
+            >
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 shrink-0 gap-1.5 rounded-lg"
+                disabled
+                title={GITHUB_ADMIN_INSTALL_TOOLTIP}
+              >
+                Install GitHub
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {GITHUB_ADMIN_INSTALL_TOOLTIP}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Keep the GitHub install CTA visible on `/works` when the current user cannot install it.
- Render the CTA disabled with admin guidance on hover.
- Add `/works` coverage for the non-admin no-install-url state.

## Validation
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-works-page.test.tsx --run`
- `env -u OPENAI_API_KEY pnpm -F api exec vitest src/signals/routes/__tests__/zero-chat-messages.test.ts --run`

## Notes
- Full `pnpm test` was also run locally. It completed with one API test failure because this environment has `OPENAI_API_KEY` set and that overrides the test fixture key; rerunning the failing file with `OPENAI_API_KEY` unset passed.