### PR TITLE
fix: surface X JSON parse errors in audit logs

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -567,7 +567,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
             "body_truncated": bool(resp_meta.get("body_truncated")),
         }
         parse_error = resp_meta.get("parse_error")
-        if isinstance(parse_error, str) and parse_error:
+        if isinstance(parse_error, str) and (parse_error := parse_error.strip()):
             log_extra["parse_error"] = parse_error
         log_proxy_entry(
             proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -561,12 +561,18 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         and req_meta.get("request_ids_count") is None
         and req_meta.get("max_results") is None
     ):
+        log_extra: dict[str, object] = {
+            "body_truncated": bool(resp_meta.get("body_truncated")),
+        }
+        parse_error = resp_meta.get("parse_error")
+        if isinstance(parse_error, str) and parse_error:
+            log_extra["parse_error"] = parse_error
         log_proxy_entry(
             proxy_log_path,
             "error",
             "X response unparseable and request carries no count hints — skipping billing",
             **log_context,
-            body_truncated=bool(resp_meta.get("body_truncated")),
+            **log_extra,
         )
 
     # Forward usage events to the platform for persistence.

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -313,6 +313,8 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     Failures (truncated buffer, malformed JSON, unexpected shape) leave
     ``body_parsed=False`` and emit no count fields, so analysis can
     distinguish "field absent in response" from "we couldn't parse it".
+    Incremental parser failures may also include ``parse_error`` for proxy
+    audit logs.
     """
     state = flow.metadata.get("stream_buffer_state") or {}
     truncated = bool(state.get("truncated", False))

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -588,6 +588,36 @@ class TestReportConnectorUsage:
         assert p["category"] == "content.create_with_url"
         assert p["quantity"] == 1
 
+    def test_x_json_parse_error_on_write_does_not_emit_lost_visibility_log(
+        self, tmp_path, real_flow
+    ):
+        """Write operations bill by method and should not emit read visibility errors."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.metadata["x_json_state"] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": "incomplete json",
+        }
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        p = self._call_and_get_single_billing(flow)
+
+        assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
+        assert proxy_log.exists()
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert all(entry["level"] != "error" for entry in entries)
+        assert all("unparseable" not in entry["message"].lower() for entry in entries)
+        assert all("parse_error" not in entry for entry in entries)
+
     def test_tweet_create_plain_text_downgrades_to_content_create(self, tmp_path, real_flow):
         """POST /2/tweets with text only (no URL, no quote, no media)
         downgrades to the cheaper Content: Create bucket."""

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -927,11 +927,18 @@ class TestReportConnectorUsage:
         assert p["category"] == "posts.read"
         assert p["quantity"] == 3
 
+    @pytest.mark.parametrize(
+        ("query", "expected_quantity"),
+        [
+            ("ids=1,2,3", 3),
+            ("max_results=50", 50),
+        ],
+    )
     def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
-        self, tmp_path, real_flow
+        self, tmp_path, real_flow, query, expected_quantity
     ):
         """Recoverable parser failures should bill from hints without lost-visibility logs."""
-        flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3")
+        flow = self._make_x_flow(real_flow, tmp_path, query=query)
         flow.metadata["x_json_state"] = {
             "body_parsed": False,
             "body_truncated": False,
@@ -942,7 +949,7 @@ class TestReportConnectorUsage:
         p = self._call_and_get_single_billing(flow)
 
         assert p["category"] == "posts.read"
-        assert p["quantity"] == 3
+        assert p["quantity"] == expected_quantity
         assert proxy_log.exists()
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert all(entry["level"] != "error" for entry in entries)

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -986,17 +986,33 @@ class TestReportConnectorUsage:
         assert p["quantity"] == 3
 
     @pytest.mark.parametrize(
-        ("query", "expected_quantity"),
+        ("path", "query", "permission", "rule", "expected_category", "expected_quantity"),
         [
-            ("ids=1,2,3", 3),
-            ("max_results=50", 50),
+            ("/2/tweets", "ids=1,2,3", "tweet.read", "GET /2/tweets", "posts.read", 3),
+            ("/2/tweets", "max_results=50", "tweet.read", "GET /2/tweets", "posts.read", 50),
+            ("/2/users/by", "usernames=a,b", "users.read", "GET /2/users/by", "user.read", 2),
         ],
     )
     def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
-        self, tmp_path, real_flow, query, expected_quantity
+        self,
+        tmp_path,
+        real_flow,
+        path,
+        query,
+        permission,
+        rule,
+        expected_category,
+        expected_quantity,
     ):
         """Recoverable parser failures should bill from hints without lost-visibility logs."""
