### PR TITLE
ci: enable sccache for runner image builds

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -206,8 +206,13 @@ jobs:
     env:
       TARGET_TRIPLE: aarch64-unknown-linux-musl
       PROFILE: vm0/default
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -245,6 +250,11 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
         run: .github/scripts/prepare-runner-image.sh
+
+      - name: Show sccache stats
+        if: always()
+        shell: bash
+        run: ${SCCACHE_PATH:-sccache} --show-stats
 
       - name: Validate manifest
         env:

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -213,6 +213,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.15.0"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -206,15 +206,32 @@ jobs:
     env:
       TARGET_TRIPLE: aarch64-unknown-linux-musl
       PROFILE: vm0/default
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
 
       - uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: "v0.15.0"
+
+      - name: Configure sccache
+        id: sccache
+        shell: bash
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: |
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+
+          if ${SCCACHE_PATH:-sccache} --start-server; then
+            {
+              echo "SCCACHE_GHA_ENABLED=true"
+              echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1"
+              echo "RUSTC_WRAPPER=sccache"
+            } >> "$GITHUB_ENV"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::sccache server failed to start; building without sccache"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -254,7 +271,7 @@ jobs:
         run: .github/scripts/prepare-runner-image.sh
 
       - name: Show sccache stats
-        if: always()
+        if: always() && steps.sccache.outputs.enabled == 'true'
         shell: bash
         run: ${SCCACHE_PATH:-sccache} --show-stats
 

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -214,24 +214,23 @@ jobs:
           version: "v0.15.0"
 
       - name: Configure sccache
-        id: sccache
         shell: bash
         env:
           SCCACHE_GHA_ENABLED: "true"
         run: |
-          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+          SCCACHE_CONF_PATH="${RUNNER_TEMP:-/tmp}/sccache.toml"
+          cat > "$SCCACHE_CONF_PATH" <<'EOF'
+          server_startup_timeout_ms = 60000
+          EOF
 
-          if ${SCCACHE_PATH:-sccache} --start-server; then
-            {
-              echo "SCCACHE_GHA_ENABLED=true"
-              echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1"
-              echo "RUSTC_WRAPPER=sccache"
-            } >> "$GITHUB_ENV"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::sccache server failed to start; building without sccache"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+          SCCACHE_CONF="$SCCACHE_CONF_PATH" ${SCCACHE_PATH:-sccache} --start-server
+
+          {
+            echo "CARGO_INCREMENTAL=0"
+            echo "SCCACHE_CONF=$SCCACHE_CONF_PATH"
+            echo "SCCACHE_GHA_ENABLED=true"
+            echo "RUSTC_WRAPPER=sccache"
+          } >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -271,7 +270,7 @@ jobs:
         run: .github/scripts/prepare-runner-image.sh
 
       - name: Show sccache stats
-        if: always() && steps.sccache.outputs.enabled == 'true'
+        if: always()
         shell: bash
         run: ${SCCACHE_PATH:-sccache} --show-stats
 

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -269,11 +269,6 @@ jobs:
           R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
         run: .github/scripts/prepare-runner-image.sh
 
-      - name: Show sccache stats
-        if: always()
-        shell: bash
-        run: ${SCCACHE_PATH:-sccache} --show-stats
-
       - name: Validate manifest
         env:
           MANIFEST_PATH: runner-image-manifest/manifest.json


### PR DESCRIPTION
## Summary

- enable sccache in the Runner Image build job using the GitHub Actions cache backend
- keep the existing Swatinem rust-cache step for Cargo cache coverage
- print explicit sccache stats after the runner image build step

Closes #14867

## Tests

- git diff --check
- python3 yaml.safe_load(.github/workflows/runner-image.yml)
- actionlint .github/workflows/runner-image.yml