### PR TITLE
test: cover idle destroy stop errors

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -335,6 +335,7 @@ mod tests {
 
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        assert_eq!(budget.allocated(), (2, 4096, 1));
         let candidate =
             ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
                 sandbox,

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -313,4 +313,51 @@ mod tests {
         assert_eq!(destroy_count.load(Ordering::SeqCst), 1);
         assert_eq!(budget.allocated(), (0, 0, 0));
     }
+
+    #[tokio::test]
+    async fn idle_stop_error_still_attempts_destroy_and_releases_budget_lease() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_stop_result(Err(sandbox::SandboxError::Start {
+            message: "simulated idle stop failure".into(),
+        }));
+        let sandbox_factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let sandbox = sandbox_factory
+            .create(sandbox::SandboxConfig {
+                id: SandboxId::new_v4(),
+                resources: sandbox::ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 4096,
+                },
+                device_rate_limits: None,
+            })
+            .await
+            .expect("create sandbox");
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox,
+                factory: Arc::new(Box::new(sandbox_factory) as Box<dyn SandboxFactory>),
+                session_id: "sess-stop-error".into(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default".into(),
+                device_rate_limits: None,
+                budget_lease: lease,
+                source_ip: "10.0.0.1".into(),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            });
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let mut jobs = pool.drain();
+        assert_eq!(jobs.len(), 1);
+
+        jobs.pop().unwrap().run().await;
+
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -911,6 +911,26 @@ mod tests {
         }
     }
 
+    async fn make_idle_destroy_payload(overrides: Arc<MockSandboxOverrides>) -> IdleDestroyPayload {
+        let sandbox_id = SandboxId::new_v4();
+        let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
+            MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
+        ));
+        let sandbox = factory
+            .create(SandboxConfig {
+                id: sandbox_id,
+                resources: ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 4096,
+                },
+                device_rate_limits: None,
+            })
+            .await
+            .expect("create sandbox");
+
+        IdleDestroyPayload { sandbox, factory }
+    }
+
     async fn make_idle_park_request(
         overrides: Arc<MockSandboxOverrides>,
         session_id: &str,
@@ -941,6 +961,32 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
         })
+    }
+
+    #[tokio::test]
+    async fn idle_destroy_payload_stop_error_completes_after_destroy() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_stop_result(Err(sandbox::SandboxError::Start {
+            message: "simulated idle stop failure".into(),
+        }));
+        let payload = make_idle_destroy_payload(Arc::clone(&overrides)).await;
+
+        let outcome = payload.stop_and_destroy().await;
+
+        assert_eq!(outcome, DestroyOutcome::Completed);
+        assert_eq!(overrides.destroy_call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn idle_destroy_payload_stop_panic_is_uncertain_after_destroy() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_stop_panic("simulated idle stop panic");
+        let payload = make_idle_destroy_payload(Arc::clone(&overrides)).await;
+
+        let outcome = payload.stop_and_destroy().await;
+
+        assert_eq!(outcome, DestroyOutcome::Uncertain);
+        assert_eq!(overrides.destroy_call_count(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add payload-level idle destroy tests for non-panic stop errors and stop panics
- assert non-panic stop errors still complete after destroy, while panics remain uncertain
- add idle job coverage for budget lease release after a non-panic stop error

Closes #14769

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner idle_pool::tests::idle_destroy_payload_stop_error_completes_after_destroy
- cargo test --manifest-path crates/Cargo.toml -p runner idle_pool::tests::idle_destroy_payload_stop_panic_is_uncertain_after_destroy
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::idle_lifecycle::tests::idle_stop_error_still_attempts_destroy_and_releases_budget_lease
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings