### PR TITLE
perf(api): reduce type-aware oxlint scope

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "oxlint && oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' && eslint . --max-warnings 0",
     "backfill:secret-kms": "tsx src/scripts/backfill-secret-kms-encryption.ts",
     "backfill:persistent-secret-kms": "tsx src/scripts/backfill-persistent-secret-kms-encryption.ts",
     "check-types": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- Limit api type-aware oxlint to src files
- Exclude api __tests__ from the type-aware oxlint pass to reduce memory pressure

## Verification
- `pnpm -F api run lint`
  - peak RSS measured locally: ~1910MB
  - type-aware oxlint checked 412 files
