### PR TITLE
refactor(mitm-addon): isolate firewall auth application flow

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -352,125 +352,6 @@ def _has_valid_expiry(value: object, now: float | None = None) -> bool:
     return (time.time() if now is None else now) < value
 
 
-def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:
-    flow.metadata["firewall_action"] = "ALLOW"
-    flow.metadata["auth_resolved_secrets"] = token_meta.get("resolved_secrets", [])
-    flow.metadata["auth_refreshed_connectors"] = token_meta.get("refreshed_connectors", [])
-    flow.metadata["auth_refreshed_secrets"] = token_meta.get("refreshed_secrets", [])
-    flow.metadata["auth_cache_hit"] = token_meta.get("cache_hit", False)
-
-
-def _apply_header_query_injection(
-    flow: http.HTTPFlow,
-    *,
-    headers: dict[str, str],
-    resolved_query: dict | None,
-) -> None:
-    for header_name, header_value in headers.items():
-        flow.request.headers[header_name] = header_value
-    if resolved_query:
-        for key, value in resolved_query.items():
-            flow.request.query[key] = value
-
-
-async def _apply_url_rewrite(
-    flow: http.HTTPFlow,
-    *,
-    allow: matching.FirewallAllow,
-    resolved_base: str,
-    headers: dict[str, str],
-    resolved_query: dict | None,
-    firewall_base: str,
-    proxy_log_path: str,
-) -> bool:
-    # The addon forwards the request itself because mitmproxy's eager
-    # connection already connected to the placeholder IP. Setting
-    # flow.response bypasses the upstream connection entirely.
-    orig_query = urllib.parse.urlparse(flow.request.path).query
-    new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
-
-    # Filter client-controlled hop-by-hop headers before adding trusted
-    # auth headers, so Connection tokens cannot suppress injected auth.
-    # Repeated request headers are preserved; resolved auth headers
-    # intentionally replace any client-supplied value with the same name.
-    req_headers = _merge_auth_headers(forwarded_request_header_pairs(flow.request.headers), headers)
-    req_body = flow.request.raw_content if flow.request.raw_content is not None else None
-
-    try:
-        status, resp_body, resp_headers = await forward_request(
-            new_url,
-            flow.request.method,
-            req_headers,
-            req_body,
-        )
-        flow.response = http.Response.make(status, resp_body, resp_headers)
-    except Exception as e:
-        log_proxy_entry(
-            proxy_log_path,
-            "error",
-            "URL rewrite forward failed",
-            type="firewall",
-            firewall_base=firewall_base,
-            error_type=type(e).__name__,
-        )
-        _set_matched_firewall_failure_response(
-            flow,
-            status=502,
-            action="ALLOW",
-            error_code="url_rewrite_forward_failed",
-            message="Failed to forward request to upstream",
-            permission=allow.name,
-        )
-        return False
-
-    flow.metadata["auth_url_rewrite"] = True
-    log_proxy_entry(
-        proxy_log_path,
-        "info",
-        f"Firewall URL rewrite: {firewall_base} -> [redacted]",
-        type="firewall",
-        firewall_base=firewall_base,
-    )
-    return True
-
-
-async def _apply_resolved_firewall_auth(
-    flow: http.HTTPFlow,
-    *,
-    allow: matching.FirewallAllow,
-    token_meta: dict,
-    firewall_base: str,
-    proxy_log_path: str,
-) -> bool:
-    """Apply resolved firewall auth.
-
-    Returns True when the caller should record common success metadata.
-    Returns False when this helper already set a local response and the
-    caller must return immediately.
-    """
-    headers = token_meta["headers"]
-    resolved_query = token_meta.get("query")
-    resolved_base = token_meta.get("base")
-
-    if resolved_base:
-        return await _apply_url_rewrite(
-            flow,
-            allow=allow,
-            resolved_base=resolved_base,
-            headers=headers,
-            resolved_query=resolved_query,
-            firewall_base=firewall_base,
-            proxy_log_path=proxy_log_path,
-        )
-
-    _apply_header_query_injection(
-        flow,
-        headers=headers,
-        resolved_query=resolved_query,
-    )
-    return True
-
-
 def _build_cache_hit(
     cached: _FirewallHeaderCacheEntry, firewall_billable: bool = False
 ) -> dict | None:
