### PR TITLE
fix: prevent stale computer-use hosts from reactivating

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import {
   zeroComputerUseCommandContract,
+  zeroComputerUseHeartbeatContract,
   zeroComputerUseHostCommandsContract,
   zeroComputerUseHostsContract,
   zeroComputerUseWriteCommandContract,
@@ -15,7 +16,7 @@ import {
 } from "@vm0/db/schema/computer-use-host";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -83,6 +84,7 @@ async function seedComputerUseHost(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly hostToken: string;
+  readonly lastSeenAt?: Date;
 }): Promise<string> {
   const writeDb = store.set(writeDb$);
   const [host] = await writeDb
@@ -96,6 +98,7 @@ async function seedComputerUseHost(args: {
       osVersion: "macOS 15",
       supportedCapabilities: [...supportedCapabilities],
       permissions: { accessibility: true, screenRecording: true },
+      ...(args.lastSeenAt ? { lastSeenAt: args.lastSeenAt } : {}),
     })
     .returning({ id: computerUseHosts.id });
 
@@ -247,6 +250,103 @@ describe("desktop computer-use runtime", () => {
     );
     expect(listed.body.hosts).toHaveLength(1);
     expect(listed.body.hosts[0]?.id).toBe(started.body.hostId);
+  });
+
+  it("rejects a stale host heartbeat when another Desktop host is active", async () => {
+    const fixture = await createOrgFixture();
+    const staleHostToken = "stale-host-token";
+    const staleHostId = await seedComputerUseHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostToken: staleHostToken,
+      lastSeenAt: new Date(now() - 120_000),
+    });
+    const hostsClient = setupApp({ context })(zeroComputerUseHostsContract);
+    const heartbeatClient = setupApp({ context })(
+      zeroComputerUseHeartbeatContract,
+    );
+
+    await accept(
+      hostsClient.start({
+        body: {
+          hostName: "Zero Desktop",
+          appVersion: "0.1.0",
+          osVersion: "macOS 15",
+          supportedCapabilities: [...supportedCapabilities],
+          permissions: { accessibility: true, screenRecording: true },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const rejected = await accept(
+      heartbeatClient.heartbeat({
+        body: {
+          hostName: "Zero Desktop",
+          appVersion: "0.1.0",
+          osVersion: "macOS 15",
+          supportedCapabilities: [...supportedCapabilities],
+          permissions: { accessibility: true, screenRecording: true },
+        },
+        headers: { authorization: `Bearer ${staleHostToken}` },
+      }),
+      [409],
+    );
+
+    expect(rejected.body.error.message).toBe(
+      "A Desktop Computer Use host is already active",
+    );
+    const writeDb = store.set(writeDb$);
+    const [staleHost] = await writeDb
+      .select()
+      .from(computerUseHosts)
+      .where(eq(computerUseHosts.id, staleHostId));
+    expect(staleHost).toMatchObject({ status: "offline" });
+    expect(staleHost?.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it("stops a Desktop host so another host can start immediately", async () => {
+    await createOrgFixture();
+    const hostsClient = setupApp({ context })(zeroComputerUseHostsContract);
+    const heartbeatClient = setupApp({ context })(
+      zeroComputerUseHeartbeatContract,
+    );
+    const body = {
+      hostName: "Zero Desktop",
+      appVersion: "0.1.0",
+      osVersion: "macOS 15",
+      supportedCapabilities: [...supportedCapabilities],
+      permissions: { accessibility: true, screenRecording: true },
+    };
+
+    const started = await accept(
+      hostsClient.start({
+        body,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const stopped = await accept(
+      heartbeatClient.stop({
+        body: {},
+        headers: { authorization: `Bearer ${started.body.hostToken}` },
+      }),
+      [200],
+    );
+
+    expect(stopped.body).toStrictEqual({
+      ok: true,
+      hostId: started.body.hostId,
+    });
+    const restarted = await accept(
+      hostsClient.start({
+        body,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(restarted.body.hostId).not.toBe(started.body.hostId);
   });
 
   it("refuses to route commands when multiple active hosts already exist", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -27,6 +27,7 @@ import {
   listComputerUseAuditEvents$,
   listComputerUseHosts$,
   startComputerUseHost$,
+  stopComputerUseHost$,
 } from "../services/zero-computer-use.service";
 import type { RouteEntry } from "../route";
 
@@ -147,6 +148,34 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     { hostToken, ...bodyResult.data },
     signal,
   );
+  signal.throwIfAborted();
+
+  if (result.status === "invalid_token") {
+    return invalidComputerUseToken;
+  }
+  if (result.status === "active_host_exists") {
+    return conflict("A Desktop Computer Use host is already active");
+  }
+  return {
+    status: 200 as const,
+    body: { ok: true as const, hostId: result.hostId },
+  };
+});
+
+const hostStopBody$ = bodyResultOf(zeroComputerUseHeartbeatContract.stop);
+const hostStopInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(hostStopBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const hostToken = parseBearerToken(get(authorization$));
+  if (!hostToken) {
+    return unauthorizedComputerUse;
+  }
+
+  const result = await set(stopComputerUseHost$, { hostToken }, signal);
   signal.throwIfAborted();
 
   if (result.status === "invalid_token") {
@@ -520,6 +549,10 @@ export const zeroComputerUseRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerUseHeartbeatContract.heartbeat,
     handler: heartbeatInner$,
+  },
+  {
+    route: zeroComputerUseHeartbeatContract.stop,
+    handler: hostStopInner$,
   },
   {
     route: zeroComputerUseHostsContract.list,

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -97,6 +97,15 @@ type StartComputerUseHostResult =
     }
   | { readonly status: "active_host_exists"; readonly hostId: string };
 
+type HeartbeatComputerUseHostResult =
+  | { readonly status: "ok"; readonly hostId: string }
+  | { readonly status: "invalid_token" }
+  | { readonly status: "active_host_exists"; readonly hostId: string };
+
+type StopComputerUseHostResult =
+  | { readonly status: "stopped"; readonly hostId: string }
+  | { readonly status: "invalid_token" };
+
 type ClaimNextComputerUseHostCommandResult =
   | { readonly status: "invalid_token" }
   | { readonly status: "idle" }
@@ -411,6 +420,31 @@ async function hostFromToken(
   return host ?? null;
 }
 
+async function hostIdentityFromToken(
+  tx: ComputerUseTx,
+  hostToken: string,
+  signal: AbortSignal,
+): Promise<{
+  readonly orgId: string;
+  readonly userId: string;
+} | null> {
+  const [host] = await tx
+    .select({
+      orgId: computerUseHosts.orgId,
+      userId: computerUseHosts.userId,
+    })
+    .from(computerUseHosts)
+    .where(
+      and(
+        eq(computerUseHosts.tokenHash, hashSecret(hostToken)),
+        isNull(computerUseHosts.revokedAt),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return host ?? null;
+}
+
 export const startComputerUseHost$ = command(
   async (
     { set },
@@ -506,17 +540,56 @@ export const heartbeatComputerUseHost$ = command(
       };
     },
     signal: AbortSignal,
-  ): Promise<
-    | { readonly status: "ok"; readonly hostId: string }
-    | { readonly status: "invalid_token" }
-  > => {
+  ): Promise<HeartbeatComputerUseHostResult> => {
     const db = set(writeDb$);
     const now = nowDate();
     const result = await db.transaction(async (tx) => {
-      const host = await hostFromToken(tx, params.hostToken, signal);
-      if (!host) {
+      const hostIdentity = await hostIdentityFromToken(
+        tx,
+        params.hostToken,
+        signal,
+      );
+      if (!hostIdentity) {
         return { status: "invalid_token" as const };
       }
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext('computer_use_host:' || ${hostIdentity.orgId} || ':' || ${hostIdentity.userId}))`,
+      );
+      signal.throwIfAborted();
+
+      const lockedHost = await hostFromToken(tx, params.hostToken, signal);
+      if (!lockedHost) {
+        return { status: "invalid_token" as const };
+      }
+
+      const existingHosts = await tx
+        .select()
+        .from(computerUseHosts)
+        .where(
+          and(
+            eq(computerUseHosts.orgId, lockedHost.orgId),
+            eq(computerUseHosts.userId, lockedHost.userId),
+            isNull(computerUseHosts.revokedAt),
+          ),
+        )
+        .for("update");
+      signal.throwIfAborted();
+
+      const activeHost = existingHosts.find((candidate) => {
+        return candidate.id !== lockedHost.id && hostIsOnline(candidate, now);
+      });
+      if (activeHost) {
+        await tx
+          .update(computerUseHosts)
+          .set({ status: "offline", revokedAt: now, updatedAt: now })
+          .where(eq(computerUseHosts.id, lockedHost.id));
+        signal.throwIfAborted();
+        return {
+          status: "active_host_exists" as const,
+          hostId: activeHost.id,
+        };
+      }
+
       await tx
         .update(computerUseHosts)
         .set({
@@ -531,9 +604,37 @@ export const heartbeatComputerUseHost$ = command(
           lastSeenAt: now,
           updatedAt: now,
         })
+        .where(eq(computerUseHosts.id, lockedHost.id));
+      signal.throwIfAborted();
+      return { status: "ok" as const, hostId: lockedHost.id };
+    });
+    signal.throwIfAborted();
+    return result;
+  },
+);
+
+export const stopComputerUseHost$ = command(
+  async (
+    { set },
+    params: {
+      readonly hostToken: string;
+    },
+    signal: AbortSignal,
+  ): Promise<StopComputerUseHostResult> => {
+    const db = set(writeDb$);
+    const now = nowDate();
+    const result = await db.transaction(async (tx) => {
+      const host = await hostFromToken(tx, params.hostToken, signal);
+      if (!host) {
+        return { status: "invalid_token" as const };
+      }
+
+      await tx
+        .update(computerUseHosts)
+        .set({ status: "offline", revokedAt: now, updatedAt: now })
         .where(eq(computerUseHosts.id, host.id));
       signal.throwIfAborted();
-      return { status: "ok" as const, hostId: host.id };
+      return { status: "stopped" as const, hostId: host.id };
     });
     signal.throwIfAborted();
     return result;

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -108,7 +108,7 @@ describe("ComputerUseHostRuntime", () => {
     });
     expect(hostFetch).not.toHaveBeenCalled();
 
-    runtime.stop();
+    await runtime.stop();
   });
 
   it("uses the host bearer token for polling after registration", async () => {
@@ -143,7 +143,7 @@ describe("ComputerUseHostRuntime", () => {
       "https://api.vm0.ai/api/zero/computer-use/hosts/start",
     );
 
-    runtime.stop();
+    await runtime.stop();
   });
 
   it("records local native command payloads and results", async () => {
@@ -231,7 +231,62 @@ describe("ComputerUseHostRuntime", () => {
       },
     });
 
-    runtime.stop();
+    await runtime.stop();
+  });
+
+  it("stops the registered host through the host API", async () => {
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async () => {
+      return jsonResponse({ ok: true, hostId: "host-1" });
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await runtime.stop();
+
+    const stopCall = hostFetch.mock.calls.find(([url]) => {
+      return url.endsWith("/api/zero/computer-use/host/stop");
+    });
+    if (!stopCall) {
+      throw new Error("Expected Computer Use host stop request");
+    }
+    const headers = new Headers(stopCall[1]?.headers);
+    expect(stopCall[1]?.method).toBe("POST");
+    expect(headers.get("authorization")).toBe("Bearer token-1");
+    expect(runtime.getState()).toMatchObject({
+      status: "idle",
+      hostId: null,
+      lastError: null,
+    });
+  });
+
+  it("reports heartbeat active host conflicts without retrying", async () => {
+    vi.useFakeTimers();
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse(
+          {
+            error: { message: "A Desktop Computer Use host is already active" },
+          },
+          { status: 409 },
+        );
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(hostFetch).toHaveBeenCalledOnce();
+    expect(hostFetch.mock.calls[0]?.[0]).toBe(
+      "https://api.vm0.ai/api/zero/computer-use/heartbeat",
+    );
+    expect(runtime.getState()).toMatchObject({
+      status: "error",
+      hostId: null,
+      lastError:
+        "Computer Use is already active in another Zero Desktop session.",
+    });
   });
 
   it("stops after a 401 registration response so retry stays manual", async () => {

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -126,11 +126,29 @@ export class ComputerUseHostRuntime {
     await this.tick();
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.running = false;
     if (this.timer) {
       this.clearScheduledTimeout(this.timer);
       this.timer = null;
+    }
+    const hostToken = this.hostToken;
+    if (!hostToken) {
+      return;
+    }
+    this.hostToken = null;
+    this.setState({
+      status: "idle",
+      hostId: null,
+      lastError: null,
+    });
+    try {
+      await this.stopHost(hostToken);
+    } catch (error) {
+      this.setState({
+        status: "error",
+        lastError: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -322,6 +340,16 @@ export class ComputerUseHostRuntime {
       });
       return false;
     }
+    if (response.status === 409) {
+      this.hostToken = null;
+      this.setState({
+        status: "error",
+        hostId: null,
+        lastError:
+          "Computer Use is already active in another Zero Desktop session.",
+      });
+      return false;
+    }
     if (!response.ok) {
       throw new Error(`Computer Use heartbeat failed: ${response.status}`);
     }
@@ -446,5 +474,25 @@ export class ComputerUseHostRuntime {
         ...init.headers,
       },
     });
+  }
+
+  private async stopHost(hostToken: string): Promise<void> {
+    const response = await this.hostFetchRequest(
+      `${this.apiBaseUrl}/api/zero/computer-use/host/stop`,
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${hostToken}`,
+        },
+      },
+    );
+    if (response.status === 401) {
+      return;
+    }
+    if (!response.ok) {
+      throw new Error(`Computer Use host stop failed: ${response.status}`);
+    }
   }
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -80,9 +80,11 @@ const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const ELECTRON_ERR_ABORTED = -3;
 const AUTH_ME_PATH = "/api/auth/me";
 const ZERO_ORG_PATH = "/api/zero/org";
+const COMPUTER_USE_QUIT_STOP_TIMEOUT_MS = 1_000;
 let mainWindow: BrowserWindow | null = null;
 let pendingDesktopAuthCode: string | null = null;
 let appIsQuitting = false;
+let computerUseQuitStopStarted = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let desktopAuthToken: string | null = null;
@@ -251,6 +253,20 @@ function installComputerUse(): void {
     },
     { rendererUrl: localRendererUrl },
   );
+}
+
+async function stopComputerUseRuntimeForQuit(): Promise<void> {
+  const runtime = computerUseRuntime;
+  if (!runtime) {
+    return;
+  }
+
+  await Promise.race([
+    runtime.stop(),
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, COMPUTER_USE_QUIT_STOP_TIMEOUT_MS);
+    }),
+  ]);
 }
 
 function installDesktopAuth(): void {
@@ -722,8 +738,16 @@ if (!hasSingleInstanceLock) {
     handleDesktopAuthCallback(url);
   });
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
     appIsQuitting = true;
+    if (!computerUseRuntime || computerUseQuitStopStarted) {
+      return;
+    }
+    computerUseQuitStopStarted = true;
+    event.preventDefault();
+    void stopComputerUseRuntimeForQuit().finally(() => {
+      app.quit();
+    });
   });
 
   void app.whenReady().then(async () => {

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2295,6 +2295,18 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/zero/computer-use")).toBe(false);
   });
 
+  it("matches the zero computer-use host stop rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath("/api/zero/computer-use/host/stop"),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath("/api/zero/computer-use/host/stop/extra"),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/zero/computer-use/host")).toBe(
+      true,
+    );
+  });
+
   it("matches the zero chat threads collection rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/zero/chat-threads")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/zero/chat-threads-extra")).toBe(

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -1264,6 +1264,13 @@ const ZERO_COMPUTER_USE_UNREGISTER_NEXT_NEGATIVE_PATHS = [
   "/api/zero/computer-use/unregister/extra",
   "/api/zero/computer-use",
 ] as const;
+const ZERO_COMPUTER_USE_HOST_STOP_REWRITE_SOURCE =
+  "/api/zero/computer-use/host/stop";
+const ZERO_COMPUTER_USE_HOST_STOP_PATH = "/api/zero/computer-use/host/stop";
+const ZERO_COMPUTER_USE_HOST_STOP_NEXT_NEGATIVE_PATHS = [
+  "/api/zero/computer-use/host/stop/extra",
+  "/api/zero/computer-use/host",
+] as const;
 const ZERO_INSIGHTS_RANGE_REWRITE_SOURCE = "/api/zero/insights/range";
 const ZERO_INSIGHTS_RANGE_PATH = "/api/zero/insights/range";
 const ZERO_INSIGHTS_RANGE_NEXT_NEGATIVE_PATHS = [
@@ -6057,6 +6064,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(ZERO_COMPUTER_USE_UNREGISTER_PATH)).toStrictEqual({});
     for (const pathname of ZERO_COMPUTER_USE_UNREGISTER_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact zero computer-use host stop rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === ZERO_COMPUTER_USE_HOST_STOP_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: ZERO_COMPUTER_USE_HOST_STOP_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/zero/computer-use/host/stop",
+    });
+
+    const matcher = getPathMatch(ZERO_COMPUTER_USE_HOST_STOP_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(ZERO_COMPUTER_USE_HOST_STOP_PATH)).toStrictEqual({});
+    for (const pathname of ZERO_COMPUTER_USE_HOST_STOP_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -244,6 +244,8 @@ const ZERO_COMPUTER_USE_COMMAND_APPROVAL_PATH_RE = new RegExp(
 );
 const ZERO_COMPUTER_USE_HEARTBEAT_REWRITE_SOURCE =
   "/api/zero/computer-use/heartbeat";
+const ZERO_COMPUTER_USE_HOST_STOP_REWRITE_SOURCE =
+  "/api/zero/computer-use/host/stop";
 const ZERO_COMPUTER_USE_HOST_COMMANDS_NEXT_REWRITE_SOURCE =
   "/api/zero/computer-use/host/commands/next";
 const ZERO_COMPUTER_USE_HOST_COMMAND_COMPLETE_REWRITE_SOURCE = `/api/zero/computer-use/host/commands/:commandId(${UUID_PATH_SEGMENT_PATTERN})/complete`;
@@ -875,6 +877,10 @@ export const API_BACKEND_REWRITES = [
   [
     ZERO_COMPUTER_USE_HEARTBEAT_REWRITE_SOURCE,
     "/api/zero/computer-use/heartbeat",
+  ],
+  [
+    ZERO_COMPUTER_USE_HOST_STOP_REWRITE_SOURCE,
+    "/api/zero/computer-use/host/stop",
   ],
   [
     ZERO_COMPUTER_USE_HOST_COMMANDS_NEXT_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -289,6 +289,13 @@ export const computerUseHeartbeatResponseSchema = z.object({
   hostId: z.string(),
 });
 
+export const computerUseHostStopBodySchema = z.object({});
+
+export const computerUseHostStopResponseSchema = z.object({
+  ok: z.literal(true),
+  hostId: z.string(),
+});
+
 export const computerUseHostListResponseSchema = z.object({
   hosts: z.array(computerUseHostSchema),
 });
@@ -427,8 +434,20 @@ export const zeroComputerUseHeartbeatContract = c.router({
     responses: {
       200: computerUseHeartbeatResponseSchema,
       401: apiErrorSchema,
+      409: apiErrorSchema,
     },
     summary: "Refresh a desktop computer-use host heartbeat",
+  },
+  stop: {
+    method: "POST",
+    path: "/api/zero/computer-use/host/stop",
+    headers: authHeadersSchema,
+    body: computerUseHostStopBodySchema,
+    responses: {
+      200: computerUseHostStopResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Stop a desktop computer-use host",
   },
 });
 


### PR DESCRIPTION
## Summary

- Reject stale Desktop computer-use host heartbeats with a 409 when another host is already active, and revoke the stale host token.
- Add a host-token stop endpoint and call it when Desktop stops the computer-use runtime or quits.
- Add the web API backend rewrite for the new stop route and focused regression tests.

## Validation

- `pnpm format`
- `pnpm check-types`
- `pnpm turbo run lint`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm vitest`
- `pnpm knip`
- `git diff --check`

Closes #14912
