### PR TITLE
fix: make gallery route public

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const clerkState = vi.hoisted(() => {
+  return {
+    protectedPaths: [] as string[],
+  };
+});
+
+type ClerkHandler = (
+  auth: { protect: () => Promise<void> },
+  request: NextRequest,
+) => Promise<NextResponse | undefined>;
+
+function routePatternToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+?^${}[\]|\\]/g, "\\$&")
+    .replace(/\/:[^/]+/g, "/[^/]+")
+    .replace(/\\\(\\.\\\*\\\)/g, ".*");
+
+  return new RegExp(`^${escaped}$`);
+}
+
+vi.mock("@clerk/nextjs/server", () => {
+  return {
+    clerkMiddleware: vi.fn((handler: ClerkHandler) => {
+      return vi.fn(async (request: NextRequest) => {
+        const auth = {
+          protect: async () => {
+            clerkState.protectedPaths.push(request.nextUrl.pathname);
+          },
+        };
+        const result = await handler(auth, request);
+        return result ?? NextResponse.next();
+      });
+    }),
+    createRouteMatcher: vi.fn((patterns: string[]) => {
+      const regexes = patterns.map(routePatternToRegex);
+      return (request: NextRequest) => {
+        return regexes.some((regex) => {
+          return regex.test(request.nextUrl.pathname);
+        });
+      };
+    }),
+  };
+});
+
+vi.mock("next-intl/middleware", () => {
+  return {
+    default: () => {
+      return () => {
+        return NextResponse.next();
+      };
+    },
+  };
+});
+
+let middleware: typeof import("../proxy").default;
+
+function createMockEvent() {
+  return {
+    sourcePage: "/test",
+    waitUntil: vi.fn(),
+  } as never;
+}
+
+describe("proxy middleware: public routes", () => {
+  beforeAll(async () => {
+    middleware = (await import("../proxy")).default;
+  });
+
+  beforeEach(() => {
+    clerkState.protectedPaths = [];
+  });
+
+  it("keeps locale-prefixed gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/gallery");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("keeps locale-less gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/gallery");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("still protects non-public page routes", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/lab");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual(["/en/lab"]);
+  });
+});

--- a/turbo/apps/web/app/[locale]/gallery/data.ts
+++ b/turbo/apps/web/app/[locale]/gallery/data.ts
@@ -94,7 +94,7 @@ export const GALLERY_ITEMS: readonly GalleryItem[] = [
     description:
       "A source-backed report example that treats tables and charts as supporting assets inside one output directory.",
     prompt:
-      "Generate a concise executive report about multimodal generation usage trends. Include a summary, ranked opportunities, risks, and a clear recommendation section. Use realistic placeholder data if live sources are unavailable.",
+      "Create a polished executive report website about multimodal generation usage trends using Zero's built-in generation flow. The final output should be a shareable website, not just a text response. Use realistic placeholder data if live sources are not available. Include a concise summary, clear trend charts, ranked opportunities, key risks, and a recommendation section with a strong point of view. Use the data-report skill for the analysis structure and the finance-report template for the layout.",
     previewImage: "/assets/bg_4.webp",
     previewKind: "website",
     generationKind: "report",

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -35,6 +35,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/use-cases/:slug/opengraph-image",
   "/rankings",
   "/:locale/rankings",
+  "/gallery",
+  "/:locale/gallery",
   "/terms-of-use",
   "/privacy-policy",
   "/support",


### PR DESCRIPTION
## Summary
- add `/gallery` and `/:locale/gallery` to the web public route matcher
- add proxy coverage proving gallery routes do not call `auth.protect()` while non-public pages still do

## Verification
- `pnpm exec prettier --check apps/web/proxy.ts apps/web/__tests__/proxy.public-routes.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web check-types`
- `pnpm exec vitest run __tests__/proxy.public-routes.test.ts __tests__/proxy.locale-guard.test.ts __tests__/proxy.legal-pages.test.ts --config vitest.proxy-local.config.ts` (temporary no-DB local config)

Note: `pnpm --filter web test -- __tests__/proxy.public-routes.test.ts` was blocked by local Postgres not running for the web global setup (`ECONNREFUSED localhost:5432`).