### PR TITLE
feat(desktop): add local computer use command log

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -3,6 +3,11 @@ import {
   ComputerUseHostRuntime,
   type ComputerUseHostFetch,
 } from "./computer-use-host";
+import type {
+  ComputerUseCommand,
+  ComputerUseCommandExecutionResult,
+} from "./computer-use-accessibility";
+import type { ComputerUsePermissionState } from "./computer-use-types";
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -15,16 +20,26 @@ function createRuntime(
   options: {
     readonly sessionFetch?: ComputerUseHostFetch;
     readonly hostFetch?: ComputerUseHostFetch;
+    readonly executeCommand?: (
+      command: ComputerUseCommand,
+      permissions: ComputerUsePermissionState,
+    ) => Promise<ComputerUseCommandExecutionResult>;
   } = {},
 ) {
   const sessionFetch =
     options.sessionFetch ??
-    vi.fn<ComputerUseHostFetch>(async () => {
+    vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.includes("/api/zero/computer-use/audit-events")) {
+        return jsonResponse({ auditEvents: [] });
+      }
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
   const hostFetch =
     options.hostFetch ??
-    vi.fn<ComputerUseHostFetch>(async () => {
+    vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
       return jsonResponse({ status: "idle" });
     });
   const runtime = new ComputerUseHostRuntime({
@@ -36,7 +51,10 @@ function createRuntime(
     getPermissions() {
       return { accessibility: true, screenRecording: false };
     },
-    async executeCommand() {
+    async executeCommand(command, permissions) {
+      if (options.executeCommand) {
+        return options.executeCommand(command, permissions);
+      }
       return { status: "succeeded", result: {} };
     },
   });
@@ -95,7 +113,10 @@ describe("ComputerUseHostRuntime", () => {
 
   it("uses the host bearer token for polling after registration", async () => {
     vi.useFakeTimers();
-    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.includes("/api/zero/computer-use/audit-events")) {
+        return jsonResponse({ auditEvents: [] });
+      }
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
@@ -121,6 +142,94 @@ describe("ComputerUseHostRuntime", () => {
     expect(sessionFetch.mock.calls[0]?.[0]).toBe(
       "https://api.vm0.ai/api/zero/computer-use/hosts/start",
     );
+
+    runtime.stop();
+  });
+
+  it("records local native command payloads and results", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T08:00:00.000Z"));
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        return jsonResponse({
+          status: "claimed",
+          command: {
+            id: "cmd-1",
+            kind: "app.state",
+            payload: { app: "Things" },
+          },
+        });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ status: "idle" });
+    });
+    const executeCommand = vi.fn<
+      (
+        command: ComputerUseCommand,
+        permissions: ComputerUsePermissionState,
+      ) => Promise<ComputerUseCommandExecutionResult>
+    >(async () => {
+      return {
+        status: "succeeded",
+        result: {
+          text: "0 standard window Inbox",
+          screenshot: "data:image/png;base64,abc123",
+          screenshotWidth: 800,
+          screenshotHeight: 600,
+          screenshotSourceName: "Inbox",
+        },
+      };
+    });
+    const { runtime } = createRuntime({ hostFetch, executeCommand });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const [entry] = runtime.getState().localCommandLog;
+    expect(entry).toMatchObject({
+      commandId: "cmd-1",
+      kind: "app.state",
+      app: "Things",
+      status: "succeeded",
+      payload: { app: "Things" },
+      result: {
+        text: "0 standard window Inbox",
+        screenshot: "data:image/png;base64,abc123",
+        screenshotWidth: 800,
+        screenshotHeight: 600,
+        screenshotSourceName: "Inbox",
+      },
+      error: null,
+      durationMs: 0,
+    });
+    expect(executeCommand).toHaveBeenCalledWith(
+      {
+        id: "cmd-1",
+        kind: "app.state",
+        payload: { app: "Things" },
+      },
+      { accessibility: true, screenRecording: false },
+    );
+    const completionCall = hostFetch.mock.calls.find(([url]) => {
+      return url.endsWith(
+        "/api/zero/computer-use/host/commands/cmd-1/complete",
+      );
+    });
+    if (!completionCall) {
+      throw new Error("Expected Computer Use command completion request");
+    }
+    expect(JSON.parse(String(completionCall[1]?.body))).toMatchObject({
+      status: "succeeded",
+      result: {
+        text: "0 standard window Inbox",
+        screenshot: "data:image/png;base64,abc123",
+      },
+    });
 
     runtime.stop();
   });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -6,6 +6,7 @@ import type {
 import { SUPPORTED_COMPUTER_USE_CAPABILITIES } from "./computer-use-accessibility";
 import type {
   ComputerUseHostRuntimeState,
+  ComputerUseLocalCommandLogEntry,
   ComputerUsePermissionState,
   ComputerUseRuntimeAuditEvent,
 } from "./computer-use-types";
@@ -101,6 +102,7 @@ export class ComputerUseHostRuntime {
     lastCommandAt: null,
     lastError: null,
     recentAuditEvents: [],
+    localCommandLog: [],
   };
 
   constructor(options: ComputerUseHostRuntimeOptions) {
@@ -147,6 +149,58 @@ export class ComputerUseHostRuntime {
   private setState(update: Partial<ComputerUseHostRuntimeState>): void {
     this.state = { ...this.state, ...update };
     this.onChange();
+  }
+
+  private startLocalCommandLogEntry(
+    command: ComputerUseCommand,
+    startedAt: string,
+  ): void {
+    const app = command.payload.app;
+    const entry: ComputerUseLocalCommandLogEntry = {
+      commandId: command.id,
+      kind: command.kind,
+      app: typeof app === "string" ? app : null,
+      status: "running",
+      payload: command.payload,
+      result: null,
+      error: null,
+      startedAt,
+      completedAt: null,
+      durationMs: null,
+    };
+    this.setState({
+      localCommandLog: [
+        entry,
+        ...this.state.localCommandLog.filter((candidate) => {
+          return candidate.commandId !== command.id;
+        }),
+      ],
+    });
+  }
+
+  private finishLocalCommandLogEntry(args: {
+    readonly commandId: string;
+    readonly status: "succeeded" | "failed";
+    readonly result: Record<string, unknown> | null;
+    readonly error: Record<string, unknown> | null;
+    readonly completedAt: string;
+    readonly durationMs: number;
+  }): void {
+    this.setState({
+      localCommandLog: this.state.localCommandLog.map((entry) => {
+        if (entry.commandId !== args.commandId) {
+          return entry;
+        }
+        return {
+          ...entry,
+          status: args.status,
+          result: args.result,
+          error: args.error,
+          completedAt: args.completedAt,
+          durationMs: args.durationMs,
+        };
+      }),
+    });
   }
 
   private schedule(delayMs: number): void {
@@ -318,10 +372,39 @@ export class ComputerUseHostRuntime {
       return;
     }
 
-    const completed = await this.executeCommand(
-      body.command,
-      this.getPermissions(),
-    );
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    this.startLocalCommandLogEntry(body.command, startedAt);
+
+    let completed: ComputerUseCommandExecutionResult;
+    try {
+      completed = await this.executeCommand(
+        body.command,
+        this.getPermissions(),
+      );
+    } catch (error) {
+      const completedAtMs = Date.now();
+      this.finishLocalCommandLogEntry({
+        commandId: body.command.id,
+        status: "failed",
+        result: null,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+        },
+        completedAt: new Date(completedAtMs).toISOString(),
+        durationMs: completedAtMs - startedAtMs,
+      });
+      throw error;
+    }
+    const completedAtMs = Date.now();
+    this.finishLocalCommandLogEntry({
+      commandId: body.command.id,
+      status: completed.status,
+      result: completed.status === "succeeded" ? completed.result : null,
+      error: completed.status === "failed" ? completed.error : null,
+      completedAt: new Date(completedAtMs).toISOString(),
+      durationMs: completedAtMs - startedAtMs,
+    });
     const response = await this.hostFetch(
       `/api/zero/computer-use/host/commands/${body.command.id}/complete`,
       {

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -24,6 +24,24 @@ export interface ComputerUseRuntimeAuditEvent {
   readonly createdAt: string;
 }
 
+export type ComputerUseLocalCommandLogStatus =
+  | "running"
+  | "succeeded"
+  | "failed";
+
+export interface ComputerUseLocalCommandLogEntry {
+  readonly commandId: string;
+  readonly kind: string;
+  readonly app: string | null;
+  readonly status: ComputerUseLocalCommandLogStatus;
+  readonly payload: Record<string, unknown>;
+  readonly result: Record<string, unknown> | null;
+  readonly error: Record<string, unknown> | null;
+  readonly startedAt: string;
+  readonly completedAt: string | null;
+  readonly durationMs: number | null;
+}
+
 export interface ComputerUseHostRuntimeState {
   readonly status: ComputerUseHostRuntimeStatus;
   readonly hostId: string | null;
@@ -31,6 +49,7 @@ export interface ComputerUseHostRuntimeState {
   readonly lastCommandAt: string | null;
   readonly lastError: string | null;
   readonly recentAuditEvents: readonly ComputerUseRuntimeAuditEvent[];
+  readonly localCommandLog: readonly ComputerUseLocalCommandLogEntry[];
 }
 
 export interface DesktopComputerUseState {
@@ -55,4 +74,5 @@ export const IDLE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =
     lastCommandAt: null,
     lastError: null,
     recentAuditEvents: [],
+    localCommandLog: [],
   });

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -1,15 +1,20 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   IconAlertCircle,
   IconBuilding,
   IconChevronDown,
   IconCheck,
+  IconChevronRight,
+  IconCode,
   IconExternalLink,
   IconHistory,
+  IconMaximize,
+  IconPhoto,
   IconPlayerPlay,
   IconRefresh,
   IconShieldCheck,
   IconUserCircle,
+  IconX,
 } from "@tabler/icons-react";
 import { useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
@@ -32,6 +37,14 @@ import {
 } from "./computer-use-state";
 
 type HostStatus = DesktopComputerUseState["host"]["status"];
+type CommandLogEntry =
+  DesktopComputerUseState["host"]["localCommandLog"][number];
+
+interface ScreenshotPreview {
+  readonly src: string;
+  readonly title: string;
+  readonly meta: string;
+}
 
 const STATUS_LABELS = {
   idle: "Idle",
@@ -42,6 +55,19 @@ const STATUS_LABELS = {
   disabled: "Disabled",
   error: "Error",
 } as const satisfies Record<HostStatus, string>;
+
+const COMMAND_STATUS_LABELS = {
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+} as const satisfies Record<CommandLogEntry["status"], string>;
+
+const RESULT_SUMMARY_KEYS_TO_SKIP = new Set([
+  "elements",
+  "screenshot",
+  "text",
+  "visibleElements",
+]);
 
 function BridgeSubscription() {
   const setupBridge = useSet(setupComputerUseBridge$);
@@ -138,6 +164,153 @@ function formatTimestamp(value: string | null): string {
     hour: "2-digit",
     minute: "2-digit",
   }).format(date);
+}
+
+function formatDuration(value: number | null): string {
+  if (value === null) {
+    return "In progress";
+  }
+  if (value < 1_000) {
+    return `${value} ms`;
+  }
+  return `${(value / 1_000).toFixed(1)} s`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordStringValue(
+  record: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  const value = record?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function recordNumberValue(
+  record: Record<string, unknown> | null,
+  key: string,
+): number | null {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2) ?? "";
+}
+
+function previewValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "None";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return formatJson(value);
+}
+
+function visibleElementRecords(
+  result: Record<string, unknown> | null,
+): readonly Record<string, unknown>[] {
+  const value = result?.visibleElements;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord);
+}
+
+function jsonDisplayRecord(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      key === "screenshot" &&
+      typeof entry === "string" &&
+      entry.startsWith("data:image/")
+    ) {
+      next[key] = `[image data URL, ${entry.length} characters]`;
+    } else {
+      next[key] = jsonDisplayValue(entry);
+    }
+  }
+  return next;
+}
+
+function jsonDisplayValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => {
+      return jsonDisplayValue(entry);
+    });
+  }
+  if (isRecord(value)) {
+    return jsonDisplayRecord(value);
+  }
+  return value;
+}
+
+function resultSummaryRecord(
+  result: Record<string, unknown>,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(result)) {
+    if (!RESULT_SUMMARY_KEYS_TO_SKIP.has(key)) {
+      summary[key] = jsonDisplayValue(value);
+    }
+  }
+  if (recordStringValue(result, "text")) {
+    summary.text = "[shown in Agent State]";
+  }
+  if (recordStringValue(result, "screenshot")) {
+    summary.screenshot = "[shown as image]";
+  }
+  const elements = result.elements;
+  if (Array.isArray(elements)) {
+    summary.elements = `${elements.length} elements`;
+  }
+  const visibleElements = result.visibleElements;
+  if (Array.isArray(visibleElements)) {
+    summary.visibleElements = `${visibleElements.length} visible elements`;
+  }
+  return summary;
+}
+
+function screenshotMeta(result: Record<string, unknown> | null): string {
+  const sourceName = recordStringValue(result, "screenshotSourceName");
+  const width = recordNumberValue(result, "screenshotWidth");
+  const height = recordNumberValue(result, "screenshotHeight");
+  const dimensions =
+    width !== null && height !== null ? `${width}x${height}` : null;
+  return [sourceName, dimensions].filter(Boolean).join(" - ");
+}
+
+function KeyValueList({
+  emptyLabel,
+  value,
+}: {
+  readonly emptyLabel: string;
+  readonly value: Record<string, unknown>;
+}) {
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    return <div className="compact-empty">{emptyLabel}</div>;
+  }
+  return (
+    <dl className="key-value-list">
+      {entries.map(([key, entry]) => {
+        return (
+          <div key={key}>
+            <dt>{key}</dt>
+            <dd>{previewValue(entry)}</dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
 }
 
 function PermissionsPanel({
@@ -314,39 +487,311 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   );
 }
 
-function HistoryPanel({ state }: { readonly state: DesktopComputerUseState }) {
-  const events = state.host.recentAuditEvents;
+function CommandStatusBadge({
+  status,
+}: {
+  readonly status: CommandLogEntry["status"];
+}) {
   return (
-    <Panel title="Recent History" icon={<IconHistory size={18} />}>
-      {events.length === 0 ? (
-        <div className="empty-state">No recent command events.</div>
+    <span className={`command-status command-status-${status}`}>
+      {COMMAND_STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+function CommandLogSection({
+  children,
+  icon,
+  title,
+}: {
+  readonly children: ReactNode;
+  readonly icon: ReactNode;
+  readonly title: string;
+}) {
+  return (
+    <section className="command-log-section">
+      <div className="command-log-section-title">
+        {icon}
+        <h3>{title}</h3>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function VisibleElements({
+  elements,
+}: {
+  readonly elements: readonly Record<string, unknown>[];
+}) {
+  if (elements.length === 0) {
+    return null;
+  }
+  const preview = elements.slice(0, 8);
+  return (
+    <CommandLogSection title="Visible Elements" icon={<IconCode size={15} />}>
+      <div className="visible-elements-list">
+        {preview.map((element, index) => {
+          const label =
+            recordStringValue(element, "text") ??
+            recordStringValue(element, "elementId") ??
+            `Element ${index + 1}`;
+          const elementIndex = recordNumberValue(element, "elementIndex");
+          const role = recordStringValue(element, "role");
+          const meta = [
+            elementIndex !== null ? `#${elementIndex.toString()}` : null,
+            role,
+          ]
+            .filter((value): value is string => {
+              return value !== null;
+            })
+            .join(" - ");
+          return (
+            <div
+              className="visible-element-row"
+              key={`${label}-${index.toString()}`}
+            >
+              <span>{label}</span>
+              {meta && <code>{meta}</code>}
+            </div>
+          );
+        })}
+      </div>
+      {elements.length > preview.length && (
+        <div className="compact-empty">
+          {elements.length - preview.length} more elements in raw result
+        </div>
+      )}
+    </CommandLogSection>
+  );
+}
+
+function ScreenshotBlock({
+  entry,
+  onPreview,
+  screenshot,
+}: {
+  readonly entry: CommandLogEntry;
+  readonly onPreview: (preview: ScreenshotPreview) => void;
+  readonly screenshot: string;
+}) {
+  const meta = screenshotMeta(entry.result);
+  return (
+    <CommandLogSection title="Screenshot" icon={<IconPhoto size={15} />}>
+      <button
+        type="button"
+        className="screenshot-thumbnail"
+        onClick={() => {
+          onPreview({
+            src: screenshot,
+            title: `${entry.kind} screenshot`,
+            meta,
+          });
+        }}
+      >
+        <img src={screenshot} alt={`${entry.kind} screenshot`} />
+        <span>
+          <IconMaximize size={14} />
+          Open
+        </span>
+      </button>
+      {meta && <div className="row-meta">{meta}</div>}
+    </CommandLogSection>
+  );
+}
+
+function CommandLogRow({
+  entry,
+  expanded,
+  onPreviewScreenshot,
+  onToggle,
+}: {
+  readonly entry: CommandLogEntry;
+  readonly expanded: boolean;
+  readonly onPreviewScreenshot: (preview: ScreenshotPreview) => void;
+  readonly onToggle: () => void;
+}) {
+  const resultText = recordStringValue(entry.result, "text");
+  const screenshot = recordStringValue(entry.result, "screenshot");
+  const visibleElements = visibleElementRecords(entry.result);
+  const completedAt = entry.completedAt ?? entry.startedAt;
+  return (
+    <article className="command-log-row">
+      <button
+        type="button"
+        className="command-log-summary"
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        <span className="command-log-chevron">
+          {expanded ? (
+            <IconChevronDown size={16} />
+          ) : (
+            <IconChevronRight size={16} />
+          )}
+        </span>
+        <span className="command-log-main">
+          <span className="row-title">{entry.kind}</span>
+          <span className="row-meta">
+            {entry.app ?? "No target app"} - {formatTimestamp(completedAt)} -{" "}
+            {formatDuration(entry.durationMs)}
+          </span>
+        </span>
+        <CommandStatusBadge status={entry.status} />
+      </button>
+      {expanded && (
+        <div className="command-log-details">
+          <CommandLogSection title="Parameters" icon={<IconCode size={15} />}>
+            <KeyValueList
+              value={entry.payload}
+              emptyLabel="No parameters were sent."
+            />
+          </CommandLogSection>
+          {entry.error && (
+            <CommandLogSection
+              title="Error"
+              icon={<IconAlertCircle size={15} />}
+            >
+              <pre className="json-block">{formatJson(entry.error)}</pre>
+            </CommandLogSection>
+          )}
+          {entry.result && (
+            <CommandLogSection title="Result" icon={<IconCheck size={15} />}>
+              <KeyValueList
+                value={resultSummaryRecord(entry.result)}
+                emptyLabel="No result fields were returned."
+              />
+            </CommandLogSection>
+          )}
+          {resultText && (
+            <CommandLogSection
+              title="Agent State"
+              icon={<IconCode size={15} />}
+            >
+              <pre className="agent-state-block">{resultText}</pre>
+            </CommandLogSection>
+          )}
+          {screenshot && (
+            <ScreenshotBlock
+              entry={entry}
+              screenshot={screenshot}
+              onPreview={onPreviewScreenshot}
+            />
+          )}
+          <VisibleElements elements={visibleElements} />
+          <details className="raw-log-details">
+            <summary>Raw Log Entry</summary>
+            <pre className="json-block">
+              {formatJson(jsonDisplayValue(entry))}
+            </pre>
+          </details>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function ScreenshotLightbox({
+  onClose,
+  preview,
+}: {
+  readonly onClose: () => void;
+  readonly preview: ScreenshotPreview | null;
+}) {
+  useEffect(() => {
+    if (!preview) {
+      return undefined;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, preview]);
+
+  if (!preview) {
+    return null;
+  }
+
+  return (
+    <div className="screenshot-lightbox" role="presentation" onClick={onClose}>
+      <div
+        className="screenshot-lightbox-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={preview.title}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <div className="screenshot-lightbox-header">
+          <div>
+            <strong>{preview.title}</strong>
+            {preview.meta && <span>{preview.meta}</span>}
+          </div>
+          <button type="button" className="icon-only-button" onClick={onClose}>
+            <IconX size={18} />
+          </button>
+        </div>
+        <img src={preview.src} alt={preview.title} />
+      </div>
+    </div>
+  );
+}
+
+function CommandLogPanel({
+  state,
+}: {
+  readonly state: DesktopComputerUseState;
+}) {
+  const entries = state.host.localCommandLog;
+  const [expandedCommandIds, setExpandedCommandIds] = useState<
+    readonly string[]
+  >([]);
+  const [screenshotPreview, setScreenshotPreview] =
+    useState<ScreenshotPreview | null>(null);
+  const toggleCommand = (commandId: string) => {
+    setExpandedCommandIds((current) => {
+      if (current.includes(commandId)) {
+        return current.filter((candidate) => {
+          return candidate !== commandId;
+        });
+      }
+      return [commandId, ...current];
+    });
+  };
+
+  return (
+    <Panel title="Command Log" icon={<IconHistory size={18} />}>
+      {entries.length === 0 ? (
+        <div className="empty-state">No local native commands have run.</div>
       ) : (
-        <div className="history-list">
-          {events.map((event) => {
+        <div className="command-log-list">
+          {entries.map((entry) => {
             return (
-              <div
-                className="history-row"
-                key={`${event.commandId}-${event.event}-${event.createdAt}`}
-              >
-                <div>
-                  <div className="row-title">
-                    {event.kind} - {event.event}
-                  </div>
-                  <div className="row-meta">
-                    {event.app ?? "No target app"} -{" "}
-                    {formatTimestamp(event.createdAt)}
-                  </div>
-                </div>
-                {event.approvalOutcome && (
-                  <span className={`outcome outcome-${event.approvalOutcome}`}>
-                    {event.approvalOutcome}
-                  </span>
-                )}
-              </div>
+              <CommandLogRow
+                key={entry.commandId}
+                entry={entry}
+                expanded={expandedCommandIds.includes(entry.commandId)}
+                onPreviewScreenshot={setScreenshotPreview}
+                onToggle={() => {
+                  toggleCommand(entry.commandId);
+                }}
+              />
             );
           })}
         </div>
       )}
+      <ScreenshotLightbox
+        preview={screenshotPreview}
+        onClose={() => {
+          setScreenshotPreview(null);
+        }}
+      />
     </Panel>
   );
 }
@@ -375,7 +820,7 @@ function ComputerUseContent({
         <>
           <PermissionsPanel state={state} />
           <RuntimePanel state={state} />
-          <HistoryPanel state={state} />
+          <CommandLogPanel state={state} />
         </>
       )}
     </>

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -20,6 +20,7 @@ function computerUseState(
       lastCommandAt: null,
       lastError: null,
       recentAuditEvents: [],
+      localCommandLog: [],
     },
     ...overrides,
   };

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -349,13 +349,12 @@ button {
 }
 
 .permission-list,
-.history-list {
+.command-log-list {
   display: grid;
   gap: 8px;
 }
 
-.permission-row,
-.history-row {
+.permission-row {
   min-height: 58px;
   border: 1px solid rgba(30, 38, 52, 0.08);
   border-radius: 7px;
@@ -365,6 +364,214 @@ button {
   justify-content: space-between;
   gap: 14px;
   background: rgba(249, 250, 251, 0.76);
+}
+
+.command-log-list {
+  gap: 10px;
+}
+
+.command-log-row {
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 7px;
+  background: rgba(249, 250, 251, 0.76);
+  overflow: hidden;
+}
+
+.command-log-summary {
+  width: 100%;
+  min-height: 58px;
+  border: 0;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.command-log-summary:hover {
+  background: rgba(244, 246, 248, 0.92);
+}
+
+.command-log-chevron {
+  width: 18px;
+  flex: 0 0 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #667085;
+}
+
+.command-log-main {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 2px;
+}
+
+.command-log-details {
+  border-top: 1px solid rgba(30, 38, 52, 0.08);
+  padding: 12px;
+  display: grid;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.command-log-section {
+  display: grid;
+  gap: 8px;
+}
+
+.command-log-section-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #3d4a5c;
+}
+
+.command-log-section-title h3 {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.key-value-list {
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.key-value-list > div {
+  display: grid;
+  grid-template-columns: minmax(96px, 180px) minmax(0, 1fr);
+  gap: 8px;
+}
+
+.key-value-list dt {
+  color: #667085;
+  font-size: 12px;
+  line-height: 1.35;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.key-value-list dd {
+  margin: 0;
+  color: #202631;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.compact-empty {
+  color: #667085;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.json-block,
+.agent-state-block {
+  max-height: 320px;
+  margin: 0;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 7px;
+  padding: 10px;
+  color: #202631;
+  background: #f8fafc;
+  overflow: auto;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.agent-state-block {
+  white-space: pre;
+}
+
+.screenshot-thumbnail {
+  width: min(420px, 100%);
+  border: 1px solid rgba(30, 38, 52, 0.12);
+  border-radius: 7px;
+  padding: 0;
+  display: grid;
+  gap: 0;
+  color: #2e3645;
+  background: #ffffff;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.screenshot-thumbnail img {
+  width: 100%;
+  max-height: 240px;
+  display: block;
+  object-fit: contain;
+  background: #111827;
+}
+
+.screenshot-thumbnail span {
+  min-height: 34px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.visible-elements-list {
+  display: grid;
+  gap: 6px;
+}
+
+.visible-element-row {
+  min-height: 30px;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 6px;
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: #f8fafc;
+}
+
+.visible-element-row span {
+  min-width: 0;
+  color: #202631;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.visible-element-row code {
+  color: #475467;
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.raw-log-details summary {
+  color: #3d4a5c;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.raw-log-details .json-block {
+  margin-top: 8px;
 }
 
 .row-title {
@@ -383,7 +590,8 @@ button {
 
 .check-pill,
 .outcome,
-.status-badge {
+.status-badge,
+.command-status {
   min-height: 24px;
   border-radius: 999px;
   padding: 0 9px;
@@ -398,7 +606,8 @@ button {
 
 .check-pill,
 .status-online,
-.outcome-approved {
+.outcome-approved,
+.command-status-succeeded {
   color: #067647;
   background: #ecfdf3;
 }
@@ -413,6 +622,11 @@ button {
   background: #eff8ff;
 }
 
+.command-status-running {
+  color: #175cd3;
+  background: #eff8ff;
+}
+
 .status-unauthenticated,
 .status-needs_organization {
   color: #b54708;
@@ -421,7 +635,8 @@ button {
 
 .status-disabled,
 .status-error,
-.outcome-denied {
+.outcome-denied,
+.command-status-failed {
   color: #b42318;
   background: #fef3f2;
 }
@@ -469,6 +684,82 @@ button {
   line-height: 1.45;
 }
 
+.screenshot-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  padding: 28px;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.screenshot-lightbox-dialog {
+  width: min(1200px, 100%);
+  max-height: min(820px, 100%);
+  border-radius: 8px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: #ffffff;
+  box-shadow: 0 24px 72px rgba(15, 23, 42, 0.34);
+  overflow: hidden;
+}
+
+.screenshot-lightbox-header {
+  min-height: 48px;
+  border-bottom: 1px solid rgba(30, 38, 52, 0.1);
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.screenshot-lightbox-header div {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.screenshot-lightbox-header strong {
+  color: #202631;
+  font-size: 13px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.screenshot-lightbox-header span {
+  color: #667085;
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.screenshot-lightbox-dialog > img {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: block;
+  object-fit: contain;
+  background: #111827;
+}
+
+.icon-only-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(30, 38, 52, 0.14);
+  border-radius: 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #2e3645;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.icon-only-button:hover {
+  background: #f4f6f8;
+}
+
 @media (max-width: 760px) {
   .app-header {
     padding-right: 12px;
@@ -483,9 +774,24 @@ button {
     grid-template-columns: 1fr;
   }
 
-  .permission-row,
-  .history-row {
+  .permission-row {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .command-log-summary {
+    align-items: flex-start;
+  }
+
+  .command-status {
+    flex: 0 0 auto;
+  }
+
+  .key-value-list > div {
+    grid-template-columns: 1fr;
+  }
+
+  .screenshot-lightbox {
+    padding: 12px;
   }
 }


### PR DESCRIPTION
## Summary

- Replace the Desktop Computer Use `Recent History` view with a local native `Command Log` panel.
- Record in-memory command entries when the Desktop host claims and executes native commands.
- Show command parameters, results/errors, agent-facing state text, screenshot thumbnails, click-to-enlarge screenshots, visible elements, and raw log JSON.

## Validation

- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop build`
- `pnpm -F @vm0/desktop exec prettier --check src/renderer/App.tsx src/renderer/styles.css src/computer-use-host.test.ts src/renderer/computer-use-state.test.ts src/computer-use-host.ts src/computer-use-types.ts`
- `pnpm knip --workspace @vm0/desktop`

Closes #14837
