### PR TITLE
feat: buffer usage-event webhook uploads

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -626,7 +626,7 @@ def done():
     ``shutdown(wait=True)`` drains already-submitted futures during graceful
     stop.
     """
-    usage.flush_usage_events()
+    usage.flush_usage_events(trigger="shutdown")
     usage.webhook.usage_executor.shutdown(wait=True)
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -11,7 +11,9 @@ This addon runs on the runner HOST (not inside VMs) and:
 
 import functools
 import json
+import signal
 import tempfile
+import threading
 import time
 import urllib.parse
 from pathlib import Path
@@ -47,6 +49,8 @@ from url_utils import AuthorityValidationError, get_trusted_authority
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
+_RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
+_usage_flush_signal_lock = threading.Lock()
 
 # ============================================================================
 # Addon Configuration
@@ -55,6 +59,7 @@ _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 
 def load(loader: Loader) -> None:
     """Register custom options for the addon."""
+    signal.signal(_RUNNER_USAGE_FLUSH_SIGNAL, _handle_runner_usage_flush_signal)
     loader.add_option(
         name="vm0_api_url",
         typespec=str,
@@ -98,6 +103,27 @@ def configure(updated: set[str]) -> None:
             str(Path(__file__).resolve().parent / "usage-pending"),
             usage_state_id=ctx.options.vm0_usage_state_id or None,
         )
+
+
+def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
+    del signum
+    thread = threading.Thread(
+        target=_flush_usage_for_runner_request,
+        name="usage-flush-request",
+        daemon=True,
+    )
+    thread.start()
+
+
+def _flush_usage_for_runner_request() -> None:
+    if not _usage_flush_signal_lock.acquire(blocking=False):
+        return
+    try:
+        usage.flush_usage_events(trigger="runner")
+    except Exception as exc:
+        ctx.log.warn(f"Failed to flush usage events after runner request: {exc}")
+    finally:
+        _usage_flush_signal_lock.release()
 
 
 def get_api_url() -> str:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -78,9 +78,19 @@ def load(loader: Loader) -> None:
         default="",
         help="Runner-generated usage-pending state id",
     )
+    loader.add_option(
+        name="vm0_usage_flush_interval_seconds",
+        typespec=float,
+        default=usage.DEFAULT_FLUSH_INTERVAL_SECONDS,
+        help="Usage-event buffer flush interval in seconds",
+    )
 
 
 def configure(updated: set[str]) -> None:
+    if "vm0_usage_flush_interval_seconds" in updated:
+        usage.configure_usage_buffer(
+            flush_interval_seconds=ctx.options.vm0_usage_flush_interval_seconds
+        )
     if "vm0_usage_state_id" in updated:
         # Custom --set options are deferred until after load() registers them,
         # so initialize this file here where ctx.options has the runner value.
@@ -612,9 +622,11 @@ def done():
     """Flush pending usage reports before mitmproxy exits.
 
     The runner waits for pending flow/report counters before stopping the
-    proxy. ``shutdown(wait=True)`` is the final mitmproxy-side drain for
-    already-submitted futures during graceful stop.
+    proxy. Buffered usage is converted into webhook reports before
+    ``shutdown(wait=True)`` drains already-submitted futures during graceful
+    stop.
     """
+    usage.flush_usage_events()
     usage.webhook.usage_executor.shutdown(wait=True)
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -652,8 +652,10 @@ def done():
     ``shutdown(wait=True)`` drains already-submitted futures during graceful
     stop.
     """
-    usage.flush_usage_events(trigger="shutdown")
-    usage.webhook.usage_executor.shutdown(wait=True)
+    try:
+        usage.flush_usage_events(trigger="shutdown")
+    finally:
+        usage.webhook.usage_executor.shutdown(wait=True)
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -3,13 +3,13 @@
 Two paths:
 
 - Model-provider responses (SSE streams and non-streaming JSON): extract
-  model token counts and report them to the platform webhook through
-  a background thread pool — see :mod:`usage.providers.model_provider`.
+  model token counts and buffer them for aggregate platform webhook upload
+  through a background thread pool — see :mod:`usage.providers.model_provider`.
 - Billable connector responses (flagged by the web layer via
   ``billableFirewalls`` → ``flow.metadata["firewall_billable"]``): compute
