### PR TITLE
feat: add styled image resource selection

### DIFF
--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -260,6 +260,69 @@ describe("zero built-in generate image command", () => {
     });
   });
 
+  it("should print styled image resource selection instructions with --styled", async () => {
+    await zeroBuiltInCommand.parseAsync([
+      "node",
+      "cli",
+      "generate",
+      "image",
+      "--styled",
+      "--prompt",
+      "Notion illustration of a product manager mapping a launch plan",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("# Zero built-in generate image --styled");
+    expect(stdout).toContain("federated generation resource-selection packet");
+    expect(stdout).toContain("## Stage 1: Resource Selection");
+    expect(stdout).toContain("## Candidate Registry Slice");
+    expect(stdout).toContain("vm0:image-style:notion-illustration");
+    expect(stdout).toContain("vm0-ai/vm0-skills");
+    expect(stdout).toContain("notion-illustration");
+    expect(stdout).toContain("## Stage 3: Generate Image");
+  });
+
+  it("should print styled image JSON resource selection metadata", async () => {
+    await zeroBuiltInCommand.parseAsync([
+      "node",
+      "cli",
+      "generate",
+      "image",
+      "--styled",
+      "--prompt",
+      "Notion illustration of a product manager mapping a launch plan",
+      "--json",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      type: "open-design-resource-selection",
+      kind: "image",
+      prompt: "Notion illustration of a product manager mapping a launch plan",
+      outputDir: "./opendesign/images",
+    });
+    expect(parsed.selection).toEqual(
+      expect.objectContaining({
+        candidates: expect.objectContaining({
+          imageStyles: expect.arrayContaining([
+            expect.objectContaining({
+              id: "vm0:image-style:notion-illustration",
+              source: expect.objectContaining({
+                repo: "vm0-ai/vm0-skills",
+                commit: "b35373eb12112b1e7a0caa372a5cafe02e214dd1",
+                path: "notion-illustration",
+              }),
+            }),
+          ]),
+        }),
+      }),
+    );
+    expect(parsed.instructions).toEqual(
+      expect.stringContaining("## Stage 2: Resolve Selected Resources"),
+    );
+  });
+
   it("should wait for an accepted async generation result", async () => {
     let statusRequested = false;
     server.use(
@@ -339,6 +402,7 @@ describe("zero built-in generate image command", () => {
     expect(helpOutput).toContain("--safety-tolerance");
     expect(helpOutput).toContain("--image-url");
     expect(helpOutput).toContain("--image-prompt-strength");
+    expect(helpOutput).toContain("--styled");
     expect(helpOutput).toContain("provider");
     expect(helpOutput).toContain("default");
     expect(helpOutput).toContain("not support transparent");

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/image.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/image.ts
@@ -5,6 +5,7 @@ export const imageCommand = createImageGenerateCommand({
   usageCommand: "zero built-in generate image",
   examples: `  Generate image:        zero built-in generate image --prompt "A watercolor fox"
   Pipe prompt:           cat prompt.txt | zero built-in generate image
+  Styled image:          zero built-in generate image --styled --prompt "A product manager mapping a launch plan"
   GPT Image model:       zero built-in generate image --model gpt-image-1.5 --prompt "A poster" --size 1024x1536 --quality high
   Flux model:            zero built-in generate image --model flux-pro-1.1 --prompt "A product hero shot" --seed 42
   Image-to-image:        zero built-in generate image --model flux-pro-1.1 --image-url https://example.com/mockup.png --prompt "Turn this mockup into a polished product shot"`,

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -71,6 +71,7 @@ function slugify(value: string): string {
 
 function titleForKind(kind: HtmlArtifactKind): string {
   const titles: Record<HtmlArtifactKind, string> = {
+    image: "image",
     presentation: "HTML presentation",
     website: "hosted website",
     "dashboard-design": "dashboard design prototype",

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -3,6 +3,7 @@ import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 import { generateWebImage } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { createStyledImageAuthoringPacket } from "./image-style-authoring";
 
 interface ImageOptions {
   prompt?: string;
@@ -20,6 +21,7 @@ interface ImageOptions {
   maskImageUrl?: string;
   inputFidelity?: string;
   imagePromptStrength?: string;
+  styled?: boolean;
   json?: boolean;
 }
 
@@ -149,6 +151,10 @@ export function createImageGenerateCommand(
       "--image-prompt-strength <0-1>",
       "Reference strength override for Flux Redux",
     )
+    .option(
+      "--styled",
+      "Print a resource-selection packet for styled image generation",
+    )
     .option("--json", "Print metadata as JSON")
     .addHelpText(
       "after",
@@ -157,7 +163,8 @@ Examples:
 ${config.examples}
 
 Output:
-  Prints the generated /f/ image file URL and metadata
+  Prints the generated /f/ image file URL and metadata. With --styled, prints
+  an Open Design resource-selection packet for the current agent.
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
@@ -192,11 +199,40 @@ Options:
   - Image-to-image: pass --image-url to use the model's fal edit/redux endpoint.
     Flux Redux accepts --image-prompt-strength to override the provider
     default; GPT edit models accept --input-fidelity and supported models
-    accept --mask-image-url.`,
+    accept --mask-image-url.
+  - Styled mode: pass --styled to select an image style resource first. In this
+    mode the agent resolves the selected style source and generates the image.`,
     )
     .action(
       withErrorHandler(async (options: ImageOptions, command: Command) => {
         const prompt = readPrompt(options, config.usageCommand);
+        if (options.styled) {
+          const packet = createStyledImageAuthoringPacket({
+            prompt,
+            details: [
+              `Model preference if direct image generation is used: ${options.model}`,
+              `Requested size: ${options.size}`,
+              `Requested quality: ${options.quality}`,
+              `Requested background: ${options.background}`,
+              `Requested format: ${options.format}`,
+              `Source image URLs: ${
+                options.imageUrl.length > 0
+                  ? options.imageUrl.join(", ")
+                  : "none"
+              }`,
+              `Mask image URL: ${options.maskImageUrl ?? "none"}`,
+            ],
+          });
+
+          if (options.json) {
+            console.log(JSON.stringify(packet));
+            return;
+          }
+
+          console.log(packet.instructions);
+          return;
+        }
+
         const compression = parseCompression(options.compression);
         const inputFidelity = parseInputFidelity(options.inputFidelity);
         const imagePromptStrength = parseImagePromptStrength(

--- a/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
@@ -1,0 +1,159 @@
+import {
+  type GenerationOutputKind,
+  type OpenDesignCandidateSlice,
+  selectOpenDesignCandidates,
+} from "./open-design-registry";
+
+interface StyledImageAuthoringOptions {
+  readonly prompt: string;
+  readonly details: readonly string[];
+}
+
+interface StyledImageAuthoringPacket {
+  readonly type: "open-design-resource-selection";
+  readonly kind: "image";
+  readonly prompt: string;
+  readonly registryVersion: string;
+  readonly artifact: {
+    readonly outputMode: "primary-image";
+    readonly primaryArtifact: {
+      readonly kind: GenerationOutputKind;
+      readonly path: string;
+    };
+    readonly supportingAssets: readonly {
+      readonly kind: GenerationOutputKind | "metadata";
+      readonly path: string;
+      readonly optional: boolean;
+    }[];
+    readonly previewKind: "image";
+    readonly outputDir: string;
+  };
+  readonly selection: {
+    readonly candidates: OpenDesignCandidateSlice["candidates"];
+    readonly outputSchema: {
+      readonly imageStyle: "string";
+      readonly skills: "string[]";
+      readonly rationale: "string";
+    };
+  };
+  readonly authoring: {
+    readonly details: readonly string[];
+    readonly artifactRules: readonly string[];
+  };
+  readonly outputDir: string;
+  readonly instructions: string;
+}
+
+const outputDir = "./opendesign/images";
+const artifactRules = [
+  "Select the image style that best matches the prompt before generation.",
+  "Resolve the selected style source before generating the image.",
+  "Use the style skill's referenced assets and generation path when it provides one.",
+  "Produce a single final image file and keep any temporary metadata under the output directory.",
+] as const;
+
+export function createStyledImageAuthoringPacket(
+  options: StyledImageAuthoringOptions,
+): StyledImageAuthoringPacket {
+  const candidateSlice = selectOpenDesignCandidates({
+    target: "image",
+    prompt: [options.prompt, ...options.details, ...artifactRules].join("\n"),
+  });
+  const selectionSchema = {
+    imageStyle: "string",
+    skills: "string[]",
+    rationale: "string",
+  } as const;
+  const artifact = {
+    outputMode: "primary-image",
+    primaryArtifact: {
+      kind: "image",
+      path: `${outputDir}/`,
+    },
+    supportingAssets: [
+      {
+        kind: "metadata",
+        path: `${outputDir}/metadata.json`,
+        optional: true,
+      },
+    ],
+    previewKind: "image",
+    outputDir,
+  } as const;
+  const instructions = [
+    "# Zero built-in generate image --styled",
+    "",
+    "This is a federated generation resource-selection packet for the current agent.",
+    "Zero is not generating this image on the server yet. You select resources, resolve them, and generate the styled image.",
+    "",
+    "## User Prompt",
+    options.prompt,
+    "",
+    "## Stage 1: Resource Selection",
+    "- Choose an image style from the bundled federated registry slice below.",
+    "- Choose only IDs present in this packet; do not invent registry IDs.",
+    "- Prefer image-style resources with matching triggers, but the user prompt is the highest-priority signal.",
+    "- Treat the selection JSON as internal working state, then continue to generation.",
+    "",
+    "## Selection Output Schema",
+    "```json",
+    JSON.stringify(selectionSchema, null, 2),
+    "```",
+    "",
+    "## Candidate Registry Slice",
+    `Registry: \`${candidateSlice.registryVersion}\``,
+    "",
+    "```json",
+    JSON.stringify(candidateSlice.candidates, null, 2),
+    "```",
+    "",
+    "## Stage 2: Resolve Selected Resources",
+    "- Fetch or read the selected resource source before generation.",
+    "- Source refs are pinned as `repo@commit:path`; use the commit in the packet for reproducibility.",
+    "- For directory refs, inspect the most relevant files such as `SKILL.md`, references, examples, and templates.",
+    "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
+    "",
+    "## Stage 3: Generate Image",
+    "- Generate one production-quality image using the selected style.",
+    "- Follow the selected style skill's generation path when it defines one.",
+    "- If the style skill delegates to a model or connector, use that flow directly instead of restating the style text manually.",
+    "",
+    "## Artifact Output Model",
+    `- Primary artifact: \`${artifact.primaryArtifact.kind}\` under \`${artifact.primaryArtifact.path}\`.`,
+    `- Output mode: \`${artifact.outputMode}\`.`,
+    "- Supporting metadata may live inside the same output directory when useful.",
+    "",
+    "## Requested Parameters",
+    ...options.details.map((detail) => {
+      return `- ${detail}`;
+    }),
+    "",
+    "## Image Authoring Rules",
+    ...artifactRules.map((rule) => {
+      return `- ${rule}`;
+    }),
+    "",
+    "## Verification",
+    "- Verify the final image exists and is nonblank.",
+    "- Check that the selected style's required reference anchors or source assets were used when applicable.",
+    "- Report the final image URL or path and the selected registry resource ID.",
+  ].join("\n");
+
+  return {
+    type: "open-design-resource-selection",
+    kind: "image",
+    prompt: options.prompt,
+    registryVersion: candidateSlice.registryVersion,
+    artifact,
+    selection: {
+      candidates: candidateSlice.candidates,
+      outputSchema: selectionSchema,
+    },
+    authoring: {
+      details: options.details,
+      artifactRules,
+    },
+    outputDir,
+    instructions,
+  };
+}

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1,4 +1,5 @@
 export type OpenDesignTarget =
+  | "image"
   | "presentation"
   | "website"
   | "dashboard-design"
@@ -100,8 +101,8 @@ export interface OpenDesignCandidateSlice {
 
 const OPEN_DESIGN_REPO = "vm0-ai/open-design";
 const OPEN_DESIGN_COMMIT = "d021b04720ace133f1d6133d1487326f5fc28f07";
-const VM0_REPO = "vm0-ai/vm0";
-const NOTION_ILLUSTRATION_COMMIT = "12d5aa42de4323c034cfb6e8005c69304dd510e5";
+const VM0_SKILLS_REPO = "vm0-ai/vm0-skills";
+const NOTION_ILLUSTRATION_COMMIT = "b35373eb12112b1e7a0caa372a5cafe02e214dd1";
 
 const OPEN_DESIGN_REGISTRY_VERSION = `federated:${OPEN_DESIGN_REPO}@${OPEN_DESIGN_COMMIT}`;
 
@@ -402,11 +403,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Zero-native illustration style for hand-drawn product spot illustrations with simple ink contours and soft backgrounds.",
     source: sourceRef(
-      VM0_REPO,
+      VM0_SKILLS_REPO,
       NOTION_ILLUSTRATION_COMMIT,
-      ".claude/skills/notion-illustration",
+      "notion-illustration",
     ),
-    targets: ["website", "poster", "presentation", "report"],
+    targets: ["image", "website", "poster", "presentation", "report"],
     tags: ["image", "illustration", "notion", "spot", "hand-drawn", "product"],
     triggers: [
       "illustration",
@@ -561,7 +562,7 @@ export function selectOpenDesignCandidates(options: {
         commit: OPEN_DESIGN_COMMIT,
       },
       {
-        repo: VM0_REPO,
+        repo: VM0_SKILLS_REPO,
         commit: NOTION_ILLUSTRATION_COMMIT,
       },
     ],


### PR DESCRIPTION
## Summary
- Point the Notion Illustration image-style registry entry at vm0-ai/vm0-skills@b35373e:notion-illustration
- Add image as an Open Design target so image-style resources can be selected directly
- Add zero built-in generate image --styled as a no-argument boolean option that prints an Open Design resource-selection packet instead of calling the image API
- Add tests for styled image instructions and JSON metadata

## Dependency
- Depends on vm0-ai/vm0-skills#201 for commit b35373eb12112b1e7a0caa372a5cafe02e214dd1 being present in vm0-skills

## Test plan
- pnpm --filter @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts
- pnpm --filter @vm0/cli check-types
- pnpm --filter @vm0/cli lint
- pnpm exec prettier --check apps/cli/src/commands/zero/shared/image-style-authoring.ts apps/cli/src/commands/zero/shared/image-generate.ts apps/cli/src/commands/zero/shared/open-design-registry.ts apps/cli/src/commands/zero/shared/html-artifact-authoring.ts apps/cli/src/commands/zero/built-in/generate/image.ts apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
- git diff --check

Note: I also accidentally invoked pnpm --filter @vm0/cli test -- src/commands/zero/built-in/generate/__tests__/image.test.ts, which ran the full CLI suite in this sandbox and failed unrelated auth/env-sensitive tests due the ambient ZERO_TOKEN. The targeted image test command above passes.