### PR TITLE
chore: delete ChatMarkdownMath/ConnectorCategories + reshape rollout for 4 flags

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -261,32 +261,8 @@ describe("GET /api/zero/connectors/search", () => {
     expect(connector?.authMethods).toStrictEqual(["oauth"]);
   });
 
-  it("hides Base44 when its feature switch is disabled", async () => {
+  it("shows Base44 as an OAuth connector", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
-
-    const client = setupApp({ context })(zeroConnectorsSearchContract);
-    const response = await accept(
-      client.search({
-        query: { keyword: "base44" },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    const connector = response.body.connectors.find((c) => {
-      return c.id === "base44";
-    });
-    expect(connector).toBeUndefined();
-  });
-
-  it("shows Base44 as an OAuth connector when its feature switch is enabled", async () => {
-    const userId = `user_${randomUUID()}`;
-    const orgId = `org_${randomUUID()}`;
-    seededFeatureSwitches.push({ orgId, userId });
-    await enableFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.Base44Connector]: true,
-    });
-    mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -11,7 +11,6 @@ import { updateChatArtifacts } from "../../../mocks/mock-helpers.ts";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
@@ -814,7 +813,7 @@ describe("zero chat thread page display - body link document preview", () => {
     });
   });
 
-  it("renders assistant inline and block math when chat markdown math is enabled", async () => {
+  it("renders assistant inline and block math", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -825,11 +824,7 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({
-      context,
-      path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatMarkdownMath]: true },
-    });
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
       const assistant = document.querySelector(
@@ -837,32 +832,6 @@ describe("zero chat thread page display - body link document preview", () => {
       );
       expect(assistant?.querySelector(".katex")).toBeInTheDocument();
       expect(assistant?.querySelector(".katex-display")).toBeInTheDocument();
-    });
-  });
-
-  it("keeps assistant math delimiters as text when chat markdown math is disabled", async () => {
-    mockChatLifecycle({
-      chatMessages: [
-        {
-          role: "assistant",
-          content: "Inline $x^2$.\n\n$$\nx^2\n$$",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatMarkdownMath]: false },
-    });
-
-    await waitFor(() => {
-      const assistant = document.querySelector(
-        '[data-role="assistant"] .zero-chat-bubble-assistant',
-      );
-      expect(assistant?.textContent).toContain("$x^2$");
-      expect(assistant?.querySelector(".katex")).toBeNull();
     });
   });
 