-  per-permission billable resource counts and forward them to the platform
-  via ``/api/webhooks/agent/usage-event`` for persistence in the
-  ``usage_event`` table — see :mod:`usage.providers.connectors`.
+  per-permission billable resource counts and buffer them for aggregate
+  platform upload via ``/api/webhooks/agent/usage-event`` — see
+  :mod:`usage.providers.connectors`.
 
 This package exposes the stable surface consumed by ``mitm_addon.py``.
 For test patching, target the submodule that **reads** the name (e.g.
@@ -24,6 +24,13 @@ from .anthropic_messages import (
     create_anthropic_messages_sse_usage_extractor,
     extract_anthropic_messages_usage_from_json,
     extract_anthropic_messages_usage_with_error_from_json,
+)
+from .buffer import (
+    DEFAULT_FLUSH_INTERVAL_SECONDS,
+    buffer_usage_events,
+    configure_usage_buffer,
+    flush_usage_events,
+    reset_usage_buffer_for_tests,
 )
 from .counters import (
     decrement_in_flight_flows,
@@ -42,6 +49,9 @@ from .providers.connectors import report_connector_usage, x
 from .providers.model_provider import report_model_provider_usage
 
 __all__ = [
+    "DEFAULT_FLUSH_INTERVAL_SECONDS",
+    "buffer_usage_events",
+    "configure_usage_buffer",
     "create_anthropic_messages_json_usage_extractor",
     "create_anthropic_messages_sse_usage_extractor",
     "create_openai_responses_json_usage_extractor",
@@ -52,10 +62,12 @@ __all__ = [
     "extract_openai_responses_usage_from_event_json",
     "extract_openai_responses_usage_from_json",
     "extract_openai_responses_usage_with_error_from_json",
+    "flush_usage_events",
     "increment_in_flight_flows",
     "merge_openai_responses_usage_result",
     "report_connector_usage",
     "report_model_provider_usage",
+    "reset_usage_buffer_for_tests",
     "set_pending_path",
     "webhook",
     "x",

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -145,13 +145,15 @@ class UsageEventBuffer:
         events: Iterable[UsageEvent],
         proxy_log_path: str,
     ) -> int:
-        destination = _DestinationKey(url, sandbox_token, proxy_log_path)
-        buckets = self._buckets.setdefault(destination, {})
+        buckets: dict[_AggregateKey, int] | None = None
         accepted_count = 0
         for event in events:
             source_key = event["idempotencyKey"]
             if source_key in self._seen_source_keys:
                 continue
+            if buckets is None:
+                destination = _DestinationKey(url, sandbox_token, proxy_log_path)
+                buckets = self._buckets.setdefault(destination, {})
             self._seen_source_keys[source_key] = None
             aggregate_key = _AggregateKey(
                 run_id=run_id,

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Protocol, TypedDict
 
+from .counters import set_buffered_usage_events
 from .namespaces import USAGE_EVENT_NAMESPACE_AGGREGATE
 from .webhook import _enqueue_webhook
 
@@ -89,6 +90,7 @@ class UsageEventBuffer:
         self._buckets: dict[_DestinationKey, dict[_AggregateKey, int]] = {}
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
         self._source_event_count = 0
+        self._enqueuing_source_event_count = 0
 
     def configure(self, *, flush_interval_seconds: float) -> None:
         """Update runtime buffer settings."""
@@ -105,6 +107,7 @@ class UsageEventBuffer:
     ) -> int:
         """Add source usage events and flush if the buffer exceeds a bound."""
         batches: list[_FlushBatch] = []
+        enqueuing_count = 0
         timer_to_start: _TimerHandle | None = None
         with self._lock:
             accepted_count = self._add_events_locked(
@@ -113,20 +116,24 @@ class UsageEventBuffer:
             if accepted_count == 0:
                 return 0
             if self._should_flush_locked():
-                batches = self._snapshot_batches_locked()
+                enqueuing_count, batches = self._snapshot_batches_locked()
+                self._enqueuing_source_event_count += enqueuing_count
             else:
                 timer_to_start = self._schedule_timer_locked()
+            self._sync_buffered_counter_locked()
 
         if timer_to_start is not None:
             timer_to_start.start()
-        _enqueue_batches(batches)
+        self._enqueue_and_clear_enqueuing(batches, enqueuing_count)
         return accepted_count
 
     def flush_usage_events(self) -> int:
         """Flush all buffered usage events now."""
         with self._lock:
-            batches = self._snapshot_batches_locked()
-        _enqueue_batches(batches)
+            enqueuing_count, batches = self._snapshot_batches_locked()
+            self._enqueuing_source_event_count += enqueuing_count
+            self._sync_buffered_counter_locked()
+        self._enqueue_and_clear_enqueuing(batches, enqueuing_count)
         return len(batches)
 
     def close(self) -> None:
@@ -134,8 +141,32 @@ class UsageEventBuffer:
         with self._lock:
             timer = self._timer
             self._timer = None
+            self._buckets = {}
+            self._seen_source_keys.clear()
+            self._source_event_count = 0
+            self._enqueuing_source_event_count = 0
+            self._sync_buffered_counter_locked()
         if timer is not None:
             timer.cancel()
+
+    def _enqueue_and_clear_enqueuing(
+        self,
+        batches: list[_FlushBatch],
+        enqueuing_count: int,
+    ) -> None:
+        try:
+            _enqueue_batches(batches)
+        finally:
+            if enqueuing_count:
+                with self._lock:
+                    self._enqueuing_source_event_count = max(
+                        0,
+                        self._enqueuing_source_event_count - enqueuing_count,
+                    )
+                    self._sync_buffered_counter_locked()
+
+    def _sync_buffered_counter_locked(self) -> None:
+        set_buffered_usage_events(self._source_event_count + self._enqueuing_source_event_count)
 
     def _add_events_locked(
         self,
@@ -206,15 +237,16 @@ class UsageEventBuffer:
         jitter = self._flush_interval_seconds * self._jitter_ratio
         return max(0.001, self._flush_interval_seconds + _jitter_rng.uniform(-jitter, jitter))
 
-    def _snapshot_batches_locked(self) -> list[_FlushBatch]:
+    def _snapshot_batches_locked(self) -> tuple[int, list[_FlushBatch]]:
         timer = self._timer
         self._timer = None
         if timer is not None:
             timer.cancel()
+        source_event_count = self._source_event_count
         if not self._buckets:
             self._seen_source_keys.clear()
             self._source_event_count = 0
-            return []
+            return 0, []
 
         self._flush_sequence += 1
         flush_sequence = self._flush_sequence
@@ -222,7 +254,7 @@ class UsageEventBuffer:
         self._buckets = {}
         self._seen_source_keys.clear()
         self._source_event_count = 0
-        return self._build_flush_batches_locked(buckets, flush_sequence)
+        return source_event_count, self._build_flush_batches_locked(buckets, flush_sequence)
 
     def _build_flush_batches_locked(
         self,

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -17,6 +17,7 @@ DEFAULT_FLUSH_INTERVAL_SECONDS = 30.0
 DEFAULT_FLUSH_JITTER_RATIO = 0.2
 MAX_BUFFERED_SOURCE_EVENTS = 1_000
 MAX_AGGREGATE_BUCKETS = 100
+MAX_BUFFERED_WEBHOOK_BATCHES = 4
 MAX_SOURCE_IDEMPOTENCY_KEYS = 10_000
 USAGE_EVENT_BATCH_SIZE = 100
 _jitter_rng = random.SystemRandom()
@@ -171,7 +172,21 @@ class UsageEventBuffer:
     def _should_flush_locked(self) -> bool:
         if self._source_event_count >= MAX_BUFFERED_SOURCE_EVENTS:
             return True
-        return sum(len(buckets) for buckets in self._buckets.values()) >= MAX_AGGREGATE_BUCKETS
+        if sum(len(buckets) for buckets in self._buckets.values()) >= MAX_AGGREGATE_BUCKETS:
+            return True
+        return self._estimated_webhook_batch_count_locked() >= MAX_BUFFERED_WEBHOOK_BATCHES
+
+    def _estimated_webhook_batch_count_locked(self) -> int:
+        count = 0
+        for buckets in self._buckets.values():
+            events_by_run: dict[str, int] = {}
+            for aggregate_key in buckets:
+                events_by_run[aggregate_key.run_id] = events_by_run.get(aggregate_key.run_id, 0) + 1
+            count += sum(
+                (event_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
+                for event_count in events_by_run.values()
+            )
+        return count
 
     def _schedule_timer_locked(self) -> _TimerHandle | None:
         if not self._timer_enabled or self._timer is not None:

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -272,6 +272,8 @@ class UsageEventBuffer:
                         self._buffer_id,
                         str(flush_sequence),
                         destination.url,
+                        destination.sandbox_token,
+                        destination.proxy_log_path,
                         aggregate_key.run_id,
                         aggregate_key.kind,
                         aggregate_key.provider,

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -100,6 +100,8 @@ class UsageEventBuffer:
         self._timer_factory = timer_factory or self._make_timer
         self._timer: _TimerHandle | None = None
         self._buckets: dict[_DestinationKey, dict[_AggregateKey, int]] = {}
+        # Keep source keys across flushes so aggregate idempotency does not
+        # turn response/error duplicates into distinct server-side rows.
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
         self._destination_source_event_counts: dict[_DestinationKey, int] = {}
         self._source_event_count = 0
@@ -275,7 +277,6 @@ class UsageEventBuffer:
         destination_source_event_counts = self._destination_source_event_counts
         self._destination_source_event_counts = {}
         if not self._buckets:
-            self._seen_source_keys.clear()
             self._source_event_count = 0
             return 0, 0, [], []
 
@@ -283,7 +284,6 @@ class UsageEventBuffer:
         flush_sequence = self._flush_sequence
         buckets = self._buckets
         self._buckets = {}
-        self._seen_source_keys.clear()
         self._source_event_count = 0
         batches = self._build_flush_batches_locked(buckets, flush_sequence)
         return (

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -7,8 +7,10 @@ import threading
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol, TypedDict
+
+from logging_utils import log_proxy_entry
 
 from .counters import set_buffered_usage_events
 from .namespaces import USAGE_EVENT_NAMESPACE_AGGREGATE
@@ -68,6 +70,16 @@ class _FlushBatch:
     proxy_log_path: str
 
 
+@dataclass
+class _FlushSummary:
+    proxy_log_path: str
+    source_event_count: int = 0
+    aggregate_event_count: int = 0
+    webhook_batch_count: int = 0
+    run_ids: set[str] = field(default_factory=set)
+    destinations: set[tuple[str, str]] = field(default_factory=set)
+
+
 class UsageEventBuffer:
     """Thread-safe process-local usage-event buffer."""
 
@@ -89,6 +101,7 @@ class UsageEventBuffer:
         self._timer: _TimerHandle | None = None
         self._buckets: dict[_DestinationKey, dict[_AggregateKey, int]] = {}
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
+        self._destination_source_event_counts: dict[_DestinationKey, int] = {}
         self._source_event_count = 0
         self._enqueuing_source_event_count = 0
 
@@ -116,24 +129,32 @@ class UsageEventBuffer:
             if accepted_count == 0:
                 return 0
             if self._should_flush_locked():
-                enqueuing_count, batches = self._snapshot_batches_locked()
+                enqueuing_count, flush_sequence, batches, summaries = (
+                    self._snapshot_batches_locked()
+                )
                 self._enqueuing_source_event_count += enqueuing_count
             else:
                 timer_to_start = self._schedule_timer_locked()
+                flush_sequence = 0
+                summaries = []
             self._sync_buffered_counter_locked()
 
         if timer_to_start is not None:
             timer_to_start.start()
-        self._enqueue_and_clear_enqueuing(batches, enqueuing_count)
+        self._enqueue_and_clear_enqueuing(
+            batches, enqueuing_count, "threshold", flush_sequence, summaries
+        )
         return accepted_count
 
-    def flush_usage_events(self) -> int:
+    def flush_usage_events(self, *, trigger: str) -> int:
         """Flush all buffered usage events now."""
         with self._lock:
-            enqueuing_count, batches = self._snapshot_batches_locked()
+            enqueuing_count, flush_sequence, batches, summaries = self._snapshot_batches_locked()
             self._enqueuing_source_event_count += enqueuing_count
             self._sync_buffered_counter_locked()
-        self._enqueue_and_clear_enqueuing(batches, enqueuing_count)
+        self._enqueue_and_clear_enqueuing(
+            batches, enqueuing_count, trigger, flush_sequence, summaries
+        )
         return len(batches)
 
     def close(self) -> None:
@@ -143,6 +164,7 @@ class UsageEventBuffer:
             self._timer = None
             self._buckets = {}
             self._seen_source_keys.clear()
+            self._destination_source_event_counts = {}
             self._source_event_count = 0
             self._enqueuing_source_event_count = 0
             self._sync_buffered_counter_locked()
@@ -153,8 +175,12 @@ class UsageEventBuffer:
         self,
         batches: list[_FlushBatch],
         enqueuing_count: int,
+        trigger: str,
+        flush_sequence: int,
+        summaries: list[_FlushSummary],
     ) -> None:
         try:
+            _log_flush_summaries(trigger, flush_sequence, summaries)
             _enqueue_batches(batches)
         finally:
             if enqueuing_count:
@@ -177,13 +203,13 @@ class UsageEventBuffer:
         proxy_log_path: str,
     ) -> int:
         buckets: dict[_AggregateKey, int] | None = None
+        destination = _DestinationKey(url, sandbox_token, proxy_log_path)
         accepted_count = 0
         for event in events:
             source_key = event["idempotencyKey"]
             if source_key in self._seen_source_keys:
                 continue
             if buckets is None:
-                destination = _DestinationKey(url, sandbox_token, proxy_log_path)
                 buckets = self._buckets.setdefault(destination, {})
             self._seen_source_keys[source_key] = None
             aggregate_key = _AggregateKey(
@@ -193,6 +219,9 @@ class UsageEventBuffer:
                 category=event["category"],
             )
             buckets[aggregate_key] = buckets.get(aggregate_key, 0) + event["quantity"]
+            self._destination_source_event_counts[destination] = (
+                self._destination_source_event_counts.get(destination, 0) + 1
+            )
             self._source_event_count += 1
             accepted_count += 1
         self._evict_source_keys_locked()
@@ -231,22 +260,24 @@ class UsageEventBuffer:
         return timer
 
     def _flush_from_timer(self) -> None:
-        self.flush_usage_events()
+        self.flush_usage_events(trigger="timer")
 
     def _next_delay_seconds(self) -> float:
         jitter = self._flush_interval_seconds * self._jitter_ratio
         return max(0.001, self._flush_interval_seconds + _jitter_rng.uniform(-jitter, jitter))
 
-    def _snapshot_batches_locked(self) -> tuple[int, list[_FlushBatch]]:
+    def _snapshot_batches_locked(self) -> tuple[int, int, list[_FlushBatch], list[_FlushSummary]]:
         timer = self._timer
         self._timer = None
         if timer is not None:
             timer.cancel()
         source_event_count = self._source_event_count
+        destination_source_event_counts = self._destination_source_event_counts
+        self._destination_source_event_counts = {}
         if not self._buckets:
             self._seen_source_keys.clear()
             self._source_event_count = 0
-            return 0, []
+            return 0, 0, [], []
 
         self._flush_sequence += 1
         flush_sequence = self._flush_sequence
@@ -254,7 +285,13 @@ class UsageEventBuffer:
         self._buckets = {}
         self._seen_source_keys.clear()
         self._source_event_count = 0
-        return source_event_count, self._build_flush_batches_locked(buckets, flush_sequence)
+        batches = self._build_flush_batches_locked(buckets, flush_sequence)
+        return (
+            source_event_count,
+            flush_sequence,
+            batches,
+            _build_flush_summaries(destination_source_event_counts, batches),
+        )
 
     def _build_flush_batches_locked(
         self,
@@ -348,6 +385,58 @@ def _enqueue_batches(batches: Iterable[_FlushBatch]) -> None:
         )
 
 
+def _build_flush_summaries(
+    source_counts: dict[_DestinationKey, int],
+    batches: Iterable[_FlushBatch],
+) -> list[_FlushSummary]:
+    summaries: dict[str, _FlushSummary] = {}
+    for destination, source_event_count in source_counts.items():
+        summary = summaries.setdefault(
+            destination.proxy_log_path,
+            _FlushSummary(proxy_log_path=destination.proxy_log_path),
+        )
+        summary.source_event_count += source_event_count
+        summary.destinations.add((destination.url, destination.proxy_log_path))
+
+    for batch in batches:
+        summary = summaries.setdefault(
+            batch.proxy_log_path,
+            _FlushSummary(proxy_log_path=batch.proxy_log_path),
+        )
+        events = batch.payload.get("events")
+        if isinstance(events, list):
+            summary.aggregate_event_count += len(events)
+        summary.webhook_batch_count += 1
+        run_id = batch.payload.get("runId")
+        if isinstance(run_id, str) and run_id:
+            summary.run_ids.add(run_id)
+
+    return [summaries[path] for path in sorted(summaries)]
+
+
+def _log_flush_summaries(
+    trigger: str,
+    flush_sequence: int,
+    summaries: Iterable[_FlushSummary],
+) -> None:
+    for summary in summaries:
+        if not summary.proxy_log_path:
+            continue
+        log_proxy_entry(
+            summary.proxy_log_path,
+            "info",
+            "Usage event buffer flushed",
+            type="usage_event_buffer_flush",
+            trigger=trigger,
+            flush_sequence=flush_sequence,
+            source_event_count=summary.source_event_count,
+            aggregate_event_count=summary.aggregate_event_count,
+            webhook_batch_count=summary.webhook_batch_count,
+            run_count=len(summary.run_ids),
+            destination_count=len(summary.destinations),
+        )
+
+
 def _encode_uuid_name(parts: tuple[str, ...]) -> str:
     return "\0".join(f"{len(part.encode('utf-8'))}:{part}" for part in parts)
 
@@ -375,8 +464,8 @@ def buffer_usage_events(
     )
 
 
-def flush_usage_events() -> int:
-    return _usage_event_buffer.flush_usage_events()
+def flush_usage_events(*, trigger: str) -> int:
+    return _usage_event_buffer.flush_usage_events(trigger=trigger)
 
 
 def reset_usage_buffer_for_tests(

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -1,0 +1,341 @@
+"""In-memory aggregation for usage-event webhook uploads."""
+
+from __future__ import annotations
+
+import random
+import threading
+import uuid
+from collections import OrderedDict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Protocol, TypedDict
+
+from .namespaces import USAGE_EVENT_NAMESPACE_AGGREGATE
+from .webhook import _enqueue_webhook
+
+DEFAULT_FLUSH_INTERVAL_SECONDS = 30.0
+DEFAULT_FLUSH_JITTER_RATIO = 0.2
+MAX_BUFFERED_SOURCE_EVENTS = 1_000
+MAX_AGGREGATE_BUCKETS = 100
+MAX_SOURCE_IDEMPOTENCY_KEYS = 10_000
+USAGE_EVENT_BATCH_SIZE = 100
+_jitter_rng = random.SystemRandom()
+
+
+class UsageEvent(TypedDict):
+    idempotencyKey: str
+    kind: str
+    provider: str
+    category: str
+    quantity: int
+
+
+class _TimerHandle(Protocol):
+    daemon: bool
+
+    def start(self) -> None:
+        """Start the scheduled callback."""
+
+    def cancel(self) -> None:
+        """Cancel the scheduled callback."""
+
+
+_TimerFactory = Callable[[float, Callable[[], None]], _TimerHandle]
+
+
+@dataclass(frozen=True)
+class _DestinationKey:
+    url: str
+    sandbox_token: str
+    proxy_log_path: str
+
+
+@dataclass(frozen=True)
+class _AggregateKey:
+    run_id: str
+    kind: str
+    provider: str
+    category: str
+
+
+@dataclass(frozen=True)
+class _FlushBatch:
+    url: str
+    sandbox_token: str
+    payload: dict
+    proxy_log_path: str
+
+
+class UsageEventBuffer:
+    """Thread-safe process-local usage-event buffer."""
+
+    def __init__(
+        self,
+        *,
+        flush_interval_seconds: float = DEFAULT_FLUSH_INTERVAL_SECONDS,
+        jitter_ratio: float = DEFAULT_FLUSH_JITTER_RATIO,
+        timer_enabled: bool = True,
+        timer_factory: _TimerFactory | None = None,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._buffer_id = str(uuid.uuid4())
+        self._flush_sequence = 0
+        self._flush_interval_seconds = max(1.0, flush_interval_seconds)
+        self._jitter_ratio = max(0.0, jitter_ratio)
+        self._timer_enabled = timer_enabled
+        self._timer_factory = timer_factory or self._make_timer
+        self._timer: _TimerHandle | None = None
+        self._buckets: dict[_DestinationKey, dict[_AggregateKey, int]] = {}
+        self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
+        self._source_event_count = 0
+
+    def configure(self, *, flush_interval_seconds: float) -> None:
+        """Update runtime buffer settings."""
+        with self._lock:
+            self._flush_interval_seconds = max(1.0, flush_interval_seconds)
+
+    def buffer_usage_events(
+        self,
+        url: str,
+        sandbox_token: str,
+        run_id: str,
+        events: Iterable[UsageEvent],
+        proxy_log_path: str,
+    ) -> int:
+        """Add source usage events and flush if the buffer exceeds a bound."""
+        batches: list[_FlushBatch] = []
+        timer_to_start: _TimerHandle | None = None
+        with self._lock:
+            accepted_count = self._add_events_locked(
+                url, sandbox_token, run_id, events, proxy_log_path
+            )
+            if accepted_count == 0:
+                return 0
+            if self._should_flush_locked():
+                batches = self._snapshot_batches_locked()
+            else:
+                timer_to_start = self._schedule_timer_locked()
+
+        if timer_to_start is not None:
+            timer_to_start.start()
+        _enqueue_batches(batches)
+        return accepted_count
+
+    def flush_usage_events(self) -> int:
+        """Flush all buffered usage events now."""
+        with self._lock:
+            batches = self._snapshot_batches_locked()
+        _enqueue_batches(batches)
+        return len(batches)
+
+    def close(self) -> None:
+        """Cancel any pending timer for test cleanup or process shutdown."""
+        with self._lock:
+            timer = self._timer
+            self._timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _add_events_locked(
+        self,
+        url: str,
+        sandbox_token: str,
+        run_id: str,
+        events: Iterable[UsageEvent],
+        proxy_log_path: str,
+    ) -> int:
+        destination = _DestinationKey(url, sandbox_token, proxy_log_path)
+        buckets = self._buckets.setdefault(destination, {})
+        accepted_count = 0
+        for event in events:
+            source_key = event["idempotencyKey"]
+            if source_key in self._seen_source_keys:
+                continue
+            self._seen_source_keys[source_key] = None
+            aggregate_key = _AggregateKey(
+                run_id=run_id,
+                kind=event["kind"],
+                provider=event["provider"],
+                category=event["category"],
+            )
+            buckets[aggregate_key] = buckets.get(aggregate_key, 0) + event["quantity"]
+            self._source_event_count += 1
+            accepted_count += 1
+        self._evict_source_keys_locked()
+        return accepted_count
+
+    def _evict_source_keys_locked(self) -> None:
+        while len(self._seen_source_keys) > MAX_SOURCE_IDEMPOTENCY_KEYS:
+            self._seen_source_keys.popitem(last=False)
+
+    def _should_flush_locked(self) -> bool:
+        if self._source_event_count >= MAX_BUFFERED_SOURCE_EVENTS:
+            return True
+        return sum(len(buckets) for buckets in self._buckets.values()) >= MAX_AGGREGATE_BUCKETS
+
+    def _schedule_timer_locked(self) -> _TimerHandle | None:
+        if not self._timer_enabled or self._timer is not None:
+            return None
+        delay = self._next_delay_seconds()
+        timer = self._timer_factory(delay, self._flush_from_timer)
+        timer.daemon = True
+        self._timer = timer
+        return timer
+
+    def _flush_from_timer(self) -> None:
+        self.flush_usage_events()
+
+    def _next_delay_seconds(self) -> float:
+        jitter = self._flush_interval_seconds * self._jitter_ratio
+        return max(0.001, self._flush_interval_seconds + _jitter_rng.uniform(-jitter, jitter))
+
+    def _snapshot_batches_locked(self) -> list[_FlushBatch]:
+        timer = self._timer
+        self._timer = None
+        if timer is not None:
+            timer.cancel()
+        if not self._buckets:
+            self._seen_source_keys.clear()
+            self._source_event_count = 0
+            return []
+
+        self._flush_sequence += 1
+        flush_sequence = self._flush_sequence
+        buckets = self._buckets
+        self._buckets = {}
+        self._seen_source_keys.clear()
+        self._source_event_count = 0
+        return self._build_flush_batches_locked(buckets, flush_sequence)
+
+    def _build_flush_batches_locked(
+        self,
+        buckets: dict[_DestinationKey, dict[_AggregateKey, int]],
+        flush_sequence: int,
+    ) -> list[_FlushBatch]:
+        batches: list[_FlushBatch] = []
+        for destination in sorted(
+            buckets,
+            key=lambda item: (item.url, item.sandbox_token, item.proxy_log_path),
+        ):
+            events_by_run = self._events_by_run(destination, buckets[destination], flush_sequence)
+            for run_id in sorted(events_by_run):
+                events = events_by_run[run_id]
+                for start in range(0, len(events), USAGE_EVENT_BATCH_SIZE):
+                    batches.append(
+                        _FlushBatch(
+                            url=destination.url,
+                            sandbox_token=destination.sandbox_token,
+                            payload={
+                                "runId": run_id,
+                                "events": events[start : start + USAGE_EVENT_BATCH_SIZE],
+                            },
+                            proxy_log_path=destination.proxy_log_path,
+                        )
+                    )
+        return batches
+
+    def _events_by_run(
+        self,
+        destination: _DestinationKey,
+        buckets: dict[_AggregateKey, int],
+        flush_sequence: int,
+    ) -> dict[str, list[dict]]:
+        events_by_run: dict[str, list[dict]] = {}
+        for aggregate_key in sorted(
+            buckets,
+            key=lambda item: (item.run_id, item.kind, item.provider, item.category),
+        ):
+            events_by_run.setdefault(aggregate_key.run_id, []).append(
+                {
+                    "idempotencyKey": self._aggregate_idempotency_key(
+                        destination, aggregate_key, flush_sequence
+                    ),
+                    "kind": aggregate_key.kind,
+                    "provider": aggregate_key.provider,
+                    "category": aggregate_key.category,
+                    "quantity": buckets[aggregate_key],
+                }
+            )
+        return events_by_run
+
+    def _aggregate_idempotency_key(
+        self,
+        destination: _DestinationKey,
+        aggregate_key: _AggregateKey,
+        flush_sequence: int,
+    ) -> str:
+        return str(
+            uuid.uuid5(
+                USAGE_EVENT_NAMESPACE_AGGREGATE,
+                _encode_uuid_name(
+                    (
+                        self._buffer_id,
+                        str(flush_sequence),
+                        destination.url,
+                        aggregate_key.run_id,
+                        aggregate_key.kind,
+                        aggregate_key.provider,
+                        aggregate_key.category,
+                    )
+                ),
+            )
+        )
+
+    @staticmethod
+    def _make_timer(delay: float, callback: Callable[[], None]) -> threading.Timer:
+        return threading.Timer(delay, callback)
+
+
+def _enqueue_batches(batches: Iterable[_FlushBatch]) -> None:
+    for batch in batches:
+        _enqueue_webhook(
+            batch.url,
+            batch.sandbox_token,
+            batch.payload,
+            batch.proxy_log_path,
+            "usage_event",
+        )
+
+
+def _encode_uuid_name(parts: tuple[str, ...]) -> str:
+    return "\0".join(f"{len(part.encode('utf-8'))}:{part}" for part in parts)
+
+
+_usage_event_buffer = UsageEventBuffer()
+
+
+def configure_usage_buffer(*, flush_interval_seconds: float) -> None:
+    _usage_event_buffer.configure(flush_interval_seconds=flush_interval_seconds)
+
+
+def buffer_usage_events(
+    url: str,
+    sandbox_token: str,
+    run_id: str,
+    events: Iterable[UsageEvent],
+    proxy_log_path: str,
+) -> int:
+    return _usage_event_buffer.buffer_usage_events(
+        url,
+        sandbox_token,
+        run_id,
+        events,
+        proxy_log_path,
+    )
+
+
+def flush_usage_events() -> int:
+    return _usage_event_buffer.flush_usage_events()
+
+
+def reset_usage_buffer_for_tests(
+    *,
+    timer_enabled: bool = False,
+    timer_factory: _TimerFactory | None = None,
+) -> None:
+    global _usage_event_buffer
+    _usage_event_buffer.close()
+    _usage_event_buffer = UsageEventBuffer(
+        timer_enabled=timer_enabled,
+        timer_factory=timer_factory,
+    )

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -1,8 +1,8 @@
-"""Dual pending counter: in-flight flows + pending reports.
+"""Pending counters for in-flight flows, buffered usage, and pending reports.
 
 The runner reads the pending-count file before sending SIGTERM so it can
-wait until both counters reach zero (all flows processed, all reports
-delivered).  File format is JSON written atomically (tmp + ``Path.replace``)
+wait until flows are processed, buffered usage is enqueued, and reports are
+delivered.  File format is JSON written atomically (tmp + ``Path.replace``)
 so the runner can reject stale state from an old mitmproxy process.
 """
 
@@ -15,9 +15,9 @@ from pathlib import Path
 
 from mitmproxy import ctx
 
-_STATE_VERSION = 1
 _counter_lock = threading.Lock()
 _in_flight_flows = 0
+_buffered_usage_events = 0
 _pending_reports = 0
 _pending_path = ""
 _usage_state_id = str(uuid.uuid4())
@@ -44,11 +44,11 @@ def set_pending_path(path: str, usage_state_id: str | None = None) -> None:
 
 def _pending_state() -> dict:
     return {
-        "version": _STATE_VERSION,
         "pid": os.getpid(),
         "usageStateId": _usage_state_id,
         "updatedAtMs": int(time.time() * 1000),
         "flows": _in_flight_flows,
+        "buffered": _buffered_usage_events,
         "reports": _pending_reports,
     }
 
@@ -65,10 +65,11 @@ def _write_pending() -> None:
         tmp.replace(_pending_path)
     except OSError as exc:
         # Best-effort: this file is observability (runner polls it to
-        # wait for in-flight flows + pending reports to drain before
-        # SIGTERM).  Transient write failures are upper-bounded by the
-        # runner's drain timeout and mitmdump stop timeout — in the worst
-        # case the runner proceeds with possible in-flight webhooks lost,
+        # wait for in-flight flows, buffered usage, and pending reports
+        # to drain before SIGTERM).  Transient write failures are
+        # upper-bounded by the runner's drain timeout and mitmdump stop
+        # timeout — in the worst case the runner proceeds with possible
+        # in-flight webhooks lost,
         # which is the same outcome as a genuinely stalled flow.
         if not _pending_write_error_logged:
             _pending_write_error_logged = True
@@ -110,4 +111,11 @@ def decrement_pending_reports() -> None:
     global _pending_reports
     with _counter_lock:
         _pending_reports = max(0, _pending_reports - 1)
+        _write_pending()
+
+
+def set_buffered_usage_events(count: int) -> None:
+    global _buffered_usage_events
+    with _counter_lock:
+        _buffered_usage_events = max(0, count)
         _write_pending()

--- a/crates/runner/mitm-addon/src/usage/namespaces.py
+++ b/crates/runner/mitm-addon/src/usage/namespaces.py
@@ -14,3 +14,6 @@ USAGE_EVENT_NAMESPACE_CONNECTOR = uuid.UUID("2f8e4a91-6d3c-4b5a-8e7f-9c1d2e3f4a5
 
 # Model-kind usage events (mitmproxy-reported model provider token records).
 USAGE_EVENT_NAMESPACE_MODEL = uuid.UUID("18a22204-d25e-4170-8973-86477f864bfb")
+
+# Aggregate flush-batch usage events (mitmproxy-reported buffered records).
+USAGE_EVENT_NAMESPACE_AGGREGATE = uuid.UUID("4c4ee19a-b1b4-47e6-aef4-642d972cf4f5")

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -1,8 +1,7 @@
 """X (Twitter) connector billing.
 
 Computes per-permission billable resource counts from successful requests
-through the X firewall and forwards them to the platform for persistence
-in the ``usage_event`` table.
+through the X firewall and buffers them for aggregate platform upload.
 """
 
 import json
@@ -18,9 +17,9 @@ import body_utils
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
+from ...buffer import UsageEvent, buffer_usage_events
 from ...json_selective import JsonSelectiveExtractor, ScalarField
 from ...namespaces import USAGE_EVENT_NAMESPACE_CONNECTOR
-from ...webhook import _enqueue_webhook
 from .x_billing import (
     classify_bucket,
     classify_includes_bucket,
@@ -34,7 +33,6 @@ from .x_billing import (
 # ambiguity of an ``OK_MAX`` that is itself excluded from the OK range.
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
-_USAGE_EVENT_BATCH_SIZE = 100
 
 # X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
 # is a regular request/response endpoint for rules management, NOT a stream).
@@ -474,12 +472,11 @@ def _compute_billable_counts(
 
 
 def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
-    """Compute billable resource counts and forward to the platform.
+    """Compute billable resource counts and buffer them for upload.
 
     Derives per-permission billable resource counts from the request and
-    response, then forwards them to the platform via
-    ``/api/webhooks/agent/usage-event`` for persistence in the
-    ``usage_event`` table.
+    response, then buffers them for aggregate upload via
+    ``/api/webhooks/agent/usage-event``.
 
     **Caller contract**: the dispatcher in
     :mod:`usage.providers.connectors` guarantees ``run_id`` is non-empty,
@@ -589,7 +586,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         )
         return
     url = f"{api_url}/api/webhooks/agent/usage-event"
-    events = []
+    events: list[UsageEvent] = []
     for category, qty in billable_counts.items():
         # UUIDv5 from stable inputs — retries produce the same key, so the
         # server-side UNIQUE(idempotency_key) dedups duplicate deliveries
@@ -609,14 +606,4 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
                 "quantity": qty,
             }
         )
-    for start in range(0, len(events), _USAGE_EVENT_BATCH_SIZE):
-        _enqueue_webhook(
-            url,
-            sandbox_token,
-            {
-                "runId": run_id,
-                "events": events[start : start + _USAGE_EVENT_BATCH_SIZE],
-            },
-            proxy_log_path,
-            "usage_event",
-        )
+    buffer_usage_events(url, sandbox_token, run_id, events, proxy_log_path)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -574,7 +574,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
             **log_extra,
         )
 
-    # Forward usage events to the platform for persistence.
+    # Buffer usage events for aggregate platform upload.
     sandbox_token = flow.metadata.get("vm_sandbox_token", "")
     api_url = get_api_url()
     if not sandbox_token or not api_url:
@@ -588,9 +588,8 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     url = f"{api_url}/api/webhooks/agent/usage-event"
     events: list[UsageEvent] = []
     for category, qty in billable_counts.items():
-        # UUIDv5 from stable inputs — retries produce the same key, so the
-        # server-side UNIQUE(idempotency_key) dedups duplicate deliveries
-        # without the addon needing to persist anything across restarts.
+        # UUIDv5 from stable source inputs. The usage buffer uses this key to
+        # dedupe duplicate response/error observations before aggregation.
         idempotency_key = str(
             uuid.uuid5(
                 USAGE_EVENT_NAMESPACE_CONNECTOR,

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -1,28 +1,29 @@
 """Model-provider billing entry point.
 
-Forwards token counts already normalized by an addon-side provider extractor
-(stored in ``flow.metadata["model_provider_usage"]``) to the platform
-``/api/webhooks/agent/usage-event`` endpoint.
+Buffers token counts already normalized by an addon-side provider extractor
+(stored in ``flow.metadata["model_provider_usage"]``) for aggregate upload to
+the platform ``/api/webhooks/agent/usage-event`` endpoint.
 """
 
 import uuid
+from typing import TypeGuard
 
 from mitmproxy import http
 
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
+from ..buffer import UsageEvent, buffer_usage_events
 from ..model_tokens import MODEL_USAGE_CATEGORIES
 from ..namespaces import USAGE_EVENT_NAMESPACE_MODEL
-from ..webhook import _enqueue_webhook
 
 MODEL_USAGE_KIND = "model"
 
 
 def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
-    """Enqueue extracted token usage for model-provider responses if available.
+    """Buffer extracted token usage for model-provider responses if available.
 
-    Returns whether a usage webhook was enqueued.
+    Returns whether usage was accepted into the reporting path.
     """
     firewall_name = flow.metadata.get("firewall_name", "")
     if not (firewall_name.startswith("model-provider:") and run_id):
@@ -53,18 +54,20 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
         )
         return False
     url = f"{api_url}/api/webhooks/agent/usage-event"
-    _enqueue_webhook(
+    buffer_usage_events(
         url,
         sandbox_token,
-        {"runId": run_id, "events": events},
+        run_id,
+        events,
         proxy_log_path,
-        "usage_event",
     )
     return True
 
 
-def _build_usage_events(run_id: str, message_id: str, provider: str, usage: dict) -> list[dict]:
-    events = []
+def _build_usage_events(
+    run_id: str, message_id: str, provider: str, usage: dict
+) -> list[UsageEvent]:
+    events: list[UsageEvent] = []
     for category in MODEL_USAGE_CATEGORIES:
         quantity = usage.get(category)
         if not _is_positive_int(quantity):
@@ -94,7 +97,7 @@ def _encode_uuid_name(parts: tuple[str, ...]) -> str:
     return "\0".join(f"{len(part.encode('utf-8'))}:{part}" for part in parts)
 
 
-def _is_positive_int(value: object) -> bool:
+def _is_positive_int(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -33,7 +33,7 @@ from usage.providers import connectors as _usage_connectors
 
 
 @pytest.fixture(autouse=True)
-def _reset_module_state() -> None:
+def _reset_module_state() -> Iterator[None]:
     """Clear cached singletons between tests.
 
     ``registry`` and ``auth`` cache registry data and firewall header
@@ -41,14 +41,17 @@ def _reset_module_state() -> None:
     entries that change later tests' behaviour (e.g. a request from IP X
     in test A primes ``_request_start_times`` seen by test B).
 
-    No teardown body — the next test's autouse invocation is itself the
-    cleanup, so we use ``return``-style (not ``yield``) per PT022.
+    The usage buffer owns a background timer in production, so tests reset
+    it before and after each case to avoid cross-test callbacks.
     """
     mitm_addon._request_start_times.clear()
     registry.reset_cache_for_tests()
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters._pending_write_error_logged = False
+    usage.reset_usage_buffer_for_tests()
+    yield
+    usage.reset_usage_buffer_for_tests()
 
 
 def _headers(*pairs: tuple[str, str]) -> http.Headers:
@@ -216,6 +219,7 @@ class _StubOptions:
     def __init__(self, *, registry_path: str, api_url: str) -> None:
         self.vm0_proxy_registry_path = registry_path
         self.vm0_api_url = api_url
+        self.vm0_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
 
 
 @pytest.fixture
@@ -335,6 +339,7 @@ def fresh_usage_executor():
     try:
         yield usage.webhook.usage_executor
     finally:
+        usage.flush_usage_events()
         usage.webhook.usage_executor.shutdown(wait=True)
         usage.webhook.usage_executor = original
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -49,6 +49,7 @@ def _reset_module_state() -> Iterator[None]:
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters._pending_write_error_logged = False
+    usage.counters._buffered_usage_events = 0
     usage.reset_usage_buffer_for_tests()
     yield
     usage.reset_usage_buffer_for_tests()

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -340,7 +340,7 @@ def fresh_usage_executor():
     try:
         yield usage.webhook.usage_executor
     finally:
-        usage.flush_usage_events()
+        usage.flush_usage_events(trigger="test")
         usage.webhook.usage_executor.shutdown(wait=True)
         usage.webhook.usage_executor = original
 

--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -9,20 +9,20 @@ def _pending_state(path: Path) -> dict:
     return json.loads(path.read_text())
 
 
-def assert_pending(path: Path, flows: int, reports: int) -> dict:
+def assert_pending(path: Path, flows: int, reports: int, buffered: int = 0) -> dict:
     state = _pending_state(path)
     assert set(state) == {
-        "version",
         "pid",
         "usageStateId",
         "updatedAtMs",
         "flows",
+        "buffered",
         "reports",
     }
-    assert state["version"] == 1
     assert state["pid"] == os.getpid()
     assert state["usageStateId"]
     assert isinstance(state["updatedAtMs"], int)
     assert state["flows"] == flows
+    assert state["buffered"] == buffered
     assert state["reports"] == reports
     return state

--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -9,7 +9,7 @@ def _pending_state(path: Path) -> dict:
     return json.loads(path.read_text())
 
 
-def assert_pending(path: Path, flows: int, reports: int, buffered: int = 0) -> dict:
+def assert_pending(path: Path, flows: int, buffered: int, reports: int) -> dict:
     state = _pending_state(path)
     assert set(state) == {
         "pid",

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -11,12 +11,19 @@ class TestAddonConfiguration:
     def test_load_registers_usage_state_id_without_pending_write(self):
         loader = MagicMock()
 
-        with patch.object(usage, "set_pending_path") as set_pending_path:
+        with (
+            patch.object(usage, "set_pending_path") as set_pending_path,
+            patch.object(mitm_addon.signal, "signal") as signal_handler,
+        ):
             mitm_addon.load(loader)
 
         option_names = [call.kwargs["name"] for call in loader.add_option.call_args_list]
         assert "vm0_usage_state_id" in option_names
         assert "vm0_usage_flush_interval_seconds" in option_names
+        signal_handler.assert_called_once_with(
+            mitm_addon._RUNNER_USAGE_FLUSH_SIGNAL,
+            mitm_addon._handle_runner_usage_flush_signal,
+        )
         set_pending_path.assert_not_called()
 
     def test_configure_initializes_pending_path_with_usage_state_id(self):

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -16,6 +16,7 @@ class TestAddonConfiguration:
 
         option_names = [call.kwargs["name"] for call in loader.add_option.call_args_list]
         assert "vm0_usage_state_id" in option_names
+        assert "vm0_usage_flush_interval_seconds" in option_names
         set_pending_path.assert_not_called()
 
     def test_configure_initializes_pending_path_with_usage_state_id(self):
@@ -54,3 +55,14 @@ class TestAddonConfiguration:
             mitm_addon.configure({"vm0_api_url"})
 
         set_pending_path.assert_not_called()
+
+    def test_configure_updates_usage_flush_interval(self):
+        options = MagicMock(vm0_usage_flush_interval_seconds=15.0)
+
+        with (
+            patch.object(mitm_addon.ctx, "options", options, create=True),
+            patch.object(usage, "configure_usage_buffer") as configure_usage_buffer,
+        ):
+            mitm_addon.configure({"vm0_usage_flush_interval_seconds"})
+
+        configure_usage_buffer.assert_called_once_with(flush_interval_seconds=15.0)

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -23,7 +23,7 @@ class TestDoneHook:
             patch.object(usage.webhook, "usage_executor", mock_executor),
         ):
             mitm_addon.done()
-        flush_usage_events.assert_called_once_with()
+        flush_usage_events.assert_called_once_with(trigger="shutdown")
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
 

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -18,8 +18,12 @@ class TestDoneHook:
     def test_done_shuts_down_executor(self):
         """done() should call shutdown(wait=True) on the executor."""
         mock_executor = MagicMock()
-        with patch.object(usage.webhook, "usage_executor", mock_executor):
+        with (
+            patch.object(usage, "flush_usage_events") as flush_usage_events,
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+        ):
             mitm_addon.done()
+        flush_usage_events.assert_called_once_with()
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
 

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from mitmproxy.flow import Error
 
 import mitm_addon
@@ -26,6 +27,23 @@ class TestDoneHook:
             mitm_addon.done()
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
+        mock_executor.shutdown.assert_called_once_with(wait=True)
+
+    def test_done_shuts_down_executor_when_flush_fails(self):
+        mock_executor = MagicMock()
+
+        with (
+            patch.object(
+                usage,
+                "flush_usage_events",
+                side_effect=RuntimeError("flush failed"),
+            ) as flush_usage_events,
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+            pytest.raises(RuntimeError, match="flush failed"),
+        ):
+            mitm_addon.done()
+
+        flush_usage_events.assert_called_once_with(trigger="shutdown")
         mock_executor.shutdown.assert_called_once_with(wait=True)
 
 

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -1,6 +1,7 @@
 """Tests for mitm addon connection-level hooks."""
 
 import json
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -26,6 +27,22 @@ class TestDoneHook:
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
+
+
+class TestRunnerUsageFlushSignal:
+    """Tests for runner-triggered usage buffer flush requests."""
+
+    def test_signal_handler_flushes_usage_in_background(self):
+        flushed = threading.Event()
+
+        def flush_usage_events(*, trigger: str) -> int:
+            assert trigger == "runner"
+            flushed.set()
+            return 0
+
+        with patch.object(usage, "flush_usage_events", side_effect=flush_usage_events):
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            assert flushed.wait(timeout=1)
 
 
 class TestTlsClienthello:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -101,6 +101,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, run_id)
+            usage.flush_usage_events()
         return [
             event
             for body in request_bodies_from_calls(mock_opener.open.call_args_list)
@@ -183,6 +184,8 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, "run-abc-123")
+            mock_opener.open.assert_not_called()
+            usage.flush_usage_events()
 
         mock_opener.open.assert_called_once()
         [payload] = request_bodies_from_calls(mock_opener.open.call_args_list)
@@ -211,6 +214,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
 
         bodies = request_bodies_from_calls(mock_opener.open.call_args_list)
         assert [len(body["events"]) for body in bodies] == [100, 1]
@@ -443,6 +447,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -480,6 +485,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
@@ -529,6 +535,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
 
         mock_opener.open.assert_not_called()
 
@@ -564,6 +571,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
@@ -1266,6 +1274,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -101,7 +101,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, run_id)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
         return [
             event
             for body in request_bodies_from_calls(mock_opener.open.call_args_list)
@@ -185,7 +185,7 @@ class TestReportConnectorUsage:
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, "run-abc-123")
             mock_opener.open.assert_not_called()
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         mock_opener.open.assert_called_once()
         [payload] = request_bodies_from_calls(mock_opener.open.call_args_list)
@@ -214,7 +214,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_connector_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         bodies = request_bodies_from_calls(mock_opener.open.call_args_list)
         assert [len(body["events"]) for body in bodies] == [100, 1]
@@ -447,7 +447,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -485,7 +485,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
@@ -535,7 +535,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         mock_opener.open.assert_not_called()
 
@@ -571,7 +571,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1
@@ -1274,7 +1274,7 @@ class TestReportConnectorUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -77,7 +77,7 @@ class TestUsagePendingCounter:
             assert_pending(pending_path, flows=0, buffered=1, reports=0)
             mock_opener.open.assert_not_called()
 
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
@@ -234,7 +234,7 @@ class TestUsagePendingCounter:
         ):
             mock_opener.open.side_effect = ConnectionError("boom")
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
@@ -258,7 +258,7 @@ class TestUsagePendingCounter:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
@@ -304,7 +304,7 @@ class TestUsagePendingCounter:
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         # Shut down the executor so _enqueue_webhook takes the sync fallback.
-        usage.flush_usage_events()
+        usage.flush_usage_events(trigger="test")
         usage.webhook.usage_executor.shutdown(wait=True)
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -320,7 +320,7 @@ class TestUsagePendingCounter:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
 
         assert usage.counters._pending_reports == 0
         assert_pending(pending_path, flows=0, reports=0)

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -12,10 +12,11 @@ from usage.providers import model_provider as usage_model_provider
 
 
 class TestUsagePendingCounter:
-    """Tests for the dual pending counter (in-flight flows + pending reports)."""
+    """Tests for usage pending counters."""
 
     def setup_method(self):
         usage.counters._in_flight_flows = 0
+        usage.counters._buffered_usage_events = 0
         usage.counters._pending_reports = 0
         usage.counters._pending_path = ""
         usage.counters._usage_state_id = "test-usage-state-id"
@@ -43,6 +44,43 @@ class TestUsagePendingCounter:
         assert_pending(pending_path, flows=0, reports=1)
 
         usage.counters.decrement_pending_reports()
+        assert_pending(pending_path, flows=0, reports=0)
+
+    def test_set_buffered_usage_events(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+        usage.counters.set_buffered_usage_events(3)
+        assert_pending(pending_path, flows=0, buffered=3, reports=0)
+
+        usage.counters.set_buffered_usage_events(0)
+        assert_pending(pending_path, flows=0, reports=0)
+
+    def test_buffered_usage_blocks_pending_until_flush(
+        self, tmp_path, real_flow, fresh_usage_executor
+    ):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok"
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["model_provider_usage"] = {"tokens.input": 1}
+
+        with (
+            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.report_model_provider_usage(flow, "run-1")
+            assert_pending(pending_path, flows=0, buffered=1, reports=0)
+            mock_opener.open.assert_not_called()
+
+            usage.flush_usage_events()
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        assert usage.counters._pending_reports == 0
         assert_pending(pending_path, flows=0, reports=0)
 
     def test_enqueue_deep_copies_nested_payload(self):
@@ -282,6 +320,7 @@ class TestUsagePendingCounter:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
 
         assert usage.counters._pending_reports == 0
         assert_pending(pending_path, flows=0, reports=0)

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -28,23 +28,23 @@ class TestUsagePendingCounter:
         usage.increment_in_flight_flows()
         usage.increment_in_flight_flows()
         assert usage.counters._in_flight_flows == 2
-        assert_pending(pending_path, flows=2, reports=0)
+        assert_pending(pending_path, flows=2, buffered=0, reports=0)
 
         usage.decrement_in_flight_flows()
-        assert_pending(pending_path, flows=1, reports=0)
+        assert_pending(pending_path, flows=1, buffered=0, reports=0)
 
         usage.decrement_in_flight_flows()
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_increment_decrement_pending_reports(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         usage.counters.increment_pending_reports()
         assert usage.counters._pending_reports == 1
-        assert_pending(pending_path, flows=0, reports=1)
+        assert_pending(pending_path, flows=0, buffered=0, reports=1)
 
         usage.counters.decrement_pending_reports()
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_set_buffered_usage_events(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
@@ -53,7 +53,7 @@ class TestUsagePendingCounter:
         assert_pending(pending_path, flows=0, buffered=3, reports=0)
 
         usage.counters.set_buffered_usage_events(0)
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_buffered_usage_blocks_pending_until_flush(
         self, tmp_path, real_flow, fresh_usage_executor
@@ -81,7 +81,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_enqueue_deep_copies_nested_payload(self):
         payload = {
@@ -159,12 +159,12 @@ class TestUsagePendingCounter:
             )
 
         assert usage.counters._pending_reports == 0
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_set_pending_path_accepts_explicit_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="explicit-usage-state-id")
-        state = assert_pending(pending_path, flows=0, reports=0)
+        state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
         assert state["usageStateId"] == "explicit-usage-state-id"
 
     def test_decrement_does_not_go_negative(self, tmp_path):
@@ -238,7 +238,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_enqueue_increments_and_drains_reports(self, tmp_path, real_flow, fresh_usage_executor):
         """Public entry increments pending on enqueue; executor drain decrements to 0."""
@@ -262,7 +262,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
         """If both response() and error() fire for the same flow, decrement only once."""
@@ -323,4 +323,4 @@ class TestUsagePendingCounter:
             usage.flush_usage_events(trigger="test")
 
         assert usage.counters._pending_reports == 0
-        assert_pending(pending_path, flows=0, reports=0)
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -196,6 +196,7 @@ class TestUsagePendingCounter:
         ):
             mock_opener.open.side_effect = ConnectionError("boom")
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
@@ -219,6 +220,7 @@ class TestUsagePendingCounter:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
@@ -264,6 +266,7 @@ class TestUsagePendingCounter:
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         # Shut down the executor so _enqueue_webhook takes the sync fallback.
+        usage.flush_usage_events()
         usage.webhook.usage_executor.shutdown(wait=True)
 
         flow = real_flow(with_response=False, host="api.anthropic.com")

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -235,6 +235,7 @@ class TestErrorHandler:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # Connector billing webhook should have been posted to _opener.
@@ -291,6 +292,7 @@ class TestErrorHandler:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -235,7 +235,7 @@ class TestErrorHandler:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # Connector billing webhook should have been posted to _opener.
@@ -292,7 +292,7 @@ class TestErrorHandler:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -271,6 +271,35 @@ class TestReportModelProviderUsage:
         body = json.loads(mock_opener.open.call_args[0][0].data)
         assert body["events"][0]["quantity"] == 10
 
+    def test_source_dedupe_separates_flows_when_message_id_missing(
+        self, real_flow, fresh_usage_executor
+    ):
+        first = real_flow(with_response=False, host="api.anthropic.com")
+        first.id = "flow-first"
+        second = real_flow(with_response=False, host="api.anthropic.com")
+        second.id = "flow-second"
+        for flow in (first, second):
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            flow.metadata["firewall_billable"] = True
+            flow.metadata["vm_sandbox_token"] = "tok-xyz"
+            flow.metadata["model_provider_usage"] = {
+                "model": "claude-sonnet-4-6",
+                "tokens.input": 10,
+            }
+
+        with (
+            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.report_model_provider_usage(first, "run-fallback")
+            usage.report_model_provider_usage(second, "run-fallback")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        body = json.loads(mock_opener.open.call_args[0][0].data)
+        assert body["events"][0]["quantity"] == 20
+
     def test_source_dedupe_preserves_message_id_over_flow_id(self, real_flow, fresh_usage_executor):
         first = real_flow(with_response=False, host="api.anthropic.com")
         first.id = "flow-first"

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -99,6 +99,7 @@ class TestReportModelProviderUsage:
         body = json.loads(mock_opener.open.call_args[0][0].data)
         assert body["events"][0]["provider"] == "unknown"
 
+        flow.metadata["model_provider_usage"]["message_id"] = "msg-usage-2"
         flow.metadata["model_provider_usage"]["model"] = "claude-sonnet-4-6"
         with (
             patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -1,12 +1,10 @@
 """Tests for model provider usage reporting."""
 
 import json
+import uuid
 from unittest.mock import MagicMock, patch
 
 import usage
-from tests.usage_helpers import (
-    model_usage_idempotency_key,
-)
 from usage.providers import model_provider as usage_model_provider
 
 
@@ -35,6 +33,8 @@ class TestReportModelProviderUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-abc-123")
+            mock_opener.open.assert_not_called()
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
@@ -43,44 +43,38 @@ class TestReportModelProviderUsage:
         body = json.loads(req.data)
         assert body["runId"] == "run-abc-123"
         assert set(body) == {"runId", "events"}
-        assert body["events"] == [
-            {
-                "idempotencyKey": model_usage_idempotency_key(
-                    "run-abc-123", "msg-usage-1", "tokens.input"
-                ),
+        by_category = {event["category"]: event for event in body["events"]}
+        assert {
+            category: {key: value for key, value in event.items() if key != "idempotencyKey"}
+            for category, event in by_category.items()
+        } == {
+            "tokens.input": {
                 "kind": "model",
                 "provider": "claude-opus-4-6",
                 "category": "tokens.input",
                 "quantity": 100,
             },
-            {
-                "idempotencyKey": model_usage_idempotency_key(
-                    "run-abc-123", "msg-usage-1", "tokens.output"
-                ),
+            "tokens.output": {
                 "kind": "model",
                 "provider": "claude-opus-4-6",
                 "category": "tokens.output",
                 "quantity": 50,
             },
-            {
-                "idempotencyKey": model_usage_idempotency_key(
-                    "run-abc-123", "msg-usage-1", "tokens.cache_read"
-                ),
+            "tokens.cache_read": {
                 "kind": "model",
                 "provider": "claude-opus-4-6",
                 "category": "tokens.cache_read",
                 "quantity": 25,
             },
-            {
-                "idempotencyKey": model_usage_idempotency_key(
-                    "run-abc-123", "msg-usage-1", "tokens.cache_creation"
-                ),
+            "tokens.cache_creation": {
                 "kind": "model",
                 "provider": "claude-opus-4-6",
                 "category": "tokens.cache_creation",
                 "quantity": 10,
             },
-        ]
+        }
+        for event in body["events"]:
+            uuid.UUID(event["idempotencyKey"])
 
     def test_falls_back_to_response_model_then_unknown(self, real_flow, fresh_usage_executor):
         """Provider falls back only when selected vm0 model metadata is absent."""
@@ -99,6 +93,7 @@ class TestReportModelProviderUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = json.loads(mock_opener.open.call_args[0][0].data)
@@ -111,6 +106,7 @@ class TestReportModelProviderUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = json.loads(mock_opener.open.call_args[0][0].data)
@@ -134,6 +130,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -156,6 +153,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -168,6 +166,7 @@ class TestReportModelProviderUsage:
 
         with patch.object(usage.webhook, "_opener") as mock_opener:
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -184,6 +183,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -196,6 +196,7 @@ class TestReportModelProviderUsage:
 
         with patch.object(usage.webhook, "_opener") as mock_opener:
             usage.report_model_provider_usage(flow, "")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -215,6 +216,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -236,7 +238,62 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
         assert proxy_log.exists()
+
+    def test_source_dedupe_uses_flow_id_when_message_id_missing(
+        self, real_flow, fresh_usage_executor
+    ):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.id = "flow-uuid-xyz-123"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage"] = {
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 10,
+        }
+
+        with (
+            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.report_model_provider_usage(flow, "run-fallback")
+            usage.report_model_provider_usage(flow, "run-fallback")
+            usage.flush_usage_events()
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        body = json.loads(mock_opener.open.call_args[0][0].data)
+        assert body["events"][0]["quantity"] == 10
+
+    def test_source_dedupe_preserves_message_id_over_flow_id(self, real_flow, fresh_usage_executor):
+        first = real_flow(with_response=False, host="api.anthropic.com")
+        first.id = "flow-first"
+        second = real_flow(with_response=False, host="api.anthropic.com")
+        second.id = "flow-second"
+        for flow in (first, second):
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            flow.metadata["firewall_billable"] = True
+            flow.metadata["vm_sandbox_token"] = "tok-xyz"
+            flow.metadata["model_provider_usage"] = {
+                "model": "claude-sonnet-4-6",
+                "message_id": "msg_real_anthropic_id",
+                "tokens.input": 10,
+            }
+
+        with (
+            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            usage.report_model_provider_usage(first, "run-preserved")
+            usage.report_model_provider_usage(second, "run-preserved")
+            usage.flush_usage_events()
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        body = json.loads(mock_opener.open.call_args[0][0].data)
+        assert body["events"][0]["quantity"] == 10

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -34,7 +34,7 @@ class TestReportModelProviderUsage:
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-abc-123")
             mock_opener.open.assert_not_called()
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
@@ -93,7 +93,7 @@ class TestReportModelProviderUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = json.loads(mock_opener.open.call_args[0][0].data)
@@ -106,7 +106,7 @@ class TestReportModelProviderUsage:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = json.loads(mock_opener.open.call_args[0][0].data)
@@ -130,7 +130,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -153,7 +153,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -166,7 +166,7 @@ class TestReportModelProviderUsage:
 
         with patch.object(usage.webhook, "_opener") as mock_opener:
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -183,7 +183,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -196,7 +196,7 @@ class TestReportModelProviderUsage:
 
         with patch.object(usage.webhook, "_opener") as mock_opener:
             usage.report_model_provider_usage(flow, "")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -216,7 +216,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -238,7 +238,7 @@ class TestReportModelProviderUsage:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             usage.report_model_provider_usage(flow, "run-abc-123")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
@@ -264,7 +264,7 @@ class TestReportModelProviderUsage:
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.report_model_provider_usage(flow, "run-fallback")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = json.loads(mock_opener.open.call_args[0][0].data)
@@ -292,7 +292,7 @@ class TestReportModelProviderUsage:
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(first, "run-preserved")
             usage.report_model_provider_usage(second, "run-preserved")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = json.loads(mock_opener.open.call_args[0][0].data)

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -1124,7 +1124,7 @@ class TestRequestHandler:
 
             assert flow.metadata["_usage_flow_tracked"] is True
             assert usage.counters._in_flight_flows == 1
-            assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, buffered=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1173,7 +1173,7 @@ class TestRequestHandler:
             assert flow.metadata["firewall_error"] == "auth_unavailable"
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, buffered=0, reports=0)
         finally:
             usage.set_pending_path("")
 
@@ -1221,7 +1221,7 @@ class TestRequestHandler:
             assert flow.id not in mitm_addon._request_start_times
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, buffered=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1278,7 +1278,7 @@ class TestRequestHandler:
             assert flow.metadata["firewall_billable"] is False
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, buffered=0, reports=0)
         finally:
             usage.set_pending_path("")
 
@@ -1338,7 +1338,7 @@ class TestRequestHandler:
             assert flow.metadata["firewall_billable"] is True
             assert flow.metadata["model_usage_provider"] == "claude-opus-4-6"
             assert flow.metadata["_usage_flow_tracked"] is True
-            assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, buffered=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1395,7 +1395,7 @@ class TestRequestHandler:
         async def forward_request(*_args):
             assert flow.metadata["_usage_flow_tracked"] is True
             assert usage.counters._in_flight_flows == 1
-            assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, buffered=0, reports=0)
             return (200, b'{"delivered":true}', {"Content-Type": "application/json"})
 
         try:
@@ -1418,13 +1418,13 @@ class TestRequestHandler:
                 assert flow.metadata["auth_url_rewrite"] is True
                 assert flow.metadata["_usage_flow_tracked"] is True
                 assert usage.counters._in_flight_flows == 1
-                assert_pending(pending_path, flows=1, reports=0)
+                assert_pending(pending_path, flows=1, buffered=0, reports=0)
 
                 mitm_addon.response(flow)
 
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, buffered=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()
@@ -1481,7 +1481,7 @@ class TestRequestHandler:
         async def fail_forward_request(*_args):
             assert flow.metadata["_usage_flow_tracked"] is True
             assert usage.counters._in_flight_flows == 1
-            assert_pending(pending_path, flows=1, reports=0)
+            assert_pending(pending_path, flows=1, buffered=0, reports=0)
             raise RuntimeError("upstream unavailable")
 
         try:
@@ -1506,7 +1506,7 @@ class TestRequestHandler:
             assert "auth_url_rewrite" not in flow.metadata
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
-            assert_pending(pending_path, flows=0, reports=0)
+            assert_pending(pending_path, flows=0, buffered=0, reports=0)
         finally:
             if usage.counters._in_flight_flows:
                 usage.decrement_in_flight_flows()

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -134,6 +134,35 @@ def test_flush_splits_aggregate_events_at_webhook_limit(tmp_path):
     assert {payload["runId"] for payload in payloads} == {"run-1"}
 
 
+def test_flushes_when_buffered_webhook_batch_count_reaches_bound(tmp_path):
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        for index in range(3):
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                "token-a",
+                f"run-{index}",
+                [_event(source_key=f"source-{index}")],
+                str(tmp_path / "proxy.jsonl"),
+            )
+        enqueue.assert_not_called()
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-3",
+            [_event(source_key="source-3")],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+    payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
+    assert [payload["runId"] for payload in payloads] == [
+        "run-0",
+        "run-1",
+        "run-2",
+        "run-3",
+    ]
+
+
 def test_empty_flush_is_noop():
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
         assert usage.flush_usage_events() == 0

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -1,0 +1,215 @@
+"""Tests for buffered usage-event aggregation."""
+
+import uuid
+from unittest.mock import patch
+
+import usage
+import usage.buffer as usage_buffer
+
+
+def _event(
+    *,
+    source_key: str,
+    category: str = "tokens.input",
+    quantity: int = 1,
+    kind: str = "model",
+    provider: str = "claude-sonnet-4-6",
+) -> usage_buffer.UsageEvent:
+    return {
+        "idempotencyKey": source_key,
+        "kind": kind,
+        "provider": provider,
+        "category": category,
+        "quantity": quantity,
+    }
+
+
+def _payloads_from_enqueue_calls(call_args_list):
+    return [call.args[2] for call in call_args_list]
+
+
+def test_flush_aggregates_same_bucket_and_dedupes_source_key(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                _event(source_key="source-1", quantity=10),
+                _event(source_key="source-2", quantity=5),
+                _event(source_key="source-1", quantity=100),
+            ],
+            proxy_log_path,
+        )
+
+        enqueue.assert_not_called()
+        assert usage.flush_usage_events() == 1
+
+    enqueue.assert_called_once()
+    payload = enqueue.call_args.args[2]
+    assert payload["runId"] == "run-1"
+    assert payload["events"] == [
+        {
+            "idempotencyKey": payload["events"][0]["idempotencyKey"],
+            "kind": "model",
+            "provider": "claude-sonnet-4-6",
+            "category": "tokens.input",
+            "quantity": 15,
+        }
+    ]
+    uuid.UUID(payload["events"][0]["idempotencyKey"])
+    assert enqueue.call_args.args[3] == proxy_log_path
+
+
+def test_flush_keeps_runs_categories_providers_and_destinations_separate(tmp_path):
+    proxy_a_log_path = str(tmp_path / "proxy-a.jsonl")
+    proxy_b_log_path = str(tmp_path / "proxy-b.jsonl")
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api-a.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                _event(source_key="source-1", category="tokens.input", quantity=10),
+                _event(source_key="source-2", category="tokens.output", quantity=5),
+            ],
+            proxy_a_log_path,
+        )
+        usage.buffer_usage_events(
+            "https://api-a.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-2",
+            [_event(source_key="source-3", category="tokens.input", quantity=7)],
+            proxy_a_log_path,
+        )
+        usage.buffer_usage_events(
+            "https://api-b.test/api/webhooks/agent/usage-event",
+            "token-b",
+            "run-1",
+            [
+                _event(
+                    source_key="source-4",
+                    category="posts.read",
+                    quantity=3,
+                    kind="connector",
+                    provider="x",
+                )
+            ],
+            proxy_b_log_path,
+        )
+
+        assert usage.flush_usage_events() == 3
+
+    payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
+    assert {(payload["runId"], len(payload["events"])) for payload in payloads} == {
+        ("run-1", 2),
+        ("run-2", 1),
+        ("run-1", 1),
+    }
+    all_events = [event for payload in payloads for event in payload["events"]]
+    assert {(event["kind"], event["provider"], event["category"]) for event in all_events} == {
+        ("model", "claude-sonnet-4-6", "tokens.input"),
+        ("model", "claude-sonnet-4-6", "tokens.output"),
+        ("connector", "x", "posts.read"),
+    }
+
+
+def test_flush_splits_aggregate_events_at_webhook_limit(tmp_path):
+    events = [
+        _event(source_key=f"source-{index}", category=f"category-{index}") for index in range(101)
+    ]
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            events,
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+    payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
+    assert [len(payload["events"]) for payload in payloads] == [100, 1]
+    assert {payload["runId"] for payload in payloads} == {"run-1"}
+
+
+def test_empty_flush_is_noop():
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events() == 0
+
+    enqueue.assert_not_called()
+
+
+def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
+    timers = []
+
+    class FakeTimer:
+        def __init__(self, delay: float, callback):
+            self.delay = delay
+            self.callback = callback
+            self.daemon = False
+            self.cancelled = False
+            self.started = False
+
+        def start(self) -> None:
+            self.started = True
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    def timer_factory(delay: float, callback):
+        timer = FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [_event(source_key="source-1", quantity=10)],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+        assert len(timers) == 1
+        assert timers[0].started is True
+        assert 24 <= timers[0].delay <= 36
+        enqueue.assert_not_called()
+
+        timers[0].callback()
+
+    enqueue.assert_called_once()
+    assert enqueue.call_args.args[2]["events"][0]["quantity"] == 10
+
+
+def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [_event(source_key="source-1", quantity=10)],
+            proxy_log_path,
+        )
+        usage.flush_usage_events()
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [_event(source_key="source-2", quantity=10)],
+            proxy_log_path,
+        )
+        usage.flush_usage_events()
+
+    keys = [
+        payload["events"][0]["idempotencyKey"]
+        for payload in _payloads_from_enqueue_calls(enqueue.call_args_list)
+    ]
+    assert len(keys) == 2
+    assert keys[0] != keys[1]
+    for key in keys:
+        uuid.UUID(key)

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -213,3 +213,24 @@ def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
     assert keys[0] != keys[1]
     for key in keys:
         uuid.UUID(key)
+
+
+def test_aggregate_idempotency_key_separates_webhook_destinations(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        for token in ("token-a", "token-b"):
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                token,
+                "run-1",
+                [_event(source_key=f"source-{token}", quantity=10)],
+                proxy_log_path,
+            )
+        usage.flush_usage_events()
+
+    keys = [
+        payload["events"][0]["idempotencyKey"]
+        for payload in _payloads_from_enqueue_calls(enqueue.call_args_list)
+    ]
+    assert len(keys) == 2
+    assert keys[0] != keys[1]

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -469,7 +469,7 @@ def test_source_dedupe_survives_flush_boundary(tmp_path):
     enqueue.assert_called_once()
 
 
-def test_source_dedupe_cache_evicts_oldest_key_after_bound(tmp_path):
+def test_source_dedupe_accepts_evicted_oldest_key_after_bound(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     source_key_count = usage_buffer.MAX_SOURCE_IDEMPOTENCY_KEYS + 1
     events = [_event(source_key=f"source-{index}", quantity=1) for index in range(source_key_count)]
@@ -484,17 +484,8 @@ def test_source_dedupe_cache_evicts_oldest_key_after_bound(tmp_path):
         )
 
         assert accepted == source_key_count
-        assert len(usage_buffer._usage_event_buffer._seen_source_keys) == (
-            usage_buffer.MAX_SOURCE_IDEMPOTENCY_KEYS
-        )
-        assert "source-0" not in usage_buffer._usage_event_buffer._seen_source_keys
-        assert "source-1" in usage_buffer._usage_event_buffer._seen_source_keys
-        assert (
-            f"source-{usage_buffer.MAX_SOURCE_IDEMPOTENCY_KEYS}"
-            in usage_buffer._usage_event_buffer._seen_source_keys
-        )
-
-        first_payload = enqueue.call_args.args[2]
+        assert len(enqueue.call_args_list) == 1
+        first_payload = enqueue.call_args_list[0].args[2]
         assert first_payload["events"][0]["quantity"] == source_key_count
 
         assert (

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -147,6 +147,12 @@ def test_flush_splits_aggregate_events_at_webhook_limit(tmp_path):
     payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
     assert [len(payload["events"]) for payload in payloads] == [100, 1]
     assert {payload["runId"] for payload in payloads} == {"run-1"}
+    all_events = [event for payload in payloads for event in payload["events"]]
+    idempotency_keys = [event["idempotencyKey"] for event in all_events]
+    assert len(idempotency_keys) == 101
+    assert len(set(idempotency_keys)) == 101
+    for idempotency_key in idempotency_keys:
+        uuid.UUID(idempotency_key)
 
 
 def test_flushes_when_buffered_webhook_batch_count_reaches_bound(tmp_path):
@@ -257,6 +263,55 @@ def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
     enqueue.assert_called_once()
     assert timers[0].cancelled is True
     assert enqueue.call_args.args[2]["events"][0]["quantity"] == 10
+
+
+def test_threshold_flush_cancels_scheduled_timer_and_allows_reschedule(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        for index in range(usage_buffer.MAX_BUFFERED_WEBHOOK_BATCHES - 1):
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                "token-a",
+                f"run-{index}",
+                [_event(source_key=f"source-{index}")],
+                str(tmp_path / "proxy.jsonl"),
+            )
+
+        assert len(timers) == 1
+        assert timers[0].started is True
+        assert timers[0].cancelled is False
+        enqueue.assert_not_called()
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-threshold",
+            [_event(source_key="source-threshold")],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+        assert timers[0].cancelled is True
+        assert len(enqueue.call_args_list) == usage_buffer.MAX_BUFFERED_WEBHOOK_BATCHES
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-next",
+            [_event(source_key="source-next")],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+        assert len(timers) == 2
+        assert timers[1].started is True
+        assert timers[1].cancelled is False
 
 
 def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -185,6 +185,39 @@ def test_flushes_when_buffered_webhook_batch_count_reaches_bound(tmp_path):
     ]
 
 
+def test_flushes_when_aggregate_bucket_count_reaches_exact_bound(tmp_path):
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                _event(source_key=f"source-{index}", category=f"category-{index}")
+                for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS - 1)
+            ],
+            str(tmp_path / "proxy.jsonl"),
+        )
+        enqueue.assert_not_called()
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                _event(
+                    source_key=f"source-{usage_buffer.MAX_AGGREGATE_BUCKETS - 1}",
+                    category=f"category-{usage_buffer.MAX_AGGREGATE_BUCKETS - 1}",
+                )
+            ],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+    enqueue.assert_called_once()
+    payload = enqueue.call_args.args[2]
+    assert payload["runId"] == "run-1"
+    assert len(payload["events"]) == usage_buffer.MAX_AGGREGATE_BUCKETS
+
+
 def test_flushes_when_source_event_count_reaches_bound(tmp_path):
     events = [
         _event(source_key=f"source-{index}", quantity=1)

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -1,5 +1,6 @@
 """Tests for buffered usage-event aggregation."""
 
+import json
 import uuid
 from unittest.mock import patch
 
@@ -59,7 +60,7 @@ def test_flush_aggregates_same_bucket_and_dedupes_source_key(tmp_path):
         )
 
         enqueue.assert_not_called()
-        assert usage.flush_usage_events() == 1
+        assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()
     payload = enqueue.call_args.args[2]
@@ -114,7 +115,7 @@ def test_flush_keeps_runs_categories_providers_and_destinations_separate(tmp_pat
             proxy_b_log_path,
         )
 
-        assert usage.flush_usage_events() == 3
+        assert usage.flush_usage_events(trigger="test") == 3
 
     payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
     assert {(payload["runId"], len(payload["events"])) for payload in payloads} == {
@@ -186,9 +187,44 @@ def test_flushes_when_buffered_webhook_batch_count_reaches_bound(tmp_path):
 
 def test_empty_flush_is_noop():
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
-        assert usage.flush_usage_events() == 0
+        assert usage.flush_usage_events(trigger="test") == 0
 
     enqueue.assert_not_called()
+
+
+def test_flush_logs_aggregate_summary_without_token(tmp_path):
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "secret-token",
+            "run-1",
+            [
+                _event(source_key="source-1", category="tokens.input", quantity=10),
+                _event(source_key="source-2", category="tokens.output", quantity=5),
+            ],
+            str(proxy_log_path),
+        )
+
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    [entry] = [
+        json.loads(line)
+        for line in proxy_log_path.read_text().splitlines()
+        if '"usage_event_buffer_flush"' in line
+    ]
+    assert entry["level"] == "info"
+    assert entry["message"] == "Usage event buffer flushed"
+    assert entry["type"] == "usage_event_buffer_flush"
+    assert entry["trigger"] == "test"
+    assert entry["flush_sequence"] == 1
+    assert entry["source_event_count"] == 2
+    assert entry["aggregate_event_count"] == 2
+    assert entry["webhook_batch_count"] == 1
+    assert entry["run_count"] == 1
+    assert entry["destination_count"] == 1
+    assert "secret-token" not in json.dumps(entry)
 
 
 def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
@@ -214,13 +250,13 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
         assert usage.counters._buffered_usage_events == 2
 
     with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook) as enqueue:
-        assert usage.flush_usage_events() == 1
+        assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()
     assert usage.counters._buffered_usage_events == 1
 
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
-        assert usage.flush_usage_events() == 1
+        assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()
     assert usage.counters._buffered_usage_events == 0
@@ -264,7 +300,7 @@ def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
         )
         assert len(usage_buffer._usage_event_buffer._buckets) == 1
 
-        assert usage.flush_usage_events() == 1
+        assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()
 
@@ -359,7 +395,7 @@ def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
             [_event(source_key="source-1", quantity=10)],
             proxy_log_path,
         )
