### PR TITLE
refactor(desktop): remove unused traffic light layout helper

### DIFF
--- a/turbo/apps/desktop/src/desktop-window-chrome.ts
+++ b/turbo/apps/desktop/src/desktop-window-chrome.ts
@@ -3,30 +3,7 @@ type DesktopWindowChromeOptions = Pick<
   "titleBarStyle" | "trafficLightPosition"
 >;
 
-type DesktopWindowTrafficLightLayout = "expanded" | "collapsed";
-
-const EXPANDED_TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 16, y: 18 };
-const COLLAPSED_TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 8, y: 18 };
-
-export function desktopWindowTrafficLightPosition(
-  layout: DesktopWindowTrafficLightLayout,
-): Electron.Point {
-  if (layout === "collapsed") {
-    return COLLAPSED_TRAFFIC_LIGHT_POSITION;
-  }
-  return EXPANDED_TRAFFIC_LIGHT_POSITION;
-}
-
-export function applyDesktopWindowTrafficLightLayout(
-  window: Pick<Electron.BrowserWindow, "setWindowButtonPosition">,
-  platform: NodeJS.Platform,
-  layout: DesktopWindowTrafficLightLayout,
-): void {
-  if (platform !== "darwin") {
-    return;
-  }
-  window.setWindowButtonPosition(desktopWindowTrafficLightPosition(layout));
-}
+const TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 16, y: 18 };
 
 export function buildDesktopWindowChromeOptions(
   platform: NodeJS.Platform,
@@ -37,6 +14,6 @@ export function buildDesktopWindowChromeOptions(
 
   return {
     titleBarStyle: "hiddenInset",
-    trafficLightPosition: desktopWindowTrafficLightPosition("expanded"),
+    trafficLightPosition: TRAFFIC_LIGHT_POSITION,
   };
 }

--- a/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
@@ -2,11 +2,7 @@ import {
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
 } from "./desktop-window-lifecycle";
-import {
-  applyDesktopWindowTrafficLightLayout,
-  buildDesktopWindowChromeOptions,
-  desktopWindowTrafficLightPosition,
-} from "./desktop-window-chrome";
+import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 
 describe("desktop window lifecycle", () => {
   it("uses integrated macOS window chrome", () => {
@@ -18,28 +14,6 @@ describe("desktop window lifecycle", () => {
 
   it("keeps non-macOS window chrome default", () => {
     expect(buildDesktopWindowChromeOptions("linux")).toStrictEqual({});
-  });
-
-  it("uses a left-aligned traffic light position for the collapsed sidebar", () => {
-    expect(desktopWindowTrafficLightPosition("collapsed")).toStrictEqual({
-      x: 8,
-      y: 18,
-    });
-  });
-
-  it("updates traffic lights on macOS only", () => {
-    const window = {
-      setWindowButtonPosition: vi.fn(),
-    };
-
-    applyDesktopWindowTrafficLightLayout(window, "darwin", "collapsed");
-    expect(window.setWindowButtonPosition).toHaveBeenCalledWith({
-      x: 8,
-      y: 18,
-    });
-
-    applyDesktopWindowTrafficLightLayout(window, "linux", "expanded");
-    expect(window.setWindowButtonPosition).toHaveBeenCalledOnce();
   });
 
   it("hides the main window on macOS close unless the app is quitting", () => {


### PR DESCRIPTION
## Summary
- remove the unused dynamic traffic light layout helper from the Desktop window chrome module
- delete tests for the obsolete collapsed-sidebar traffic light position
- keep the static macOS hiddenInset window chrome configuration unchanged

## Validation
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop build
- pnpm format
- pnpm knip
- pnpm turbo run lint
- pnpm check-types

## Notes
- Attempted full pnpm vitest locally, but it stopped during web global setup because local PostgreSQL was not running on localhost:5432; the desktop package tests passed independently.