### PR TITLE
refactor(api): wrap integration model route in command

### DIFF
--- a/turbo/apps/api/src/signals/routes/cron-aggregate-insights.ts
+++ b/turbo/apps/api/src/signals/routes/cron-aggregate-insights.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { aggregateInsights$ } from "../services/cron-aggregate-insights.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const aggregateInsightsRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-aggregate-usage.ts
+++ b/turbo/apps/api/src/signals/routes/cron-aggregate-usage.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { aggregateUsageDaily$ } from "../services/cron-aggregate-usage.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const aggregateUsageRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-auth.ts
+++ b/turbo/apps/api/src/signals/routes/cron-auth.ts
@@ -1,9 +1,7 @@
-import type { Computed } from "ccstate";
+import { computed } from "ccstate";
 
 import { env } from "../../lib/env";
 import { authorization$ } from "../context/hono";
-
-type CronGetter = <T>(source: Computed<T>) => T;
 
 interface CronUnauthorizedResponse {
   readonly status: 401;
@@ -27,6 +25,6 @@ export function cronUnauthorized(): CronUnauthorizedResponse {
   };
 }
 
-export function hasValidCronSecret(get: CronGetter): boolean {
+export const hasValidCronSecret$ = computed((get): boolean => {
   return get(authorization$) === `Bearer ${env("CRON_SECRET")}`;
-}
+});

--- a/turbo/apps/api/src/signals/routes/cron-cleanup-sandboxes.ts
+++ b/turbo/apps/api/src/signals/routes/cron-cleanup-sandboxes.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { cleanupSandboxes$ } from "../services/cron-cleanup-sandboxes.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const cleanupSandboxesRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-drain-email-outbox.ts
+++ b/turbo/apps/api/src/signals/routes/cron-drain-email-outbox.ts
@@ -6,11 +6,11 @@ import {
   cleanupExpiredEmailOutbox$,
   drainEmailOutboxBatch$,
 } from "../services/zero-email-common.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const drainEmailOutboxRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-execute-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/cron-execute-schedules.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { executeDueSchedules$ } from "../services/zero-schedules.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const executeSchedulesRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-process-usage-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-process-usage-events.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { processStaleUsageEvents$ } from "../services/cron-process-usage-events.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const processUsageEventsRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-reconcile-billing-entitlements.ts
+++ b/turbo/apps/api/src/signals/routes/cron-reconcile-billing-entitlements.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { reconcileBillingEntitlements$ } from "../services/cron-billing-entitlements.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const reconcileBillingEntitlementsRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-sync-skills.ts
+++ b/turbo/apps/api/src/signals/routes/cron-sync-skills.ts
@@ -3,10 +3,10 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { syncSkills$ } from "../services/cron-sync-skills.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const syncSkillsRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!hasValidCronSecret(get)) {
+  if (!get(hasValidCronSecret$)) {
     return cronUnauthorized();
   }
 

--- a/turbo/apps/api/src/signals/routes/cron-telegram-cleanup.ts
+++ b/turbo/apps/api/src/signals/routes/cron-telegram-cleanup.ts
@@ -3,11 +3,11 @@ import { command } from "ccstate";
 
 import type { RouteEntry } from "../route";
 import { cleanupTelegramMessages$ } from "../services/cron-telegram-cleanup.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const telegramCleanupRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/cron-voice-chat-cleanup.ts
+++ b/turbo/apps/api/src/signals/routes/cron-voice-chat-cleanup.ts
@@ -5,11 +5,11 @@ import { waitUntil } from "../context/wait-until";
 import type { RouteEntry } from "../route";
 import { resetStuckVoiceChatReasoners$ } from "../services/cron-voice-chat-cleanup.service";
 import { triggerVoiceChatReasoning$ } from "../services/zero-voice-chat.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const voiceChatCleanupRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/routes/vercel-sandbox-smoke.ts
+++ b/turbo/apps/api/src/signals/routes/vercel-sandbox-smoke.ts
@@ -7,7 +7,7 @@ import {
   runVercelSandboxSmoke,
   type VercelSandboxSmokeResult,
 } from "../services/vercel-sandbox-smoke.service";
-import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const c = initContract();
 
