### PR TITLE
fix: add static website hosting context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -421,6 +421,11 @@ describe("POST /api/zero/runs", () => {
     expect(run?.appendSystemPrompt).toContain("# Agent Tools");
     for (const toolHint of [
       "zero web download-file -h",
+      "Localhost URLs, local dev server ports, and processes started inside the agent runtime are generally only reachable inside that runtime",
+      "Local dev servers are useful for agent-side verification",
+      "For static web artifacts, Zero provides `zero host <dir> --site <slug> [--spa]`",
+      "For apps or services that require a long-running backend, database, worker, external service, or framework-specific runtime",
+      "zero host --help",
       "zero connector status <type>",
       "zero doctor check-connector --help",
       "zero doctor generate -h",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -153,6 +153,10 @@ function buildIntegrationToolsPrompt(
 ): readonly string[] {
   const localFileContext = [
     "Local filesystem paths are only visible to the agent runtime. Users cannot open local paths directly.",
+    "Localhost URLs, local dev server ports, and processes started inside the agent runtime are generally only reachable inside that runtime; users cannot rely on them as a way to view the result directly.",
+    "Local dev servers are useful for agent-side verification, but they are not by themselves a user-facing deliverable.",
+    "For static web artifacts, Zero provides `zero host <dir> --site <slug> [--spa]` to publish a directory containing `index.html` to a public URL that users can open.",
+    "For apps or services that require a long-running backend, database, worker, external service, or framework-specific runtime, `zero host` may not be sufficient; use the project's own deployment workflow or hosting platform to make the change visible to users.",
     "A local file needs separate delivery only when it is the requested artifact or the only available user-accessible copy. If the artifact is already available through a hosted URL, email, cloud document, or another user-accessible destination, duplicate file upload is usually unnecessary unless the user asks for the file itself.",
   ];
   const localFileContextLines = localFileContext.map((line) => {
@@ -207,6 +211,7 @@ function buildAgentToolsPrompt(triggerSource: TriggerSource): string {
     "- Search agent run logs, web chat messages, or external services via connectors: `zero search --help`.",
     "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
     ...buildIntegrationToolsPrompt(triggerSource),
+    "- Static web artifacts can be published with `zero host <dir> --site <slug> [--spa]`; run `zero host --help` for details.",
     "- Third-party services (GitHub, Slack, Notion, 100+ more) are accessed via connectors that expose env vars like `GH_TOKEN`. Find: `zero connector search <keyword>`. List connected: `zero connector list`. Inspect: `zero connector status <type>`.",
     "- Model availability and provider routing are workspace model settings, separate from connectors. Use `zero model ls` to list allowed models, `zero model switch` for model-switching guidance, and `zero model-provider ls` to inspect built-in/BYOK routing.",
     "- Credit diagnostics: use `zero doctor credit` when a run or generation fails with insufficient credits, when the user asks how to recharge, or before buying credits. It reports the org balance, tier, purchase eligibility, current user admin status, and org admins.",

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
@@ -277,9 +277,42 @@ describe("zero doctor generate command", () => {
     expect(text).toContain("Built-in website generation");
     expect(text).toContain("Models: gpt-5.5");
     expect(text).toContain("Use: zero built-in generate website -h");
+    expect(text).toContain("Context:");
+    expect(text).toContain(
+      "Standalone static website artifacts can be authored locally and published with zero host for a public URL.",
+    );
+    expect(text).toContain(
+      "zero host is for static directories with index.html; it is not a general deploy system for apps that need a backend, database, worker, or long-running process.",
+    );
+    expect(text).toContain(
+      "Existing web app changes should usually follow the project's own build, test, and deploy workflow.",
+    );
     expect(text).not.toContain("Model: gpt-5.5");
     expect(text).not.toContain("Fallback option:");
     expect(text).not.toContain("Official provider:");
+  });
+
+  it("includes website context in machine-readable JSON", async () => {
+    server.use(
+      stubConnectorsWithConfiguredTypes([], []),
+      stubUserConnectors([]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", "website", "--json"]);
+
+    const json = JSON.parse(output()) as {
+      builtInCommand: { command: string } | null;
+      generationContext: { lines: string[] } | null;
+    };
+    expect(json.builtInCommand).toMatchObject({
+      command: "zero built-in generate website -h",
+    });
+    expect(json.generationContext?.lines).toEqual(
+      expect.arrayContaining([
+        "Standalone static website artifacts can be authored locally and published with zero host for a public URL.",
+        "zero host is for static directories with index.html; it is not a general deploy system for apps that need a backend, database, worker, or long-running process.",
+      ]),
+    );
   });
 
   it.each([

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -40,6 +40,10 @@ interface BuiltInGenerationCommand {
   models: string;
 }
 
+interface GenerationContext {
+  readonly lines: readonly string[];
+}
+
 const BUILT_IN_GENERATION_PROVIDERS: Partial<
   Record<DoctorGenerationType, readonly BuiltInGenerationProvider[]>
 > = {
@@ -249,6 +253,18 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
   },
 };
 
+const GENERATION_CONTEXT: Partial<
+  Record<DoctorGenerationType, GenerationContext>
+> = {
+  website: {
+    lines: [
+      "Standalone static website artifacts can be authored locally and published with zero host for a public URL.",
+      "zero host is for static directories with index.html; it is not a general deploy system for apps that need a backend, database, worker, or long-running process.",
+      "Existing web app changes should usually follow the project's own build, test, and deploy workflow.",
+    ],
+  },
+};
+
 const GENERATION_TYPE_ORDER: readonly DoctorGenerationType[] = [
   "image",
   "video",
@@ -342,6 +358,12 @@ function getBuiltInCommand(
   generationType: DoctorGenerationType,
 ): BuiltInGenerationCommand | null {
   return BUILT_IN_GENERATION_COMMANDS[generationType] ?? null;
+}
+
+function getGenerationContext(
+  generationType: DoctorGenerationType,
+): GenerationContext | null {
+  return GENERATION_CONTEXT[generationType] ?? null;
 }
 
 function getAvailableGenerationTypes(): DoctorGenerationType[] {
@@ -552,6 +574,17 @@ function renderBuiltInProvider(generationType: DoctorGenerationType): void {
   }
 }
 
+function renderGenerationContext(generationType: DoctorGenerationType): void {
+  const context = getGenerationContext(generationType);
+  if (!context) return;
+
+  console.log("");
+  console.log("Context:");
+  for (const line of context.lines) {
+    console.log(`  - ${line}`);
+  }
+}
+
 function renderText(params: {
   generationType: DoctorGenerationType;
   agentId: string | undefined;
@@ -589,6 +622,7 @@ function renderText(params: {
   }
 
   renderBuiltInProvider(generationType);
+  renderGenerationContext(generationType);
 
   if (showAll && other.length > 0) {
     console.log("");
@@ -662,6 +696,8 @@ export const generateCommand = new Command()
               agentId: agentId ?? null,
               choices: ready,
               otherCandidates: other,
+              builtInCommand: getBuiltInCommand(generationType),
+              generationContext: getGenerationContext(generationType),
               builtInProvider: builtInProviders[0] ?? null,
               builtInProviders,
             },


### PR DESCRIPTION
## Summary
- add shared agent runtime context explaining that local files, localhost URLs, and dev servers are not user-facing deliverables
- document Zero Host as the static web artifact publishing path while clarifying its boundary for backend/long-running apps
- add website-specific context to `zero doctor generate website`, including JSON output, plus tests

## Tests
- `pnpm exec prettier --write apps/api/src/signals/services/zero-runs-create.service.ts apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts apps/cli/src/commands/zero/doctor/generate.ts apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts`
- `pnpm exec vitest run apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts`
- `pnpm -F @vm0/cli check-types`
- `NODE_OPTIONS='--max-old-space-size=4096' pnpm -F api check-types`

## Notes
- `DATABASE_URL='postgresql://postgres@localhost:5432/vm0_test' pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts` was attempted after starting local Postgres, but the local test database had no schema (`relation ... does not exist`).`