### PR TITLE
feat: improve desktop account controls

### DIFF
--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -2,10 +2,7 @@ import type { IpcMainInvokeEvent } from "electron";
 import { BrowserWindow, ipcMain, shell } from "electron";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { isDesktopComputerUsePageUrl } from "./computer-use-page-url";
-import type {
-  ComputerUseApprovalAction,
-  DesktopComputerUseState,
-} from "./computer-use-types";
+import type { DesktopComputerUseState } from "./computer-use-types";
 
 interface ComputerUseIpcOptions {
   readonly rendererUrl: string;
@@ -15,24 +12,6 @@ interface ComputerUseNativeApi {
   readonly getState: () => DesktopComputerUseState;
   readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => DesktopComputerUseState;
-  readonly decideCommand: (
-    action: ComputerUseApprovalAction,
-  ) => Promise<DesktopComputerUseState>;
-}
-
-function approvalActionArg(value: unknown): ComputerUseApprovalAction {
-  if (typeof value !== "object" || value === null) {
-    throw new Error("Expected Computer Use approval action");
-  }
-  const action = value as Partial<ComputerUseApprovalAction>;
-  if (
-    typeof action.commandId !== "string" ||
-    action.commandId.length === 0 ||
-    (action.decision !== "approve" && action.decision !== "deny")
-  ) {
-    throw new Error("Expected Computer Use approval action");
-  }
-  return { commandId: action.commandId, decision: action.decision };
 }
 
 export function notifyDesktopComputerUseChanged(): void {
@@ -89,13 +68,6 @@ export function installComputerUseIpc(
       await shell.openExternal(
         "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
       );
-    },
-  );
-  ipcMain.handle(
-    COMPUTER_USE_CHANNELS.decideCommand,
-    async (event: IpcMainInvokeEvent, value: unknown) => {
-      assertComputerUsePage(event);
-      return api.decideCommand(approvalActionArg(value));
     },
   );
 }

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -5,9 +5,7 @@ import type {
 } from "./computer-use-accessibility";
 import { SUPPORTED_COMPUTER_USE_CAPABILITIES } from "./computer-use-accessibility";
 import type {
-  ComputerUseApprovalAction,
   ComputerUseHostRuntimeState,
-  ComputerUsePendingApprovalRuntimeEvent,
   ComputerUsePermissionState,
   ComputerUseRuntimeAuditEvent,
 } from "./computer-use-types";
@@ -102,7 +100,6 @@ export class ComputerUseHostRuntime {
     lastHeartbeatAt: null,
     lastCommandAt: null,
     lastError: null,
-    pendingApprovals: [],
     recentAuditEvents: [],
   };
 
@@ -137,28 +134,6 @@ export class ComputerUseHostRuntime {
 
   getState(): ComputerUseHostRuntimeState {
     return this.state;
-  }
-
-  async decideCommand(args: ComputerUseApprovalAction): Promise<void> {
-    const response = await this.sessionFetch(
-      `${this.apiBaseUrl}/api/zero/computer-use/commands/${encodeURIComponent(args.commandId)}/approval`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ decision: args.decision }),
-      },
-    );
-    if (!response.ok) {
-      const message = `Computer Use approval failed: ${response.status}`;
-      this.setState({ lastError: message });
-      throw new Error(message);
-    }
-
-    this.setState({
-      lastError: null,
-      lastCommandAt: new Date().toISOString(),
-    });
-    await this.refreshAuditEvents();
   }
 
   private runtimeBody(): Record<string, unknown> {
@@ -310,7 +285,7 @@ export class ComputerUseHostRuntime {
 
     const response = await this.sessionFetch(url.toString(), { method: "GET" });
     if (response.status === 401 || response.status === 403) {
-      this.setState({ pendingApprovals: [], recentAuditEvents: [] });
+      this.setState({ recentAuditEvents: [] });
       return;
     }
     if (!response.ok) {
@@ -321,7 +296,6 @@ export class ComputerUseHostRuntime {
 
     const body = (await response.json()) as ComputerUseAuditEventsResponse;
     this.setState({
-      pendingApprovals: derivePendingApprovals(body.auditEvents),
       recentAuditEvents: body.auditEvents,
     });
   }
@@ -381,33 +355,4 @@ export class ComputerUseHostRuntime {
       },
     });
   }