@@ -877,11 +846,7 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({
-      context,
-      path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatMarkdownMath]: true },
-    });
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
       const assistant = document.querySelector(
@@ -903,11 +868,7 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({
-      context,
-      path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatMarkdownMath]: true },
-    });
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
       const assistant = document.querySelector(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx
@@ -45,11 +45,7 @@ describe("connectors page - count display", () => {
       { type: "openai", authMethod: "api-token" },
     ]);
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(screen.getByTestId("connector-category-ai")).toBeInTheDocument();
@@ -71,11 +67,7 @@ describe("connectors page - count display", () => {
   it("only matching categories are shown for search-filtered results (CONN-D-002)", async () => {
     mockConnectors([{ type: "github" }]);
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(screen.getByTestId("connector-category-ai")).toBeInTheDocument();
@@ -104,35 +96,6 @@ describe("connectors page - count display", () => {
 });
 
 describe("connectors page - grouped display", () => {
-  it("does not render categories or the category menu when the feature switch is off", async () => {
-    mockConnectors([
-      { type: "github" },
-      { type: "openai", authMethod: "api-token" },
-    ]);
-
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: false },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.queryByTestId("connector-category-ai"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("connector-category-engineering-team-execution"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("navigation", {
-        name: "Connector categories",
-      }),
-    ).not.toBeInTheDocument();
-  });
-
   it("renders a category menu that scrolls to grouped sections", async () => {
     const scrollIntoView = vi
       .spyOn(Element.prototype, "scrollIntoView")
@@ -143,11 +106,7 @@ describe("connectors page - grouped display", () => {
       { type: "openai", authMethod: "api-token" },
     ]);
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await screen.findByRole("navigation", {
       name: "Connector categories",
@@ -172,11 +131,7 @@ describe("connectors page - grouped display", () => {
   it("connected connectors are shown before available ones within a category", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCategories]: true },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2430,12 +2430,10 @@ function BodyContentBlocks({
   blocks,
   openLightbox,
   hardBreaks,
-  mathEnabled,
 }: {
   blocks: BodyRenderBlock[];
   openLightbox: (url: string) => void;
   hardBreaks: boolean;
-  mathEnabled: boolean;
 }) {
   const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
 
@@ -2452,7 +2450,7 @@ function BodyContentBlocks({
                   : block.content
               }
               mediaPreview
-              mathEnabled={mathEnabled}
+              mathEnabled
               onImageClick={openLightbox}
             />
           );
@@ -3063,8 +3061,6 @@ function PagedUserMessage({
     parseBodyRenderBlocks(strippedContent, { previews: false }).blocks,
   );
   const pageSignal = useGet(pageSignal$);
-  const features = useLastResolved(featureSwitch$);
-  const mathEnabled = features?.[FeatureSwitchKey.ChatMarkdownMath] ?? false;
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openLightbox = (url: string) => {
     openImageLightbox(url);
@@ -3103,7 +3099,6 @@ function PagedUserMessage({
                   blocks={bodyBlocks}
                   openLightbox={openLightbox}
                   hardBreaks
-                  mathEnabled={mathEnabled}
                 />
               </div>
             )}
@@ -3173,8 +3168,6 @@ function PagedAssistantMessageItem({
   message: EnrichedChatMessage;
 }) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
-  const features = useLastResolved(featureSwitch$);
-  const mathEnabled = features?.[FeatureSwitchKey.ChatMarkdownMath] ?? false;
   const openLightbox = (url: string) => {
     openImageLightbox(url);
   };
@@ -3196,7 +3189,6 @@ function PagedAssistantMessageItem({
             blocks={blocks}
             openLightbox={openLightbox}
             hardBreaks={false}
-            mathEnabled={mathEnabled}
           />
         ) : null}
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -19,7 +19,6 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
@@ -64,7 +63,6 @@ import {
   type ConnectorCategoryGroup,
 } from "../../signals/zero-page/settings/connector-categories.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
 import { ConnectorPermissionDialog } from "./components/settings/connector-permission-dialog.tsx";
@@ -589,16 +587,14 @@ function AvailableConnectorCard({
 
 function renderBuiltinList({
   loadingState,
-  showConnectorCategories,
   grouped,
-  filtered,
+  filteredCount,
   renderCard,
   search,
 }: {
   loadingState: "loading" | "hasData" | "hasError";
-  showConnectorCategories: boolean;
   grouped: ConnectorCategoryGroup<ConnectorTypeWithStatus>[];
-  filtered: ConnectorTypeWithStatus[];
+  filteredCount: number;
   renderCard: (connector: ConnectorTypeWithStatus) => ReactNode;
   search: string;
 }): ReactNode {
@@ -626,7 +622,7 @@ function renderBuiltinList({
     );
   }
 
-  if (filtered.length === 0 && search) {
+  if (filteredCount === 0 && search) {
     return (
       <div className="flex flex-col items-center gap-3 py-12">
         <img
@@ -641,23 +637,15 @@ function renderBuiltinList({
     );
   }
 
-  if (showConnectorCategories) {
-    return grouped.map((group) => {
-      return (
-        <ConnectorCategoryGroupSection
-          key={group.id}
-          group={group}
-          renderCard={renderCard}
-        />
-      );
-    });
-  }
-
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {filtered.map(renderCard)}
-    </div>
-  );
+  return grouped.map((group) => {
+    return (
+      <ConnectorCategoryGroupSection
+        key={group.id}
+        group={group}
+        renderCard={renderCard}
+      />
+    );
+  });
 }
 
 export function ZeroConnectorsPage() {
@@ -681,13 +669,8 @@ export function ZeroConnectorsPage() {
   const activeCategoryId = useGet(activeConnectorCategoryId$);
   const attachScrollTracking = useSet(attachConnectorCategoryScrollTracking$);
   const resetActiveCategory = useSet(resetActiveConnectorCategory$);
-  const features = useLastResolved(featureSwitch$);
-  const showConnectorCategories =
-    features?.[FeatureSwitchKey.ConnectorCategories] ?? false;
   const categoryTrackingEnabled =
-    activeTab === "builtin" &&
-    allTypesLoadable.state === "hasData" &&
-    showConnectorCategories;
+    activeTab === "builtin" && allTypesLoadable.state === "hasData";
   const scrollContainerRef = useScrollTrackingRef(
     categoryTrackingEnabled,
     attachScrollTracking,
@@ -773,15 +756,12 @@ export function ZeroConnectorsPage() {
     );
   };
 
-  const grouped = showConnectorCategories
-    ? groupConnectorsByCategory(filtered.map(getEffective))
-    : [];
+  const grouped = groupConnectorsByCategory(filtered.map(getEffective));
 
   const builtinList = renderBuiltinList({
     loadingState: allTypesLoadable.state,
-    showConnectorCategories,
     grouped,
-    filtered,
+    filteredCount: filtered.length,
     renderCard,
     search,
   });
@@ -823,14 +803,12 @@ export function ZeroConnectorsPage() {
 
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
         <div className="relative mx-auto w-full max-w-[900px]">
-          {activeTab === "builtin" &&
-            allTypesLoadable.state === "hasData" &&
-            showConnectorCategories && (
-              <ConnectorCategoryMenu
-                activeCategoryId={activeCategoryId}
-                groups={grouped}
-              />
-            )}
+          {activeTab === "builtin" && allTypesLoadable.state === "hasData" && (
+            <ConnectorCategoryMenu
+              activeCategoryId={activeCategoryId}
+              groups={grouped}
+            />
+          )}
 
           <div className="min-w-0 flex w-full max-w-[900px] flex-col gap-6">
             <div className="flex items-center justify-between">

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -47,7 +47,6 @@ export enum FeatureSwitchKey {
   ChatHeaderNewButton = "chatHeaderNewButton",
 
   ChatMessageStartButton = "chatMessageStartButton",
-  ChatMarkdownMath = "chatMarkdownMath",
   ChatThreadRename = "chatThreadRename",
   DocsSite = "docsSite",
   FreshdeskConnector = "freshdeskConnector",
@@ -55,7 +54,6 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   ApiKeys = "apiKeys",
   ApiBackend = "apiBackend",
-  ConnectorCategories = "connectorCategories",
 
   ZapierConnector = "zapierConnector",
   HostedSites = "hostedSites",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -81,22 +81,6 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(false);
   });
-
-  it("should enable Base44 connector for staff orgs only", () => {
-    expect(isFeatureEnabled(FeatureSwitchKey.Base44Connector, {})).toBe(false);
-
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.Base44Connector, {
-        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-      }),
-    ).toBe(true);
-
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.Base44Connector, {
-        orgId: "org_nonexistent",
-      }),
-    ).toBe(false);
-  });
 });
 
 describe("getAllFeatureStates", () => {
@@ -131,7 +115,6 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GoogleAdsConnector]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.Base44Connector]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatHeaderNewButton]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatMessageStartButton]).toBe(false);
@@ -142,7 +125,6 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GoogleAdsConnector]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.Base44Connector]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(false);
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -47,8 +47,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.Base44Connector]: {
     maintainer: "liangyou@vm0.ai",
     description: "Enable the Base44 connector",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.BentomlConnector]: {
     maintainer: "ethan@vm0.ai",
@@ -182,9 +181,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.GitHubIntegration]: {
     maintainer: "linghan@vm0.ai",
     description:
-      "Show the GitHub integration card on the Works page for installing GitHub, connecting users, and managing label listeners.",
+      "Show the GitHub integration card on the Works page for installing GitHub, connecting users, and managing label listeners. Off by default; individuals opt in via the feature-switch overrides API.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DataExport]: {
     maintainer: "ethan@vm0.ai",
@@ -211,16 +209,14 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.LocalBrowserUse]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Enable the Local Browser connector and user-authorized browser host lifecycle",
+      "Enable the Local Browser connector and user-authorized browser host lifecycle. Off by default; individuals opt in via the feature-switch overrides API.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.LocalAgentConnector]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Show the Local Agent connector entry on the Connectors settings page. Staff-only while adoption is being re-evaluated.",
+      "Show the Local Agent connector entry on the Connectors settings page. Off by default; individuals opt in via the feature-switch overrides API.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Lab]: {
     maintainer: "ethan@vm0.ai",
@@ -261,12 +257,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show an icon button in assistant message group actions that scrolls back to the start of that message group.",
     enabled: false,
-  },
-  [FeatureSwitchKey.ChatMarkdownMath]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Enable synchronous math rendering for inline and block formulas in chat Markdown.",
-    enabled: true,
   },
   [FeatureSwitchKey.ChatThreadRename]: {
     maintainer: "ethan@vm0.ai",
@@ -310,12 +300,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Route platform API traffic to the api backend host instead of the www backend host. Unported endpoints continue through the api backend's web fallback proxy.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.ConnectorCategories]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show category sections and the hover-reveal outline menu on the Connectors settings page.",
-    enabled: true,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Four registry follow-ups:

- **ChatMarkdownMath — deleted**. Flag was already `enabled: true` after #14891. Drop the registry entry + enum, remove the `mathEnabled` prop from `BodyContentBlocks`, strip the two callers in `zero-chat-thread-page.tsx` that resolved the flag. The chat surface now passes `mathEnabled` as a literal to `Markdown`. The `Markdown` component still keeps the `mathEnabled` prop (default off) for non-chat surfaces — no behavior change there.
- **ConnectorCategories — deleted**. Flag was already `enabled: true` after #14891. Drop the registry entry + enum, simplify `renderBuiltinList` to always render grouped category sections (the flat fallback grid is gone), and remove the `showConnectorCategories` derivation + `featureSwitch$` import in `zero-connectors-page.tsx`. The category menu and scroll tracking are now always on. Tests that asserted the off-path are deleted; the rest drop the now-redundant override.
- **LocalBrowserUse / LocalAgentConnector / GitHubIntegration — drop staff-org auto-on**. These are now plain `enabled: false` flags; individuals opt in via the feature-switch overrides API. Descriptions updated to reflect the new "off by default; individuals opt in" rollout shape.
- **Base44Connector — fully GA**. Flip to `enabled: true`, drop the staff-org override (kept the flag for rollback). Remove the now-stale dedicated "Base44 staff-org only" feature-switch test (covered by the equivalent `CliAuthStripe` case) and drop Base44 from the staff-org rollout matrix.

7 files / +34 / -184.

## Test plan

- [ ] CI: pnpm test across apps/platform, packages/core
- [ ] Manual: chat renders LaTeX math inline + block for everyone (no flag required)
- [ ] Manual: /connectors always shows category sections + the right-edge category menu
- [ ] Manual: LocalBrowser, LocalAgent, GitHub integration cards hidden for staff orgs by default; can re-enable via `POST /api/zero/feature-switches`
- [ ] Manual: Base44 connector visible on the connectors page for non-staff orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)