### PR TITLE
fix: load chat thread video poster frame

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -971,7 +971,7 @@ describe("zero chat thread page display - attachment video preview", () => {
     expect(
       within(previewButton).getByTestId("chat-video-preview-poster"),
     ).toBeInTheDocument();
-    expect(posterVideo?.getAttribute("src")).toBe(videoUrl);
+    expect(posterVideo?.getAttribute("src")).toBe(`${videoUrl}#t=0.001`);
     expect(posterVideo?.hasAttribute("controls")).toBeFalsy();
     expect(
       screen.queryByLabelText("Video preview for clip.mp4"),

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -710,7 +710,7 @@ function VideoLightbox({ filename, url }: { filename: string; url: string }) {
           <IconX size={20} stroke={2} />
         </button>
       </div>
-      <div className="relative z-10 flex w-[min(92vw,1100px)] min-w-0 overflow-hidden rounded-2xl bg-black shadow-2xl animate-in zoom-in-95 duration-200">
+      <div className="relative z-10 flex w-[min(92vw,1100px)] min-w-0 overflow-hidden bg-black shadow-2xl animate-in zoom-in-95 duration-200">
         <video
           src={videoUrl}
           controls

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1124,6 +1124,12 @@ type ChatVideoPreviewButtonProps = {
   videoClassName: string;
 };
 
+function videoPosterFrameUrl(url: string): string {
+  const hashIndex = url.indexOf("#");
+  const urlWithoutHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  return `${urlWithoutHash}#t=0.001`;
+}
+
 function ChatVideoPreviewButton({
   ariaLabel,
   buttonClassName,
@@ -1134,6 +1140,7 @@ function ChatVideoPreviewButton({
   videoClassName,
 }: ChatVideoPreviewButtonProps) {
   const videoUrl = publicAttachmentUrl(url);
+  const posterVideoUrl = videoPosterFrameUrl(videoUrl);
 
   return (
     <button
@@ -1156,7 +1163,7 @@ function ChatVideoPreviewButton({
         <IconVideo size={22} stroke={1.5} />
       </span>
       <video
-        src={videoUrl}
+        src={posterVideoUrl}
         preload="metadata"
         muted
         playsInline


### PR DESCRIPTION
## Summary
- force chat-thread video poster previews to request a decoded first frame on mobile browsers
- keep video lightbox playback on the original attachment URL

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pre-commit: prettier, knip, check-types