### PR TITLE
feat: simplify computer-use host selection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -211,6 +211,76 @@ describe("desktop computer-use runtime", () => {
     expect(fixture.orgId).toBeTruthy();
   });
 
+  it("rejects a second active Desktop app computer-use host", async () => {
+    await createOrgFixture();
+    const client = setupApp({ context })(zeroComputerUseHostsContract);
+    const body = {
+      hostName: "Zero Desktop",
+      appVersion: "0.1.0",
+      osVersion: "macOS 15",
+      supportedCapabilities: [...supportedCapabilities],
+      permissions: { accessibility: true, screenRecording: true },
+    };
+
+    const started = await accept(
+      client.start({
+        body,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const rejected = await accept(
+      client.start({
+        body,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(rejected.body.error.message).toBe(
+      "A Desktop Computer Use host is already active",
+    );
+    const listed = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(listed.body.hosts).toHaveLength(1);
+    expect(listed.body.hosts[0]?.id).toBe(started.body.hostId);
+  });
+
+  it("refuses to route commands when multiple active hosts already exist", async () => {
+    const fixture = await createOrgFixture();
+    await seedComputerUseHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostToken: "host-token-1",
+    });
+    await seedComputerUseHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostToken: "host-token-2",
+    });
+    const commandClient = setupApp({ context })(zeroComputerUseCommandContract);
+    const token = mintZeroToken({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      capabilities: ["computer-use:write"],
+    });
+
+    const response = await accept(
+      commandClient.create({
+        body: { kind: "app.state", app: "Safari", timeoutMs: 15_000 },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Multiple active computer-use hosts are online",
+    );
+  });
+
   it("runs a read command through the host claim and complete flow", async () => {
     const fixture = await createOrgFixture();
     const hostToken = "host-token";

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -120,7 +120,13 @@ const hostStartInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
   signal.throwIfAborted();
 
-  return { status: 200 as const, body: result };
+  if (result.status === "active_host_exists") {
+    return conflict("A Desktop Computer Use host is already active");
+  }
+  return {
+    status: 200 as const,
+    body: { hostId: result.hostId, hostToken: result.hostToken },
+  };
 });
 
 const heartbeatBody$ = bodyResultOf(zeroComputerUseHeartbeatContract.heartbeat);
@@ -216,10 +222,6 @@ const commandCreateInner$ = command(
         timeoutMs: bodyResult.data.timeoutMs,
         requiresApproval: false,
         ...(auth.tokenType === "zero" ? { runId: auth.runId } : {}),
-        ...(bodyResult.data.hostId ? { hostId: bodyResult.data.hostId } : {}),
-        ...(bodyResult.data.hostName
-          ? { hostName: bodyResult.data.hostName }
-          : {}),
       },
       signal,
     );
@@ -228,11 +230,8 @@ const commandCreateInner$ = command(
     if (result.status === "no_host") {
       return notFound("No linked computer-use host found");
     }
-    if (result.status === "host_not_found") {
-      return notFound("Computer-use host not found");
-    }
     if (result.status === "host_ambiguous") {
-      return conflict("Multiple computer-use hosts have this name");
+      return conflict("Multiple active computer-use hosts are online");
     }
     if (result.status === "host_offline") {
       return conflict("No online computer-use host found");
@@ -275,10 +274,6 @@ const writeCommandCreateInner$ = command(
         timeoutMs: bodyResult.data.timeoutMs,
         requiresApproval: false,
         ...(auth.tokenType === "zero" ? { runId: auth.runId } : {}),
-        ...(bodyResult.data.hostId ? { hostId: bodyResult.data.hostId } : {}),
-        ...(bodyResult.data.hostName
-          ? { hostName: bodyResult.data.hostName }
-          : {}),
       },
       signal,
     );
@@ -287,11 +282,8 @@ const writeCommandCreateInner$ = command(
     if (result.status === "no_host") {
       return notFound("No linked computer-use host found");
     }
-    if (result.status === "host_not_found") {
-      return notFound("Computer-use host not found");
-    }
     if (result.status === "host_ambiguous") {
-      return conflict("Multiple computer-use hosts have this name");
+      return conflict("Multiple active computer-use hosts are online");
     }
     if (result.status === "host_offline") {
       return conflict("No online computer-use host found");

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 
 import { command } from "ccstate";
-import { and, asc, desc, eq, inArray, isNull, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import type {
   ComputerUseCommandError,
   ComputerUseCommandKind,
@@ -69,7 +69,6 @@ type CreateComputerUseCommandResult =
       readonly commandStatus: "queued" | "pending_approval";
     }
   | { readonly status: "no_host" }
-  | { readonly status: "host_not_found" }
   | { readonly status: "host_ambiguous" }
   | { readonly status: "host_offline" }
   | { readonly status: "host_unsupported" };
@@ -83,13 +82,20 @@ type ApproveComputerUseWriteCommandResult =
 type ResolveComputerUseCommandTargetsResult =
   | {
       readonly status: "resolved";
-      readonly targetHostId?: string;
+      readonly targetHostId: string;
       readonly notifyHosts: readonly ComputerUseHostRow[];
     }
-  | { readonly status: "host_not_found" }
   | { readonly status: "host_ambiguous" }
   | { readonly status: "host_offline" }
   | { readonly status: "host_unsupported" };
+
+type StartComputerUseHostResult =
+  | {
+      readonly status: "started";
+      readonly hostId: string;
+      readonly hostToken: string;
+    }
+  | { readonly status: "active_host_exists"; readonly hostId: string };
 
 type ClaimNextComputerUseHostCommandResult =
   | { readonly status: "invalid_token" }
@@ -357,70 +363,31 @@ async function insertComputerUseCommandAuditEvent(
 }
 
 function resolveComputerUseCommandTargets(params: {
-  readonly hosts: readonly ComputerUseHostRow[];
   readonly onlineHosts: readonly ComputerUseHostRow[];
   readonly kind: ComputerUseCommandKind;
-  readonly hostId?: string;
-  readonly hostName?: string;
 }): ResolveComputerUseCommandTargetsResult {
-  if (params.hostId) {
-    const host = params.hosts.find((candidate) => {
-      return candidate.id === params.hostId;
-    });
-    if (!host) {
-      return { status: "host_not_found" };
-    }
-    if (
-      !params.onlineHosts.some((candidate) => {
-        return candidate.id === host.id;
-      })
-    ) {
-      return { status: "host_offline" };
-    }
-    if (!hostSupportsCommand(host, params.kind)) {
-      return { status: "host_unsupported" };
-    }
-    return { status: "resolved", targetHostId: host.id, notifyHosts: [host] };
+  if (params.onlineHosts.length === 0) {
+    return { status: "host_offline" };
   }
 
-  let candidates = params.onlineHosts;
-  if (params.hostName) {
-    const normalized = normalizeHostName(params.hostName).toLowerCase();
-    candidates = candidates.filter((host) => {
-      return host.displayName.toLowerCase() === normalized;
-    });
-    if (candidates.length === 0) {
-      const namedHosts = params.hosts.filter((host) => {
-        return host.displayName.toLowerCase() === normalized;
-      });
-      return namedHosts.length === 0
-        ? { status: "host_not_found" }
-        : { status: "host_offline" };
-    }
-    if (candidates.length > 1) {
-      return { status: "host_ambiguous" };
-    }
-  }
-
-  const supported = candidates.filter((host) => {
+  const supported = params.onlineHosts.filter((host) => {
     return hostSupportsCommand(host, params.kind);
   });
   if (supported.length === 0) {
     return { status: "host_unsupported" };
   }
-
-  if (supported.length === 1 || params.hostName) {
-    const [host] = supported;
-    return {
-      status: "resolved",
-      targetHostId: host?.id,
-      notifyHosts: host ? [host] : [],
-    };
+  if (supported.length > 1) {
+    return { status: "host_ambiguous" };
   }
 
+  const [host] = supported;
+  if (!host) {
+    throw new Error("Expected a supported computer-use host");
+  }
   return {
     status: "resolved",
-    notifyHosts: supported,
+    targetHostId: host.id,
+    notifyHosts: [host],
   };
 }
 
@@ -460,36 +427,67 @@ export const startComputerUseHost$ = command(
       };
     },
     signal: AbortSignal,
-  ): Promise<{ readonly hostId: string; readonly hostToken: string }> => {
+  ): Promise<StartComputerUseHostResult> => {
     const db = set(writeDb$);
     const hostToken = generateOpaqueToken("vm0_computer_use_host");
     const now = nowDate();
-    const [host] = await db
-      .insert(computerUseHosts)
-      .values({
-        orgId: params.orgId,
-        userId: params.userId,
-        displayName: normalizeHostName(params.hostName),
-        tokenHash: hashSecret(hostToken),
-        appVersion: normalizeVersion(params.appVersion),
-        osVersion: normalizeOsVersion(params.osVersion),
-        supportedCapabilities: normalizeCapabilities(
-          params.supportedCapabilities,
-        ),
-        permissions: params.permissions,
-        status: "online",
-        lastSeenAt: now,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning({ id: computerUseHosts.id });
+    const result = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext('computer_use_host:' || ${params.orgId} || ':' || ${params.userId}))`,
+      );
+
+      const existingHosts = await tx
+        .select()
+        .from(computerUseHosts)
+        .where(
+          and(
+            eq(computerUseHosts.orgId, params.orgId),
+            eq(computerUseHosts.userId, params.userId),
+            isNull(computerUseHosts.revokedAt),
+          ),
+        )
+        .for("update");
+      signal.throwIfAborted();
+
+      const activeHost = existingHosts.find((host) => {
+        return hostIsOnline(host, now);
+      });
+      if (activeHost) {
+        return {
+          status: "active_host_exists" as const,
+          hostId: activeHost.id,
+        };
+      }
+
+      const [host] = await tx
+        .insert(computerUseHosts)
+        .values({
+          orgId: params.orgId,
+          userId: params.userId,
+          displayName: normalizeHostName(params.hostName),
+          tokenHash: hashSecret(hostToken),
+          appVersion: normalizeVersion(params.appVersion),
+          osVersion: normalizeOsVersion(params.osVersion),
+          supportedCapabilities: normalizeCapabilities(
+            params.supportedCapabilities,
+          ),
+          permissions: params.permissions,
+          status: "online",
+          lastSeenAt: now,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning({ id: computerUseHosts.id });
+      signal.throwIfAborted();
+
+      if (!host) {
+        throw new Error("Failed to start computer-use host");
+      }
+
+      return { status: "started" as const, hostId: host.id, hostToken };
+    });
     signal.throwIfAborted();
-
-    if (!host) {
-      throw new Error("Failed to start computer-use host");
-    }
-
-    return { hostId: host.id, hostToken };
+    return result;
   },
 );
 
@@ -611,8 +609,6 @@ export const createComputerUseCommand$ = command(
       readonly kind: ComputerUseCommandKind;
       readonly payload: ComputerUseCommandPayload;
       readonly timeoutMs?: number;
-      readonly hostId?: string;
-      readonly hostName?: string;
       readonly requiresApproval: boolean;
     },
     signal: AbortSignal,
@@ -644,11 +640,8 @@ export const createComputerUseCommand$ = command(
       return hostIsOnline(host, now);
     });
     const target = resolveComputerUseCommandTargets({
-      hosts,
       onlineHosts,
       kind: params.kind,
-      hostId: params.hostId,
-      hostName: params.hostName,
     });
     if (target.status !== "resolved") {
       return target;
@@ -665,7 +658,7 @@ export const createComputerUseCommand$ = command(
           orgId: params.orgId,
           userId: params.userId,
           runId: params.runId ?? null,
-          hostId: target.targetHostId ?? null,
+          hostId: target.targetHostId,
           kind: params.kind,
           status: commandStatus,
           payload,

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -136,6 +136,25 @@ describe("computer-use command visibility", () => {
     expect(subNames).not.toContain("audit");
   });
 
+  it("should not expose host targeting options on agent-facing commands", () => {
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const computerUse = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    expect(computerUse).toBeDefined();
+
+    for (const subCommand of computerUse!.commands) {
+      const longOptions = subCommand.options.map((option) => {
+        return option.long;
+      });
+      expect(longOptions).toContain("--timeout");
+      expect(longOptions).not.toContain("--host");
+      expect(longOptions).not.toContain("--host-id");
+    }
+  });
+
   it("should write screenshot data URLs to a local file in command result console output", async () => {
     const screenshotBytes = Buffer.from("test-png-data");
     const screenshotBase64 = screenshotBytes.toString("base64");

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -14,8 +14,6 @@ import {
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
 interface ComputerUseCommandOptions {
-  readonly host?: string;
-  readonly hostId?: string;
   readonly timeout?: string;
 }
 
@@ -273,8 +271,6 @@ async function runReadCommand(
   const created = await createComputerUseReadCommand({
     kind,
     timeoutMs: timeoutSeconds * 1000,
-    ...(options.host ? { hostName: options.host } : {}),
-    ...(options.hostId ? { hostId: options.hostId } : {}),
     ...payload,
   });
   await waitForCommand(created.commandId, timeoutSeconds);
@@ -304,18 +300,13 @@ async function runWriteCommand(
   const created = await createComputerUseWriteCommand({
     kind,
     timeoutMs: timeoutSeconds * 1000,
-    ...(options.host ? { hostName: options.host } : {}),
-    ...(options.hostId ? { hostId: options.hostId } : {}),
     ...payload,
   });
   await waitForCommand(created.commandId, timeoutSeconds);
 }
 
 function addTargetOptions(command: Command): Command {
-  return command
-    .option("--host <name>", "Run on a named computer-use host")
-    .option("--host-id <id>", "Run on a specific computer-use host id")
-    .option("--timeout <seconds>", "Maximum time to wait", "30");
+  return command.option("--timeout <seconds>", "Maximum time to wait", "30");
 }
 
 function appOption(command: Command): Command {

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -62,8 +62,6 @@ interface ComputerUseCommandParams<
   Kind extends ComputerUseReadCommandKind | ComputerUseWriteCommandKind,
 > {
   readonly kind: Kind;
-  readonly hostId?: string;
-  readonly hostName?: string;
   readonly app?: string;
   readonly snapshotId?: string;
   readonly elementId?: string;
@@ -87,8 +85,6 @@ function commandBody<
   return {
     kind: params.kind,
     timeoutMs: params.timeoutMs ?? 15_000,
-    ...(params.hostId ? { hostId: params.hostId } : {}),
-    ...(params.hostName ? { hostName: params.hostName } : {}),
     ...(params.app ? { app: params.app } : {}),
     ...(params.snapshotId ? { snapshotId: params.snapshotId } : {}),
     ...(params.elementId ? { elementId: params.elementId } : {}),

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -168,4 +168,26 @@ describe("ComputerUseHostRuntime", () => {
         "Zero Desktop is signed in but no workspace is active. Select a workspace and retry.",
     });
   });
+
+  it("reports an active host conflict without retrying registration", async () => {
+    vi.useFakeTimers();
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
+      return jsonResponse(
+        { error: { message: "A Desktop Computer Use host is already active" } },
+        { status: 409 },
+      );
+    });
+    const { runtime } = createRuntime({ sessionFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(sessionFetch).toHaveBeenCalledOnce();
+    expect(runtime.getState()).toMatchObject({
+      status: "error",
+      hostId: null,
+      lastError:
+        "Computer Use is already active in another Zero Desktop session.",
+    });
+  });
 });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -244,6 +244,15 @@ export class ComputerUseHostRuntime {
       });
       return null;
     }
+    if (response.status === 409) {
+      this.setState({
+        status: "error",
+        hostId: null,
+        lastError:
+          "Computer Use is already active in another Zero Desktop session.",
+      });
+      return null;
+    }
     if (!response.ok) {
       throw new Error(`Failed to start Computer Use host: ${response.status}`);
     }

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -76,8 +76,6 @@ const computerUseRuntimeBodySchema = z.object({
 });
 
 const computerUseCommandTargetShape = {
-  hostId: z.string().min(1).optional(),
-  hostName: hostNameSchema.optional(),
   timeoutMs: z.number().int().min(1_000).max(60_000).default(15_000),
 } as const;
 
@@ -390,6 +388,7 @@ export const zeroComputerUseHostsContract = c.router({
       200: computerUseHostStartResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      409: apiErrorSchema,
     },
     summary: "Start or reactivate a desktop computer-use host",
   },


### PR DESCRIPTION
Closes #14844

## Summary
- remove agent-facing `zero computer-use` host targeting options and request fields
- route commands to the single active supported desktop host automatically
- reject a second active Desktop Computer Use host registration with 409

## Validation
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts`
- `pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts`
- `pnpm check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm vitest`
- `pnpm knip`