### PR TITLE
refactor: add connector auth lifecycle helpers

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -9,9 +9,12 @@ import {
   getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
   hasRequiredScopes,
+  getConnectorAuthCodeGrantConfig,
   getConnectorAuthMethod,
   getConnectorCliAuthFlow,
   getConnectorCliAuthModes,
+  getConnectorDeviceAuthGrantConfig,
+  getConnectorInteractivePairingGrantConfig,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorEnvironmentMapping,
@@ -22,6 +25,8 @@ import {
   getConnectorOAuthConfig,
   getConnectorOAuthConfigIfSupported,
   getConnectorOAuthFlow,
+  getConnectorOAuthGrantConfigIfSupported,
+  getConnectorOAuthScopes,
   getConnectorManualGrantFields,
   getEligibleConnectorTypes,
   getRuntimeAvailableConnectorTypes,
@@ -189,6 +194,10 @@ describe("connector auth method config", () => {
     expect(method?.access).toStrictEqual({ kind: "none" });
     expect(method?.revoke).toStrictEqual({ kind: "none" });
     expect(method?.featureFlag).toBe(FeatureSwitchKey.CliAuthStripe);
+    expect(getConnectorInteractivePairingGrantConfig("stripe")).toStrictEqual(
+      method?.grant,
+    );
+    expect(getConnectorInteractivePairingGrantConfig("github")).toBeUndefined();
     expect(getConnectorCliAuthFlow("stripe")).toBe("browser-verification");
     expect(getConnectorCliAuthModes("stripe")).toStrictEqual([
       {
@@ -1328,13 +1337,104 @@ describe("getConnectorProvidedSecretNames", () => {
 describe("getConnectorOAuthConfig - google-meet scopes", () => {
   it("uses meetings.space.readonly for google meet oauth scopes", () => {
     const config = getConnectorOAuthConfig("google-meet");
-    const scopes = config.scopes;
+    const scopes = getConnectorOAuthScopes("google-meet");
+    expect(scopes).toStrictEqual(config.scopes);
     expect(scopes).toContain(
       "https://www.googleapis.com/auth/meetings.space.readonly",
     );
     expect(scopes).not.toContain(
       "https://www.googleapis.com/auth/meetings.conferencerecords.readonly",
     );
+
+    scopes.push("test-mutated-scope");
+    expect(getConnectorOAuthScopes("google-meet")).not.toContain(
+      "test-mutated-scope",
+    );
+  });
+});
+
+describe("connector OAuth lifecycle grant helpers", () => {
+  it("returns auth-code grant config for GitHub", () => {
+    const method = getConnectorAuthMethod("github", "oauth");
+
+    expect(getConnectorOAuthGrantConfigIfSupported("github")).toStrictEqual(
+      method?.grant,
+    );
+    expect(getConnectorAuthCodeGrantConfig("github")).toMatchObject({
+      kind: "auth-code",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      scopes: ["repo", "project", "workflow"],
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GH_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
+      },
+    });
+  });
+
+  it("returns device-auth grant config for device OAuth connectors", () => {
+    expect(
+      getConnectorDeviceAuthGrantConfig("test-oauth-device"),
+    ).toMatchObject({
+      kind: "device-auth",
+      deviceAuthUrl: "/api/test/oauth-provider/device/code",
+      tokenUrl: "/api/test/oauth-provider/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientId: "test-oauth-device-client",
+      },
+      scopes: ["read"],
+    });
+    expect(getConnectorDeviceAuthGrantConfig("base44")).toMatchObject({
+      kind: "device-auth",
+      deviceAuthUrl: "https://app.base44.com/oauth/device/code",
+      tokenUrl: "https://app.base44.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientId: "base44_cli",
+      },
+      scopes: ["apps:read", "apps:write", "offline"],
+    });
+  });
+
+  it("returns undefined for connectors without OAuth grants", () => {
+    expect(getConnectorOAuthGrantConfigIfSupported("axiom")).toBeUndefined();
+  });
+
+  it("keeps legacy OAuth config equivalent to lifecycle grant projections", () => {
+    for (const type of connectorTypeSchema.options) {
+      const grant = getConnectorOAuthGrantConfigIfSupported(type);
+      const config = getConnectorOAuthConfigIfSupported(type);
+
+      switch (grant?.kind) {
+        case "auth-code":
+          expect(config, `${type}: auth-code OAuth config`).toStrictEqual({
+            flow: "authorization-code",
+            tokenUrl: grant.tokenUrl,
+            client: grant.client,
+            scopes: [...grant.scopes],
+          });
+          break;
+        case "device-auth":
+          expect(config, `${type}: device-auth OAuth config`).toStrictEqual({
+            flow: "device-authorization",
+            deviceAuthUrl: grant.deviceAuthUrl,
+            tokenUrl: grant.tokenUrl,
+            client: grant.client,
+            scopes: [...grant.scopes],
+          });
+          break;
+        case undefined:
+          expect(config, `${type}: no OAuth config`).toBeUndefined();
+          break;
+      }
+    }
   });
 });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -9,12 +9,12 @@ import {
   getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
   hasRequiredScopes,
-  getConnectorAuthCodeGrantConfig,
+  getConnectorAuthCodeGrantConfigIfSupported,
   getConnectorAuthMethod,
   getConnectorCliAuthFlow,
   getConnectorCliAuthModes,
-  getConnectorDeviceAuthGrantConfig,
-  getConnectorInteractivePairingGrantConfig,
+  getConnectorDeviceAuthGrantConfigIfSupported,
+  getConnectorInteractivePairingGrantConfigIfSupported,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorEnvironmentMapping,
@@ -194,10 +194,12 @@ describe("connector auth method config", () => {
     expect(method?.access).toStrictEqual({ kind: "none" });
     expect(method?.revoke).toStrictEqual({ kind: "none" });
     expect(method?.featureFlag).toBe(FeatureSwitchKey.CliAuthStripe);
-    expect(getConnectorInteractivePairingGrantConfig("stripe")).toStrictEqual(
-      method?.grant,
-    );
-    expect(getConnectorInteractivePairingGrantConfig("github")).toBeUndefined();
+    expect(
+      getConnectorInteractivePairingGrantConfigIfSupported("stripe"),
+    ).toStrictEqual(method?.grant);
+    expect(
+      getConnectorInteractivePairingGrantConfigIfSupported("github"),
+    ).toBeUndefined();
     expect(getConnectorCliAuthFlow("stripe")).toBe("browser-verification");
     expect(getConnectorCliAuthModes("stripe")).toStrictEqual([
       {
@@ -1360,7 +1362,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
     expect(getConnectorOAuthGrantConfigIfSupported("github")).toStrictEqual(
       method?.grant,
     );
-    expect(getConnectorAuthCodeGrantConfig("github")).toMatchObject({
+    expect(getConnectorAuthCodeGrantConfigIfSupported("github")).toMatchObject({
       kind: "auth-code",
       tokenUrl: "https://github.com/login/oauth/access_token",
       scopes: ["repo", "project", "workflow"],
@@ -1376,7 +1378,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
 
   it("returns device-auth grant config for device OAuth connectors", () => {
     expect(
-      getConnectorDeviceAuthGrantConfig("test-oauth-device"),
+      getConnectorDeviceAuthGrantConfigIfSupported("test-oauth-device"),
     ).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "/api/test/oauth-provider/device/code",
@@ -1389,7 +1391,9 @@ describe("connector OAuth lifecycle grant helpers", () => {
       },
       scopes: ["read"],
     });
-    expect(getConnectorDeviceAuthGrantConfig("base44")).toMatchObject({
+    expect(
+      getConnectorDeviceAuthGrantConfigIfSupported("base44"),
+    ).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://app.base44.com/oauth/device/code",
       tokenUrl: "https://app.base44.com/oauth/token",
@@ -1405,6 +1409,13 @@ describe("connector OAuth lifecycle grant helpers", () => {
 
   it("returns undefined for connectors without OAuth grants", () => {
     expect(getConnectorOAuthGrantConfigIfSupported("axiom")).toBeUndefined();
+    expect(getConnectorOAuthScopes("axiom")).toStrictEqual([]);
+    expect(
+      getConnectorAuthCodeGrantConfigIfSupported("base44"),
+    ).toBeUndefined();
+    expect(
+      getConnectorDeviceAuthGrantConfigIfSupported("github"),
+    ).toBeUndefined();
   });
 
   it("keeps legacy OAuth config equivalent to lifecycle grant projections", () => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -138,14 +138,14 @@ export function getConnectorOAuthGrantConfigIfSupported(
   }
 }
 
-export function getConnectorAuthCodeGrantConfig(
+export function getConnectorAuthCodeGrantConfigIfSupported(
   type: ConnectorType,
 ): ConnectorAuthCodeGrantConfig | undefined {
   const grant = getConnectorOAuthGrantConfigIfSupported(type);
   return grant?.kind === "auth-code" ? grant : undefined;
 }
 
-export function getConnectorDeviceAuthGrantConfig(
+export function getConnectorDeviceAuthGrantConfigIfSupported(
   type: ConnectorType,
 ): ConnectorDeviceAuthGrantConfig | undefined {
   const grant = getConnectorOAuthGrantConfigIfSupported(type);
@@ -156,7 +156,7 @@ export function getConnectorOAuthScopes(type: ConnectorType): string[] {
   return [...(getConnectorOAuthGrantConfigIfSupported(type)?.scopes ?? [])];
 }
 
-export function getConnectorInteractivePairingGrantConfig(
+export function getConnectorInteractivePairingGrantConfigIfSupported(
   type: ConnectorType,
 ): ConnectorInteractivePairingGrantConfig | undefined {
   const method = getConnectorAuthMethod(type, "cli-auth");
@@ -178,13 +178,15 @@ export function getConnectorInteractivePairingGrantConfig(
 export function getConnectorCliAuthFlow(
   type: ConnectorType,
 ): ConnectorCliAuthFlow | undefined {
-  return getConnectorInteractivePairingGrantConfig(type)?.flow;
+  return getConnectorInteractivePairingGrantConfigIfSupported(type)?.flow;
 }
 
 export function getConnectorCliAuthModes(
   type: ConnectorType,
 ): NonNullable<ConnectorCliAuthConfig["modes"]> {
-  return getConnectorInteractivePairingGrantConfig(type)?.modes ?? [];
+  return (
+    getConnectorInteractivePairingGrantConfigIfSupported(type)?.modes ?? []
+  );
 }
 
 export function getConnectorGenerationTypes(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -12,6 +12,7 @@ import {
   type ConnectorConfig,
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorGenerationType,
+  type ConnectorInteractivePairingGrantConfig,
   type DynamicPublicConnectorOAuthClientConfig,
   type ConnectorOAuthClientConfig,
   type ConnectorOAuthConfig,
@@ -56,37 +57,6 @@ export function getConnectorAuthMethod(
   authMethod: ConnectorAuthMethodType,
 ): ConnectorAuthMethodConfig | undefined {
   return getConnectorAuthMethods(type)[authMethod];
-}
-
-/**
- * Get CLI auth flow config for connector types that support provider CLI auth.
- */
-function getConnectorCliAuthConfig(
-  type: ConnectorType,
-): ConnectorCliAuthConfig | undefined {
-  const method = getConnectorAuthMethod(type, "cli-auth");
-  if (method?.grant.kind !== "interactive-pairing") {
-    return undefined;
-  }
-  return {
-    flow: method.grant.flow,
-    modes: method.grant.modes,
-  };
-}
-
-/**
- * Get the frontend CLI auth flow for connector types that support it.
- */
-export function getConnectorCliAuthFlow(
-  type: ConnectorType,
-): ConnectorCliAuthFlow | undefined {
-  return getConnectorCliAuthConfig(type)?.flow;
-}
-
-export function getConnectorCliAuthModes(
-  type: ConnectorType,
-): NonNullable<ConnectorCliAuthConfig["modes"]> {
-  return getConnectorCliAuthConfig(type)?.modes ?? [];
 }
 
 function connectorAuthMethodValues(
@@ -148,25 +118,73 @@ function authMethodAccessPriority(method: ConnectorAuthMethodConfig): number {
   }
 }
 
-type ConnectorOAuthGrant =
+export type ConnectorOAuthGrantConfig =
   | ConnectorAuthCodeGrantConfig
   | ConnectorDeviceAuthGrantConfig;
 
-function getConnectorOAuthGrant(
+export function getConnectorOAuthGrantConfigIfSupported(
   type: ConnectorType,
-): ConnectorOAuthGrant | undefined {
-  for (const method of connectorAuthMethodValues(type)) {
-    switch (method.grant.kind) {
-      case "auth-code":
-      case "device-auth":
-        return method.grant;
-      case "manual":
-      case "managed":
-      case "interactive-pairing":
-        continue;
-    }
+): ConnectorOAuthGrantConfig | undefined {
+  const method = getConnectorAuthMethod(type, "oauth");
+  switch (method?.grant.kind) {
+    case "auth-code":
+    case "device-auth":
+      return method.grant;
+    case "manual":
+    case "managed":
+    case "interactive-pairing":
+    case undefined:
+      return undefined;
   }
-  return undefined;
+}
+
+export function getConnectorAuthCodeGrantConfig(
+  type: ConnectorType,
+): ConnectorAuthCodeGrantConfig | undefined {
+  const grant = getConnectorOAuthGrantConfigIfSupported(type);
+  return grant?.kind === "auth-code" ? grant : undefined;
+}
+
+export function getConnectorDeviceAuthGrantConfig(
+  type: ConnectorType,
+): ConnectorDeviceAuthGrantConfig | undefined {
+  const grant = getConnectorOAuthGrantConfigIfSupported(type);
+  return grant?.kind === "device-auth" ? grant : undefined;
+}
+
+export function getConnectorOAuthScopes(type: ConnectorType): string[] {
+  return [...(getConnectorOAuthGrantConfigIfSupported(type)?.scopes ?? [])];
+}
+
+export function getConnectorInteractivePairingGrantConfig(
+  type: ConnectorType,
+): ConnectorInteractivePairingGrantConfig | undefined {
+  const method = getConnectorAuthMethod(type, "cli-auth");
+  switch (method?.grant.kind) {
+    case "interactive-pairing":
+      return method.grant;
+    case "manual":
+    case "auth-code":
+    case "device-auth":
+    case "managed":
+    case undefined:
+      return undefined;
+  }
+}
+
+/**
+ * Get the frontend CLI auth flow for connector types that support it.
+ */
+export function getConnectorCliAuthFlow(
+  type: ConnectorType,
+): ConnectorCliAuthFlow | undefined {
+  return getConnectorInteractivePairingGrantConfig(type)?.flow;
+}
+
+export function getConnectorCliAuthModes(
+  type: ConnectorType,
+): NonNullable<ConnectorCliAuthConfig["modes"]> {
+  return getConnectorInteractivePairingGrantConfig(type)?.modes ?? [];
 }
 
 export function getConnectorGenerationTypes(
@@ -315,7 +333,7 @@ function hasEnvValue(readEnv: ConnectorEnvReader, name: string): boolean {
 export function getConnectorOAuthClientConfig(
   type: ConnectorType,
 ): ConnectorOAuthClientConfig | undefined {
-  return getConnectorOAuthConfigIfSupported(type)?.client;
+  return getConnectorOAuthGrantConfigIfSupported(type)?.client;
 }
 
 export function resolveConnectorOAuthClientCredentials(
@@ -561,7 +579,7 @@ export function getConnectorProvidedSecretNames(
 export function getConnectorOAuthConfigIfSupported(
   type: ConnectorType,
 ): ConnectorOAuthConfig | undefined {
-  const grant = getConnectorOAuthGrant(type);
+  const grant = getConnectorOAuthGrantConfigIfSupported(type);
   switch (grant?.kind) {
     case "auth-code":
       return {
@@ -605,17 +623,13 @@ export function getConnectorOAuthFlow(
 export function isOAuthAuthCodeConnectorType(
   type: ConnectorType,
 ): type is OAuthAuthCodeConnectorType {
-  return (
-    getConnectorOAuthConfigIfSupported(type)?.flow === "authorization-code"
-  );
+  return getConnectorOAuthGrantConfigIfSupported(type)?.kind === "auth-code";
 }
 
 export function isOAuthDeviceAuthConnectorType(
   type: ConnectorType,
 ): type is OAuthDeviceAuthConnectorType {
-  return (
-    getConnectorOAuthConfigIfSupported(type)?.flow === "device-authorization"
-  );
+  return getConnectorOAuthGrantConfigIfSupported(type)?.kind === "device-auth";
 }
 
 export function getConnectorOAuthDeviceAuthConfig(
@@ -637,12 +651,12 @@ export function hasRequiredScopes(
   connectorType: ConnectorType,
   storedScopes: string[] | null,
 ): boolean {
-  const oauthConfig = getConnectorOAuthConfigIfSupported(connectorType);
-  if (!oauthConfig) return true;
-  if (oauthConfig.scopes.length === 0) return true;
+  const scopes = getConnectorOAuthGrantConfigIfSupported(connectorType)?.scopes;
+  if (!scopes) return true;
+  if (scopes.length === 0) return true;
   if (!storedScopes) return false;
   const storedSet = new Set(storedScopes);
-  return oauthConfig.scopes.every((s) => {
+  return scopes.every((s) => {
     return storedSet.has(s);
   });
 }
@@ -661,8 +675,9 @@ export function getScopeDiff(
   connectorType: ConnectorType,
   storedScopes: string[] | null,
 ): ScopeDiff {
-  const oauthConfig = getConnectorOAuthConfigIfSupported(connectorType);
-  const currentScopes = oauthConfig?.scopes ?? [];
+  const currentScopes = [
+    ...(getConnectorOAuthGrantConfigIfSupported(connectorType)?.scopes ?? []),
+  ];
   const stored = storedScopes ?? [];
   const storedSet = new Set(stored);
   const currentSet = new Set(currentScopes);


### PR DESCRIPTION
## Summary

- add lifecycle-native connector auth grant helpers for OAuth and interactive pairing
- layer existing OAuth and CLI compatibility helpers on the lifecycle helpers
- add connector utility coverage for helper output and legacy projection equivalence

Closes #14881

## Tests

- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pre-commit: pnpm knip
- pre-commit: pnpm check-types
