### PR TITLE
fix(web): order docs sections by intended reading order

### DIFF
--- a/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
@@ -119,7 +119,7 @@ describe("docs/strapi", () => {
     expect(pages[0]?.section).toEqual({
       title: "Getting Started",
       slug: "getting-started",
-      order: 0,
+      order: 20,
     });
   });
 

--- a/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
@@ -218,6 +218,62 @@ describe("docs/strapi", () => {
     expect(capturedStatus).toBe("draft");
   });
 
+  it("orders known sections by intended reading order, not alphabetically", async () => {
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 100,
+              title: "Skills",
+              slug: "skills",
+              path: "skills",
+              section: "Core concepts",
+              order: 10,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+              publishedAt: "2026-01-01T00:00:00.000Z",
+              body: "Skills body.",
+            },
+            {
+              id: 101,
+              title: "Quickstart",
+              slug: "quickstart",
+              path: "quickstart",
+              section: "Get started",
+              order: 10,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+              publishedAt: "2026-01-01T00:00:00.000Z",
+              body: "Quickstart body.",
+            },
+            {
+              id: 102,
+              title: "What is Zero?",
+              slug: "what-is-zero",
+              path: "what-is-zero",
+              section: "Overview",
+              order: 10,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+              publishedAt: "2026-01-01T00:00:00.000Z",
+              body: "Overview body.",
+            },
+          ],
+          meta: {},
+        });
+      }),
+    );
+
+    const pages = await getDocsPagesFromStrapi("en");
+
+    expect(
+      pages.map((page) => {
+        return page.section.title;
+      }),
+    ).toEqual(["Overview", "Get started", "Core concepts"]);
+  });
+
   it("requests draft content for the page list when draft option is set", async () => {
     let capturedStatus: string | null = null;
 

--- a/turbo/apps/web/app/lib/docs/strapi.ts
+++ b/turbo/apps/web/app/lib/docs/strapi.ts
@@ -115,6 +115,23 @@ function resolvePathAndSlug(page: StrapiDocsPage): {
   return { path, slug };
 }
 
+// Sections are stored as free-text strings on docs-page, so the data layer
+// has no natural ordering for them. This map encodes the intended reading
+// order; sections not listed sort to the end alphabetically.
+const SECTION_ORDER: Record<string, number> = {
+  Overview: 10,
+  "Get started": 20,
+  "Getting Started": 20,
+  "Core concepts": 30,
+  "Core Concepts": 30,
+  "What Zero delivers": 40,
+  Channels: 50,
+  Connectors: 60,
+  "Who it's for": 70,
+};
+
+const UNKNOWN_SECTION_ORDER = 1000;
+
 function resolveSection(
   section: string | StrapiDocsSection | undefined,
 ): DocsSection {
@@ -123,14 +140,20 @@ function resolveSection(
     if (!title) {
       return { title: "Docs", slug: "docs", order: 0 };
     }
-    return { title, slug: slugify(title), order: 0 };
+    return {
+      title,
+      slug: slugify(title),
+      order: SECTION_ORDER[title] ?? UNKNOWN_SECTION_ORDER,
+    };
   }
   const sectionTitle = section?.title || section?.name || "Docs";
   const sectionSlug = section?.slug || slugify(sectionTitle);
+  const explicitOrder = section?.order;
   return {
     title: sectionTitle,
     slug: sectionSlug,
-    order: section?.order ?? 0,
+    order:
+      explicitOrder ?? SECTION_ORDER[sectionTitle] ?? UNKNOWN_SECTION_ORDER,
   };
 }
 


### PR DESCRIPTION
## Summary

- `DocsSection.order` was hard-coded to `0` for any section stored as a free-text string (the only form actually used today), so `compareDocsPages` fell back to alphabetical sort on section title. Live `/docs` reads `Core Concepts → Getting Started → Overview` — the opposite of the intended order.
- Add a small `SECTION_ORDER` map in `resolveSection` that gives the known docs sections their intended order while leaving unrecognized sections at the end.
- Recognizes both the legacy capitalized titles (`Getting Started`, `Core Concepts`) and the new sentence-case ones (`Get started`, `Core concepts`) so the published site and the in-flight drafts both order correctly.

## Visual result

Before: `Core Concepts · Getting Started · Overview · Connectors`
After:  `Overview · Get started · Core concepts · What Zero delivers · Channels · Connectors · Who it's for`

## Test plan

- [x] Added an integration test in `strapi.test.ts` that mocks three pages from three known sections in scrambled alphabetical order and asserts they come back in `Overview → Get started → Core concepts` order.
- [x] `pnpm exec eslint` on touched files — passes
- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm prettier --write` — formatted
- [x] `pnpm knip --workspace apps/web` — passes
- [ ] After deploy: open `https://www.vm0.ai/en/docs` and `/docs?status=draft` and confirm the sidebar lists sections in the intended order

🤖 Generated with [Claude Code](https://claude.com/claude-code)