-        usage.flush_usage_events()
+        usage.flush_usage_events(trigger="test")
         usage.buffer_usage_events(
             "https://api.test/api/webhooks/agent/usage-event",
             "token-a",
@@ -367,7 +403,7 @@ def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
             [_event(source_key="source-2", quantity=10)],
             proxy_log_path,
         )
-        usage.flush_usage_events()
+        usage.flush_usage_events(trigger="test")
 
     keys = [
         payload["events"][0]["idempotencyKey"]
@@ -390,7 +426,7 @@ def test_aggregate_idempotency_key_separates_webhook_destinations(tmp_path):
                 [_event(source_key=f"source-{token}", quantity=10)],
                 proxy_log_path,
             )
-        usage.flush_usage_events()
+        usage.flush_usage_events(trigger="test")
 
     keys = [
         payload["events"][0]["idempotencyKey"]

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -469,6 +469,54 @@ def test_source_dedupe_survives_flush_boundary(tmp_path):
     enqueue.assert_called_once()
 
 
+def test_source_dedupe_cache_evicts_oldest_key_after_bound(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    source_key_count = usage_buffer.MAX_SOURCE_IDEMPOTENCY_KEYS + 1
+    events = [_event(source_key=f"source-{index}", quantity=1) for index in range(source_key_count)]
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        accepted = usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            events,
+            proxy_log_path,
+        )
+
+        assert accepted == source_key_count
+        assert len(usage_buffer._usage_event_buffer._seen_source_keys) == (
+            usage_buffer.MAX_SOURCE_IDEMPOTENCY_KEYS
+        )
+        assert "source-0" not in usage_buffer._usage_event_buffer._seen_source_keys
+        assert "source-1" in usage_buffer._usage_event_buffer._seen_source_keys
+        assert (
+            f"source-{usage_buffer.MAX_SOURCE_IDEMPOTENCY_KEYS}"
+            in usage_buffer._usage_event_buffer._seen_source_keys
+        )
+
+        first_payload = enqueue.call_args.args[2]
+        assert first_payload["events"][0]["quantity"] == source_key_count
+
+        assert (
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                "token-a",
+                "run-1",
+                [
+                    _event(source_key="source-0", quantity=1),
+                    _event(source_key="source-1", quantity=100),
+                ],
+                proxy_log_path,
+            )
+            == 1
+        )
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    assert len(enqueue.call_args_list) == 2
+    second_payload = enqueue.call_args_list[1].args[2]
+    assert second_payload["events"][0]["quantity"] == 1
+
+
 def test_aggregate_idempotency_key_separates_webhook_destinations(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -191,6 +191,41 @@ def test_empty_flush_is_noop():
     enqueue.assert_not_called()
 
 
+def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        proxy_log_path,
+    )
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+        usage.buffer_usage_events(
+            url,
+            sandbox_token,
+            "run-2",
+            [_event(source_key="source-2")],
+            path,
+        )
+        assert log_type == "usage_event"
+        assert payload["runId"] == "run-1"
+        assert usage.counters._buffered_usage_events == 2
+
+    with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook) as enqueue:
+        assert usage.flush_usage_events() == 1
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 1
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events() == 1
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
         assert (

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -185,6 +185,37 @@ def test_flushes_when_buffered_webhook_batch_count_reaches_bound(tmp_path):
     ]
 
 
