### PR TITLE
refactor(mitm-addon): rename shared test helpers

### DIFF
--- a/crates/runner/mitm-addon/tests/firewall_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_helpers.py
@@ -3,12 +3,12 @@
 import asyncio
 
 
-def _wrap_firewalls(apis, name="test"):
+def wrap_firewalls(apis, name="test"):
     """Wrap a list of API entries into a firewall entry list."""
     return [{"name": name, "apis": apis}]
 
 
-def _grant_all(firewalls, unknown_policy="deny"):
+def grant_all(firewalls, unknown_policy="deny"):
     """Build networkPolicies that grants all permissions for each firewall."""
     result = {}
     for fw in firewalls or []:
@@ -25,7 +25,7 @@ def _grant_all(firewalls, unknown_policy="deny"):
     return result
 
 
-async def _cancel_pending_task(task: asyncio.Task | None) -> None:
+async def cancel_pending_task(task: asyncio.Task | None) -> None:
     if task is None or task.done():
         return
     task.cancel()

--- a/crates/runner/mitm-addon/tests/flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/flow_helpers.py
@@ -5,11 +5,11 @@ from collections.abc import Callable, Iterable
 from mitmproxy import http
 
 
-def _header_map(values: dict[str, str]) -> http.Headers:
+def header_map(values: dict[str, str]) -> http.Headers:
     return http.Headers([(name.encode(), value.encode()) for name, value in values.items()])
 
 
-def _response_stream(flow: http.HTTPFlow) -> Callable[[bytes], bytes | Iterable[bytes]]:
+def response_stream(flow: http.HTTPFlow) -> Callable[[bytes], bytes | Iterable[bytes]]:
     assert flow.response is not None
     stream = flow.response.stream
     assert callable(stream)

--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -9,7 +9,7 @@ def _pending_state(path: Path) -> dict:
     return json.loads(path.read_text())
 
 
