### PR TITLE
test: remove voice chat feature flag fixture

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2977,7 +2977,7 @@ mod tests {
         let mut ctx = minimal_context();
         let mut flags = HashMap::new();
         flags.insert("computerUse".into(), true);
-        flags.insert("voiceChat".into(), false);
+        flags.insert("audioOutput".into(), false);
         ctx.feature_flags = Some(flags);
         let env = build_env_for_test(&ctx, "http://localhost");
         let raw = env
@@ -2985,7 +2985,7 @@ mod tests {
             .expect("VM0_FEATURE_FLAGS should be set");
         let parsed: HashMap<String, bool> = serde_json::from_str(raw).unwrap();
         assert_eq!(parsed.get("computerUse"), Some(&true));
-        assert_eq!(parsed.get("voiceChat"), Some(&false));
+        assert_eq!(parsed.get("audioOutput"), Some(&false));
     }
 
     #[test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -457,7 +457,7 @@ mod tests {
             "tools": ["Bash", "Read"],
             "settings": "{\"hooks\":{}}",
             "experimentalProfile": "browser",
-            "featureFlags": {"computerUse": true, "voiceChat": false},
+            "featureFlags": {"computerUse": true, "audioOutput": false},
             "billableFirewalls": ["model-provider:vm0"],
             "modelUsageProvider": "claude-sonnet-4-6"
         });
@@ -483,7 +483,7 @@ mod tests {
         assert!(ctx.storage_manifest.is_some());
         let flags = ctx.feature_flags.as_ref().unwrap();
         assert_eq!(flags.get("computerUse"), Some(&true));
-        assert_eq!(flags.get("voiceChat"), Some(&false));
+        assert_eq!(flags.get("audioOutput"), Some(&false));
         assert_eq!(
             ctx.billable_firewalls,
             vec!["model-provider:vm0".to_string()]


### PR DESCRIPTION
## Summary
- replace the remaining runner test fixture `voiceChat` feature flag example with the still-supported `audioOutput` flag
- keep feature flag serialization/deserialization coverage without retaining the removed voice-chat flag name

## DB check
- current schema/latest snapshot no longer declares voice-chat tables
- migration `0397_new_the_hood` drops `voice_chat_items`, `voice_chat_realtime_sessions`, `voice_chat_sessions`, and `voice_chat_tasks`
- local database has no public tables matching voice/trinity/talk patterns after migrations
- historical changelogs and older migrations/snapshots still mention voice-chat by design and were not modified

## Tests
- `cargo test -p runner build_env_json_with_feature_flags`
- `cargo test -p runner execution_context_all_optional_fields`
- `cargo fmt -p runner --check`
- `git diff --check`
- pre-commit crates fmt/doc/clippy via lefthook