@@ -592,6 +473,125 @@ async def get_firewall_headers(
         if result.get("query"):
             ret["query"] = result["query"]
         return ret
+
+
+def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:
+    flow.metadata["firewall_action"] = "ALLOW"
+    flow.metadata["auth_resolved_secrets"] = token_meta.get("resolved_secrets", [])
+    flow.metadata["auth_refreshed_connectors"] = token_meta.get("refreshed_connectors", [])
+    flow.metadata["auth_refreshed_secrets"] = token_meta.get("refreshed_secrets", [])
+    flow.metadata["auth_cache_hit"] = token_meta.get("cache_hit", False)
+
+
+def _apply_header_query_injection(
+    flow: http.HTTPFlow,
+    *,
+    headers: dict[str, str],
+    resolved_query: dict | None,
+) -> None:
+    for header_name, header_value in headers.items():
+        flow.request.headers[header_name] = header_value
+    if resolved_query:
+        for key, value in resolved_query.items():
+            flow.request.query[key] = value
+
+
+async def _apply_url_rewrite(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    resolved_base: str,
+    headers: dict[str, str],
+    resolved_query: dict | None,
+    firewall_base: str,
+    proxy_log_path: str,
+) -> bool:
+    # The addon forwards the request itself because mitmproxy's eager
+    # connection already connected to the placeholder IP. Setting
+    # flow.response bypasses the upstream connection entirely.
+    orig_query = urllib.parse.urlparse(flow.request.path).query
+    new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
+
+    # Filter client-controlled hop-by-hop headers before adding trusted
+    # auth headers, so Connection tokens cannot suppress injected auth.
+    # Repeated request headers are preserved; resolved auth headers
+    # intentionally replace any client-supplied value with the same name.
+    req_headers = _merge_auth_headers(forwarded_request_header_pairs(flow.request.headers), headers)
+    req_body = flow.request.raw_content if flow.request.raw_content is not None else None
+
+    try:
+        status, resp_body, resp_headers = await forward_request(
+            new_url,
+            flow.request.method,
+            req_headers,
+            req_body,
+        )
+        flow.response = http.Response.make(status, resp_body, resp_headers)
+    except Exception as e:
+        log_proxy_entry(
+            proxy_log_path,
+            "error",
+            "URL rewrite forward failed",
+            type="firewall",
+            firewall_base=firewall_base,
+            error_type=type(e).__name__,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=502,
+            action="ALLOW",
+            error_code="url_rewrite_forward_failed",
+            message="Failed to forward request to upstream",
+            permission=allow.name,
+        )
+        return False
+
+    flow.metadata["auth_url_rewrite"] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "info",
+        f"Firewall URL rewrite: {firewall_base} -> [redacted]",
+        type="firewall",
+        firewall_base=firewall_base,
+    )
+    return True
+
+
+async def _apply_resolved_firewall_auth(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    token_meta: dict,
+    firewall_base: str,
+    proxy_log_path: str,
+) -> bool:
+    """Apply resolved firewall auth.
+
+    Returns True when the caller should record common success metadata.
+    Returns False when this helper already set a local response and the
+    caller must return immediately.
+    """
+    headers = token_meta["headers"]
+    resolved_query = token_meta.get("query")
+    resolved_base = token_meta.get("base")
+
+    if resolved_base:
+        return await _apply_url_rewrite(
+            flow,
+            allow=allow,
+            resolved_base=resolved_base,
+            headers=headers,
+            resolved_query=resolved_query,
+            firewall_base=firewall_base,
+            proxy_log_path=proxy_log_path,
+        )
+
+    _apply_header_query_injection(
+        flow,
+        headers=headers,
+        resolved_query=resolved_query,
+    )
+    return True
 
 
 async def handle_firewall_request(

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -352,6 +352,125 @@ def _has_valid_expiry(value: object, now: float | None = None) -> bool:
     return (time.time() if now is None else now) < value
 
 
+def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:
+    flow.metadata["firewall_action"] = "ALLOW"
+    flow.metadata["auth_resolved_secrets"] = token_meta.get("resolved_secrets", [])
+    flow.metadata["auth_refreshed_connectors"] = token_meta.get("refreshed_connectors", [])
+    flow.metadata["auth_refreshed_secrets"] = token_meta.get("refreshed_secrets", [])
+    flow.metadata["auth_cache_hit"] = token_meta.get("cache_hit", False)
+
+
+def _apply_header_query_injection(
+    flow: http.HTTPFlow,
+    *,
+    headers: dict[str, str],
+    resolved_query: dict | None,
+) -> None:
+    for header_name, header_value in headers.items():
+        flow.request.headers[header_name] = header_value
+    if resolved_query:
+        for key, value in resolved_query.items():
+            flow.request.query[key] = value
+
+
+async def _apply_url_rewrite(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    resolved_base: str,
+    headers: dict[str, str],
+    resolved_query: dict | None,
+    firewall_base: str,
+    proxy_log_path: str,
+) -> bool:
+    # The addon forwards the request itself because mitmproxy's eager
+    # connection already connected to the placeholder IP. Setting
+    # flow.response bypasses the upstream connection entirely.
+    orig_query = urllib.parse.urlparse(flow.request.path).query
+    new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
+
+    # Filter client-controlled hop-by-hop headers before adding trusted
+    # auth headers, so Connection tokens cannot suppress injected auth.
+    # Repeated request headers are preserved; resolved auth headers
+    # intentionally replace any client-supplied value with the same name.
+    req_headers = _merge_auth_headers(forwarded_request_header_pairs(flow.request.headers), headers)
+    req_body = flow.request.raw_content if flow.request.raw_content is not None else None
+
+    try:
+        status, resp_body, resp_headers = await forward_request(
+            new_url,
+            flow.request.method,
+            req_headers,
+            req_body,
+        )
+        flow.response = http.Response.make(status, resp_body, resp_headers)
+    except Exception as e:
+        log_proxy_entry(
+            proxy_log_path,
+            "error",
+            "URL rewrite forward failed",
+            type="firewall",
+            firewall_base=firewall_base,
+            error_type=type(e).__name__,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=502,
+            action="ALLOW",
+            error_code="url_rewrite_forward_failed",
+            message="Failed to forward request to upstream",
+            permission=allow.name,
+        )
+        return False
+
+    flow.metadata["auth_url_rewrite"] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "info",
+        f"Firewall URL rewrite: {firewall_base} -> [redacted]",
+        type="firewall",
+        firewall_base=firewall_base,
+    )
+    return True
+
+
+async def _apply_resolved_firewall_auth(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    token_meta: dict,
+    firewall_base: str,
+    proxy_log_path: str,
+) -> bool:
+    """Apply resolved firewall auth.
+
+    Returns True when the caller should record common success metadata.
+    Returns False when this helper already set a local response and the
+    caller must return immediately.
+    """
+    headers = token_meta["headers"]
+    resolved_query = token_meta.get("query")
+    resolved_base = token_meta.get("base")
+
+    if resolved_base:
+        return await _apply_url_rewrite(
+            flow,
+            allow=allow,
+            resolved_base=resolved_base,
+            headers=headers,
+            resolved_query=resolved_query,
+            firewall_base=firewall_base,
+            proxy_log_path=proxy_log_path,
+        )
+
+    _apply_header_query_injection(
+        flow,
+        headers=headers,
+        resolved_query=resolved_query,
+    )
+    return True
+
+
 def _build_cache_hit(
     cached: _FirewallHeaderCacheEntry, firewall_billable: bool = False
 ) -> dict | None:
