### PR TITLE
fix: force new session for queued model switches

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -32,6 +32,7 @@ export interface AppendQueuedMessageArgs {
   clientMessageId: string;
   hasTextContent: boolean;
   modelSelection: ModelSelectionRequest | null;
+  forceNewSession?: boolean;
 }
 
 export interface RecallMessageArgs {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -211,6 +211,18 @@ function formatDonePhrase(lastMsg: PagedChatMessage | undefined): string {
   return pick(time);
 }
 
+function shouldForceNewSessionForModelChange(
+  thread: ChatThread | null,
+  selectedModel: string | undefined,
+): boolean {
+  const threadPinSelectedModel = thread?.selectedModel ?? null;
+  return (
+    threadPinSelectedModel !== null &&
+    selectedModel !== undefined &&
+    threadPinSelectedModel !== selectedModel
+  );
+}
+
 // ---------------------------------------------------------------------------
 // ChatThreadSignals — returned by createChatThreadSignals
 // ---------------------------------------------------------------------------
@@ -1508,11 +1520,10 @@ function createSendMessage(deps: SendMessageDeps) {
       // PROVIDER_INCOMPATIBLE (or "Invalid signature in thinking block") on
       // the runner side. The server then injects prior chat messages into
       // the system prompt so the agent still has conversation context.
-      const threadPinSelectedModel = thread?.selectedModel ?? null;
-      const forceNewSession =
-        threadPinSelectedModel !== null &&
-        effectiveSelectedModel !== undefined &&
-        threadPinSelectedModel !== effectiveSelectedModel;
+      const forceNewSession = shouldForceNewSessionForModelChange(
+        thread,
+        effectiveSelectedModel,
+      );
 
       const client = get(zeroClient$)(chatMessagesContract);
       const [, sendResult] = await Promise.all([
@@ -1584,6 +1595,10 @@ function createQueueMessage(deps: QueueMessageDeps) {
 
     const modelSelection = await get(modelSelection$);
     signal.throwIfAborted();
+    const forceNewSession = shouldForceNewSessionForModelChange(
+      thread,
+      modelSelection?.selectedModel,
+    );
     const result = await set(
       prepareUserMessageFromDraft$,
       draft,
@@ -1616,6 +1631,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         attachFiles: result.attachments,
         createdAt: nowIso,
       },
+      ...(forceNewSession ? { forceNewSession: true } : {}),
     });
     animationFrame(
       () => {
@@ -1636,6 +1652,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
           clientMessageId,
           hasTextContent: result.hasTextContent,
           modelSelection,
+          ...(forceNewSession ? { forceNewSession: true } : {}),
         },
         signal,
       ),

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-messages.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-messages.ts
@@ -7,6 +7,7 @@ export interface OptimisticChatMessageEntry {
   threadId: string;
   message: PagedChatMessage;
   optimisticUserMessageAssociation?: OptimisticUserMessageAssociation;
+  forceNewSession?: boolean;
 }
 
 const internalOptimisticChatMessages$ = state<OptimisticChatMessageEntry[]>([]);

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -123,6 +123,7 @@ async function appendQueuedMessage(
         clientMessageId: append.clientMessageId,
         modelSelection: append.modelSelection,
         attachFiles: append.attachments ?? undefined,
+        ...(append.forceNewSession ? { forceNewSession: true } : {}),
       },
       fetchOptions: { signal },
     }),
@@ -155,6 +156,7 @@ function queuedReplayAppendArgs({
     clientMessageId: entry.message.id,
     hasTextContent: hasTextContentForQueuedReplay(entry.message),
     modelSelection,
+    ...(entry.forceNewSession ? { forceNewSession: true } : {}),
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -54,6 +54,7 @@ const appendQueuedMessage$ = command(
       clientMessageId,
       hasTextContent,
       modelSelection,
+      forceNewSession,
     }: AppendQueuedMessageArgs,
     signal: AbortSignal,
   ) => {
@@ -68,6 +69,7 @@ const appendQueuedMessage$ = command(
           clientMessageId,
           modelSelection,
           attachFiles: attachments ?? undefined,
+          ...(forceNewSession ? { forceNewSession: true } : {}),
         },
         fetchOptions: { signal },
       }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
@@ -45,6 +45,7 @@ const THREAD_ID = "thread-editable-1";
 
 function makeThreadDetail(
   overrides: Partial<{
+    activeRunIds: string[];
     modelProviderId: string | null;
     selectedModel: string | null;
   }> = {},
@@ -234,6 +235,64 @@ describe("chat thread page — model picker editable", () => {
       user,
       textarea as HTMLTextAreaElement,
       "Use Opus now",
+    );
+
+    await waitFor(() => {
+      expect(capturedBody).toBeDefined();
+    });
+    expect(capturedBody?.modelSelection?.selectedModel).toBe("claude-opus-4-7");
+    expect(capturedBody?.forceNewSession).toBeTruthy();
+  });
+
+  // CHAT-MODEL-EDIT-006: queued sends share the same model-switch semantics as
+  // direct sends so the backend can start a compatible CLI session.
+  it("sends forceNewSession for queued messages after changing model on an active thread (CHAT-MODEL-EDIT-006)", async () => {
+    const user = userEvent.setup();
+    let capturedBody:
+      | {
+          modelSelection?: {
+            modelProviderId: string;
+            selectedModel: string;
+          } | null;
+          forceNewSession?: boolean;
+        }
+      | undefined;
+
+    setupMocks([makeUserMessage()], {
+      activeRunIds: ["run-active-1"],
+      selectedModel: "claude-sonnet-4-6",
+    });
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedBody = {
+          modelSelection:
+            "modelSelection" in body ? body.modelSelection : undefined,
+          forceNewSession:
+            "forceNewSession" in body ? body.forceNewSession : undefined,
+        };
+        return respond(201, {
+          runId: null,
+          threadId: THREAD_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await user.click(
+      await screen.findByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+    );
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Opus 4\.7/i }),
+    );
+    const textarea = await screen.findByPlaceholderText(
+      /Type your next message/,
+    );
+    await sendMessageInUI(
+      user,
+      textarea as HTMLTextAreaElement,
+      "Queue this on Opus",
     );
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- carry forceNewSession through queued chat message args and remote sends
- preserve the flag on optimistic queued messages so replay uses the same model-switch semantics
- cover active-thread queued sends after changing the model

## Tests
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pre-commit: turbo run check-types --concurrency=1