### PR TITLE
feat(platform): add Personal sidebar group label and tighten Time Zone copy

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -106,7 +106,7 @@ interface SidebarGroup {
 }
 
 const PERSONAL_GROUP = {
-  label: null,
+  label: "Personal",
   items: [
     {
       id: "preference",

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -46,9 +46,6 @@ export function TimezoneSettings() {
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-sm text-muted-foreground">
-        Used to schedule tasks and send notifications at the right time.
-      </p>
       <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">


### PR DESCRIPTION
Closes #14806.

## Summary
- Label the personal-scope group (Preference, API Keys, Model, Debug) as **Personal** so it matches the existing **Workspace** and **Billing & pricing** groups in the settings sidebar.
- Drop the redundant intro paragraph inside `TimezoneSettings` — the section heading already says "Times shown to you and used for scheduled work.", so the second line was just duplicating it.

## Before
![Sidebar — missing Personal label](https://github.com/vm0-ai/vm0/releases/download/sandbox-fc-v0.35.11/preference-sidebar-1779693661.png)
![Time Zone — duplicate description](https://github.com/vm0-ai/vm0/releases/download/sandbox-fc-v0.35.11/timezone-desc-1779693661.png)

## Test plan
- [x] `pnpm check-types` (platform)
- [x] `pnpm exec eslint` on the two touched files
- [x] `pnpm exec oxlint` on the two touched files
- [x] Prettier check
- [ ] Open Settings → confirm the sidebar shows a `Personal` group label and the Time Zone section shows a single description line