### PR TITLE
fix: avoid foreground activation in computer use

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -337,7 +337,9 @@ const getAppStateCommand = appOption(
   addTargetOptions(
     new Command()
       .name("get-app-state")
-      .description("Get screenshot and accessibility state for an app")
+      .description(
+        "Get screenshot and accessibility state without activating an app",
+      )
       .action(
         withErrorHandler(async (options: ComputerUseAppOptions) => {
           await runReadCommand("app.state", options, { app: options.app });
@@ -350,7 +352,9 @@ const clickCommand = appOption(
   addTargetOptions(
     new Command()
       .name("click")
-      .description("Click an accessibility element or screenshot coordinate")
+      .description(
+        "Click an accessibility element or background screenshot coordinate",
+      )
       .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
       .option("--element <id>", "Element id from get-app-state")
       .option("--element-index <index>", "Element index from get-app-state")
@@ -451,7 +455,7 @@ const pressKeyCommand = appOption(
   addTargetOptions(
     new Command()
       .name("press-key")
-      .description("Press a key or key combination in the target app")
+      .description("Send a background key or key combination to the target app")
       .requiredOption(
         "--key <key>",
         "Key or key combination to press, for example Command+K or Control+K",
@@ -493,7 +497,7 @@ const openAppCommand = appOption(
   addTargetOptions(
     new Command()
       .name("open-app")
-      .description("Open or activate an app on the Desktop host")
+      .description("Open an app on the Desktop host without activating it")
       .action(
         withErrorHandler(async (options: ComputerUseAppOptions) => {
           await runWriteCommand("app.open", options, { app: options.app });

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -77,46 +77,6 @@ final class LaunchResultBox: @unchecked Sendable {
     var error: Error?
 }
 
-final class CoreRunLoopThread: @unchecked Sendable {
-    static let shared = CoreRunLoopThread()
-
-    private final class RunLoopBox: @unchecked Sendable {
-        var runLoop: CFRunLoop?
-    }
-
-    private let runLoop: CFRunLoop
-
-    private init() {
-        let condition = NSCondition()
-        let box = RunLoopBox()
-        let thread = Thread {
-            let timer = Timer(timeInterval: 3600, repeats: true) { _ in }
-            RunLoop.current.add(timer, forMode: .common)
-
-            condition.lock()
-            box.runLoop = CFRunLoopGetCurrent()
-            condition.signal()
-            condition.unlock()
-
-            RunLoop.current.run()
-        }
-        thread.name = "ComputerUseHelper.FocusSuppression"
-        thread.start()
-
-        condition.lock()
-        while box.runLoop == nil {
-            condition.wait()
-        }
-        runLoop = box.runLoop!
-        condition.unlock()
-    }
-
-    func addSource(_ source: CFRunLoopSource, mode: CFRunLoopMode = .commonModes) {
-        CFRunLoopAddSource(runLoop, source, mode)
-        CFRunLoopWakeUp(runLoop)
-    }
-}
-
 enum BackgroundWindowLocalEvent {
     private typealias SetWindowLocationFn = @convention(c) (CGEvent, CGPoint) -> Void
 
@@ -212,221 +172,6 @@ struct AddressedEventDispatcher {
         event.setWindowAddressingFields(windowNumber: target.windowNumber)
         event.postToPid(target.pid)
     }
-}
-
-final class BackgroundActivationSession: @unchecked Sendable {
-    enum TapKind {
-        case previous
-        case target
-    }
-
-    enum Phase {
-        case deliveringToTarget
-        case holding
-        case finished
-    }
-
-    final class TapContext {
-        let session: BackgroundActivationSession
-        let kind: TapKind
-
-        init(session: BackgroundActivationSession, kind: TapKind) {
-            self.session = session
-            self.kind = kind
-        }
-    }
-
-    private static let focusSuppressionEventMask = CGEventMask.max
-
-    private let target: WindowTarget
-    private let previousApp: NSRunningApplication?
-    private let stateLock = NSLock()
-    private var phase: Phase = .deliveringToTarget
-    private var taps: [CFMachPort] = []
-    private var contexts: [TapContext] = []
-    private var finished = false
-
-    private init(target: WindowTarget, previousApp: NSRunningApplication?) {
-        self.target = target
-        self.previousApp = previousApp
-    }
-
-    static func start(target: WindowTarget) throws -> BackgroundActivationSession {
-        let previousApp = NSWorkspace.shared.frontmostApplication
-        let session = BackgroundActivationSession(target: target, previousApp: previousApp)
-        do {
-            try session.installTapsIfNeeded()
-            return session
-        } catch {
-            session.finish()
-            throw error
-        }
-    }
-
-    func activateWindow() throws {
-        beginTargetDelivery()
-        postWindowActivationEvent()
-        try postWindowCenterPrimer()
-        holdFocusSuppressionUntilFinish()
-    }
-
-    func restoreBackgroundActivationIfNeeded() {
-        guard NSWorkspace.shared.frontmostApplication?.processIdentifier != target.pid else {
-            restorePreviousFrontmostIfNeeded()
-            return
-        }
-        beginTargetDelivery()
-        postApplicationFocusEvent(subtype: 2)
-        usleep(20_000)
-    }
-
-    func finish() {
-        let shouldFinish = stateLock.withLock {
-            guard !finished else { return false }
-            finished = true
-            phase = .finished
-            return true
-        }
-        guard shouldFinish else { return }
-        for tap in taps {
-            CFMachPortInvalidate(tap)
-        }
-        taps.removeAll()
-        contexts.removeAll()
-    }
-
-    deinit {
-        finish()
-    }
-
-    private func beginTargetDelivery() {
-        setPhase(.deliveringToTarget)
-    }
-
-    private func holdFocusSuppressionUntilFinish() {
-        setPhase(.holding)
-    }
-
-    private func setPhase(_ newPhase: Phase) {
-        stateLock.withLock {
-            phase = newPhase
-        }
-    }
-
-    private func installTapsIfNeeded() throws {
-        guard let previousApp, previousApp.processIdentifier != target.pid else { return }
-        try installTap(kind: .previous, pid: previousApp.processIdentifier)
-        try installTap(kind: .target, pid: target.pid)
-    }
-
-    private func installTap(kind: TapKind, pid: pid_t) throws {
-        let context = TapContext(session: self, kind: kind)
-        let pointer = Unmanaged.passUnretained(context).toOpaque()
-        guard let tap = CGEvent.tapCreateForPid(
-            pid: pid,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: Self.focusSuppressionEventMask,
-            callback: backgroundActivationEventTapCallback,
-            userInfo: pointer
-        ) else {
-            throw HelperFailure(
-                code: "accessibility_unavailable",
-                message: "Unable to install focus suppression event tap for pid \(pid)"
-            )
-        }
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            CFMachPortInvalidate(tap)
-            throw HelperFailure(
-                code: "accessibility_unavailable",
-                message: "Unable to create focus suppression run loop source for pid \(pid)"
-            )
-        }
-        CoreRunLoopThread.shared.addSource(source)
-        CGEvent.tapEnable(tap: tap, enable: true)
-        contexts.append(context)
-        taps.append(tap)
-    }
-
-    private func postWindowActivationEvent() {
-        guard target.windowNumber != 0 else { return }
-        let event = NSEvent.otherEvent(
-            with: .appKitDefined,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: target.windowNumber,
-            context: nil,
-            subtype: Int16(1),
-            data1: 0,
-            data2: 0
-        )?.cgEvent
-        guard let event else { return }
-        event.setWindowAddressingFields(windowNumber: target.windowNumber)
-        event.postToPid(target.pid)
-        usleep(20_000)
-    }
-
-    private func postApplicationFocusEvent(subtype: Int16) {
-        let event = NSEvent.otherEvent(
-            with: .appKitDefined,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: target.windowNumber,
-            context: nil,
-            subtype: subtype,
-            data1: 0,
-            data2: 0
-        )?.cgEvent
-        guard let event else { return }
-        event.setWindowAddressingFields(windowNumber: target.windowNumber)
-        event.postToPid(target.pid)
-    }
-
-    private func postWindowCenterPrimer() throws {
-        guard target.windowNumber != 0, target.frame.width > 0, target.frame.height > 0 else { return }
-        let point = CGPoint(x: target.frame.midX, y: target.frame.midY)
-        let dispatcher = AddressedEventDispatcher(target: target)
-        try dispatcher.postMouse(.leftMouseDown, at: point, button: .left, clickState: 1, pressure: 1)
-        usleep(30_000)
-        try dispatcher.postMouse(.leftMouseUp, at: point, button: .left, clickState: 1, pressure: 0)
-        usleep(20_000)
-    }
-
-    private func restorePreviousFrontmostIfNeeded() {
-        guard let previousApp, previousApp.processIdentifier != target.pid else { return }
-        _ = previousApp.activate(options: [.activateIgnoringOtherApps])
-    }
-
-    func shouldDrop(kind: TapKind, type: CGEventType) -> Bool {
-        guard type.rawValue == 13 || type.rawValue == 19 || type.rawValue == 20 else { return false }
-        let currentPhase = stateLock.withLock { phase }
-        switch currentPhase {
-        case .deliveringToTarget, .holding:
-            return kind == .previous
-        case .finished:
-            return false
-        }
-    }
-}
-
-private func backgroundActivationEventTapCallback(
-    _: CGEventTapProxy,
-    type: CGEventType,
-    event: CGEvent,
-    rawContext: UnsafeMutableRawPointer?
-) -> Unmanaged<CGEvent>? {
-    guard let rawContext else {
-        return Unmanaged.passUnretained(event)
-    }
-    let context = Unmanaged<BackgroundActivationSession.TapContext>
-        .fromOpaque(rawContext)
-        .takeUnretainedValue()
-    if context.session.shouldDrop(kind: context.kind, type: type) {
-        return nil
-    }
-    return Unmanaged.passUnretained(event)
 }
 
 func isRecord(_ value: Any) -> [String: Any]? {
@@ -901,42 +646,7 @@ func performWithRequiredBackgroundTarget<T>(
         )
     }
 
-    if NSWorkspace.shared.frontmostApplication?.processIdentifier == target.pid {
-        return try action(target)
-    }
-
-    let session = try BackgroundActivationSession.start(target: target)
-    defer {
-        session.restoreBackgroundActivationIfNeeded()
-        session.finish()
-    }
-    try session.activateWindow()
     return try action(target)
-}
-
-func performWithOptionalBackgroundActivation<T>(
-    appName: String,
-    preferredScreenPoint: CGPoint? = nil,
-    _ action: () throws -> T
-) throws -> T {
-    let app = try resolveRunningApp(named: appName)
-    guard NSWorkspace.shared.frontmostApplication?.processIdentifier != app.processIdentifier,
-          let target = resolveWindowTarget(app: app, preferredScreenPoint: preferredScreenPoint),
-          let session = try? BackgroundActivationSession.start(target: target)
-    else {
-        return try action()
-    }
-
-    defer {
-        session.restoreBackgroundActivationIfNeeded()
-        session.finish()
-    }
-    do {
-        try session.activateWindow()
-    } catch {
-        return try action()
-    }
-    return try action()
 }
 
 func applicationURL(named appName: String) -> URL? {
@@ -1361,26 +1071,6 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
 
     let root = AXUIElementCreateApplication(runningApp.processIdentifier)
     enableBestEffortAccessibilityModes(root)
-    let target = resolveWindowTarget(app: runningApp, root: root)
-    let backgroundSession: BackgroundActivationSession?
-    if NSWorkspace.shared.frontmostApplication?.processIdentifier != runningApp.processIdentifier,
-       let target,
-       let session = try? BackgroundActivationSession.start(target: target)
-    {
-        do {
-            try session.activateWindow()
-            backgroundSession = session
-        } catch {
-            session.finish()
-            backgroundSession = nil
-        }
-    } else {
-        backgroundSession = nil
-    }
-    defer {
-        backgroundSession?.restoreBackgroundActivationIfNeeded()
-        backgroundSession?.finish()
-    }
 
     var nodeCount = 0
     var truncationReasons: [String] = []
@@ -1435,18 +1125,7 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
 func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let previousApp = NSWorkspace.shared.frontmostApplication
-    if let runningApp = findRunningApp(named: appName) {
-        if let target = resolveWindowTarget(app: runningApp),
-           NSWorkspace.shared.frontmostApplication?.processIdentifier != runningApp.processIdentifier
-        {
-            let session = try BackgroundActivationSession.start(target: target)
-            defer {
-                session.restoreBackgroundActivationIfNeeded()
-                session.finish()
-                restorePreviousFrontmostIfNeeded(previousApp: previousApp, targetPID: runningApp.processIdentifier)
-            }
-            try session.activateWindow()
-        }
+    if findRunningApp(named: appName) != nil {
         return [:]
     }
 
@@ -1456,17 +1135,6 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
         throw HelperFailure(code: "app_open_failed", message: "Unable to find launched app: \(appName)")
     }
     restorePreviousFrontmostIfNeeded(previousApp: previousApp, targetPID: launchedApp.processIdentifier)
-    if let target = waitForWindowTarget(app: launchedApp),
-       NSWorkspace.shared.frontmostApplication?.processIdentifier != launchedApp.processIdentifier
-    {
-        let session = try BackgroundActivationSession.start(target: target)
-        defer {
-            session.restoreBackgroundActivationIfNeeded()
-            session.finish()
-            restorePreviousFrontmostIfNeeded(previousApp: previousApp, targetPID: launchedApp.processIdentifier)
-        }
-        try session.activateWindow()
-    }
     return [:]
 }
 
@@ -1474,19 +1142,17 @@ func handleElementClick(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let elementId = try requiredString(request, "elementId")
     let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
-    try performWithOptionalBackgroundActivation(appName: appName) {
-        let element = try resolveElement(appName: appName, elementId: elementId)
-        for index in 0..<clickCount {
-            let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
-            if error != .success {
-                throw HelperFailure(
-                    code: "accessibility_unavailable",
-                    message: "Unable to press \(elementId): \(error.rawValue)"
-                )
-            }
-            if index + 1 < clickCount {
-                usleep(50_000)
-            }
+    let element = try resolveElement(appName: appName, elementId: elementId)
+    for index in 0..<clickCount {
+        let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
+        if error != .success {
+            throw HelperFailure(
+                code: "accessibility_unavailable",
+                message: "Unable to press \(elementId): \(error.rawValue)"
+            )
+        }
+        if index + 1 < clickCount {
+            usleep(50_000)
         }
     }
     return [:]

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1464,7 +1464,7 @@ async function openApp(
       app,
       dispatchMode: "background_app_open",
       dispatchTarget: "target_app",
-      inputRisk: "background_target_prepare",
+      inputRisk: "background_app_launch",
       text: `Opened ${app}`,
     },
   };
@@ -1663,9 +1663,9 @@ async function clickElement(args: {
         screenY: screenPoint.screenY,
         button: args.button,
         clickCount: args.clickCount,
-        dispatchMode: "targeted_mouse_event",
+        dispatchMode: "background_mouse_event",
         dispatchTarget: "app_process",
-        inputRisk: "targeted_app_pointer",
+        inputRisk: "background_app_pointer",
         text: `Clicked ${args.x},${args.y}`,
       },
     };
@@ -1762,9 +1762,9 @@ async function pressKey(
     result: {
       app,
       key: parsed.normalizedKey,
-      dispatchMode: "targeted_keyboard_event",
+      dispatchMode: "background_keyboard_event",
       dispatchTarget: "app_process",
-      inputRisk: "targeted_app_shortcut",
+      inputRisk: "background_app_shortcut",
       text: `Pressed ${parsed.normalizedKey}`,
     },
   };

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -26,7 +26,7 @@ process.stdin.on("end", () => {
 describe("computer use native backend", () => {
   it.each([
     ["app_not_found", "Unable to open Things: Unable to find application"],
-    ["app_open_failed", "Unable to activate Things"],
+    ["app_open_failed", "Unable to open Things"],
   ])("preserves %s helper failures", async (code, message) => {
     const helper = await createHelper({
       status: "failed",

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -487,7 +487,7 @@ describe("computer use desktop runtime", () => {
     });
   });
 
-  it("reports app open as a background target preparation", async () => {
+  it("reports app open as a background launch without target preparation", async () => {
     const openApp = vi.fn<ComputerUseNativeBackend["openApp"]>();
     const result = await executeComputerUseCommand(
       { id: "cmd_1", kind: "app.open", payload: { app: "Safari" } },
@@ -507,7 +507,7 @@ describe("computer use desktop runtime", () => {
         app: "Safari",
         dispatchMode: "background_app_open",
         dispatchTarget: "target_app",
-        inputRisk: "background_target_prepare",
+        inputRisk: "background_app_launch",
       },
     });
     expect(openApp).toHaveBeenCalledWith("Safari");
@@ -1182,9 +1182,9 @@ describe("computer use desktop runtime", () => {
         screenY: 800,
         button: "right",
         clickCount: 2,
-        dispatchMode: "targeted_mouse_event",
+        dispatchMode: "background_mouse_event",
         dispatchTarget: "app_process",
-        inputRisk: "targeted_app_pointer",
+        inputRisk: "background_app_pointer",
       },
     });
     expect(clickPoint).toHaveBeenCalledWith({
@@ -1253,9 +1253,9 @@ describe("computer use desktop runtime", () => {
         screenY: 380,
         button: "left",
         clickCount: 1,
-        dispatchMode: "targeted_mouse_event",
+        dispatchMode: "background_mouse_event",
         dispatchTarget: "app_process",
-        inputRisk: "targeted_app_pointer",
+        inputRisk: "background_app_pointer",
       },
     });
     expect(captureCount).toBe(1);
@@ -1289,7 +1289,7 @@ describe("computer use desktop runtime", () => {
     });
   });
 
-  it("parses press-key combinations before posting targeted input", async () => {
+  it("parses press-key combinations before posting background input", async () => {
     const cases = [
       {
         key: "Command+K",
@@ -1378,9 +1378,9 @@ describe("computer use desktop runtime", () => {
       status: "succeeded",
       result: {
         key: "Command+K",
-        dispatchMode: "targeted_keyboard_event",
+        dispatchMode: "background_keyboard_event",
         dispatchTarget: "app_process",
-        inputRisk: "targeted_app_shortcut",
+        inputRisk: "background_app_shortcut",
       },
     });
     expect(pressKey).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- make computer-use app.open avoid activating already-running apps
- remove temporary foreground activation for app state reads and element clicks
- update CLI/runtime metadata to describe background app dispatch semantics

## Tests
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/cli lint
- pnpm turbo run lint
- pnpm check-types
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm vitest
- pnpm knip