@@ -581,78 +700,17 @@ async def handle_firewall_request(
         )
         return
 
-    # Inject resolved auth headers into the request
-    headers = token_meta["headers"]
+    should_continue = await _apply_resolved_firewall_auth(
+        flow,
+        allow=allow,
+        token_meta=token_meta,
+        firewall_base=firewall_base,
+        proxy_log_path=proxy_log_path,
+    )
+    if not should_continue:
+        return
 
-    # URL rewrite path: auth.base is present (webhook-url connectors).
-    # The addon forwards the request itself because mitmproxy's eager
-    # connection already connected to the placeholder IP — we can't redirect
-    # it. Setting flow.response bypasses the upstream connection entirely.
-    resolved_query = token_meta.get("query")
-
-    resolved_base = token_meta.get("base")
-    if resolved_base:
-        orig_query = urllib.parse.urlparse(flow.request.path).query
-        new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
-
-        # Filter client-controlled hop-by-hop headers before adding trusted
-        # auth headers, so Connection tokens cannot suppress injected auth.
-        # Repeated request headers are preserved; resolved auth headers
-        # intentionally replace any client-supplied value with the same name.
-        req_headers = _merge_auth_headers(
-            forwarded_request_header_pairs(flow.request.headers), headers
-        )
-        req_body = flow.request.raw_content if flow.request.raw_content is not None else None
-
-        try:
-            status, resp_body, resp_headers = await forward_request(
-                new_url,
-                flow.request.method,
-                req_headers,
-                req_body,
-            )
-            flow.response = http.Response.make(status, resp_body, resp_headers)
-        except Exception as e:
-            log_proxy_entry(
-                proxy_log_path,
-                "error",
-                "URL rewrite forward failed",
-                type="firewall",
-                firewall_base=firewall_base,
-                error_type=type(e).__name__,
-            )
-            _set_matched_firewall_failure_response(
-                flow,
-                status=502,
-                action="ALLOW",
-                error_code="url_rewrite_forward_failed",
-                message="Failed to forward request to upstream",
-                permission=allow.name,
-            )
-            return
-
-        flow.metadata["auth_url_rewrite"] = True
-        log_proxy_entry(
-            proxy_log_path,
-            "info",
-            f"Firewall URL rewrite: {firewall_base} -> [redacted]",
-            type="firewall",
-            firewall_base=firewall_base,
-        )
-    else:
-        # Standard header injection path
-        for header_name, header_value in headers.items():
-            flow.request.headers[header_name] = header_value
-        # Standard query param injection path
-        if resolved_query:
-            for key, value in resolved_query.items():
-                flow.request.query[key] = value
-
-    flow.metadata["firewall_action"] = "ALLOW"
-    flow.metadata["auth_resolved_secrets"] = token_meta.get("resolved_secrets", [])
-    flow.metadata["auth_refreshed_connectors"] = token_meta.get("refreshed_connectors", [])
-    flow.metadata["auth_refreshed_secrets"] = token_meta.get("refreshed_secrets", [])
-    flow.metadata["auth_cache_hit"] = token_meta.get("cache_hit", False)
+    _record_firewall_auth_success_metadata(flow, token_meta)
 
     trusted_host = flow.metadata.get("trusted_authority_host") or flow.request.pretty_host
     log_proxy_entry(

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -157,8 +157,12 @@ class TestAuthQueryInjection:
         assert flow.request.query["key"] == "resolved-query-value"
 
     async def test_query_params_merged_into_rewrite_url(self, real_flow, mitm_ctx):
-        """auth.query params are appended to the forwarded URL in the URL rewrite path."""
-        flow = real_flow(with_response=False, host="firewall-placeholder.vm3.ai", path="/hook")
+        """auth.query params are forwarded without mutating the placeholder request."""
+        flow = real_flow(
+            with_response=False,
+            host="firewall-placeholder.vm3.ai",
+            path="/hook?client=visible",
+        )
         flow.metadata["vm_run_id"] = "test-run"
         api_entry = {
             "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
@@ -193,8 +197,12 @@ class TestAuthQueryInjection:
         # Verify the forwarded URL contains the auth.query params
         call_args = mock_forward.call_args
         forwarded_url = call_args[0][0]
-        assert "api_key=resolved-key-456" in forwarded_url
+        query = parse_qs(urlparse(forwarded_url).query)
+        assert query["api_key"] == ["resolved-key-456"]
+        assert query["client"] == ["visible"]
         assert forwarded_url.startswith("https://real-api.com/webhook/secret")
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["client"] == "visible"
 
     async def test_query_params_overwrite_existing_rewrite_url_keys(self, real_flow, mitm_ctx):
         """auth.query overwrites duplicate keys while preserving other query values."""

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -555,6 +555,8 @@ class TestHandleFirewallRequest:
     ):
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
         flow.metadata["vm_run_id"] = "test-run"
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         api_entry = {
             "id": "run-1:0",
             "base": "https://api.github.com",
@@ -602,6 +604,10 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_permission"] == "repo-read"
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
+        log_text = await asyncio.to_thread(
+            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
+        )
+        assert "Firewall https://api.github.com: api.github.com" in log_text
 
     async def test_missing_billable_firewalls_falls_back_to_empty(
         self, real_flow, headers, mitm_ctx, tmp_path

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
@@ -597,7 +596,8 @@ class TestAuthBaseUrlRewriteEdgeCases:
                 "cache_hit": False,
             },
         )
-        flow.metadata["vm_proxy_log_path"] = vm_info["networkLogPath"]
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -623,9 +623,8 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert "auth_refreshed_secrets" not in flow.metadata
         assert "auth_cache_hit" not in flow.metadata
         # Success-path log line must not be written.
-        log_path = Path(vm_info["networkLogPath"])
         log_text = await asyncio.to_thread(
-            lambda: log_path.read_text() if log_path.exists() else ""
+            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
         )
         assert "URL rewrite forward failed" in log_text
         assert "Firewall URL rewrite:" not in log_text

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -424,14 +424,23 @@ class TestAuthBaseUrlRewriteEdgeCases:
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"
 
-    async def test_forward_request_includes_auth_headers(self, real_flow, mitm_ctx, tmp_path):
-        """auth.headers are included in the forwarded request to the real URL."""
+    async def test_forward_request_includes_auth_headers(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        """auth.headers are forwarded without mutating the placeholder request."""
         flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
             resolved_base="https://discord.com/api/webhooks/123/abc",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Authorization", "Bearer agent"),
+            ),
         )