-}
-
-function derivePendingApprovals(
-  auditEvents: readonly ComputerUseRuntimeAuditEvent[],
-): readonly ComputerUsePendingApprovalRuntimeEvent[] {
-  const resolvedCommandIds = new Set(
-    auditEvents
-      .filter((event) => {
-        return event.event !== "created";
-      })
-      .map((event) => {
-        return event.commandId;
-      }),
-  );
-
-  return auditEvents
-    .filter((event) => {
-      return (
-        event.event === "created" && !resolvedCommandIds.has(event.commandId)
-      );
-    })
-    .map((event) => {
-      return {
-        commandId: event.commandId,
-        kind: event.kind,
-        app: event.app,
-        createdAt: event.createdAt,
-      };
-    });
 }

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -4,6 +4,5 @@ export const COMPUTER_USE_CHANNELS = {
   requestAccessibilityPermission: "computer-use:request-accessibility",
   openAccessibilitySettings: "computer-use:open-accessibility-settings",
   openScreenRecordingSettings: "computer-use:open-screen-recording-settings",
-  decideCommand: "computer-use:decide-command",
   changed: "computer-use:changed",
 } as const;

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -14,13 +14,6 @@ export type ComputerUseHostRuntimeStatus =
   | "disabled"
   | "error";
 
-export interface ComputerUsePendingApprovalRuntimeEvent {
-  readonly commandId: string;
-  readonly kind: string;
-  readonly app: string | null;
-  readonly createdAt: string;
-}
-
 export interface ComputerUseRuntimeAuditEvent {
   readonly commandId: string;
   readonly kind: string;
@@ -37,13 +30,7 @@ export interface ComputerUseHostRuntimeState {
   readonly lastHeartbeatAt: string | null;
   readonly lastCommandAt: string | null;
   readonly lastError: string | null;
-  readonly pendingApprovals: readonly ComputerUsePendingApprovalRuntimeEvent[];
   readonly recentAuditEvents: readonly ComputerUseRuntimeAuditEvent[];
-}
-
-export interface ComputerUseApprovalAction {
-  readonly commandId: string;
-  readonly decision: "approve" | "deny";
 }
 
 export interface DesktopComputerUseState {
@@ -67,6 +54,5 @@ export const IDLE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =
     lastHeartbeatAt: null,
     lastCommandAt: null,
     lastError: null,
-    pendingApprovals: [],
     recentAuditEvents: [],
   });

--- a/turbo/apps/desktop/src/desktop-auth-electron.ts
+++ b/turbo/apps/desktop/src/desktop-auth-electron.ts
@@ -1,5 +1,6 @@
 import type { IpcMainInvokeEvent } from "electron";
 import { BrowserWindow, ipcMain } from "electron";
+import type { DesktopAuthState } from "./desktop-bridge";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { isDesktopRendererUrl } from "./desktop-renderer-url";
 
