### PR TITLE
fix: protect auth polling loops

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -10,7 +10,7 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
-import { onRef, resetSignal, settle } from "../../utils.ts";
+import { onRef, resetSignal, settle, setLoop } from "../../utils.ts";
 import { writeToClipboard } from "../clipboard.ts";
 
 type CodexDeviceAuthDialogMode = "connect" | "reconnect";
@@ -243,67 +243,84 @@ async function pollCodexDeviceAuth(args: {
   readonly closeDialog: () => void;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  while (Date.now() < activeFlowOrExpired(args.getFlow(), args.requestId)) {
-    const current = args.getFlow();
-    if (!isCurrentActive(current, args.requestId)) {
-      return false;
-    }
+  let completed = false;
+  let expired = false;
 
-    args.setFlow({ ...current, status: "polling" });
-    const completed = await settle(
-      completeCodexDeviceAuth({
-        createClient: args.createClient,
-        sessionToken: current.sessionToken,
-        signal: args.signal,
-      }),
-      args.signal,
-    );
-    args.signal.throwIfAborted();
+  await setLoop(
+    async (signal) => {
+      const remainingMs =
+        activeFlowOrExpired(args.getFlow(), args.requestId) - Date.now();
+      if (remainingMs <= 0) {
+        expired = true;
+        return true;
+      }
 
-    const latest = args.getFlow();
-    if (!isCurrentActive(latest, args.requestId)) {
-      return false;
-    }
+      const current = args.getFlow();
+      if (!isCurrentActive(current, args.requestId)) {
+        return true;
+      }
 
-    if (!completed.ok) {
+      args.setFlow({ ...current, status: "polling" });
+      const completion = await settle(
+        completeCodexDeviceAuth({
+          createClient: args.createClient,
+          sessionToken: current.sessionToken,
+          signal,
+        }),
+        signal,
+      );
+      signal.throwIfAborted();
+
+      const latest = args.getFlow();
+      if (!isCurrentActive(latest, args.requestId)) {
+        return true;
+      }
+
+      if (!completion.ok) {
+        args.setFlow({
+          status: "error",
+          message: codexDeviceAuthErrorMessage(completion.error),
+        });
+        return true;
+      }
+
+      if (completion.value.status === "complete") {
+        args.reloadProviders();
+        toast.success("ChatGPT connected");
+        args.closeDialog();
+        completed = true;
+        return true;
+      }
+
       args.setFlow({
-        status: "error",
-        message: codexDeviceAuthErrorMessage(completed.error),
+        ...latest,
+        status: "pending",
+        errorMessage: completion.value.errorMessage,
       });
+
+      const nextRemainingMs = latest.expiresAtMs - Date.now();
+      if (nextRemainingMs <= 0) {
+        expired = true;
+        return true;
+      }
+      await delay(Math.min(latest.pollIntervalMs, nextRemainingMs), {
+        signal,
+      });
+      signal.throwIfAborted();
       return false;
-    }
-
-    if (completed.value.status === "complete") {
-      args.reloadProviders();
-      toast.success("ChatGPT connected");
-      args.closeDialog();
-      return true;
-    }
-
-    args.setFlow({
-      ...latest,
-      status: "pending",
-      errorMessage: completed.value.errorMessage,
-    });
-
-    const remainingMs = latest.expiresAtMs - Date.now();
-    if (remainingMs <= 0) {
-      break;
-    }
-    await delay(Math.min(latest.pollIntervalMs, remainingMs), {
-      signal: args.signal,
-    });
-    args.signal.throwIfAborted();
-  }
+    },
+    0,
+    args.signal,
+  );
 
   const latest = args.getFlow();
-  if (isCurrentActive(latest, args.requestId)) {
+  if (expired && isCurrentActive(latest, args.requestId)) {
     args.setFlow({
       status: "expired",
       message: "Codex connection session expired. Start again to retry.",
     });
   }
-  return false;
+  return completed;
 }
 
 function activeFlowOrExpired(

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -64,6 +64,7 @@ import {
   onRef,
   resetSignal,
   settle,
+  setLoop,
   withCleanup,
 } from "../../utils.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
@@ -1443,83 +1444,95 @@ const pollConnectorCliAuthBrowserVerification$ = command(
     }: PollConnectorCliAuthBrowserVerificationArgs,
     signal: AbortSignal,
   ): Promise<boolean> => {
-    while (Date.now() < expiresAtMs) {
-      const latest = get(internalConnectorCliAuthState$);
-      if (!isCurrentConnectorCliAuthRequest(latest, type, requestId)) {
-        return false;
-      }
+    let completed = false;
+    let expired = false;
 
-      if (!latest.approvalOpened) {
+    await setLoop(
+      async (sig) => {
         const remainingMs = expiresAtMs - Date.now();
         if (remainingMs <= 0) {
-          break;
+          expired = true;
+          return true;
         }
-        await delay(Math.min(CLI_AUTH_MIN_POLL_INTERVAL_MS, remainingMs), {
-          signal,
-        });
-        signal.throwIfAborted();
-        continue;
-      }
 
-      set(internalConnectorCliAuthState$, {
-        ...latest,
-        status: "polling",
-      });
+        const latest = get(internalConnectorCliAuthState$);
+        if (!isCurrentConnectorCliAuthRequest(latest, type, requestId)) {
+          return true;
+        }
 
-      const completeSettled = await settle(
-        adapter.complete({
-          createClient,
-          sessionToken: latest.sessionToken,
-          signal,
-        }),
-        signal,
-      );
-      const completeResult = completeSettled.ok
-        ? completeSettled.value
-        : {
-            status: "error" as const,
-            message: cliAuthErrorMessage(completeSettled.error),
-          };
+        if (!latest.approvalOpened) {
+          await delay(Math.min(CLI_AUTH_MIN_POLL_INTERVAL_MS, remainingMs), {
+            signal: sig,
+          });
+          sig.throwIfAborted();
+          return false;
+        }
 
-      const current = get(internalConnectorCliAuthState$);
-      if (!isCurrentConnectorCliAuthRequest(current, type, requestId)) {
-        return false;
-      }
-
-      if (completeResult.status === "complete") {
-        return set(finishConnectorCliAuthConnection$, type, options);
-      }
-
-      if (completeResult.status === "error") {
         set(internalConnectorCliAuthState$, {
-          status: "error",
-          connectorType: type,
-          mode: current.mode,
-          message: completeResult.message,
+          ...latest,
+          status: "polling",
         });
+
+        const completeSettled = await settle(
+          adapter.complete({
+            createClient,
+            sessionToken: latest.sessionToken,
+            signal: sig,
+          }),
+          sig,
+        );
+        const completeResult = completeSettled.ok
+          ? completeSettled.value
+          : {
+              status: "error" as const,
+              message: cliAuthErrorMessage(completeSettled.error),
+            };
+
+        const current = get(internalConnectorCliAuthState$);
+        if (!isCurrentConnectorCliAuthRequest(current, type, requestId)) {
+          return true;
+        }
+
+        if (completeResult.status === "complete") {
+          completed = set(finishConnectorCliAuthConnection$, type, options);
+          return true;
+        }
+
+        if (completeResult.status === "error") {
+          set(internalConnectorCliAuthState$, {
+            status: "error",
+            connectorType: type,
+            mode: current.mode,
+            message: completeResult.message,
+          });
+          return true;
+        }
+
+        set(internalConnectorCliAuthState$, {
+          ...current,
+          status: "pending",
+          errorMessage: completeResult.errorMessage
+            ? userFacingConnectorCliAuthMessage(completeResult.errorMessage)
+            : null,
+        });
+
+        const nextRemainingMs = expiresAtMs - Date.now();
+        if (nextRemainingMs <= 0) {
+          expired = true;
+          return true;
+        }
+        await delay(Math.min(pollIntervalMs, nextRemainingMs), {
+          signal: sig,
+        });
+        sig.throwIfAborted();
         return false;
-      }
-
-      set(internalConnectorCliAuthState$, {
-        ...current,
-        status: "pending",
-        errorMessage: completeResult.errorMessage
-          ? userFacingConnectorCliAuthMessage(completeResult.errorMessage)
-          : null,
-      });
-
-      const remainingMs = expiresAtMs - Date.now();
-      if (remainingMs <= 0) {
-        break;
-      }
-      await delay(Math.min(pollIntervalMs, remainingMs), {
-        signal,
-      });
-      signal.throwIfAborted();
-    }
+      },
+      0,
+      signal,
+    );
 
     const latest = get(internalConnectorCliAuthState$);
-    if (isCurrentConnectorCliAuthRequest(latest, type, requestId)) {
+    if (expired && isCurrentConnectorCliAuthRequest(latest, type, requestId)) {
       set(internalConnectorCliAuthState$, {
         status: "expired",
         connectorType: type,
@@ -1527,7 +1540,7 @@ const pollConnectorCliAuthBrowserVerification$ = command(
         message: "Connection session expired. Start again to retry.",
       });
     }
-    return false;
+    return completed;
   },
 );
 
@@ -1765,105 +1778,122 @@ const pollConnectorOAuthDeviceAuth$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const client = createClient(zeroConnectorOauthDeviceAuthSessionContract);
+    let completed = false;
+    let expired = false;
 
-    while (true) {
-      const current = get(internalConnectorOAuthDeviceAuthState$);
-      if (!isCurrentConnectorOAuthDeviceAuthRequest(current, type, requestId)) {
-        return false;
-      }
+    await setLoop(
+      async (sig) => {
+        const current = get(internalConnectorOAuthDeviceAuthState$);
+        if (
+          !isCurrentConnectorOAuthDeviceAuthRequest(current, type, requestId)
+        ) {
+          return true;
+        }
 
-      const remainingMs = current.expiresAtMs - Date.now();
-      if (remainingMs <= 0) {
-        break;
-      }
+        const remainingMs = current.expiresAtMs - Date.now();
+        if (remainingMs <= 0) {
+          expired = true;
+          return true;
+        }
 
-      if (!current.approvalOpened) {
-        await delay(
-          Math.min(OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS, remainingMs),
-          { signal },
-        );
-        signal.throwIfAborted();
-        continue;
-      }
+        if (!current.approvalOpened) {
+          await delay(
+            Math.min(OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS, remainingMs),
+            { signal: sig },
+          );
+          sig.throwIfAborted();
+          return false;
+        }
 
-      set(internalConnectorOAuthDeviceAuthState$, {
-        ...current,
-        status: "polling",
-      });
-
-      const pollSettled = await settle(
-        accept(
-          client.poll({
-            params: { type, sessionId: current.sessionId },
-            body: { sessionToken: current.sessionToken },
-            fetchOptions: { signal },
-          }),
-          [200],
-          { toast: false },
-        ),
-        signal,
-      );
-      const pollResult = pollSettled.ok
-        ? pollSettled.value.body
-        : {
-            status: "error" as const,
-            errorMessage: oauthDeviceAuthErrorMessage(pollSettled.error),
-          };
-
-      const latest = get(internalConnectorOAuthDeviceAuthState$);
-      if (!isCurrentConnectorOAuthDeviceAuthRequest(latest, type, requestId)) {
-        return false;
-      }
-
-      if (pollResult.status === "complete") {
-        set(finishConnectorConnection$, type, {
-          ...options,
-          clearSelectedConnector: true,
-        });
-        set(
-          internalConnectorOAuthDeviceAuthState$,
-          createIdleConnectorOAuthDeviceAuthState(),
-        );
-        return true;
-      }
-
-      if (pollResult.status !== "pending") {
         set(internalConnectorOAuthDeviceAuthState$, {
-          status: pollResult.status,
-          connectorType: type,
-          message: getOAuthDeviceAuthTerminalMessage(pollResult),
+          ...current,
+          status: "polling",
         });
+
+        const pollSettled = await settle(
+          accept(
+            client.poll({
+              params: { type, sessionId: current.sessionId },
+              body: { sessionToken: current.sessionToken },
+              fetchOptions: { signal: sig },
+            }),
+            [200],
+            { toast: false },
+          ),
+          sig,
+        );
+        const pollResult = pollSettled.ok
+          ? pollSettled.value.body
+          : {
+              status: "error" as const,
+              errorMessage: oauthDeviceAuthErrorMessage(pollSettled.error),
+            };
+
+        const latest = get(internalConnectorOAuthDeviceAuthState$);
+        if (
+          !isCurrentConnectorOAuthDeviceAuthRequest(latest, type, requestId)
+        ) {
+          return true;
+        }
+
+        if (pollResult.status === "complete") {
+          set(finishConnectorConnection$, type, {
+            ...options,
+            clearSelectedConnector: true,
+          });
+          set(
+            internalConnectorOAuthDeviceAuthState$,
+            createIdleConnectorOAuthDeviceAuthState(),
+          );
+          completed = true;
+          return true;
+        }
+
+        if (pollResult.status !== "pending") {
+          set(internalConnectorOAuthDeviceAuthState$, {
+            status: pollResult.status,
+            connectorType: type,
+            message: getOAuthDeviceAuthTerminalMessage(pollResult),
+          });
+          return true;
+        }
+
+        const pollIntervalMs = Math.max(
+          secondsToMilliseconds(pollResult.interval),
+          OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS,
+        );
+        set(internalConnectorOAuthDeviceAuthState$, {
+          ...latest,
+          status: "pending",
+          pollIntervalMs,
+          errorMessage: null,
+        });
+
+        const nextRemainingMs = latest.expiresAtMs - Date.now();
+        if (nextRemainingMs <= 0) {
+          expired = true;
+          return true;
+        }
+        await delay(Math.min(pollIntervalMs, nextRemainingMs), { signal: sig });
+        sig.throwIfAborted();
         return false;
-      }
-
-      const pollIntervalMs = Math.max(
-        secondsToMilliseconds(pollResult.interval),
-        OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS,
-      );
-      set(internalConnectorOAuthDeviceAuthState$, {
-        ...latest,
-        status: "pending",
-        pollIntervalMs,
-        errorMessage: null,
-      });
-
-      const nextRemainingMs = latest.expiresAtMs - Date.now();
-      if (nextRemainingMs <= 0) {
-        break;
-      }
-      await delay(Math.min(pollIntervalMs, nextRemainingMs), { signal });
-      signal.throwIfAborted();
-    }
+      },
+      0,
+      signal,
+    );
 
     const latest = get(internalConnectorOAuthDeviceAuthState$);
-    if (isCurrentConnectorOAuthDeviceAuthRequest(latest, type, requestId)) {
+    if (
+      expired &&
+      isCurrentConnectorOAuthDeviceAuthRequest(latest, type, requestId)
+    ) {
       set(internalConnectorOAuthDeviceAuthState$, {
         status: "expired",
         connectorType: type,
         message: "Connection session expired. Start again to retry.",
       });
     }
-    return false;
+    return completed;
   },
 );
 


### PR DESCRIPTION
## Summary
- wrap Stripe CLI auth browser verification polling in `setLoop` while preserving the existing flow signal lifecycle
- wrap connector OAuth device auth and Codex device auth polling in `setLoop`
- keep the existing dynamic per-iteration delays for approval-opened state and provider poll intervals

## Notes
- follows the existing `setLoop(..., signal)` pattern without adding extra `AbortSignal.any` root-signal handling at call sites
- reviewed other loop candidates; streaming/event-driven/data-bounded loops were left unchanged

## Tests
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm vitest run --project=@vm0/app src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx`
- `git diff --check`