### PR TITLE
feat: add Open Design artifact generation commands

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -742,4 +742,48 @@ describe("built-in generate feature switch visibility", () => {
 
     expect(visibleCommandNames(generateCommand)).toContain("website");
   });
+
+  it("should hide Open Design artifact generation when openDesignGenerate is disabled", async () => {
+    const token = buildZeroToken({
+      userId: "user-non-staff",
+      orgId: "org-non-staff",
+      scope: "zero",
+      capabilities: ["host:write"],
+      featureSwitches: { [FeatureSwitchKey.OpenDesignGenerate]: false },
+    });
+
+    const generateCommand = await importGenerateCommand(token);
+
+    expect(visibleCommandNames(generateCommand)).not.toContain("report");
+    expect(visibleCommandNames(generateCommand)).not.toContain("docs-design");
+    expect(visibleCommandNames(generateCommand)).not.toContain("poster");
+    expect(visibleCommandNames(generateCommand)).not.toContain(
+      "dashboard-design",
+    );
+    expect(visibleCommandNames(generateCommand)).not.toContain(
+      "mobile-app-design",
+    );
+  });
+
+  it("should show Open Design artifact generation when openDesignGenerate is enabled", async () => {
+    const token = buildZeroToken({
+      userId: "user-enabled",
+      orgId: "org-non-staff",
+      scope: "zero",
+      capabilities: ["host:write"],
+      featureSwitches: { [FeatureSwitchKey.OpenDesignGenerate]: true },
+    });
+
+    const generateCommand = await importGenerateCommand(token);
+
+    expect(visibleCommandNames(generateCommand)).toEqual(
+      expect.arrayContaining([
+        "report",
+        "docs-design",
+        "poster",
+        "dashboard-design",
+        "mobile-app-design",
+      ]),
+    );
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/open-design-artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/open-design-artifacts.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import chalk from "chalk";
+import { zeroBuiltInCommand } from "../../index";
+
+function buildZeroToken(openDesignGenerate: boolean): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(
+    JSON.stringify({
+      userId: "user-1",
+      runId: "run-1",
+      orgId: "org-1",
+      scope: "zero",
+      capabilities: ["host:write"],
+      featureSwitches: {
+        [FeatureSwitchKey.OpenDesignGenerate]: openDesignGenerate,
+      },
+      iat: 1_700_000_000,
+      exp: 1_700_007_200,
+    }),
+  ).toString("base64url");
+  return `vm0_sandbox_${header}.${body}.test-signature`;
+}
+
+describe("zero built-in generate Open Design artifact commands", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("ZERO_TOKEN", buildZeroToken(true));
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  function output(): string {
+    return mockConsoleLog.mock.calls.flat().join("\n");
+  }
+
+  it.each([
+    {
+      command: "report",
+      prompt: "Q2 generation usage report",
+      template: "od:template:finance-report",
+    },
+    {
+      command: "docs-design",
+      prompt: "Docs for adding built-in artifact targets",
+      template: "od:template:docs-page",
+    },
+    {
+      command: "poster",
+      prompt: "A poster for Open Design generation",
+      template: "od:template:html-ppt-zhangzara-retro-zine",
+    },
+    {
+      command: "dashboard-design",
+      prompt: "A dashboard for generation run health",
+      template: "od:template:dashboard",
+    },
+    {
+      command: "mobile-app-design",
+      prompt: "A mobile app design for reviewing generated artifacts",
+      template: "od:template:mobile-app",
+    },
+  ])(
+    "prints an Open Design resource selection packet for $command",
+    async ({ command, prompt, template }) => {
+      await zeroBuiltInCommand.parseAsync([
+        "node",
+        "cli",
+        "generate",
+        command,
+        "--prompt",
+        prompt,
+        "--site",
+        `${command}-demo`,
+        "--title",
+        `${command} demo`,
+        "--audience",
+        "internal product team",
+      ]);
+
+      const stdout = output();
+      expect(stdout).toContain(`# Zero built-in generate ${command}`);
+      expect(stdout).toContain("Open Design resource-selection packet");
+      expect(stdout).toContain(prompt);
+      expect(stdout).toContain(template);
+      expect(stdout).toContain(`Artifact kind: ${command}`);
+      expect(stdout).toContain(
+        `Write the artifact under \`./opendesign/mockups/${command}-demo/\`.`,
+      );
+      expect(stdout).toContain(
+        `zero host ./opendesign/mockups/${command}-demo --site ${command}-demo`,
+      );
+    },
+  );
+
+  it("prints JSON metadata for mobile-app-design", async () => {
+    await zeroBuiltInCommand.parseAsync([
+      "node",
+      "cli",
+      "generate",
+      "mobile-app-design",
+      "--prompt",
+      "A mobile review screen",
+      "--site",
+      "mobile-review",
+      "--json",
+    ]);
+
+    const parsed = JSON.parse(output()) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      type: "open-design-resource-selection",
+      kind: "mobile-app-design",
+      prompt: "A mobile review screen",
+      outputDir: "./opendesign/mockups/mobile-review",
+      site: "mobile-review",
+    });
+  });
+
+  it("rejects Open Design artifact generation when the feature is disabled", async () => {
+    vi.stubEnv("ZERO_TOKEN", buildZeroToken(false));
+
+    await expect(async () => {
+      await zeroBuiltInCommand.parseAsync([
+        "node",
+        "cli",
+        "generate",
+        "report",
+        "--prompt",
+        "Q2 report",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("requires the openDesignGenerate feature switch"),
+    );
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/index.ts
@@ -2,6 +2,13 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Command } from "commander";
 import { zeroTokenAllowsFeatureSwitch } from "../../../../lib/api/zero-token";
 import { imageCommand } from "./image";
+import {
+  dashboardDesignCommand,
+  docsDesignCommand,
+  mobileAppDesignCommand,
+  posterCommand,
+  reportCommand,
+} from "./open-design-artifacts";
 import { presentationCommand } from "./presentation";
 import { videoCommand } from "./video";
 import { websiteCommand } from "./website";
@@ -11,6 +18,12 @@ function buildGenerateHelpText(): string {
   const examples = [
     '  Generate image:   zero built-in generate image --prompt "A watercolor fox"',
     '  Generate deck:    zero built-in generate presentation --prompt "A product roadmap"',
+    ...(zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.OpenDesignGenerate)
+      ? [
+          '  Generate report:  zero built-in generate report --prompt "A Q2 usage report"',
+          '  Generate docs:    zero built-in generate docs-design --prompt "A setup guide"',
+        ]
+      : []),
     '  Generate video:   zero built-in generate video --prompt "A cinematic city shot"',
     ...(zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.HostedSites)
       ? [
@@ -23,11 +36,22 @@ function buildGenerateHelpText(): string {
   return `\nExamples:\n${examples.join("\n")}`;
 }
 
+const openDesignCommandOptions = zeroTokenAllowsFeatureSwitch(
+  FeatureSwitchKey.OpenDesignGenerate,
+)
+  ? {}
+  : { hidden: true };
+
 export const generateCommand = new Command()
   .name("generate")
   .description("Generate assets with built-in vm0 services")
   .addCommand(imageCommand)
   .addCommand(presentationCommand)
+  .addCommand(reportCommand, openDesignCommandOptions)
+  .addCommand(docsDesignCommand, openDesignCommandOptions)
+  .addCommand(posterCommand, openDesignCommandOptions)
+  .addCommand(dashboardDesignCommand, openDesignCommandOptions)
+  .addCommand(mobileAppDesignCommand, openDesignCommandOptions)
   .addCommand(videoCommand)
   .addCommand(
     websiteCommand,

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/open-design-artifacts.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/open-design-artifacts.ts
@@ -1,0 +1,92 @@
+import { createOpenDesignArtifactGenerateCommand } from "../../shared/open-design-artifact-generate";
+
+function standardDetails(kind: string) {
+  return (options: { title?: string; audience?: string }) => {
+    return [
+      `Artifact kind: ${kind}`,
+      `Requested title/name: ${options.title ?? "not specified"}`,
+      `Audience: ${options.audience ?? "not specified"}`,
+    ];
+  };
+}
+
+export const reportCommand = createOpenDesignArtifactGenerateCommand({
+  name: "report",
+  target: "report",
+  description: "Generate an Open Design HTML report from a prompt",
+  usageCommand: "zero built-in generate report",
+  examples: `  Generate report:      zero built-in generate report --prompt "A Q2 usage report for the API team"
+  Stable hosted slug:    zero built-in generate report --site api-usage-q2 --prompt "A Q2 usage report"`,
+  details: standardDetails("report"),
+  artifactRules: [
+    "Produce an analytical report, not a marketing page.",
+    "Use concrete metrics, tables, chart-like visuals, and a clear findings section.",
+    "Keep source assumptions visible when the prompt does not provide real data.",
+    "Verify the report is readable at desktop and mobile widths.",
+  ],
+});
+
+export const docsDesignCommand = createOpenDesignArtifactGenerateCommand({
+  name: "docs-design",
+  target: "docs-design",
+  description: "Generate an Open Design documentation design from a prompt",
+  usageCommand: "zero built-in generate docs-design",
+  examples: `  Generate docs design: zero built-in generate docs-design --prompt "Docs for adding OpenDesign artifact targets"
+  Stable hosted slug:    zero built-in generate docs-design --site opendesign-target-docs --prompt "OpenDesign target docs"`,
+  details: standardDetails("docs-design"),
+  artifactRules: [
+    "Produce a documentation design mockup, not a production documentation system.",
+    "Include navigation, article structure, code or command examples when relevant, and clear section anchors as static design content.",
+    "Use restrained documentation styling optimized for long-form reading.",
+    "Verify the page works at mobile and desktop widths.",
+  ],
+});
+
+export const posterCommand = createOpenDesignArtifactGenerateCommand({
+  name: "poster",
+  target: "poster",
+  description: "Generate an Open Design HTML poster from a prompt",
+  usageCommand: "zero built-in generate poster",
+  examples: `  Generate poster:      zero built-in generate poster --prompt "A launch poster for OpenDesign artifact targets"
+  Stable hosted slug:    zero built-in generate poster --site opendesign-poster --prompt "A launch poster"`,
+  details: standardDetails("poster"),
+  artifactRules: [
+    "Produce a poster-style HTML artifact with strong hierarchy and composition.",
+    "Treat this as an HTML poster surface; do not imply a raster image was generated unless image assets are actually created.",
+    "Make the poster responsive enough to inspect on mobile and desktop.",
+    "Keep text deliberate and avoid placeholder copy.",
+  ],
+});
+
+export const dashboardDesignCommand = createOpenDesignArtifactGenerateCommand({
+  name: "dashboard-design",
+  target: "dashboard-design",
+  description: "Generate an Open Design dashboard design from a prompt",
+  usageCommand: "zero built-in generate dashboard-design",
+  examples: `  Generate dash design: zero built-in generate dashboard-design --prompt "An ops dashboard for generation runs"
+  Stable hosted slug:    zero built-in generate dashboard-design --site generation-ops --prompt "A generation ops dashboard"`,
+  details: standardDetails("dashboard-design"),
+  artifactRules: [
+    "Produce a dashboard design mockup, not a live operational dashboard.",
+    "Include scannable KPIs, chart-like visuals, lists or tables, and realistic empty/loading/error states as static design content.",
+    "Prioritize dense, repeat-use UI over decorative sections.",
+    "Verify the dashboard does not overflow at desktop and mobile widths.",
+  ],
+});
+
+export const mobileAppDesignCommand = createOpenDesignArtifactGenerateCommand({
+  name: "mobile-app-design",
+  target: "mobile-app-design",
+  description:
+    "Generate an Open Design mobile app design prototype from a prompt",
+  usageCommand: "zero built-in generate mobile-app-design",
+  examples: `  Generate mobile UI:   zero built-in generate mobile-app-design --prompt "A mobile review screen for generation artifacts"
+  Stable hosted slug:    zero built-in generate mobile-app-design --site generation-mobile-review --prompt "A mobile review screen"`,
+  details: standardDetails("mobile-app-design"),
+  artifactRules: [
+    "Produce a design prototype, not a runnable or installable mobile app.",
+    "Render the design inside a realistic phone frame with status bar, device chrome, and home indicator when possible.",
+    "Focus on one mobile screen and one primary job.",
+    "Use mobile-appropriate tap targets, type sizes, and spacing.",
+  ],
+});

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
@@ -282,6 +282,37 @@ describe("zero doctor generate command", () => {
     expect(text).not.toContain("Official provider:");
   });
 
+  it.each([
+    ["report", "Report", "Built-in report generation"],
+    ["docs-design", "Docs design", "Built-in docs design generation"],
+    ["poster", "Poster", "Built-in poster generation"],
+    [
+      "dashboard-design",
+      "Dashboard design",
+      "Built-in dashboard design generation",
+    ],
+    [
+      "mobile-app-design",
+      "Mobile app design",
+      "Built-in mobile app design generation",
+    ],
+  ])("suggests the built-in %s command", async (type, label, commandLabel) => {
+    server.use(
+      stubConnectorsWithConfiguredTypes([], []),
+      stubUserConnectors([]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", type]);
+
+    const text = output();
+    expect(text).toContain(`${label} generation choices for current agent`);
+    expect(text).not.toContain(`No ready ${type} generation connectors found.`);
+    expect(text).toContain("Built-in command:");
+    expect(text).toContain(commandLabel);
+    expect(text).toContain("Models: gpt-5.5");
+    expect(text).toContain(`Use: zero built-in generate ${type} -h`);
+  });
+
   it("suggests the built-in voice command when no voice connector is ready", async () => {
     server.use(
       stubConnectorsWithConfiguredTypes(

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -7,16 +7,23 @@ import {
   type ConnectorGenerationType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { getConnectorGenerationTypes } from "@vm0/connectors/connector-utils";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
 import { listZeroConnectors } from "../../../lib/api/domains/zero-connectors";
+import { zeroTokenAllowsFeatureSwitch } from "../../../lib/api/zero-token";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
 
 type BuiltInGenerationType =
+  | "dashboard-design"
+  | "docs-design"
   | "image"
+  | "mobile-app-design"
+  | "poster"
   | "presentation"
+  | "report"
   | "video"
   | "voice"
   | "website";
@@ -96,6 +103,46 @@ const BUILT_IN_GENERATION_PROVIDERS: Partial<
       reason: "available without connector setup",
     },
   ],
+  report: [
+    {
+      label: "Built-in",
+      model: "gpt-5.5",
+      command: "zero built-in generate report -h",
+      reason: "available without connector setup",
+    },
+  ],
+  "docs-design": [
+    {
+      label: "Built-in",
+      model: "gpt-5.5",
+      command: "zero built-in generate docs-design -h",
+      reason: "available without connector setup",
+    },
+  ],
+  poster: [
+    {
+      label: "Built-in",
+      model: "gpt-5.5",
+      command: "zero built-in generate poster -h",
+      reason: "available without connector setup",
+    },
+  ],
+  "dashboard-design": [
+    {
+      label: "Built-in",
+      model: "gpt-5.5",
+      command: "zero built-in generate dashboard-design -h",
+      reason: "available without connector setup",
+    },
+  ],
+  "mobile-app-design": [
+    {
+      label: "Built-in",
+      model: "gpt-5.5",
+      command: "zero built-in generate mobile-app-design -h",
+      reason: "available without connector setup",
+    },
+  ],
   website: [
     {
       label: "Built-in",
@@ -167,6 +214,31 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
     command: "zero built-in generate presentation -h",
     models: "gpt-5.5",
   },
+  report: {
+    label: "Built-in report generation",
+    command: "zero built-in generate report -h",
+    models: "gpt-5.5",
+  },
+  "docs-design": {
+    label: "Built-in docs design generation",
+    command: "zero built-in generate docs-design -h",
+    models: "gpt-5.5",
+  },
+  poster: {
+    label: "Built-in poster generation",
+    command: "zero built-in generate poster -h",
+    models: "gpt-5.5",
+  },
+  "dashboard-design": {
+    label: "Built-in dashboard design generation",
+    command: "zero built-in generate dashboard-design -h",
+    models: "gpt-5.5",
+  },
+  "mobile-app-design": {
+    label: "Built-in mobile app design generation",
+    command: "zero built-in generate mobile-app-design -h",
+    models: "gpt-5.5",
+  },
   website: {
     label: "Built-in website generation",
     command: "zero built-in generate website -h",
@@ -189,14 +261,24 @@ const GENERATION_TYPE_ORDER: readonly DoctorGenerationType[] = [
   "document",
   "presentation",
   "website",
+  "report",
+  "docs-design",
+  "poster",
+  "dashboard-design",
+  "mobile-app-design",
 ];
 
 const GENERATION_TYPE_LABELS: Record<DoctorGenerationType, string> = {
   audio: "Audio",
   code: "Code",
+  "dashboard-design": "Dashboard design",
   document: "Document",
+  "docs-design": "Docs design",
   image: "Image",
+  "mobile-app-design": "Mobile app design",
+  poster: "Poster",
   presentation: "Presentation",
+  report: "Report",
   text: "Text",
   video: "Video",
   voice: "Voice",
@@ -230,24 +312,64 @@ interface GenerationCandidate {
 
 function getConnectorGenerationType(
   generationType: DoctorGenerationType,
-): ConnectorGenerationType {
-  if (generationType === "voice") {
-    return "audio";
+): ConnectorGenerationType | null {
+  switch (generationType) {
+    case "voice":
+      return "audio";
+    case "dashboard-design":
+    case "docs-design":
+    case "mobile-app-design":
+    case "poster":
+    case "report":
+      return null;
+    case "audio":
+    case "code":
+    case "document":
+    case "image":
+    case "presentation":
+    case "text":
+    case "video":
+    case "website":
+      return generationType;
   }
-
-  return generationType;
 }
 
 function getBuiltInProviders(
   generationType: DoctorGenerationType,
 ): readonly BuiltInGenerationProvider[] {
+  if (
+    isOpenDesignArtifactGenerationType(generationType) &&
+    !zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.OpenDesignGenerate)
+  ) {
+    return [];
+  }
+
   return BUILT_IN_GENERATION_PROVIDERS[generationType] ?? [];
 }
 
 function getBuiltInCommand(
   generationType: DoctorGenerationType,
 ): BuiltInGenerationCommand | null {
+  if (
+    isOpenDesignArtifactGenerationType(generationType) &&
+    !zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.OpenDesignGenerate)
+  ) {
+    return null;
+  }
+
   return BUILT_IN_GENERATION_COMMANDS[generationType] ?? null;
+}
+
+function isOpenDesignArtifactGenerationType(
+  generationType: DoctorGenerationType,
+): boolean {
+  return (
+    generationType === "dashboard-design" ||
+    generationType === "docs-design" ||
+    generationType === "mobile-app-design" ||
+    generationType === "poster" ||
+    generationType === "report"
+  );
 }
 
 function getAvailableGenerationTypes(): DoctorGenerationType[] {
@@ -259,9 +381,11 @@ function getAvailableGenerationTypes(): DoctorGenerationType[] {
   }
 
   return GENERATION_TYPE_ORDER.filter((type) => {
+    const connectorGenerationType = getConnectorGenerationType(type);
     return (
       getBuiltInProviders(type).length > 0 ||
-      available.has(getConnectorGenerationType(type))
+      (connectorGenerationType !== null &&
+        available.has(connectorGenerationType))
     );
   });
 }
@@ -533,19 +657,21 @@ export const generateCommand = new Command()
       );
       const configuredTypes = new Set(connectorList.configuredTypes);
       const authorizedTypes = enabledTypes ? new Set(enabledTypes) : null;
-      const candidates = getGenerationConnectors(connectorGenerationType).map(
-        ([connectorType, config]) => {
-          return toCandidate({
-            type: connectorType,
-            config,
-            connector: connectedMap.get(connectorType),
-            configuredTypes,
-            authorizedTypes,
-            agentId,
-            platformOrigin,
-          });
-        },
-      );
+      const candidates = connectorGenerationType
+        ? getGenerationConnectors(connectorGenerationType).map(
+            ([connectorType, config]) => {
+              return toCandidate({
+                type: connectorType,
+                config,
+                connector: connectedMap.get(connectorType),
+                configuredTypes,
+                authorizedTypes,
+                agentId,
+                platformOrigin,
+              });
+            },
+          )
+        : [];
       const ready = candidates.filter((candidate) => {
         return candidate.status === "ready";
       });

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -54,12 +54,12 @@ function titleForKind(kind: HtmlArtifactKind): string {
   const titles: Record<HtmlArtifactKind, string> = {
     presentation: "HTML presentation",
     website: "hosted website",
-    dashboard: "dashboard",
-    "mobile-app": "mobile app prototype",
+    "dashboard-design": "dashboard design prototype",
+    "mobile-app-design": "mobile app design prototype",
     poster: "poster",
     "intro-video": "intro video storyboard",
     report: "report",
-    docs: "documentation site",
+    "docs-design": "documentation design prototype",
   };
 
   return titles[kind];

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-artifact-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-artifact-generate.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { Command } from "commander";
+import { zeroTokenAllowsFeatureSwitch } from "../../../lib/api/zero-token";
+import { withErrorHandler } from "../../../lib/command";
+import {
+  type OpenDesignTarget,
+  toOpenDesignTarget,
+} from "./open-design-registry";
+import { createHtmlArtifactAuthoringPacket } from "./html-artifact-authoring";
+
+interface OpenDesignArtifactOptions {
+  prompt?: string;
+  site?: string;
+  title?: string;
+  audience?: string;
+  json?: boolean;
+}
+
+interface OpenDesignArtifactCommandConfig {
+  name: string;
+  target: OpenDesignTarget;
+  description: string;
+  usageCommand: string;
+  examples: string;
+  details: (options: OpenDesignArtifactOptions) => readonly string[];
+  artifactRules: readonly string[];
+}
+
+function readPrompt(
+  options: OpenDesignArtifactOptions,
+  usageCommand: string,
+): string {
+  if (options.prompt?.trim()) {
+    return options.prompt.trim();
+  }
+
+  if (process.stdin.isTTY === false) {
+    const prompt = readFileSync("/dev/stdin", "utf8").trim();
+    if (prompt.length > 0) {
+      return prompt;
+    }
+  }
+
+  throw new Error("--prompt is required", {
+    cause: new Error(`Usage: ${usageCommand} --prompt "A product report"`),
+  });
+}
+
+export function createOpenDesignArtifactGenerateCommand(
+  config: OpenDesignArtifactCommandConfig,
+): Command {
+  return new Command()
+    .name(config.name)
+    .description(config.description)
+    .option("--prompt <text>", "Artifact prompt; can also be piped via stdin")
+    .option("--site <slug>", "Hosted site slug; defaults to generated name")
+    .option("--title <text>", "Requested artifact title or name")
+    .option("--audience <text>", "Audience context")
+    .option("--json", "Print metadata as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+${config.examples}
+
+Output:
+  Prints an Open Design resource-selection packet for the current agent. The
+  agent authors a static HTML artifact and hosts it with zero host.
+
+Notes:
+  - Authenticates via ZERO_TOKEN
+  - OpenDesign path is gated by the openDesignGenerate feature switch`,
+    )
+    .action(
+      withErrorHandler(async (options: OpenDesignArtifactOptions) => {
+        if (
+          !zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.OpenDesignGenerate)
+        ) {
+          throw new Error(
+            `${config.usageCommand} requires the openDesignGenerate feature switch`,
+          );
+        }
+
+        const prompt = readPrompt(options, config.usageCommand);
+        const packet = createHtmlArtifactAuthoringPacket({
+          kind: toOpenDesignTarget(config.target),
+          prompt,
+          slugSource: options.title,
+          site: options.site,
+          details: config.details(options),
+          artifactRules: config.artifactRules,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(packet));
+          return;
+        }
+
+        console.log(packet.instructions);
+      }),
+    );
+}

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1,12 +1,12 @@
 export type OpenDesignTarget =
   | "presentation"
   | "website"
-  | "dashboard"
-  | "mobile-app"
+  | "dashboard-design"
+  | "mobile-app-design"
   | "poster"
   | "intro-video"
   | "report"
-  | "docs";
+  | "docs-design";
 
 type OpenDesignResourceKind = "skill" | "template" | "design-system";
 type OpenDesignResourceStatus = "curated" | "experimental" | "hidden";
@@ -67,7 +67,13 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Turns source-backed data, rankings, metrics, or lists into a concise analytical report.",
     source: source("skills/data-report/SKILL.md"),
-    targets: ["presentation", "website", "dashboard", "report", "docs"],
+    targets: [
+      "presentation",
+      "website",
+      "dashboard-design",
+      "report",
+      "docs-design",
+    ],
     tags: ["analysis", "data", "report", "ranking", "sources", "table"],
     triggers: ["report", "top 10", "ranking", "metrics", "analysis"],
     bestFor: ["source-backed reports", "ranked lists", "data summaries"],
@@ -81,7 +87,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Shapes research or editorial material into a magazine-like narrative with strong hierarchy.",
     source: source("skills/article-magazine/SKILL.md"),
-    targets: ["presentation", "website", "poster", "report", "docs"],
+    targets: ["presentation", "website", "poster", "report", "docs-design"],
     tags: ["editorial", "magazine", "article", "narrative", "research"],
     triggers: ["magazine", "editorial", "story", "essay", "briefing"],
     bestFor: [
@@ -99,7 +105,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Converts a product, brand, or feature request into a structured design brief.",
     source: source("skills/design-brief/SKILL.md"),
-    targets: ["presentation", "website", "mobile-app", "docs"],
+    targets: ["presentation", "website", "mobile-app-design", "docs-design"],
     tags: ["design", "brief", "product", "brand", "requirements"],
     triggers: ["design brief", "brand", "product direction", "requirements"],
     bestFor: ["product design briefs", "brand-driven websites"],
@@ -113,7 +119,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Dense operational dashboard layout for KPIs, lists, filters, and repeated scanning.",
     source: source("design-templates/dashboard"),
-    targets: ["website", "dashboard", "report"],
+    targets: ["website", "dashboard-design", "report"],
     tags: ["dashboard", "analytics", "kpi", "metrics", "operations", "table"],
     triggers: ["dashboard", "analytics", "monitoring", "metrics", "ops"],
     bestFor: ["metric-heavy pages", "status surfaces", "operational summaries"],
@@ -143,13 +149,35 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Documentation-style page layout for structured explanations, navigation, and examples.",
     source: source("design-templates/docs-page"),
-    targets: ["website", "docs", "report"],
+    targets: ["website", "docs-design", "report"],
     tags: ["docs", "explanation", "guide", "structured", "reference"],
     triggers: ["docs", "documentation", "guide", "explain", "how to"],
     bestFor: ["technical explainers", "product docs", "implementation notes"],
     compatibleWith: ["od:skill:design-brief", "od:design-system:mono"],
     status: "curated",
     priority: 26,
+  },
+  {
+    id: "od:template:mobile-app",
+    kind: "template",
+    name: "Mobile App Design",
+    description:
+      "Single-screen mobile UI design rendered in a realistic iPhone device frame.",
+    source: source("design-templates/mobile-app"),
+    targets: ["mobile-app-design"],
+    tags: ["mobile", "app", "ios", "design", "prototype", "phone"],
+    triggers: [
+      "mobile app",
+      "ios app",
+      "android app",
+      "phone screen",
+      "app ui",
+      "app mockup",
+    ],
+    bestFor: ["mobile UI mockups", "single-screen app design reviews"],
+    compatibleWith: ["od:skill:design-brief", "od:design-system:apple"],
+    status: "curated",
+    priority: 38,
   },
   {
     id: "od:template:html-ppt-graphify-dark-graph",
@@ -198,7 +226,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Compact update deck/page structure for highlights, risks, next steps, and metrics.",
     source: source("design-templates/weekly-update"),
-    targets: ["presentation", "report", "docs"],
+    targets: ["presentation", "report", "docs-design"],
     tags: ["update", "status", "briefing", "report", "metrics"],
     triggers: ["weekly", "status", "update", "briefing"],
     bestFor: ["team updates", "status reports", "progress summaries"],
@@ -228,7 +256,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Quiet, dense interface system for dashboards, tables, filters, and repeat workflows.",
     source: source("design-systems/dashboard"),
-    targets: ["website", "dashboard", "report"],
+    targets: ["website", "dashboard-design", "report"],
     tags: ["dashboard", "neutral", "dense", "table", "operations", "charts"],
     triggers: ["dashboard", "analytics", "metrics", "ops", "report"],
     bestFor: ["operational UIs", "data reports", "admin surfaces"],
@@ -242,7 +270,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Dark dense market-terminal aesthetic for charts, feeds, tables, and high information density.",
     source: source("design-systems/trading-terminal"),
-    targets: ["presentation", "website", "dashboard", "report"],
+    targets: ["presentation", "website", "dashboard-design", "report"],
     tags: ["dark", "terminal", "finance", "data", "charts", "dense"],
     triggers: ["dark", "terminal", "trading", "chart", "graph"],
     bestFor: ["dark analytical reports", "graph-heavy dashboards"],
@@ -256,7 +284,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Warm editorial design system for readable narrative pages, zines, and reports.",
     source: source("design-systems/warm-editorial"),
-    targets: ["presentation", "website", "poster", "report", "docs"],
+    targets: ["presentation", "website", "poster", "report", "docs-design"],
     tags: ["warm", "editorial", "magazine", "narrative", "readable"],
     triggers: ["editorial", "magazine", "zine", "warm", "story"],
     bestFor: ["narrative reports", "editorial decks", "long-form pages"],
@@ -270,7 +298,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Clean editorial design system with strong typography, media framing, and section rhythm.",
     source: source("design-systems/editorial"),
-    targets: ["presentation", "website", "poster", "report", "docs"],
+    targets: ["presentation", "website", "poster", "report", "docs-design"],
     tags: ["editorial", "typography", "media", "brand", "article"],
     triggers: ["editorial", "article", "brand", "landing", "magazine"],
     bestFor: ["brand sites", "article-style reports", "visual narratives"],
@@ -284,14 +312,44 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Minimal monospace-oriented system for documentation, technical pages, and precise reports.",
     source: source("design-systems/mono"),
-    targets: ["website", "docs", "report"],
+    targets: ["website", "docs-design", "report"],
     tags: ["mono", "docs", "technical", "minimal", "structured"],
     triggers: ["docs", "technical", "reference", "minimal", "api"],
     bestFor: ["technical documentation", "implementation reports"],
     status: "curated",
     priority: 20,
   },
+  {
+    id: "od:design-system:apple",
+    kind: "design-system",
+    name: "Apple",
+    description:
+      "Apple-inspired interface system for polished mobile and product UI design.",
+    source: source("design-systems/apple"),
+    targets: ["mobile-app-design", "website"],
+    tags: ["apple", "mobile", "ios", "clean", "product"],
+    triggers: ["mobile", "ios", "iphone", "app design", "app ui"],
+    bestFor: ["phone-framed product mocks", "consumer mobile UI"],
+    status: "curated",
+    priority: 34,
+  },
 ];
+
+export function toOpenDesignTarget(value: string): OpenDesignTarget {
+  if (value === "dashboard") {
+    return "dashboard-design";
+  }
+
+  if (value === "docs") {
+    return "docs-design";
+  }
+
+  if (value === "mobile-app") {
+    return "mobile-app-design";
+  }
+
+  return value as OpenDesignTarget;
+}
 
 function normalizeText(value: string): string {
   return value.toLowerCase();


### PR DESCRIPTION
## Summary
- Add built-in OpenDesign artifact commands for report, docs-design, poster, dashboard-design, and mobile-app-design.
- Rename design-only surfaces to docs-design, dashboard-design, and mobile-app-design so the CLI does not imply runnable docs, dashboards, or mobile apps.
- Add mobile template / Apple design-system registry coverage and map legacy OpenDesign target aliases to the design target names.
- Gate the new commands and doctor discovery behind the openDesignGenerate feature switch.
- Update zero doctor generate so these artifact types show built-in generation without connector lookup.

## Validation
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/open-design-artifacts.test.ts src/commands/zero/doctor/__tests__/generate.test.ts src/__tests__/zero-capability-visibility.test.ts