-def _assert_pending(path: Path, flows: int, reports: int) -> dict:
+def assert_pending(path: Path, flows: int, reports: int) -> dict:
     state = _pending_state(path)
     assert set(state) == {
         "version",

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import matching
-from tests.firewall_helpers import _wrap_firewalls
+from tests.firewall_helpers import wrap_firewalls
 
 
 class TestCompiledFirewallMatching:
@@ -29,7 +29,7 @@ class TestCompiledFirewallMatching:
         assert compiled is raw
 
     def test_matches_raw_for_mixed_base_and_greedy_rule(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api-{region}.example.com/v1/{org}",
@@ -61,7 +61,7 @@ class TestCompiledFirewallMatching:
         }
 
     def test_matches_raw_for_greedy_host_base_params(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://{sub+}.example.com",
@@ -114,7 +114,7 @@ class TestCompiledFirewallMatching:
         assert compiled.params == {"sub": "", "id": "123"}
 
     def test_matches_raw_for_static_base_boundary_and_query(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.anthropic.com/v1/messages",
@@ -153,7 +153,7 @@ class TestCompiledFirewallMatching:
         assert compiled is None
 
     def test_matches_raw_for_parameterized_host_nonstandard_port_rejection(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api-{region}.example.com",
@@ -180,7 +180,7 @@ class TestCompiledFirewallMatching:
         assert compiled is None
 
     def test_matches_raw_for_unknown_policy_when_api_has_no_permissions(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.example.com",
@@ -218,7 +218,7 @@ class TestCompiledFirewallMatching:
         assert compiled.reason == "unknown_endpoint"
 
     def test_matches_raw_for_ask_permission_block(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -311,7 +311,7 @@ class TestCompiledFirewallMatching:
                 }
             ],
         }
-        fws = _wrap_firewalls([api_entry], name="github")
+        fws = wrap_firewalls([api_entry], name="github")
         policies = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "deny"}}
 
         result = matching.match_compiled_firewall_request(
@@ -326,7 +326,7 @@ class TestCompiledFirewallMatching:
         assert result.rule == "ANY /repos/{owner}/{repo}"
 
     def test_later_allowed_permission_still_wins_after_earlier_denied_match(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -361,7 +361,7 @@ class TestCompiledFirewallMatching:
         assert compiled.permission == "repo-admin"
 
     def test_denied_permission_names_keep_encounter_order_and_deduplicate(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -403,7 +403,7 @@ class TestCompiledFirewallMatching:
         assert compiled.reason == "permission_denied"
 
     def test_malformed_rule_fails_closed_without_allowing_permission(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -429,7 +429,7 @@ class TestCompiledFirewallMatching:
         assert result.reason == "malformed_firewall_config"
 
     def test_malformed_rule_blocks_unknown_policy_allow(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -455,7 +455,7 @@ class TestCompiledFirewallMatching:
         assert result.reason == "malformed_firewall_config"
 
     def test_denied_match_takes_priority_over_malformed_config_reason(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -488,7 +488,7 @@ class TestCompiledFirewallMatching:
         assert result.reason == "permission_denied"
 
     def test_valid_later_permission_can_still_allow_after_malformed_rule(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -520,7 +520,7 @@ class TestCompiledFirewallMatching:
         assert result.permission == "repo-read"
 
     def test_malformed_rules_shape_fails_closed_without_compile_error(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -549,7 +549,7 @@ class TestCompiledFirewallMatching:
         assert matching.compile_firewalls([{"name": "github", "apis": None}]) is None
 
     def test_request_url_is_parsed_once_for_multiple_api_entries(self):
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {"base": "https://one.example.com", "permissions": []},
                 {

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -11,10 +11,10 @@ from mitmproxy.test import tutils
 import body_utils
 import mitm_addon
 import usage
-from tests.flow_helpers import _header_map, _response_stream
+from tests.flow_helpers import header_map, response_stream
 from tests.usage_helpers import (
-    _request_bodies_from_calls,
-    _usage_event_events_from_calls,
+    request_bodies_from_calls,
+    usage_event_events_from_calls,
 )
 from usage.providers.connectors import x as usage_x_connector
 
@@ -78,7 +78,7 @@ class TestReportConnectorUsage:
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(
             status_code=status,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-type": "application/json",
                     "content-encoding": content_encoding,
@@ -103,7 +103,7 @@ class TestReportConnectorUsage:
             usage.report_connector_usage(flow, run_id)
         return [
             event
-            for body in _request_bodies_from_calls(mock_opener.open.call_args_list)
+            for body in request_bodies_from_calls(mock_opener.open.call_args_list)
             for event in body["events"]
         ]
 
@@ -185,7 +185,7 @@ class TestReportConnectorUsage:
             usage.report_connector_usage(flow, "run-abc-123")
 
         mock_opener.open.assert_called_once()
-        [payload] = _request_bodies_from_calls(mock_opener.open.call_args_list)
+        [payload] = request_bodies_from_calls(mock_opener.open.call_args_list)
         assert payload["runId"] == "run-abc-123"
         assert "idempotencyKey" not in payload
         by_cat = {event["category"]: event for event in payload["events"]}
@@ -212,7 +212,7 @@ class TestReportConnectorUsage:
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, "run-abc-123")
 
-        bodies = _request_bodies_from_calls(mock_opener.open.call_args_list)
+        bodies = request_bodies_from_calls(mock_opener.open.call_args_list)
         assert [len(body["events"]) for body in bodies] == [100, 1]
         assert {body["runId"] for body in bodies} == {"run-abc-123"}
         assert all(
@@ -424,11 +424,11 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b'{"data":[{"id":"1","text":"')
         callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096))
         callback(b'"}],"includes":{"users":[{"id":"u1"}]},"meta":{"result_count":1}}')
@@ -444,7 +444,7 @@ class TestReportConnectorUsage:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"posts.read": 1, "user.read": 1}
 
@@ -466,11 +466,11 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/{id}"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"data":{"id":"1","text":"hello"}}')
+        response_stream(flow)(b'{"data":{"id":"1","text":"hello"}}')
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -481,7 +481,7 @@ class TestReportConnectorUsage:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 1
@@ -504,11 +504,11 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(
+        response_stream(flow)(
             json.dumps(
                 {
                     "errors": [
@@ -550,11 +550,11 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'[{"id":"1"}]')
+        response_stream(flow)(b'[{"id":"1"}]')
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -565,7 +565,7 @@ class TestReportConnectorUsage:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3
@@ -1084,13 +1084,13 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
         flow.response = tutils.tresp(status_code=200)
         # X streams return application/json with chunked transfer, not x-ndjson.
-        flow.response.headers = _header_map({"content-type": "application/json"})
+        flow.response.headers = header_map({"content-type": "application/json"})
         flow.response.stream = False
         mitm_addon._request_start_times[flow.id] = time.time()
 
         # 1. responseheaders - registers NDJSON parser
         mitm_addon.responseheaders(flow)
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         assert "x_ndjson_state" in flow.metadata
         assert "x_json_response_finish" not in flow.metadata
 
@@ -1117,7 +1117,7 @@ class TestReportConnectorUsage:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads
-        payloads = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # 3 tweets primary + 0 from includes.tweets (none here) = 3
         assert by_cat["posts.read"] == 3

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -7,7 +7,7 @@ import pytest
 
 import mitm_addon
 import usage
-from tests.pending_helpers import _assert_pending
+from tests.pending_helpers import assert_pending
 from usage.providers import model_provider as usage_model_provider
 
 
@@ -27,23 +27,23 @@ class TestUsagePendingCounter:
         usage.increment_in_flight_flows()
         usage.increment_in_flight_flows()
         assert usage.counters._in_flight_flows == 2
-        _assert_pending(pending_path, flows=2, reports=0)
+        assert_pending(pending_path, flows=2, reports=0)
 
         usage.decrement_in_flight_flows()
-        _assert_pending(pending_path, flows=1, reports=0)
+        assert_pending(pending_path, flows=1, reports=0)
 
         usage.decrement_in_flight_flows()
-        _assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, reports=0)
 
     def test_increment_decrement_pending_reports(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         usage.counters.increment_pending_reports()
         assert usage.counters._pending_reports == 1
-        _assert_pending(pending_path, flows=0, reports=1)
+        assert_pending(pending_path, flows=0, reports=1)
 
         usage.counters.decrement_pending_reports()
-        _assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, reports=0)
 
     def test_enqueue_deep_copies_nested_payload(self):
         payload = {
@@ -121,12 +121,12 @@ class TestUsagePendingCounter:
             )
 
         assert usage.counters._pending_reports == 0
-        _assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, reports=0)
 
     def test_set_pending_path_accepts_explicit_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="explicit-usage-state-id")
-        state = _assert_pending(pending_path, flows=0, reports=0)
+        state = assert_pending(pending_path, flows=0, reports=0)
         assert state["usageStateId"] == "explicit-usage-state-id"
 
     def test_decrement_does_not_go_negative(self, tmp_path):
@@ -199,7 +199,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        _assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, reports=0)
 
     def test_enqueue_increments_and_drains_reports(self, tmp_path, real_flow, fresh_usage_executor):
         """Public entry increments pending on enqueue; executor drain decrements to 0."""
@@ -222,7 +222,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        _assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, reports=0)
 
     def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
         """If both response() and error() fire for the same flow, decrement only once."""
@@ -281,4 +281,4 @@ class TestUsagePendingCounter:
             usage.report_model_provider_usage(flow, "run-1")
 
         assert usage.counters._pending_reports == 0
-        _assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, reports=0)

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -10,10 +10,10 @@ from mitmproxy.test import tutils
 
 import mitm_addon
 import usage
-from tests.flow_helpers import _header_map, _response_stream
+from tests.flow_helpers import header_map, response_stream
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 from tests.usage_helpers import (
-    _usage_event_events_from_calls,
+    usage_event_events_from_calls,
 )
 
 
@@ -46,11 +46,11 @@ class TestErrorHandler:
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"model":"claude-sonnet-4-6","usage":')
+        response_stream(flow)(b'{"model":"claude-sonnet-4-6","usage":')
         flow.error = Error("connection reset")
 
         with mitm_ctx():
@@ -70,11 +70,11 @@ class TestErrorHandler:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"data":[{"id":"1"}')
+        response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "x_json_response_finish" in flow.metadata
         flow.error = Error("connection reset")
 
@@ -103,11 +103,11 @@ class TestErrorHandler:
         flow.metadata["firewall_rule_match"] = "GET /2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"data":[{"id":"1"}')
+        response_stream(flow)(b'{"data":[{"id":"1"}')
         flow.error = Error("connection reset")
 
         with (
@@ -223,7 +223,7 @@ class TestErrorHandler:
         flow.metadata["stream_buffer_state"] = {"truncated": False}
         flow.response = tutils.tresp(status_code=200)
         # X streams return application/json with chunked transfer, not x-ndjson.
-        flow.response.headers = _header_map({"content-type": "application/json"})
+        flow.response.headers = header_map({"content-type": "application/json"})
         flow.error = Error("connection reset by peer")
         flow.metadata["vm_sandbox_token"] = "test-token"
 
@@ -239,7 +239,7 @@ class TestErrorHandler:
 
         # Connector billing webhook should have been posted to _opener.
         assert mock_opener.open.called
-        payloads = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 23
         assert by_cat["user.read"] == 5
@@ -266,12 +266,12 @@ class TestErrorHandler:
         flow.metadata["firewall_permission"] = "tweet.read"
         flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         # 1. Register parser
         mitm_addon.responseheaders(flow)
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         assert "x_ndjson_state" in flow.metadata
 
         # 2. Receive two complete tweets, then a partial third (cut off)
@@ -294,7 +294,7 @@ class TestErrorHandler:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
-        payloads = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 2  # not 3 — partial trailing dropped
         assert by_cat["user.read"] == 1

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -21,7 +21,7 @@ from tests.auth_state_helpers import (
     require_last_force_refresh_at,
     set_cached_headers,
 )
-from tests.firewall_helpers import _cancel_pending_task
+from tests.firewall_helpers import cancel_pending_task
 
 
 def _upstream_headers(*pairs: tuple[str, str]) -> Message:
@@ -439,7 +439,7 @@ class TestGetFirewallHeaders:
                 result = await task
             finally:
                 allow_fetch_return.set()
-                await _cancel_pending_task(task)
+                await cancel_pending_task(task)
 
         assert first_force_refresh_values == [False]
         assert result["headers"] == {"Authorization": "Bearer maybe-stale"}
@@ -505,7 +505,7 @@ class TestGetFirewallHeaders:
             finally:
                 allow_first_fetch_return.set()
                 for task in (leader, waiter):
-                    await _cancel_pending_task(task)
+                    await cancel_pending_task(task)
 
         assert force_refresh_values == [False, True]
         assert leader_result["headers"] == {"Authorization": "Bearer maybe-stale"}

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -1,7 +1,7 @@
 """Tests for raw firewall request matching."""
 
 import matching
-from tests.firewall_helpers import _grant_all, _wrap_firewalls
+from tests.firewall_helpers import grant_all, wrap_firewalls
 
 
 class TestMatchFirewallRequest:
@@ -9,7 +9,7 @@ class TestMatchFirewallRequest:
 
     def test_no_permissions_blocks(self, headers):
         """Missing permissions field → block (fail-closed)."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {"base": "https://api.github.com", "auth": {"headers": {}}},
             ],
@@ -19,7 +19,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallBlock)
         assert result.reason == "unknown_endpoint"
@@ -30,7 +30,7 @@ class TestMatchFirewallRequest:
         assert result.permissions == ()
 
     def test_permission_match_allows(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -44,7 +44,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos/octocat/hello",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.name == "github"
@@ -53,7 +53,7 @@ class TestMatchFirewallRequest:
         assert result.rule == "GET /repos/{owner}/{repo}"
 
     def test_any_method_matches(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -66,13 +66,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/anything",
             "DELETE",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.permission == "full-access"
 
     def test_method_case_insensitive(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -85,12 +85,12 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
 
     def test_wrong_method_blocks(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -103,12 +103,12 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos/a/b",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallBlock)
 
     def test_wrong_path_blocks(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -121,12 +121,12 @@ class TestMatchFirewallRequest:
             "https://api.github.com/users/octocat",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallBlock)
 
     def test_no_base_match_returns_none(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -139,14 +139,14 @@ class TestMatchFirewallRequest:
             "https://api.gitlab.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert result is None
 
     def test_no_firewall_returns_none(self):
         assert (
             matching.match_firewall_request(
-                "https://api.github.com", "GET", None, network_policies=_grant_all(None)
+                "https://api.github.com", "GET", None, network_policies=grant_all(None)
             )
             is None
         )
@@ -154,14 +154,14 @@ class TestMatchFirewallRequest:
     def test_empty_firewall_returns_none(self):
         assert (
             matching.match_firewall_request(
-                "https://api.github.com", "GET", [], network_policies=_grant_all([])
+                "https://api.github.com", "GET", [], network_policies=grant_all([])
             )
             is None
         )
 
     def test_exact_base_no_path(self, headers):
         """URL equals base exactly (rest='') → rel_path='/' → matches root rule."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -171,14 +171,14 @@ class TestMatchFirewallRequest:
             ]
         )
         result = matching.match_firewall_request(
-            "https://api.github.com", "GET", fw_configs, network_policies=_grant_all(fw_configs)
+            "https://api.github.com", "GET", fw_configs, network_policies=grant_all(fw_configs)
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.permission == "root"
 
     def test_trailing_slash_on_url(self, headers):
         """URL trailing slash doesn't affect matching (split filters empty segments)."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -191,13 +191,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos/",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
 
     def test_trailing_slash_on_base_config(self, headers):
         """Base URL with trailing slash still matches (rstrip strips it)."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com/",
@@ -210,13 +210,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
 
     def test_port_boundary_rejected(self, headers):
         """Port in URL (rest starts with ':') is not a valid path boundary."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -229,12 +229,12 @@ class TestMatchFirewallRequest:
             "https://api.github.com:8443/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert result is None
 
     def test_evil_domain_not_matched(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -247,12 +247,12 @@ class TestMatchFirewallRequest:
             "https://api.github.com.evil.com/steal",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert result is None
 
     def test_multiple_permissions_first_match_wins(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://slack.com/api",
@@ -268,14 +268,14 @@ class TestMatchFirewallRequest:
             "https://slack.com/api/chat.postMessage",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.permission == "messages-send"
 
     def test_malformed_rules_skipped(self, headers):
         """Rules without 'METHOD /path' format are silently skipped, not crash or false-allow."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -291,7 +291,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         # Non-matching path still blocks (malformed rules don't accidentally allow)
@@ -299,13 +299,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/users",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result2, matching.FirewallBlock)
 
     def test_path_case_sensitive(self, headers):
         """URL paths are case-sensitive — /REPOS must not match /repos."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -318,7 +318,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com/REPOS/octocat",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallBlock)
 
@@ -349,7 +349,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(gh, matching.FirewallAllow)
         assert gh.name == "github"
@@ -358,13 +358,13 @@ class TestMatchFirewallRequest:
             "https://slack.com/api/chat.postMessage",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(sl, matching.FirewallAllow)
         assert sl.name == "slack"
 
     def test_query_string_stripped_for_matching(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -377,12 +377,12 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos?page=1",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
 
     def test_fragment_stripped_for_matching(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -395,13 +395,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos#section",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
 
     def test_empty_permissions_list_blocks(self, headers):
         """If permissions is present but empty, no rules can match → block."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -414,13 +414,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallBlock)
 
     def test_different_bases_same_permission_name(self, headers):
         """Same permission name across different api_entries — each matches its own base."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://slack.com/api",
@@ -439,7 +439,7 @@ class TestMatchFirewallRequest:
             "https://slack.com/api/conversations.history",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer api-token"
@@ -450,7 +450,7 @@ class TestMatchFirewallRequest:
             "https://files.slack.com/files-pri/T1/download",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer files-token"
@@ -458,7 +458,7 @@ class TestMatchFirewallRequest:
 
     def test_same_base_different_permissions(self, headers):
         """Same base URL with different permissions/auth — second api_entry can match."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://slack.com/api",
@@ -476,7 +476,7 @@ class TestMatchFirewallRequest:
             "https://slack.com/api/chat.postMessage",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer user"
@@ -484,7 +484,7 @@ class TestMatchFirewallRequest:
 
     def test_parameterized_host_allows(self, headers):
         """Base URL with {subdomain} in host matches dynamically."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{subdomain}.zendesk.com",
@@ -498,7 +498,7 @@ class TestMatchFirewallRequest:
             "https://acme.zendesk.com/api/v2/tickets",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.name == "zendesk"
@@ -507,7 +507,7 @@ class TestMatchFirewallRequest:
 
     def test_parameterized_host_blocks_no_permission(self, headers):
         """Base URL with host param matches but no rule → block."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{subdomain}.zendesk.com",
@@ -521,14 +521,14 @@ class TestMatchFirewallRequest:
             "https://acme.zendesk.com/api/v2/users",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallBlock)
         assert result.name == "zendesk"
 
     def test_parameterized_host_no_match_returns_none(self, headers):
         """Different domain entirely → None (pass-through)."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{subdomain}.zendesk.com",
@@ -541,13 +541,13 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert result is None
 
     def test_parameterized_path_allows(self, headers):
         """Base URL with {param} in path matches dynamically."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://api.example.com/v1/{org}",
@@ -560,14 +560,14 @@ class TestMatchFirewallRequest:
             "https://api.example.com/v1/acme/projects/123",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.params == {"org": "acme", "id": "123"}
 
     def test_parameterized_host_and_path(self, headers):
         """Both host and path params extracted."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{tenant}.api.example.com/v1/{org}",
@@ -580,14 +580,14 @@ class TestMatchFirewallRequest:
             "https://us.api.example.com/v1/acme/data",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.params == {"tenant": "us", "org": "acme"}
 
     def test_greedy_host_param_matches_multi_level(self, headers):
         """Greedy {sub+} in host matches multiple subdomain levels."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{sub+}.example.com",
@@ -600,14 +600,14 @@ class TestMatchFirewallRequest:
             "https://a.b.c.example.com/api",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.params["sub"] == "a.b.c"
 
     def test_greedy_star_host_param_matches_zero(self, headers):
         """Greedy {sub*} in host matches zero subdomains."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{sub*}.example.com",
@@ -617,7 +617,7 @@ class TestMatchFirewallRequest:
             ]
         )
         result = matching.match_firewall_request(
-            "https://example.com/api", "GET", fw_configs, network_policies=_grant_all(fw_configs)
+            "https://example.com/api", "GET", fw_configs, network_policies=grant_all(fw_configs)
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.params["sub"] == ""
@@ -650,7 +650,7 @@ class TestMatchFirewallRequest:
             "https://api.github.com/repos",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(gh, matching.FirewallAllow)
         assert gh.name == "github"
@@ -659,7 +659,7 @@ class TestMatchFirewallRequest:
             "https://acme.zendesk.com/api/v2/tickets",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(zd, matching.FirewallAllow)
         assert zd.name == "zendesk"
@@ -667,7 +667,7 @@ class TestMatchFirewallRequest:
 
     def test_parameterized_host_with_query_string(self, headers):
         """Parameterized base URL + query string in request."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{sub}.zendesk.com",
@@ -680,14 +680,14 @@ class TestMatchFirewallRequest:
             "https://acme.zendesk.com/api/v2/tickets?page=2",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.params["sub"] == "acme"
 
     def test_parameterized_host_rejects_nonstandard_port(self, headers):
         """Non-standard port must NOT match — prevents auth header leaking to rogue server."""
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://{sub}.zendesk.com",
@@ -700,7 +700,7 @@ class TestMatchFirewallRequest:
             "https://acme.zendesk.com:8443/api",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert result is None
 
@@ -717,12 +717,12 @@ class TestMatchFirewallRequestMixedSegments:
                 ],
             }
         ]
-        firewalls = _wrap_firewalls(apis)
+        firewalls = wrap_firewalls(apis)
         result = matching.match_firewall_request(
             "https://github.com/octocat/hello.git/info/refs",
             "GET",
             firewalls,
-            _grant_all(firewalls),
+            grant_all(firewalls),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.params == {"owner": "octocat", "repo": "hello"}
@@ -734,7 +734,7 @@ class TestMatchFirewallRequestRelPath:
     """Tests that match_firewall_request includes rel_path in allow result."""
 
     def test_rel_path_included_in_allow_result(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
@@ -748,13 +748,13 @@ class TestMatchFirewallRequestRelPath:
             "https://firewall-placeholder.vm3.ai/discord-webhook/hook",
             "POST",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.rel_path == "/"
 
     def test_rel_path_with_remaining_segments(self, headers):
-        fw_configs = _wrap_firewalls(
+        fw_configs = wrap_firewalls(
             [
                 {
                     "base": "https://firewall-placeholder.vm3.ai/bitrix/rest/{uid}/{code}",
@@ -768,7 +768,7 @@ class TestMatchFirewallRequestRelPath:
             "https://firewall-placeholder.vm3.ai/bitrix/rest/0/placeholder/crm.deal.list",
             "GET",
             fw_configs,
-            network_policies=_grant_all(fw_configs),
+            network_policies=grant_all(fw_configs),
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.rel_path == "/crm.deal.list"
@@ -778,7 +778,7 @@ class TestThreeLevelMatching:
     """Tests for three-level matching with network_policies."""
 
     def _firewalls(self):
-        return _wrap_firewalls(
+        return wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -995,7 +995,7 @@ class TestThreeLevelMatching:
 
     def test_empty_permissions_with_unknown_policy_allow(self, headers):
         """Firewall with no permission rules + unknownPolicy=allow allows all."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.hubspot.com",
@@ -1017,7 +1017,7 @@ class TestThreeLevelMatching:
 
     def test_overlapping_permissions_allows_if_any_not_blocked(self, headers):
         """Same endpoint in two permissions — one denied, one allowed → ALLOW."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -1044,7 +1044,7 @@ class TestThreeLevelMatching:
 
     def test_overlapping_permissions_denies_if_all_blocked(self, headers):
         """Same endpoint in two permissions — both denied → DENY."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -1174,7 +1174,7 @@ class TestThreeLevelMatching:
 
     def test_denied_known_not_overridden_by_unknown_policy(self, headers):
         """A known permission that is denied must stay denied even with unknownPolicy=allow."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -1200,7 +1200,7 @@ class TestThreeLevelMatching:
 
     def test_denied_permission_deduped_across_rules(self, headers):
         """Same permission with multiple matching rules appears once in permissions."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -1231,7 +1231,7 @@ class TestThreeLevelMatching:
 
     def test_empty_permissions_list_denies_all_known(self, headers):
         """All permissions in deny list — all known endpoints denied."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -1257,7 +1257,7 @@ class TestThreeLevelMatching:
 
     def test_name_absent_from_policies_allows(self, headers):
         """Firewall name not in networkPolicies → fully permissive."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",
@@ -1290,7 +1290,7 @@ class TestThreeLevelMatching:
 
     def test_multi_api_mixed_permissions(self, headers):
         """One API has permissions, another doesn't — mixed within same firewall."""
-        fws = _wrap_firewalls(
+        fws = wrap_firewalls(
             [
                 {
                     "base": "https://api.github.com",

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import usage
 from tests.usage_helpers import (
-    _model_usage_idempotency_key,
+    model_usage_idempotency_key,
 )
 from usage.providers import model_provider as usage_model_provider
 
@@ -45,7 +45,7 @@ class TestReportModelProviderUsage:
         assert set(body) == {"runId", "events"}
         assert body["events"] == [
             {
-                "idempotencyKey": _model_usage_idempotency_key(
+                "idempotencyKey": model_usage_idempotency_key(
                     "run-abc-123", "msg-usage-1", "tokens.input"
                 ),
                 "kind": "model",
@@ -54,7 +54,7 @@ class TestReportModelProviderUsage:
                 "quantity": 100,
             },
             {
-                "idempotencyKey": _model_usage_idempotency_key(
+                "idempotencyKey": model_usage_idempotency_key(
                     "run-abc-123", "msg-usage-1", "tokens.output"
                 ),
                 "kind": "model",
@@ -63,7 +63,7 @@ class TestReportModelProviderUsage:
                 "quantity": 50,
             },
             {
-                "idempotencyKey": _model_usage_idempotency_key(
+                "idempotencyKey": model_usage_idempotency_key(
                     "run-abc-123", "msg-usage-1", "tokens.cache_read"
                 ),
                 "kind": "model",
@@ -72,7 +72,7 @@ class TestReportModelProviderUsage:
                 "quantity": 25,
             },
             {
-                "idempotencyKey": _model_usage_idempotency_key(
+                "idempotencyKey": model_usage_idempotency_key(
                     "run-abc-123", "msg-usage-1", "tokens.cache_creation"
                 ),
                 "kind": "model",

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -9,7 +9,7 @@ import pytest
 import auth
 import mitm_addon
 import usage
-from tests.pending_helpers import _assert_pending
+from tests.pending_helpers import assert_pending
 
 
 def _write_registry(
@@ -1124,7 +1124,7 @@ class TestRequestHandler:
 
             assert flow.metadata["_usage_flow_tracked"] is True
             assert usage.counters._in_flight_flows == 1
-            _assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1173,7 +1173,7 @@ class TestRequestHandler:
             assert flow.metadata["firewall_error"] == "auth_unavailable"
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            _assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, reports=0)
         finally:
             usage.set_pending_path("")
 
@@ -1221,7 +1221,7 @@ class TestRequestHandler:
             assert flow.id not in mitm_addon._request_start_times
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            _assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1278,7 +1278,7 @@ class TestRequestHandler:
             assert flow.metadata["firewall_billable"] is False
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            _assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, reports=0)
         finally:
             usage.set_pending_path("")
 
@@ -1338,7 +1338,7 @@ class TestRequestHandler:
             assert flow.metadata["firewall_billable"] is True
             assert flow.metadata["model_usage_provider"] == "claude-opus-4-6"
             assert flow.metadata["_usage_flow_tracked"] is True
-            _assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1395,7 +1395,7 @@ class TestRequestHandler:
         async def forward_request(*_args):
             assert flow.metadata["_usage_flow_tracked"] is True
             assert usage.counters._in_flight_flows == 1
-            _assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, reports=0)
             return (200, b'{"delivered":true}', {"Content-Type": "application/json"})
 
         try:
@@ -1418,13 +1418,13 @@ class TestRequestHandler:
                 assert flow.metadata["auth_url_rewrite"] is True
                 assert flow.metadata["_usage_flow_tracked"] is True
                 assert usage.counters._in_flight_flows == 1
-                _assert_pending(pending_path, flows=1, reports=0)
+                assert_pending(pending_path, flows=1, reports=0)
 
                 mitm_addon.response(flow)
 
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            _assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1481,7 +1481,7 @@ class TestRequestHandler:
         async def fail_forward_request(*_args):
             assert flow.metadata["_usage_flow_tracked"] is True
             assert usage.counters._in_flight_flows == 1
-            _assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, reports=0)
             raise RuntimeError("upstream unavailable")
 
         try:
@@ -1506,7 +1506,7 @@ class TestRequestHandler:
             assert "auth_url_rewrite" not in flow.metadata
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            _assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -17,7 +17,7 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_at,
 )
-from tests.flow_helpers import _header_map, _response_stream
+from tests.flow_helpers import header_map, response_stream
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
@@ -39,7 +39,7 @@ class TestResponseHandler:
         # Add response
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-length": "256",
                     "content-type": "application/json",
@@ -80,12 +80,12 @@ class TestResponseHandler:
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-length": "999", "content-type": "application/json"}),
+            headers=header_map({"content-length": "999", "content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b"x" * 40)
-        _response_stream(flow)(b"y" * 60)
+        response_stream(flow)(b"x" * 40)
+        response_stream(flow)(b"y" * 60)
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
@@ -110,12 +110,12 @@ class TestResponseHandler:
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-length": "12", "content-type": "application/json"}),
+            headers=header_map({"content-length": "12", "content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(body[:123])
-        _response_stream(flow)(body[123:])
+        response_stream(flow)(body[:123])
+        response_stream(flow)(body[123:])
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -140,7 +140,7 @@ class TestResponseHandler:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-length": "50000"})
+            status_code=200, headers=header_map({"content-length": "50000"})
         )
 
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -165,7 +165,7 @@ class TestResponseHandler:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -189,7 +189,7 @@ class TestResponseHandler:
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-length": "50000", "content-type": "application/json"}),
+            headers=header_map({"content-length": "50000", "content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
@@ -216,12 +216,12 @@ class TestResponseHandler:
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(body[:123])
-        _response_stream(flow)(body[123:])
+        response_stream(flow)(body[:123])
+        response_stream(flow)(body[123:])
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -7,7 +7,7 @@ from mitmproxy.test import tutils
 
 import body_utils
 import mitm_addon
-from tests.flow_helpers import _header_map, _response_stream
+from tests.flow_helpers import header_map, response_stream
 
 
 class TestResponseHeadersHandler:
@@ -17,12 +17,12 @@ class TestResponseHeadersHandler:
         """All responses should be streamed via a buffer callback."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        assert callable(_response_stream(flow))
+        assert callable(response_stream(flow))
         assert "stream_buffer" in flow.metadata
         assert isinstance(flow.metadata["stream_buffer"], bytearray)
 
@@ -30,12 +30,12 @@ class TestResponseHeadersHandler:
         """The stream callback should accumulate chunks in the buffer."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         result1 = callback(b"hello ")
         result2 = callback(b"world")
 
@@ -48,12 +48,12 @@ class TestResponseHeadersHandler:
         """Buffering should stop when exceeding the size limit."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         # Fill buffer to just under limit
         chunk = b"x" * body_utils.STREAM_BUFFER_LIMIT
         result = callback(chunk)
@@ -71,12 +71,12 @@ class TestResponseHeadersHandler:
         """A single chunk larger than the limit should still capture the first part."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         big_chunk = b"A" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         result = callback(big_chunk)
         assert result == big_chunk  # full chunk forwarded to client
@@ -87,12 +87,12 @@ class TestResponseHeadersHandler:
         """Partial fill followed by an oversized chunk should capture up to the limit."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         half = body_utils.STREAM_BUFFER_LIMIT // 2
         callback(b"A" * half)
         assert flow.metadata["stream_buffer_state"]["truncated"] is False
@@ -109,25 +109,25 @@ class TestResponseHeadersHandler:
         """When capture_body is set, streaming should still be enabled."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["capture_body"] = True
 
         mitm_addon.responseheaders(flow)
 
-        assert callable(_response_stream(flow))
+        assert callable(response_stream(flow))
         assert "stream_buffer" in flow.metadata
 
     def test_stream_callback_empty_chunk(self, real_flow, headers):
         """Empty chunks should be forwarded without affecting the buffer."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         result = callback(b"")
         assert result == b""
         assert len(flow.metadata["stream_buffer"]) == 0
@@ -157,13 +157,13 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
         assert "x_ndjson_state" in flow.metadata
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         callback(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n')
         state = flow.metadata["x_ndjson_state"]
@@ -176,12 +176,12 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         # First parseable line, then ~200 KB of junk.  Parser sees the first
         # line; buffer truncates at STREAM_BUFFER_LIMIT.
         callback(b'{"data":{"id":"1"}}\n' + b"x" * (200 * 1024))
@@ -196,12 +196,12 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/users/by?ids=1,2,3"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b'{"data":[{"id":"1","text":"')
         callback(b"x" * (200 * 1024))
         callback(b'"}],"includes":{"users":[{"id":"u1"}]}}')
@@ -222,7 +222,7 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_name"] = "x"
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream/rules"
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
@@ -242,7 +242,7 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
-            status_code=401, headers=_header_map({"content-type": "application/json"})
+            status_code=401, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
@@ -250,7 +250,7 @@ class TestResponseHeadersHandler:
         # No NDJSON parser — error body would fail NDJSON parsing anyway.
         assert "x_ndjson_state" not in flow.metadata
         assert "x_json_response_finish" not in flow.metadata
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         error_body = b'{"title":"Unauthorized","detail":"' + b"x" * (200 * 1024) + b'"}'
         callback(error_body)
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
@@ -270,7 +270,7 @@ class TestResponseHeadersHandler:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-type": "application/json",
                     "content-encoding": "gzip",
@@ -280,7 +280,7 @@ class TestResponseHeadersHandler:
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         # Feed compressed bytes in two chunks to exercise incremental decompression.
         mid = len(compressed) // 2
         callback(compressed[:mid])
@@ -303,12 +303,12 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json", "content-encoding": "gzip"}),
+            headers=header_map({"content-type": "application/json", "content-encoding": "gzip"}),
         )
 
         mitm_addon.responseheaders(flow)
 
-        _response_stream(flow)(gzip.compress(body))
+        response_stream(flow)(gzip.compress(body))
         usage_result, error = flow.metadata["model_json_usage_finish"]()
         assert error is None
         assert usage_result["message_id"] == "msg_1"
@@ -334,12 +334,12 @@ class TestResponseHeadersHandler:
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json", "content-encoding": "gzip"}),
+            headers=header_map({"content-type": "application/json", "content-encoding": "gzip"}),
         )
 
         mitm_addon.responseheaders(flow)
 
-        _response_stream(flow)(gzip.compress(body))
+        response_stream(flow)(gzip.compress(body))
         usage_result, error = flow.metadata["model_json_usage_finish"]()
         assert error is None
         assert usage_result["message_id"] == "resp_1"
@@ -363,12 +363,12 @@ class TestResponseHeadersHandler:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json", "content-encoding": "gzip"}),
+            headers=header_map({"content-type": "application/json", "content-encoding": "gzip"}),
         )
 
         mitm_addon.responseheaders(flow)
 
-        _response_stream(flow)(gzip.compress(body))
+        response_stream(flow)(gzip.compress(body))
         json_state, error = flow.metadata["x_json_response_finish"]()
         assert error is None
         assert json_state["response_data_count"] == 2

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -8,7 +8,7 @@ from mitmproxy.test import tutils
 import mitm_addon
 import response_streaming
 import usage
-from tests.flow_helpers import _header_map, _response_stream
+from tests.flow_helpers import header_map, response_stream
 
 
 class TestNdjsonExtractor:
@@ -141,7 +141,7 @@ class TestResponseHeadersSseParser:
     def test_sets_up_sse_parser_for_model_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
@@ -153,7 +153,7 @@ class TestResponseHeadersSseParser:
         assert "model_sse_usage_finish" in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata
         # Feed SSE data through the callback
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":'
@@ -167,7 +167,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "Text/Event-Stream"}),
+            headers=header_map({"content-type": "Text/Event-Stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
@@ -176,7 +176,7 @@ class TestResponseHeadersSseParser:
         mitm_addon.responseheaders(flow)
 
         assert "model_provider_usage" in flow.metadata
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
@@ -189,7 +189,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
@@ -197,7 +197,7 @@ class TestResponseHeadersSseParser:
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
@@ -214,7 +214,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
@@ -223,7 +223,7 @@ class TestResponseHeadersSseParser:
         mitm_addon.responseheaders(flow)
 
         assert "model_provider_usage" in flow.metadata
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
@@ -238,7 +238,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="chatgpt.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
         flow.metadata["cli_agent_type"] = "codex"
@@ -247,7 +247,7 @@ class TestResponseHeadersSseParser:
         mitm_addon.responseheaders(flow)
 
         assert "model_provider_usage" in flow.metadata
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
@@ -263,7 +263,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="chatgpt.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
         if cli_agent_type is not None:
@@ -272,7 +272,7 @@ class TestResponseHeadersSseParser:
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":'
@@ -287,7 +287,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-type": "text/event-stream; charset=utf-8",
                     "content-encoding": "gzip",
@@ -300,7 +300,7 @@ class TestResponseHeadersSseParser:
         mitm_addon.responseheaders(flow)
 
         assert "model_provider_usage" in flow.metadata
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         plaintext = (
             b"event: message_start\n"
             b'data: {"type":"message_start","message":'
@@ -318,7 +318,7 @@ class TestResponseHeadersSseParser:
     def test_no_sse_parser_for_non_model_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.github.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata["firewall_name"] = "github"
 
@@ -329,7 +329,7 @@ class TestResponseHeadersSseParser:
     def test_no_sse_parser_for_non_sse_response(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
 
@@ -340,7 +340,7 @@ class TestResponseHeadersSseParser:
     def test_no_sse_parser_for_non_billable_model_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = False
@@ -352,7 +352,7 @@ class TestResponseHeadersSseParser:
     def test_no_sse_parser_without_firewall_name(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         # No firewall_name set (e.g. auto-allowed VM0 API request)
 

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -367,14 +367,14 @@ class TestReleaseResponseStreamState:
     def test_preserves_externally_replaced_stream_callback(self, real_flow):
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         def external_stream(chunk):
             return chunk
 
         mitm_addon.responseheaders(flow)
-        assert callable(_response_stream(flow))
+        assert callable(response_stream(flow))
 
         flow.response.stream = external_stream
 
@@ -438,7 +438,7 @@ class TestReleaseResponseStreamState:
         flow.metadata.update(metadata)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": response_content_type}),
+            headers=header_map({"content-type": response_content_type}),
         )
 
         mitm_addon.responseheaders(flow)
@@ -467,11 +467,11 @@ class TestReleaseResponseStreamState:
     def test_configured_release_is_idempotent(self, real_flow):
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
-        assert callable(_response_stream(flow))
+        assert callable(response_stream(flow))
 
         response_streaming.release_response_stream_state(flow)
         response_streaming.release_response_stream_state(flow)
@@ -486,11 +486,11 @@ class TestReleaseResponseStreamState:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
         mitm_addon.responseheaders(flow)
-        assert callable(_response_stream(flow))
+        assert callable(response_stream(flow))
         assert "model_json_usage_finish" in flow.metadata
 
         flow.response = None

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -19,10 +19,10 @@ import body_utils
 import mitm_addon
 import response_streaming
 import usage
-from tests.flow_helpers import _header_map, _response_stream
+from tests.flow_helpers import header_map, response_stream
 from tests.usage_helpers import (
-    _model_usage_idempotency_key,
-    _usage_event_events_from_calls,
+    model_usage_idempotency_key,
+    usage_event_events_from_calls,
 )
 
 
@@ -70,7 +70,7 @@ def _model_provider_sse_flow(
         flow.metadata["cli_agent_type"] = cli_agent_type
     flow.response = tutils.tresp(
         status_code=200,
-        headers=_header_map({"content-type": "text/event-stream"}),
+        headers=header_map({"content-type": "text/event-stream"}),
     )
 
     mitm_addon.responseheaders(flow)
@@ -163,7 +163,7 @@ class TestResponseUsageReporting:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {"content-type": "application/json", "content-length": str(len(body))}
             ),
         )
@@ -214,7 +214,7 @@ class TestResponseUsageReporting:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {"content-type": "application/json", "content-length": str(len(body))}
             ),
         )
@@ -234,7 +234,7 @@ class TestResponseUsageReporting:
         assert extracted["tokens.input"] == 40
         assert extracted["tokens.output"] == 200
         assert extracted["tokens.cache_read"] == 10
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
@@ -261,7 +261,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -308,7 +308,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -350,7 +350,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -465,7 +465,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-type": "application/json",
                     "content-encoding": content_encoding,
@@ -536,7 +536,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-type": "application/json",
                     "content-encoding": encoding_case,
@@ -624,7 +624,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {
                     "content-type": "application/json",
                     "content-encoding": encoding_case,
@@ -649,7 +649,7 @@ class TestResponseUsageReporting:
         assert extracted["tokens.output"] == 200
         if provider_case == "openai":
             assert extracted["tokens.cache_read"] == 10
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         expected = {
             "tokens.input": 40 if provider_case == "openai" else 50,
@@ -684,7 +684,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -720,7 +720,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -782,7 +782,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         _set_stream_buffer(flow, body)
-        flow.response = tutils.tresp(status_code=200, headers=_header_map(response_headers))
+        flow.response = tutils.tresp(status_code=200, headers=header_map(response_headers))
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -816,7 +816,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -883,7 +883,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -928,7 +928,7 @@ class TestResponseUsageReporting:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map(
+            headers=header_map(
                 {"content-type": "application/json", "content-length": str(len(body))}
             ),
         )
@@ -948,7 +948,7 @@ class TestResponseUsageReporting:
         assert extracted["tokens.input"] == 40
         assert extracted["tokens.output"] == 200
         assert extracted["tokens.cache_read"] == 10
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
@@ -978,7 +978,7 @@ class TestResponseUsageReporting:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -1012,7 +1012,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -1044,11 +1044,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
             b'"usage":{"input_tokens":50,"output_tokens":20,'
@@ -1064,7 +1064,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
@@ -1087,11 +1087,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: response.incomplete\n"
             b'data: {"response":{"id":"resp_incomplete","model":"gpt-5.5",'
             b'"usage":{"input_tokens":8000,"output_tokens":1024,'
@@ -1107,7 +1107,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 6000,
@@ -1126,7 +1126,7 @@ class TestResponseUsageReporting:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -1156,7 +1156,7 @@ class TestResponseUsageReporting:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
         flow.error = Error("connection reset by peer")
@@ -1187,7 +1187,7 @@ class TestResponseUsageReporting:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
-        _response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
+        response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -1215,7 +1215,7 @@ class TestResponseUsageReporting:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"id":"msg_1",'
             b'"model":"claude-sonnet-4-6","usage":{"input_tokens":50}}}\n\n'
@@ -1232,7 +1232,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"tokens.input": 50}
         assert {event["provider"] for event in events} == {"claude-sonnet-4-6"}
@@ -1253,7 +1253,7 @@ class TestResponseUsageReporting:
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
@@ -1285,7 +1285,7 @@ class TestResponseUsageReporting:
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt\n'
             b"event: response.completed\n\n"
         )
@@ -1316,7 +1316,7 @@ class TestResponseUsageReporting:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude'
         )
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -1342,7 +1342,7 @@ class TestResponseUsageReporting:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: content_block_delta\n"
             b'data: {"type":"content_block_delta","delta":{"text":"hello'
         )
@@ -1370,7 +1370,7 @@ class TestResponseUsageReporting:
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -1397,7 +1397,7 @@ class TestResponseUsageReporting:
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
         )
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: response.in_progress\n"
             b'data: {"type":"response.in_progress","response":{"id":"resp_1","model":"gpt'
         )
@@ -1429,11 +1429,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"response":{"id":"resp_sse_1","model":"gpt-5.5",'
             b'"usage":{"input_tokens":100,"output_tokens":40}}}\n\n'
@@ -1451,7 +1451,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
         assert by_category == {
@@ -1459,10 +1459,10 @@ class TestResponseUsageReporting:
             "tokens.output": 40,
         }
         assert idempotency_by_category == {
-            "tokens.input": _model_usage_idempotency_key(
+            "tokens.input": model_usage_idempotency_key(
                 "run-abc-123", "resp_sse_1", "tokens.input"
             ),
-            "tokens.output": _model_usage_idempotency_key(
+            "tokens.output": model_usage_idempotency_key(
                 "run-abc-123", "resp_sse_1", "tokens.output"
             ),
         }
@@ -1520,7 +1520,7 @@ class TestResponseUsageReporting:
             mitm_addon.websocket_end(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert flow.metadata["model_provider_usage"]["message_id"] == "resp_ws_1"
         assert by_category == {
@@ -1576,7 +1576,7 @@ class TestResponseUsageReporting:
             mitm_addon.websocket_end(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
         assert by_category == {
@@ -1584,10 +1584,8 @@ class TestResponseUsageReporting:
             "tokens.output": 40,
         }
         assert idempotency_by_category == {
-            "tokens.input": _model_usage_idempotency_key(
-                "run-abc-123", "resp_ws_1", "tokens.input"
-            ),
-            "tokens.output": _model_usage_idempotency_key(
+            "tokens.input": model_usage_idempotency_key("run-abc-123", "resp_ws_1", "tokens.input"),
+            "tokens.output": model_usage_idempotency_key(
                 "run-abc-123", "resp_ws_1", "tokens.output"
             ),
         }
@@ -1874,7 +1872,7 @@ class TestResponseUsageReporting:
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -1888,7 +1886,7 @@ class TestResponseUsageReporting:
             mitm_addon.error(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert [event["category"] for event in events] == ["tokens.output"]
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
         if proxy_log.exists():
@@ -1915,7 +1913,7 @@ class TestResponseUsageReporting:
         flow.metadata["model_provider_usage"] = {"model": "gpt-5.5"}
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -1932,7 +1930,7 @@ class TestResponseUsageReporting:
             mitm_addon.error(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert [event["category"] for event in events] == ["tokens.output"]
 
     def test_full_pipeline_large_model_json_uses_bounded_buffer(
@@ -1952,11 +1950,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"')
         callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096))
         callback(b'"}],"usage":{"input_tokens":50,"output_tokens":200}}')
@@ -1972,7 +1970,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"tokens.input": 50, "tokens.output": 200}
 
@@ -2018,13 +2016,13 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json", "content-encoding": "gzip"}),
+            headers=header_map({"content-type": "application/json", "content-encoding": "gzip"}),
         )
 
         mitm_addon.responseheaders(flow)
         midpoint = len(compressed) // 2
-        _response_stream(flow)(compressed[:midpoint])
-        _response_stream(flow)(compressed[midpoint:])
+        response_stream(flow)(compressed[:midpoint])
+        response_stream(flow)(compressed[midpoint:])
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -2043,7 +2041,7 @@ class TestResponseUsageReporting:
         assert extracted["tokens.output"] == 200
         if provider_case == "openai":
             assert extracted["tokens.cache_read"] == 10
-        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
         expected = {
             "tokens.input": 40 if provider_case == "openai" else 50,
@@ -2069,11 +2067,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(
+        response_stream(flow)(
             b'{"id":"msg_1","model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":50,"output_tokens":200}'
         )
@@ -2121,11 +2119,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json", "content-encoding": "gzip"}),
+            headers=header_map({"content-type": "application/json", "content-encoding": "gzip"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(raw_json)
+        response_stream(flow)(raw_json)
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -2162,11 +2160,11 @@ class TestResponseUsageReporting:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(body)
+        response_stream(flow)(body)
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -2191,11 +2189,11 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"model":"claude-sonnet-4-6"}')
+        response_stream(flow)(b'{"model":"claude-sonnet-4-6"}')
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
@@ -2214,11 +2212,11 @@ class TestResponseUsageReporting:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(b'{"data":[{"id":"1"}]}')
+        response_stream(flow)(b'{"data":[{"id":"1"}]}')
         assert "x_json_response_finish" in flow.metadata
 
         mitm_addon.response(flow)
@@ -2236,11 +2234,11 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "text/event-stream"}),
+            headers=header_map({"content-type": "text/event-stream"}),
         )
 
         mitm_addon.responseheaders(flow)
-        _response_stream(flow)(
+        response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5","usage":{"output_tokens":7}}}\n'
         )
@@ -2289,11 +2287,11 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
-            headers=_header_map({"content-type": "application/json"}),
+            headers=header_map({"content-type": "application/json"}),
         )
 
         mitm_addon.responseheaders(flow)
-        vm0_stream = _response_stream(flow)
+        vm0_stream = response_stream(flow)
         vm0_stream(b'{"model":"claude-sonnet-4-6"}')
         flow.response.stream = external_stream
         mitm_addon._request_start_times[flow.id] = time.time()
@@ -2309,14 +2307,14 @@ class TestResponseUsageReporting:
         """Billable model provider JSON should parse usage without unbounded buffering."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"')
         callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
         callback(b'"}],"usage":{"input_tokens":50,"output_tokens":100}}')
@@ -2336,14 +2334,14 @@ class TestResponseUsageReporting:
         """Non-billable model providers should use the normal bounded buffer."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = False
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
@@ -2358,13 +2356,13 @@ class TestResponseUsageReporting:
         """Non-model-provider responses should truncate at 64KB."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         # No firewall_name — not a model provider
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
@@ -2377,7 +2375,7 @@ class TestResponseUsageReporting:
         """Billable X connector responses should not buffer the full body."""
         flow = real_flow(with_response=False, host="api.x.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_billable"] = True
@@ -2385,7 +2383,7 @@ class TestResponseUsageReporting:
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b'{"data":[{"id":"1","text":"')
         callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
         callback(b'"}],"meta":{"result_count":1}}')
@@ -2403,7 +2401,7 @@ class TestResponseUsageReporting:
         """Non-billable X JSON should not attach the billable response parser."""
         flow = real_flow(with_response=False, host="api.x.com")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_billable"] = False
@@ -2411,7 +2409,7 @@ class TestResponseUsageReporting:
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
 
         buf = flow.metadata["stream_buffer"]
@@ -2425,14 +2423,14 @@ class TestResponseUsageReporting:
         """Future billable connectors must not get unbounded buffers by default."""
         flow = real_flow(with_response=False, host="api.gamma.example")
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "gamma"  # hypothetical future billable connector
         flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
-        callback = _response_stream(flow)
+        callback = response_stream(flow)
         large_chunk = b"g" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
         callback(large_chunk)
 
@@ -2461,7 +2459,7 @@ class TestResponseUsageReporting:
         body = b'{"incomplete":'
         _set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "application/json"})
+            status_code=200, headers=header_map({"content-type": "application/json"})
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -2501,7 +2499,7 @@ class TestResponseUsageReporting:
             "tokens.output": 500,
         }
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -2560,7 +2558,7 @@ class TestResponseUsageReporting:
         assert body["runId"] == "run-int-002"
         assert body["events"] == [
             {
-                "idempotencyKey": _model_usage_idempotency_key(
+                "idempotencyKey": model_usage_idempotency_key(
                     "run-int-002", flow.id, "tokens.input"
                 ),
                 "kind": "model",
@@ -2595,7 +2593,7 @@ class TestResponseUsageReporting:
             # no message_id set
         }
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -2610,7 +2608,7 @@ class TestResponseUsageReporting:
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
-        assert body["events"][0]["idempotencyKey"] == _model_usage_idempotency_key(
+        assert body["events"][0]["idempotencyKey"] == model_usage_idempotency_key(
             "run-fallback", "flow-uuid-xyz-123", "tokens.input"
         )
 
@@ -2635,7 +2633,7 @@ class TestResponseUsageReporting:
             "tokens.input": 10,
         }
         flow.response = tutils.tresp(
-            status_code=200, headers=_header_map({"content-type": "text/event-stream"})
+            status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         mitm_addon._request_start_times[flow.id] = time.time()
 
@@ -2650,6 +2648,6 @@ class TestResponseUsageReporting:
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
-        assert body["events"][0]["idempotencyKey"] == _model_usage_idempotency_key(
+        assert body["events"][0]["idempotencyKey"] == model_usage_idempotency_key(
             "run-preserved", "msg_real_anthropic_id", "tokens.input"
         )

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -13,7 +13,7 @@ import pytest
 import auth
 import usage
 from tests.usage_helpers import (
-    _model_usage_idempotency_key,
+    model_usage_idempotency_key,
 )
 from usage.providers import model_provider as usage_model_provider
 
@@ -128,7 +128,7 @@ class TestUsageWebhookDelivery:
         assert set(body) == {"runId", "events"}
         assert body["events"] == [
             {
-                "idempotencyKey": _model_usage_idempotency_key("run-1", flow.id, "tokens.input"),
+                "idempotencyKey": model_usage_idempotency_key("run-1", flow.id, "tokens.input"),
                 "kind": "model",
                 "provider": "claude-sonnet-4-6",
                 "category": "tokens.input",

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -6,17 +6,15 @@ import uuid
 from usage.namespaces import USAGE_EVENT_NAMESPACE_MODEL
 
 
-def _request_bodies_from_calls(call_args_list):
+def request_bodies_from_calls(call_args_list):
     return [json.loads(call[0][0].data) for call in call_args_list]
 
 
-def _usage_event_events_from_calls(call_args_list):
-    return [
-        event for body in _request_bodies_from_calls(call_args_list) for event in body["events"]
-    ]
+def usage_event_events_from_calls(call_args_list):
+    return [event for body in request_bodies_from_calls(call_args_list) for event in body["events"]]
 
 
-def _model_usage_idempotency_key(run_id: str, message_id: str, category: str) -> str:
+def model_usage_idempotency_key(run_id: str, message_id: str, category: str) -> str:
     encoded = "\0".join(
         f"{len(part.encode('utf-8'))}:{part}" for part in (run_id, message_id, category)
     )


### PR DESCRIPTION
## Summary
- Rename shared mitm-addon test helpers imported across test modules from underscore-prefixed private names to public-by-use names.
- Update all affected imports and call sites, including the pending helper, while leaving module-local and production private APIs untouched.
- Keep the change test-only with no runtime behavior changes.

Closes #14781

## Tests
- `/tmp/mitm-addon-venv/bin/python -m ruff check .` from `crates/runner/mitm-addon`
- `VIRTUAL_ENV=/tmp/mitm-addon-venv PATH=/tmp/mitm-addon-venv/bin:/home/vscode/.codex/tmp/arg0/codex-arg0br620A:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/home/vscode/.local/share/pnpm:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:/workspaces/vm3/bin:/opt/aarch64--musl--stable-2025.08-1/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /tmp/mitm-addon-venv/bin/python -m basedpyright --pythonpath /tmp/mitm-addon-venv/bin/python` from `crates/runner/mitm-addon`
- `/tmp/mitm-addon-venv/bin/python -m pytest` from `crates/runner/mitm-addon`
- `pnpm format`
- `pnpm turbo run lint --concurrency=1`
- `pnpm check-types`
- `pnpm vitest --maxWorkers=4`
- `pnpm knip`