### PR TITLE
refactor: migrate connector auth callers to lifecycle helpers

### DIFF
--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,5 +1,5 @@
 import {
-  getConnectorOAuthConfigIfSupported,
+  getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthCredentials,
   isOAuthAuthCodeConnectorType,
   type ConnectorEnvReader,
@@ -54,7 +54,7 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
 export function resolveConnectorOAuthStartType(
   type: ConnectorType,
 ): ResolveConnectorOAuthStartTypeResult {
-  if (!getConnectorOAuthConfigIfSupported(type)) {
+  if (!getConnectorOAuthGrantConfigIfSupported(type)) {
     return { ok: false, reason: "connector_does_not_use_oauth" };
   }
   if (!isOAuthConnectorType(type)) {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -5,7 +5,7 @@ import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/con
 import {
   isOAuthAuthCodeConnectorType,
   getConnectorOAuthCredentials,
-  getConnectorOAuthConfig,
+  getConnectorOAuthScopes,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -200,7 +200,7 @@ async function exchangeTokenForConnector(args: {
 function getRequestedScopes(
   connectorType: OAuthAuthCodeConnectorType,
 ): readonly string[] {
-  return getConnectorOAuthConfig(connectorType).scopes;
+  return getConnectorOAuthScopes(connectorType);
 }
 
 function resolveOAuthConnectorType(

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -4,8 +4,8 @@ import {
   type GithubOauthConnectQuery,
 } from "@vm0/api-contracts/contracts/github-oauth";
 import {
-  getConnectorOAuthConfig,
   getConnectorOAuthCredentials,
+  getConnectorOAuthScopes,
   isStaticConfidentialConnectorOAuthCredentials,
   type StaticConfidentialConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
@@ -382,9 +382,7 @@ const connectGithubUserAfterSetup$ = command(
           accessToken,
           userInfo,
           oauthScopes:
-            scopes.length > 0
-              ? scopes
-              : getConnectorOAuthConfig("github").scopes,
+            scopes.length > 0 ? scopes : getConnectorOAuthScopes("github"),
         },
         signal,
       );
@@ -760,7 +758,7 @@ const callbackGithubUserOauth$ = command(
         type: "github",
         accessToken: token.accessToken,
         userInfo: token.userInfo,
-        oauthScopes: getConnectorOAuthConfig("github").scopes,
+        oauthScopes: getConnectorOAuthScopes("github"),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -3,6 +3,7 @@ import {
   githubOauthContract,
   type GithubOauthConnectQuery,
 } from "@vm0/api-contracts/contracts/github-oauth";
+import type { OAuthAuthCodeConnectorType } from "@vm0/connectors/connectors";
 import {
   getConnectorOAuthCredentials,
   getConnectorOAuthScopes,
@@ -51,6 +52,7 @@ import {
 } from "./oauth-web-origin";
 
 const REDIRECT_STATUS = 307;
+const GITHUB_CONNECTOR_TYPE = "github" satisfies OAuthAuthCodeConnectorType;
 const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
 const L = logger("GithubOAuthRoute");
 
@@ -382,7 +384,9 @@ const connectGithubUserAfterSetup$ = command(
           accessToken,
           userInfo,
           oauthScopes:
-            scopes.length > 0 ? scopes : getConnectorOAuthScopes("github"),
+            scopes.length > 0
+              ? scopes
+              : getConnectorOAuthScopes(GITHUB_CONNECTOR_TYPE),
         },
         signal,
       );
@@ -758,7 +762,7 @@ const callbackGithubUserOauth$ = command(
         type: "github",
         accessToken: token.accessToken,
         userInfo: token.userInfo,
-        oauthScopes: getConnectorOAuthScopes("github"),
+        oauthScopes: getConnectorOAuthScopes(GITHUB_CONNECTOR_TYPE),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -10,7 +10,7 @@ import type {
   OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthConfigIfSupported,
+  getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthCredentials,
   isConnectorAuthMethodAvailable,
   isOAuthDeviceAuthConnectorType,
@@ -184,7 +184,7 @@ function resolveDeviceAuthType(
   | OAuthDeviceAuthConnectorType
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof internalServerError> {
-  if (!getConnectorOAuthConfigIfSupported(type)) {
+  if (!getConnectorOAuthGrantConfigIfSupported(type)) {
     return badRequestMessage(`${type} connector does not use OAuth`);
   }
   if (!isOAuthConnectorType(type)) {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -16,7 +16,7 @@ import {
   getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethod,
-  getConnectorCliAuthModes,
+  getConnectorInteractivePairingGrantConfigIfSupported,
   getConnectorTags,
   hasRequiredScopes,
   isGoogleOAuthConnector,
@@ -1388,7 +1388,10 @@ function getConnectorCliAuthMode(
 }
 
 function connectorCliAuthRequiresMode(type: ConnectorType): boolean {
-  return getConnectorCliAuthModes(type).length > 0;
+  return (
+    (getConnectorInteractivePairingGrantConfigIfSupported(type)?.modes
+      ?.length ?? 0) > 0
+  );
 }
 
 function connectorCliAuthModeIsAllowed(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/cli-auth-connect-methods.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/cli-auth-connect-methods.tsx
@@ -4,8 +4,7 @@ import { Button } from "@vm0/ui/components/ui/button";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthMethod,
-  getConnectorCliAuthFlow,
-  getConnectorCliAuthModes,
+  getConnectorInteractivePairingGrantConfigIfSupported,
 } from "@vm0/connectors/connector-utils";
 import type { MouseEventHandler, ReactElement } from "react";
 
@@ -52,7 +51,9 @@ function stateForConnector(
 }
 
 function cliAuthModeOptions(type: ConnectorType): readonly CliAuthModeOption[] {
-  return getConnectorCliAuthModes(type);
+  return (
+    getConnectorInteractivePairingGrantConfigIfSupported(type)?.modes ?? []
+  );
 }
 
 function CliAuthModePicker({
@@ -260,7 +261,7 @@ function BrowserVerificationCliAuthConnectMethodContent({
 export function getCliAuthConnectMethodContentComponent(
   type: ConnectorType,
 ): CliAuthConnectMethodContentComponent | null {
-  switch (getConnectorCliAuthFlow(type)) {
+  switch (getConnectorInteractivePairingGrantConfigIfSupported(type)?.flow) {
     case "browser-verification": {
       return BrowserVerificationCliAuthConnectMethodContent;
     }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -5,7 +5,6 @@ import type {
   OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorDeviceAuthGrantConfigIfSupported,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isOAuthAuthCodeConnectorType,
   isStaticConfidentialConnectorOAuthCredentials,
@@ -40,6 +39,7 @@ import {
   type OAuthRefreshResult,
   type OAuthTokenResult,
 } from "./oauth/types";
+import { getDeviceAuthGrantConfig } from "./oauth/grant-config";
 import { providerEnvFromObject, type ProviderEnv } from "./provider-env";
 import { ahrefsProvider } from "./oauth/providers/ahrefs-provider";
 import { airtableProvider } from "./oauth/providers/airtable-provider";
@@ -309,10 +309,7 @@ export async function startConnectorOAuthDeviceAuth<
   readonly credentials: ConnectorOAuthCredentials;
 }): Promise<OAuthDeviceAuthStartResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const grant = getConnectorDeviceAuthGrantConfigIfSupported(args.type);
-  if (!grant) {
-    throw new Error(`${args.type} device-auth grant config not found`);
-  }
+  const grant = getDeviceAuthGrantConfig(args.type);
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.startDeviceAuth({

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -5,7 +5,7 @@ import type {
   OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthDeviceAuthConfig,
+  getConnectorDeviceAuthGrantConfigIfSupported,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isOAuthAuthCodeConnectorType,
   isStaticConfidentialConnectorOAuthCredentials,
@@ -309,12 +309,15 @@ export async function startConnectorOAuthDeviceAuth<
   readonly credentials: ConnectorOAuthCredentials;
 }): Promise<OAuthDeviceAuthStartResult> {
   assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
-  const oauthConfig = getConnectorOAuthDeviceAuthConfig(args.type);
+  const grant = getConnectorDeviceAuthGrantConfigIfSupported(args.type);
+  if (!grant) {
+    throw new Error(`${args.type} device-auth grant config not found`);
+  }
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.startDeviceAuth({
     ...connectorCredentialArgs(args.credentials),
-    scopes: oauthConfig.scopes,
+    scopes: grant.scopes,
   } as ConnectorOAuthDeviceAuthStartArgs<T>);
 }
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/google.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "./grant-config";
 import type { GoogleOAuthConnectorType } from "./google-connectors";
 import { throwOAuthError } from "./error";
 
@@ -38,12 +39,12 @@ export function buildGoogleAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
+  const authCodeGrant = getAuthCodeGrantConfig(connectorType);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     access_type: "offline",
     prompt: "consent",
@@ -63,8 +64,8 @@ export async function exchangeGoogleOAuthCode(
   code: string,
   redirectUri: string,
 ): Promise<GoogleTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig(connectorType);
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -124,8 +125,8 @@ export async function refreshGoogleToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GoogleRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig(connectorType);
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
@@ -1,0 +1,30 @@
+import type {
+  ConnectorAuthCodeGrantConfig,
+  ConnectorDeviceAuthGrantConfig,
+  OAuthAuthCodeConnectorType,
+  OAuthDeviceAuthConnectorType,
+} from "@vm0/connectors/connectors";
+import {
+  getConnectorAuthCodeGrantConfigIfSupported,
+  getConnectorDeviceAuthGrantConfigIfSupported,
+} from "@vm0/connectors/connector-utils";
+
+export function getAuthCodeGrantConfig(
+  type: OAuthAuthCodeConnectorType,
+): ConnectorAuthCodeGrantConfig {
+  const grant = getConnectorAuthCodeGrantConfigIfSupported(type);
+  if (!grant) {
+    throw new Error(`${type} auth-code grant config not found`);
+  }
+  return grant;
+}
+
+export function getDeviceAuthGrantConfig(
+  type: OAuthDeviceAuthConnectorType,
+): ConnectorDeviceAuthGrantConfig {
+  const grant = getConnectorDeviceAuthGrantConfigIfSupported(type);
+  if (!grant) {
+    throw new Error(`${type} device-auth grant config not found`);
+  }
+  return grant;
+}

--- a/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
@@ -16,7 +16,7 @@ export function getAuthCodeGrantConfig(
   if (!grant) {
     throw new Error(`${type} auth-code grant config not found`);
   }
-  return grant;
+  return { ...grant, scopes: [...grant.scopes] };
 }
 
 export function getDeviceAuthGrantConfig(
@@ -26,5 +26,5 @@ export function getDeviceAuthGrantConfig(
   if (!grant) {
     throw new Error(`${type} device-auth grant config not found`);
   }
-  return grant;
+  return { ...grant, scopes: [...grant.scopes] };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -1,6 +1,7 @@
 import type { OAuthAuthCodeConnectorType } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "./grant-config";
 import { throwOAuthError } from "./error";
 
 const MICROSOFT_AUTHORIZATION_URL =
@@ -43,12 +44,12 @@ export function buildMicrosoftAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
+  const authCodeGrant = getAuthCodeGrantConfig(connectorType);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     prompt: "consent",
   });
@@ -67,8 +68,8 @@ export async function exchangeMicrosoftOAuthCode(
   code: string,
   redirectUri: string,
 ): Promise<MicrosoftTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig(connectorType);
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -128,8 +129,8 @@ export async function refreshMicrosoftToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MicrosoftRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig(connectorType);
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const AHREFS_AUTHORIZATION_URL = "https://app.ahrefs.com/api/auth";
@@ -35,12 +36,12 @@ export function buildAhrefsAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("ahrefs");
+  const authCodeGrant = getAuthCodeGrantConfig("ahrefs");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -56,8 +57,8 @@ export async function exchangeAhrefsCode(
   code: string,
   redirectUri: string,
 ): Promise<AhrefsTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("ahrefs");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("ahrefs");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -115,8 +116,8 @@ export async function refreshAhrefsToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AhrefsRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("ahrefs");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("ahrefs");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const AIRTABLE_AUTHORIZATION_URL = "https://airtable.com/oauth2/v1/authorize";
@@ -60,7 +61,7 @@ export async function buildAirtableAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<{ url: string; codeVerifier: string }> {
-  const oauthConfig = getConnectorOAuthConfig("airtable");
+  const authCodeGrant = getAuthCodeGrantConfig("airtable");
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -68,7 +69,7 @@ export async function buildAirtableAuthorizationUrl(
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -91,14 +92,14 @@ export async function exchangeAirtableCode(
   redirectUri: string,
   codeVerifier?: string,
 ): Promise<AirtableTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("airtable");
+  const authCodeGrant = getAuthCodeGrantConfig("airtable");
   if (!codeVerifier) {
     throw new Error("Airtable requires PKCE code_verifier for token exchange");
   }
 
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -156,10 +157,10 @@ export async function refreshAirtableToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AirtableRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("airtable");
+  const authCodeGrant = getAuthCodeGrantConfig("airtable");
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const ASANA_AUTHORIZATION_URL = "https://app.asana.com/-/oauth_authorize";
@@ -52,8 +53,8 @@ export async function exchangeAsanaCode(
   code: string,
   redirectUri: string,
 ): Promise<AsanaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("asana");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("asana");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -108,7 +109,7 @@ export async function exchangeAsanaCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     userInfo,
   };
 }
@@ -159,8 +160,8 @@ export async function refreshAsanaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AsanaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("asana");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("asana");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
@@ -1,6 +1,6 @@
-import { getConnectorOAuthDeviceAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 
+import { getDeviceAuthGrantConfig } from "../grant-config";
 import type {
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
@@ -51,8 +51,8 @@ const userInfoResponseSchema = z
   })
   .passthrough();
 
-function base44OauthConfig() {
-  return getConnectorOAuthDeviceAuthConfig("base44");
+function base44DeviceAuthGrant() {
+  return getDeviceAuthGrantConfig("base44");
 }
 
 function parseScopes(scope: string | undefined): string[] {
@@ -107,7 +107,7 @@ export async function startBase44DeviceAuth(args: {
   readonly clientId: string;
   readonly scopes: readonly string[];
 }): Promise<OAuthDeviceAuthStartResult> {
-  const response = await fetch(base44OauthConfig().deviceAuthUrl, {
+  const response = await fetch(base44DeviceAuthGrant().deviceAuthUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -137,7 +137,7 @@ export async function pollBase44DeviceAuth(args: {
   readonly clientId: string;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  const response = await fetch(base44OauthConfig().tokenUrl, {
+  const response = await fetch(base44DeviceAuthGrant().tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -189,7 +189,7 @@ export async function refreshBase44Token(args: {
   readonly clientId: string;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  const response = await fetch(base44OauthConfig().tokenUrl, {
+  const response = await fetch(base44DeviceAuthGrant().tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const CANVA_AUTHORIZATION_URL = "https://www.canva.com/api/oauth/authorize";
@@ -68,7 +69,7 @@ export async function buildCanvaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("canva");
+  const authCodeGrant = getAuthCodeGrantConfig("canva");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -76,7 +77,7 @@ export async function buildCanvaAuthorizationUrl(
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -95,12 +96,12 @@ export async function refreshCanvaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<CanvaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("canva");
+  const authCodeGrant = getAuthCodeGrantConfig("canva");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -151,13 +152,13 @@ export async function exchangeCanvaCode(
   redirectUri: string,
   state: string,
 ): Promise<CanvaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("canva");
+  const authCodeGrant = getAuthCodeGrantConfig("canva");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const CLOSE_AUTHORIZATION_URL = "https://app.close.com/oauth2/authorize/";
@@ -51,8 +52,8 @@ export async function exchangeCloseCode(
   code: string,
   redirectUri: string,
 ): Promise<CloseTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("close");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("close");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -97,7 +98,7 @@ export async function exchangeCloseCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : oauthConfig.scopes,
+    scopes: data.scope ? data.scope.split(" ") : authCodeGrant.scopes,
     userInfo: {
       id: userInfo.id ?? data.user_id ?? "unknown",
       email: userInfo.email,
@@ -115,8 +116,8 @@ export async function refreshCloseToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<CloseRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("close");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("close");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const DEEL_AUTHORIZATION_URL = "https://app.deel.com/oauth2/authorize";
@@ -67,7 +68,7 @@ export async function buildDeelAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("deel");
+  const authCodeGrant = getAuthCodeGrantConfig("deel");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -75,7 +76,7 @@ export async function buildDeelAuthorizationUrl(
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -95,12 +96,12 @@ export async function refreshDeelToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DeelRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("deel");
+  const authCodeGrant = getAuthCodeGrantConfig("deel");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -151,13 +152,13 @@ export async function exchangeDeelCode(
   redirectUri: string,
   state: string,
 ): Promise<DeelTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("deel");
+  const authCodeGrant = getAuthCodeGrantConfig("deel");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const DOCUSIGN_AUTHORIZATION_URL = "https://account-d.docusign.com/oauth/auth";
@@ -67,7 +68,7 @@ export async function buildDocuSignAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("docusign");
+  const authCodeGrant = getAuthCodeGrantConfig("docusign");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -75,7 +76,7 @@ export async function buildDocuSignAuthorizationUrl(
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -95,13 +96,13 @@ export async function exchangeDocuSignCode(
   redirectUri: string,
   state: string,
 ): Promise<DocuSignTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("docusign");
+  const authCodeGrant = getAuthCodeGrantConfig("docusign");
   const codeVerifier = await deriveCodeVerifier(state);
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -160,12 +161,12 @@ export async function refreshDocuSignToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DocuSignRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("docusign");
+  const authCodeGrant = getAuthCodeGrantConfig("docusign");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const DROPBOX_AUTHORIZATION_URL = "https://www.dropbox.com/oauth2/authorize";
@@ -36,12 +37,12 @@ export function buildDropboxAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("dropbox");
+  const authCodeGrant = getAuthCodeGrantConfig("dropbox");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     token_access_type: "offline",
     force_reapprove: "true",
@@ -59,8 +60,8 @@ export async function exchangeDropboxCode(
   code: string,
   redirectUri: string,
 ): Promise<DropboxTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("dropbox");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("dropbox");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -118,8 +119,8 @@ export async function refreshDropboxToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DropboxRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("dropbox");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("dropbox");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const FIGMA_AUTHORIZATION_URL = "https://www.figma.com/oauth";
@@ -34,12 +35,12 @@ export function buildFigmaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("figma");
+  const authCodeGrant = getAuthCodeGrantConfig("figma");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(","),
+    scope: authCodeGrant.scopes.join(","),
     state,
   });
 
@@ -56,12 +57,12 @@ export async function exchangeFigmaCode(
   code: string,
   redirectUri: string,
 ): Promise<FigmaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("figma");
+  const authCodeGrant = getAuthCodeGrantConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -118,12 +119,12 @@ export async function refreshFigmaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<FigmaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("figma");
+  const authCodeGrant = getAuthCodeGrantConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const GARMIN_CONNECT_AUTHORIZATION_URL =
@@ -94,10 +95,10 @@ export async function exchangeGarminConnectCode(
   code: string,
   state: string,
 ): Promise<GarminConnectTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
+  const authCodeGrant = getAuthCodeGrantConfig("garmin-connect");
   const codeVerifier = await deriveCodeVerifier(state);
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -156,8 +157,8 @@ export async function refreshGarminConnectToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GarminConnectRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("garmin-connect");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/github.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/github.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const GITHUB_AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
@@ -20,11 +21,11 @@ export function buildGitHubAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("github");
+  const authCodeGrant = getAuthCodeGrantConfig("github");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -40,7 +41,7 @@ export async function exchangeGitHubCode(
   code: string,
   redirectUri?: string,
 ): Promise<{ accessToken: string; scopes: string[] }> {
-  const oauthConfig = getConnectorOAuthConfig("github");
+  const authCodeGrant = getAuthCodeGrantConfig("github");
   const body = new URLSearchParams({
     client_id: clientId,
     client_secret: clientSecret,
@@ -50,7 +51,7 @@ export async function exchangeGitHubCode(
     body.set("redirect_uri", redirectUri);
   }
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { buildGoogleAuthorizationUrl } from "../google";
 import { throwOAuthError } from "../error";
 
@@ -42,8 +43,8 @@ export async function exchangeGmailCode(
   code: string,
   redirectUri: string,
 ): Promise<GmailTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("gmail");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("gmail");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const GUMROAD_AUTHORIZATION_URL = "https://gumroad.com/oauth/authorize";
@@ -31,12 +32,12 @@ export function buildGumroadAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("gumroad");
+  const authCodeGrant = getAuthCodeGrantConfig("gumroad");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -49,8 +50,8 @@ export async function exchangeGumroadCode(
   code: string,
   redirectUri: string,
 ): Promise<GumroadTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("gumroad");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("gumroad");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -103,8 +104,8 @@ export async function refreshGumroadToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GumroadRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("gumroad");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("gumroad");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const HUBSPOT_AUTHORIZATION_URL = "https://app.hubspot.com/oauth/authorize";
@@ -34,11 +35,11 @@ export function buildHubSpotAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("hubspot");
+  const authCodeGrant = getAuthCodeGrantConfig("hubspot");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -54,8 +55,8 @@ export async function exchangeHubSpotCode(
   code: string,
   redirectUri: string,
 ): Promise<HubSpotTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("hubspot");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("hubspot");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -97,7 +98,7 @@ export async function exchangeHubSpotCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     userInfo,
   };
 }
@@ -111,8 +112,8 @@ export async function refreshHubSpotToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<HubSpotRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("hubspot");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("hubspot");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/intervals-icu.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/intervals-icu.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const INTERVALS_ICU_AUTHORIZATION_URL = "https://intervals.icu/oauth/authorize";
@@ -23,12 +24,12 @@ export function buildIntervalsIcuAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("intervals-icu");
+  const authCodeGrant = getAuthCodeGrantConfig("intervals-icu");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(","),
+    scope: authCodeGrant.scopes.join(","),
     state,
   });
 
@@ -45,8 +46,8 @@ export async function exchangeIntervalsIcuCode(
   clientSecret: string,
   code: string,
 ): Promise<IntervalsIcuTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("intervals-icu");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("intervals-icu");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -90,7 +91,7 @@ export async function exchangeIntervalsIcuCode(
 
   return {
     accessToken: data.access_token,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     userInfo: {
       id: data.athlete.id,
       username: data.athlete.name ?? null,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
@@ -1,10 +1,11 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const LINEAR_AUTHORIZATION_URL = "https://linear.app/oauth/authorize";
 
-// User info URL is not part of ConnectorOAuthConfig since it uses GraphQL (POST), not a standard
+// User info URL is not part of the auth-code grant config since it uses GraphQL (POST), not a standard
 // REST GET endpoint. Same pattern as GMAIL_PROFILE_URL in gmail.ts.
 const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 
@@ -36,12 +37,12 @@ export function buildLinearAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("linear");
+  const authCodeGrant = getAuthCodeGrantConfig("linear");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(","),
+    scope: authCodeGrant.scopes.join(","),
     state,
     actor: "user",
     prompt: "consent",
@@ -60,8 +61,8 @@ export async function exchangeLinearCode(
   code: string,
   redirectUri: string,
 ): Promise<LinearTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("linear");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("linear");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -119,8 +120,8 @@ export async function refreshLinearToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<LinearRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("linear");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("linear");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mailchimp.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mailchimp.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const MAILCHIMP_AUTHORIZATION_URL =
@@ -47,8 +48,8 @@ export async function exchangeMailchimpCode(
   code: string,
   redirectUri: string,
 ): Promise<MailchimpTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("mailchimp");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("mailchimp");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -85,7 +86,7 @@ export async function exchangeMailchimpCode(
 
   return {
     accessToken: data.access_token,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     apiEndpoint: metadata.apiEndpoint,
     userInfo: metadata.userInfo,
   };

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const MERCURY_AUTHORIZATION_URL = "https://oauth2.mercury.com/oauth2/auth";
@@ -35,12 +36,12 @@ export function buildMercuryAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("mercury");
+  const authCodeGrant = getAuthCodeGrantConfig("mercury");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -56,8 +57,8 @@ export async function exchangeMercuryCode(
   code: string,
   redirectUri: string,
 ): Promise<MercuryTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("mercury");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("mercury");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -115,8 +116,8 @@ export async function refreshMercuryToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MercuryRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("mercury");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("mercury");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/meta-ads.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/meta-ads.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const META_ADS_AUTHORIZATION_URL =
@@ -30,13 +31,13 @@ export function buildMetaAdsAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("meta-ads");
+  const authCodeGrant = getAuthCodeGrantConfig("meta-ads");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     state,
     response_type: "code",
-    scope: oauthConfig.scopes.join(","),
+    scope: authCodeGrant.scopes.join(","),
   });
 
   return `${META_ADS_AUTHORIZATION_URL}?${params.toString()}`;
@@ -52,9 +53,9 @@ export async function exchangeMetaAdsCode(
   code: string,
   redirectUri: string,
 ): Promise<MetaAdsTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("meta-ads");
+  const authCodeGrant = getAuthCodeGrantConfig("meta-ads");
   // Step 1: Exchange code for short-lived token
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -107,7 +108,7 @@ export async function exchangeMetaAdsCode(
     accessToken: longLivedToken.accessToken,
     refreshToken: null,
     expiresIn: longLivedToken.expiresIn,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const MONDAY_AUTHORIZATION_URL = "https://auth.monday.com/oauth2/authorize";
@@ -34,12 +35,12 @@ export function buildMondayAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("monday");
+  const authCodeGrant = getAuthCodeGrantConfig("monday");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -56,8 +57,8 @@ export async function exchangeMondayCode(
   code: string,
   redirectUri: string,
 ): Promise<MondayTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("monday");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("monday");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -114,8 +115,8 @@ export async function refreshMondayToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MondayRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("monday");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("monday");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const NEON_AUTHORIZATION_URL = "https://oauth2.neon.tech/oauth2/auth";
@@ -35,13 +36,13 @@ export function buildNeonAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("neon");
+  const authCodeGrant = getAuthCodeGrantConfig("neon");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
     state,
     redirect_uri: redirectUri,
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
   });
 
   return `${NEON_AUTHORIZATION_URL}?${params.toString()}`;
@@ -57,8 +58,8 @@ export async function exchangeNeonCode(
   code: string,
   redirectUri: string,
 ): Promise<NeonTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("neon");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("neon");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -116,8 +117,8 @@ export async function refreshNeonToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<NeonRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("neon");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("neon");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const NOTION_AUTHORIZATION_URL = "https://api.notion.com/v1/oauth/authorize";
@@ -61,8 +62,8 @@ export async function exchangeNotionCode(
   code: string,
   redirectUri: string,
 ): Promise<NotionTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("notion");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("notion");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,
@@ -131,8 +132,8 @@ export async function refreshNotionToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<NotionRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("notion");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("notion");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const POSTHOG_AUTHORIZATION_URL = "https://us.posthog.com/oauth/authorize";
@@ -34,12 +35,12 @@ export function buildPosthogAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("posthog");
+  const authCodeGrant = getAuthCodeGrantConfig("posthog");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -55,8 +56,8 @@ export async function exchangePosthogCode(
   code: string,
   redirectUri: string,
 ): Promise<PosthogTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("posthog");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("posthog");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -113,8 +114,8 @@ export async function refreshPosthogToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<PosthogRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("posthog");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("posthog");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const REDDIT_AUTHORIZATION_URL = "https://www.reddit.com/api/v1/authorize";
@@ -38,14 +39,14 @@ export function buildRedditAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("reddit");
+  const authCodeGrant = getAuthCodeGrantConfig("reddit");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
     state,
     redirect_uri: redirectUri,
     duration: "permanent",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
   });
 
   return `${REDDIT_AUTHORIZATION_URL}?${params.toString()}`;
@@ -61,8 +62,8 @@ export async function exchangeRedditCode(
   code: string,
   redirectUri: string,
 ): Promise<RedditTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("reddit");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("reddit");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,
@@ -160,8 +161,8 @@ export async function refreshRedditToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<RedditRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("reddit");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("reddit");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const SENTRY_AUTHORIZATION_URL = "https://sentry.io/oauth/authorize/";
@@ -32,12 +33,12 @@ export function buildSentryAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("sentry");
+  const authCodeGrant = getAuthCodeGrantConfig("sentry");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -54,8 +55,8 @@ export async function exchangeSentryCode(
   code: string,
   redirectUri: string,
 ): Promise<SentryTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("sentry");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("sentry");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -126,8 +127,8 @@ export async function refreshSentryToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SentryRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("sentry");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("sentry");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slack.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slack.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const SLACK_AUTHORIZATION_URL = "https://slack.com/oauth/v2/authorize";
@@ -25,11 +26,11 @@ export function buildSlackAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("slack");
+  const authCodeGrant = getAuthCodeGrantConfig("slack");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
-    user_scope: oauthConfig.scopes.join(","),
+    user_scope: authCodeGrant.scopes.join(","),
     state,
   });
 
@@ -46,8 +47,8 @@ export async function exchangeSlackCode(
   code: string,
   redirectUri: string,
 ): Promise<SlackTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("slack");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("slack");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const SPOTIFY_AUTHORIZATION_URL = "https://accounts.spotify.com/authorize";
@@ -34,12 +35,12 @@ export function buildSpotifyAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("spotify");
+  const authCodeGrant = getAuthCodeGrantConfig("spotify");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -56,12 +57,12 @@ export async function exchangeSpotifyCode(
   code: string,
   redirectUri: string,
 ): Promise<SpotifyTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("spotify");
+  const authCodeGrant = getAuthCodeGrantConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -117,12 +118,12 @@ export async function refreshSpotifyToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SpotifyRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("spotify");
+  const authCodeGrant = getAuthCodeGrantConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const STRAVA_AUTHORIZATION_URL = "https://www.strava.com/oauth/authorize";
@@ -35,12 +36,12 @@ export function buildStravaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("strava");
+  const authCodeGrant = getAuthCodeGrantConfig("strava");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(","),
+    scope: authCodeGrant.scopes.join(","),
     state,
     approval_prompt: "force",
   });
@@ -57,8 +58,8 @@ export async function exchangeStravaCode(
   clientSecret: string,
   code: string,
 ): Promise<StravaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("strava");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("strava");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -133,8 +134,8 @@ export async function refreshStravaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<StravaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("strava");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("strava");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const STRIPE_AUTHORIZATION_URL = "https://connect.stripe.com/oauth/authorize";
@@ -34,12 +35,12 @@ export function buildStripeAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("stripe");
+  const authCodeGrant = getAuthCodeGrantConfig("stripe");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -55,8 +56,8 @@ export async function exchangeStripeCode(
   clientSecret: string,
   code: string,
 ): Promise<StripeTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("stripe");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("stripe");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -116,8 +117,8 @@ export async function refreshStripeToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<StripeRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("stripe");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("stripe");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const SUPABASE_AUTHORIZATION_URL =
@@ -68,7 +69,7 @@ export async function buildSupabaseAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("supabase");
+  const authCodeGrant = getAuthCodeGrantConfig("supabase");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -76,7 +77,7 @@ export async function buildSupabaseAuthorizationUrl(
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -95,12 +96,12 @@ export async function refreshSupabaseToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SupabaseRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("supabase");
+  const authCodeGrant = getAuthCodeGrantConfig("supabase");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -152,13 +153,13 @@ export async function exchangeSupabaseCode(
   redirectUri: string,
   state: string,
 ): Promise<SupabaseTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("supabase");
+  const authCodeGrant = getAuthCodeGrantConfig("supabase");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
@@ -1,6 +1,6 @@
-import { getConnectorOAuthDeviceAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 
+import { getDeviceAuthGrantConfig } from "../grant-config";
 import type {
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
@@ -45,14 +45,14 @@ const tokenErrorResponseSchema = z.object({
 function getDeviceAuthUrl(): string {
   return resolveTestOAuthProviderUrl(
     "deviceAuthUrl",
-    getConnectorOAuthDeviceAuthConfig("test-oauth-device").deviceAuthUrl,
+    getDeviceAuthGrantConfig("test-oauth-device").deviceAuthUrl,
   );
 }
 
 function getDeviceTokenUrl(): string {
   return resolveTestOAuthProviderUrl(
     "tokenUrl",
-    getConnectorOAuthDeviceAuthConfig("test-oauth-device").tokenUrl,
+    getDeviceAuthGrantConfig("test-oauth-device").tokenUrl,
   );
 }
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
@@ -9,8 +9,9 @@
  * the provider routes themselves 404 in production via isTestEndpointAllowed().
  */
 
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 export {
   TEST_OAUTH_CLIENT_ID,
@@ -139,7 +140,7 @@ function getAuthorizationUrl(): string {
 function getTestOAuthTokenUrl(): string {
   return resolveTestOAuthProviderUrl(
     "tokenUrl",
-    getConnectorOAuthConfig("test-oauth").tokenUrl,
+    getAuthCodeGrantConfig("test-oauth").tokenUrl,
   );
 }
 
@@ -231,7 +232,7 @@ export async function fetchTestOAuthUserInfo(
   accessToken: string,
 ): Promise<UserInfo> {
   // userinfo is not part of the OAuth 2 spec's token and authorization
-  // endpoints, so ConnectorOAuthConfig doesn't carry it. Derive from the same app.
+  // endpoints, so the auth-code grant config doesn't carry it. Derive from the same app.
   const response = await fetch(
     `${runtimeBaseUrl()}/api/test/oauth-provider/userinfo`,
     {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/todoist.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/todoist.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const TODOIST_AUTHORIZATION_URL = "https://todoist.com/oauth/authorize";
@@ -25,10 +26,10 @@ export function buildTodoistAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("todoist");
+  const authCodeGrant = getAuthCodeGrantConfig("todoist");
   const params = new URLSearchParams({
     client_id: clientId,
-    scope: oauthConfig.scopes.join(","),
+    scope: authCodeGrant.scopes.join(","),
     state,
     redirect_uri: redirectUri,
   });
@@ -47,8 +48,8 @@ export async function exchangeTodoistCode(
   code: string,
   redirectUri: string,
 ): Promise<TodoistTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("todoist");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("todoist");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -85,7 +86,7 @@ export async function exchangeTodoistCode(
 
   return {
     accessToken: data.access_token,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/vercel.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/vercel.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 interface VercelUserInfo {
@@ -42,8 +43,8 @@ export async function exchangeVercelCode(
   code: string,
   redirectUri: string,
 ): Promise<VercelTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("vercel");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("vercel");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/webflow.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/webflow.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const WEBFLOW_AUTHORIZATION_URL = "https://webflow.com/oauth/authorize";
@@ -22,11 +23,11 @@ export function buildWebflowAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("webflow");
+  const authCodeGrant = getAuthCodeGrantConfig("webflow");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     redirect_uri: redirectUri,
   });
@@ -44,8 +45,8 @@ export async function exchangeWebflowCode(
   code: string,
   redirectUri: string,
 ): Promise<WebflowTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("webflow");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("webflow");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -74,7 +75,7 @@ export async function exchangeWebflowCode(
 
   return {
     accessToken: data.access_token,
-    scopes: oauthConfig.scopes,
+    scopes: authCodeGrant.scopes,
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const X_AUTHORIZATION_URL = "https://twitter.com/i/oauth2/authorize";
@@ -68,7 +69,7 @@ export async function buildXAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("x");
+  const authCodeGrant = getAuthCodeGrantConfig("x");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -76,7 +77,7 @@ export async function buildXAuthorizationUrl(
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -95,12 +96,12 @@ export async function refreshXToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<XRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("x");
+  const authCodeGrant = getAuthCodeGrantConfig("x");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -151,13 +152,13 @@ export async function exchangeXCode(
   redirectUri: string,
   state: string,
 ): Promise<XTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("x");
+  const authCodeGrant = getAuthCodeGrantConfig("x");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const XERO_AUTHORIZATION_URL =
@@ -35,12 +36,12 @@ export function buildXeroAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("xero");
+  const authCodeGrant = getAuthCodeGrantConfig("xero");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -57,8 +58,8 @@ export async function exchangeXeroCode(
   code: string,
   redirectUri: string,
 ): Promise<XeroTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("xero");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("xero");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -117,8 +118,8 @@ export async function refreshXeroToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<XeroRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("xero");
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const authCodeGrant = getAuthCodeGrantConfig("xero");
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
@@ -1,5 +1,6 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
+
+import { getAuthCodeGrantConfig } from "../grant-config";
 import { throwOAuthError } from "../error";
 
 const ZOOM_AUTHORIZATION_URL = "https://zoom.us/oauth/authorize";
@@ -34,12 +35,12 @@ export function buildZoomAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("zoom");
+  const authCodeGrant = getAuthCodeGrantConfig("zoom");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: oauthConfig.scopes.join(" "),
+    scope: authCodeGrant.scopes.join(" "),
     state,
   });
 
@@ -58,12 +59,12 @@ export async function exchangeZoomCode(
   code: string,
   redirectUri: string,
 ): Promise<ZoomTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("zoom");
+  const authCodeGrant = getAuthCodeGrantConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -120,12 +121,12 @@ export async function refreshZoomToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<ZoomRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("zoom");
+  const authCodeGrant = getAuthCodeGrantConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
 
-  const response = await fetch(oauthConfig.tokenUrl, {
+  const response = await fetch(authCodeGrant.tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
Closes #14882

## Summary
- add an OAuth provider-layer grant config helper for auth-code and device-auth grant reads
- migrate production provider/API/platform callers off legacy OAuth/CliAuth config helper calls
- keep legacy compatibility helpers and their tests in place for the follow-up removal issue

## Tests
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm check-types
- pnpm format
- pnpm knip
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/auth-providers/oauth/providers/__tests__
- pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/github-oauth.test.ts
- pnpm -F @vm0/app exec vitest run src/views/conn/__tests__/add-connection-dialog.test.tsx src/signals/zero-page/__tests__/zero-connectors.test.ts

## Notes
- Full local pnpm vitest was attempted and failed outside this change area due local environment/schema failures such as chat_threads.last_message_at missing, plus unrelated network insights assertions.