### PR TITLE
docs(vsock-proto): document exec control status api

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -56,9 +56,7 @@
 //! `[1B control_flags][16B nonce]` where `control_flags` uses `SINK=0x01`.
 //! `exec_start.stdin_policy` uses 0=no explicit stdin, or 1 followed by
 //! `[4B stdin_len][stdin_bytes]` with a bounded payload.
-//! `exec_control_result.status` uses 0=delivered, 1=inactive,
-//! 2=nonce_mismatch, 3=unsupported, 4=rejected, 5=sink_unavailable,
-//! 6=sink_timeout, 7=queue_full, and 8=sink_error.
+//! `exec_control_result.status` is an [`ExecControlStatus`] wire value.
 //! `exec_control.request_timeout_ms` is the caller-visible budget, counted
 //! from guest receipt through local sink connection, request write, and response
 //! read. Host encoders round non-zero sub-millisecond durations up to 1ms and

--- a/crates/vsock-proto/src/payloads/exec_control.rs
+++ b/crates/vsock-proto/src/payloads/exec_control.rs
@@ -4,35 +4,47 @@ use crate::read::{
     expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
 
+/// Number of bytes in an exec-control nonce.
 pub const EXEC_CONTROL_NONCE_LEN: usize = 16;
 /// Mirrors `process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES` so host-side
 /// encoding rejects requests that the guest-side local IPC channel cannot carry.
 pub const EXEC_CONTROL_MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
 
+/// Opaque token registered with an exec operation and echoed by control messages.
 pub type ExecControlNonce = [u8; EXEC_CONTROL_NONCE_LEN];
 
-const EXEC_CONTROL_STATUS_DELIVERED: u8 = 0x00;
-const EXEC_CONTROL_STATUS_INACTIVE: u8 = 0x01;
-const EXEC_CONTROL_STATUS_NONCE_MISMATCH: u8 = 0x02;
-const EXEC_CONTROL_STATUS_UNSUPPORTED: u8 = 0x03;
-const EXEC_CONTROL_STATUS_REJECTED: u8 = 0x04;
-const EXEC_CONTROL_STATUS_SINK_UNAVAILABLE: u8 = 0x05;
-const EXEC_CONTROL_STATUS_SINK_TIMEOUT: u8 = 0x06;
-const EXEC_CONTROL_STATUS_QUEUE_FULL: u8 = 0x07;
-const EXEC_CONTROL_STATUS_SINK_ERROR: u8 = 0x08;
-
+/// Terminal status carried by the `exec_control_result.status` byte.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecControlStatus {
-    Delivered,
-    Inactive,
-    NonceMismatch,
-    Unsupported,
-    Rejected,
-    SinkUnavailable,
-    SinkTimeout,
-    QueueFull,
-    SinkError,
+    /// Wire value `0x00`: the control request reached the sink and was accepted.
+    Delivered = 0x00,
+    /// Wire value `0x01`: no active exec operation exists for the target sequence.
+    Inactive = 0x01,
+    /// Wire value `0x02`: the target operation exists, but the nonce did not match.
+    NonceMismatch = 0x02,
+    /// Wire value `0x03`: the target operation does not support exec control.
+    Unsupported = 0x03,
+    /// Wire value `0x04`: the sink received the request and rejected it.
+    Rejected = 0x04,
+    /// Wire value `0x05`: the peer reports that the control sink is unavailable.
+    SinkUnavailable = 0x05,
+    /// Wire value `0x06`: the sink did not respond before the request timeout.
+    SinkTimeout = 0x06,
+    /// Wire value `0x07`: the target operation cannot queue another control request.
+    QueueFull = 0x07,
+    /// Wire value `0x08`: the sink failed while processing or exchanging the request.
+    SinkError = 0x08,
 }
+
+const EXEC_CONTROL_STATUS_DELIVERED: u8 = ExecControlStatus::Delivered as u8;
+const EXEC_CONTROL_STATUS_INACTIVE: u8 = ExecControlStatus::Inactive as u8;
+const EXEC_CONTROL_STATUS_NONCE_MISMATCH: u8 = ExecControlStatus::NonceMismatch as u8;
+const EXEC_CONTROL_STATUS_UNSUPPORTED: u8 = ExecControlStatus::Unsupported as u8;
+const EXEC_CONTROL_STATUS_REJECTED: u8 = ExecControlStatus::Rejected as u8;
+const EXEC_CONTROL_STATUS_SINK_UNAVAILABLE: u8 = ExecControlStatus::SinkUnavailable as u8;
+const EXEC_CONTROL_STATUS_SINK_TIMEOUT: u8 = ExecControlStatus::SinkTimeout as u8;
+const EXEC_CONTROL_STATUS_QUEUE_FULL: u8 = ExecControlStatus::QueueFull as u8;
+const EXEC_CONTROL_STATUS_SINK_ERROR: u8 = ExecControlStatus::SinkError as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedControl<'a> {

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1423,6 +1423,29 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
 }
 
 #[test]
+fn exec_control_result_status_wire_values_are_stable() {
+    let cases: &[(ExecControlStatus, u8)] = &[
+        (ExecControlStatus::Delivered, 0x00),
+        (ExecControlStatus::Inactive, 0x01),
+        (ExecControlStatus::NonceMismatch, 0x02),
+        (ExecControlStatus::Unsupported, 0x03),
+        (ExecControlStatus::Rejected, 0x04),
+        (ExecControlStatus::SinkUnavailable, 0x05),
+        (ExecControlStatus::SinkTimeout, 0x06),
+        (ExecControlStatus::QueueFull, 0x07),
+        (ExecControlStatus::SinkError, 0x08),
+    ];
+    let status_offset = 4 + EXEC_CONTROL_NONCE_LEN + 2 + "message".len();
+
+    for &(status, expected_wire) in cases {
+        let payload = encode_exec_control_result(7, NONCE, "message", status, "ok").unwrap();
+
+        assert_eq!(payload[status_offset], expected_wire);
+        assert_eq!(decode_exec_control_result(&payload).unwrap().status, status);
+    }
+}
+
+#[test]
 fn exec_control_result_rejects_truncated_fields() {
     let payload =
         encode_exec_control_result(7, NONCE, "message", ExecControlStatus::Delivered, "ok")


### PR DESCRIPTION
## Summary

- document the public exec-control nonce and status API in `vsock-proto`
- anchor `ExecControlStatus` variants to their protocol wire byte values
- add coverage that every exec-control result status encodes and decodes to the documented byte

Closes #14768.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto exec_control_result -- --nocapture`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
