### PR TITLE
perf(test): expand role-walk lint rule and route callers through queryallbyrolefast

### DIFF
--- a/turbo/apps/platform/custom-eslint/rules/no-get-by-role-name.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-get-by-role-name.ts
@@ -1,21 +1,34 @@
 /**
  * ESLint rule: no-get-by-role-name
  *
- * Warns when *ByRole queries use the `name` option for roles whose accessible
- * name comes from subtree text content (button, link, menuitem, tab, …).
+ * Warns when *ByRole queries are used for roles whose accessible name comes
+ * from subtree text content (button, link, menuitem, tab, …).
  *
- * In happy-dom, `getByRole("button", { name: /text/ })` must compute the ARIA
- * accessible name for every matching element, traversing each element's entire
- * subtree. With 20+ buttons in a rendered page this costs ~300–900ms per call
- * — a 100–900× slowdown compared to text-content alternatives.
+ * Two layers of cost in @testing-library/happy-dom:
+ *
+ * 1. Adding `{ name }` forces the accessible-name algorithm to walk every
+ *    candidate element's subtree. With 20+ buttons that is ~300–900ms per
+ *    call.
+ * 2. Even without `{ name }`, *ByRole walks the entire document running ARIA
+ *    role inference per node. Profiling the /connectors page showed
+ *    `getAllByRole("button")` taking ~360ms with only 5 buttons present —
+ *    pushed the stripe CLI close test over the 5s vitest timeout in CI
+ *    (#14871, then re-skipped in #14891) until we replaced the call.
+ *
+ * For native HTML elements (`button`, `a` → `link`, `[role="tab"]`, …) the
+ * tag is the role, so querySelectorAll resolves the same set without the
+ * ARIA tree walk.
  *
  * Bad:
- *   screen.getByRole("button", { name: /Add member/i })     // ~333ms
- *   within(dialog).getByRole("link", { name: "Cancel" })    // still slow
+ *   screen.getByRole("button", { name: /Add member/i })       // ~333ms
+ *   within(dialog).getByRole("link", { name: "Cancel" })      // still slow
+ *   screen.getAllByRole("button").find(el => /…/.test(el.textContent ?? ""))
  *
- * Good — use text content directly:
- *   screen.getByText("Add member")
- *   screen.getAllByRole("button").find(el => /Add member/i.test(el.textContent ?? ""))
+ * Good — native tag selector + textContent filter:
+ *   for (const btn of document.body.querySelectorAll<HTMLButtonElement>("button")) {
+ *     if (/Add member/.test(btn.textContent ?? "")) return btn;
+ *   }
+ *   // or, when uniqueness is guaranteed, screen.getByText("Add member")
  *
  * Exception — roles that have few instances or whose names come from labels
  * (heading, dialog, combobox, textbox, checkbox) are not flagged because they
@@ -73,7 +86,7 @@ export default createRule<[], MessageIds>({
     schema: [],
     messages: {
       avoidRoleWithName:
-        'Avoid *ByRole("{{role}}", { name }) — accessible name computation traverses every matching element\'s subtree and costs ~300ms per call in happy-dom. Use getByText("label") or getAllByRole("{{role}}").find(el => /label/.test(el.textContent ?? "")) instead.',
+        'Avoid *ByRole("{{role}}", …) — even without `{ name }` this walks the whole DOM running ARIA role inference per node (~360ms per call on a typical page). Use `queryAllByRoleFast("{{role}}"[, container])` from src/__tests__/page-helper, then filter on textContent.',
     },
   },
   defaultOptions: [],
@@ -108,23 +121,6 @@ export default createRule<[], MessageIds>({
 
         const role = roleArg.value;
         if (!TEXT_CONTENT_ROLES.has(role)) {
-          return;
-        }
-
-        // Second argument must be an options object containing a `name` key.
-        const optionsArg = node.arguments[1];
-        if (!optionsArg || optionsArg.type !== "ObjectExpression") {
-          return;
-        }
-
-        const hasNameProp = optionsArg.properties.some(
-          (prop) =>
-            prop.type === "Property" &&
-            prop.key.type === "Identifier" &&
-            prop.key.name === "name",
-        );
-
-        if (!hasNameProp) {
           return;
         }
 

--- a/turbo/apps/platform/src/__tests__/page-helper.test.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, afterEach } from "vitest";
+
+import { queryAllByRoleFast } from "./page-helper.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("queryAllByRoleFast role disambiguation", () => {
+  it('treats <th scope="row"> as rowheader, not columnheader', () => {
+    document.body.innerHTML = `
+      <table>
+        <thead><tr><th>Col A</th><th>Col B</th></tr></thead>
+        <tbody>
+          <tr><th scope="row">Row 1</th><td>v1</td></tr>
+          <tr><th scope="row">Row 2</th><td>v2</td></tr>
+        </tbody>
+      </table>
+    `;
+
+    const columnheaders = queryAllByRoleFast("columnheader").map((el) => {
+      return el.textContent?.trim();
+    });
+    expect(columnheaders).toStrictEqual(["Col A", "Col B"]);
+
+    const rowheaders = queryAllByRoleFast("rowheader").map((el) => {
+      return el.textContent?.trim();
+    });
+    expect(rowheaders).toStrictEqual(["Row 1", "Row 2"]);
+  });
+
+  it("treats explicit role override the same as a native tag", () => {
+    document.body.innerHTML = `
+      <div>
+        <button>native</button>
+        <div role="button">aria</div>
+        <span role="link">link via role</span>
+        <a href="/foo">native link</a>
+        <a>no href, no role</a>
+      </div>
+    `;
+
+    expect(
+      queryAllByRoleFast("button").map((el) => {
+        return el.textContent;
+      }),
+    ).toStrictEqual(["native", "aria"]);
+    expect(
+      queryAllByRoleFast("link").map((el) => {
+        return el.textContent;
+      }),
+    ).toStrictEqual(["link via role", "native link"]);
+  });
+
+  it("excludes descendants of aria-hidden, hidden, or inert subtrees", () => {
+    document.body.innerHTML = `
+      <button>visible</button>
+      <div aria-hidden="true"><button>hidden via aria</button></div>
+      <div inert><button>hidden via inert</button></div>
+      <div hidden><button>hidden via hidden</button></div>
+    `;
+
+    expect(
+      queryAllByRoleFast("button").map((el) => {
+        return el.textContent;
+      }),
+    ).toStrictEqual(["visible"]);
+  });
+
+  it("scopes results to the given container", () => {
+    document.body.innerHTML = `
+      <button>outside</button>
+      <div id="scope"><button>inside-a</button><button>inside-b</button></div>
+    `;
+    const scope = document.getElementById("scope")!;
+
+    expect(
+      queryAllByRoleFast("button", scope).map((el) => {
+        return el.textContent;
+      }),
+    ).toStrictEqual(["inside-a", "inside-b"]);
+  });
+});

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -211,3 +211,71 @@ export function click(element: Element): void {
   fireEvent.pointerDown(element, { button: 0 });
   fireEvent.click(element);
 }
+
+/**
+ * Text-content ARIA roles — roles whose accessible name is derived from a
+ * subtree text walk, so `*ByRole(role)` from @testing-library pays for an
+ * O(documentSize) ARIA tree traversal even without `{ name }`. Profiling
+ * showed `screen.getAllByRole("button")` taking ~360ms on the /connectors
+ * page with only 5 buttons rendered.
+ */
+type TextContentRole =
+  | "button"
+  | "link"
+  | "menuitem"
+  | "menuitemcheckbox"
+  | "menuitemradio"
+  | "tab"
+  | "cell"
+  | "columnheader"
+  | "rowheader"
+  | "gridcell";
+
+const ROLE_SELECTORS: Record<TextContentRole, string> = {
+  button: 'button, [role="button"]',
+  link: 'a[href], [role="link"]',
+  menuitem: '[role="menuitem"]',
+  menuitemcheckbox: '[role="menuitemcheckbox"]',
+  menuitemradio: '[role="menuitemradio"]',
+  tab: '[role="tab"]',
+  cell: 'td, [role="cell"]',
+  // Plain <th> inside <thead> has implicit role="columnheader".
+  columnheader: 'th, [role="columnheader"]',
+  rowheader: 'th[scope="row"], [role="rowheader"]',
+  gridcell: '[role="gridcell"]',
+};
+
+/**
+ * Element is hidden from the accessibility tree — used to match the default
+ * `getAllByRole(role, { hidden: false })` behaviour from
+ * `@testing-library/dom`, which excludes ancestors flagged with
+ * `aria-hidden="true"`, the `hidden` attribute, or `inert`. Radix overlays
+ * commonly leave background portals mounted with `aria-hidden`; matching
+ * those would inflate counts vs. the original role queries.
+ */
+function isAccessibilityHidden(element: Element): boolean {
+  return element.closest('[aria-hidden="true"], [hidden], [inert]') !== null;
+}
+
+/**
+ * Fast role lookup that returns the same elements as
+ * `getAllByRole(role)` for text-content roles, without the ARIA tree walk
+ * `@testing-library/dom` performs. Use this anywhere you'd otherwise call
+ * `screen.getAllByRole("button").find(el => /label/.test(el.textContent))`
+ * or `within(container).getAllByRole("link")`.
+ *
+ * The native tag is the primary lookup; the `[role="…"]` fallback covers
+ * elements that override their role explicitly. Elements inside an
+ * `aria-hidden`, `hidden`, or `inert` subtree are filtered out to match the
+ * default `getAllByRole` visibility semantics.
+ */
+export function queryAllByRoleFast(
+  role: TextContentRole,
+  container: ParentNode = document.body,
+): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(ROLE_SELECTORS[role]),
+  ).filter((el) => {
+    return !isAccessibilityHidden(el);
+  });
+}

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -239,8 +239,10 @@ const ROLE_SELECTORS: Record<TextContentRole, string> = {
   menuitemradio: '[role="menuitemradio"]',
   tab: '[role="tab"]',
   cell: 'td, [role="cell"]',
-  // Plain <th> inside <thead> has implicit role="columnheader".
-  columnheader: 'th, [role="columnheader"]',
+  // Plain <th> inside <thead> has implicit role="columnheader"; a <th
+  // scope="row"> is a rowheader, so exclude it here to match
+  // @testing-library/dom's role disambiguation.
+  columnheader: 'th:not([scope="row"]), [role="columnheader"]',
   rowheader: 'th[scope="row"], [role="rowheader"]',
   gridcell: '[role="gridcell"]',
 };

--- a/turbo/apps/platform/src/views/activity/__tests__/activity-inspect-page.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/activity-inspect-page.test.tsx
@@ -3,7 +3,11 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   loadInspectLogFile$,
   inspectStepSearch$,
