### PR TITLE
fix: move guest exec exit warnings to callers

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3207,21 +3207,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_guest_timezone_valid_tz() {
-        let sandbox = MockSandbox::new("test");
-        let mut ctx = minimal_context();
-        ctx.user_timezone = Some("America/New_York".into());
-        // Should exec one command and not panic.
-        sync_guest_timezone(&sandbox, &ctx).await;
+    async fn sync_guest_timezone_accepts_common_timezone_name_shapes() {
+        for tz in [
+            "UTC",
+            "Etc/GMT+1",
+            "Etc/GMT-14",
+            "America/Argentina/Buenos_Aires",
+        ] {
+            let sandbox = MockSandbox::new("test");
+            let mut ctx = minimal_context();
+            ctx.user_timezone = Some(tz.into());
 
-        let calls = sandbox.exec_calls();
-        assert_eq!(calls.len(), 1);
-        assert!(
-            calls[0]
-                .cmd
-                .starts_with("if test -f /usr/share/zoneinfo/America/New_York; then ")
-        );
-        assert!(calls[0].cmd.ends_with(" fi"));
+            sync_guest_timezone(&sandbox, &ctx).await;
+
+            let calls = sandbox.exec_calls();
+            assert_eq!(calls.len(), 1, "timezone {tz:?} should call guest exec");
+            assert!(
+                calls[0]
+                    .cmd
+                    .starts_with(&format!("if test -f /usr/share/zoneinfo/{tz}; then ")),
+                "unexpected timezone command: {}",
+                calls[0].cmd
+            );
+            assert!(
+                calls[0]
+                    .cmd
+                    .contains(&format!("echo '{tz}' > /etc/timezone")),
+                "unexpected timezone command: {}",
+                calls[0].cmd
+            );
+            assert!(
+                calls[0]
+                    .cmd
+                    .contains(&format!("echo 'TZ={tz}' >> /etc/environment")),
+                "unexpected timezone command: {}",
+                calls[0].cmd
+            );
+            assert!(calls[0].cmd.ends_with(" fi"));
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3228,20 +3228,32 @@ mod tests {
     async fn sync_guest_timezone_skips_when_none() {
         let sandbox = MockSandbox::new("test");
         let ctx = minimal_context();
-        // No timezone — should skip without calling exec.
-        // Push an error to detect if exec is called unexpectedly.
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
+
+        assert!(sandbox.exec_calls().is_empty());
     }
 
     #[tokio::test]
-    async fn sync_guest_timezone_rejects_shell_injection() {
-        let sandbox = MockSandbox::new("test");
-        let mut ctx = minimal_context();
-        ctx.user_timezone = Some("$(rm -rf /)".into());
-        // Push an error to detect if exec is called — it should NOT be.
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
-        sync_guest_timezone(&sandbox, &ctx).await;
+    async fn sync_guest_timezone_rejects_invalid_timezone_names() {
+        for invalid_tz in [
+            "$(rm -rf /)",
+            "../UTC",
+            "Etc/../UTC",
+            "America/New York",
+            "UTC;id",
+            "UTC'",
+        ] {
+            let sandbox = MockSandbox::new("test");
+            let mut ctx = minimal_context();
+            ctx.user_timezone = Some(invalid_tz.into());
+
+            sync_guest_timezone(&sandbox, &ctx).await;
+
+            assert!(
+                sandbox.exec_calls().is_empty(),
+                "timezone {invalid_tz:?} should be rejected before guest exec"
+            );
+        }
     }
 
     #[tokio::test]
@@ -3249,8 +3261,23 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();
         ctx.user_timezone = Some(String::new());
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
+
+        assert!(sandbox.exec_calls().is_empty());
+    }
+
+    async fn capture_sync_guest_timezone_events(
+        sandbox: &dyn Sandbox,
+        ctx: &ExecutionContext,
+    ) -> Vec<CapturedEvent> {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        sync_guest_timezone(sandbox, ctx).await;
+
+        captured.entries()
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -3264,14 +3291,7 @@ mod tests {
         let mut ctx = minimal_context();
         ctx.user_timezone = Some("America/New_York".into());
 
-        let captured = CapturedEvents::default();
-        let subscriber = tracing_subscriber::registry().with(captured.clone());
-        let _guard = tracing::subscriber::set_default(subscriber);
-        tracing::callsite::rebuild_interest_cache();
-
-        sync_guest_timezone(&sandbox, &ctx).await;
-
-        let events = captured.entries();
+        let events = capture_sync_guest_timezone_events(&sandbox, &ctx).await;
         let event = events
             .iter()
             .find(|event| {
@@ -3302,6 +3322,41 @@ mod tests {
                 .fields
                 .get("stdout_excerpt")
                 .is_some_and(|value| value.contains("timezone stdout")),
+            "event={event:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sync_guest_timezone_logs_exec_error() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_exec_result(Err(sandbox_exec_error("vsock disconnected")));
+        let mut ctx = minimal_context();
+        ctx.user_timezone = Some("America/New_York".into());
+
+        let events = capture_sync_guest_timezone_events(&sandbox, &ctx).await;
+
+        let event = events
+            .iter()
+            .find(|event| {
+                event.level == Level::WARN
+                    && event.fields.get("message").map(String::as_str)
+                        == Some("failed to set guest timezone")
+            })
+            .unwrap_or_else(|| panic!("missing timezone warning; events={events:#?}"));
+        let run_id = RunId::nil().to_string();
+        assert_eq!(
+            event.fields.get("run_id").map(String::as_str),
+            Some(run_id.as_str())
+        );
+        assert_eq!(
+            event.fields.get("tz").map(String::as_str),
+            Some("America/New_York")
+        );
+        assert!(
+            event
+                .fields
+                .get("error")
+                .is_some_and(|value| value.contains("vsock disconnected")),
             "event={event:#?}"
         );
     }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1358,7 +1358,7 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
             .as_secs_f64()
     );
     let date_cmd = format!("date -s \"@{timestamp}\"");
-    sandbox
+    let result = sandbox
         .exec(&ExecRequest {
             cmd: &date_cmd,
             timeout: DEFAULT_EXEC_TIMEOUT,
@@ -1368,6 +1368,12 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
             output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
+    if result.exit_code != 0 {
+        return Err(RunnerError::Internal(format_guest_exec_failure(
+            "guest clock sync",
+            &result,
+        )));
+    }
     Ok(())
 }
 
@@ -1436,14 +1442,15 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
         return;
     }
     let cmd = format!(
-        "test -f /usr/share/zoneinfo/{tz} && \
+        "if test -f /usr/share/zoneinfo/{tz}; then \
          echo '{tz}' > /etc/timezone && \
          ln -sf /usr/share/zoneinfo/{tz} /etc/localtime && \
          sed -i '/^TZ=/d' /etc/environment && \
-         echo 'TZ={tz}' >> /etc/environment"
+         echo 'TZ={tz}' >> /etc/environment; \
+         fi"
     );
     // Best-effort: don't fail the run if timezone setup fails.
-    if let Err(e) = sandbox
+    match sandbox
         .exec(&ExecRequest {
             cmd: &cmd,
             timeout: DEFAULT_EXEC_TIMEOUT,
@@ -1454,7 +1461,24 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
         })
         .await
     {
-        tracing::warn!(tz = %tz, error = %e, "failed to set guest timezone");
+        Ok(result) if result.exit_code != 0 => {
+            let stderr_excerpt =
+                format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
+            let stdout_excerpt =
+                format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
+            tracing::warn!(
+                run_id = %context.run_id,
+                tz = %tz,
+                exit_code = result.exit_code,
+                stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+                stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+                "failed to set guest timezone"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(run_id = %context.run_id, tz = %tz, error = %e, "failed to set guest timezone");
+        }
     }
 }
 
@@ -1607,7 +1631,11 @@ async fn download_storages(
 }
 
 fn format_guest_download_failure(result: &sandbox::ExecResult) -> String {
-    let mut message = format!("storage download failed (exit code {})", result.exit_code);
+    format_guest_exec_failure("storage download", result)
+}
+
+fn format_guest_exec_failure(operation: &str, result: &sandbox::ExecResult) -> String {
+    let mut message = format!("{operation} failed (exit code {})", result.exit_code);
 
     if let Some(stderr) =
         format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated)
@@ -2074,9 +2102,73 @@ mod tests {
     };
     use async_trait::async_trait;
     use sandbox_mock::MockSandboxFactory;
-    use std::sync::Arc;
+    use std::collections::BTreeMap;
+    use std::fmt;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Level, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::prelude::*;
 
     const RUN_IN_SANDBOX_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[derive(Clone, Debug)]
+    struct CapturedEvent {
+        level: Level,
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedEvents {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl CapturedEvents {
+        fn entries(&self) -> Vec<CapturedEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl<S> Layer<S> for CapturedEvents
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = CapturedFields::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                level: *event.metadata().level(),
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturedFields {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for CapturedFields {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
 
     fn api_storage(name: &str, mount_path: &str, version: &str, archive_url: &str) -> StorageEntry {
         StorageEntry {
@@ -3052,6 +3144,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fix_guest_clock_fails_on_nonzero_exit() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            2,
+            b"date stdout".to_vec(),
+            b"date stderr".to_vec(),
+        )));
+
+        let result = fix_guest_clock(&sandbox).await;
+
+        let message = result.unwrap_err().to_string();
+        assert!(
+            message.contains("guest clock sync failed (exit code 2)"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("stderr (captured): date stderr"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("stdout (captured): date stdout"),
+            "got: {message}"
+        );
+    }
+
+    #[tokio::test]
     async fn reseed_guest_entropy_succeeds() {
         let sandbox = MockSandbox::new("test");
         reseed_guest_entropy(&sandbox).await.unwrap();
@@ -3095,6 +3213,15 @@ mod tests {
         ctx.user_timezone = Some("America/New_York".into());
         // Should exec one command and not panic.
         sync_guest_timezone(&sandbox, &ctx).await;
+
+        let calls = sandbox.exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(
+            calls[0]
+                .cmd
+                .starts_with("if test -f /usr/share/zoneinfo/America/New_York; then ")
+        );
+        assert!(calls[0].cmd.ends_with(" fi"));
     }
 
     #[tokio::test]
@@ -3124,6 +3251,59 @@ mod tests {
         ctx.user_timezone = Some(String::new());
         sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sync_guest_timezone_logs_nonzero_exit() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            2,
+            b"timezone stdout".to_vec(),
+            b"timezone stderr".to_vec(),
+        )));
+        let mut ctx = minimal_context();
+        ctx.user_timezone = Some("America/New_York".into());
+
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        sync_guest_timezone(&sandbox, &ctx).await;
+
+        let events = captured.entries();
+        let event = events
+            .iter()
+            .find(|event| {
+                event.level == Level::WARN
+                    && event.fields.get("message").map(String::as_str)
+                        == Some("failed to set guest timezone")
+            })
+            .unwrap_or_else(|| panic!("missing timezone warning; events={events:#?}"));
+        let run_id = RunId::nil().to_string();
+        assert_eq!(
+            event.fields.get("run_id").map(String::as_str),
+            Some(run_id.as_str())
+        );
+        assert_eq!(
+            event.fields.get("tz").map(String::as_str),
+            Some("America/New_York")
+        );
+        assert_eq!(event.fields.get("exit_code").map(String::as_str), Some("2"));
+        assert!(
+            event
+                .fields
+                .get("stderr_excerpt")
+                .is_some_and(|value| value.contains("timezone stderr")),
+            "event={event:#?}"
+        );
+        assert!(
+            event
+                .fields
+                .get("stdout_excerpt")
+                .is_some_and(|value| value.contains("timezone stdout")),
+            "event={event:#?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -153,7 +153,7 @@ pub struct SupervisedExecRequest<'a> {
     pub stdout: ExecOutputPolicy,
     /// Stderr output policy requested from the guest.
     pub stderr: ExecOutputPolicy,
-    /// Exit codes that should not be treated as notable in diagnostics.
+    /// Exit codes that should be marked expected in the guest-side exec request.
     pub expected_exit_codes: &'a [i32],
     /// Optional bounded stdin payload written to the child and then closed.
     pub stdin_bytes: Option<&'a [u8]>,
@@ -454,11 +454,10 @@ enum ExecTerminalLogSeverity {
 }
 
 #[derive(Clone, Copy)]
-struct ExecTerminalLogContext<'a> {
+struct ExecTerminalLogContext {
     lifecycle: ExecTerminalLogLifecycle,
     slow: bool,
     termination: ExecTermination,
-    expected_exit_codes: &'a [i32],
     stdout_truncated: bool,
     stderr_truncated: bool,
     stream_overflowed: bool,
@@ -469,7 +468,6 @@ struct ExecTerminalLogContext<'a> {
 struct ExecOperationDiagnostic {
     seq: u32,
     label_log: String,
-    expected_exit_codes: Vec<i32>,
     registered_at: Instant,
     first_output_at: Option<Instant>,
 }
@@ -571,11 +569,10 @@ impl Drop for ExecOperationFrameWriteGuard {
 }
 
 impl ExecOperationDiagnostic {
-    fn new(seq: u32, label: &str, expected_exit_codes: &[i32]) -> Self {
+    fn new(seq: u32, label: &str) -> Self {
         Self {
             seq,
             label_log: exec_operation_label_log(label),
-            expected_exit_codes: expected_exit_codes.to_vec(),
             registered_at: Instant::now(),
             first_output_at: None,
         }
@@ -634,7 +631,6 @@ impl ExecOperationDiagnostic {
             lifecycle,
             slow,
             termination: result.termination,
-            expected_exit_codes: &self.expected_exit_codes,
             stdout_truncated,
             stderr_truncated,
             stream_overflowed,
@@ -1335,12 +1331,14 @@ fn duration_to_request_timeout_ms(timeout: Duration) -> u32 {
         .max(1)
 }
 
-fn exec_termination_is_notable(termination: ExecTermination, expected_exit_codes: &[i32]) -> bool {
-    !matches!(
-        termination,
-        ExecTermination::Exited { exit_code }
-            if exit_code == 0 || expected_exit_codes.contains(&exit_code)
-    )
+fn exec_termination_requires_low_level_warning(termination: ExecTermination) -> bool {
+    match termination {
+        ExecTermination::Exited { .. } => false,
+        ExecTermination::TimedOut
+        | ExecTermination::Cancelled
+        | ExecTermination::StartFailed
+        | ExecTermination::WaitFailed => true,
+    }
 }
 
 fn exec_terminal_log_lifecycle(lifecycle: &ExecOperationLifecycle) -> ExecTerminalLogLifecycle {
@@ -1351,10 +1349,8 @@ fn exec_terminal_log_lifecycle(lifecycle: &ExecOperationLifecycle) -> ExecTermin
     }
 }
 
-fn exec_terminal_log_severity(
-    context: ExecTerminalLogContext<'_>,
-) -> Option<ExecTerminalLogSeverity> {
-    let notable = exec_termination_is_notable(context.termination, context.expected_exit_codes)
+fn exec_terminal_log_severity(context: ExecTerminalLogContext) -> Option<ExecTerminalLogSeverity> {
+    let notable = exec_termination_requires_low_level_warning(context.termination)
         || context.stdout_truncated
         || context.stderr_truncated
         || context.stream_overflowed
@@ -2260,7 +2256,7 @@ async fn start_exec_operation_on_shared_with_tracking(
     };
     let (result_tx, result_rx) = oneshot::channel();
     let seq = shared.next_seq();
-    let diagnostic = ExecOperationDiagnostic::new(seq, request.label, request.expected_exit_codes);
+    let diagnostic = ExecOperationDiagnostic::new(seq, request.label);
     let normal_operation = match tracking {
         ExecOperationTracking::Tracked => Some(ExecOperationNormalTracking::Owned(
             shared.reserve_normal_operation()?,
@@ -2401,7 +2397,7 @@ where
     let (result_tx, result_rx) = oneshot::channel();
     let (start_tx, start_rx) = oneshot::channel();
     let seq = shared.next_seq();
-    let diagnostic = ExecOperationDiagnostic::new(seq, request.label, request.expected_exit_codes);
+    let diagnostic = ExecOperationDiagnostic::new(seq, request.label);
     let operation = ExecOperation {
         normal_operation: Some(ExecOperationNormalTracking::Owned(
             shared.reserve_normal_operation()?,
@@ -2898,7 +2894,7 @@ mod tests {
                 normal_operations.reserve().unwrap(),
             )),
             lifecycle: ExecOperationLifecycle::OneShot,
-            diagnostic: ExecOperationDiagnostic::new(seq, label, &[]),
+            diagnostic: ExecOperationDiagnostic::new(seq, label),
             result_tx,
             stream_tx: None,
             stdout_capture: ExecCaptureState::Discard,
@@ -2926,51 +2922,28 @@ mod tests {
         slow: bool,
         result: &vsock_proto::DecodedExecResult<'_>,
     ) -> Vec<Level> {
-        capture_terminal_log_levels_with_context(lifecycle, slow, &[], result, false)
-    }
-
-    fn capture_terminal_log_levels_with_expected_exit_codes(
-        lifecycle: ExecTerminalLogLifecycle,
-        slow: bool,
-        expected_exit_codes: &[i32],
-        result: &vsock_proto::DecodedExecResult<'_>,
-    ) -> Vec<Level> {
-        capture_terminal_log_levels_with_context(
-            lifecycle,
-            slow,
-            expected_exit_codes,
-            result,
-            false,
-        )
+        capture_terminal_log_levels_with_context(lifecycle, slow, result, false)
     }
 
     fn capture_terminal_log_levels_with_context(
         lifecycle: ExecTerminalLogLifecycle,
         slow: bool,
-        expected_exit_codes: &[i32],
         result: &vsock_proto::DecodedExecResult<'_>,
         stream_overflowed: bool,
     ) -> Vec<Level> {
-        capture_terminal_log_events_with_context(
-            lifecycle,
-            slow,
-            expected_exit_codes,
-            result,
-            stream_overflowed,
-        )
-        .into_iter()
-        .map(|event| event.level)
-        .collect()
+        capture_terminal_log_events_with_context(lifecycle, slow, result, stream_overflowed)
+            .into_iter()
+            .map(|event| event.level)
+            .collect()
     }
 
     fn capture_terminal_log_events_with_context(
         lifecycle: ExecTerminalLogLifecycle,
         slow: bool,
-        expected_exit_codes: &[i32],
         result: &vsock_proto::DecodedExecResult<'_>,
         stream_overflowed: bool,
     ) -> Vec<CapturedEvent> {
-        let mut diagnostic = ExecOperationDiagnostic::new(7, "terminal-log", expected_exit_codes);
+        let mut diagnostic = ExecOperationDiagnostic::new(7, "terminal-log");
         if slow {
             diagnostic.registered_at =
                 Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
@@ -3003,22 +2976,24 @@ mod tests {
     }
 
     #[test]
-    fn exec_termination_notable_tracks_nonzero_exit() {
-        assert!(!exec_termination_is_notable(
-            ExecTermination::Exited { exit_code: 0 },
-            &[]
+    fn exec_termination_warning_tracks_low_level_terminal_states() {
+        assert!(!exec_termination_requires_low_level_warning(
+            ExecTermination::Exited { exit_code: 0 }
         ));
-        assert!(exec_termination_is_notable(
-            ExecTermination::Exited { exit_code: 1 },
-            &[]
+        assert!(!exec_termination_requires_low_level_warning(
+            ExecTermination::Exited { exit_code: 1 }
         ));
-        assert!(!exec_termination_is_notable(
-            ExecTermination::Exited { exit_code: 66 },
-            &[66]
+        assert!(exec_termination_requires_low_level_warning(
+            ExecTermination::TimedOut
         ));
-        assert!(exec_termination_is_notable(
-            ExecTermination::TimedOut,
-            &[124]
+        assert!(exec_termination_requires_low_level_warning(
+            ExecTermination::Cancelled
+        ));
+        assert!(exec_termination_requires_low_level_warning(
+            ExecTermination::StartFailed
+        ));
+        assert!(exec_termination_requires_low_level_warning(
+            ExecTermination::WaitFailed
         ));
     }
 
@@ -3038,13 +3013,13 @@ mod tests {
                 .is_empty()
         );
 
-        let notable = vsock_proto::DecodedExecResult {
+        let nonzero_exit = vsock_proto::DecodedExecResult {
             termination: ExecTermination::Exited { exit_code: 1 },
             ..clean
         };
         assert_eq!(
-            capture_terminal_log_levels(ExecTerminalLogLifecycle::Supervised, true, &notable),
-            vec![Level::WARN]
+            capture_terminal_log_levels(ExecTerminalLogLifecycle::Supervised, true, &nonzero_exit),
+            vec![Level::INFO]
         );
     }
 
@@ -3054,7 +3029,6 @@ mod tests {
         let info_events = capture_terminal_log_events_with_context(
             ExecTerminalLogLifecycle::Supervised,
             true,
-            &[],
             &clean,
             false,
         );
@@ -3092,7 +3066,6 @@ mod tests {
         let warn_events = capture_terminal_log_events_with_context(
             ExecTerminalLogLifecycle::Supervised,
             false,
-            &[],
             &warn_result,
             true,
         );
@@ -3143,7 +3116,6 @@ mod tests {
                 capture_terminal_log_levels_with_context(
                     ExecTerminalLogLifecycle::Supervised,
                     false,
-                    &[],
                     &result,
                     stream_overflowed,
                 ),
@@ -3185,40 +3157,29 @@ mod tests {
     }
 
     #[test]
-    fn exec_operation_diagnostic_respects_expected_exit_codes_for_terminal_logs() {
-        let expected_nonzero = vsock_proto::DecodedExecResult {
+    fn exec_operation_diagnostic_treats_nonzero_exits_as_ordinary_terminal_results() {
+        let nonzero_exit = vsock_proto::DecodedExecResult {
             termination: ExecTermination::Exited { exit_code: 66 },
             ..clean_terminal_result()
         };
         assert_eq!(
-            capture_terminal_log_levels_with_expected_exit_codes(
-                ExecTerminalLogLifecycle::Supervised,
-                true,
-                &[66],
-                &expected_nonzero
-            ),
+            capture_terminal_log_levels(ExecTerminalLogLifecycle::Supervised, true, &nonzero_exit),
             vec![Level::INFO]
         );
         assert!(
-            capture_terminal_log_levels_with_expected_exit_codes(
-                ExecTerminalLogLifecycle::OneShot,
-                false,
-                &[66],
-                &expected_nonzero
-            )
-            .is_empty()
+            capture_terminal_log_levels(ExecTerminalLogLifecycle::OneShot, false, &nonzero_exit)
+                .is_empty()
         );
 
-        let expected_nonzero_with_diagnostic = vsock_proto::DecodedExecResult {
-            diagnostic: "expected nonzero with diagnostic",
-            ..expected_nonzero
+        let nonzero_exit_with_diagnostic = vsock_proto::DecodedExecResult {
+            diagnostic: "nonzero with diagnostic",
+            ..nonzero_exit
         };
         assert_eq!(
-            capture_terminal_log_levels_with_expected_exit_codes(
+            capture_terminal_log_levels(
                 ExecTerminalLogLifecycle::Supervised,
                 true,
-                &[66],
-                &expected_nonzero_with_diagnostic
+                &nonzero_exit_with_diagnostic
             ),
             vec![Level::WARN]
         );
@@ -3243,7 +3204,7 @@ mod tests {
             normal_operations: crate::operation_tracker::NormalOperationTracker::new(),
             close_notify: tokio::sync::Notify::new(),
         });
-        let mut diagnostic = ExecOperationDiagnostic::new(7, label, &[]);
+        let mut diagnostic = ExecOperationDiagnostic::new(7, label);
         diagnostic.registered_at =
             Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
         {
@@ -3373,12 +3334,11 @@ mod tests {
         lifecycle: ExecTerminalLogLifecycle,
         slow: bool,
         termination: ExecTermination,
-    ) -> ExecTerminalLogContext<'static> {
+    ) -> ExecTerminalLogContext {
         ExecTerminalLogContext {
             lifecycle,
             slow,
             termination,
-            expected_exit_codes: &[],
             stdout_truncated: false,
             stderr_truncated: false,
             stream_overflowed: false,
@@ -3431,42 +3391,39 @@ mod tests {
     }
 
     #[test]
-    fn exec_terminal_log_severity_respects_expected_nonzero_exit_codes() {
-        let fast_expected = ExecTerminalLogContext {
-            expected_exit_codes: &[66],
-            ..clean_terminal_log_context(
-                ExecTerminalLogLifecycle::Supervised,
-                false,
-                ExecTermination::Exited { exit_code: 66 },
-            )
-        };
-        let slow_expected = ExecTerminalLogContext {
+    fn exec_terminal_log_severity_treats_nonzero_exits_as_ordinary_results() {
+        let fast_nonzero = clean_terminal_log_context(
+            ExecTerminalLogLifecycle::Supervised,
+            false,
+            ExecTermination::Exited { exit_code: 66 },
+        );
+        let slow_nonzero = ExecTerminalLogContext {
             slow: true,
-            ..fast_expected
+            ..fast_nonzero
         };
-        let fast_one_shot_expected = ExecTerminalLogContext {
+        let fast_one_shot_nonzero = ExecTerminalLogContext {
             lifecycle: ExecTerminalLogLifecycle::OneShot,
-            ..fast_expected
+            ..fast_nonzero
         };
-        let slow_one_shot_expected = ExecTerminalLogContext {
+        let slow_one_shot_nonzero = ExecTerminalLogContext {
             lifecycle: ExecTerminalLogLifecycle::OneShot,
-            ..slow_expected
+            ..slow_nonzero
         };
 
-        assert_eq!(exec_terminal_log_severity(fast_expected), None);
-        assert_eq!(exec_terminal_log_severity(fast_one_shot_expected), None);
+        assert_eq!(exec_terminal_log_severity(fast_nonzero), None);
+        assert_eq!(exec_terminal_log_severity(fast_one_shot_nonzero), None);
         assert_eq!(
-            exec_terminal_log_severity(slow_expected),
+            exec_terminal_log_severity(slow_nonzero),
             Some(ExecTerminalLogSeverity::Info)
         );
         assert_eq!(
-            exec_terminal_log_severity(slow_one_shot_expected),
+            exec_terminal_log_severity(slow_one_shot_nonzero),
             Some(ExecTerminalLogSeverity::Warn)
         );
     }
 
     #[test]
-    fn exec_terminal_log_severity_warns_for_unexpected_nonzero_exit_code() {
+    fn exec_terminal_log_severity_suppresses_fast_nonzero_exits() {
         for lifecycle in [
             ExecTerminalLogLifecycle::OneShot,
             ExecTerminalLogLifecycle::Supervised,
@@ -3477,10 +3434,7 @@ mod tests {
                 ExecTermination::Exited { exit_code: 1 },
             );
 
-            assert_eq!(
-                exec_terminal_log_severity(context),
-                Some(ExecTerminalLogSeverity::Warn)
-            );
+            assert_eq!(exec_terminal_log_severity(context), None);
         }
     }
 
@@ -3492,10 +3446,6 @@ mod tests {
             ExecTermination::Exited { exit_code: 0 },
         );
         for context in [
-            ExecTerminalLogContext {
-                termination: ExecTermination::Exited { exit_code: 1 },
-                ..clean_slow
-            },
             ExecTerminalLogContext {
                 stdout_truncated: true,
                 ..clean_slow
@@ -3628,7 +3578,7 @@ mod tests {
             "{}secret-tail",
             "a".repeat(EXEC_OPERATION_LABEL_LOG_PREFIX_MAX_BYTES)
         );
-        let mut diagnostic = ExecOperationDiagnostic::new(7, &label, &[]);
+        let mut diagnostic = ExecOperationDiagnostic::new(7, &label);
         diagnostic.registered_at =
             Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
 
@@ -3653,7 +3603,6 @@ mod tests {
         let mut diagnostic = ExecOperationDiagnostic {
             seq: 9,
             label_log: "slow-first-output".to_string(),
-            expected_exit_codes: Vec::new(),
             registered_at: Instant::now()
                 - EXEC_OPERATION_STAGE_SLOW_THRESHOLD
                 - Duration::from_millis(1),


### PR DESCRIPTION
## Summary

- Stop treating plain non-zero guest exec exits as low-level `vsock-host` warnings by default.
- Explicitly handle runner setup command exit codes for guest clock sync and timezone sync.
- Make missing guest zoneinfo a successful timezone no-op and log real timezone setup failures with `run_id`, timezone, exit code, and bounded output context.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_terminal_log_severity`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation_diagnostic`
- `cargo test --manifest-path crates/Cargo.toml -p runner fix_guest_clock`
- `cargo test --manifest-path crates/Cargo.toml -p runner sync_guest_timezone`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p runner --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features` from `crates/`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`

Fixes #14884