### PR TITLE
fix: restore platform url origins

### DIFF
--- a/turbo/apps/api/src/lib/slack-webhook-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-blocks.ts
@@ -37,7 +37,7 @@ interface AppHomeOptions {
 }
 
 function appUrl(): string {
-  return env("VM0_WEB_URL");
+  return env("APP_URL");
 }
 
 function buildAppHomeHeaderBlocks(): SlackBlocks {

--- a/turbo/apps/api/src/signals/routes/__tests__/email-unsubscribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/email-unsubscribe.test.ts
@@ -110,7 +110,7 @@ describe("GET /api/email/unsubscribe", () => {
     expect(response.headers.get("content-type")).toContain("text/html");
     const html = await response.text();
     expect(html).toContain("You have been unsubscribed");
-    expect(html).toContain("http://localhost:3001/settings");
+    expect(html).toContain("http://localhost:3002/settings");
     await expect(findUser(userId)).resolves.toStrictEqual({
       emailUnsubscribed: true,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
@@ -633,7 +633,9 @@ describe("POST /api/internal/callbacks/github/issues", () => {
     expect(response.status).toBe(200);
     expect(capturedComments).toHaveLength(1);
     expect(capturedComments[0]!.body).toContain("Audit");
-    expect(capturedComments[0]!.body).toContain(`/activities/${runId}`);
+    expect(capturedComments[0]!.body).toContain(
+      `http://localhost:3002/activities/${runId}`,
+    );
   });
 
   it("posts a failed run comment with the run error", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
@@ -15,6 +15,7 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
 import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
@@ -456,6 +457,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     await setOrgDefaultAgent(fixture, null);
     await setRunSelectedModel(fixture.runId, "claude-opus-4-7");
     await seedAdditionalMentioner(fixture);
+    mockEnv("APP_URL", "https://app.vm0.test");
     completedOutput("footer output");
 
     const response = await postSignedCallback({
@@ -468,7 +470,9 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(response.status).toBe(200);
     const blocks = JSON.stringify(firstPostMessageCall().blocks);
     expect(blocks).toContain("Audit");
-    expect(blocks).toContain(`/activities/${fixture.runId}`);
+    expect(blocks).toContain(
+      `https://app.vm0.test/activities/${fixture.runId}`,
+    );
     expect(blocks).toContain("Responded by Slack Agent");
     expect(blocks).toContain(`Reply to <@${fixture.slackUserId}>`);
     expect(blocks).toContain("Claude Opus 4.7");

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
@@ -644,6 +644,7 @@ describe("POST /api/internal/callbacks/telegram", () => {
       .set({ selectedModel: "claude-opus-4-7" })
       .where(eq(zeroRuns.id, fixture.runId));
     const telegram = telegramApiMocks();
+    mockEnv("APP_URL", "https://app.vm0.test");
     completedOutput("Plain result");
 
     const response = await postSignedCallback({
@@ -656,7 +657,7 @@ describe("POST /api/internal/callbacks/telegram", () => {
     expect(response.status).toBe(200);
     const text = telegram.sentMessages[0]?.text ?? "";
     expect(text).toContain("📋 Audit");
-    expect(text).toContain(`/activities/${fixture.runId}`);
+    expect(text).toContain(`https://app.vm0.test/activities/${fixture.runId}`);
     expect(text).toContain("Claude Opus 4.7");
     expect(text).not.toContain("Responded by");
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -59,7 +59,8 @@ async function seedVm0ManagedKeys(): Promise<void> {
 function configureSlackProbeTest(): void {
   mockEnv("ENV", "development");
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
-  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_WEB_URL", "https://www.vm0.test");
+  mockEnv("APP_URL", "https://app.vm0.test");
   mockEnv("VM0_API_URL", "https://api.vm0.test");
   context.mocks.s3.send.mockResolvedValue({});
   context.mocks.slack.assistant.threads.setStatus.mockResolvedValue({

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
@@ -207,6 +207,7 @@ async function seedFixture(): Promise<TelegramProbeFixture> {
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   mockOptionalEnv("VM0_API_URL", "http://localhost:3000");
   mockOptionalEnv("VM0_WEB_URL", "http://localhost:3000");
+  mockEnv("APP_URL", "http://localhost:3002");
   return fixture;
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -274,6 +274,7 @@ function configureAgentPhoneEnv(): void {
   mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
   mockEnv("R2_USER_ARTIFACTS_BUCKET_NAME", "test-user-artifacts");
   mockEnv("R2_USER_STORAGES_BUCKET_NAME", "test-user-storages");
+  mockEnv("APP_URL", "https://app.vm0.test");
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   mockOptionalEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
   mockOptionalEnv("AGENTPHONE_API_KEY", "agentphone-test-key");
@@ -756,7 +757,9 @@ describe("AgentPhone migrated API routes", () => {
       agentphoneUserLinkId: null,
       direction: "inbound",
     });
-    expect(sendCalls[0]?.body).toContain("/agentphone/connect?");
+    expect(sendCalls[0]?.body).toContain(
+      "https://app.vm0.test/agentphone/connect?",
+    );
   });
 
   it("starts a new AgentPhone session when the selected model provider changed", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -874,7 +874,8 @@ describe("POST /api/telegram/register", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockEnv("VM0_API_URL", "https://api.example.test");
-    mockEnv("VM0_WEB_URL", "https://app.example.test");
+    mockEnv("VM0_WEB_URL", "https://www.example.test");
+    mockEnv("APP_URL", "https://app.example.test");
     mockTelegramGetMe({ botId: telegramBotId, username: "registered_bot" });
     context.mocks.telegram.setWebhook.mockResolvedValue(undefined);
     context.mocks.telegram.setMyCommands.mockResolvedValue(undefined);
@@ -902,7 +903,7 @@ describe("POST /api/telegram/register", () => {
     });
     expect(context.mocks.telegram.setWebhook).toHaveBeenCalledWith(
       TEST_BOT_TOKEN,
-      `https://app.example.test/api/telegram/webhook/${telegramBotId}`,
+      `https://www.example.test/api/telegram/webhook/${telegramBotId}`,
       expect.stringMatching(/^[0-9a-f]{64}$/u),
     );
     expect(context.mocks.telegram.setMyCommands).toHaveBeenCalledWith(
@@ -1653,7 +1654,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     const buttonUrl =
       telegramMocks.sentMessages[1]?.reply_markup?.inline_keyboard[0]?.[0]
         ?.url ?? "";
-    expect(buttonUrl).toContain("/telegram/connect?bot=");
+    expect(buttonUrl).toContain("http://localhost:3002/telegram/connect?bot=");
     expect(buttonUrl).toContain("tgUser=91612");
 
     const help = await postWebhook({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
@@ -595,7 +595,7 @@ describe("POST /api/zero/permission-access-requests", () => {
     expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining(
-          `/agents/${fixture.agentId}/permissions?request=${response.body.id}`,
+          `http://localhost:3002/agents/${fixture.agentId}/permissions?request=${response.body.id}`,
         ),
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-browser-connect.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, beforeEach } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
@@ -20,6 +21,7 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const CONNECT_PATH = "http://api.test/api/zero/slack/connect";
+const APP_ORIGIN = "https://app.vm0.test";
 
 function connectUrl(params: {
   readonly workspaceId?: string;
@@ -62,6 +64,7 @@ describe("GET /api/zero/slack/connect", () => {
   });
 
   beforeEach(() => {
+    mockEnv("APP_URL", APP_ORIGIN);
     context.mocks.slack.chat.postMessage.mockResolvedValue({
       ok: true,
       ts: "mock.ts",
@@ -91,7 +94,7 @@ describe("GET /api/zero/slack/connect", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
-    expect(location).toContain("/slack/connect?error=");
+    expect(location).toContain(`${APP_ORIGIN}/settings/slack?error=`);
     expect(decodeURIComponent(location ?? "")).toContain(
       "Invalid connect link.",
     );
@@ -115,7 +118,9 @@ describe("GET /api/zero/slack/connect", () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toContain("status=connected");
+    expect(response.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/slack?status=connected`,
+    );
 
     const connection = await store.set(
       findSlackOrgConnection$,
@@ -147,7 +152,7 @@ describe("GET /api/zero/slack/connect", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
-    expect(location).toContain("/slack/connect?error=");
+    expect(location).toContain(`${APP_ORIGIN}/settings/slack?error=`);
     expect(decodeURIComponent(location ?? "")).toContain("Workspace not found");
   });
 
@@ -170,7 +175,7 @@ describe("GET /api/zero/slack/connect", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
-    expect(location).toContain("/slack/connect?error=");
+    expect(location).toContain(`${APP_ORIGIN}/settings/slack?error=`);
     expect(decodeURIComponent(location ?? "")).toContain("admin");
   });
 
@@ -192,9 +197,13 @@ describe("GET /api/zero/slack/connect", () => {
     const second = await requestConnect(url);
 
     expect(first.status).toBe(307);
-    expect(first.headers.get("location")).toContain("status=connected");
+    expect(first.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/slack?status=connected`,
+    );
     expect(second.status).toBe(307);
-    expect(second.headers.get("location")).toContain("status=connected");
+    expect(second.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/slack?status=connected`,
+    );
     await expect(
       store.set(
         countSlackOrgConnections$,
@@ -219,7 +228,9 @@ describe("GET /api/zero/slack/connect", () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toContain("status=connected");
+    expect(response.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/slack?status=connected`,
+    );
   });
 
   it("redirects org mismatch to the legacy organization error", async () => {
@@ -238,7 +249,7 @@ describe("GET /api/zero/slack/connect", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
-    expect(location).toContain("/slack/connect?error=");
+    expect(location).toContain(`${APP_ORIGIN}/settings/slack?error=`);
     expect(decodeURIComponent(location ?? "")).toContain("active organization");
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
@@ -24,7 +24,8 @@ const COMMAND_PATH = "/api/zero/slack/commands";
 function configureSlackWebhookTest(): void {
   mockOptionalEnv("SLACK_SIGNING_SECRET", SIGNING_SECRET);
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
-  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_WEB_URL", "https://www.vm0.test");
+  mockEnv("APP_URL", "https://app.vm0.test");
   mockEnv("VM0_API_URL", "https://api.vm0.test");
   context.mocks.slack.chat.postMessage.mockResolvedValue({
     ok: true,
@@ -233,7 +234,9 @@ describe("POST /api/zero/slack/commands", () => {
       }),
     );
     expect(login.status).toBe(200);
-    expect(JSON.stringify(login.body)).toContain("Connect");
+    const loginBody = JSON.stringify(login.body);
+    expect(loginBody).toContain("Connect");
+    expect(loginBody).toContain("https://app.vm0.test/settings/slack");
 
     const connected = await track(
       store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -74,7 +74,8 @@ async function seedVm0ManagedKeys(): Promise<void> {
 function configureSlackWebhookTest(): void {
   mockOptionalEnv("SLACK_SIGNING_SECRET", SIGNING_SECRET);
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
-  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_WEB_URL", "https://www.vm0.test");
+  mockEnv("APP_URL", "https://app.vm0.test");
   mockEnv("VM0_API_URL", "https://api.vm0.test");
   context.mocks.s3.send.mockResolvedValue({});
   context.mocks.slack.assistant.threads.setStatus.mockResolvedValue({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
@@ -26,7 +26,8 @@ const INTERACTIVE_PATH = "/api/zero/slack/interactive";
 function configureSlackWebhookTest(): void {
   mockOptionalEnv("SLACK_SIGNING_SECRET", SIGNING_SECRET);
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
-  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_WEB_URL", "https://www.vm0.test");
+  mockEnv("APP_URL", "https://app.vm0.test");
   mockEnv("VM0_API_URL", "https://api.vm0.test");
   context.mocks.slack.chat.postEphemeral.mockResolvedValue({
     ok: true,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
@@ -24,6 +24,7 @@ const context = testContext();
 const store = createStore();
 const API_ORIGIN = "https://api.vm0.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
+const APP_ORIGIN = "https://app.vm0.ai";
 
 async function appRequest(
   path: string,
@@ -110,6 +111,7 @@ describe("Slack OAuth API routes", () => {
 
   beforeEach(() => {
     mockEnv("VM0_WEB_URL", WEB_ORIGIN);
+    mockEnv("APP_URL", APP_ORIGIN);
     mockSlackEnv();
     context.mocks.slack.chat.postMessage.mockResolvedValue({
       ok: true,
@@ -479,7 +481,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
-        "/settings/slack?status=connected",
+        `${APP_ORIGIN}/settings/slack?status=connected`,
       );
 
       const installation = await store.set(
@@ -633,7 +635,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       const location = response.headers.get("location");
-      expect(location).toContain("/settings/slack");
+      expect(location).toContain(`${APP_ORIGIN}/settings/slack`);
       expect(location).toContain(`w=${fixture.slackWorkspaceId}`);
       expect(location).toContain(`u=${fixture.slackUserId}`);
 
@@ -657,7 +659,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       const location = response.headers.get("location");
-      expect(location).toContain("/slack/failed");
+      expect(location).toContain(`${APP_ORIGIN}/slack/failed`);
       expect(decodeURIComponent(location ?? "")).toContain(
         "Failed to complete Slack installation",
       );
@@ -743,7 +745,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
-        "/settings/slack?status=connected",
+        `${APP_ORIGIN}/settings/slack?status=connected`,
       );
       const installation = await store.set(
         findSlackOrgInstallation$,
@@ -885,7 +887,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
-        "/settings/slack?status=connected",
+        `${APP_ORIGIN}/settings/slack?status=connected`,
       );
 
       const connection = await store.set(
@@ -923,7 +925,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
-        "/settings/slack?status=connected",
+        `${APP_ORIGIN}/settings/slack?status=connected`,
       );
       await clearAllDetached();
       expect(
@@ -1035,7 +1037,7 @@ describe("Slack OAuth API routes", () => {
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
-        "/?tab=works&updated=1",
+        `${APP_ORIGIN}/?tab=works&updated=1`,
       );
     });
 
@@ -1051,7 +1053,7 @@ describe("Slack OAuth API routes", () => {
       );
       expect(slackError.status).toBe(307);
       expect(slackError.headers.get("location")).toBe(
-        `${WEB_ORIGIN}/slack/failed?error=access_denied`,
+        `${APP_ORIGIN}/slack/failed?error=access_denied`,
       );
     });
   });

--- a/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
+++ b/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
@@ -18,7 +18,7 @@ function invalidTokenResponse() {
 }
 
 function confirmationHtmlResponse(): Response {
-  const appUrl = env("VM0_WEB_URL");
+  const appUrl = env("APP_URL");
   const html = `<!DOCTYPE html>
 <html>
 <head>

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
@@ -264,7 +264,7 @@ async function resolveGitHubAuditLogsUrl(args: {
     return undefined;
   }
 
-  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+  return `${env("APP_URL")}/activities/${encodeURIComponent(args.runId)}`;
 }
 
 async function resolveGitHubRunError(args: {

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
@@ -95,7 +95,7 @@ function parsePayload(payload: unknown): SlackOrgCallbackPayload | null {
 }
 
 function buildLogsUrl(runId: string): string {
-  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(runId)}`;
+  return `${env("APP_URL")}/activities/${encodeURIComponent(runId)}`;
 }
 
 async function loadInstallation(args: {

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
@@ -128,7 +128,7 @@ async function resolveTelegramAuditLogsUrl(args: {
     return undefined;
   }
 
-  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+  return `${env("APP_URL")}/activities/${encodeURIComponent(args.runId)}`;
 }
 
 async function deleteThinkingMessageIfPresent(args: {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -222,7 +222,7 @@ async function publishAppHome(
 
 function buildConnectUrl(workspaceId: string, slackUserId: string): string {
   const params = new URLSearchParams({ w: workspaceId, u: slackUserId });
-  return `${env("VM0_WEB_URL")}/settings/slack?${params.toString()}`;
+  return `${env("APP_URL")}/settings/slack?${params.toString()}`;
 }
 
 function buildDisconnectedAppHomeView(args: {
@@ -293,7 +293,7 @@ function buildUninstalledAppHomeView(): View {
           {
             type: "button",
             text: { type: "plain_text", text: "Open Zero Settings" },
-            url: `${env("VM0_WEB_URL")}/works`,
+            url: `${env("APP_URL")}/works`,
             action_id: "home_open_settings",
             style: "primary",
           },

--- a/turbo/apps/api/src/signals/routes/zero-slack-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-browser-connect.ts
@@ -29,15 +29,15 @@ function redirectResponse(url: string): Response {
 }
 
 function appRedirect(path: string): Response {
-  return redirectResponse(`${env("VM0_WEB_URL")}${path}`);
+  return redirectResponse(`${env("APP_URL")}${path}`);
 }
 
 function connectError(message: string): Response {
-  return appRedirect(`/slack/connect?error=${encodeURIComponent(message)}`);
+  return appRedirect(`/settings/slack?error=${encodeURIComponent(message)}`);
 }
 
 function connectSuccess(): Response {
-  return appRedirect("/slack/connect?status=connected");
+  return appRedirect("/settings/slack?status=connected");
 }
 
 function signInRedirect(requestUrl: string): Response {

--- a/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
@@ -68,7 +68,7 @@ function jsonErrorResponse(error: string, status: number): Response {
 }
 
 function appUrl(path: string): string {
-  return `${env("VM0_WEB_URL")}${path}`;
+  return `${env("APP_URL")}${path}`;
 }
 
 function failedRedirect(message: string): Response {

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1942,7 +1942,7 @@ async function resolveAgentPhoneRunFailureAuditLogsUrl(args: {
   if (!enabled) {
     return undefined;
   }
-  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+  return `${env("APP_URL")}/activities/${encodeURIComponent(args.runId)}`;
 }
 
 export function formatAgentPhoneAuditLink(logsUrl: string): string {
@@ -2253,7 +2253,7 @@ export async function resolveAgentPhoneAuditLogsUrl(args: {
   if (!enabled) {
     return undefined;
   }
-  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+  return `${env("APP_URL")}/activities/${encodeURIComponent(args.runId)}`;
 }
 
 export async function publishAgentPhoneUserChanged(

--- a/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
@@ -154,7 +154,7 @@ function connectorLabel(connectorRef: string): string {
 }
 
 function buildReviewUrl(agentId: string, requestId: string): string {
-  const appUrl = env("VM0_WEB_URL");
+  const appUrl = env("APP_URL");
   return `${appUrl}/agents/${agentId}/permissions?request=${requestId}`;
 }
 

--- a/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
@@ -173,7 +173,7 @@ function buildSlackConnectUrl(
   slackUserId: string,
 ): string {
   const params = new URLSearchParams({ w: workspaceId, u: slackUserId });
-  return `${env("VM0_WEB_URL")}/settings/slack?${params.toString()}`;
+  return `${env("APP_URL")}/settings/slack?${params.toString()}`;
 }
 
 async function refreshSlackAppHome(args: {
@@ -201,7 +201,7 @@ async function refreshSlackAppHome(args: {
     await args.client.views.publish({
       user_id: args.slackUserId,
       view: buildAppHomeView({
-        appUrl: env("VM0_WEB_URL"),
+        appUrl: env("APP_URL"),
         isLinked: false,
         loginUrl: buildSlackConnectUrl(
           args.installation.slackWorkspaceId,
@@ -243,7 +243,7 @@ async function refreshSlackAppHome(args: {
   await args.client.views.publish({
     user_id: args.slackUserId,
     view: buildAppHomeView({
-      appUrl: env("VM0_WEB_URL"),
+      appUrl: env("APP_URL"),
       isLinked: true,
       vm0UserId: connection.vm0UserId,
       userEmail: await getPrimaryUserEmail(

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -364,7 +364,7 @@ function buildOrgConnectUrl(
   if (threadTs) {
     params.set("t", threadTs);
   }
-  return `${env("VM0_WEB_URL")}/settings/slack?${params.toString()}`;
+  return `${env("APP_URL")}/settings/slack?${params.toString()}`;
 }
 
 function buildNotInstalledMessage(detail?: string): unknown[] {
@@ -384,7 +384,7 @@ function buildNotInstalledMessage(detail?: string): unknown[] {
         {
           type: "button",
           text: { type: "plain_text", text: "Set up on Platform" },
-          url: `${env("VM0_WEB_URL")}/works`,
+          url: `${env("APP_URL")}/works`,
           action_id: "open_platform_setup",
         },
       ],
@@ -1164,7 +1164,7 @@ async function postPreDispatchErrorReply(args: {
     orgId: args.orgId,
     overrides,
   })
-    ? `${env("VM0_WEB_URL")}/activities`
+    ? `${env("APP_URL")}/activities`
     : undefined;
   const orgDefaultComposeId = await resolveDefaultComposeId(
     args.db,
@@ -1372,7 +1372,7 @@ async function handleSlackRunResult(args: {
 }): Promise<void> {
   const { message, resolved, result } = args;
   if (result.status === "queued") {
-    const queueUrl = `${env("VM0_WEB_URL")}/?queue=1`;
+    const queueUrl = `${env("APP_URL")}/?queue=1`;
     await resolved.client.chat.postEphemeral({
       channel: message.channelId,
       user: message.slackUserId,

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -369,7 +369,7 @@ function customTelegramBotStatus(args: {
           userId: args.userId,
         }),
       ),
-      checkTelegramDomain(args.installation.telegramBotId, env("VM0_WEB_URL")),
+      checkTelegramDomain(args.installation.telegramBotId, env("APP_URL")),
     ]);
 
     return { ...bot, domainConfigured, environment };
@@ -387,7 +387,7 @@ function officialTelegramBotStatus(args: {
       get(buildOfficialTelegramBot(args)),
       get(telegramEnvironment({ compose: official.compose, ...args })),
       config.botId
-        ? checkTelegramDomain(config.botId, env("VM0_WEB_URL"))
+        ? checkTelegramDomain(config.botId, env("APP_URL"))
         : Promise.resolve(false),
     ]);
 
@@ -458,7 +458,7 @@ type TelegramLinkStatusResult =
 
 function resolveTelegramLoginOrigin(originParam: string | undefined): string {
   if (!originParam) {
-    return env("VM0_WEB_URL");
+    return env("APP_URL");
   }
 
   const originUrl = safeUrlParse(originParam);
@@ -469,7 +469,7 @@ function resolveTelegramLoginOrigin(originParam: string | undefined): string {
     return originUrl.origin;
   }
 
-  return env("VM0_WEB_URL");
+  return env("APP_URL");
 }
 
 function orgMismatchResult(): TelegramLinkStatusResult {

--- a/turbo/apps/api/src/signals/services/zero-telegram-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-dispatch.service.ts
@@ -239,7 +239,7 @@ function buildConnectUrl(args: {
   if (telegramDisplayName) {
     params.set("tgDisplayName", telegramDisplayName);
   }
-  return `${env("VM0_WEB_URL")}/telegram/connect?${params.toString()}`;
+  return `${env("APP_URL")}/telegram/connect?${params.toString()}`;
 }
 
 function agentDisplayLabel(agent: TelegramAgent): string {
@@ -437,7 +437,7 @@ async function sendAgentError(args: {
   readonly replyToMessageId?: number;
 }): Promise<void> {
   const logsUrl = args.runId
-    ? `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`
+    ? `${env("APP_URL")}/activities/${encodeURIComponent(args.runId)}`
     : undefined;
   await sendMessage(
     args.botToken,

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -730,7 +730,7 @@ export const registerTelegramBot$ = command(
 
 function resolveProbeOrigin(origin: string | undefined): string {
   if (!origin) {
-    return env("VM0_WEB_URL");
+    return env("APP_URL");
   }
 
   const parsed = safeUrlParse(origin);
@@ -738,7 +738,7 @@ function resolveProbeOrigin(origin: string | undefined): string {
     return parsed.origin;
   }
 
-  return env("VM0_WEB_URL");
+  return env("APP_URL");
 }
 
 function isInvalidTelegramTokenError(error: unknown): boolean {
@@ -1201,7 +1201,7 @@ function buildConnectUrl(args: {
   if (displayName) {
     params.set("tgDisplayName", displayName);
   }
-  return `${env("VM0_WEB_URL")}/telegram/connect?${params.toString()}`;
+  return `${env("APP_URL")}/telegram/connect?${params.toString()}`;
 }
 
 function buildTelegramConnectReplyMarkup(connectUrl: string) {


### PR DESCRIPTION
## Summary
- restore APP_URL for platform-facing Slack, Telegram, AgentPhone, GitHub issue callback, email unsubscribe, and permission request links
- keep VM0_WEB_URL for web/API origin flows such as Slack OAuth start and Telegram webhook URLs
- update tests to assert APP_URL and VM0_WEB_URL stay distinct

## Tests
- pnpm turbo run lint
- pnpm check-types
- pnpm format
- pnpm vitest (first run exposed stale local DB; after `pnpm -F web db:migrate`, rerun passed: 770 files / 9275 tests)
- pnpm knip