+def test_flushes_when_source_event_count_reaches_bound(tmp_path):
+    events = [
+        _event(source_key=f"source-{index}", quantity=1)
+        for index in range(usage_buffer.MAX_BUFFERED_SOURCE_EVENTS)
+    ]
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        accepted = usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            events,
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+    assert accepted == usage_buffer.MAX_BUFFERED_SOURCE_EVENTS
+    enqueue.assert_called_once()
+    payload = enqueue.call_args.args[2]
+    assert payload["runId"] == "run-1"
+    assert payload["events"] == [
+        {
+            "idempotencyKey": payload["events"][0]["idempotencyKey"],
+            "kind": "model",
+            "provider": "claude-sonnet-4-6",
+            "category": "tokens.input",
+            "quantity": usage_buffer.MAX_BUFFERED_SOURCE_EVENTS,
+        }
+    ]
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_empty_flush_is_noop():
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
         assert usage.flush_usage_events(trigger="test") == 0

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -415,6 +415,29 @@ def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
         uuid.UUID(key)
 
 
+def test_source_dedupe_survives_flush_boundary(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [_event(source_key="source-1", quantity=10)],
+            proxy_log_path,
+        )
+        usage.flush_usage_events(trigger="test")
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [_event(source_key="source-1", quantity=10)],
+            proxy_log_path,
+        )
+        usage.flush_usage_events(trigger="test")
+
+    enqueue.assert_called_once()
+
+
 def test_aggregate_idempotency_key_separates_webhook_destinations(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -28,6 +28,21 @@ def _payloads_from_enqueue_calls(call_args_list):
     return [call.args[2] for call in call_args_list]
 
 
+class _FakeTimer:
+    def __init__(self, delay: float, callback):
+        self.delay = delay
+        self.callback = callback
+        self.daemon = False
+        self.cancelled = False
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
 def test_flush_aggregates_same_bucket_and_dedupes_source_key(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
@@ -170,25 +185,54 @@ def test_empty_flush_is_noop():
     enqueue.assert_not_called()
 
 
+def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert (
+            usage.buffer_usage_events(
+                "https://api-empty.test/api/webhooks/agent/usage-event",
+                "token-empty",
+                "run-empty",
+                [],
+                str(tmp_path / "empty-proxy.jsonl"),
+            )
+            == 0
+        )
+        assert usage_buffer._usage_event_buffer._buckets == {}
+
+        assert (
+            usage.buffer_usage_events(
+                "https://api-a.test/api/webhooks/agent/usage-event",
+                "token-a",
+                "run-1",
+                [_event(source_key="source-1")],
+                str(tmp_path / "proxy-a.jsonl"),
+            )
+            == 1
+        )
+        assert len(usage_buffer._usage_event_buffer._buckets) == 1
+
+        assert (
+            usage.buffer_usage_events(
+                "https://api-b.test/api/webhooks/agent/usage-event",
+                "token-b",
+                "run-2",
+                [_event(source_key="source-1")],
+                str(tmp_path / "proxy-b.jsonl"),
+            )
+            == 0
+        )
+        assert len(usage_buffer._usage_event_buffer._buckets) == 1
+
+        assert usage.flush_usage_events() == 1
+
+    enqueue.assert_called_once()
+
+
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
     timers = []
 
-    class FakeTimer:
-        def __init__(self, delay: float, callback):
-            self.delay = delay
-            self.callback = callback
-            self.daemon = False
-            self.cancelled = False
-            self.started = False
-
-        def start(self) -> None:
-            self.started = True
-
-        def cancel(self) -> None:
-            self.cancelled = True
-
     def timer_factory(delay: float, callback):
-        timer = FakeTimer(delay, callback)
+        timer = _FakeTimer(delay, callback)
         timers.append(timer)
         return timer
 
@@ -211,6 +255,7 @@ def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
         timers[0].callback()
 
     enqueue.assert_called_once()
+    assert timers[0].cancelled is True
     assert enqueue.call_args.args[2]["events"][0]["quantity"] == 10
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -177,7 +177,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # JSON fallback should populate model_provider_usage in metadata
@@ -227,7 +227,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -273,7 +273,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -321,7 +321,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -364,7 +364,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -485,7 +485,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -557,7 +557,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -646,7 +646,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -702,7 +702,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -739,7 +739,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -801,7 +801,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -837,7 +837,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -905,7 +905,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -953,7 +953,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -1002,7 +1002,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1037,7 +1037,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1078,7 +1078,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1122,7 +1122,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1155,7 +1155,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1187,7 +1187,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1216,7 +1216,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1251,7 +1251,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1287,7 +1287,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1320,7 +1320,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1351,7 +1351,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1379,7 +1379,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1407,7 +1407,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1436,7 +1436,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1477,7 +1477,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1542,7 +1542,7 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.websocket_message(flow)
             mitm_addon.websocket_end(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1599,7 +1599,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.websocket_end(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1868,7 +1868,7 @@ class TestResponseUsageReporting:
         ):
             mitm_addon.websocket_message(flow)
             mitm_addon.websocket_end(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1908,7 +1908,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1953,7 +1953,7 @@ class TestResponseUsageReporting:
             flow.metadata["model_provider_usage"]["tokens.output"] = 20
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1994,7 +1994,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -2058,7 +2058,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -2111,7 +2111,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -2161,7 +2161,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -2203,7 +2203,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -2635,7 +2635,7 @@ class TestResponseUsageReporting:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 0  # urllib external boundary (#9991)
@@ -2676,7 +2676,7 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
             # Flush the executor to ensure the background POST completes
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # Verify the webhook POST reached _opener with correct payload
@@ -2717,7 +2717,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
@@ -2772,7 +2772,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
@@ -2812,7 +2812,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2742,9 +2742,9 @@ class TestResponseUsageReporting:
     ):
         """Missing message_id in model_provider_usage falls back to flow.id.
 
-        Without a stable per-flow key, server-side dedup of usage webhook
-        retries fails, which would double-charge.  flow.id is stable
-        across retries because _enqueue_webhook copies the dict once.
+        Without a stable per-flow source key, duplicate response/error
+        observations could be aggregated twice before the webhook payload is
+        built.
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -3,6 +3,7 @@
 import gzip
 import json
 import time
+import uuid
 import zlib
 from collections.abc import Callable
 from pathlib import Path
@@ -21,7 +22,6 @@ import response_streaming
 import usage
 from tests.flow_helpers import header_map, response_stream
 from tests.usage_helpers import (
-    model_usage_idempotency_key,
     usage_event_events_from_calls,
 )
 
@@ -177,6 +177,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # JSON fallback should populate model_provider_usage in metadata
@@ -226,6 +227,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -271,6 +273,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -318,6 +321,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -360,6 +364,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -480,6 +485,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -551,6 +557,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -639,6 +646,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -694,6 +702,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -730,6 +739,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -791,6 +801,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -826,6 +837,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -893,6 +905,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -940,6 +953,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -988,6 +1002,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1022,6 +1037,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1062,6 +1078,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1105,6 +1122,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1137,6 +1155,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1168,6 +1187,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1196,6 +1216,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1230,6 +1251,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1265,6 +1287,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1297,6 +1320,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1327,6 +1351,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1354,6 +1379,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1381,6 +1407,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1409,6 +1436,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1449,6 +1477,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1458,14 +1487,9 @@ class TestResponseUsageReporting:
             "tokens.input": 100,
             "tokens.output": 40,
         }
-        assert idempotency_by_category == {
-            "tokens.input": model_usage_idempotency_key(
-                "run-abc-123", "resp_sse_1", "tokens.input"
-            ),
-            "tokens.output": model_usage_idempotency_key(
-                "run-abc-123", "resp_sse_1", "tokens.output"
-            ),
-        }
+        assert set(idempotency_by_category) == {"tokens.input", "tokens.output"}
+        for key in idempotency_by_category.values():
+            uuid.UUID(key)
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
     def test_full_pipeline_model_websocket_reports_usage(
@@ -1518,6 +1542,7 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.websocket_message(flow)
             mitm_addon.websocket_end(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1574,6 +1599,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.websocket_end(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1583,12 +1609,9 @@ class TestResponseUsageReporting:
             "tokens.input": 100,
             "tokens.output": 40,
         }
-        assert idempotency_by_category == {
-            "tokens.input": model_usage_idempotency_key("run-abc-123", "resp_ws_1", "tokens.input"),
-            "tokens.output": model_usage_idempotency_key(
-                "run-abc-123", "resp_ws_1", "tokens.output"
-            ),
-        }
+        assert set(idempotency_by_category) == {"tokens.input", "tokens.output"}
+        for key in idempotency_by_category.values():
+            uuid.UUID(key)
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
     def test_model_websocket_zero_frame_preserves_prior_positive_usage(self, tmp_path, real_flow):
@@ -1845,6 +1868,7 @@ class TestResponseUsageReporting:
         ):
             mitm_addon.websocket_message(flow)
             mitm_addon.websocket_end(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -1884,6 +1908,7 @@ class TestResponseUsageReporting:
             mitm_addon.response(flow)
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1928,6 +1953,7 @@ class TestResponseUsageReporting:
             flow.metadata["model_provider_usage"]["tokens.output"] = 20
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -1968,6 +1994,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
@@ -2031,6 +2058,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         extracted = flow.metadata["model_provider_usage"]
@@ -2083,6 +2111,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -2132,6 +2161,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -2173,6 +2203,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
@@ -2604,6 +2635,7 @@ class TestResponseUsageReporting:
             patch.object(usage.webhook, "_opener") as mock_opener,
         ):
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 0  # urllib external boundary (#9991)
@@ -2644,6 +2676,7 @@ class TestResponseUsageReporting:
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
             # Flush the executor to ensure the background POST completes
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # Verify the webhook POST reached _opener with correct payload
@@ -2684,23 +2717,25 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.error(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
         assert body["runId"] == "run-int-002"
-        assert body["events"] == [
+        assert [
+            {key: value for key, value in event.items() if key != "idempotencyKey"}
+            for event in body["events"]
+        ] == [
             {
-                "idempotencyKey": model_usage_idempotency_key(
-                    "run-int-002", flow.id, "tokens.input"
-                ),
                 "kind": "model",
                 "provider": "claude-sonnet-4-6",
                 "category": "tokens.input",
                 "quantity": 80,
             }
         ]
+        uuid.UUID(body["events"][0]["idempotencyKey"])
 
     def test_uses_flow_id_when_message_id_missing(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
@@ -2737,14 +2772,14 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
-        assert body["events"][0]["idempotencyKey"] == model_usage_idempotency_key(
-            "run-fallback", "flow-uuid-xyz-123", "tokens.input"
-        )
+        assert body["events"][0]["quantity"] == 10
+        uuid.UUID(body["events"][0]["idempotencyKey"])
 
     def test_preserves_message_id_from_response(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
@@ -2777,11 +2812,11 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
         req = mock_opener.open.call_args[0][0]
         body = json.loads(req.data)
-        assert body["events"][0]["idempotencyKey"] == model_usage_idempotency_key(
-            "run-preserved", "msg_real_anthropic_id", "tokens.input"
-        )
+        assert body["events"][0]["quantity"] == 10
+        uuid.UUID(body["events"][0]["idempotencyKey"])

--- a/crates/runner/mitm-addon/tests/test_usage_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting.py
@@ -2379,6 +2379,7 @@ class TestResponseUsageReporting:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
 
         events = usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert len(events) == 1

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -3,6 +3,7 @@
 import json
 import threading
 import urllib.error
+import uuid
 from email.message import Message
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -12,9 +13,6 @@ import pytest
 
 import auth
 import usage
-from tests.usage_helpers import (
-    model_usage_idempotency_key,
-)
 from usage.providers import model_provider as usage_model_provider
 
 
@@ -115,6 +113,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
@@ -126,15 +125,18 @@ class TestUsageWebhookDelivery:
         body = json.loads(req.data)
         assert body["runId"] == "run-1"
         assert set(body) == {"runId", "events"}
-        assert body["events"] == [
+        assert [
+            {key: value for key, value in event.items() if key != "idempotencyKey"}
+            for event in body["events"]
+        ] == [
             {
-                "idempotencyKey": model_usage_idempotency_key("run-1", flow.id, "tokens.input"),
                 "kind": "model",
                 "provider": "claude-sonnet-4-6",
                 "category": "tokens.input",
                 "quantity": 100,
             }
         ]
+        uuid.UUID(body["events"][0]["idempotencyKey"])
 
     def test_closes_http_error_response(self, tmp_path, real_flow, fresh_usage_executor):
         """HTTPError sockets must be closed to avoid leaking; retries still apply."""
@@ -149,6 +151,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = http_err
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # Cleanup must run once per HTTPError — tracks attempt count so the
@@ -164,6 +167,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         req = mock_opener.open.call_args[0][0]
@@ -177,6 +181,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
@@ -215,6 +220,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = ConnectionError("fail")
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
@@ -250,6 +256,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_sleep.assert_called_once_with(0.5)  # syscall boundary; pins retry backoff (#9991)
@@ -300,6 +307,7 @@ class TestUsageWebhookDelivery:
         """After executor shutdown, delivery happens synchronously before return."""
         flow = self._model_flow(real_flow, tmp_path)
         flow.metadata["model_provider_usage"] = {"tokens.input": 42}
+        usage.flush_usage_events()
         usage.webhook.usage_executor.shutdown(wait=True)
 
         with (
@@ -308,6 +316,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events()
             # Sync fallback: _opener must have been called before the call returned.
             mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
 

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -113,7 +113,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
@@ -151,7 +151,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = http_err
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # Cleanup must run once per HTTPError — tracks attempt count so the
@@ -167,7 +167,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         req = mock_opener.open.call_args[0][0]
@@ -181,7 +181,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
@@ -220,7 +220,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = ConnectionError("fail")
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
@@ -256,7 +256,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_sleep.assert_called_once_with(0.5)  # syscall boundary; pins retry backoff (#9991)
@@ -307,7 +307,7 @@ class TestUsageWebhookDelivery:
         """After executor shutdown, delivery happens synchronously before return."""
         flow = self._model_flow(real_flow, tmp_path)
         flow.metadata["model_provider_usage"] = {"tokens.input": 42}
-        usage.flush_usage_events()
+        usage.flush_usage_events(trigger="test")
         usage.webhook.usage_executor.shutdown(wait=True)
 
         with (
@@ -316,7 +316,7 @@ class TestUsageWebhookDelivery:
         ):
             mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events()
+            usage.flush_usage_events(trigger="test")
             # Sync fallback: _opener must have been called before the call returned.
             mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
 

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -1,9 +1,6 @@
 """Shared usage assertion helpers for mitm-addon tests."""
 
 import json
-import uuid
-
-from usage.namespaces import USAGE_EVENT_NAMESPACE_MODEL
 
 
 def request_bodies_from_calls(call_args_list):
@@ -12,10 +9,3 @@ def request_bodies_from_calls(call_args_list):
 
 def usage_event_events_from_calls(call_args_list):
     return [event for body in request_bodies_from_calls(call_args_list) for event in body["events"]]
-
-
-def model_usage_idempotency_key(run_id: str, message_id: str, category: str) -> str:
-    encoded = "\0".join(
-        f"{len(part.encode('utf-8'))}:{part}" for part in (run_id, message_id, category)
-    )
-    return str(uuid.uuid5(USAGE_EVENT_NAMESPACE_MODEL, encoded))

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1291,14 +1291,17 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Wait for buffered and pending usage reports before stopping the proxy.
     // The addon writes the current mitmdump identity plus in-flight flow,
     // buffered event, and pending report counts; this remains bounded
-    // best-effort and falls back to stopping the proxy on timeout.
+    // best-effort, and timeout is the abnormal data-loss path.
     let phase = teardown.phase_start("wait_usage_flush");
     if let Some(usage_flush_target) = mitm.usage_flush_target() {
+        info!("requesting proxy usage flush");
+        mitm.request_usage_flush();
         info!("waiting for proxy usage reports to flush");
-        let flushed = proxy::wait_usage_flush(
+        let flushed = proxy::wait_usage_flush_requesting(
             &base_dir.join("mitm-addon"),
             proxy::USAGE_FLUSH_TIMEOUT,
             &usage_flush_target,
+            || mitm.request_usage_flush(),
         )
         .await;
         if flushed {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1288,10 +1288,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     shutdown_factories(&mut factories, runtime.as_mut(), Some(&teardown)).await;
     teardown.phase_complete("shutdown_factories", phase);
 
-    // Wait for pending usage reports to flush before stopping the proxy.
-    // The addon writes the current mitmdump identity plus in-flight flow
-    // and pending report counts; this remains bounded best-effort and
-    // falls back to stopping the proxy on timeout.
+    // Wait for buffered and pending usage reports before stopping the proxy.
+    // The addon writes the current mitmdump identity plus in-flight flow,
+    // buffered event, and pending report counts; this remains bounded
+    // best-effort and falls back to stopping the proxy on timeout.
     let phase = teardown.phase_start("wait_usage_flush");
     if let Some(usage_flush_target) = mitm.usage_flush_target() {
         info!("waiting for proxy usage reports to flush");

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -74,25 +74,21 @@ const TEXT_BUSY_SPAWN_MAX_RETRIES: usize = 5;
 
 /// Timeout for graceful shutdown before SIGKILL.
 ///
-/// Must be long enough for `done()` in the mitmproxy addon to enqueue buffered
-/// usage and flush one webhook retry cycle (10 s HTTP timeout × 2 attempts plus
-/// 0.5 s backoff). Additional pending reports are still bounded by the
-/// pre-stop usage flush wait below.
+/// Must be long enough for mitmproxy's shutdown hook to drain any reports that
+/// race with the pre-stop usage flush wait below.
 const STOP_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum time to wait for pending usage reports to flush before stopping.
+/// Maximum time to wait for buffered and pending usage reports before stopping.
 ///
 /// The runner polls `{addon_dir}/usage-pending` (written by the Python
-/// addon) and waits until both counters reach zero or this timeout expires.
-/// 30 s is generous for worst-case webhook delivery (10 s timeout × 2
-/// retries = 20.5 s) with headroom for mitmproxy event-loop drain.
-pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
+/// addon) and waits until all counters reach zero or this timeout expires.
+/// 70 s covers the default buffered flush timer max (30 s + 20% jitter) plus
+/// one webhook retry cycle (10 s timeout × 2 attempts plus 0.5 s backoff) with
+/// headroom for mitmproxy event-loop drain.
+pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(70);
 
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
-
-/// Current JSON schema version for `{addon_dir}/usage-pending`.
-const USAGE_PENDING_VERSION: u32 = 1;
 
 /// Tolerated wall-clock skew when validating addon timestamps.
 const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
@@ -106,11 +102,11 @@ pub struct UsageFlushTarget {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct UsagePendingState {
-    version: u32,
     pid: u32,
     usage_state_id: String,
     updated_at_ms: u64,
     flows: u32,
+    buffered: u32,
     reports: u32,
 }
 
@@ -120,6 +116,7 @@ struct UsagePendingSnapshot {
     usage_state_id: String,
     updated_at_ms: u64,
     flows: u32,
+    buffered: u32,
     reports: u32,
 }
 
@@ -130,6 +127,7 @@ impl From<&UsagePendingState> for UsagePendingSnapshot {
             usage_state_id: state.usage_state_id.clone(),
             updated_at_ms: state.updated_at_ms,
             flows: state.flows,
+            buffered: state.buffered,
             reports: state.reports,
         }
     }
@@ -392,12 +390,6 @@ fn validate_usage_pending_state(
     target: &UsageFlushTarget,
     now_ms: u64,
 ) -> Result<(), String> {
-    if state.version != USAGE_PENDING_VERSION {
-        return Err(format!(
-            "unsupported version {}, expected {}",
-            state.version, USAGE_PENDING_VERSION
-        ));
-    }
     if state.usage_state_id != target.expected_usage_state_id {
         return Err("usage state id does not match current mitmdump process".to_string());
     }
@@ -423,12 +415,13 @@ fn validate_usage_pending_state(
 /// Wait for all pending proxy usage reports to be delivered.
 ///
 /// The Python addon writes JSON to `{addon_dir}/usage-pending` with the
-/// mitmdump usage-state identity plus in-flight flow and report counters.
-/// A successful drain requires current valid state with `flows == 0` and
-/// `reports == 0`. Missing, unreadable, stale, wrong state id, or invalid
-/// state is treated as not ready and waits until timeout. The JSON `pid`
-/// is diagnostic only: mitmdump launchers can keep the runner's direct
-/// child as a wrapper while the Python addon runs in a child process.
+/// mitmdump usage-state identity plus in-flight flow, buffered event, and
+/// report counters. A successful drain requires current valid state with
+/// `flows == 0`, `buffered == 0`, and `reports == 0`. Missing, unreadable,
+/// stale, wrong state id, or invalid state is treated as not ready and waits
+/// until timeout. The JSON `pid` is diagnostic only: mitmdump launchers can
+/// keep the runner's direct child as a wrapper while the Python addon runs in a
+/// child process.
 pub async fn wait_usage_flush(
     addon_dir: &Path,
     timeout: Duration,
@@ -443,11 +436,14 @@ pub async fn wait_usage_flush(
                     let snapshot = Some(UsagePendingSnapshot::from(&state));
                     match validate_usage_pending_state(&state, target, now_millis()) {
                         Ok(()) => {
-                            if state.flows == 0 && state.reports == 0 {
+                            if state.flows == 0 && state.buffered == 0 && state.reports == 0 {
                                 return true;
                             }
                             (
-                                format!("pending flows={} reports={}", state.flows, state.reports),
+                                format!(
+                                    "pending flows={} buffered={} reports={}",
+                                    state.flows, state.buffered, state.reports
+                                ),
                                 snapshot,
                             )
                         }
@@ -468,6 +464,7 @@ pub async fn wait_usage_flush(
                     usage_state_id = %snapshot.usage_state_id,
                     updated_at_ms = snapshot.updated_at_ms,
                     flows = snapshot.flows,
+                    buffered = snapshot.buffered,
                     reports = snapshot.reports,
                     "usage flush timed out, proceeding with proxy stop"
                 ),
@@ -1720,13 +1717,13 @@ exit 0
         }
     }
 
-    fn usage_state(flows: u32, reports: u32) -> String {
+    fn usage_state(flows: u32, buffered: u32, reports: u32) -> String {
         serde_json::json!({
-            "version": 1,
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": 1_770_000_000_001u64,
             "flows": flows,
+            "buffered": buffered,
             "reports": reports,
         })
         .to_string()
@@ -1738,7 +1735,7 @@ exit 0
     async fn wait_usage_flush_returns_true_when_zero() {
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
-        std::fs::write(dir.path().join("usage-pending"), usage_state(0, 0)).unwrap();
+        std::fs::write(dir.path().join("usage-pending"), usage_state(0, 0, 0)).unwrap();
         assert!(wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
 
@@ -1758,7 +1755,7 @@ exit 0
         let p = path.clone();
         let handle = tokio::spawn(async move {
             tokio::time::sleep(USAGE_FLUSH_TEST_DELAY).await;
-            std::fs::write(&p, usage_state(0, 0)).unwrap();
+            std::fs::write(&p, usage_state(0, 0, 0)).unwrap();
         });
 
         let d = dir.path().to_path_buf();
@@ -1771,12 +1768,30 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let path = dir.path().join("usage-pending");
-        std::fs::write(&path, usage_state(2, 1)).unwrap();
+        std::fs::write(&path, usage_state(2, 0, 1)).unwrap();
 
         let p = path.clone();
         let handle = tokio::spawn(async move {
             tokio::time::sleep(USAGE_FLUSH_TEST_DELAY).await;
-            std::fs::write(&p, usage_state(0, 0)).unwrap();
+            std::fs::write(&p, usage_state(0, 0, 0)).unwrap();
+        });
+
+        let d = dir.path().to_path_buf();
+        assert!(wait_usage_flush(&d, Duration::from_secs(5), &target).await);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_usage_flush_waits_until_buffered_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let path = dir.path().join("usage-pending");
+        std::fs::write(&path, usage_state(0, 2, 0)).unwrap();
+
+        let p = path.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(USAGE_FLUSH_TEST_DELAY).await;
+            std::fs::write(&p, usage_state(0, 0, 0)).unwrap();
         });
 
         let d = dir.path().to_path_buf();
@@ -1788,7 +1803,7 @@ exit 0
     async fn wait_usage_flush_timeout() {
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
-        std::fs::write(dir.path().join("usage-pending"), usage_state(1, 3)).unwrap();
+        std::fs::write(dir.path().join("usage-pending"), usage_state(1, 0, 3)).unwrap();
         // Very short timeout — should return false.
         assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
     }
@@ -1814,11 +1829,11 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 1,
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": 1_770_000_000_001u64,
             "flows": 0,
+            "buffered": 0,
             "reports": 0,
             "extraField": "unexpected",
         });
@@ -1827,11 +1842,10 @@ exit 0
     }
 
     #[tokio::test(start_paused = true)]
-    async fn wait_usage_flush_rejects_unsupported_version() {
+    async fn wait_usage_flush_rejects_legacy_state_without_buffered_count() {
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 2,
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": 1_770_000_000_001u64,
@@ -1847,11 +1861,11 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 1,
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": 1_770_000_000_001u64,
             "flows": 0,
+            "buffered": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
         assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &target).await);
@@ -1862,11 +1876,11 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 1,
             "pid": 1234,
             "usageStateId": "old-state",
             "updatedAtMs": 1_770_000_000_001u64,
             "flows": 0,
+            "buffered": 0,
             "reports": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
@@ -1878,11 +1892,11 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 1,
             "pid": 5678,
             "usageStateId": "state-test",
             "updatedAtMs": 1_770_000_000_001u64,
             "flows": 0,
+            "buffered": 0,
             "reports": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
@@ -1894,11 +1908,11 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 1,
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": 1_769_000_000_000u64,
             "flows": 0,
+            "buffered": 0,
             "reports": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();
@@ -1910,11 +1924,11 @@ exit 0
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();
         let state = serde_json::json!({
-            "version": 1,
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": now_millis() + USAGE_PENDING_CLOCK_SKEW.as_millis() as u64 + 60_000,
             "flows": 0,
+            "buffered": 0,
             "reports": 0,
         });
         std::fs::write(dir.path().join("usage-pending"), state.to_string()).unwrap();

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1760,9 +1760,12 @@ exit 0
             format!(
                 r#"#!/usr/bin/env bash
 set -euo pipefail
+fifo="$0.fifo"
+mkfifo "$fifo"
+exec 3<>"$fifo"
 trap 'touch "{}"; exit 0' USR1
 echo ready
-while true; do sleep 1; done
+while true; do read -r _ <&3 || true; done
 "#,
                 signal_file.display()
             ),

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -74,21 +74,26 @@ const TEXT_BUSY_SPAWN_MAX_RETRIES: usize = 5;
 
 /// Timeout for graceful shutdown before SIGKILL.
 ///
-/// Must be long enough for mitmproxy's shutdown hook to drain any reports that
-/// race with the pre-stop usage flush wait below.
-const STOP_TIMEOUT: Duration = Duration::from_secs(30);
+/// Usage upload drain is handled before SIGTERM; this only bounds mitmproxy's
+/// own graceful process exit.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Maximum time to wait for buffered and pending usage reports before stopping.
 ///
 /// The runner polls `{addon_dir}/usage-pending` (written by the Python
 /// addon) and waits until all counters reach zero or this timeout expires.
-/// 70 s covers the default buffered flush timer max (30 s + 20% jitter) plus
-/// one webhook retry cycle (10 s timeout × 2 attempts plus 0.5 s backoff) with
-/// headroom for mitmproxy event-loop drain.
-pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(70);
+/// Before polling and while buffered events remain, the runner asks the addon
+/// to flush buffered usage; 30 s covers one webhook retry cycle (10 s timeout
+/// × 2 attempts plus 0.5 s backoff) with headroom for request delivery and
+/// mitmproxy event-loop drain.
+pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
+
+/// Minimum interval between runner-triggered usage flush requests while the
+/// addon still reports buffered events.
+const USAGE_FLUSH_REQUEST_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Tolerated wall-clock skew when validating addon timestamps.
 const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
@@ -294,6 +299,16 @@ impl MitmProxy {
         })
     }
 
+    /// Ask the running addon to flush buffered usage before shutdown.
+    pub fn request_usage_flush(&self) {
+        let Some(child) = self.child.as_ref() else {
+            return;
+        };
+        if !send_usage_flush_signal(child) {
+            warn!("failed to request mitmdump usage flush");
+        }
+    }
+
     /// Prepare for restart: kill any lingering child, permanently silence
     /// its stdout monitor, and return fresh parameters for
     /// [`spawn_mitmdump`].
@@ -422,13 +437,22 @@ fn validate_usage_pending_state(
 /// until timeout. The JSON `pid` is diagnostic only: mitmdump launchers can
 /// keep the runner's direct child as a wrapper while the Python addon runs in a
 /// child process.
-pub async fn wait_usage_flush(
+#[cfg(test)]
+async fn wait_usage_flush(addon_dir: &Path, timeout: Duration, target: &UsageFlushTarget) -> bool {
+    wait_usage_flush_requesting(addon_dir, timeout, target, || {}).await
+}
+
+/// Wait for proxy usage drain while actively asking the addon to flush buffered events.
+pub async fn wait_usage_flush_requesting(
     addon_dir: &Path,
     timeout: Duration,
     target: &UsageFlushTarget,
+    mut request_flush: impl FnMut(),
 ) -> bool {
     let path = addon_dir.join("usage-pending");
-    let deadline = tokio::time::Instant::now() + timeout;
+    let started_at = tokio::time::Instant::now();
+    let deadline = started_at + timeout;
+    let mut next_flush_request_at = started_at + USAGE_FLUSH_REQUEST_INTERVAL;
     loop {
         let (not_ready, snapshot) = match tokio::fs::read_to_string(&path).await {
             Ok(content) => match parse_usage_pending_state(&content) {
@@ -438,6 +462,11 @@ pub async fn wait_usage_flush(
                         Ok(()) => {
                             if state.flows == 0 && state.buffered == 0 && state.reports == 0 {
                                 return true;
+                            }
+                            let now = tokio::time::Instant::now();
+                            if state.buffered > 0 && now >= next_flush_request_at {
+                                request_flush();
+                                next_flush_request_at = now + USAGE_FLUSH_REQUEST_INTERVAL;
                             }
                             (
                                 format!(
@@ -857,6 +886,17 @@ fn send_sigterm(child: &tokio::process::Child) {
             nix::sys::signal::Signal::SIGTERM,
         );
     }
+}
+
+fn send_usage_flush_signal(child: &tokio::process::Child) -> bool {
+    let Some(pid) = child.id() else {
+        return false;
+    };
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGUSR1,
+    )
+    .is_ok()
 }
 
 #[cfg(test)]
@@ -1710,6 +1750,55 @@ exit 0
         assert!(proxy.child.is_none());
     }
 
+    #[tokio::test]
+    async fn request_usage_flush_signals_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let signal_file = dir.path().join("usage-flush-requested");
+        let script = dir.path().join("trap-usage-flush.sh");
+        std::fs::write(
+            &script,
+            format!(
+                r#"#!/usr/bin/env bash
+set -euo pipefail
+trap 'touch "{}"; exit 0' USR1
+echo ready
+while true; do sleep 1; done
+"#,
+                signal_file.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let mut child = tokio::process::Command::new(&script)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let mut ready_lines = tokio::io::BufReader::new(stdout).lines();
+        proxy.child = Some(child);
+
+        let ready = tokio::time::timeout(Duration::from_secs(2), ready_lines.next_line())
+            .await
+            .expect("child did not install SIGUSR1 trap")
+            .unwrap();
+        assert_eq!(ready.as_deref(), Some("ready"));
+
+        proxy.request_usage_flush();
+
+        let status =
+            tokio::time::timeout(Duration::from_secs(2), proxy.child.as_mut().unwrap().wait())
+                .await
+                .expect("child did not observe SIGUSR1")
+                .unwrap();
+        assert!(status.success(), "child exited with {status}");
+        assert!(signal_file.exists(), "child did not observe SIGUSR1");
+        proxy.child = None;
+    }
+
     fn usage_target() -> UsageFlushTarget {
         UsageFlushTarget {
             expected_usage_state_id: "state-test".to_string(),
@@ -1797,6 +1886,27 @@ exit 0
         let d = dir.path().to_path_buf();
         assert!(wait_usage_flush(&d, Duration::from_secs(5), &target).await);
         handle.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_usage_flush_requests_flush_when_buffered() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let path = dir.path().join("usage-pending");
+        std::fs::write(&path, usage_state(0, 2, 0)).unwrap();
+        let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let p = path.clone();
+        let requests = std::sync::Arc::clone(&request_count);
+        let d = dir.path().to_path_buf();
+        let flushed = wait_usage_flush_requesting(&d, Duration::from_secs(5), &target, || {
+            requests.fetch_add(1, Ordering::SeqCst);
+            std::fs::write(&p, usage_state(0, 0, 0)).unwrap();
+        })
+        .await;
+
+        assert!(flushed);
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1913,6 +1913,28 @@ while true; do read -r _ <&3 || true; done
     }
 
     #[tokio::test(start_paused = true)]
+    async fn wait_usage_flush_throttles_buffered_flush_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        std::fs::write(dir.path().join("usage-pending"), usage_state(0, 2, 0)).unwrap();
+        let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let requests = std::sync::Arc::clone(&request_count);
+        let flushed = wait_usage_flush_requesting(
+            dir.path(),
+            USAGE_FLUSH_REQUEST_INTERVAL - Duration::from_millis(1),
+            &target,
+            || {
+                requests.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await;
+
+        assert!(!flushed);
+        assert_eq!(request_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn wait_usage_flush_timeout() {
         let dir = tempfile::tempdir().unwrap();
         let target = usage_target();

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -74,9 +74,11 @@ const TEXT_BUSY_SPAWN_MAX_RETRIES: usize = 5;
 
 /// Timeout for graceful shutdown before SIGKILL.
 ///
-/// Must be long enough for `done()` in the mitmproxy addon to flush
-/// all in-flight usage reports (each POST has a 10 s HTTP timeout).
-const STOP_TIMEOUT: Duration = Duration::from_secs(15);
+/// Must be long enough for `done()` in the mitmproxy addon to enqueue buffered
+/// usage and flush one webhook retry cycle (10 s HTTP timeout × 2 attempts plus
+/// 0.5 s backoff). Additional pending reports are still bounded by the
+/// pre-stop usage flush wait below.
+const STOP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Maximum time to wait for pending usage reports to flush before stopping.
 ///


### PR DESCRIPTION
## Summary

- Add a mitm-addon usage-event buffer that aggregates source events by run/kind/provider/category before webhook upload.
- Flush buffered usage on a 30s jittered timer, bounded buffer size, explicit tests, and the mitmproxy done hook.
- Preserve the existing webhook/API contract and direct API-side usage writers; aggregate rows use new immutable idempotency keys.

## Tests

- `cd crates/runner/mitm-addon && pytest tests -q`
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && basedpyright`

Closes #14803
