### PR TITLE
refactor: add connector auth method id foundation

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -25,7 +25,6 @@ import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
-  type ConnectorWellKnownAuthMethodId,
   type ConnectorType,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
@@ -641,7 +640,7 @@ export const deleteZeroConnectorLocalState$ = command(
 
       const secretNames = getConnectorSecretNames(
         args.type,
-        existing.authMethod as ConnectorWellKnownAuthMethodId,
+        existing.authMethod,
       );
 
       for (const name of secretNames) {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -25,7 +25,7 @@ import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
-  type ConnectorAuthMethodType,
+  type ConnectorWellKnownAuthMethodId,
   type ConnectorType,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
@@ -641,7 +641,7 @@ export const deleteZeroConnectorLocalState$ = command(
 
       const secretNames = getConnectorSecretNames(
         args.type,
-        existing.authMethod as ConnectorAuthMethodType,
+        existing.authMethod as ConnectorWellKnownAuthMethodId,
       );
 
       for (const name of secretNames) {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,10 +3,10 @@ import { delay } from "signal-timers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
-  CONNECTOR_AUTH_METHOD_TYPES,
+  CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  type ConnectorAuthMethodType,
+  type ConnectorWellKnownAuthMethodId,
   type ConnectorBrowserVerificationCliAuthConnectorType,
   type ConnectorType,
   type ConnectorDisplayCategory,
@@ -119,7 +119,7 @@ export interface ConnectorTypeWithStatus {
   connected: boolean;
   connector: ConnectorResponse | null;
   /** Auth methods available for this connector (considering feature flags). */
-  availableAuthMethods: ConnectorAuthMethodType[];
+  availableAuthMethods: ConnectorWellKnownAuthMethodId[];
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;
   /** True if stored OAuth scopes don't cover all currently required scopes. */
@@ -136,8 +136,8 @@ type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
 
 export function getConfiguredConnectorAuthMethods(
   type: ConnectorType,
-): ConnectorAuthMethodType[] {
-  return CONNECTOR_AUTH_METHOD_TYPES.filter((authMethod) => {
+): ConnectorWellKnownAuthMethodId[] {
+  return CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS.filter((authMethod) => {
     return authMethod in CONNECTOR_TYPES[type].authMethods;
   });
 }
@@ -148,7 +148,7 @@ export function getConnectorConnectLaunchMode({
   preferModalForGoogleOAuth = false,
 }: {
   readonly type: ConnectorType;
-  readonly availableAuthMethods: readonly ConnectorAuthMethodType[];
+  readonly availableAuthMethods: readonly ConnectorWellKnownAuthMethodId[];
   readonly preferModalForGoogleOAuth?: boolean;
 }): ConnectorConnectLaunchMode {
   const hasAuthCodeGrant = availableAuthMethods.some((authMethod) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,10 +3,10 @@ import { delay } from "signal-timers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
-  CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS,
+  CONNECTOR_LEGACY_AUTH_METHOD_ORDER,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  type ConnectorWellKnownAuthMethodId,
+  type ConnectorAuthMethodId,
   type ConnectorBrowserVerificationCliAuthConnectorType,
   type ConnectorType,
   type ConnectorDisplayCategory,
@@ -119,7 +119,7 @@ export interface ConnectorTypeWithStatus {
   connected: boolean;
   connector: ConnectorResponse | null;
   /** Auth methods available for this connector (considering feature flags). */
-  availableAuthMethods: ConnectorWellKnownAuthMethodId[];
+  availableAuthMethods: ConnectorAuthMethodId[];
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;
   /** True if stored OAuth scopes don't cover all currently required scopes. */
@@ -136,8 +136,8 @@ type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
 
 export function getConfiguredConnectorAuthMethods(
   type: ConnectorType,
-): ConnectorWellKnownAuthMethodId[] {
-  return CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS.filter((authMethod) => {
+): ConnectorAuthMethodId[] {
+  return CONNECTOR_LEGACY_AUTH_METHOD_ORDER.filter((authMethod) => {
     return authMethod in CONNECTOR_TYPES[type].authMethods;
   });
 }
@@ -148,7 +148,7 @@ export function getConnectorConnectLaunchMode({
   preferModalForGoogleOAuth = false,
 }: {
   readonly type: ConnectorType;
-  readonly availableAuthMethods: readonly ConnectorWellKnownAuthMethodId[];
+  readonly availableAuthMethods: readonly ConnectorAuthMethodId[];
   readonly preferModalForGoogleOAuth?: boolean;
 }): ConnectorConnectLaunchMode {
   const hasAuthCodeGrant = availableAuthMethods.some((authMethod) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -15,9 +15,9 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import {
-  CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS,
+  CONNECTOR_LEGACY_AUTH_METHOD_ORDER,
   CONNECTOR_TYPES,
-  type ConnectorWellKnownAuthMethodId,
+  type ConnectorAuthMethodId,
   type ConnectorGrantKind,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -186,8 +186,11 @@ type ConnectMethodContentComponent = (
   props: ConnectMethodContentProps,
 ) => ReactElement;
 
+type LegacyConnectAuthMethodId =
+  (typeof CONNECTOR_LEGACY_AUTH_METHOD_ORDER)[number];
+
 type ConnectMethodContentEntry = {
-  authMethod: ConnectorWellKnownAuthMethodId;
+  authMethod: LegacyConnectAuthMethodId;
   Content: ConnectMethodContentComponent;
 };
 
@@ -888,7 +891,7 @@ function getApiConnectContentComponent(
 
 function getConnectMethodContentComponent(
   item: ConnectorTypeWithStatus,
-  authMethod: ConnectorWellKnownAuthMethodId,
+  authMethod: LegacyConnectAuthMethodId,
 ): ConnectMethodContentComponent | null {
   switch (authMethod) {
     case "oauth": {
@@ -915,7 +918,7 @@ function getConnectMethodContentComponent(
 function getConnectMethodContentEntries(
   item: ConnectorTypeWithStatus,
 ): ConnectMethodContentEntry[] {
-  return CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS.filter((authMethod) => {
+  return CONNECTOR_LEGACY_AUTH_METHOD_ORDER.filter((authMethod) => {
     return item.availableAuthMethods.includes(authMethod);
   }).flatMap((authMethod) => {
     const Content = getConnectMethodContentComponent(item, authMethod);
@@ -925,7 +928,7 @@ function getConnectMethodContentEntries(
 
 function hasAuthMethodGrantKind(
   type: ConnectorType,
-  authMethods: readonly ConnectorWellKnownAuthMethodId[],
+  authMethods: readonly ConnectorAuthMethodId[],
   kind: ConnectorGrantKind,
 ): boolean {
   return authMethods.some((authMethod) => {
@@ -952,7 +955,7 @@ function ConnectMethodHeading({
   show,
 }: {
   item: ConnectorTypeWithStatus;
-  authMethod: ConnectorWellKnownAuthMethodId;
+  authMethod: LegacyConnectAuthMethodId;
   show: boolean;
 }) {
   if (!show) {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -15,9 +15,9 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import {
-  CONNECTOR_AUTH_METHOD_TYPES,
+  CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS,
   CONNECTOR_TYPES,
-  type ConnectorAuthMethodType,
+  type ConnectorWellKnownAuthMethodId,
   type ConnectorGrantKind,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -187,7 +187,7 @@ type ConnectMethodContentComponent = (
 ) => ReactElement;
 
 type ConnectMethodContentEntry = {
-  authMethod: ConnectorAuthMethodType;
+  authMethod: ConnectorWellKnownAuthMethodId;
   Content: ConnectMethodContentComponent;
 };
 
@@ -888,7 +888,7 @@ function getApiConnectContentComponent(
 
 function getConnectMethodContentComponent(
   item: ConnectorTypeWithStatus,
-  authMethod: ConnectorAuthMethodType,
+  authMethod: ConnectorWellKnownAuthMethodId,
 ): ConnectMethodContentComponent | null {
   switch (authMethod) {
     case "oauth": {
@@ -915,7 +915,7 @@ function getConnectMethodContentComponent(
 function getConnectMethodContentEntries(
   item: ConnectorTypeWithStatus,
 ): ConnectMethodContentEntry[] {
-  return CONNECTOR_AUTH_METHOD_TYPES.filter((authMethod) => {
+  return CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS.filter((authMethod) => {
     return item.availableAuthMethods.includes(authMethod);
   }).flatMap((authMethod) => {
     const Content = getConnectMethodContentComponent(item, authMethod);
@@ -925,7 +925,7 @@ function getConnectMethodContentEntries(
 
 function hasAuthMethodGrantKind(
   type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodType[],
+  authMethods: readonly ConnectorWellKnownAuthMethodId[],
   kind: ConnectorGrantKind,
 ): boolean {
   return authMethods.some((authMethod) => {
@@ -952,7 +952,7 @@ function ConnectMethodHeading({
   show,
 }: {
   item: ConnectorTypeWithStatus;
-  authMethod: ConnectorAuthMethodType;
+  authMethod: ConnectorWellKnownAuthMethodId;
   show: boolean;
 }) {
   if (!show) {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   CONNECTOR_TYPES,
-  type ConnectorAuthMethodType,
+  type ConnectorWellKnownAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -54,7 +54,7 @@ import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
 function runDirectedConnect(params: {
-  authMethods: readonly ConnectorAuthMethodType[];
+  authMethods: readonly ConnectorWellKnownAuthMethodId[];
   connectorType: ConnectorType;
   signal: AbortSignal;
   connect: (

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   CONNECTOR_TYPES,
-  type ConnectorWellKnownAuthMethodId,
+  type ConnectorAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -54,7 +54,7 @@ import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
 function runDirectedConnect(params: {
-  authMethods: readonly ConnectorWellKnownAuthMethodId[];
+  authMethods: readonly ConnectorAuthMethodId[];
   connectorType: ConnectorType;
   signal: AbortSignal;
   connect: (

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -704,7 +704,7 @@ export {
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodType,
+  type ConnectorWellKnownAuthMethodId,
 } from "@vm0/connectors/connectors";
 export {
   getConnectorAuthMethods,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -704,7 +704,7 @@ export {
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,
   type ConnectorAuthMethodConfig,
-  type ConnectorWellKnownAuthMethodId,
+  type ConnectorAuthMethodId,
 } from "@vm0/connectors/connectors";
 export {
   getConnectorAuthMethods,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -228,6 +228,13 @@ describe("connector auth method config", () => {
       "oauth" | "api-token" | "api" | "cli-auth" | "app-credentials"
     >();
     expectTypeOf<"app-credentials">().toMatchTypeOf<ConnectorAuthMethodId>();
+    expectTypeOf<"app-credential">().not.toMatchTypeOf<ConnectorAuthMethodId>();
+    expectTypeOf<"app-credential">().not.toMatchTypeOf<
+      keyof ConnectorConfig["authMethods"]
+    >();
+    expectTypeOf<"app-credential">().not.toMatchTypeOf<
+      ConnectorConfig["defaultAuthMethod"]
+    >();
     expectTypeOf<
       ConnectorConfigAuthMethodIds<FixtureConfig>
     >().toEqualTypeOf<"app-credentials">();
@@ -239,34 +246,6 @@ describe("connector auth method config", () => {
         typeof connectorLocalAuthMethodFixture
       >
     >().toEqualTypeOf<never>();
-
-    const invalidMethodKeyFixture = {
-      "invalid-local-auth-method-key-fixture": {
-        label: "Invalid Local Auth Method Key Fixture",
-        category: "data-automation-infrastructure",
-        helpText: "Fixture used for connector auth method type coverage.",
-        authMethods: {
-          // @ts-expect-error connector-local auth method ids must be explicit union members.
-          "app-credential": localAuthMethodConfig,
-        },
-        defaultAuthMethod: "app-credentials",
-      },
-    } as const satisfies Record<string, ConnectorConfig>;
-    void invalidMethodKeyFixture;
-
-    const invalidDefaultFixture = {
-      "invalid-local-auth-method-default-fixture": {
-        label: "Invalid Local Auth Method Default Fixture",
-        category: "data-automation-infrastructure",
-        helpText: "Fixture used for connector auth method type coverage.",
-        authMethods: {
-          "app-credentials": localAuthMethodConfig,
-        },
-        // @ts-expect-error default auth method ids must be explicit union members.
-        defaultAuthMethod: "app-credential",
-      },
-    } as const satisfies Record<string, ConnectorConfig>;
-    void invalidDefaultFixture;
 
     const missingDefaultMethodFixture = {
       "missing-default-method-fixture": {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,8 +1,22 @@
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+} from "vitest";
 import {
   connectorTypeSchema,
+  type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodId,
+  type ConnectorConfig,
+  type ConnectorInvalidDefaultAuthMethodType,
+  type ConnectorLocalAuthMethodId,
+  type ConnectorWellKnownAuthMethodId,
   type OAuthAuthCodeConnectorType,
 } from "../connectors";
 import {
@@ -124,6 +138,44 @@ function restoreEnv(values: Record<string, string | undefined>): void {
   }
 }
 
+const localAuthMethodConfig = {
+  label: "App Credentials",
+  helpText: "Enter app credentials.",
+  grant: {
+    kind: "manual",
+    fields: {
+      APP_CREDENTIALS_TOKEN: {
+        label: "Token",
+        required: true,
+      },
+    },
+  },
+  access: {
+    kind: "static",
+    outputs: {
+      APP_CREDENTIALS_TOKEN: "$secrets.APP_CREDENTIALS_TOKEN",
+    },
+  },
+  revoke: { kind: "none" },
+} as const satisfies ConnectorAuthMethodConfig;
+
+const connectorLocalAuthMethodFixture = {
+  "connector-local-auth-method-fixture": {
+    label: "Connector Local Auth Method Fixture",
+    category: "data-automation-infrastructure",
+    helpText: "Fixture used for connector auth method type coverage.",
+    authMethods: {
+      "app-credentials": localAuthMethodConfig,
+    },
+    defaultAuthMethod: "app-credentials",
+  },
+} as const satisfies Record<string, ConnectorConfig>;
+
+type ConnectorConfigAuthMethodIds<Config extends ConnectorConfig> = Extract<
+  keyof Config["authMethods"],
+  string
+>;
+
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
     // computer connector has no oauth config
@@ -170,6 +222,69 @@ describe("hasRequiredScopes", () => {
 });
 
 describe("connector auth method config", () => {
+  it("keeps connector-local auth method ids explicit and typed", () => {
+    type FixtureConfig =
+      (typeof connectorLocalAuthMethodFixture)["connector-local-auth-method-fixture"];
+
+    expectTypeOf<ConnectorLocalAuthMethodId>().toEqualTypeOf<"app-credentials">();
+    expectTypeOf<ConnectorLocalAuthMethodId>().toMatchTypeOf<ConnectorAuthMethodId>();
+    expectTypeOf<ConnectorWellKnownAuthMethodId>().toMatchTypeOf<ConnectorAuthMethodId>();
+    expectTypeOf<
+      ConnectorConfigAuthMethodIds<FixtureConfig>
+    >().toEqualTypeOf<"app-credentials">();
+    expectTypeOf<
+      FixtureConfig["defaultAuthMethod"]
+    >().toEqualTypeOf<"app-credentials">();
+    expectTypeOf<
+      ConnectorInvalidDefaultAuthMethodType<
+        typeof connectorLocalAuthMethodFixture
+      >
+    >().toEqualTypeOf<never>();
+
+    const invalidMethodKeyFixture = {
+      "invalid-local-auth-method-key-fixture": {
+        label: "Invalid Local Auth Method Key Fixture",
+        category: "data-automation-infrastructure",
+        helpText: "Fixture used for connector auth method type coverage.",
+        authMethods: {
+          // @ts-expect-error connector-local auth method ids must be explicit union members.
+          "app-credential": localAuthMethodConfig,
+        },
+        defaultAuthMethod: "app-credentials",
+      },
+    } as const satisfies Record<string, ConnectorConfig>;
+    void invalidMethodKeyFixture;
+
+    const invalidDefaultFixture = {
+      "invalid-local-auth-method-default-fixture": {
+        label: "Invalid Local Auth Method Default Fixture",
+        category: "data-automation-infrastructure",
+        helpText: "Fixture used for connector auth method type coverage.",
+        authMethods: {
+          "app-credentials": localAuthMethodConfig,
+        },
+        // @ts-expect-error default auth method ids must be explicit union members.
+        defaultAuthMethod: "app-credential",
+      },
+    } as const satisfies Record<string, ConnectorConfig>;
+    void invalidDefaultFixture;
+
+    const missingDefaultMethodFixture = {
+      "missing-default-method-fixture": {
+        label: "Missing Default Method Fixture",
+        category: "data-automation-infrastructure",
+        helpText: "Fixture used for connector auth method type coverage.",
+        authMethods: {
+          "api-token": localAuthMethodConfig,
+        },
+        defaultAuthMethod: "app-credentials",
+      },
+    } as const satisfies Record<string, ConnectorConfig>;
+    expectTypeOf<
+      ConnectorInvalidDefaultAuthMethodType<typeof missingDefaultMethodFixture>
+    >().toEqualTypeOf<"missing-default-method-fixture">();
+  });
+
   it("returns a single auth method config when present", () => {
     expect(getConnectorAuthMethod("stripe", "cli-auth")?.label).toBe(
       "Sign in with Stripe",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -15,8 +15,6 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorConfig,
   type ConnectorInvalidDefaultAuthMethodType,
-  type ConnectorLocalAuthMethodId,
-  type ConnectorWellKnownAuthMethodId,
   type OAuthAuthCodeConnectorType,
 } from "../connectors";
 import {
@@ -226,9 +224,10 @@ describe("connector auth method config", () => {
     type FixtureConfig =
       (typeof connectorLocalAuthMethodFixture)["connector-local-auth-method-fixture"];
 
-    expectTypeOf<ConnectorLocalAuthMethodId>().toEqualTypeOf<"app-credentials">();
-    expectTypeOf<ConnectorLocalAuthMethodId>().toMatchTypeOf<ConnectorAuthMethodId>();
-    expectTypeOf<ConnectorWellKnownAuthMethodId>().toMatchTypeOf<ConnectorAuthMethodId>();
+    expectTypeOf<ConnectorAuthMethodId>().toEqualTypeOf<
+      "oauth" | "api-token" | "api" | "cli-auth" | "app-credentials"
+    >();
+    expectTypeOf<"app-credentials">().toMatchTypeOf<ConnectorAuthMethodId>();
     expectTypeOf<
       ConnectorConfigAuthMethodIds<FixtureConfig>
     >().toEqualTypeOf<"app-credentials">();

--- a/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { connectorTypeSchema } from "../connectors";
 import {
-  CONNECTOR_AUTH_METHOD_TYPES,
-  connectorTypeSchema,
-} from "../connectors";
-import {
+  getConnectorAuthMethods,
   getConnectorEnvironmentMapping,
-  getConnectorManualGrantFields,
 } from "../connector-utils";
 import { getConnectorFirewall, isFirewallConnectorType } from "../firewalls";
 
@@ -49,13 +46,24 @@ describe("firewall secret name consistency", () => {
         }
       } else {
         // API-token path: use manual grant fields directly.
-        for (const authMethod of CONNECTOR_AUTH_METHOD_TYPES) {
-          const fields = getConnectorManualGrantFields(
-            connectorType,
-            authMethod,
-          );
-          for (const name of Object.keys(fields ?? {})) {
-            connectorSecretNames.add(name);
+        for (const method of Object.values(
+          getConnectorAuthMethods(connectorType),
+        )) {
+          switch (method.grant.kind) {
+            case "manual":
+              for (const name of Object.keys(method.grant.fields)) {
+                connectorSecretNames.add(name);
+              }
+              break;
+            case "managed":
+              for (const name of Object.keys(method.grant.fields ?? {})) {
+                connectorSecretNames.add(name);
+              }
+              break;
+            case "auth-code":
+            case "device-auth":
+            case "interactive-pairing":
+              break;
           }
         }
       }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,10 +1,11 @@
 import {
-  CONNECTOR_AUTH_METHOD_TYPES,
+  CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodType,
+  type ConnectorAuthMethodId,
+  type ConnectorWellKnownAuthMethodId,
   type ConnectorAccessConfig,
   type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
@@ -41,7 +42,7 @@ export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors
  */
 export function getConnectorAuthMethods(
   type: ConnectorType,
-): Partial<Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>> {
+): Partial<Record<ConnectorAuthMethodId, ConnectorAuthMethodConfig>> {
   return CONNECTOR_TYPES[type].authMethods;
 }
 
@@ -50,7 +51,7 @@ export function getConnectorAuthMethods(
  */
 export function getConnectorAuthMethod(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodType,
+  authMethod: ConnectorWellKnownAuthMethodId,
 ): ConnectorAuthMethodConfig | undefined {
   return getConnectorAuthMethods(type)[authMethod];
 }
@@ -81,7 +82,7 @@ function getManualGrantFields(
 
 export function getConnectorManualGrantFields(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodType,
+  authMethod: ConnectorWellKnownAuthMethodId,
 ): Record<string, ConnectorManualGrantFieldConfig> | undefined {
   return getManualGrantFields(getConnectorAuthMethod(type, authMethod));
 }
@@ -196,7 +197,7 @@ export interface AvailableConnectorAuthMethodsOptions {
 
 export function isConnectorAuthMethodAvailable(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodType,
+  authMethod: ConnectorWellKnownAuthMethodId,
   featureStates: ConnectorFeatureStates,
 ): boolean {
   const method = getConnectorAuthMethod(type, authMethod);
@@ -229,11 +230,11 @@ export function getAvailableConnectorAuthMethods(
   type: ConnectorType,
   featureStates: ConnectorFeatureStates,
   options: AvailableConnectorAuthMethodsOptions = {},
-): ConnectorAuthMethodType[] {
+): ConnectorWellKnownAuthMethodId[] {
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
-  const availableAuthMethods: ConnectorAuthMethodType[] = [];
+  const availableAuthMethods: ConnectorWellKnownAuthMethodId[] = [];
 
-  for (const authMethod of CONNECTOR_AUTH_METHOD_TYPES) {
+  for (const authMethod of CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS) {
     if (!getConnectorAuthMethod(type, authMethod)) {
       continue;
     }
@@ -429,9 +430,14 @@ export function getRuntimeAvailableConnectorTypes(
  */
 export function getConnectorSecretNames(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodType,
+  authMethod: ConnectorWellKnownAuthMethodId,
 ): string[] {
-  const method = getConnectorAuthMethod(type, authMethod);
+  return connectorMethodSecretNames(getConnectorAuthMethod(type, authMethod));
+}
+
+function connectorMethodSecretNames(
+  method: ConnectorAuthMethodConfig | undefined,
+): string[] {
   if (!method) {
     return [];
   }
@@ -503,8 +509,8 @@ export function getConnectorDerivedNames(
   for (const type of allTypes) {
     const config = CONNECTOR_TYPES[type];
 
-    const found = CONNECTOR_AUTH_METHOD_TYPES.some((authMethod) => {
-      return getConnectorSecretNames(type, authMethod).includes(secretName);
+    const found = Object.values(config.authMethods).some((method) => {
+      return connectorMethodSecretNames(method).includes(secretName);
     });
     if (!found) {
       continue;
@@ -636,8 +642,8 @@ export function getConnectorManagedSecretNames(
         managed.add(name);
       }
     }
-    for (const authMethod of CONNECTOR_AUTH_METHOD_TYPES) {
-      for (const name of getConnectorSecretNames(type, authMethod)) {
+    for (const method of Object.values(config.authMethods)) {
+      for (const name of connectorMethodSecretNames(method)) {
         managed.add(name);
       }
     }
@@ -666,8 +672,8 @@ export function getConnectorTypeForSecretName(
         return type;
       }
     }
-    for (const authMethod of CONNECTOR_AUTH_METHOD_TYPES) {
-      if (getConnectorSecretNames(type, authMethod).includes(name)) {
+    for (const method of Object.values(config.authMethods)) {
+      if (connectorMethodSecretNames(method).includes(name)) {
         return type;
       }
     }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,11 +1,10 @@
 import {
-  CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS,
+  CONNECTOR_LEGACY_AUTH_METHOD_ORDER,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
-  type ConnectorWellKnownAuthMethodId,
   type ConnectorAccessConfig,
   type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
@@ -23,6 +22,9 @@ import {
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors";
+
+type ConnectorLegacyAuthMethodId =
+  (typeof CONNECTOR_LEGACY_AUTH_METHOD_ORDER)[number];
 
 /**
  * Connector utility vocabulary:
@@ -46,14 +48,28 @@ export function getConnectorAuthMethods(
   return CONNECTOR_TYPES[type].authMethods;
 }
 
+function lookupConnectorAuthMethod(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorAuthMethodConfig | undefined {
+  for (const [methodId, method] of Object.entries(
+    CONNECTOR_TYPES[type].authMethods,
+  )) {
+    if (methodId === authMethod) {
+      return method;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Get one auth method config for a connector type.
  */
 export function getConnectorAuthMethod(
   type: ConnectorType,
-  authMethod: ConnectorWellKnownAuthMethodId,
+  authMethod: ConnectorAuthMethodId,
 ): ConnectorAuthMethodConfig | undefined {
-  return getConnectorAuthMethods(type)[authMethod];
+  return lookupConnectorAuthMethod(type, authMethod);
 }
 
 function connectorAuthMethodValues(
@@ -82,7 +98,7 @@ function getManualGrantFields(
 
 export function getConnectorManualGrantFields(
   type: ConnectorType,
-  authMethod: ConnectorWellKnownAuthMethodId,
+  authMethod: ConnectorAuthMethodId,
 ): Record<string, ConnectorManualGrantFieldConfig> | undefined {
   return getManualGrantFields(getConnectorAuthMethod(type, authMethod));
 }
@@ -197,7 +213,7 @@ export interface AvailableConnectorAuthMethodsOptions {
 
 export function isConnectorAuthMethodAvailable(
   type: ConnectorType,
-  authMethod: ConnectorWellKnownAuthMethodId,
+  authMethod: ConnectorAuthMethodId,
   featureStates: ConnectorFeatureStates,
 ): boolean {
   const method = getConnectorAuthMethod(type, authMethod);
@@ -230,11 +246,11 @@ export function getAvailableConnectorAuthMethods(
   type: ConnectorType,
   featureStates: ConnectorFeatureStates,
   options: AvailableConnectorAuthMethodsOptions = {},
-): ConnectorWellKnownAuthMethodId[] {
+): ConnectorLegacyAuthMethodId[] {
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
-  const availableAuthMethods: ConnectorWellKnownAuthMethodId[] = [];
+  const availableAuthMethods: ConnectorLegacyAuthMethodId[] = [];
 
-  for (const authMethod of CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS) {
+  for (const authMethod of CONNECTOR_LEGACY_AUTH_METHOD_ORDER) {
     if (!getConnectorAuthMethod(type, authMethod)) {
       continue;
     }
@@ -430,9 +446,11 @@ export function getRuntimeAvailableConnectorTypes(
  */
 export function getConnectorSecretNames(
   type: ConnectorType,
-  authMethod: ConnectorWellKnownAuthMethodId,
+  authMethod: string,
 ): string[] {
-  return connectorMethodSecretNames(getConnectorAuthMethod(type, authMethod));
+  return connectorMethodSecretNames(
+    lookupConnectorAuthMethod(type, authMethod),
+  );
 }
 
 function connectorMethodSecretNames(

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -886,6 +886,7 @@ type ConnectorAuthMethodGrantKindById = {
   readonly "api-token": "manual";
   readonly api: "managed";
   readonly "cli-auth": "interactive-pairing";
+  readonly "app-credentials": "manual";
 };
 
 type ConnectorAuthMethodAccessKindById = {
@@ -893,6 +894,7 @@ type ConnectorAuthMethodAccessKindById = {
   readonly "api-token": "static";
   readonly api: "managed" | "none";
   readonly "cli-auth": "none";
+  readonly "app-credentials": "static";
 };
 
 type ConnectorAuthMethodRevokeKindById = {
@@ -900,7 +902,14 @@ type ConnectorAuthMethodRevokeKindById = {
   readonly "api-token": "none";
   readonly api: "none";
   readonly "cli-auth": "none";
+  readonly "app-credentials": "none";
 };
+
+export type ConnectorAuthMethodKindMapsCoverUnion = AssertNever<
+  | Exclude<ConnectorAuthMethodId, keyof ConnectorAuthMethodGrantKindById>
+  | Exclude<ConnectorAuthMethodId, keyof ConnectorAuthMethodAccessKindById>
+  | Exclude<ConnectorAuthMethodId, keyof ConnectorAuthMethodRevokeKindById>
+>;
 
 type InvalidAuthMethodGrantKindConnectorType = {
   [Type in ConnectorType]: {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -448,48 +448,30 @@ export interface ConnectorAuthMethodConfig {
 }
 
 /**
- * Well-known connector auth method ids exposed as configured connection flows.
+ * Connector auth method ids exposed as configured connection flows.
  *
- * These values describe the choices users can select when connecting a
- * service. They are not necessarily the same as the persisted connected
- * credential shape returned by connector APIs.
- *
- * - `oauth` — full OAuth 2.0 flow. Enablement stored as a DB row in
- *   `connectors` (with scopes, external identity, token refresh metadata).
- * - `api-token` — user supplies an API token via the UI. No DB row:
- *   enablement is derived from the presence of required secrets/variables.
- * - `api` — service-managed connection flow for integrations established
- *   outside OAuth or user-entered API-token forms.
- * - `cli-auth` — user imports credentials through a provider CLI. The imported
- *   result may still be stored as another credential shape such as `api-token`.
+ * These values describe user-selectable connection choices. Behavior must be
+ * derived from the auth method lifecycle config, not from the id itself.
  */
-export type ConnectorWellKnownAuthMethodId =
+export type ConnectorAuthMethodId =
   | "oauth"
   | "api-token"
   | "api"
-  | "cli-auth";
+  | "cli-auth"
+  | "app-credentials";
 
-export type ConnectorLocalAuthMethodId = "app-credentials";
-
-export type ConnectorAuthMethodId =
-  | ConnectorWellKnownAuthMethodId
-  | ConnectorLocalAuthMethodId;
-
-export const CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS = [
+/**
+ * Temporary ordering for auth method ids still handled by legacy key-based
+ * API/UI paths. This is intentionally not exhaustive over ConnectorAuthMethodId.
+ */
+export const CONNECTOR_LEGACY_AUTH_METHOD_ORDER = [
   "oauth",
   "api-token",
   "api",
   "cli-auth",
-] as const satisfies readonly ConnectorWellKnownAuthMethodId[];
-
-type MissingConnectorWellKnownAuthMethodId = Exclude<
-  ConnectorWellKnownAuthMethodId,
-  (typeof CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS)[number]
->;
+] as const satisfies readonly ConnectorAuthMethodId[];
 
 type AssertNever<T extends never> = T;
-export type ConnectorWellKnownAuthMethodIdsCoverUnion =
-  AssertNever<MissingConnectorWellKnownAuthMethodId>;
 
 export type ConnectorDisplayCategory =
   | "ai-general-models"
@@ -897,7 +879,7 @@ export type ConnectorAuthMethodIds<Type extends ConnectorType> = Extract<
   string
 >;
 type ConnectorAuthMethodKeys<Type extends ConnectorType> =
-  ConnectorAuthMethodIds<Type> & ConnectorWellKnownAuthMethodId;
+  ConnectorAuthMethodIds<Type> & keyof ConnectorAuthMethodGrantKindById;
 
 type ConnectorAuthMethodGrantKindById = {
   readonly oauth: "auth-code" | "device-auth";

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -365,7 +365,7 @@ export interface ConnectorInteractivePairingGrantConfig {
     label: string;
     description?: string;
   }[];
-  readonly importsAuthMethod?: ConnectorAuthMethodType;
+  readonly importsAuthMethod?: ConnectorAuthMethodId;
 }
 
 export interface ConnectorManagedGrantConfig {
@@ -448,7 +448,7 @@ export interface ConnectorAuthMethodConfig {
 }
 
 /**
- * Connector auth method variants exposed as configured connection flows.
+ * Well-known connector auth method ids exposed as configured connection flows.
  *
  * These values describe the choices users can select when connecting a
  * service. They are not necessarily the same as the persisted connected
@@ -463,27 +463,33 @@ export interface ConnectorAuthMethodConfig {
  * - `cli-auth` — user imports credentials through a provider CLI. The imported
  *   result may still be stored as another credential shape such as `api-token`.
  */
-export type ConnectorAuthMethodType =
+export type ConnectorWellKnownAuthMethodId =
   | "oauth"
   | "api-token"
   | "api"
   | "cli-auth";
 
-export const CONNECTOR_AUTH_METHOD_TYPES = [
+export type ConnectorLocalAuthMethodId = "app-credentials";
+
+export type ConnectorAuthMethodId =
+  | ConnectorWellKnownAuthMethodId
+  | ConnectorLocalAuthMethodId;
+
+export const CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS = [
   "oauth",
   "api-token",
   "api",
   "cli-auth",
-] as const satisfies readonly ConnectorAuthMethodType[];
+] as const satisfies readonly ConnectorWellKnownAuthMethodId[];
 
-type MissingConnectorAuthMethodType = Exclude<
-  ConnectorAuthMethodType,
-  (typeof CONNECTOR_AUTH_METHOD_TYPES)[number]
+type MissingConnectorWellKnownAuthMethodId = Exclude<
+  ConnectorWellKnownAuthMethodId,
+  (typeof CONNECTOR_WELL_KNOWN_AUTH_METHOD_IDS)[number]
 >;
 
 type AssertNever<T extends never> = T;
-export type ConnectorAuthMethodTypesCoverUnion =
-  AssertNever<MissingConnectorAuthMethodType>;
+export type ConnectorWellKnownAuthMethodIdsCoverUnion =
+  AssertNever<MissingConnectorWellKnownAuthMethodId>;
 
 export type ConnectorDisplayCategory =
   | "ai-general-models"
@@ -594,14 +600,14 @@ export const CONNECTOR_DISPLAY_CATEGORY_ORDER: readonly ConnectorDisplayCategory
   ];
 
 type ConnectorAuthMethods = Partial<
-  Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>
+  Record<ConnectorAuthMethodId, ConnectorAuthMethodConfig>
 >;
 
 type ConnectorConfigBase = {
   readonly label: string;
   readonly helpText: string;
   readonly category: ConnectorDisplayCategory;
-  readonly defaultAuthMethod?: ConnectorAuthMethodType;
+  readonly defaultAuthMethod?: ConnectorAuthMethodId;
   /**
    * Output categories this connector skill can generate. This is product
    * metadata for discovery and routing, not a permission/capability grant.
@@ -891,7 +897,7 @@ export type ConnectorAuthMethodIds<Type extends ConnectorType> = Extract<
   string
 >;
 type ConnectorAuthMethodKeys<Type extends ConnectorType> =
-  ConnectorAuthMethodIds<Type> & ConnectorAuthMethodType;
+  ConnectorAuthMethodIds<Type> & ConnectorWellKnownAuthMethodId;
 
 type ConnectorAuthMethodGrantKindById = {
   readonly oauth: "auth-code" | "device-auth";
@@ -1007,17 +1013,21 @@ export type ConnectorBrowserVerificationCliAuthConnectorType = {
   }[keyof ConnectorAuthMethodsOf<Type>];
 }[ConnectorType];
 
-type InvalidDefaultAuthMethodConnectorType = {
-  [Type in ConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type] extends {
+export type ConnectorInvalidDefaultAuthMethodType<
+  Configs extends Record<string, ConnectorConfig>,
+> = {
+  [Type in keyof Configs & string]: Configs[Type] extends {
     readonly defaultAuthMethod: infer DefaultMethod;
   }
-    ? DefaultMethod extends ConnectorAuthMethodIds<Type>
+    ? DefaultMethod extends Extract<keyof Configs[Type]["authMethods"], string>
       ? never
       : Type
     : never;
-}[ConnectorType];
-export type ConnectorDefaultAuthMethodsMatchConfig =
-  AssertNever<InvalidDefaultAuthMethodConnectorType>;
+}[keyof Configs & string];
+
+export type ConnectorDefaultAuthMethodsMatchConfig = AssertNever<
+  ConnectorInvalidDefaultAuthMethodType<typeof CONNECTOR_TYPES_DEF>
+>;
 
 export const CONNECTOR_TYPES = CONNECTOR_TYPES_DEF;
 export const CONNECTOR_TYPE_KEYS = Object.freeze(

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -577,7 +577,7 @@ export {
   type OAuthConnectorType,
   type ConnectorConfig,
   type ConnectorAuthMethodConfig,
-  type ConnectorWellKnownAuthMethodId,
+  type ConnectorAuthMethodId,
   type ScopeDiff,
   type ConnectorSearchResult,
   type ConnectorSearchOutput,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -577,7 +577,7 @@ export {
   type OAuthConnectorType,
   type ConnectorConfig,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodType,
+  type ConnectorWellKnownAuthMethodId,
   type ScopeDiff,
   type ConnectorSearchResult,
   type ConnectorSearchOutput,


### PR DESCRIPTION
## Summary

- Split connector auth method ids into `ConnectorWellKnownAuthMethodId`, `ConnectorLocalAuthMethodId`, and the closed `ConnectorAuthMethodId` union.
- Remove the ambiguous `ConnectorAuthMethodType` export and update call sites to use the precise well-known id type.
- Keep connector config method keys, `defaultAuthMethod`, and `importsAuthMethod` union-constrained while allowing the explicit local `app-credentials` id.
- Update connector utilities/tests to avoid treating the well-known id list as the complete method universe.

Closes #14902

## Testing

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts src/__tests__/firewall-secret-consistency.test.ts`
- `pnpm check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/core lint`
- `pnpm format`
- `pnpm knip` via pre-commit

Note: `pnpm turbo run lint` was also attempted, but the `web` lint job failed while oxlint was reading files under `node_modules` with `Cannot allocate memory (os error 12)`. The touched packages' lint commands above passed.