-        flow = self._make_x_flow(real_flow, tmp_path, query=query)
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path=path,
+            query=query,
+            permission=permission,
+            rule=rule,
+        )
         flow.metadata["x_json_state"] = {
             "body_parsed": False,
             "body_truncated": False,
@@ -1006,7 +1022,7 @@ class TestReportConnectorUsage:
 
         p = self._call_and_get_single_billing(flow)
 
-        assert p["category"] == "posts.read"
+        assert p["category"] == expected_category
         assert p["quantity"] == expected_quantity
         assert proxy_log.exists()
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -892,10 +892,11 @@ class TestReportConnectorUsage:
         proxy_log = tmp_path / "proxy.jsonl"
         assert self._call_and_get_billing(flow) == []
         assert proxy_log.exists()
-        content = proxy_log.read_text()
-        assert "unparseable" in content.lower()
-        assert '"level":"error"' in content or '"level": "error"' in content
-        assert "tweet.read" in content  # permission is included for auditing
+        entry = json.loads(proxy_log.read_text().splitlines()[0])
+        assert entry["level"] == "error"
+        assert "unparseable" in entry["message"].lower()
+        assert entry["permission"] == "tweet.read"
+        assert "parse_error" not in entry
 
     def test_unparseable_x_json_state_logs_parse_error(self, tmp_path, real_flow):
         """Incremental parser failures should surface the parse reason for audit."""

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -1030,6 +1030,24 @@ class TestReportConnectorUsage:
         assert all("unparseable" not in entry["message"].lower() for entry in entries)
         assert all("parse_error" not in entry for entry in entries)
 
+    def test_x_json_parse_error_with_zero_max_results_is_noop_hint(self, tmp_path, real_flow):
+        """A zero max_results hint should suppress lost-visibility logs without billing."""
+        flow = self._make_x_flow(real_flow, tmp_path, query="max_results=0")
+        flow.metadata["x_json_state"] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": "incomplete json",
+        }
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+
+        if proxy_log.exists():
+            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+            assert all(entry["level"] != "error" for entry in entries)
+            assert all("unparseable" not in entry["message"].lower() for entry in entries)
+            assert all("parse_error" not in entry for entry in entries)
+
     @pytest.mark.parametrize(
         ("query", "expected_quantity"),
         [

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -927,6 +927,27 @@ class TestReportConnectorUsage:
         assert p["category"] == "posts.read"
         assert p["quantity"] == 3
 
+    def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
+        self, tmp_path, real_flow
+    ):
+        """Recoverable parser failures should bill from hints without lost-visibility logs."""
+        flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3")
+        flow.metadata["x_json_state"] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": "incomplete json",
+        }
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        p = self._call_and_get_single_billing(flow)
+
+        assert p["category"] == "posts.read"
+        assert p["quantity"] == 3
+        if proxy_log.exists():
+            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+            assert all("unparseable" not in entry["message"].lower() for entry in entries)
+            assert all("parse_error" not in entry for entry in entries)
+
     @pytest.mark.parametrize(
         ("query", "expected_quantity"),
         [

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -943,10 +943,11 @@ class TestReportConnectorUsage:
 
         assert p["category"] == "posts.read"
         assert p["quantity"] == 3
-        if proxy_log.exists():
-            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
-            assert all("unparseable" not in entry["message"].lower() for entry in entries)
-            assert all("parse_error" not in entry for entry in entries)
+        assert proxy_log.exists()
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert all(entry["level"] != "error" for entry in entries)
+        assert all("unparseable" not in entry["message"].lower() for entry in entries)
+        assert all("parse_error" not in entry for entry in entries)
 
     @pytest.mark.parametrize(
         ("query", "expected_quantity"),

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -885,7 +885,15 @@ class TestReportConnectorUsage:
         ops audits via the proxy error log instead."""
         flow = self._make_x_flow(real_flow, tmp_path, body=b"{")
         flow.metadata["stream_buffer_state"] = {"truncated": True}
+        proxy_log = tmp_path / "proxy.jsonl"
+
         assert self._call_and_get_billing(flow) == []
+
+        entry = json.loads(proxy_log.read_text().splitlines()[0])
+        assert entry["level"] == "error"
+        assert "unparseable" in entry["message"].lower()
+        assert entry["body_truncated"] is True
+        assert "parse_error" not in entry
 
     def test_invalid_json_with_no_hints_skips_billing(self, tmp_path, real_flow):
         """Malformed body + no URL hints → skip emission (see above)."""

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -950,7 +950,10 @@ class TestReportConnectorUsage:
         assert "unparseable" in entry["message"].lower()
         assert entry["parse_error"] == "incomplete json"
 
-    @pytest.mark.parametrize("parse_error", ["", None, {"reason": "incomplete json"}])
+    @pytest.mark.parametrize(
+        "parse_error",
+        ["", None, b"incomplete json", {"reason": "incomplete json"}],
+    )
     def test_unparseable_x_json_state_omits_invalid_parse_error(
         self, tmp_path, real_flow, parse_error
     ):

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -897,6 +897,28 @@ class TestReportConnectorUsage:
         assert '"level":"error"' in content or '"level": "error"' in content
         assert "tweet.read" in content  # permission is included for auditing
 
+    def test_unparseable_x_json_state_logs_parse_error(self, tmp_path, real_flow):
+        """Incremental parser failures should surface the parse reason for audit."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            rule="GET /2/tweets/search/recent",
+        )
+        flow.metadata["x_json_state"] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": "incomplete json",
+        }
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+
+        entry = json.loads(proxy_log.read_text().splitlines()[0])
+        assert entry["level"] == "error"
+        assert "unparseable" in entry["message"].lower()
+        assert entry["parse_error"] == "incomplete json"
+
     def test_billable_counts_fallback_only_when_no_hints(self, tmp_path, real_flow):
         """body unparseable but ?ids= present -> uses ids_count, no fallback."""
         flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=b"not json")

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -950,6 +950,31 @@ class TestReportConnectorUsage:
         assert "unparseable" in entry["message"].lower()
         assert entry["parse_error"] == "incomplete json"
 