-        token_meta["headers"] = {"X-Custom": "injected-value"}
+        token_meta["headers"] = {
+            "Authorization": "Bearer real-token",
+            "X-Custom": "injected-value",
+        }
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -443,7 +452,11 @@ class TestAuthBaseUrlRewriteEdgeCases:
         # Auth headers passed to forward_request.
         call_args = mock_forward.call_args
         req_headers = call_args[0][2]
+        assert ("Authorization", "Bearer agent") not in req_headers
+        assert ("Authorization", "Bearer real-token") in req_headers
         assert ("X-Custom", "injected-value") in req_headers
+        assert flow.request.headers["Authorization"] == "Bearer agent"
+        assert "X-Custom" not in flow.request.headers
 
     async def test_forward_request_preserves_duplicate_headers_and_auth_override(
         self, headers, real_flow, mitm_ctx, tmp_path

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -666,14 +666,32 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert "super-secret-token" not in json.dumps(log_kwargs)
 
     async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
-        """Empty string base from server is treated as absent — no URL rewrite."""
-        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        """Empty string base from server uses standard auth injection."""
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            auth_overrides={
+                "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+                "query": {"api_key": "${{ secrets.API_KEY }}"},
+            },
+            token_overrides={
+                "headers": {"Authorization": "Bearer real-token"},
+                "query": {"api_key": "resolved-key"},
+                "resolved_secrets": ["TOKEN", "API_KEY"],
+            },
+        )
         token_meta["base"] = ""
