### PR TITLE
fix: force fresh X OAuth login

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
@@ -254,6 +254,7 @@ describe("GET /api/connectors/:type/authorize", () => {
     expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("force_login")).toBe("true");
     expect(url.searchParams.get("state")).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -521,6 +521,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(url.searchParams.get("client_id")).toBe("x-test-client-id");
     expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("force_login")).toBe("true");
   });
 
   it("deletes existing local connector state before reauthorization", async () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/x.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/x.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { buildXAuthorizationUrl } from "../x";
+
+describe("buildXAuthorizationUrl", () => {
+  it("requests a fresh X login when building the OAuth URL", async () => {
+    const authorizationUrl = new URL(
+      await buildXAuthorizationUrl(
+        "x-client-id",
+        "https://app.vm0.ai/api/connectors/x/callback",
+        "state-123",
+      ),
+    );
+
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://twitter.com/i/oauth2/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("x-client-id");
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.ai/api/connectors/x/callback",
+    );
+    expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
+    expect(authorizationUrl.searchParams.get("code_challenge")).toMatch(
+      /^[A-Za-z0-9_-]+$/,
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256",
+    );
+    expect(authorizationUrl.searchParams.get("force_login")).toBe("true");
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
@@ -80,6 +80,7 @@ export async function buildXAuthorizationUrl(
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
+    force_login: "true",
   });
 
   return `${X_AUTHORIZATION_URL}?${params.toString()}`;


### PR DESCRIPTION
## Summary
- Add `force_login=true` to the X OAuth2 authorization URL so reconnect attempts ask X for a fresh login when supported
- Cover the new X authorization parameter in the direct and zero connector authorize route tests
- Add a provider-level unit test for the X authorization URL

## Verification
- `pnpm vitest --run packages/connectors/src/auth-providers/oauth/providers/__tests__/x.test.ts`
- `pnpm prettier --check packages/connectors/src/auth-providers/oauth/providers/x.ts packages/connectors/src/auth-providers/oauth/providers/__tests__/x.test.ts apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts`

## Notes
- X documents `force_login` for older Twitter OAuth authorization flows, but not for the current OAuth2 `/i/oauth2/authorize` endpoint. This is intentionally low-risk because unsupported OAuth query parameters should be ignored by the provider, while supported behavior should let users switch accounts.
- The route-level vitest files require a local Postgres on port 5432 in this environment; without it they fail with `ECONNREFUSED 127.0.0.1:5432`.

Fixes #14849