@@ -96,7 +96,7 @@ function failureMessage(
 
 const vercelSandboxSmokeRoute$ = command(
   async ({ get }, signal: AbortSignal) => {
-    if (!hasValidCronSecret(get)) {
+    if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 

--- a/turbo/apps/api/src/signals/services/integration-model-route.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-model-route.service.ts
@@ -1,4 +1,4 @@
-import type { Getter, Setter } from "ccstate";
+import { command } from "ccstate";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
@@ -11,46 +11,49 @@ export interface IntegrationModelRoutePin {
   readonly selectedModel: string;
 }
 
-export async function resolveIntegrationModelRouteForUser(args: {
-  readonly get: Getter;
-  readonly set: Setter;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-}): Promise<IntegrationModelRoutePin | undefined> {
-  const preference = await args.get(
-    userModelPreference({ orgId: args.orgId, userId: args.userId }),
-  );
-  args.signal.throwIfAborted();
+export const resolveIntegrationModelRouteForUser$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<IntegrationModelRoutePin | undefined> => {
+    const preference = await get(
+      userModelPreference({ orgId: args.orgId, userId: args.userId }),
+    );
+    signal.throwIfAborted();
 
-  const policies = await args.set(
-    listOrgModelPolicies$,
-    { orgId: args.orgId, userId: args.userId },
-    args.signal,
-  );
+    const policies = await set(
+      listOrgModelPolicies$,
+      { orgId: args.orgId, userId: args.userId },
+      signal,
+    );
 
-  const preferredPolicy = preference.selectedModel
-    ? policies.policies.find((policy) => {
-        return policy.model === preference.selectedModel;
-      })
-    : undefined;
-  const defaultPolicy = policies.policies.find((policy) => {
-    return policy.id === policies.workspaceDefaultPolicyId;
-  });
-  const routePolicy =
-    preferredPolicy ??
-    defaultPolicy ??
-    policies.policies.find((policy) => {
-      return policy.isDefault;
+    const preferredPolicy = preference.selectedModel
+      ? policies.policies.find((policy) => {
+          return policy.model === preference.selectedModel;
+        })
+      : undefined;
+    const defaultPolicy = policies.policies.find((policy) => {
+      return policy.id === policies.workspaceDefaultPolicyId;
     });
-  if (!routePolicy || routePolicy.routeStatus !== "valid") {
-    return undefined;
-  }
+    const routePolicy =
+      preferredPolicy ??
+      defaultPolicy ??
+      policies.policies.find((policy) => {
+        return policy.isDefault;
+      });
+    if (!routePolicy || routePolicy.routeStatus !== "valid") {
+      return undefined;
+    }
 
-  return {
-    modelProviderType: routePolicy.defaultProviderType,
-    modelProviderId: routePolicy.modelProviderId,
-    modelProviderCredentialScope: routePolicy.credentialScope,
-    selectedModel: routePolicy.model,
-  };
-}
+    return {
+      modelProviderType: routePolicy.defaultProviderType,
+      modelProviderId: routePolicy.modelProviderId,
+      modelProviderCredentialScope: routePolicy.credentialScope,
+      selectedModel: routePolicy.model,
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -32,7 +32,7 @@ import {
 import { getGithubInstallationAccessToken } from "./github-app.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import {
-  resolveIntegrationModelRouteForUser,
+  resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
@@ -1141,13 +1141,14 @@ const dispatchGithubAgentRun$ = command(
       composeId: params.composeId,
       signal,
     });
-    const modelRoute = await resolveIntegrationModelRouteForUser({
-      get,
-      set,
-      orgId: target.orgId,
-      userId: params.vm0UserId,
+    const modelRoute = await set(
+      resolveIntegrationModelRouteForUser$,
+      {
+        orgId: target.orgId,
+        userId: params.vm0UserId,
+      },
       signal,
-    });
+    );
     signal.throwIfAborted();
 
     const sessionResult = await resolveExistingSession({

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -42,7 +42,7 @@ import {
 import { safeUrlParse, settle } from "../utils";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import {
-  resolveIntegrationModelRouteForUser,
+  resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
@@ -2051,13 +2051,14 @@ export const handleAgentPhoneMessage$ = command(
     await refreshTypingIfSupported(params.event, signal);
     signal.throwIfAborted();
 
-    const modelRoute = await resolveIntegrationModelRouteForUser({
-      get,
-      set,
-      orgId: params.userLink.orgId,
-      userId: params.userLink.vm0UserId,
+    const modelRoute = await set(
+      resolveIntegrationModelRouteForUser$,
+      {
+        orgId: params.userLink.orgId,
+        userId: params.userLink.vm0UserId,
+      },
       signal,
-    });
+    );
     signal.throwIfAborted();
 
     const rootMessageId = agentPhoneThreadRootMessageId(params.event);

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -70,7 +70,7 @@ import { writeDb$, type Db } from "../external/db";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import {
-  resolveIntegrationModelRouteForUser,
+  resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
@@ -1309,13 +1309,14 @@ async function buildRunAgentParams(
     client: resolved.client,
     userId: args.slackUserId,
   });
-  const modelRoute = await resolveIntegrationModelRouteForUser({
-    get: args.get,
-    set: args.set,
-    orgId: resolved.installation.orgId,
-    userId: resolved.connection.vm0UserId,
-    signal: args.signal,
-  });
+  const modelRoute = await args.set(
+    resolveIntegrationModelRouteForUser$,
+    {
+      orgId: resolved.installation.orgId,
+      userId: resolved.connection.vm0UserId,
+    },
+    args.signal,
+  );
   const existingSessionId = await resolveCompatibleThreadSession({
     db: args.db,
     channelId: args.channelId,

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -60,7 +60,7 @@ import {
   encryptPersistentSecretValue,
 } from "./crypto.utils";
 import {
-  resolveIntegrationModelRouteForUser,
+  resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
@@ -1954,13 +1954,14 @@ async function handleTelegramAgentMessage(args: {
   args.signal.throwIfAborted();
 
   const rootMessageId = rootMessageIdForAgentMessage(args);
-  const modelRoute = await resolveIntegrationModelRouteForUser({
-    get: args.get,
-    set: args.set,
-    orgId: args.orgId,
-    userId: args.userLink.vm0UserId,
-    signal: args.signal,
-  });
+  const modelRoute = await args.set(
+    resolveIntegrationModelRouteForUser$,
+    {
+      orgId: args.orgId,
+      userId: args.userLink.vm0UserId,
+    },
+    args.signal,
+  );
   args.signal.throwIfAborted();
   const session = await lookupAgentThreadSession({
     db: args.db,


### PR DESCRIPTION
## Summary
- convert `resolveIntegrationModelRouteForUser` into a ccstate `command`
- update Slack, Telegram, AgentPhone, and GitHub integration call sites to invoke it through `set(...)`
- remove direct `Getter` / `Setter` dependencies from the shared integration model route helper
- convert cron secret validation from `hasValidCronSecret(get)` into `hasValidCronSecret$` computed and update cron route call sites

## Verification
- `git diff --check`
- `rg -n "CronGetter|hasValidCronSecret\(" turbo/apps/api/src/signals/routes --glob "!**/__tests__/**"` *(no matches)*
- `pnpm --dir turbo --filter api check-types` *(fails locally: `tsc` not found because `node_modules` is not installed in this checkout)*