-        original_url = flow.request.url
+        original_url = urlparse(flow.request.url)
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
-        assert flow.request.url == original_url
+        updated_url = urlparse(flow.request.url)
+        assert updated_url.scheme == original_url.scheme
+        assert updated_url.netloc == original_url.netloc
+        assert updated_url.path == original_url.path
         assert "auth_url_rewrite" not in flow.metadata
+        assert flow.request.headers["Authorization"] == "Bearer real-token"
+        assert flow.request.query["api_key"] == "resolved-key"
+        assert flow.metadata["auth_resolved_secrets"] == ["TOKEN", "API_KEY"]

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -333,7 +333,16 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
     async def test_sets_auth_url_rewrite_metadata_and_response(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is set and flow.response is populated via forward_request."""
-        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            token_overrides={
+                "resolved_secrets": ["WEBHOOK"],
+                "refreshed_connectors": ["discord"],
+                "refreshed_secrets": ["WEBHOOK"],
+                "cache_hit": False,
+            },
+        )
         mock_forward = AsyncMock(
             return_value=(200, b'{"ok":true}', {"Content-Type": "application/json"})
         )
@@ -344,6 +353,11 @@ class TestAuthBaseUrlRewriteEdgeCases:
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
         assert flow.metadata["auth_url_rewrite"] is True
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["auth_resolved_secrets"] == ["WEBHOOK"]
+        assert flow.metadata["auth_refreshed_connectors"] == ["discord"]
+        assert flow.metadata["auth_refreshed_secrets"] == ["WEBHOOK"]
+        assert flow.metadata["auth_cache_hit"] is False
         assert flow.response is not None
         assert flow.response.status_code == 200
         # forward_request called with the rewritten URL

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -587,7 +587,16 @@ class TestAuthBaseUrlRewriteEdgeCases:
         log were emitted on failure, and ``firewall_error`` was left unset —
         making failed rewrites indistinguishable from successful ones in
         dashboards."""
-        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            token_overrides={
+                "resolved_secrets": ["WEBHOOK"],
+                "refreshed_connectors": ["discord"],
+                "refreshed_secrets": ["WEBHOOK"],
+                "cache_hit": False,
+            },
+        )
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -608,6 +617,10 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert "auth_resolved_secrets" not in flow.metadata
+        assert "auth_refreshed_connectors" not in flow.metadata
+        assert "auth_refreshed_secrets" not in flow.metadata
+        assert "auth_cache_hit" not in flow.metadata
         # Success-path log line must not be written.
         log_path = Path(vm_info["networkLogPath"])
         log_text = await asyncio.to_thread(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -719,10 +719,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
         assert flow.response is not None
         assert b"super-secret-token" not in flow.response.content
-        log_args = mock_log.call_args.args
-        log_kwargs = mock_log.call_args.kwargs
-        assert "super-secret-token" not in json.dumps(log_args)
-        assert "super-secret-token" not in json.dumps(log_kwargs)
+        for log_call in mock_log.call_args_list:
+            assert "super-secret-token" not in json.dumps(log_call.args)
+            assert "super-secret-token" not in json.dumps(log_call.kwargs)
 
     async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
         """Empty string base from server uses standard auth injection."""

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -370,6 +370,30 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert "Firewall URL rewrite:" in log_text
         assert f"Firewall {allow.api_entry['base']}:" in log_text
 
+    async def test_upstream_error_response_is_forwarded(self, real_flow, mitm_ctx, tmp_path):
+        """A non-2xx upstream response is still a successful local forward."""
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(real_flow, tmp_path)
+        mock_forward = AsyncMock(
+            return_value=(
+                500,
+                b'{"error":"upstream"}',
+                {"Content-Type": "application/json"},
+            )
+        )
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 500
+        assert flow.response.content == b'{"error":"upstream"}'
+        assert flow.metadata["auth_url_rewrite"] is True
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert "firewall_error" not in flow.metadata
+
     async def test_no_auth_url_rewrite_metadata_when_no_base(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is absent when no URL rewrite happens."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from mitmproxy import http
 
@@ -659,6 +659,14 @@ class TestAuthBaseUrlRewriteEdgeCases:
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
+        failed_url = mock_forward.call_args[0][0]
+        failed_query = parse_qs(urlparse(failed_url).query, keep_blank_values=True)
+        failed_headers = mock_forward.call_args[0][2]
+        assert failed_query["api_key"] == ["resolved-key"]
+        assert failed_query["client"] == ["visible"]
+        assert ("Authorization", "Bearer agent") not in failed_headers
+        assert ("Authorization", "Bearer real-token") in failed_headers
+        assert ("X-Custom", "injected-value") in failed_headers
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.response.headers["Content-Type"] == "application/json"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -597,6 +597,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
                 "cache_hit": False,
             },
         )
