### PR TITLE
fix: improve usage buffer flush shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -656,7 +656,10 @@ def done():
     ``shutdown(wait=True)`` drains already-submitted futures during graceful stop.
     """
     try:
-        usage.flush_usage_events(trigger="shutdown")
+        # A SIGUSR1 flush can already have snapshotted buffered events but not
+        # yet enqueued them; wait before closing the executor.
+        with _usage_flush_signal_lock:
+            usage.flush_usage_events(trigger="shutdown")
     finally:
         usage.webhook.usage_executor.shutdown(wait=True)
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -124,8 +124,7 @@ def _flush_usage_for_runner_request() -> None:
             usage.flush_usage_events(trigger="runner")
         except Exception as exc:
             ctx.log.warn(
-                "Failed to flush usage events after runner request "
-                f"({type(exc).__name__})"
+                f"Failed to flush usage events after runner request ({type(exc).__name__})"
             )
         finally:
             usage.write_pending_snapshot(flush_request_id=flush_request_id)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -123,7 +123,10 @@ def _flush_usage_for_runner_request() -> None:
         try:
             usage.flush_usage_events(trigger="runner")
         except Exception as exc:
-            ctx.log.warn(f"Failed to flush usage events after runner request: {exc}")
+            ctx.log.warn(
+                "Failed to flush usage events after runner request "
+                f"({type(exc).__name__})"
+            )
         finally:
             usage.write_pending_snapshot(flush_request_id=flush_request_id)
     finally:

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 import threading
+import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
@@ -181,9 +182,27 @@ class UsageEventBuffer:
         flush_sequence: int,
         summaries: list[_FlushSummary],
     ) -> None:
+        started_at = time.monotonic()
         try:
-            _log_flush_summaries(trigger, flush_sequence, summaries)
+            _log_flush_summaries("started", trigger, flush_sequence, summaries)
             _enqueue_batches(batches)
+            _log_flush_summaries(
+                "completed",
+                trigger,
+                flush_sequence,
+                summaries,
+                duration_ms=_elapsed_ms(started_at),
+            )
+        except Exception as exc:
+            _log_flush_summaries(
+                "failed",
+                trigger,
+                flush_sequence,
+                summaries,
+                duration_ms=_elapsed_ms(started_at),
+                error_type=type(exc).__name__,
+            )
+            raise
         finally:
             if enqueuing_count:
                 with self._lock:
@@ -415,26 +434,42 @@ def _build_flush_summaries(
 
 
 def _log_flush_summaries(
+    phase: str,
     trigger: str,
     flush_sequence: int,
     summaries: Iterable[_FlushSummary],
+    *,
+    duration_ms: int | None = None,
+    error_type: str | None = None,
 ) -> None:
     for summary in summaries:
         if not summary.proxy_log_path:
             continue
+        extra: dict[str, object] = {
+            "type": "usage_event_buffer_flush",
+            "phase": phase,
+            "trigger": trigger,
+            "flush_sequence": flush_sequence,
+            "source_event_count": summary.source_event_count,
+            "aggregate_event_count": summary.aggregate_event_count,
+            "webhook_batch_count": summary.webhook_batch_count,
+            "run_count": len(summary.run_ids),
+            "destination_count": len(summary.destinations),
+        }
+        if duration_ms is not None:
+            extra["duration_ms"] = duration_ms
+        if error_type is not None:
+            extra["error_type"] = error_type
         log_proxy_entry(
             summary.proxy_log_path,
-            "info",
-            "Usage event buffer flushed",
-            type="usage_event_buffer_flush",
-            trigger=trigger,
-            flush_sequence=flush_sequence,
-            source_event_count=summary.source_event_count,
-            aggregate_event_count=summary.aggregate_event_count,
-            webhook_batch_count=summary.webhook_batch_count,
-            run_count=len(summary.run_ids),
-            destination_count=len(summary.destinations),
+            "error" if phase == "failed" else "info",
+            f"Usage event buffer flush {phase}",
+            **extra,
         )
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return max(0, int((time.monotonic() - started_at) * 1000))
 
 
 def _encode_uuid_name(parts: tuple[str, ...]) -> str:

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -30,6 +30,73 @@ class TestDoneHook:
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
 
+    def test_done_waits_for_runner_flush_before_executor_shutdown(self):
+        """done() must not shut down the executor while a SIGUSR1 flush is enqueueing."""
+
+        class _InstrumentedLock:
+            def __init__(self) -> None:
+                self._lock = threading.Lock()
+                self.blocking_acquire_started = threading.Event()
+
+            def acquire(self, blocking: bool = True) -> bool:
+                if blocking:
+                    self.blocking_acquire_started.set()
+                return self._lock.acquire(blocking)
+
+            def release(self) -> None:
+                self._lock.release()
+
+            def __enter__(self):
+                self.acquire()
+                return self
+
+            def __exit__(self, exc_type, exc, traceback) -> None:
+                del exc_type, exc, traceback
+                self.release()
+
+        lock = _InstrumentedLock()
+        runner_flush_started = threading.Event()
+        release_runner_flush = threading.Event()
+        shutdown_called = threading.Event()
+        calls: list[str] = []
+
+        def flush_usage_events(*, trigger: str) -> int:
+            calls.append(f"flush:{trigger}")
+            if trigger == "runner":
+                runner_flush_started.set()
+                if not release_runner_flush.wait(timeout=1):
+                    calls.append("runner_flush_timeout")
+            return 0
+
+        def shutdown(*, wait: bool) -> None:
+            calls.append(f"shutdown:{wait}")
+            shutdown_called.set()
+
+        mock_executor = MagicMock()
+        mock_executor.shutdown.side_effect = shutdown
+
+        with (
+            patch.object(mitm_addon, "_usage_flush_signal_lock", lock),
+            patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+        ):
+            runner_thread = threading.Thread(target=mitm_addon._flush_usage_for_runner_request)
+            runner_thread.start()
+            assert runner_flush_started.wait(timeout=1)
+
+            done_thread = threading.Thread(target=mitm_addon.done)
+            done_thread.start()
+            assert lock.blocking_acquire_started.wait(timeout=1)
+            assert not shutdown_called.is_set()
+
+            release_runner_flush.set()
+            runner_thread.join(timeout=1)
+            done_thread.join(timeout=1)
+
+        assert not runner_thread.is_alive()
+        assert not done_thread.is_alive()
+        assert calls == ["flush:runner", "flush:shutdown", "shutdown:True"]
+
     def test_done_shuts_down_executor_when_flush_fails(self):
         mock_executor = MagicMock()
 

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -220,6 +220,24 @@ class TestRunnerUsageFlushSignal:
             usage.counters.decrement_pending_reports()
             usage.set_pending_path("")
 
+    def test_runner_flush_failure_warns_without_error_text(self):
+        log = MagicMock()
+
+        with (
+            patch.object(mitm_addon.ctx, "log", log, create=True),
+            patch.object(
+                usage,
+                "flush_usage_events",
+                side_effect=RuntimeError("secret-token"),
+            ),
+        ):
+            mitm_addon._flush_usage_for_runner_request()
+
+        log.warn.assert_called_once()
+        message = log.warn.call_args.args[0]
+        assert "RuntimeError" in message
+        assert "secret-token" not in message
+
 
 class TestTlsClienthello:
     def test_unregistered_vm_ignored(self, registry_file, make_tls_data, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -4,6 +4,8 @@ import json
 import uuid
 from unittest.mock import patch
 
+import pytest
+
 import usage
 import usage.buffer as usage_buffer
 
@@ -27,6 +29,14 @@ def _event(
 
 def _payloads_from_enqueue_calls(call_args_list):
     return [call.args[2] for call in call_args_list]
+
+
+def _flush_log_entries(proxy_log_path):
+    return [
+        json.loads(line)
+        for line in proxy_log_path.read_text().splitlines()
+        if '"usage_event_buffer_flush"' in line
+    ]
 
 
 class _FakeTimer:
@@ -273,22 +283,58 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
         assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()
-    [entry] = [
-        json.loads(line)
-        for line in proxy_log_path.read_text().splitlines()
-        if '"usage_event_buffer_flush"' in line
+    entries = _flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "completed"]
+    assert [entry["message"] for entry in entries] == [
+        "Usage event buffer flush started",
+        "Usage event buffer flush completed",
     ]
-    assert entry["level"] == "info"
-    assert entry["message"] == "Usage event buffer flushed"
-    assert entry["type"] == "usage_event_buffer_flush"
-    assert entry["trigger"] == "test"
-    assert entry["flush_sequence"] == 1
-    assert entry["source_event_count"] == 2
-    assert entry["aggregate_event_count"] == 2
-    assert entry["webhook_batch_count"] == 1
-    assert entry["run_count"] == 1
-    assert entry["destination_count"] == 1
-    assert "secret-token" not in json.dumps(entry)
+    for entry in entries:
+        assert entry["level"] == "info"
+        assert entry["type"] == "usage_event_buffer_flush"
+        assert entry["trigger"] == "test"
+        assert entry["flush_sequence"] == 1
+        assert entry["source_event_count"] == 2
+        assert entry["aggregate_event_count"] == 2
+        assert entry["webhook_batch_count"] == 1
+        assert entry["run_count"] == 1
+        assert entry["destination_count"] == 1
+        assert "secret-token" not in json.dumps(entry)
+    assert "duration_ms" not in entries[0]
+    assert isinstance(entries[1]["duration_ms"], int)
+    assert entries[1]["duration_ms"] >= 0
+
+
+def test_flush_logs_failure_without_token(tmp_path):
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "secret-token",
+        "run-1",
+        [_event(source_key="source-1")],
+        str(proxy_log_path),
+    )
+
+    with (
+        patch.object(
+            usage_buffer,
+            "_enqueue_webhook",
+            side_effect=RuntimeError("secret-token"),
+        ) as enqueue,
+        pytest.raises(RuntimeError, match="secret-token"),
+    ):
+        usage.flush_usage_events(trigger="test")
+
+    enqueue.assert_called_once()
+    entries = _flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "failed"]
+    assert entries[1]["level"] == "error"
+    assert entries[1]["message"] == "Usage event buffer flush failed"
+    assert entries[1]["error_type"] == "RuntimeError"
+    assert isinstance(entries[1]["duration_ms"], int)
+    assert entries[1]["duration_ms"] >= 0
+    assert "secret-token" not in json.dumps(entries)
+    assert usage.counters._buffered_usage_events == 0
 
 
 def test_flush_preserves_events_buffered_during_enqueue(tmp_path):


### PR DESCRIPTION
## Summary
- log usage buffer flush started/completed/failed phases with duration metadata
- avoid writing sensitive exception text in flush failure logs
- wait for in-flight runner-requested flush before shutting down the usage executor

## Tests
- pytest tests/test_usage_buffer.py::test_flush_logs_aggregate_summary_without_token tests/test_usage_buffer.py::test_flush_logs_failure_without_token tests/test_connection_hooks.py::TestDoneHook -q
- ruff check src/usage/buffer.py src/mitm_addon.py tests/test_usage_buffer.py tests/test_connection_hooks.py
- basedpyright src/usage/buffer.py src/mitm_addon.py tests/test_usage_buffer.py tests/test_connection_hooks.py