### PR TITLE
feat: make base44 connector generally available

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -54,21 +54,6 @@ async function enableTestOauthDevice(userId: string, orgId: string) {
     });
 }
 
-async function enableBase44(userId: string, orgId: string) {
-  await store
-    .set(writeDb$)
-    .insert(userFeatureSwitches)
-    .values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.Base44Connector]: true },
-    })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches: { [FeatureSwitchKey.Base44Connector]: true } },
-    });
-}
-
 async function cleanupUser(userId: string, orgId: string) {
   const db = store.set(writeDb$);
   await db
@@ -650,7 +635,6 @@ describe("OAuth device authorization connector routes", () => {
     const orgId = `org_${randomUUID()}`;
     users.push({ userId, orgId });
     mocks.clerk.session(userId, orgId);
-    await enableBase44(userId, orgId);
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -261,7 +261,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(connector?.authMethods).toStrictEqual(["oauth"]);
   });
 
-  it("shows Base44 as an OAuth connector", async () => {
+  it("shows Base44 as an OAuth connector without a feature switch", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -931,13 +931,10 @@ describe("getAvailableConnectorAuthMethods", () => {
     ).toStrictEqual(["api-token"]);
   });
 
-  it("exposes Base44 OAuth only when its switch is enabled", () => {
-    expect(getAvailableConnectorAuthMethods("base44", {})).toStrictEqual([]);
-    expect(
-      getAvailableConnectorAuthMethods("base44", {
-        [FeatureSwitchKey.Base44Connector]: true,
-      }),
-    ).toStrictEqual(["oauth"]);
+  it("exposes Base44 OAuth without a feature switch", () => {
+    expect(getAvailableConnectorAuthMethods("base44", {})).toStrictEqual([
+      "oauth",
+    ]);
   });
 
   it("exposes Lark API-token auth only when its switch is enabled", () => {

--- a/turbo/packages/connectors/src/connectors/base44.ts
+++ b/turbo/packages/connectors/src/connectors/base44.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const base44 = {
   base44: {
@@ -9,7 +8,6 @@ export const base44 = {
       "Connect your Base44 account to let agents access and manage your Base44 apps",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.Base44Connector,
         label: "OAuth",
         helpText: "Sign in with Base44 to grant access.",
         grant: {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -6,7 +6,6 @@
 export enum FeatureSwitchKey {
   Dummy = "dummy",
   AhrefsConnector = "ahrefsConnector",
-  Base44Connector = "base44Connector",
   BentomlConnector = "bentomlConnector",
   CanvaConnector = "canvaConnector",
   ComputerConnector = "computerConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -44,11 +44,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Ahrefs SEO connector",
     enabled: false,
   },
-  [FeatureSwitchKey.Base44Connector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Base44 connector",
-    enabled: true,
-  },
   [FeatureSwitchKey.BentomlConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the BentoML model serving connector",


### PR DESCRIPTION
## Summary
- remove the Base44 connector feature switch registry entry and enum key
- expose Base44 OAuth by default in connector auth methods and search
- update Base44 connector tests to stop seeding feature switch overrides

## Verification
- pnpm exec prettier --check packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/connectors/src/connectors/base44.ts packages/core/src/__tests__/feature-switch.test.ts packages/connectors/src/__tests__/connectors.test.ts apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
- pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts
- pnpm -F @vm0/core test -- src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F api lint
- git commit pre-commit hook: prettier, knip, turbo check-types

## Notes
- Targeted API vitest for connector search/device auth was blocked locally by an out-of-date database schema; `pnpm -F web db:migrate` was blocked by existing local `credit_usage` rows with negative processed token quantities.