+        flow.metadata["vm_proxy_log_path"] = vm_info["networkLogPath"]
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -626,6 +627,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
         log_text = await asyncio.to_thread(
             lambda: log_path.read_text() if log_path.exists() else ""
         )
+        assert "URL rewrite forward failed" in log_text
         assert "Firewall URL rewrite:" not in log_text
         assert f"Firewall {allow.api_entry['base']}:" not in log_text
 

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -342,6 +342,8 @@ class TestAuthBaseUrlRewriteEdgeCases:
                 "cache_hit": False,
             },
         )
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         mock_forward = AsyncMock(
             return_value=(200, b'{"ok":true}', {"Content-Type": "application/json"})
         )
@@ -362,6 +364,11 @@ class TestAuthBaseUrlRewriteEdgeCases:
         # forward_request called with the rewritten URL
         call_args = mock_forward.call_args
         assert call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
+        log_text = await asyncio.to_thread(
+            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
+        )
+        assert "Firewall URL rewrite:" in log_text
+        assert f"Firewall {allow.api_entry['base']}:" in log_text
 
     async def test_no_auth_url_rewrite_metadata_when_no_base(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is absent when no URL rewrite happens."""

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -627,6 +627,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
             lambda: log_path.read_text() if log_path.exists() else ""
         )
         assert "Firewall URL rewrite:" not in log_text
+        assert f"Firewall {allow.api_entry['base']}:" not in log_text
 
     async def test_forward_failure_does_not_log_resolved_url_secret(
         self, real_flow, mitm_ctx, tmp_path

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -621,7 +621,7 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
         assert mock_forward.call_args[0][3] is None
 
-    async def test_forward_failure_returns_502(self, real_flow, mitm_ctx, tmp_path):
+    async def test_forward_failure_returns_502(self, headers, real_flow, mitm_ctx, tmp_path):
         """forward_request exception produces a 502 error response and marks
         firewall_error without falling through to the success-path metadata.
 
@@ -633,7 +633,17 @@ class TestAuthBaseUrlRewriteEdgeCases:
         flow, allow, vm_info, token_meta = make_rewrite_inputs(
             real_flow,
             tmp_path,
+            path="/hook?client=visible",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Authorization", "Bearer agent"),
+            ),
             token_overrides={
+                "headers": {
+                    "Authorization": "Bearer real-token",
+                    "X-Custom": "injected-value",
+                },
+                "query": {"api_key": "resolved-key"},
                 "resolved_secrets": ["WEBHOOK"],
                 "refreshed_connectors": ["discord"],
                 "refreshed_secrets": ["WEBHOOK"],
@@ -666,6 +676,10 @@ class TestAuthBaseUrlRewriteEdgeCases:
         assert "auth_refreshed_connectors" not in flow.metadata
         assert "auth_refreshed_secrets" not in flow.metadata
         assert "auth_cache_hit" not in flow.metadata
+        assert flow.request.headers["Authorization"] == "Bearer agent"
+        assert "X-Custom" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["client"] == "visible"
         # Success-path log line must not be written.
         log_text = await asyncio.to_thread(
             lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""


### PR DESCRIPTION
## Summary

- Split resolved firewall auth application out of `handle_firewall_request`
- Add an explicit `should_continue` contract for terminal local responses
- Keep URL rewrite forwarding and standard header/query injection behavior unchanged

Closes #14780

## Testing

- `cd crates/runner/mitm-addon && pytest tests/`
- `cd crates/runner/mitm-addon && pytest tests/test_firewall_rewrite.py tests/test_auth_query_injection.py tests/test_firewall_auth.py tests/test_request_handler.py`
- `cd crates/runner/mitm-addon && python3 -m ruff check .`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check .`
- `cd crates/runner/mitm-addon && basedpyright`
- `git diff --check`