@@ -272,7 +276,7 @@ describe("activityInspectPage", () => {
       await loadInspectData(makeInspectData());
 
       await waitFor(() => {
-        const tabs = screen.getAllByRole("tab");
+        const tabs = queryAllByRoleFast("tab");
         expect(
           tabs.some((el) => {
             return el.textContent?.trim() === "Steps";
@@ -303,17 +307,17 @@ describe("activityInspectPage", () => {
       });
 
       expect(
-        screen.queryAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return el.textContent?.trim() === "Steps";
         }),
       ).toBeUndefined();
       expect(
-        screen.queryAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return el.textContent?.trim() === "Context";
         }),
       ).toBeUndefined();
       expect(
-        screen.queryAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return el.textContent?.trim() === "Network";
         }),
       ).toBeUndefined();

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setTheme$ } from "../../../signals/theme.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -254,7 +257,7 @@ describe("chat-d-066: markdown links open in new tab", () => {
     detachedSetupPage({ context, path: "/chats/thread-link" });
 
     await waitFor(() => {
-      const link = screen.getAllByRole("link").find((el) => {
+      const link = queryAllByRoleFast("link").find((el) => {
         return /example/.test(el.textContent ?? "");
       });
       expect(link).toHaveAttribute("href", "https://example.com");

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -20,7 +20,11 @@ import { zeroCliAuthStripeContract } from "@vm0/api-contracts/contracts/zero-con
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   connectorCliAuthState$,
   setSelectedConnectorType$,
@@ -65,19 +69,13 @@ function elementTextMatches(
 }
 
 function getButtonByText(matcher: string | RegExp): HTMLElement {
-  // `screen.getAllByRole("button")` triggers @testing-library's ARIA-role
-  // resolution across the whole document — that single call took ~360ms in
-  // happy-dom on this page even with only 5 buttons present, which alone
-  // pushed the stripe CLI close test over the default 5s timeout under CI
-  // load. Native `querySelectorAll("button")` returns the same set without
-  // the ARIA tree walk.
-  const buttons = document.body.querySelectorAll<HTMLButtonElement>("button");
-  for (const button of buttons) {
-    if (elementTextMatches(button, matcher)) {
-      return button;
-    }
+  const button = queryAllByRoleFast("button").find((element) => {
+    return elementTextMatches(element, matcher);
+  });
+  if (!button) {
+    throw new Error(`Button not found: ${String(matcher)}`);
   }
-  throw new Error(`Button not found: ${String(matcher)}`);
+  return button;
 }
 
 function mockConnectorOauthStart() {

--- a/turbo/apps/platform/src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
@@ -3,7 +3,11 @@ import { screen, waitFor } from "@testing-library/react";
 import { zeroIntegrationsAgentPhoneContract } from "@vm0/api-contracts/contracts/zero-integrations-agentphone";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { parseAgentPhoneConnectParams } from "../../../signals/zero-page/agentphone-connect-params.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
@@ -19,7 +23,7 @@ const VALID_SMS_PATH = `${VALID_PATH}&channel=sms`;
 const VALID_IMESSAGE_PATH = `${VALID_PATH}&channel=imessage`;
 
 function buttonWithText(text: string): HTMLButtonElement {
-  const button = screen.getAllByRole("button").find((element) => {
+  const button = queryAllByRoleFast("button").find((element) => {
     return element.textContent === text;
   });
   expect(button).toBeDefined();

--- a/turbo/apps/platform/src/views/conn/__tests__/zero-slack-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/zero-slack-connect-page.test.tsx
@@ -11,7 +11,11 @@ import { screen, waitFor } from "@testing-library/react";
 import { zeroSlackConnectContract } from "@vm0/api-contracts/contracts/zero-slack-connect";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
@@ -112,7 +116,7 @@ describe("zero-slack-connect-page - back to settings link (CONN-N-055)", () => {
     detachedSetupPage({ context, path: "/settings/slack?w=ws1&u=u1" });
 
     await waitFor(() => {
-      const link = screen.getAllByRole("link").find((el) => {
+      const link = queryAllByRoleFast("link").find((el) => {
         return /Back to settings/i.test(el.textContent ?? "");
       });
       expect(link).toBeDefined();
@@ -146,7 +150,7 @@ describe("zero-slack-connect-page - connect button (CONN-I-056)", () => {
       ).toBeInTheDocument();
     });
 
-    const connectButton = screen.getAllByRole("button").find((el) => {
+    const connectButton = queryAllByRoleFast("button").find((el) => {
       return /^Connect$/i.test(el.textContent ?? "");
     })!;
 
@@ -182,14 +186,14 @@ describe("zero-slack-connect-page - connect button (CONN-I-056)", () => {
       ).toBeInTheDocument();
     });
 
-    const connectButton = screen.getAllByRole("button").find((el) => {
+    const connectButton = queryAllByRoleFast("button").find((el) => {
       return /^Connect$/i.test(el.textContent ?? "");
     })!;
 
     click(connectButton);
 
     await waitFor(() => {
-      const loadingButton = screen.getAllByRole("button").find((el) => {
+      const loadingButton = queryAllByRoleFast("button").find((el) => {
         return /Connecting.../i.test(el.textContent ?? "");
       });
       expect(loadingButton).toBeDisabled();
@@ -211,7 +215,7 @@ describe("zero-slack-connect-page - open slack button on success (CONN-I-057)", 
     detachedSetupPage({ context, path: "/settings/slack?w=ws1&u=u1" });
 
     const openSlackBtn = await waitFor(() => {
-      const btn = screen.getAllByRole("button").find((el) => {
+      const btn = queryAllByRoleFast("button").find((el) => {
         return /Open Slack/i.test(el.textContent ?? "");
       });
       expect(btn).toBeDefined();

--- a/turbo/apps/platform/src/views/conn/__tests__/zero-telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/zero-telegram-connect-page.test.tsx
@@ -3,7 +3,11 @@ import { screen, waitFor } from "@testing-library/react";
 import { zeroIntegrationsTelegramContract } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { parseTelegramConnectParams } from "../../../signals/zero-page/telegram-connect-params.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
@@ -17,7 +21,7 @@ const VALID_PATH =
   "&tgUserName=ada_tg&tgDisplayName=Ada%20Lovelace";
 
 function buttonWithText(text: string): HTMLButtonElement {
-  const button = screen.getAllByRole("button").find((element) => {
+  const button = queryAllByRoleFast("button").find((element) => {
     return element.textContent === text;
   });
   expect(button).toBeDefined();
@@ -25,7 +29,7 @@ function buttonWithText(text: string): HTMLButtonElement {
 }
 
 function buttonWithAriaLabel(label: string): HTMLButtonElement {
-  const button = screen.getAllByRole("button").find((element) => {
+  const button = queryAllByRoleFast("button").find((element) => {
     return element.getAttribute("aria-label") === label;
   });
   expect(button).toBeDefined();

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import {
@@ -10,7 +10,11 @@ import {
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
@@ -141,11 +145,9 @@ function getPermissionRow(permissionName: string): HTMLElement {
 }
 
 function getPolicyButton(row: HTMLElement, label: string): HTMLElement {
-  const button = within(row)
-    .getAllByRole("button")
-    .find((el) => {
-      return el.textContent?.includes(label) ?? false;
-    });
+  const button = queryAllByRoleFast("button", row).find((el) => {
+    return el.textContent?.includes(label) ?? false;
+  });
   if (!(button instanceof HTMLElement)) {
     throw new Error(`Policy button not found: ${label}`);
   }
@@ -194,11 +196,11 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     const insertCommentsRow = insertCommentsCode?.closest("div")
       ?.parentElement as HTMLElement;
-    const denyBtn = within(insertCommentsRow)
-      .getAllByRole("button")
-      .find((b) => {
+    const denyBtn = queryAllByRoleFast("button", insertCommentsRow).find(
+      (b) => {
         return b.textContent?.includes("Deny") ?? false;
-      });
+      },
+    );
     expect(denyBtn).toHaveAttribute("aria-pressed", "true");
 
     // read_content row should show Allow as pressed (default)
@@ -207,11 +209,9 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     const readContentRow = readContentCode?.closest("div")
       ?.parentElement as HTMLElement;
-    const allowBtn = within(readContentRow)
-      .getAllByRole("button")
-      .find((b) => {
-        return b.textContent?.includes("Allow") ?? false;
-      });
+    const allowBtn = queryAllByRoleFast("button", readContentRow).find((b) => {
+      return b.textContent?.includes("Allow") ?? false;
+    });
     expect(allowBtn).toHaveAttribute("aria-pressed", "true");
   });
 });
@@ -358,7 +358,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       expect(screen.getByText("Apply")).toBeInTheDocument();
     });
 
-    const allButtons = screen.getAllByRole("button");
+    const allButtons = queryAllByRoleFast("button");
     const policyButtons = allButtons.filter((b) => {
       return (
         (b.textContent?.includes("Allow") ?? false) ||

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -3,7 +3,10 @@ import { screen, waitFor } from "@testing-library/react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 
 const context = testContext();
 
@@ -21,7 +24,7 @@ describe("lab page", () => {
       screen.getByText("Toggle experimental features on or off."),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("button").find((btn) => {
+      queryAllByRoleFast("button").find((btn) => {
         return btn.textContent === "Reset all";
       }),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -8,7 +8,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -946,7 +950,7 @@ describe("network insights page - embedded usage panels", () => {
     });
     click(screen.getByText("Last 7 Days"));
     const findYesterdayItem = () => {
-      return screen.getAllByRole("menuitem").find((item) => {
+      return queryAllByRoleFast("menuitem").find((item) => {
         return item.textContent === "Yesterday";
       });
     };

--- a/turbo/apps/platform/src/views/org/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-general-tab.test.tsx
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { refreshOrg$ } from "../../../signals/org.ts";
 import {
@@ -221,13 +222,13 @@ describe("org general tab - interaction", () => {
     await openGeneralTab();
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Leave";
         }),
       ).toBeInTheDocument();
     });
     click(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Leave";
       })!,
     );
@@ -242,7 +243,7 @@ describe("org general tab - interaction", () => {
     await openGeneralTab();
     // Wait for page to load
     await screen.findByDisplayValue("acme-org");
-    const deleteButton = screen.getAllByRole("button").find((el) => {
+    const deleteButton = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Delete";
     });
     expect(deleteButton).toBeDefined();
@@ -262,7 +263,7 @@ describe("org general tab - validation", () => {
     setMockOrg({ slug: "my-workspace" });
     await openGeneralTab();
     await screen.findByDisplayValue("my-workspace");
-    const deleteWorkspaceBtn = screen.getAllByRole("button").find((el) => {
+    const deleteWorkspaceBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Delete";
     });
     expect(deleteWorkspaceBtn).toBeDefined();
@@ -271,7 +272,7 @@ describe("org general tab - validation", () => {
       expect(screen.getByText("Delete workspace?")).toBeInTheDocument();
     });
     // Get the destructive "Delete workspace" button inside the dialog footer
-    const deleteBtn = screen.getAllByRole("button").find((el) => {
+    const deleteBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Delete workspace";
     });
     expect(deleteBtn).toBeDefined();

--- a/turbo/apps/platform/src/views/org/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-invoices-tab.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   setMockBillingInvoices,
   resetMockBilling,
@@ -110,7 +113,7 @@ it("shows download link only when hostedInvoiceUrl is available", async () => {
   await waitFor(() => {
     expect(screen.getByText("INV-001")).toBeInTheDocument();
   });
-  const downloadLinks = screen.getAllByRole("link").filter((el) => {
+  const downloadLinks = queryAllByRoleFast("link").filter((el) => {
     return /Download invoice/.test(el.getAttribute("aria-label") ?? "");
   });
   expect(downloadLinks).toHaveLength(1);
@@ -157,12 +160,12 @@ it("shows tooltip when hovering download link", async () => {
   await openInvoicesTab();
   await waitFor(() => {
     expect(
-      screen.getAllByRole("link").some((el) => {
+      queryAllByRoleFast("link").some((el) => {
         return /Download invoice/.test(el.getAttribute("aria-label") ?? "");
       }),
     ).toBeTruthy();
   });
-  const downloadLink = screen.getAllByRole("link").find((el) => {
+  const downloadLink = queryAllByRoleFast("link").find((el) => {
     return /Download invoice/.test(el.getAttribute("aria-label") ?? "");
   });
   if (!downloadLink) {

--- a/turbo/apps/platform/src/views/org/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-members-tab.test.tsx
@@ -6,6 +6,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import type {
   OrgMember,
@@ -197,7 +198,7 @@ test("opens invite dialog when Add member button is clicked", async () => {
   await waitFor(() => {
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
   });
-  const addMemberButton = screen.getAllByRole("button").find((el) => {
+  const addMemberButton = queryAllByRoleFast("button").find((el) => {
     return /Add member/i.test(el.textContent ?? "");
   });
   expect(addMemberButton).toBeDefined();
@@ -223,7 +224,7 @@ test("sends invite with typed email when Send invitation is clicked", async () =
   await waitFor(() => {
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
   });
-  const addMemberButton031 = screen.getAllByRole("button").find((el) => {
+  const addMemberButton031 = queryAllByRoleFast("button").find((el) => {
     return /Add member/i.test(el.textContent ?? "");
   });
   expect(addMemberButton031).toBeDefined();
@@ -235,7 +236,7 @@ test("sends invite with typed email when Send invitation is clicked", async () =
   });
   const emailInput = screen.getByPlaceholderText("email@example.com");
   await fill(emailInput, "test@invite.com");
-  const sendButton031 = screen.getAllByRole("button").find((el) => {
+  const sendButton031 = queryAllByRoleFast("button").find((el) => {
     return el.textContent === "Send invitation";
   });
   expect(sendButton031).toBeDefined();
@@ -259,7 +260,7 @@ test("sends invite with Admin role when Admin is selected in role dropdown", asy
   await waitFor(() => {
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
   });
-  const addMemberButton032 = screen.getAllByRole("button").find((el) => {
+  const addMemberButton032 = queryAllByRoleFast("button").find((el) => {
     return /Add member/i.test(el.textContent ?? "");
   });
   expect(addMemberButton032).toBeDefined();
@@ -276,7 +277,7 @@ test("sends invite with Admin role when Admin is selected in role dropdown", asy
     expect(screen.getByRole("option", { name: "Admin" })).toBeInTheDocument();
   });
   click(screen.getByRole("option", { name: "Admin" }));
-  const sendButton032 = screen.getAllByRole("button").find((el) => {
+  const sendButton032 = queryAllByRoleFast("button").find((el) => {
     return el.textContent === "Send invitation";
   });
   expect(sendButton032).toBeDefined();

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -28,6 +28,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockSchedules } from "../../../mocks/handlers/api-schedules.ts";
@@ -107,12 +108,12 @@ describe("internal connector logos - interaction (ORG-I-121)", () => {
       // Default size button is "128" — clicking "16" should switch to a smaller size
       await waitFor(() => {
         expect(
-          screen.getAllByRole("button").find((el) => {
+          queryAllByRoleFast("button").find((el) => {
             return /128/.test(el.textContent ?? "");
           }),
         ).toBeInTheDocument();
       });
-      const btn16 = screen.getAllByRole("button").find((el) => {
+      const btn16 = queryAllByRoleFast("button").find((el) => {
         return /^16$/.test(el.textContent ?? "");
       });
       click(btn16!);
@@ -259,7 +260,7 @@ describe("zero unsaved bar - display (ORG-D-111)", () => {
     // ZeroUnsavedBar appears with Save/Discard buttons when there are unsaved changes
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Discard$/.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
@@ -278,19 +279,19 @@ describe("zero unsaved bar - interaction (ORG-I-113)", () => {
     await fill(descInput, "Changed description");
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Discard$/.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
     });
     click(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /^Discard$/.test(el.textContent ?? "");
       })!,
     );
     await waitFor(() => {
       expect(
-        screen.queryAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Discard$/.test(el.textContent ?? "");
         }),
       ).toBeUndefined();
@@ -315,19 +316,19 @@ describe("zero unsaved bar - interaction (ORG-I-114)", () => {
     await fill(descInput, "New description");
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Discard$/.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
     });
     click(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /^Save$/.test(el.textContent ?? "");
       })!,
     );
     await waitFor(() => {
       expect(
-        screen.queryAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Discard$/.test(el.textContent ?? "");
         }),
       ).toBeUndefined();

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   type UserPreferencesResponse,
   zeroUserPreferencesContract,
@@ -108,7 +112,7 @@ describe("zero preferences page - send mode interaction", () => {
       expect(screen.getByText("Send message with")).toBeInTheDocument();
     });
 
-    const cmdEnterButton = screen.getAllByRole("button").find((btn) => {
+    const cmdEnterButton = queryAllByRoleFast("button").find((btn) => {
       return (
         btn.textContent?.includes("Enter") &&
         btn.textContent?.includes("\u2318")

--- a/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   setMockSchedules,
   createMockScheduleResponse,
@@ -52,7 +55,7 @@ describe("schedule page", () => {
     });
 
     // The "Add schedule" button appears in the header and in the empty state
-    const addButtons = screen.getAllByRole("button").filter((el) => {
+    const addButtons = queryAllByRoleFast("button").filter((el) => {
       return /Add schedule/.test(el.textContent ?? "");
     });
     expect(addButtons.length).toBeGreaterThanOrEqual(1);

--- a/turbo/apps/platform/src/views/team-page/__tests__/job-custom-connectors-section.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/job-custom-connectors-section.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
   zeroAgentsByIdContract,
@@ -72,7 +75,7 @@ describe("jobCustomConnectorsSection", () => {
 
     // Verify the Authorization tab is visible (the tab where custom connectors section lives)
     expect(
-      screen.getAllByRole("tab").find((el) => {
+      queryAllByRoleFast("tab").find((el) => {
         return /Authorization/.test(el.textContent ?? "");
       }),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { resetAllMockHandlers } from "../../../mocks/handlers/index.ts";
 import { server } from "../../../mocks/server.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
@@ -42,7 +45,7 @@ describe("/usage page", () => {
       expect(screen.getByText("My Schedule")).toBeInTheDocument();
     });
 
-    const scheduleLink = screen.getAllByRole("link").find((el) => {
+    const scheduleLink = queryAllByRoleFast("link").find((el) => {
       return /My Schedule/.test(el.textContent ?? "");
     });
     expect(scheduleLink).toBeInTheDocument();
@@ -51,7 +54,7 @@ describe("/usage page", () => {
       expect(screen.getByText("Chat with Agent")).toBeInTheDocument();
     });
 
-    const chatLink = screen.getAllByRole("link").find((el) => {
+    const chatLink = queryAllByRoleFast("link").find((el) => {
       return /Chat with Agent/.test(el.textContent ?? "");
     });
     expect(chatLink).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
@@ -8,7 +8,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   resetMockBilling,
   setMockBillingStatus,
@@ -128,13 +132,13 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Save";
         }),
       ).toBeDefined();
     });
 
-    const saveBtn1 = screen.getAllByRole("button").find((el) => {
+    const saveBtn1 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn1).toBeDefined();
@@ -142,7 +146,7 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Saving...";
         }),
       ).toBeDisabled();
@@ -152,7 +156,7 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Save";
         }),
       ).not.toBeDisabled();
@@ -266,7 +270,7 @@ describe("chat-c-076: Button text changes based on isUpgrade/isDowngrade determi
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /Upgrade to Team/i.test(el.textContent ?? "");
         }),
       ).toBeDefined();
@@ -292,7 +296,7 @@ describe("chat-c-076: Button text changes based on isUpgrade/isDowngrade determi
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Downgrade$/i.test(el.textContent ?? "");
         }),
       ).toBeDefined();
@@ -335,13 +339,13 @@ describe("chat-c-077: Action button is disabled during redirect", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /Upgrade to Team/i.test(el.textContent ?? "");
         }),
       ).toBeDefined();
     });
 
-    const upgradeBtn1 = screen.getAllByRole("button").find((el) => {
+    const upgradeBtn1 = queryAllByRoleFast("button").find((el) => {
       return /Upgrade to Team/i.test(el.textContent ?? "");
     });
     expect(upgradeBtn1).toBeDefined();
@@ -349,7 +353,7 @@ describe("chat-c-077: Action button is disabled during redirect", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /Redirecting/i.test(el.textContent ?? "");
         }),
       ).toBeDisabled();
@@ -359,7 +363,7 @@ describe("chat-c-077: Action button is disabled during redirect", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /Upgrade to Team/i.test(el.textContent ?? "");
         }),
       ).not.toBeDisabled();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -12,6 +12,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import {
   resetMockBilling,
@@ -148,7 +149,7 @@ describe("chat-i-079: threshold input updates form state on change", () => {
     const thresholdInput = screen.getByPlaceholderText("e.g. 1000");
     await fill(thresholdInput, "2000");
 
-    const saveBtn1 = screen.getAllByRole("button").find((el) => {
+    const saveBtn1 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn1).toBeDefined();
@@ -191,7 +192,7 @@ describe("chat-i-080: amount input updates form state on change", () => {
     const amountInput = screen.getByPlaceholderText("e.g. 10000");
     await fill(amountInput, "20000");
 
-    const saveBtn2 = screen.getAllByRole("button").find((el) => {
+    const saveBtn2 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn2).toBeDefined();
@@ -229,13 +230,13 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Save";
         }),
       ).toBeDefined();
     });
 
-    const saveBtn3 = screen.getAllByRole("button").find((el) => {
+    const saveBtn3 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn3).toBeDefined();
@@ -251,7 +252,7 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Save";
         }),
       ).not.toBeDisabled();
@@ -319,13 +320,13 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /Upgrade to Team/i.test(el.textContent ?? "");
         }),
       ).toBeDefined();
     });
 
-    const upgradeBtn1 = screen.getAllByRole("button").find((el) => {
+    const upgradeBtn1 = queryAllByRoleFast("button").find((el) => {
       return /Upgrade to Team/i.test(el.textContent ?? "");
     });
     expect(upgradeBtn1).toBeDefined();
@@ -360,13 +361,13 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^Downgrade$/i.test(el.textContent ?? "");
         }),
       ).toBeDefined();
     });
 
-    const downgradeBtn = screen.getAllByRole("button").find((el) => {
+    const downgradeBtn = queryAllByRoleFast("button").find((el) => {
       return /^Downgrade$/i.test(el.textContent ?? "");
     });
     expect(downgradeBtn).toBeDefined();
@@ -443,7 +444,7 @@ describe("chat-i-086: form overrides clear after successful save", () => {
     await fill(amountInput, "20000");
 
     // Click Save
-    const saveBtn = screen.getAllByRole("button").find((el) => {
+    const saveBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/connector-permission-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/connector-permission-dialog.test.tsx
@@ -12,7 +12,11 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setPermissionDialogType$ } from "../../../signals/zero-page/settings/connectors.ts";
 import { permissionDialogSelected$ } from "../../../signals/zero-page/settings/permission-dialog.ts";
 import type { ConnectorType } from "@vm0/connectors/connectors";
@@ -112,7 +116,7 @@ describe("connector permission dialog", () => {
     });
 
     // Click to select — the avatar should be replaced by a check icon
-    const agentButton = screen.getAllByRole("button").find((el) => {
+    const agentButton = queryAllByRoleFast("button").find((el) => {
       return /Agent Alpha/.test(el.textContent ?? "");
     })!;
     click(agentButton);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/connector-permission-scope.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/connector-permission-scope.test.tsx
@@ -11,7 +11,11 @@ import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setScopeReviewType$ } from "../../../signals/zero-page/settings/connectors.ts";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
@@ -132,13 +136,13 @@ describe("scope review modal - display", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Reconnect";
         }),
       ).toBeDefined();
     });
     const dialog = screen.getByRole("dialog");
-    const closeButtons = within(dialog).getAllByRole("button");
+    const closeButtons = queryAllByRoleFast("button", dialog);
     const textCloseButton = closeButtons.find((btn) => {
       return btn.textContent?.trim() === "Close";
     });
@@ -166,7 +170,7 @@ describe("scope review modal - states", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
     expect(
-      screen.queryAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Reconnect";
       }),
     ).toBeUndefined();
@@ -193,7 +197,7 @@ describe("scope review modal - states", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
     expect(
-      screen.queryAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Reconnect";
       }),
     ).toBeUndefined();
@@ -217,13 +221,13 @@ describe("scope review modal - interactions", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Reconnect";
         }),
       ).toBeDefined();
     });
 
-    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+    const reconnectBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Reconnect";
     });
     expect(reconnectBtn).toBeDefined();
@@ -254,7 +258,7 @@ describe("scope review modal - interactions", () => {
     });
 
     const dialog = screen.getByRole("dialog");
-    const closeButtons = within(dialog).getAllByRole("button");
+    const closeButtons = queryAllByRoleFast("button", dialog);
     const textCloseButton = closeButtons.find((btn) => {
       return btn.textContent?.trim() === "Close";
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   type RunContextResponse,
@@ -177,7 +181,7 @@ function getTypeFilterButton(): HTMLButtonElement {
 }
 
 function getMenuCheckbox(label: string): HTMLElement {
-  const item = screen.getAllByRole("menuitemcheckbox").find((el) => {
+  const item = queryAllByRoleFast("menuitemcheckbox").find((el) => {
     return el.textContent?.trim() === label;
   });
   expect(item).toBeTruthy();
@@ -185,7 +189,7 @@ function getMenuCheckbox(label: string): HTMLElement {
 }
 
 function queryMenuCheckbox(label: string): HTMLElement | undefined {
-  return screen.getAllByRole("menuitemcheckbox").find((el) => {
+  return queryAllByRoleFast("menuitemcheckbox").find((el) => {
     return el.textContent?.trim() === label;
   });
 }
@@ -201,7 +205,7 @@ async function openNetworkTypeFilter() {
 }
 
 function getAllTypesMenuItem(): HTMLElement {
-  const item = screen.getAllByRole("menuitemcheckbox").find((el) => {
+  const item = queryAllByRoleFast("menuitemcheckbox").find((el) => {
     return el.textContent?.trim() === "All types";
   });
   expect(item).toBeTruthy();
@@ -455,11 +459,11 @@ describe("networkContent", () => {
 
     // Check column headers exist
     expect(
-      screen.getAllByRole("columnheader").find((el) => {
+      queryAllByRoleFast("columnheader").find((el) => {
         return el.textContent?.trim() === "Time";
       }),
     ).toBeDefined();
-    const columnHeaders = screen.getAllByRole("columnheader");
+    const columnHeaders = queryAllByRoleFast("columnheader");
     expect(
       columnHeaders.find((el) => {
         return el.textContent?.trim() === "Type";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/create-teammate-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/create-teammate-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -53,11 +54,11 @@ async function openCreateDialog() {
   if (!privateSection) {
     throw new Error("Private section not found");
   }
-  const createButton = within(privateSection)
-    .getAllByRole("button")
-    .find((el) => {
+  const createButton = queryAllByRoleFast("button", privateSection).find(
+    (el) => {
       return el.textContent?.trim() === "Create";
-    });
+    },
+  );
   if (!createButton) {
     throw new Error("Create button not found in Private section");
   }
@@ -113,11 +114,9 @@ describe("create agent dialog - avatar", () => {
     const input = screen.getByPlaceholderText("e.g. Research Assistant");
     await fill(input, "My New Agent");
     const dialog = screen.getByRole("dialog");
-    const dialogCreate = within(dialog)
-      .getAllByRole("button")
-      .find((el) => {
-        return el.textContent?.trim() === "Create";
-      });
+    const dialogCreate = queryAllByRoleFast("button", dialog).find((el) => {
+      return el.textContent?.trim() === "Create";
+    });
     if (!dialogCreate) {
       throw new Error("Create button not found in dialog");
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -6,6 +6,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
 import { reloadBillingStatus$ } from "../../../signals/zero-page/billing.ts";
@@ -65,7 +66,7 @@ describe("org billing tab - plan display", () => {
     });
 
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /^Upgrade$/i.test(el.textContent?.trim() ?? "");
       }),
     ).toBeDefined();
@@ -150,7 +151,7 @@ describe("org billing tab - pricing sub-page navigation", () => {
     });
 
     // The "Current plan" button for the pro plan should be disabled
-    const currentPlanButtons = screen.getAllByRole("button").filter((el) => {
+    const currentPlanButtons = queryAllByRoleFast("button").filter((el) => {
       return /Current plan/i.test(el.textContent ?? "");
     });
     expect(currentPlanButtons.length).toBeGreaterThanOrEqual(1);
@@ -601,7 +602,7 @@ describe("org billing tab - cancellation pending", () => {
     });
 
     expect(
-      screen.queryAllByRole("button").filter((el) => {
+      queryAllByRoleFast("button").filter((el) => {
         return el.textContent?.trim() === "Downgrade";
       }),
     ).toHaveLength(0);
@@ -624,7 +625,7 @@ describe("org billing tab - cancellation pending", () => {
     });
 
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Manage";
       }),
     ).toBeDefined();
@@ -647,7 +648,7 @@ describe("org billing tab - cancellation pending", () => {
     });
 
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Downgrade";
       }),
     ).toBeDefined();
@@ -674,19 +675,19 @@ describe("org billing tab - plan card details", () => {
 
     // Plan cards are rendered for each tier
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /Upgrade to Pro/i.test(el.textContent ?? "");
       }),
     ).toBeDefined();
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /Upgrade to Team/i.test(el.textContent ?? "");
       }),
     ).toBeDefined();
 
     // Current plan card shows "Current plan" label
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /Current plan/i.test(el.textContent ?? "");
       }),
     ).toBeDefined();
@@ -774,7 +775,7 @@ describe("org billing tab - billing states", () => {
     });
 
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /^Retry$/i.test(el.textContent?.trim() ?? "");
       }),
     ).toBeDefined();
@@ -807,7 +808,7 @@ describe("org billing tab - plan card actions", () => {
       expect(screen.getByText("Compare plans")).toBeInTheDocument();
     });
 
-    const upgradeToProBtn = screen.getAllByRole("button").find((el) => {
+    const upgradeToProBtn = queryAllByRoleFast("button").find((el) => {
       return /Upgrade to Pro/i.test(el.textContent ?? "");
     });
     expect(upgradeToProBtn).toBeDefined();
@@ -848,7 +849,7 @@ describe("org billing tab - stripe portal", () => {
       expect(screen.getByText("Pro plan")).toBeInTheDocument();
     });
 
-    const manageBtn = screen.getAllByRole("button").find((el) => {
+    const manageBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Manage";
     });
     expect(manageBtn).toBeDefined();
@@ -878,7 +879,7 @@ describe("org billing tab - downgrade flow", () => {
     });
 
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Downgrade";
       }),
     ).toBeDefined();
@@ -899,7 +900,7 @@ describe("org billing tab - downgrade flow", () => {
     });
 
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Downgrade";
       }),
     ).toBeDefined();
@@ -915,7 +916,7 @@ describe("org billing tab - downgrade flow", () => {
     });
 
     expect(
-      screen.queryAllByRole("button").filter((el) => {
+      queryAllByRoleFast("button").filter((el) => {
         return el.textContent?.trim() === "Downgrade";
       }),
     ).toHaveLength(0);
@@ -935,7 +936,7 @@ describe("org billing tab - downgrade flow", () => {
       expect(screen.getByText("Pro plan")).toBeInTheDocument();
     });
 
-    const downgradeBtn1 = screen.getAllByRole("button").find((el) => {
+    const downgradeBtn1 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Downgrade";
     });
     expect(downgradeBtn1).toBeDefined();
@@ -965,7 +966,7 @@ describe("org billing tab - downgrade flow", () => {
       expect(screen.getByText("Team plan")).toBeInTheDocument();
     });
 
-    const downgradeBtn2 = screen.getAllByRole("button").find((el) => {
+    const downgradeBtn2 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Downgrade";
     });
     expect(downgradeBtn2).toBeDefined();
@@ -1003,7 +1004,7 @@ describe("org billing tab - downgrade flow", () => {
       expect(screen.getByText("Pro plan")).toBeInTheDocument();
     });
 
-    const downgradeBtn3 = screen.getAllByRole("button").find((el) => {
+    const downgradeBtn3 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Downgrade";
     });
     expect(downgradeBtn3).toBeDefined();
@@ -1013,7 +1014,7 @@ describe("org billing tab - downgrade flow", () => {
       expect(screen.getByText("Downgrade plan")).toBeInTheDocument();
     });
 
-    const downgradeToFreeBtn = screen.getAllByRole("button").find((el) => {
+    const downgradeToFreeBtn = queryAllByRoleFast("button").find((el) => {
       return /Downgrade to Free/i.test(el.textContent ?? "");
     });
     expect(downgradeToFreeBtn).toBeDefined();
@@ -1046,7 +1047,7 @@ describe("org billing tab - downgrade flow", () => {
       expect(screen.getByText("Pro plan")).toBeInTheDocument();
     });
 
-    const downgradeBtn4 = screen.getAllByRole("button").find((el) => {
+    const downgradeBtn4 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Downgrade";
     });
     expect(downgradeBtn4).toBeDefined();
@@ -1057,11 +1058,9 @@ describe("org billing tab - downgrade flow", () => {
     });
 
     const dialog = screen.getByRole("dialog");
-    const cancelBtn = within(dialog)
-      .getAllByRole("button")
-      .find((el) => {
-        return /^Cancel$/i.test(el.textContent?.trim() ?? "");
-      });
+    const cancelBtn = queryAllByRoleFast("button", dialog).find((el) => {
+      return /^Cancel$/i.test(el.textContent?.trim() ?? "");
+    });
     expect(cancelBtn).toBeDefined();
     click(cancelBtn!);
 
@@ -1094,7 +1093,7 @@ describe("org billing tab - downgrade flow", () => {
     });
 
     // Click "Manage subscription" (the downgrade button on pricing page for free tier)
-    const manageButtons = screen.getAllByRole("button").filter((el) => {
+    const manageButtons = queryAllByRoleFast("button").filter((el) => {
       return /Manage subscription/i.test(el.textContent ?? "");
     });
     expect(manageButtons.length).toBeGreaterThanOrEqual(1);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import {
@@ -375,7 +376,7 @@ describe("org general tab - danger zone", () => {
     await openGeneralTab();
 
     const leaveTrigger = await waitFor(() => {
-      const btn = screen.getAllByRole("button").find((el) => {
+      const btn = queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Leave";
       });
       expect(btn).toBeInTheDocument();
@@ -384,7 +385,7 @@ describe("org general tab - danger zone", () => {
     click(leaveTrigger);
 
     const confirmBtn = await waitFor(() => {
-      const buttons = screen.getAllByRole("button");
+      const buttons = queryAllByRoleFast("button");
       const btn = buttons.find((el) => {
         return (
           el.textContent?.trim() === "Leave" && el.closest('[role="dialog"]')
@@ -423,7 +424,7 @@ describe("org general tab - danger zone", () => {
     await openGeneralTab();
 
     const deleteTrigger = await waitFor(() => {
-      const btn = screen.getAllByRole("button").find((el) => {
+      const btn = queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Delete";
       });
       expect(btn).toBeInTheDocument();
@@ -435,7 +436,7 @@ describe("org general tab - danger zone", () => {
     await fill(slugInput, "my-org");
 
     const confirmBtn = await waitFor(() => {
-      const buttons = screen.getAllByRole("button");
+      const buttons = queryAllByRoleFast("button");
       const btn = buttons.find((el) => {
         return el.textContent?.trim() === "Delete workspace";
       });
@@ -475,7 +476,7 @@ describe("org general tab - danger zone", () => {
     await openGeneralTab();
 
     const leaveTrigger = await waitFor(() => {
-      const btn = screen.getAllByRole("button").find((el) => {
+      const btn = queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Leave";
       });
       expect(btn).toBeInTheDocument();
@@ -484,7 +485,7 @@ describe("org general tab - danger zone", () => {
     click(leaveTrigger);
 
     const confirmBtn = await waitFor(() => {
-      const buttons = screen.getAllByRole("button");
+      const buttons = queryAllByRoleFast("button");
       const btn = buttons.find((el) => {
         return (
           el.textContent?.trim() === "Leave" && el.closest('[role="dialog"]')

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-manage-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-manage-dialog.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
 import {
   setMockOrgMembers,
@@ -33,12 +37,12 @@ describe("org manage dialog - display", () => {
 
     // Always-visible tabs
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /General/i.test(el.textContent ?? "");
       })!,
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /Members/i.test(el.textContent ?? "");
       })!,
     ).toBeInTheDocument();
@@ -67,7 +71,7 @@ describe("org manage dialog - conditional", () => {
 
     // Desktop sidebar has tab buttons
     expect(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /General/i.test(el.textContent ?? "");
       })!,
     ).toBeInTheDocument();
@@ -118,7 +122,7 @@ describe("org manage dialog - interaction", () => {
     });
 
     click(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return /Members/i.test(el.textContent ?? "");
       })!,
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
@@ -13,7 +13,11 @@ import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   orgOpenAddDialog$,
   orgOpenEditDialog$,
@@ -255,7 +259,7 @@ describe("org-provider-dialog - interaction", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return /^(Add|Saving)/i.test(el.textContent?.trim() ?? "");
         })!,
       ).toBeDisabled();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -5,7 +5,10 @@ import userEvent, {
 } from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
 import {
   setMockUsageMembers,
@@ -101,7 +104,7 @@ describe("org usage tab - credit balance display", () => {
       );
     });
 
-    const comparePlansButton = screen.getAllByRole("button").find((el) => {
+    const comparePlansButton = queryAllByRoleFast("button").find((el) => {
       return el.textContent === "Compare plans";
     });
     expect(comparePlansButton).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/permissions-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import {
   zeroAgentsByIdContract,
@@ -9,7 +9,11 @@ import {
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
@@ -181,7 +185,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     expect(readRow).not.toBeNull();
 
     // Within that row, find the Allow/Deny buttons (the PolicyPill)
-    const pillButtons = within(readRow).getAllByRole("button");
+    const pillButtons = queryAllByRoleFast("button", readRow);
     // Filter to just Allow and Deny buttons (exclude the chevron toggle button)
     const allowBtn = pillButtons.find((b) => {
       return b.textContent?.includes("Allow") ?? false;
@@ -208,7 +212,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       ".flex.items-center.justify-between",
     ) as HTMLElement;
 
-    const pillButtons = within(readRow).getAllByRole("button");
+    const pillButtons = queryAllByRoleFast("button", readRow);
     const allowBtn = pillButtons.find((b) => {
       return b.textContent?.includes("Allow") ?? false;
     });
@@ -232,7 +236,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       ".flex.items-center.justify-between",
     ) as HTMLElement;
 
-    const pillButtons = within(readRow).getAllByRole("button");
+    const pillButtons = queryAllByRoleFast("button", readRow);
     const denyBtn = pillButtons.find((b) => {
       return b.textContent?.includes("Deny") ?? false;
     });
@@ -250,7 +254,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     const actionsReadRow = screen
       .getByText("bookmarks:read")
       .closest(".flex.items-center") as HTMLElement;
-    const individualButtons = within(actionsReadRow).getAllByRole("button");
+    const individualButtons = queryAllByRoleFast("button", actionsReadRow);
     const individualDeny = individualButtons.find((b) => {
       return b.textContent?.includes("Deny") ?? false;
     });
@@ -271,7 +275,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     ) as HTMLElement;
     expect(unknownRow).not.toBeNull();
 
-    const pillButtons = within(unknownRow).getAllByRole("button");
+    const pillButtons = queryAllByRoleFast("button", unknownRow);
     const allowBtn = pillButtons.find((b) => {
       return b.textContent?.includes("Allow") ?? false;
     });
@@ -288,7 +292,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       ".flex.items-center.justify-between",
     ) as HTMLElement;
 
-    const pillButtons = within(unknownRow).getAllByRole("button");
+    const pillButtons = queryAllByRoleFast("button", unknownRow);
     const allowBtn = pillButtons.find((b) => {
       return b.textContent?.includes("Allow") ?? false;
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-calendar-view.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-calendar-view.test.tsx
@@ -3,7 +3,11 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { setCalendarSelectedDay$ } from "../../../signals/schedule-page/schedule-page-ui.ts";
 import { setMockSchedules } from "../../../mocks/handlers/api-schedules.ts";
@@ -157,14 +161,14 @@ async function switchToCalendarView() {
     const hasScheduled =
       screen.queryAllByLabelText(/More actions for/i).length > 0;
     const hasEmpty = screen.queryByText("No runs scheduled") !== null;
-    const hasTab = screen.queryAllByRole("tab").some((el) => {
+    const hasTab = queryAllByRoleFast("tab").some((el) => {
       return /Calendar/i.test(el.textContent ?? "");
     });
     if (!hasTab || (!hasScheduled && !hasEmpty)) {
       throw new Error("page not loaded");
     }
   });
-  const calendarTab = screen.getAllByRole("tab").find((el) => {
+  const calendarTab = queryAllByRoleFast("tab").find((el) => {
     return /Calendar/i.test(el.textContent ?? "");
   });
   expect(calendarTab).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-list-view.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-list-view.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
@@ -79,17 +83,17 @@ describe("schedule list view - schedule list renders (SCHED-D-081)", () => {
       ).toBeInTheDocument();
     });
     expect(
-      screen.getAllByRole("columnheader").find((el) => {
+      queryAllByRoleFast("columnheader").find((el) => {
         return /Instruction/.test(el.textContent ?? "");
       }),
     ).toBeDefined();
     expect(
-      screen.getAllByRole("columnheader").find((el) => {
+      queryAllByRoleFast("columnheader").find((el) => {
         return /Schedule at/.test(el.textContent ?? "");
       }),
     ).toBeDefined();
     expect(
-      screen.getAllByRole("columnheader").find((el) => {
+      queryAllByRoleFast("columnheader").find((el) => {
         return /Status/.test(el.textContent ?? "");
       }),
     ).toBeDefined();
@@ -186,7 +190,7 @@ describe("schedule list view - running action indicator (SCHED-D-085)", () => {
     );
     await waitFor(() => {
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Run now");
         }),
       ).toBeDefined();
@@ -194,7 +198,7 @@ describe("schedule list view - running action indicator (SCHED-D-085)", () => {
 
     // Click Run now — API hangs
     click(
-      screen.getAllByRole("menuitem").find((el) => {
+      queryAllByRoleFast("menuitem").find((el) => {
         return el.textContent?.includes("Run now");
       })!,
     );
@@ -221,7 +225,7 @@ describe("schedule list view - empty state add schedule button (SCHED-D-086)", (
     });
 
     // The empty state "Add schedule" button
-    const addButtons = screen.getAllByRole("button").filter((el) => {
+    const addButtons = queryAllByRoleFast("button").filter((el) => {
       return /Add schedule/i.test(el.textContent ?? "");
     });
     // At least one Add schedule button exists in the empty state
@@ -338,17 +342,17 @@ describe("schedule list view - more actions dropdown (SCHED-D-089)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Run now");
         }),
       ).toBeDefined();
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Edit");
         }),
       ).toBeDefined();
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Delete");
         }),
       ).toBeDefined();
@@ -384,14 +388,14 @@ describe("schedule list view - run now action (SCHED-D-090)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Run now");
         }),
       ).toBeDefined();
     });
 
     click(
-      screen.getAllByRole("menuitem").find((el) => {
+      queryAllByRoleFast("menuitem").find((el) => {
         return el.textContent?.includes("Run now");
       })!,
     );
@@ -422,14 +426,14 @@ describe("schedule list view - edit action (SCHED-D-091)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Edit");
         }),
       ).toBeDefined();
     });
 
     click(
-      screen.getAllByRole("menuitem").find((el) => {
+      queryAllByRoleFast("menuitem").find((el) => {
         return el.textContent?.includes("Edit");
       })!,
     );
@@ -461,14 +465,14 @@ describe("schedule list view - delete action (SCHED-D-092)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("menuitem").find((el) => {
+        queryAllByRoleFast("menuitem").find((el) => {
           return el.textContent?.includes("Delete");
         }),
       ).toBeDefined();
     });
 
     click(
-      screen.getAllByRole("menuitem").find((el) => {
+      queryAllByRoleFast("menuitem").find((el) => {
         return el.textContent?.includes("Delete");
       })!,
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -3,7 +3,11 @@ import { splitChatThreadListResponse } from "./chat-test-helpers.ts";
 import { screen, waitFor, within } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -128,7 +132,7 @@ async function deleteThread(nthButton: number) {
   click(menuTriggers[nthButton - 1]);
 
   const deleteItem = await waitFor(() => {
-    const item = screen.getAllByRole("menuitem").find((el) => {
+    const item = queryAllByRoleFast("menuitem").find((el) => {
       return /Delete chat/i.test(el.textContent ?? "");
     });
     if (!item) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -14,7 +14,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import {
   setSidebarExpanded$,
@@ -49,7 +53,7 @@ describe("sidebar layout - breadcrumb section text (SIDEBAR-D-045)", () => {
     await waitFor(() => {
       // The breadcrumb renders a link in the mobile top bar pointing to /agents
       expect(
-        screen.getAllByRole("link").some((el) => {
+        queryAllByRoleFast("link").some((el) => {
           return (
             el.getAttribute("href") === "/agents" &&
             el.textContent?.trim() === "Agents"
@@ -162,7 +166,7 @@ describe("sidebar layout - breadcrumb section link navigates (SIDEBAR-D-051)", (
     });
 
     // Click the breadcrumb section link to /agents in the mobile top bar
-    const agentsLink = screen.getAllByRole("link").find((el) => {
+    const agentsLink = queryAllByRoleFast("link").find((el) => {
       return (
         el.getAttribute("href") === "/agents" &&
         el.textContent?.trim() === "Agents"

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-account-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-account-page.test.tsx
@@ -8,7 +8,11 @@ import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   type UserPreferencesResponse,
   zeroUserPreferencesContract,
@@ -39,13 +43,13 @@ function makeDeferred() {
 }
 
 function findButtonByText(text: string) {
-  return screen.getAllByRole("button").find((btn) => {
+  return queryAllByRoleFast("button").find((btn) => {
     return btn.textContent?.trim() === text;
   });
 }
 
 function findCmdEnterButton() {
-  return screen.getAllByRole("button").find((btn) => {
+  return queryAllByRoleFast("button").find((btn) => {
     const text = btn.textContent?.replace(/\s+/g, " ").trim() ?? "";
     return text.includes("Enter") && text !== "Enter";
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { logsByIdContract } from "@vm0/api-contracts/contracts/logs";
 import { zeroRunAgentEventsContract } from "@vm0/api-contracts/contracts/zero-runs";
@@ -101,7 +105,7 @@ describe("zeroActivityDetailPage", () => {
     });
 
     // The breadcrumb link to /activity should not be present
-    const activityLinks = screen.queryAllByRole("link").filter((el) => {
+    const activityLinks = queryAllByRoleFast("link").filter((el) => {
       return /Activity/i.test(el.textContent ?? "");
     });
     expect(activityLinks).toHaveLength(0);
@@ -123,7 +127,7 @@ describe("zeroActivityDetailPage", () => {
     });
 
     // The breadcrumb link to /activity should be present
-    const activityLinks = screen.queryAllByRole("link").filter((el) => {
+    const activityLinks = queryAllByRoleFast("link").filter((el) => {
       return /Activity/i.test(el.textContent ?? "");
     });
     expect(activityLinks.length).toBeGreaterThan(0);
@@ -230,7 +234,7 @@ describe("zeroActivityDetailPage", () => {
     // "Schedule" should be plain text, not a link
     expect(screen.getByText("Schedule")).toBeInTheDocument();
     expect(
-      screen.queryAllByRole("link").find((el) => {
+      queryAllByRoleFast("link").find((el) => {
         return el.textContent?.trim() === "Schedule";
       }),
     ).toBeUndefined();
@@ -253,7 +257,7 @@ describe("zeroActivityDetailPage", () => {
     // "Web" source should be plain text, not a link
     expect(screen.getByText("Web")).toBeInTheDocument();
     expect(
-      screen.queryAllByRole("link").find((el) => {
+      queryAllByRoleFast("link").find((el) => {
         return el.textContent?.trim() === "Web";
       }),
     ).toBeUndefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -19,6 +19,7 @@ import { computed } from "ccstate";
 import { server } from "../../../mocks/server.ts";
 import { http, HttpResponse } from "msw";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { fetchPreviewText } from "../../../signals/chat-page/parse-body-blocks.ts";
 import { lightboxUrl$ } from "../../../signals/zero-page/zero-attachment-chips.ts";
@@ -417,7 +418,7 @@ describe("text preview loading and error states", () => {
     });
 
     // Click to collapse
-    const button = screen.getAllByRole("button").find((el) => {
+    const button = queryAllByRoleFast("button").find((el) => {
       return /collapse/i.test(el.getAttribute("aria-label") ?? "");
     })!;
     fireEvent.click(button);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
@@ -10,7 +10,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { createDeferredPromise } from "../../../signals/utils.ts";
@@ -199,7 +203,7 @@ describe("zero chat list page - delete confirmation", () => {
     });
 
     // Click delete button (aria-label, one per thread)
-    const deleteButtons = screen.getAllByRole("button").filter((el) => {
+    const deleteButtons = queryAllByRoleFast("button").filter((el) => {
       return /Delete chat/.test(el.getAttribute("aria-label") ?? "");
     });
     expect(deleteButtons.length).toBeGreaterThan(0);
@@ -215,7 +219,7 @@ describe("zero chat list page - delete confirmation", () => {
     });
 
     // Click delete button to open dialog
-    const deleteButtons = screen.getAllByRole("button").filter((el) => {
+    const deleteButtons = queryAllByRoleFast("button").filter((el) => {
       return /Delete chat/.test(el.getAttribute("aria-label") ?? "");
     });
     expect(deleteButtons.length).toBeGreaterThan(0);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-display.test.tsx
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
 
 const context = testContext();
@@ -44,7 +47,7 @@ describe("zero chat page display - suggested prompt connector icons", () => {
       return screen.getByText(/Ideas & use cases/);
     });
     const promptGrid = exploreText.closest("button")!.parentElement!;
-    const gridButtons = within(promptGrid).getAllByRole("button");
+    const gridButtons = queryAllByRoleFast("button", promptGrid);
 
     const promptCards = gridButtons.filter((btn) => {
       return !btn.textContent?.includes("Ideas & use cases");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
@@ -9,6 +9,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -52,7 +53,7 @@ describe("zero chat page - suggested prompts", () => {
 
     // The prompt grid is the grandparent: <p> → <button> → <div.grid>
     const promptGrid = exploreText.closest("button")!.parentElement!;
-    const gridButtons = within(promptGrid).getAllByRole("button");
+    const gridButtons = queryAllByRoleFast("button", promptGrid);
 
     // 2 random prompt cards + 1 "Ideas & use cases" card
     expect(gridButtons).toHaveLength(3);
@@ -77,7 +78,7 @@ describe("zero chat page - suggested prompts", () => {
       return screen.getByText(/Ideas & use cases/);
     });
     const promptGrid = exploreText.closest("button")!.parentElement!;
-    const gridButtons = within(promptGrid).getAllByRole("button");
+    const gridButtons = queryAllByRoleFast("button", promptGrid);
 
     // Find the first random prompt card (not "Ideas & use cases")
     const promptCard = gridButtons.find((btn) => {
@@ -233,7 +234,7 @@ describe("zero chat page - connectors popover", () => {
 
     // Default mock has no org connectors, so all types are unconnected.
     // Check that at least one "Connect X" button exists.
-    const connectButtons = screen.getAllByRole("button").filter((el) => {
+    const connectButtons = queryAllByRoleFast("button").filter((el) => {
       return (el.getAttribute("aria-label") ?? "").startsWith("Connect ");
     });
     expect(connectButtons.length).toBeGreaterThan(0);
@@ -558,7 +559,7 @@ describe("zero chat page - ideation page", () => {
     await navigateToIdeation();
 
     // Click a specific category tab
-    const githubCategoryBtn = screen.getAllByRole("button").find((el) => {
+    const githubCategoryBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "GitHub";
     });
     expect(githubCategoryBtn).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -10,7 +10,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
@@ -27,7 +31,7 @@ const mockApi = createMockApi(context);
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
 function getButtonByText(text: string): HTMLElement {
-  const button = screen.getAllByRole("button").find((element) => {
+  const button = queryAllByRoleFast("button").find((element) => {
     return element.textContent?.trim() === text;
   });
   if (!button) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -11,7 +11,11 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -129,7 +133,7 @@ describe("directed connect page", () => {
       expect(screen.getByText("GitHub connected")).toBeInTheDocument();
     });
     expect(screen.getByText("Connected")).toBeInTheDocument();
-    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+    const reconnectBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Reconnect";
     });
     expect(reconnectBtn).toBeDefined();
@@ -146,13 +150,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Reconnect";
         }),
       ).toBeDefined();
     });
 
-    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+    const reconnectBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Reconnect";
     });
     expect(reconnectBtn).toBeDefined();
@@ -177,13 +181,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Reconnect";
         }),
       ).toBeDefined();
     });
 
-    const reconnectBtn = screen.getAllByRole("button").find((el) => {
+    const reconnectBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Reconnect";
     });
     expect(reconnectBtn).toBeDefined();
@@ -296,13 +300,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Connect";
         }),
       ).toBeDefined();
     });
 
-    const connectBtn1 = screen.getAllByRole("button").find((el) => {
+    const connectBtn1 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectBtn1).toBeDefined();
@@ -313,7 +317,7 @@ describe("directed connect page", () => {
     });
 
     await user.type(screen.getByPlaceholderText("xaat-..."), "bad-token");
-    const saveBtn1 = screen.getAllByRole("button").find((el) => {
+    const saveBtn1 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn1).toBeDefined();
@@ -335,13 +339,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Connect";
         }),
       ).toBeDefined();
     });
 
-    const connectBtn2 = screen.getAllByRole("button").find((el) => {
+    const connectBtn2 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectBtn2).toBeDefined();
@@ -383,7 +387,7 @@ describe("directed connect page", () => {
       ).toBeInTheDocument();
     });
 
-    const connectButton = screen.getAllByRole("button").find((el) => {
+    const connectButton = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectButton).toBeDefined();
@@ -424,13 +428,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Connect";
         }),
       ).toBeDefined();
     });
 
-    const connectBtn3 = screen.getAllByRole("button").find((el) => {
+    const connectBtn3 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectBtn3).toBeDefined();
@@ -444,7 +448,7 @@ describe("directed connect page", () => {
       screen.getByPlaceholderText("xaat-..."),
       "test-token-value",
     );
-    const saveBtn2 = screen.getAllByRole("button").find((el) => {
+    const saveBtn2 = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn2).toBeDefined();
@@ -487,13 +491,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Connect";
         }),
       ).toBeDefined();
     });
 
-    const connectBtn = screen.getAllByRole("button").find((el) => {
+    const connectBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectBtn).toBeDefined();
@@ -507,7 +511,7 @@ describe("directed connect page", () => {
       screen.getByPlaceholderText("xaat-..."),
       "test-token-value",
     );
-    const saveBtn = screen.getAllByRole("button").find((el) => {
+    const saveBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn).toBeDefined();
@@ -659,13 +663,13 @@ describe("directed connect page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "Connect";
         }),
       ).toBeDefined();
     });
 
-    const connectBtn = screen.getAllByRole("button").find((el) => {
+    const connectBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Connect";
     });
     expect(connectBtn).toBeDefined();
@@ -679,7 +683,7 @@ describe("directed connect page", () => {
       screen.getByPlaceholderText("xaat-..."),
       "test-token-value",
     );
-    const saveBtn = screen.getAllByRole("button").find((el) => {
+    const saveBtn = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "Save";
     });
     expect(saveBtn).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -6,6 +6,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -78,7 +79,7 @@ describe("ideation page - category tabs", () => {
 
     for (const category of categories) {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === category.title;
         }),
       ).toBeDefined();
@@ -107,7 +108,7 @@ describe("ideation page - category tabs", () => {
     const allTab = await waitFor(() => {
       return screen.getByText("All");
     });
-    const githubTab = screen.getAllByRole("button").find((el) => {
+    const githubTab = queryAllByRoleFast("button").find((el) => {
       return el.textContent?.trim() === "GitHub";
     });
     expect(githubTab).toBeDefined();
@@ -131,14 +132,14 @@ describe("ideation page - category tabs", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "GitHub";
         }),
       ).toBeDefined();
     });
 
     click(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "GitHub";
       })!,
     );
@@ -160,14 +161,14 @@ describe("ideation page - category tabs", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("button").find((el) => {
+        queryAllByRoleFast("button").find((el) => {
           return el.textContent?.trim() === "GitHub";
         }),
       ).toBeDefined();
     });
 
     click(
-      screen.getAllByRole("button").find((el) => {
+      queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "GitHub";
       })!,
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -8,7 +8,11 @@ import {
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
@@ -259,7 +263,7 @@ describe("zero job detail page - connector display", () => {
 
 describe("zero job detail page - tab visibility", () => {
   function findTab(label: RegExp) {
-    return screen.getAllByRole("tab").find((el) => {
+    return queryAllByRoleFast("tab").find((el) => {
       return label.test(el.textContent ?? "");
     });
   }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
@@ -9,7 +9,11 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
@@ -105,7 +109,7 @@ describe("zero job detail page - interaction and state", () => {
     await waitForPageLoad();
 
     // Switch to Scheduled tab
-    const scheduledTab = screen.getAllByRole("tab").find((el) => {
+    const scheduledTab = queryAllByRoleFast("tab").find((el) => {
       return /Scheduled/i.test(el.textContent ?? "");
     });
     expect(scheduledTab).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
   zeroAgentsByIdContract,
@@ -75,7 +79,7 @@ describe("zero job detail page", () => {
     expect(screen.getByText("A helpful agent")).toBeInTheDocument();
 
     // All tabs should be visible
-    const tabs = screen.getAllByRole("tab");
+    const tabs = queryAllByRoleFast("tab");
     expect(
       tabs.some((el) => {
         return /Authorization/i.test(el.textContent ?? "");
@@ -109,7 +113,7 @@ describe("zero job detail page", () => {
     });
 
     // Click Profile tab
-    const profileTab = screen.getAllByRole("tab").find((el) => {
+    const profileTab = queryAllByRoleFast("tab").find((el) => {
       return /Profile/i.test(el.textContent ?? "");
     });
     expect(profileTab).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -45,11 +46,9 @@ function mockTeamAPI(
 }
 
 function findCreateButton(scope: HTMLElement): HTMLElement {
-  const button = within(scope)
-    .getAllByRole("button")
-    .find((el) => {
-      return el.textContent?.trim() === "Create";
-    });
+  const button = queryAllByRoleFast("button", scope).find((el) => {
+    return el.textContent?.trim() === "Create";
+  });
   if (!button) {
     throw new Error("Create button not found");
   }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import {
   setMockSchedules,
@@ -98,7 +101,7 @@ describe("zero jobs page - team list", () => {
       expect(screen.getByText("Public")).toBeInTheDocument();
     });
     expect(screen.getByText("Private")).toBeInTheDocument();
-    const createButtons = screen.getAllByRole("button").filter((el) => {
+    const createButtons = queryAllByRoleFast("button").filter((el) => {
       return el.textContent?.trim() === "Create";
     });
     expect(createButtons).toHaveLength(2);
@@ -112,7 +115,7 @@ describe("zero jobs page - team list", () => {
       expect(screen.getByText("Public")).toBeInTheDocument();
     });
     expect(screen.getByText("Private")).toBeInTheDocument();
-    const createButtons = screen.getAllByRole("button").filter((el) => {
+    const createButtons = queryAllByRoleFast("button").filter((el) => {
       return el.textContent?.trim() === "Create";
     });
     expect(createButtons).toHaveLength(2);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   fireClerkListeners,
   mockedClerk,
@@ -203,7 +207,7 @@ describe("zero org switcher - manage button opens org management (SIDEBAR-D-060)
     click(screen.getByText("Current Org"));
 
     const manageBtn = await waitFor(() => {
-      const btn = screen.getAllByRole("button").find((el) => {
+      const btn = queryAllByRoleFast("button").find((el) => {
         return el.textContent?.trim() === "Manage";
       });
       expect(btn).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
@@ -15,6 +15,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -114,12 +115,12 @@ async function openMenuAndClick(
   click(menuTrigger);
   await waitFor(() => {
     expect(
-      screen.getAllByRole("menuitem").find((el) => {
+      queryAllByRoleFast("menuitem").find((el) => {
         return el.textContent?.includes(action);
       }),
     ).toBeDefined();
   });
-  const item = screen.getAllByRole("menuitem").find((el) => {
+  const item = queryAllByRoleFast("menuitem").find((el) => {
     return el.textContent?.includes(action);
   });
   expect(item).toBeDefined();
@@ -186,10 +187,10 @@ describe("zero-schedule-card - view mode", () => {
     });
 
     // Both view mode tabs should be present in the card header
-    const listTab = screen.getAllByRole("tab").find((el) => {
+    const listTab = queryAllByRoleFast("tab").find((el) => {
       return /^List$/i.test(el.textContent?.trim() ?? "");
     });
-    const calendarTab = screen.getAllByRole("tab").find((el) => {
+    const calendarTab = queryAllByRoleFast("tab").find((el) => {
       return /^Calendar$/i.test(el.textContent?.trim() ?? "");
     });
     expect(listTab).toBeDefined();
@@ -208,7 +209,7 @@ describe("zero-schedule-card - view mode", () => {
       ).toBeInTheDocument();
     });
 
-    const calendarTab = screen.getAllByRole("tab").find((el) => {
+    const calendarTab = queryAllByRoleFast("tab").find((el) => {
       return /Calendar/i.test(el.textContent ?? "");
     });
     expect(calendarTab).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import {
   setMockSchedules,
@@ -286,7 +287,7 @@ describe("zero schedule detail page - instruction save button saves instructions
     detachedSetupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
     await waitForPageLoad();
 
-    const instructionsTab = screen.getAllByRole("tab").find((el) => {
+    const instructionsTab = queryAllByRoleFast("tab").find((el) => {
       return /Instructions/.test(el.textContent ?? "");
     });
     click(instructionsTab!);
@@ -318,7 +319,7 @@ describe("zero schedule detail page - instruction discard button reverts changes
     detachedSetupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
     await waitForPageLoad();
 
-    const instructionsTab = screen.getAllByRole("tab").find((el) => {
+    const instructionsTab = queryAllByRoleFast("tab").find((el) => {
       return /Instructions/.test(el.textContent ?? "");
     });
     click(instructionsTab!);
@@ -555,7 +556,7 @@ describe("zero schedule detail page - tab triggers switch between tabs (SCHED-D-
     detachedSetupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
     await waitForPageLoad();
 
-    const instructionsTab = screen.getAllByRole("tab").find((el) => {
+    const instructionsTab = queryAllByRoleFast("tab").find((el) => {
       return /Instructions/.test(el.textContent ?? "");
     });
     click(instructionsTab!);
@@ -563,7 +564,7 @@ describe("zero schedule detail page - tab triggers switch between tabs (SCHED-D-
       expect(document.querySelector("[contenteditable]")).toBeInTheDocument();
     });
 
-    const runHistoryTab = screen.getAllByRole("tab").find((el) => {
+    const runHistoryTab = queryAllByRoleFast("tab").find((el) => {
       return /Run History/.test(el.textContent ?? "");
     });
     click(runHistoryTab!);
@@ -573,7 +574,7 @@ describe("zero schedule detail page - tab triggers switch between tabs (SCHED-D-
       ).toBeInTheDocument();
     });
 
-    const settingsTab = screen.getAllByRole("tab").find((el) => {
+    const settingsTab = queryAllByRoleFast("tab").find((el) => {
       return /Settings/.test(el.textContent ?? "");
     });
     click(settingsTab!);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page-display.test.tsx
@@ -9,7 +9,11 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   setMockSchedules,
   createMockScheduleResponse,
@@ -51,13 +55,13 @@ describe("zero schedule page - view tabs (post run-history removal)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return /list/i.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
     });
     expect(
-      screen.getAllByRole("tab").find((el) => {
+      queryAllByRoleFast("tab").find((el) => {
         return /calendar/i.test(el.textContent ?? "");
       }),
     ).toBeInTheDocument();
@@ -69,14 +73,14 @@ describe("zero schedule page - view tabs (post run-history removal)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return /list/i.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
     });
 
     // History tab should not exist
-    const historyTabs = screen.getAllByRole("tab").filter((el) => {
+    const historyTabs = queryAllByRoleFast("tab").filter((el) => {
       return /history/i.test(el.textContent ?? "");
     });
     expect(historyTabs).toHaveLength(0);
@@ -88,14 +92,14 @@ describe("zero schedule page - view tabs (post run-history removal)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return /list/i.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
     });
 
     click(
-      screen.getAllByRole("tab").find((el) => {
+      queryAllByRoleFast("tab").find((el) => {
         return /calendar/i.test(el.textContent ?? "");
       })!,
     );
@@ -111,7 +115,7 @@ describe("zero schedule page - view tabs (post run-history removal)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("tab").find((el) => {
+        queryAllByRoleFast("tab").find((el) => {
           return /list/i.test(el.textContent ?? "");
         }),
       ).toBeInTheDocument();
@@ -119,7 +123,7 @@ describe("zero schedule page - view tabs (post run-history removal)", () => {
 
     // Go to calendar first
     click(
-      screen.getAllByRole("tab").find((el) => {
+      queryAllByRoleFast("tab").find((el) => {
         return /calendar/i.test(el.textContent ?? "");
       })!,
     );
@@ -129,7 +133,7 @@ describe("zero schedule page - view tabs (post run-history removal)", () => {
 
     // Go back to list
     click(
-      screen.getAllByRole("tab").find((el) => {
+      queryAllByRoleFast("tab").find((el) => {
         return /list/i.test(el.textContent ?? "");
       })!,
     );
@@ -175,7 +179,7 @@ describe("zero schedule page - display after refactor", () => {
     });
 
     click(
-      screen.getAllByRole("tab").find((el) => {
+      queryAllByRoleFast("tab").find((el) => {
         return /calendar/i.test(el.textContent ?? "");
       })!,
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
@@ -97,13 +98,13 @@ async function openMenuAndClick(
   click(menuTrigger);
   await waitFor(() => {
     expect(
-      screen.getAllByRole("menuitem").find((el) => {
+      queryAllByRoleFast("menuitem").find((el) => {
         return el.textContent?.includes(action);
       }),
     ).toBeDefined();
   });
   click(
-    screen.getAllByRole("menuitem").find((el) => {
+    queryAllByRoleFast("menuitem").find((el) => {
       return el.textContent?.includes(action);
     })!,
   );
@@ -261,7 +262,7 @@ describe("zero schedule page - agent labels", () => {
     ).toBeInTheDocument();
     // Two distinct schedules from two distinct agents should both be rendered
     expect(
-      screen.getAllByRole("link").filter((el) => {
+      queryAllByRoleFast("link").filter((el) => {
         return /Open schedule/.test(el.getAttribute("aria-label") ?? "");
       }),
     ).toHaveLength(2);
@@ -334,7 +335,7 @@ describe("zero schedule page - list view", () => {
         screen.getAllByText("Summarize yesterday's threads")[0],
       ).toBeInTheDocument();
     });
-    const menus = screen.getAllByRole("button").filter((el) => {
+    const menus = queryAllByRoleFast("button").filter((el) => {
       return /More actions for/.test(el.getAttribute("aria-label") ?? "");
     });
     expect(menus).toHaveLength(3);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -10,6 +10,7 @@ import {
   detachedSetupPage,
   fill,
   click,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -420,7 +421,7 @@ describe("zero settings tab - interaction", () => {
       expect(screen.getByText("Delete My Agent?")).toBeInTheDocument();
     });
 
-    const deleteButtons = screen.getAllByRole("button").filter((el) => {
+    const deleteButtons = queryAllByRoleFast("button").filter((el) => {
       return /Delete agent/i.test(el.textContent ?? "");
     });
     click(deleteButtons[deleteButtons.length - 1]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -3,7 +3,11 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
@@ -487,11 +491,9 @@ describe("managePinnedAgentsDialog - pin button adds agent to pinned (SIDEBAR-D-
 
     await waitFor(() => {
       // The agent should now appear in pinned section with unpin button
-      const unpinBtn = within(dialog)
-        .getAllByRole("button")
-        .find((el) => {
-          return /Unpin /.test(el.getAttribute("aria-label") ?? "");
-        });
+      const unpinBtn = queryAllByRoleFast("button", dialog).find((el) => {
+        return /Unpin /.test(el.getAttribute("aria-label") ?? "");
+      });
       expect(unpinBtn).toBeDefined();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -19,7 +19,11 @@ import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
@@ -192,11 +196,9 @@ describe("zero sidebar - active tab indicator (SIDEBAR-D-007)", () => {
 
     await waitFor(() => {
       const nav = getSidebar();
-      const agentsLink = within(nav)
-        .getAllByRole("link")
-        .find((el) => {
-          return el.textContent?.trim() === "Agents";
-        });
+      const agentsLink = queryAllByRoleFast("link", nav).find((el) => {
+        return el.textContent?.trim() === "Agents";
+      });
       expect(agentsLink).toBeDefined();
       expect(agentsLink).toHaveAttribute("aria-current", "page");
     });
@@ -278,7 +280,7 @@ describe("zero sidebar - Slack scope mismatch indicator (SIDEBAR-D-009)", () => 
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("link").find((el) => {
+        queryAllByRoleFast("link").find((el) => {
           return /Where Zero works/i.test(el.textContent ?? "");
         }),
       ).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -20,7 +20,11 @@ import {
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   fireClerkListeners,
   mockedClerk,
@@ -390,7 +394,7 @@ describe("zero sidebar - delete thread button shows confirmation (SIDEBAR-D-018)
     const menuTriggers = screen.getAllByLabelText("Open chat menu");
     click(menuTriggers[0]);
     const deleteItem = await waitFor(() => {
-      const item = screen.getAllByRole("menuitem").find((el) => {
+      const item = queryAllByRoleFast("menuitem").find((el) => {
         return /Delete chat/i.test(el.textContent ?? "");
       });
       if (!item) {
@@ -453,7 +457,7 @@ describe("zero sidebar - confirm delete removes thread (SIDEBAR-D-019)", () => {
     const menuTriggers = screen.getAllByLabelText("Open chat menu");
     click(menuTriggers[0]);
     const deleteItem = await waitFor(() => {
-      const item = screen.getAllByRole("menuitem").find((el) => {
+      const item = queryAllByRoleFast("menuitem").find((el) => {
         return /Delete chat/i.test(el.textContent ?? "");
       });
       if (!item) {
@@ -467,11 +471,9 @@ describe("zero sidebar - confirm delete removes thread (SIDEBAR-D-019)", () => {
       return screen.getByRole("dialog");
     });
 
-    const confirmButton = within(dialog)
-      .getAllByRole("button")
-      .find((el) => {
-        return el.textContent?.trim() === "Delete";
-      });
+    const confirmButton = queryAllByRoleFast("button", dialog).find((el) => {
+      return el.textContent?.trim() === "Delete";
+    });
     expect(confirmButton).toBeDefined();
     click(confirmButton!);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -7,6 +7,7 @@ import {
   click,
   detachedSetupPage,
   fill,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import {
   getMockTelegramIntegration,
@@ -501,7 +502,7 @@ describe("telegram settings page", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Uninstall")).not.toBeInTheDocument();
 
-    const connectLink = screen.getAllByRole("link").find((element) => {
+    const connectLink = queryAllByRoleFast("link").find((element) => {
       return element.textContent === "Connect";
     });
     expect(connectLink).toBeDefined();
@@ -588,7 +589,7 @@ describe("telegram settings page", () => {
       expect(screen.getByText("@alpha_bot")).toBeInTheDocument();
     });
 
-    const connectLink = screen.getAllByRole("link").find((element) => {
+    const connectLink = queryAllByRoleFast("link").find((element) => {
       return element.textContent === "Connect";
     });
     expect(connectLink).toBeDefined();
@@ -619,7 +620,7 @@ describe("telegram settings page", () => {
     click(screen.getByText("Reinstall"));
     const dialog = await screen.findByRole("dialog");
     await fill(screen.getByLabelText("New bot token"), "123:new-token");
-    const reinstallButton = screen.getAllByRole("button").find((element) => {
+    const reinstallButton = queryAllByRoleFast("button").find((element) => {
       return element.textContent === "Reinstall" && dialog.contains(element);
     });
     expect(reinstallButton).toBeDefined();
@@ -646,7 +647,7 @@ describe("telegram settings page", () => {
       expect(screen.getByText("@alpha_bot")).toBeInTheDocument();
     });
 
-    const connectLink = screen.getAllByRole("link").find((element) => {
+    const connectLink = queryAllByRoleFast("link").find((element) => {
       return element.textContent === "Connect";
     });
     expect(connectLink).toBeDefined();
@@ -679,7 +680,7 @@ describe("telegram settings page", () => {
     click(uninstallButton);
 
     const dialog = await screen.findByRole("dialog");
-    const confirmButton = screen.getAllByRole("button").find((element) => {
+    const confirmButton = queryAllByRoleFast("button").find((element) => {
       return element.textContent === "Uninstall" && dialog.contains(element);
     });
     expect(confirmButton).toBeDefined();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -19,6 +19,7 @@ import { testContext } from "../../../../../signals/__tests__/test-helpers.ts";
 import {
   detachedSetupPage,
   click,
+  queryAllByRoleFast,
 } from "../../../../../__tests__/page-helper.ts";
 import {
   setMockOrgModelProviders,
@@ -113,11 +114,9 @@ function findReconnectDialogTitle(): HTMLElement | null {
 }
 
 function getActionsButton(row: HTMLElement): HTMLElement {
-  const button = within(row)
-    .getAllByRole("button")
-    .find((item) => {
-      return /Actions for/i.test(item.getAttribute("aria-label") ?? "");
-    });
+  const button = queryAllByRoleFast("button", row).find((item) => {
+    return /Actions for/i.test(item.getAttribute("aria-label") ?? "");
+  });
   expect(button).toBeDefined();
   return button!;
 }
@@ -157,11 +156,9 @@ function clickRouteChoice(dialog: HTMLElement, label: string): void {
 }
 
 function getDialogButton(dialog: HTMLElement, label: string): HTMLElement {
-  const button = within(dialog)
-    .getAllByRole("button")
-    .find((item) => {
-      return item.textContent?.trim() === label;
-    });
+  const button = queryAllByRoleFast("button", dialog).find((item) => {
+    return item.textContent?.trim() === label;
+  });
   expect(button).toBeDefined();
   return button!;
 }


### PR DESCRIPTION
## Summary

Follow-up to #14901. While profiling the stripe CLI close test there I traced the dominant cost to `screen.getAllByRole("button")` — `@testing-library/dom` ran the full ARIA tree walk against the whole document, ~360ms per call on the /connectors page even with only 5 buttons rendered. With each of 5 stripe tests calling the role helper 3–4 times that single API was responsible for the four `triggerAblyEvent`-driven tests hovering at ~5s in CI ([job 77751504588 had them all timing out together](https://github.com/vm0-ai/vm0/actions/runs/26413040588/job/77751504588)). #14901 worked around it inline; this PR ships the rule + helper + migration that prevents the smell from coming back.

**Three coordinated changes:**

1. **Lint rule** — `no-get-by-role-name` now flags every `*ByRole(text-content-role, …)` call, not just the `{ name }` variant. Plain `getAllByRole("button")` is also slow because of the tree walk, so the rule's recommendation now points at `queryAllByRoleFast` for any `button | link | menuitem* | tab | cell | columnheader | rowheader | gridcell` query.

2. **Helper** — `queryAllByRoleFast(role[, container])` in `src/__tests__/page-helper.ts` maps each text-content role to `tag, [role="…"]` selectors via native `querySelectorAll`, then filters out ancestors with `aria-hidden="true"` / `hidden` / `inert` to preserve the default `getAllByRole({ hidden: false })` visibility semantics. (Radix overlay portals routinely leave background mounts with `aria-hidden` — without this filter counts inflate vs. the original role queries.)

3. **Codemod-driven migration** — 215 call sites across 58 test files swapped from `screen.(get|query)AllByRole("foo")` (and `within(x).…`) to `queryAllByRoleFast`. Six files had `within` left unused after the rewrite and lost the import.

## Results

| metric | before | after |
|---|---|---|
| full platform vitest run | 235s | **204s** (~13% faster) |
| clears Stripe CLI auth state when the dialog closes | 1837ms (then skipped) | 596ms |
| clears Stripe CLI auth state when switching connectors | 1376ms | 781ms |
| keeps Stripe CLI auth open when completion is still pending | 1254ms (CI timeout) | 841ms |
| stops polling when terminal failure | 1412ms (CI timeout) | 844ms |
| completes Stripe CLI auth and opens permission dialog | 1498ms (CI timeout) | 1036ms |

## Test plan

- [x] `pnpm -F @vm0/app run lint` / `check-types`
- [x] `pnpm -F @vm0/app exec vitest run` — 2378/2378 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)