@@ -9,6 +10,7 @@ interface DesktopAuthIpcOptions {
 }
 
 interface DesktopAuthNativeApi {
+  readonly getState: () => Promise<DesktopAuthState> | DesktopAuthState;
   readonly openSignIn: () => void;
   readonly openOrgSelection: () => Promise<void>;
   readonly completeSignIn: (token: string) => Promise<void> | void;
@@ -66,6 +68,10 @@ export function installDesktopAuthIpc(
     return { token: value.token };
   };
 
+  ipcMain.handle(DESKTOP_AUTH_CHANNELS.getState, (event) => {
+    assertDesktopRenderer(event);
+    return api.getState();
+  });
   ipcMain.handle(DESKTOP_AUTH_CHANNELS.openSignIn, (event) => {
     assertDesktopRenderer(event);
     api.openSignIn();

--- a/turbo/apps/desktop/src/desktop-auth-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-auth-ipc-channels.ts
@@ -1,4 +1,5 @@
 export const DESKTOP_AUTH_CHANNELS = {
+  getState: "desktop-auth:get-state",
   openSignIn: "desktop-auth:open-sign-in",
   openOrgSelection: "desktop-auth:open-org-selection",
   completeSignIn: "desktop-auth:complete-sign-in",

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -1,9 +1,30 @@
-import type {
-  ComputerUseApprovalAction,
-  DesktopComputerUseState,
-} from "./computer-use-types";
+import type { DesktopComputerUseState } from "./computer-use-types";
+
+export interface DesktopAuthUser {
+  readonly userId: string;
+  readonly email: string;
+}
+
+export interface DesktopAuthOrganization {
+  readonly id: string;
+  readonly name: string;
+  readonly slug: string | null;
+}
+
+export type DesktopAuthState =
+  | {
+      readonly status: "signed_out";
+      readonly user: null;
+      readonly organization: null;
+    }
+  | {
+      readonly status: "signed_in";
+      readonly user: DesktopAuthUser;
+      readonly organization: DesktopAuthOrganization | null;
+    };
 
 export interface DesktopAuthApi {
+  readonly getState: () => Promise<DesktopAuthState>;
   readonly openSignIn: () => Promise<void>;
   readonly openOrgSelection: () => Promise<void>;
   readonly completeSignIn: (params: {
@@ -18,9 +39,6 @@ export interface DesktopComputerUseApi {
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly openAccessibilitySettings: () => Promise<void>;
   readonly openScreenRecordingSettings: () => Promise<void>;
-  readonly decideCommand: (
-    action: ComputerUseApprovalAction,
-  ) => Promise<DesktopComputerUseState>;
   readonly subscribe: (callback: () => void) => () => void;
 }
 

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -17,15 +17,18 @@ import {
   installComputerUseIpc,
   notifyDesktopComputerUseChanged,
 } from "./computer-use-electron";
-import { ComputerUseHostRuntime } from "./computer-use-host";
+import {
+  ComputerUseHostRuntime,
+  resolveComputerUseApiBaseUrl,
+} from "./computer-use-host";
 import { captureComputerUseScreenshot } from "./computer-use-screenshot";
 import {
   COMPUTER_USE_FEATURE_SWITCH_KEY,
   IDLE_COMPUTER_USE_HOST_STATE,
   hasRequiredComputerUsePermissions,
-  type ComputerUseApprovalAction,
   type DesktopComputerUseState,
 } from "./computer-use-types";
+import type { DesktopAuthState } from "./desktop-bridge";
 import {
   getComputerUsePermissionState,
   requestComputerUseAccessibilityPermission,
@@ -62,6 +65,7 @@ import {
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
 const config = resolveDesktopConfig();
+const desktopApiBaseUrl = resolveComputerUseApiBaseUrl(config.platformUrl);
 const desktopAuthStartUrl = buildDesktopAuthStartUrl(
   config.webUrl,
   config.identity.authScheme,
@@ -74,6 +78,8 @@ const desktopAuthTokenUrl = buildDesktopAuthTokenUrl(config.webUrl);
 const localRendererUrl = desktopRendererUrl();
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const ELECTRON_ERR_ABORTED = -3;
+const AUTH_ME_PATH = "/api/auth/me";
+const ZERO_ORG_PATH = "/api/zero/org";
 let mainWindow: BrowserWindow | null = null;
 let pendingDesktopAuthCode: string | null = null;
 let appIsQuitting = false;
@@ -134,6 +140,73 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
   };
 }
 
+interface AuthMeResponse {
+  readonly userId: string;
+  readonly email: string;
+}
+
+interface ZeroOrgResponse {
+  readonly id: string;
+  readonly name: string;
+  readonly slug?: string;
+}
+
+function signedOutDesktopAuthState(): DesktopAuthState {
+  return {
+    status: "signed_out",
+    user: null,
+    organization: null,
+  };
+}
+
+async function getDesktopAuthState(): Promise<DesktopAuthState> {
+  if (!desktopAuthToken) {
+    return signedOutDesktopAuthState();
+  }
+
+  const authHeaders = {
+    authorization: `Bearer ${desktopAuthToken}`,
+  };
+  const meResponse = await fetch(`${desktopApiBaseUrl}${AUTH_ME_PATH}`, {
+    headers: authHeaders,
+  });
+  if (meResponse.status === 401) {
+    desktopAuthToken = null;
+    return signedOutDesktopAuthState();
+  }
+  if (!meResponse.ok) {
+    throw new Error(`Desktop auth status failed: ${meResponse.status}`);
+  }
+
+  const user = (await meResponse.json()) as AuthMeResponse;
+  const orgResponse = await fetch(`${desktopApiBaseUrl}${ZERO_ORG_PATH}`, {
+    headers: authHeaders,
+  });
+  if (orgResponse.status === 401) {
+    desktopAuthToken = null;
+    return signedOutDesktopAuthState();
+  }
+  if (orgResponse.status === 404) {
+    return { status: "signed_in", user, organization: null };
+  }
+  if (!orgResponse.ok) {
+    throw new Error(
+      `Desktop organization status failed: ${orgResponse.status}`,
+    );
+  }
+
+  const organization = (await orgResponse.json()) as ZeroOrgResponse;
+  return {
+    status: "signed_in",
+    user,
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      slug: organization.slug ?? null,
+    },
+  };
+}
+
 async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
   const desktopSession = session.fromPartition(config.sessionPartition);
   if (!computerUseRuntime) {
@@ -163,16 +236,6 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
   return getComputerUseBridgeState();
 }
 
-async function decideComputerUseCommand(
-  action: ComputerUseApprovalAction,
-): Promise<DesktopComputerUseState> {
-  if (!computerUseRuntime) {
-    return getComputerUseBridgeState();
-  }
-  await computerUseRuntime.decideCommand(action);
-  return getComputerUseBridgeState();
-}
-
 function requestComputerUsePermission(): DesktopComputerUseState {
   requestComputerUseAccessibilityPermission();
   notifyDesktopComputerUseChanged();
@@ -185,7 +248,6 @@ function installComputerUse(): void {
       getState: getComputerUseBridgeState,
       start: startComputerUseRuntime,
       requestAccessibilityPermission: requestComputerUsePermission,
-      decideCommand: decideComputerUseCommand,
     },
     { rendererUrl: localRendererUrl },
   );
@@ -194,6 +256,7 @@ function installComputerUse(): void {
 function installDesktopAuth(): void {
   installDesktopAuthIpc(
     {
+      getState: getDesktopAuthState,
       openSignIn: () => {
         openExternal(desktopAuthStartUrl);
       },

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -2,12 +2,12 @@ import { contextBridge, ipcRenderer } from "electron";
 import type { DesktopAuthApi, DesktopComputerUseApi } from "./desktop-bridge";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
-import type {
-  ComputerUseApprovalAction,
-  DesktopComputerUseState,
-} from "./computer-use-types";
+import type { DesktopComputerUseState } from "./computer-use-types";
 
 const desktopAuthApi: DesktopAuthApi = {
+  getState() {
+    return ipcRenderer.invoke(DESKTOP_AUTH_CHANNELS.getState);
+  },
   openSignIn(): Promise<void> {
     return ipcRenderer.invoke(DESKTOP_AUTH_CHANNELS.openSignIn);
   },
@@ -47,11 +47,6 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
     return ipcRenderer.invoke(
       COMPUTER_USE_CHANNELS.openScreenRecordingSettings,
     );
-  },
-  decideCommand(
-    action: ComputerUseApprovalAction,
-  ): Promise<DesktopComputerUseState> {
-    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.decideCommand, action);
   },
   subscribe(callback: () => void): () => void {
     const listener = (): void => {

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -2,24 +2,22 @@ import { useEffect, type ReactNode } from "react";
 import {
   IconAlertCircle,
   IconBuilding,
+  IconChevronDown,
   IconCheck,
-  IconClock,
   IconExternalLink,
   IconHistory,
   IconPlayerPlay,
   IconRefresh,
   IconShieldCheck,
-  IconX,
+  IconUserCircle,
 } from "@tabler/icons-react";
 import { useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import type {
-  ComputerUseApprovalAction,
-  DesktopComputerUseState,
-} from "../computer-use-types";
+import type { DesktopAuthState } from "../desktop-bridge";
+import type { DesktopComputerUseState } from "../computer-use-types";
 import {
   computerUseData$,
-  decideComputerUseCommand$,
+  desktopAuthData$,
   hasDesktopAuthBridge,
   hasDesktopComputerUseBridge,
   maybeAutoStartComputerUse$,
@@ -316,74 +314,6 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   );
 }
 
-function PendingApprovalRow({
-  action,
-}: {
-  readonly action: DesktopComputerUseState["host"]["pendingApprovals"][number];
-}) {
-  const [decisionLoadable, decide] = useLoadableSet(decideComputerUseCommand$);
-  const disabled = decisionLoadable.state === "loading";
-  const decideWith = (decision: ComputerUseApprovalAction["decision"]) => {
-    void decide({ commandId: action.commandId, decision });
-  };
-
-  return (
-    <div className="approval-row">
-      <div>
-        <div className="row-title">{action.kind}</div>
-        <div className="row-meta">
-          {action.app ?? "No target app"} - {formatTimestamp(action.createdAt)}
-        </div>
-      </div>
-      <div className="row-actions">
-        <IconButton
-          tone="primary"
-          icon={<IconCheck size={15} />}
-          onClick={() => {
-            decideWith("approve");
-          }}
-          disabled={disabled}
-        >
-          Approve
-        </IconButton>
-        <IconButton
-          tone="danger"
-          icon={<IconX size={15} />}
-          onClick={() => {
-            decideWith("deny");
-          }}
-          disabled={disabled}
-        >
-          Deny
-        </IconButton>
-      </div>
-    </div>
-  );
-}
-
-function PendingApprovalsPanel({
-  state,
-}: {
-  readonly state: DesktopComputerUseState;
-}) {
-  const approvals = state.host.pendingApprovals;
-  return (
-    <Panel title="Pending Approvals" icon={<IconClock size={18} />}>
-      {approvals.length === 0 ? (
-        <div className="empty-state">No commands are waiting.</div>
-      ) : (
-        <div className="approval-list">
-          {approvals.map((action) => {
-            return (
-              <PendingApprovalRow key={action.commandId} action={action} />
-            );
-          })}
-        </div>
-      )}
-    </Panel>
-  );
-}
-
 function HistoryPanel({ state }: { readonly state: DesktopComputerUseState }) {
   const events = state.host.recentAuditEvents;
   return (
@@ -445,7 +375,6 @@ function ComputerUseContent({
         <>
           <PermissionsPanel state={state} />
           <RuntimePanel state={state} />
-          <PendingApprovalsPanel state={state} />
           <HistoryPanel state={state} />
         </>
       )}
@@ -490,9 +419,99 @@ function ComputerUsePage() {
   );
 }
 
+function AccountMenu({
+  authState,
+  loading,
+  onSelectOrg,
+  onSignIn,
+  orgSelectionLoading,
+  signInLoading,
+}: {
+  readonly authState: DesktopAuthState | null;
+  readonly loading: boolean;
+  readonly onSelectOrg: () => void;
+  readonly onSignIn: () => void;
+  readonly orgSelectionLoading: boolean;
+  readonly signInLoading: boolean;
+}) {
+  if (!authState || authState.status === "signed_out") {
+    return (
+      <IconButton
+        icon={<IconExternalLink size={15} />}
+        onClick={onSignIn}
+        disabled={loading || signInLoading}
+      >
+        {loading ? "Checking" : "Sign in"}
+      </IconButton>
+    );
+  }
+
+  const workspaceLabel = authState.organization?.name ?? "Select workspace";
+  const workspaceMeta = authState.organization?.slug
+    ? `/${authState.organization.slug}`
+    : "No active workspace";
+
+  return (
+    <details className="account-menu">
+      <summary className="account-summary">
+        <IconUserCircle size={17} />
+        <span className="account-copy">
+          <span className="account-email">{authState.user.email}</span>
+          <span
+            className={
+              authState.organization
+                ? "account-workspace"
+                : "account-workspace account-workspace-missing"
+            }
+          >
+            {workspaceLabel}
+          </span>
+        </span>
+        <IconChevronDown size={14} />
+      </summary>
+      <div className="account-popover">
+        <div className="account-popover-heading">
+          <span>Signed in as</span>
+          <strong>{authState.user.email}</strong>
+        </div>
+        <div className="account-popover-heading">
+          <span>Workspace</span>
+          <strong>{workspaceLabel}</strong>
+          <small>{workspaceMeta}</small>
+        </div>
+        <button
+          type="button"
+          className="account-menu-item"
+          onClick={onSelectOrg}
+          disabled={orgSelectionLoading}
+        >
+          <IconBuilding size={15} />
+          <span>
+            {authState.organization ? "Switch workspace" : "Select workspace"}
+          </span>
+        </button>
+        <button
+          type="button"
+          className="account-menu-item"
+          onClick={onSignIn}
+          disabled={signInLoading}
+        >
+          <IconExternalLink size={15} />
+          <span>Sign in again</span>
+        </button>
+      </div>
+    </details>
+  );
+}
+
 function Header() {
+  const authLoadable = useLastLoadable(desktopAuthData$);
   const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
-  const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
+  const [orgSelectionLoadable, selectOrg] = useLoadableSet(
+    openDesktopOrgSelection$,
+  );
+  const authState = authLoadable.state === "hasData" ? authLoadable.data : null;
+  const authLoading = authLoadable.state === "loading";
   return (
     <header className="app-header">
       <div className="titlebar-title">
@@ -500,25 +519,19 @@ function Header() {
       </div>
       <div className="header-actions">
         {hasDesktopAuthBridge() && (
-          <IconButton
-            icon={<IconExternalLink size={15} />}
-            onClick={() => {
+          <AccountMenu
+            authState={authState}
+            loading={authLoading}
+            onSignIn={() => {
               void signIn();
             }}
-            disabled={signInLoadable.state === "loading"}
-          >
-            Sign in
-          </IconButton>
+            onSelectOrg={() => {
+              void selectOrg();
+            }}
+            orgSelectionLoading={orgSelectionLoadable.state === "loading"}
+            signInLoading={signInLoadable.state === "loading"}
+          />
         )}
-        <IconButton
-          icon={<IconRefresh size={15} />}
-          onClick={() => {
-            void refresh();
-          }}
-          disabled={refreshLoadable.state === "loading"}
-        >
-          Refresh
-        </IconButton>
       </div>
     </header>
   );

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -19,7 +19,6 @@ function computerUseState(
       lastHeartbeatAt: null,
       lastCommandAt: null,
       lastError: null,
-      pendingApprovals: [],
       recentAuditEvents: [],
     },
     ...overrides,

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -1,12 +1,16 @@
 import { command, computed, state } from "ccstate";
-import type { DesktopAuthApi, DesktopComputerUseApi } from "../desktop-bridge";
+import type {
+  DesktopAuthApi,
+  DesktopAuthState,
+  DesktopComputerUseApi,
+} from "../desktop-bridge";
 import {
   hasRequiredComputerUsePermissions,
-  type ComputerUseApprovalAction,
   type DesktopComputerUseState,
 } from "../computer-use-types";
 
 const reloadComputerUseState$ = state(0);
+const reloadDesktopAuthState$ = state(0);
 const autoStartAttempted$ = state(false);
 
 function desktopComputerUseApi(): DesktopComputerUseApi {
@@ -51,8 +55,19 @@ export const computerUseData$ = computed(
   },
 );
 
+export const desktopAuthData$ = computed((get): Promise<DesktopAuthState> => {
+  get(reloadDesktopAuthState$);
+  return desktopAuthApi().getState();
+});
+
 export const refreshComputerUse$ = command(({ set }) => {
   set(reloadComputerUseState$, (count) => {
+    return count + 1;
+  });
+});
+
+const refreshDesktopAuth$ = command(({ set }) => {
+  set(reloadDesktopAuthState$, (count) => {
     return count + 1;
   });
 });
@@ -64,6 +79,7 @@ export const setupComputerUseBridge$ = command(
     });
     const unsubscribeAuth = window.vm0DesktopAuth?.subscribe(() => {
       set(autoStartAttempted$, false);
+      set(refreshDesktopAuth$);
       set(refreshComputerUse$);
     });
 
@@ -75,6 +91,7 @@ export const setupComputerUseBridge$ = command(
       },
       { once: true },
     );
+    set(refreshDesktopAuth$);
     set(refreshComputerUse$);
   },
 );
@@ -108,13 +125,6 @@ export const openScreenRecordingSettings$ = command(async () => {
   await desktopComputerUseApi().openScreenRecordingSettings();
 });
 
-export const decideComputerUseCommand$ = command(
-  async ({ set }, action: ComputerUseApprovalAction) => {
-    await desktopComputerUseApi().decideCommand(action);
-    set(refreshComputerUse$);
-  },
-);
-
 export const openDesktopSignIn$ = command(async () => {
   await desktopAuthApi().openSignIn();
 });
@@ -122,5 +132,6 @@ export const openDesktopSignIn$ = command(async () => {
 export const openDesktopOrgSelection$ = command(async ({ set }) => {
   await desktopAuthApi().openOrgSelection();
   set(autoStartAttempted$, false);
+  set(refreshDesktopAuth$);
   set(refreshComputerUse$);
 });

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -114,6 +114,128 @@ button {
   white-space: nowrap;
 }
 
+.account-menu {
+  -webkit-app-region: no-drag;
+  position: relative;
+}
+
+.account-summary {
+  min-height: 30px;
+  min-width: 0;
+  max-width: min(360px, calc(100vw - 160px));
+  border: 1px solid rgba(30, 38, 52, 0.14);
+  border-radius: 6px;
+  padding: 0 9px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #2e3645;
+  background: #ffffff;
+  cursor: pointer;
+  list-style: none;
+}
+
+.account-summary::-webkit-details-marker {
+  display: none;
+}
+
+.account-summary:hover {
+  border-color: rgba(30, 38, 52, 0.25);
+  background: #f4f6f8;
+}
+
+.account-copy {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.account-email,
+.account-workspace {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-email {
+  color: #202631;
+  font-size: 12px;
+  line-height: 1.15;
+  font-weight: 650;
+}
+
+.account-workspace {
+  color: #667085;
+  font-size: 11px;
+  line-height: 1.1;
+  font-weight: 500;
+}
+
+.account-workspace-missing {
+  color: #b54708;
+}
+
+.account-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 30;
+  width: 286px;
+  border: 1px solid rgba(30, 38, 52, 0.12);
+  border-radius: 8px;
+  padding: 8px;
+  display: grid;
+  gap: 6px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgba(17, 24, 39, 0.16);
+}
+
+.account-popover-heading {
+  min-width: 0;
+  padding: 6px 7px;
+  display: grid;
+  gap: 2px;
+}
+
+.account-popover-heading span,
+.account-popover-heading small {
+  color: #667085;
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.account-popover-heading strong {
+  min-width: 0;
+  color: #202631;
+  font-size: 12px;
+  line-height: 1.3;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.account-menu-item {
+  min-height: 34px;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 7px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #2e3645;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.account-menu-item:hover:not(:disabled) {
+  background: #f4f6f8;
+}
+
+.account-menu-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .content {
   -webkit-app-region: no-drag;
   flex: 1;
@@ -227,14 +349,12 @@ button {
 }
 
 .permission-list,
-.approval-list,
 .history-list {
   display: grid;
   gap: 8px;
 }
 
 .permission-row,
-.approval-row,
 .history-row {
   min-height: 58px;
   border: 1px solid rgba(30, 38, 52, 0.08);
@@ -364,7 +484,6 @@ button {
   }
 
   .permission-row,
-  .approval-row,
   .history-row {
     align-items: flex-start;
     flex-direction: column;


### PR DESCRIPTION
## Summary

- remove the Desktop Computer Use Pending Approvals panel and approval decision bridge
- add a Desktop auth state bridge that resolves the signed-in account and active workspace
- replace the titlebar sign-in/refresh actions with an account/workspace menu while keeping Runtime status refresh available

## Validation

- pnpm format
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- pnpm knip --workspace @vm0/desktop

Closes #14833