### PR TITLE
fix: inject connector env at run creation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -618,6 +618,13 @@ describe("POST /api/agent/runs", () => {
     await db.insert(secretsTable).values({
       orgId: fx.orgId,
       userId: fx.userId,
+      name: "DECLARED_SECRET",
+      encryptedValue: encryptSecretForTests("declared-value"),
+      type: "user",
+    });
+    await db.insert(secretsTable).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
       name: "ZENDESK_API_TOKEN",
       encryptedValue: encryptSecretForTests("zendesk-real-token"),
       type: "user",
@@ -627,7 +634,8 @@ describe("POST /api/agent/runs", () => {
       overrides: {
         environment: {
           ANTHROPIC_API_KEY: "test-key",
-          ZENDESK_API_TOKEN: vm0Template("{{ secrets.ZENDESK_API_TOKEN }}"),
+          DECLARED_SECRET: vm0Template("{{ secrets.DECLARED_SECRET }}"),
+          ZENDESK_EMAIL: "compose@example.com",
         },
       },
     });
@@ -658,7 +666,12 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.environment.ZENDESK_API_TOKEN).toBe(
       "zkTkn_CoffeeSafeLocalCoffeeSafeLocalCoffeeSa",
     );
+    expect(executionContext.environment.ZENDESK_EMAIL).toBe(
+      "compose@example.com",
+    );
+    expect(executionContext.environment.ZENDESK_SUBDOMAIN).toBe("acme");
     expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      DECLARED_SECRET: "declared-value",
       ZENDESK_API_TOKEN: "zendesk-real-token",
     });
     const zendesk = executionContext.firewalls.find((firewall) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -618,15 +618,15 @@ describe("POST /api/agent/runs", () => {
     await db.insert(secretsTable).values({
       orgId: fx.orgId,
       userId: fx.userId,
-      name: "DECLARED_SECRET",
-      encryptedValue: encryptSecretForTests("declared-value"),
+      name: "ZENDESK_API_TOKEN",
+      encryptedValue: encryptSecretForTests("zendesk-real-token"),
       type: "user",
     });
     await db.insert(secretsTable).values({
       orgId: fx.orgId,
       userId: fx.userId,
-      name: "ZENDESK_API_TOKEN",
-      encryptedValue: encryptSecretForTests("zendesk-real-token"),
+      name: "MERCURY_TOKEN",
+      encryptedValue: encryptSecretForTests("mercury-real-token"),
       type: "user",
     });
     const compose = await createCompose({
@@ -634,7 +634,6 @@ describe("POST /api/agent/runs", () => {
       overrides: {
         environment: {
           ANTHROPIC_API_KEY: "test-key",
-          DECLARED_SECRET: vm0Template("{{ secrets.DECLARED_SECRET }}"),
           ZENDESK_EMAIL: "compose@example.com",
         },
       },
@@ -670,10 +669,16 @@ describe("POST /api/agent/runs", () => {
       "compose@example.com",
     );
     expect(executionContext.environment.ZENDESK_SUBDOMAIN).toBe("acme");
+    expect(executionContext.environment.MERCURY_TOKEN).toBe(
+      "CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafe",
+    );
     expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
-      DECLARED_SECRET: "declared-value",
       ZENDESK_API_TOKEN: "zendesk-real-token",
+      MERCURY_TOKEN: "mercury-real-token",
     });
+    expect(
+      decryptSecretsMap(executionContext.encryptedSecrets),
+    ).not.toHaveProperty("MERCURY_ACCESS_TOKEN");
     const zendesk = executionContext.firewalls.find((firewall) => {
       return firewall.name === "zendesk";
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
@@ -48,8 +48,6 @@ const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const ZERO_AGENT_ID_TEMPLATE = ["$", "{{ vars.ZERO_AGENT_ID }}"].join("");
 const ZERO_TOKEN_TEMPLATE = ["$", "{{ secrets.ZERO_TOKEN }}"].join("");
-const GH_TOKEN_TEMPLATE = ["$", "{{ secrets.GH_TOKEN }}"].join("");
-const GITHUB_TOKEN_TEMPLATE = ["$", "{{ secrets.GITHUB_TOKEN }}"].join("");
 const ORG_SENTINEL_USER_ID = "__org__";
 
 function authHeaders() {
@@ -267,8 +265,8 @@ describe("POST /api/zero/agents", () => {
     expect(storedAgent.instructions).toBe("CLAUDE.md");
     expect(environment.ZERO_AGENT_ID).toBe(ZERO_AGENT_ID_TEMPLATE);
     expect(environment.ZERO_TOKEN).toBe(ZERO_TOKEN_TEMPLATE);
-    expect(environment.GH_TOKEN).toBe(GH_TOKEN_TEMPLATE);
-    expect(environment.GITHUB_TOKEN).toBe(GITHUB_TOKEN_TEMPLATE);
+    expect(environment.GH_TOKEN).toBeUndefined();
+    expect(environment.GITHUB_TOKEN).toBeUndefined();
     expect(content.volumes).toBeUndefined();
 
     const [instructionsStorage] = await db

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1318,6 +1318,7 @@ describe("POST /api/zero/runs", () => {
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, response.body.runId));
     const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
       readonly secretConnectorMap: Record<string, string> | null;
       readonly firewalls: readonly {
@@ -1328,6 +1329,14 @@ describe("POST /api/zero/runs", () => {
         }[];
       }[];
     };
+    expect(executionContext.environment.BASE44_TOKEN).toBe(
+      "base44_placeholder_token",
+    );
+    expect(executionContext.environment).not.toHaveProperty(
+      "BASE44_ACCESS_TOKEN",
+    );
+    expect(executionContext.environment).not.toHaveProperty("LARK_TOKEN");
+    expect(executionContext.environment).not.toHaveProperty("LARK_APP_ID");
     const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
     expect(decrypted).toMatchObject({ BASE44_TOKEN: "base44-access" });
     expect(decrypted).not.toHaveProperty("BASE44_REFRESH_TOKEN");

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -1,11 +1,6 @@
 import { command } from "ccstate";
 import { createHash } from "node:crypto";
 import {
-  getConnectorEnvironmentMapping,
-  getEligibleConnectorTypes,
-} from "@vm0/connectors/connector-utils";
-import { connectorTypeSchema } from "@vm0/connectors/connectors";
-import {
   getInstructionsFilename,
   SUPPORTED_FRAMEWORKS,
 } from "@vm0/core/frameworks";
@@ -24,35 +19,16 @@ import { uploadVolumeServerSide$ } from "./storage-volume-upload.service";
  * Build canonical compose content for a zero agent. Pure function — same
  * inputs always yield the same output. The API owns this zero-agent compose
  * shape now; keep it stable because existing compose version hashes depend on
- * the canonical content.
+ * the canonical content. Connector environment is injected later from the
+ * authorized run context.
  */
 function buildZeroAgentComposeContent(
   agentName: string,
 ): Record<string, unknown> {
-  const eligibleConnectorTypes = getEligibleConnectorTypes();
-
   const environment: Record<string, string> = {
     ZERO_AGENT_ID: `\${{ vars.ZERO_AGENT_ID }}`,
     ZERO_TOKEN: `\${{ secrets.ZERO_TOKEN }}`,
   };
-
-  for (const connector of eligibleConnectorTypes) {
-    const parsed = connectorTypeSchema.safeParse(connector);
-    if (!parsed.success) {
-      continue;
-    }
-    const mapping = getConnectorEnvironmentMapping(parsed.data);
-    for (const [envVar, valueRef] of Object.entries(mapping)) {
-      if (envVar in environment) {
-        continue;
-      }
-      if (valueRef.startsWith("$secrets.")) {
-        environment[envVar] = `\${{ secrets.${envVar} }}`;
-      } else if (valueRef.startsWith("$vars.")) {
-        environment[envVar] = `\${{ vars.${envVar} }}`;
-      }
-    }
-  }
 
   const agentDef: Record<string, unknown> = {
     framework: "claude-code",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -154,6 +154,8 @@ const ORG_SENTINEL_USER_ID = "__org__";
 const CUSTOM_CONNECTOR_SECRET_PLACEHOLDER = "{{secret}}";
 const PLATFORM_ENV_SECRET_NAMES = ["GOOGLE_ADS_DEVELOPER_TOKEN"] as const;
 const L = logger("AgentRunCreate");
+const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
+const CONNECTOR_VAR_REF_PREFIX = "$vars.";
 
 type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
 type ComputedGetter = Getter;
@@ -631,27 +633,61 @@ function isOfficialRunnerGroup(group: string): boolean {
   return group.split("/")[0] === "vm0";
 }
 
-function expandEnvironment(
-  content: AgentComposeContent,
-  vars: Record<string, string> | undefined,
-  secrets: Record<string, string> | undefined,
-  additionalEnvironment: Record<string, string> | undefined,
-  environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined,
-): Record<string, string> | null {
-  const environment = firstAgent(content)?.environment;
-  const mergedEnvironment = {
-    ...additionalEnvironment,
-    ...environment,
-  };
-  if (Object.keys(mergedEnvironment).length === 0) {
+function connectorEnvironmentTemplates(
+  connectorTypes: readonly ConnectorType[],
+): Record<string, string> | undefined {
+  const environment: Record<string, string> = {};
+  for (const connectorType of connectorTypes) {
+    const mapping = getConnectorEnvironmentMapping(connectorType);
+    for (const [envName, valueRef] of Object.entries(mapping)) {
+      if (envName in environment) {
+        continue;
+      }
+      if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+        environment[envName] = `\${{ secrets.${envName} }}`;
+      } else if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
+        environment[envName] = `\${{ vars.${envName} }}`;
+      }
+    }
+  }
+  return compactRecord(environment);
+}
+
+function environmentTemplates(args: {
+  readonly content: AgentComposeContent;
+  readonly additionalEnvironment: Record<string, string> | undefined;
+  readonly connectorEnvironment: Record<string, string> | undefined;
+}): Record<string, string> | undefined {
+  const environment = firstAgent(args.content)?.environment;
+  return mergeRecords(
+    args.connectorEnvironment,
+    args.additionalEnvironment,
+    environment,
+  );
+}
+
+function expandEnvironment(args: {
+  readonly content: AgentComposeContent;
+  readonly vars: Record<string, string> | undefined;
+  readonly secrets: Record<string, string> | undefined;
+  readonly additionalEnvironment: Record<string, string> | undefined;
+  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly connectorEnvironment: Record<string, string> | undefined;
+}): Record<string, string> | null {
+  const mergedEnvironment = environmentTemplates({
+    content: args.content,
+    additionalEnvironment: args.additionalEnvironment,
+    connectorEnvironment: args.connectorEnvironment,
+  });
+  if (!mergedEnvironment) {
     return null;
   }
 
   const { result } = expandVariables(mergedEnvironment, {
-    vars,
+    vars: args.vars,
     secrets: {
-      ...secrets,
-      ...firewallSecretPlaceholders(environmentFirewalls),
+      ...args.secrets,
+      ...firewallSecretPlaceholders(args.environmentFirewalls),
     },
   });
   return result;
@@ -680,21 +716,29 @@ function firewallSecretPlaceholders(
   return Object.keys(placeholders).length > 0 ? placeholders : undefined;
 }
 
-function missingEnvironmentReferences(
-  content: AgentComposeContent,
-  vars: Record<string, string> | undefined,
-  secrets: Record<string, string> | undefined,
-  environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined,
-): string[] {
-  const environment = firstAgent(content)?.environment;
+function missingEnvironmentReferences(args: {
+  readonly content: AgentComposeContent;
+  readonly vars: Record<string, string> | undefined;
+  readonly secrets: Record<string, string> | undefined;
+  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly additionalEnvironment: Record<string, string> | undefined;
+  readonly connectorEnvironment: Record<string, string> | undefined;
+}): string[] {
+  const environment = environmentTemplates({
+    content: args.content,
+    additionalEnvironment: args.additionalEnvironment,
+    connectorEnvironment: args.connectorEnvironment,
+  });
   if (!environment) {
     return [];
   }
   const grouped = extractAndGroupVariables(environment);
-  const firewallPlaceholders = firewallSecretPlaceholders(environmentFirewalls);
+  const firewallPlaceholders = firewallSecretPlaceholders(
+    args.environmentFirewalls,
+  );
   const missingVars = grouped.vars
     .filter((ref) => {
-      return vars?.[ref.name] === undefined;
+      return args.vars?.[ref.name] === undefined;
     })
     .map((ref) => {
       return `vars.${ref.name}`;
@@ -702,7 +746,7 @@ function missingEnvironmentReferences(
   const missingSecrets = grouped.secrets
     .filter((ref) => {
       return (
-        secrets?.[ref.name] === undefined &&
+        args.secrets?.[ref.name] === undefined &&
         firewallPlaceholders?.[ref.name] === undefined
       );
     })
@@ -2182,6 +2226,8 @@ function validateCompose(
   options?: {
     readonly validateEnvironmentReferences?: boolean;
     readonly environmentFirewalls?: readonly ExpandedFirewallConfig[];
+    readonly additionalEnvironment?: Record<string, string>;
+    readonly connectorEnvironment?: Record<string, string>;
   },
 ): { readonly framework: SupportedFramework } | CreateRunErrorResult {
   const framework = resolveFramework(content);
@@ -2192,12 +2238,14 @@ function validateCompose(
   }
 
   if (options?.validateEnvironmentReferences !== false) {
-    const missing = missingEnvironmentReferences(
+    const missing = missingEnvironmentReferences({
       content,
       vars,
       secrets,
-      options?.environmentFirewalls,
-    );
+      environmentFirewalls: options?.environmentFirewalls,
+      additionalEnvironment: options?.additionalEnvironment,
+      connectorEnvironment: options?.connectorEnvironment,
+    });
     if (missing.length > 0) {
       return badRequestMessage(
         `Missing required values: ${missing.join(", ")}`,
@@ -2438,6 +2486,9 @@ async function buildStoredExecutionContext(args: {
     connectorTypes: args.connectorContext.connectorTypes,
     customConnectorFirewalls: args.customConnectorContext.firewalls,
   });
+  const connectorEnvironment = connectorEnvironmentTemplates(
+    args.connectorContext.connectorTypes,
+  );
   const executionSecrets = buildStoredExecutionSecrets({
     connectorContext: args.connectorContext,
     modelProvider: args.modelProvider,
@@ -2456,13 +2507,14 @@ async function buildStoredExecutionContext(args: {
       workingDir: frameworkWorkingDir(args.framework),
       storageManifest: args.storageManifest,
       environment: {
-        ...expandEnvironment(
-          args.resolved.content,
-          args.body.vars,
-          executionSecrets.secrets,
-          args.modelProvider?.environment,
-          permissions?.environmentFirewalls,
-        ),
+        ...expandEnvironment({
+          content: args.resolved.content,
+          vars: args.body.vars,
+          secrets: executionSecrets.secrets,
+          additionalEnvironment: args.modelProvider?.environment,
+          environmentFirewalls: permissions?.environmentFirewalls,
+          connectorEnvironment,
+        }),
         ...args.extraEnvironment,
       },
       resumeSession: args.resolved.resumeSession ?? null,
@@ -3122,6 +3174,9 @@ function validateRunEnvironmentReferences(args: {
     bodySecrets: args.body.secrets,
     customConnectorContext: args.customConnectorContext,
   });
+  const connectorEnvironment = connectorEnvironmentTemplates(
+    args.connectorContext.connectorTypes,
+  );
   const validation = validateCompose(
     args.resolved.content,
     args.body.vars,
@@ -3129,6 +3184,8 @@ function validateRunEnvironmentReferences(args: {
     {
       validateEnvironmentReferences: args.validateEnvironmentReferences,
       environmentFirewalls: validationPermissions?.environmentFirewalls,
+      additionalEnvironment: args.modelProvider?.environment,
+      connectorEnvironment,
     },
   );
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -653,6 +653,21 @@ function connectorEnvironmentTemplates(
   return compactRecord(environment);
 }
 
+function connectorEnvironmentSecretTemplateNames(
+  connectorTypes: readonly ConnectorType[],
+): Set<string> {
+  const names = new Set<string>();
+  for (const connectorType of connectorTypes) {
+    const mapping = getConnectorEnvironmentMapping(connectorType);
+    for (const [envName, valueRef] of Object.entries(mapping)) {
+      if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+        names.add(envName);
+      }
+    }
+  }
+  return names;
+}
+
 function environmentTemplates(args: {
   readonly content: AgentComposeContent;
   readonly additionalEnvironment: Record<string, string> | undefined;
@@ -754,6 +769,18 @@ function missingEnvironmentReferences(args: {
       return `secrets.${ref.name}`;
     });
   return [...missingVars, ...missingSecrets];
+}
+
+function allowedApiTokenConnectorTypes(args: {
+  readonly apiTokenTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+}): readonly ConnectorType[] {
+  if (!args.allowedConnectorTypes) {
+    return args.apiTokenTypes;
+  }
+  return args.apiTokenTypes.filter((type) => {
+    return args.allowedConnectorTypes?.includes(type);
+  });
 }
 
 function hasExplicitFrameworkApiKey(
@@ -1261,16 +1288,22 @@ async function loadReferencedSecrets(
   },
 ): Promise<Record<string, string> | undefined> {
   const environment = firstAgent(args.content)?.environment;
-  if (!environment) {
-    return args.runSecrets;
-  }
-
-  const referencedNames = extractAndGroupVariables(environment).secrets.map(
-    (ref) => {
-      return ref.name;
-    },
+  const referencedNames = environment
+    ? extractAndGroupVariables(environment).secrets.map((ref) => {
+        return ref.name;
+      })
+    : [];
+  const apiTokenTypes = await loadApiTokenConnectorTypes(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+  });
+  const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
+    allowedApiTokenConnectorTypes({
+      apiTokenTypes,
+      allowedConnectorTypes: args.allowedConnectorTypes,
+    }),
   );
-  if (referencedNames.length === 0) {
+  if (referencedNames.length === 0 && dynamicConnectorSecretNames.size === 0) {
     return args.runSecrets;
   }
 
@@ -1278,29 +1311,23 @@ async function loadReferencedSecrets(
   // api-token connector credentials are consumed by firewall auth templates,
   // which the compose environment never references. Connector-owned secrets
   // are still scoped by filterDbSecretsByConnectorPermissions below.
-  const [rows, apiTokenTypes] = await Promise.all([
-    db
-      .select({
-        name: secretsTable.name,
-        encryptedValue: secretsTable.encryptedValue,
-        userId: secretsTable.userId,
-      })
-      .from(secretsTable)
-      .where(
-        and(
-          eq(secretsTable.orgId, args.orgId),
-          eq(secretsTable.type, "user"),
-          or(
-            eq(secretsTable.userId, ORG_SENTINEL_USER_ID),
-            eq(secretsTable.userId, args.userId),
-          ),
+  const rows = await db
+    .select({
+      name: secretsTable.name,
+      encryptedValue: secretsTable.encryptedValue,
+      userId: secretsTable.userId,
+    })
+    .from(secretsTable)
+    .where(
+      and(
+        eq(secretsTable.orgId, args.orgId),
+        eq(secretsTable.type, "user"),
+        or(
+          eq(secretsTable.userId, ORG_SENTINEL_USER_ID),
+          eq(secretsTable.userId, args.userId),
         ),
       ),
-    loadApiTokenConnectorTypes(db, {
-      orgId: args.orgId,
-      userId: args.userId,
-    }),
-  ]);
+    );
 
   const orgSecrets: Record<string, string> = {};
   const userSecrets: Record<string, string> = {};
@@ -1318,7 +1345,11 @@ async function loadReferencedSecrets(
     allApiTokenTypes: apiTokenTypes,
     allowedConnectorTypes: args.allowedConnectorTypes,
   });
-  const merged = { ...filteredSecrets, ...args.runSecrets };
+  const connectorSecrets =
+    referencedNames.length === 0
+      ? filterRecordKeys(filteredSecrets, dynamicConnectorSecretNames)
+      : filteredSecrets;
+  const merged = { ...connectorSecrets, ...args.runSecrets };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
@@ -1401,6 +1432,22 @@ function compactRecord(
   values: Record<string, string>,
 ): Record<string, string> | undefined {
   return Object.keys(values).length > 0 ? values : undefined;
+}
+
+function filterRecordKeys(
+  values: Record<string, string> | undefined,
+  keys: ReadonlySet<string>,
+): Record<string, string> | undefined {
+  if (!values) {
+    return undefined;
+  }
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (keys.has(key)) {
+      filtered[key] = value;
+    }
+  }
+  return compactRecord(filtered);
 }
 
 function mergeRecords(


### PR DESCRIPTION
## Summary

- remove connector env injection from static zero compose builders
- inject authorized connector env templates during run creation before expansion
- cover Base44 placeholder env injection, hidden connector absence, Zendesk vars expansion, and compose override behavior

Fixes #14804

## Tests

- pnpm -F web exec vitest run src/lib/zero/__tests__/build-compose-content.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm -F api lint
- pnpm -F web lint
- git diff --check