### PR TITLE
fix(platform): state-aware OAuth CTA (Connect → Authorize)

### DIFF
--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -129,12 +129,23 @@ describe("connect modal - display", () => {
 });
 
 describe("connect modal - content by auth method", () => {
-  it("shows OAuth button for OAuth connectors (CONN-C-018)", async () => {
+  it("shows Connect button for OAuth connectors not yet connected (CONN-C-018)", async () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
     });
+  });
+
+  it("shows Authorize button for OAuth connectors already connected", async () => {
+    mockConnectors([{ type: "github" }]);
+
+    await openConnectModal("github");
+
+    await waitFor(() => {
+      expect(screen.getByText("Authorize")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Connect")).not.toBeInTheDocument();
   });
 
   it("shows device auth code before opening provider verification", async () => {
@@ -167,9 +178,6 @@ describe("connect modal - content by auth method", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByText("Sign in with Test OAuth Device (internal)"),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Connection methods unavailable"),
     ).not.toBeInTheDocument();
@@ -338,10 +346,10 @@ describe("connect modal - content by auth method", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Connect"));
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
@@ -365,7 +373,7 @@ describe("connect modal - content by auth method", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with Deel")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
     });
 
     expect(
@@ -407,10 +415,10 @@ describe("connect modal - loading states", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Connect"));
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
@@ -430,10 +438,10 @@ describe("connect modal - interactions", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Connect"));
 
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledWith(
@@ -599,10 +607,10 @@ describe("connect modal - state management", () => {
     await openConnectModal("github");
 
     await waitFor(() => {
-      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Connect")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Sign in with GitHub"));
+    click(screen.getByText("Connect"));
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -253,13 +253,11 @@ function getOAuthAuthCodeProgressContent({
 
 function OAuthAuthCodeConnectButton({
   item,
-  label,
   onSuccess,
   showPermissionDialogOnConnect,
   connectOAuthAuthCodeAndSettle,
   signal,
 }: ConnectModalContentProps & {
-  label: string;
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   signal: AbortSignal;
 }) {
@@ -281,7 +279,7 @@ function OAuthAuthCodeConnectButton({
       }}
       className="w-full"
     >
-      Sign in with {label}
+      {item.connected ? "Authorize" : "Connect"}
     </Button>
   );
 }
@@ -290,7 +288,6 @@ function OAuthAuthCodeConnectMethodContent(props: ConnectMethodContentProps) {
   return (
     <OAuthAuthCodeConnectButton
       item={props.item}
-      label={CONNECTOR_TYPES[props.item.type].label}
       onSuccess={props.onSuccess}
       showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
       connectOAuthAuthCodeAndSettle={props.connectOAuthAuthCodeAndSettle}


### PR DESCRIPTION
## Summary

Replaces the static `Sign in with {Provider}` label on the OAuth auth-code button with a state-aware copy:

- `item.connected === false` → **Connect** (user hasn't linked this provider yet — clicking runs OAuth + agent grant in one shot, existing behavior)
- `item.connected === true` → **Authorize** (provider already linked — clicking re-runs OAuth + grants the current agent, existing behavior)

No new endpoints, no toggle/revoke behavior — only the label reflects state. Closes the earlier #14927 which always read `Authorize` regardless of state.

This matches Ming's spec from the Slack thread: "用户没有这个 connector，点击 connect" vs "已经链接了，应该显示 Authorize".

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run views/conn/__tests__/add-connection-dialog.test.tsx` — 33 / 33 passing (new test covers the Authorize-when-connected case)
- [x] `pnpm -F @vm0/app check-types` — clean
- [x] `pnpm -F @vm0/app lint` — clean
- [ ] Manual: open Connect dialog for an unlinked OAuth connector → button reads `Connect`
- [ ] Manual: open Connect dialog for an already-linked OAuth connector → button reads `Authorize`
- [ ] Manual: confirm Stripe CLI-auth flow still reads `Sign in with Stripe` (different code path, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)