### PR TITLE
fix: render connector connect links as action cards

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
@@ -196,6 +196,25 @@ describe("parseBodyRenderBlocks", () => {
     });
   });
 
+  it("renders markdown connector connect links with agent IDs as connector action blocks", () => {
+    const url =
+      "https://app.vm0.ai/connectors/strapi/connect?agentId=4f189ea8-ada2-416d-83a9-9c25ddb960c9";
+
+    const { cleanContent, blocks } = parseBodyRenderBlocks(
+      `[Connect and authorize Strapi](${url})`,
+    );
+
+    expect(cleanContent).toBe("");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "connector-action",
+      id: "connector-action-1",
+      connectorType: "strapi",
+      agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+      originalUrl: url,
+    });
+  });
+
   it("does not render external connector authorize URLs as action blocks", () => {
     const url =
       "https://evil.example/connectors/strapi/authorize?agentId=4f189ea8-ada2-416d-83a9-9c25ddb960c9";

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -86,7 +86,9 @@ export function parseConnectorAuthorizeUrl(
     return null;
   }
 
-  const match = url.pathname.match(/^\/connectors\/([^/]+)\/authorize$/);
+  const match = url.pathname.match(
+    /^\/connectors\/([^/]+)\/(?:authorize|connect)$/,
+  );
   const connectorType = match?.[1]?.toLowerCase();
   const agentId = url.searchParams.get("agentId");
   if (!connectorType || !agentId || !isConnectorType(connectorType)) {


### PR DESCRIPTION
## Summary
- Treat `/connect` connector URLs with `agentId` the same as `/authorize` URLs in chat body parsing.
- Add coverage for markdown connector connect links rendering as connector action blocks.

## Test
- `cd turbo/apps/platform && timeout 90s pnpm exec vitest run src/signals/chat-page/__tests__/parse-body-blocks.test.ts --reporter verbose --pool=forks --fileParallelism=false`

Closes the remaining useful delta from #14862.