### PR TITLE
fix(platform): rename OAuth CTA to 'Authorize'

### DIFF
--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -126,7 +126,7 @@ describe("connect modal - content by auth method", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Authorize")).toBeInTheDocument();
     });
   });
 
@@ -160,9 +160,7 @@ describe("connect modal - content by auth method", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByText("Sign in with Test OAuth Device (internal)"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Authorize")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Connection methods unavailable"),
     ).not.toBeInTheDocument();
@@ -318,7 +316,7 @@ describe("connect modal - content by auth method", () => {
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).getByText(/No online hosts yet/)).toBeInTheDocument();
     expect(within(dialog).queryByText("Save")).not.toBeInTheDocument();
-    expect(within(dialog).queryByText(/Sign in with/)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Authorize")).not.toBeInTheDocument();
   });
 
   it("shows Local Browser connector-specific API content", async () => {
@@ -332,7 +330,7 @@ describe("connect modal - content by auth method", () => {
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).getByText("Browser hosts")).toBeInTheDocument();
     expect(within(dialog).queryByText("Save")).not.toBeInTheDocument();
-    expect(within(dialog).queryByText(/Sign in with/)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Authorize")).not.toBeInTheDocument();
   });
 
   it("keeps API-only content visible while OAuth is settling elsewhere", async () => {
@@ -361,10 +359,10 @@ describe("connect modal - content by auth method", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Authorize")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Authorize"));
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
@@ -388,7 +386,7 @@ describe("connect modal - content by auth method", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with Deel")).toBeInTheDocument();
+      expect(screen.getByText("Authorize")).toBeInTheDocument();
     });
 
     expect(
@@ -467,10 +465,10 @@ describe("connect modal - loading states", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Authorize")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Authorize"));
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
@@ -490,10 +488,10 @@ describe("connect modal - interactions", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Authorize")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Authorize"));
 
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledWith(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -664,13 +664,11 @@ function getOAuthAuthCodeProgressContent({
 
 function OAuthAuthCodeConnectButton({
   item,
-  label,
   onSuccess,
   showPermissionDialogOnConnect,
   connectOAuthAuthCodeAndSettle,
   signal,
 }: ConnectModalContentProps & {
-  label: string;
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   signal: AbortSignal;
 }) {
@@ -692,7 +690,7 @@ function OAuthAuthCodeConnectButton({
       }}
       className="w-full"
     >
-      Sign in with {label}
+      Authorize
     </Button>
   );
 }
@@ -701,7 +699,6 @@ function OAuthAuthCodeConnectMethodContent(props: ConnectMethodContentProps) {
   return (
     <OAuthAuthCodeConnectButton
       item={props.item}
-      label={CONNECTOR_TYPES[props.item.type].label}
       onSuccess={props.onSuccess}
       showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
       connectOAuthAuthCodeAndSettle={props.connectOAuthAuthCodeAndSettle}


### PR DESCRIPTION
## Summary

Replaces the OAuth auth-code CTA "Sign in with {Provider}" with a cleaner "Authorize" on the connector add/connect dialog. The dialog header already shows the provider's name and icon, so the button copy can stay focused on the action.

Reported by Ming in Slack — the button label was misleading since the same control acts as a connect toggle, and "Authorize" reads more accurately for the OAuth grant step.

**Scope (intentionally narrow):**

- `OAuthAuthCodeConnectButton` → label becomes `Authorize`; the unused `label` prop is removed.
- Tests in `add-connection-dialog.test.tsx` that asserted "Sign in with {GitHub|Deel}" updated to "Authorize".
- Negative assertions on API-only and local-host connectors updated to confirm the new "Authorize" copy is absent.

**Out of scope (separate follow-ups):**

- Stripe `cli-auth` button still uses the connector-defined `Sign in with Stripe` label (different flow).
- Claude Code / Codex device-auth dialogs keep their existing copy.
- Toggle behavior (Authorize ↔ Disconnect / Revoke) on the same control — the original feedback also flagged this; tracking separately.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run views/conn/__tests__/add-connection-dialog.test.tsx` — 32 / 32 passing
- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean
- [ ] Manual: open Connect dialog for GitHub / Notion / etc. and confirm the OAuth button reads "Authorize"
- [ ] Manual: confirm Stripe CLI-auth flow still reads "Sign in with Stripe"

🤖 Generated with [Claude Code](https://claude.com/claude-code)