### PR TITLE
feat(web): show drafts in docs index and sidebar when ?status=draft

### DIFF
--- a/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
@@ -91,15 +91,16 @@ export default async function DocsPage({
 
   const { locale, slug } = await params;
   const { status } = await searchParams;
+  const draft = status === "draft";
   const path = pathFromSlug(slug);
-  const page = await getDocsPage(path, locale, { draft: status === "draft" });
+  const page = await getDocsPage(path, locale, { draft });
 
   if (!page) {
     notFound();
   }
 
   const t = await getTranslations({ locale, namespace: "docs" });
-  const navigation = await getDocsNavigation(locale);
+  const navigation = await getDocsNavigation(locale, { draft });
   const pageUrl = `${getDocsBaseUrl()}/${locale}/docs/${page.path}`;
 
   const breadcrumbJsonLd = {
@@ -162,9 +163,13 @@ export default async function DocsPage({
         navigation={navigation}
         homeLabel={t("home")}
         activePath={page.path}
+        draft={draft}
       >
         <header className="docs-article-header">
-          <Link href="/docs" className="blog-post-back">
+          <Link
+            href={draft ? "/docs?status=draft" : "/docs"}
+            className="blog-post-back"
+          >
             <svg
               viewBox="0 0 24 24"
               fill="none"

--- a/turbo/apps/web/app/[locale]/docs/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/page.tsx
@@ -18,6 +18,7 @@ const BASE_URL = "https://www.vm0.ai";
 
 interface DocsIndexPageProps {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export const dynamic = "force-dynamic";
@@ -60,14 +61,19 @@ export async function generateMetadata({
   };
 }
 
-export default async function DocsIndexPage({ params }: DocsIndexPageProps) {
+export default async function DocsIndexPage({
+  params,
+  searchParams,
+}: DocsIndexPageProps) {
   if (!(await canViewDocs())) {
     notFound();
   }
 
   const { locale } = await params;
+  const { status } = await searchParams;
+  const draft = status === "draft";
   const t = await getTranslations({ locale, namespace: "docs" });
-  const pages = await getDocsPages(locale);
+  const pages = await getDocsPages(locale, { draft });
   const navigation = buildDocsNavigation(pages);
 
   const breadcrumbJsonLd = {
@@ -104,14 +110,18 @@ export default async function DocsIndexPage({ params }: DocsIndexPageProps) {
           <p className="docs-description">{t("description")}</p>
         </div>
       </section>
-      <DocsShell navigation={navigation} homeLabel={t("home")}>
+      <DocsShell navigation={navigation} homeLabel={t("home")} draft={draft}>
         {pages.length > 0 ? (
           <div className="docs-index-grid">
             {pages.map((page) => {
               return (
                 <Link
                   key={page.path}
-                  href={`/docs/${page.path}`}
+                  href={
+                    draft
+                      ? `/docs/${page.path}?status=draft`
+                      : `/docs/${page.path}`
+                  }
                   className="docs-index-card"
                 >
                   <span className="docs-index-section">

--- a/turbo/apps/web/app/components/docs/DocsShell.tsx
+++ b/turbo/apps/web/app/components/docs/DocsShell.tsx
@@ -6,20 +6,26 @@ interface DocsShellProps {
   navigation: DocsNavigationSection[];
   homeLabel: string;
   activePath?: string;
+  draft?: boolean;
   children: ReactNode;
+}
+
+function withDraft(href: string, draft?: boolean): string {
+  return draft ? `${href}?status=draft` : href;
 }
 
 export function DocsShell({
   navigation,
   homeLabel,
   activePath,
+  draft,
   children,
 }: DocsShellProps) {
   return (
     <div className="docs-shell">
       <aside className="docs-sidebar" aria-label="Documentation navigation">
         <Link
-          href="/docs"
+          href={withDraft("/docs", draft)}
           className={`docs-nav-home${activePath ? "" : " active"}`}
         >
           {homeLabel}
@@ -33,7 +39,7 @@ export function DocsShell({
                   return (
                     <li key={page.path}>
                       <Link
-                        href={`/docs/${page.path}`}
+                        href={withDraft(`/docs/${page.path}`, draft)}
                         className={`docs-nav-link${
                           activePath === page.path ? " active" : ""
                         }`}

--- a/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
@@ -218,6 +218,22 @@ describe("docs/strapi", () => {
     expect(capturedStatus).toBe("draft");
   });
 
+  it("requests draft content for the page list when draft option is set", async () => {
+    let capturedStatus: string | null = null;
+
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedStatus = url.searchParams.get("status");
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    await getDocsPagesFromStrapi("en", { draft: true });
+
+    expect(capturedStatus).toBe("draft");
+  });
+
   it("throws when Strapi fetch fails", async () => {
     server.use(
       http.get(`${STRAPI_URL}/api/docs-pages`, () => {

--- a/turbo/apps/web/app/lib/docs/data-source.ts
+++ b/turbo/apps/web/app/lib/docs/data-source.ts
@@ -5,8 +5,11 @@ import type {
 } from "./types";
 import { getDocsPageByPathFromStrapi, getDocsPagesFromStrapi } from "./strapi";
 
-export async function getDocsPages(locale: string = "en"): Promise<DocsPage[]> {
-  return getDocsPagesFromStrapi(locale);
+export async function getDocsPages(
+  locale: string = "en",
+  options: { draft?: boolean } = {},
+): Promise<DocsPage[]> {
+  return getDocsPagesFromStrapi(locale, options);
 }
 
 export async function getDocsPage(
@@ -62,8 +65,9 @@ export function buildDocsNavigation(
 
 export async function getDocsNavigation(
   locale: string = "en",
+  options: { draft?: boolean } = {},
 ): Promise<DocsNavigationSection[]> {
-  return buildDocsNavigation(await getDocsPages(locale));
+  return buildDocsNavigation(await getDocsPages(locale, options));
 }
 
 export async function getDocsAvailableLocales(

--- a/turbo/apps/web/app/lib/docs/strapi.ts
+++ b/turbo/apps/web/app/lib/docs/strapi.ts
@@ -179,24 +179,33 @@ function compareDocsPages(a: DocsPage, b: DocsPage): number {
   );
 }
 
-function buildBaseDocsParams(locale: string): URLSearchParams {
+function buildBaseDocsParams(
+  locale: string,
+  draft: boolean = false,
+): URLSearchParams {
   const params = new URLSearchParams();
   params.set("locale", locale);
   params.set("pagination[pageSize]", "100");
   params.append("populate[0]", "blocks");
   params.append("sort[0]", "order:asc");
   params.append("sort[1]", "title:asc");
+  if (draft) {
+    params.set("status", "draft");
+  }
   return params;
 }
 
 export async function getDocsPagesFromStrapi(
   locale: string = "en",
+  options: { draft?: boolean } = {},
 ): Promise<DocsPage[]> {
-  const params = buildBaseDocsParams(locale);
+  const params = buildBaseDocsParams(locale, options.draft);
   const url = `${getStrapiUrl()}/api/docs-pages?${params.toString()}`;
 
   const res = await fetch(url, {
-    next: { revalidate: 3600 },
+    ...(options.draft
+      ? { cache: "no-store" as const }
+      : { next: { revalidate: 3600 } }),
     signal: AbortSignal.timeout(10_000),
   });
 
@@ -223,12 +232,9 @@ export async function getDocsPageByPathFromStrapi(
   options: { draft?: boolean } = {},
 ): Promise<DocsPage | null> {
   const normalizedPath = normalizeDocsPath(path);
-  const params = buildBaseDocsParams(locale);
+  const params = buildBaseDocsParams(locale, options.draft);
   params.set("filters[$or][0][path][$eq]", normalizedPath);
   params.set("filters[$or][1][slug][$eq]", normalizedPath);
-  if (options.draft) {
-    params.set("status", "draft");
-  }
 
   const url = `${getStrapiUrl()}/api/docs-pages?${params.toString()}`;
 


### PR DESCRIPTION
## Summary

- The docs detail route already honors `?status=draft` for the page body, but `/docs?status=draft` and the `DocsShell` sidebar both read published content only. Draft-only pages are therefore invisible from the index, and the sidebar around a draft page still shows the published structure.
- Thread an optional `{ draft?: boolean }` through `getDocsPagesFromStrapi`, `getDocsPages`, and `getDocsNavigation`; read `?status=draft` on the index route; and append the same query string to internal links rendered by `DocsShell` so navigation stays in draft mode across clicks.
- Backward compatible — all new params are optional and default to published behavior.

## Why

Currently staging a docs rewrite is hard: editors can preview one page at a time via the direct draft URL, but the index card grid and sidebar never include drafts of new pages, so reviewers can't browse the reorganized IA in place. This change makes `/docs?status=draft` a true preview surface.

## Test plan

- [x] `pnpm exec eslint` on touched files — passes
- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm prettier --check` on touched files — passes
- [x] `pnpm knip --workspace apps/web` — passes
- [x] Added a unit test for `getDocsPagesFromStrapi("en", { draft: true })` asserting `status=draft` query param
- [ ] Vitest suite (deferred to CI — no local Postgres in this environment)
- [ ] After deploy: open `https://www.vm0.ai/en/docs?status=draft` signed-in and confirm the new IA appears in the card grid and sidebar; click around to confirm `?status=draft` is preserved in nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)