+    @pytest.mark.parametrize("parse_error", ["", None, {"reason": "incomplete json"}])
+    def test_unparseable_x_json_state_omits_invalid_parse_error(
+        self, tmp_path, real_flow, parse_error
+    ):
+        """Only non-empty string parse errors should be written to the audit log."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            rule="GET /2/tweets/search/recent",
+        )
+        flow.metadata["x_json_state"] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": parse_error,
+        }
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+
+        entry = json.loads(proxy_log.read_text().splitlines()[0])
+        assert entry["level"] == "error"
+        assert "unparseable" in entry["message"].lower()
+        assert "parse_error" not in entry
+
     def test_billable_counts_fallback_only_when_no_hints(self, tmp_path, real_flow):
         """body unparseable but ?ids= present -> uses ids_count, no fallback."""
         flow = self._make_x_flow(real_flow, tmp_path, query="ids=1,2,3", body=b"not json")

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -960,7 +960,7 @@ class TestReportConnectorUsage:
 
     @pytest.mark.parametrize(
         "parse_error",
-        ["", None, b"incomplete json", {"reason": "incomplete json"}],
+        ["", "   ", None, b"incomplete json", {"reason": "incomplete json"}],
     )
     def test_unparseable_x_json_state_omits_invalid_parse_error(
         self, tmp_path, real_flow, parse_error

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -142,7 +142,7 @@ class TestXJsonFinalize:
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_billable"] = True
@@ -161,7 +161,7 @@ class TestXJsonFinalize:
         mitm_addon.responseheaders(flow)
         assert "x_json_response_finish" in flow.metadata
 
-        _response_stream(flow)(b'{"data":[{"id":"1"}]}')
+        response_stream(flow)(b'{"data":[{"id":"1"}]}')
         response_streaming.finalize_x_json_state(flow)
 
         state = dict(flow.metadata["x_json_state"])
@@ -178,7 +178,7 @@ class TestXJsonFinalize:
         mitm_addon.responseheaders(flow)
         assert "x_json_response_finish" in flow.metadata
 
-        _response_stream(flow)(b'{"data":[1')
+        response_stream(flow)(b'{"data":[1')
         response_streaming.finalize_x_json_state(flow)
 
         state = dict(flow.metadata["x_json_state"])
@@ -195,7 +195,7 @@ class TestXJsonFinalize:
         mitm_addon.responseheaders(flow)
         assert "x_json_response_finish" in flow.metadata
 
-        _response_stream(flow)(b"[1,2,3]")
+        response_stream(flow)(b"[1,2,3]")
         response_streaming.finalize_x_json_state(flow)
 
         state = flow.metadata["x_json_state"]

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -135,6 +135,62 @@ class TestNdjsonExtractor:
         assert state["data_count"] == 1
 
 
+class TestXJsonFinalize:
+    """Tests for finalizing non-streaming X JSON parser state."""
+
+    def _billable_x_json_flow(self, real_flow):
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        return flow
+
+    def test_no_registered_x_json_finalizer_is_noop(self, real_flow):
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+
+        response_streaming.finalize_x_json_state(flow)
+
+        assert "x_json_state" not in flow.metadata
+
+    def test_finalizes_successful_x_json_state(self, real_flow):
+        flow = self._billable_x_json_flow(real_flow)
+        mitm_addon.responseheaders(flow)
+        assert "x_json_response_finish" in flow.metadata
+
+        _response_stream(flow)(b'{"data":[{"id":"1"}]}')
+        response_streaming.finalize_x_json_state(flow)
+
+        state = dict(flow.metadata["x_json_state"])
+        assert "x_json_response_finish" not in flow.metadata
+        assert state["body_parsed"] is True
+        assert state["response_data_count"] == 1
+        assert "parse_error" not in state
+
+        response_streaming.finalize_x_json_state(flow)
+        assert flow.metadata["x_json_state"] == state
+
+    def test_finalizes_x_json_parse_error(self, real_flow):
+        flow = self._billable_x_json_flow(real_flow)
+        mitm_addon.responseheaders(flow)
+        assert "x_json_response_finish" in flow.metadata
+
+        _response_stream(flow)(b'{"data":[1')
+        response_streaming.finalize_x_json_state(flow)
+
+        state = dict(flow.metadata["x_json_state"])
+        assert "x_json_response_finish" not in flow.metadata
+        assert state["body_parsed"] is False
+        assert isinstance(state["parse_error"], str)
+        assert state["parse_error"]
+
+        response_streaming.finalize_x_json_state(flow)
+        assert flow.metadata["x_json_state"] == state
+
+
 class TestResponseHeadersSseParser:
     """Tests for SSE parser setup in responseheaders()."""
 

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -190,6 +190,19 @@ class TestXJsonFinalize:
         response_streaming.finalize_x_json_state(flow)
         assert flow.metadata["x_json_state"] == state
 
+    def test_finalizes_non_object_x_json_without_parse_error(self, real_flow):
+        flow = self._billable_x_json_flow(real_flow)
+        mitm_addon.responseheaders(flow)
+        assert "x_json_response_finish" in flow.metadata
+
+        _response_stream(flow)(b"[1,2,3]")
+        response_streaming.finalize_x_json_state(flow)
+
+        state = flow.metadata["x_json_state"]
+        assert "x_json_response_finish" not in flow.metadata
+        assert state["body_parsed"] is False
+        assert "parse_error" not in state
+
 
 class TestResponseHeadersSseParser:
     """Tests for SSE parser setup in responseheaders()."""

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2226,6 +2226,50 @@ class TestResponseUsageReporting:
         assert "stream_buffer_state" not in flow.metadata
         assert "x_json_response_finish" not in flow.metadata
 
+    def test_response_logs_incremental_x_json_parse_error(self, tmp_path, real_flow, mitm_ctx):
+        """Full response hook should audit parse errors from the incremental X JSON parser."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/recent")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/recent?query=vm0"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/recent"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        _response_stream(flow)(b'{"data":[{"id":"1"}')
+        assert "x_json_response_finish" in flow.metadata
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(api_url="https://app.test"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        mock_opener.open.assert_not_called()
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        lost_visibility_entries = [
+            entry for entry in entries if "unparseable" in entry["message"].lower()
+        ]
+        assert len(lost_visibility_entries) == 1
+        entry = lost_visibility_entries[0]
+        assert entry["level"] == "error"
+        assert entry["body_truncated"] is False
+        assert isinstance(entry["parse_error"], str)
+        assert entry["parse_error"]
+        assert "x_json_response_finish" not in flow.metadata
+
     def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
         """Early-returning SSE flows should not retain parser closures."""
         flow = real_flow(with_response=False, host="api.openai.com")

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2243,11 +2243,11 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/recent"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"data":[{"id":"1"}')
+        response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "x_json_response_finish" in flow.metadata
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -2289,11 +2289,11 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"data":[{"id":"1"}')
+        response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "x_json_response_finish" in flow.metadata
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -2304,7 +2304,7 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2272,6 +2272,49 @@ class TestResponseUsageReporting:
         assert entry["parse_error"]
         assert "x_json_response_finish" not in flow.metadata
 
+    def test_response_uses_request_hints_for_incremental_x_json_parse_error(
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+    ):
+        """Incremental X JSON parser failures should still bill from URL hints."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets?ids=1,2,3")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets?ids=1,2,3"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=_header_map({"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        _response_stream(flow)(b'{"data":[{"id":"1"}')
+        assert "x_json_response_finish" in flow.metadata
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(api_url="https://app.test"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        assert len(events) == 1
+        assert events[0]["category"] == "posts.read"
+        assert events[0]["quantity"] == 3
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert all(entry["level"] != "error" for entry in entries)
+        assert all("unparseable" not in entry["message"].lower() for entry in entries)
+        assert all("parse_error" not in entry for entry in entries)
+        assert "x_json_response_finish" not in flow.metadata
+
     def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
         """Early-returning SSE flows should not retain parser closures."""
         flow = real_flow(with_response=False, host="api.openai.com")

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2226,7 +2226,9 @@ class TestResponseUsageReporting:
         assert "stream_buffer_state" not in flow.metadata
         assert "x_json_response_finish" not in flow.metadata
 
-    def test_response_logs_incremental_x_json_parse_error(self, tmp_path, real_flow, mitm_ctx):
+    def test_response_logs_incremental_x_json_parse_error(
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+    ):
         """Full response hook should audit parse errors from the incremental X JSON parser."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/recent")
         flow.metadata["vm_run_id"] = "run-abc-123"

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2272,6 +2272,51 @@ class TestResponseUsageReporting:
         assert entry["parse_error"]
         assert "x_json_response_finish" not in flow.metadata
 
+    def test_response_logs_x_json_parse_error_after_forensic_buffer_truncates(
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+    ):
+        """The X JSON parser should stay authoritative after the forensic buffer fills."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/recent")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/recent?query=vm0"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/recent"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(b'{"data":[{"id":"1"},' + b" " * body_utils.STREAM_BUFFER_LIMIT)
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(api_url="https://app.test"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        mock_opener.open.assert_not_called()
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        lost_visibility_entries = [
+            entry for entry in entries if "unparseable" in entry["message"].lower()
+        ]
+        assert len(lost_visibility_entries) == 1
+        entry = lost_visibility_entries[0]
+        assert entry["level"] == "error"
+        assert entry["body_truncated"] is False
+        assert entry["parse_error"] == "incomplete json"
+        assert "x_json_response_finish" not in flow.metadata
+
     def test_response_uses_request_hints_for_incremental_x_json_parse_error(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
     ):


### PR DESCRIPTION
## Summary

- Add targeted coverage for `finalize_x_json_state()` no-op, success, parse-error, and double-finalize behavior using the real response streaming parser path.
- Include incremental X JSON `parse_error` in the existing lost-visibility proxy error log when billing is skipped with no request hints.
- Add connector usage coverage proving the parse reason is visible in the proxy audit log.

Closes #14784

## Tests

- `pytest tests/test_response_streaming.py::TestXJsonFinalize`
- `pytest tests/test_connector_usage.py::TestReportConnectorUsage::test_unparseable_x_json_state_logs_parse_error`
- `pytest tests/test_response_streaming.py tests/test_connector_usage.py`
- `basedpyright`
- `ruff check .`
- `ruff format --check .`
- `pytest`
- `git diff --check`
