### PR TITLE
chore: update notion illustration source ref

### DIFF
--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -310,7 +310,7 @@ describe("zero built-in generate image command", () => {
               id: "vm0:image-style:notion-illustration",
               source: expect.objectContaining({
                 repo: "vm0-ai/vm0-skills",
-                commit: "b35373eb12112b1e7a0caa372a5cafe02e214dd1",
+                commit: "main",
                 path: "notion-illustration",
               }),
             }),

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -102,7 +102,7 @@ export interface OpenDesignCandidateSlice {
 const OPEN_DESIGN_REPO = "vm0-ai/open-design";
 const OPEN_DESIGN_COMMIT = "d021b04720ace133f1d6133d1487326f5fc28f07";
 const VM0_SKILLS_REPO = "vm0-ai/vm0-skills";
-const NOTION_ILLUSTRATION_COMMIT = "b35373eb12112b1e7a0caa372a5cafe02e214dd1";
+const VM0_SKILLS_REF = "main";
 
 const OPEN_DESIGN_REGISTRY_VERSION = `federated:${OPEN_DESIGN_REPO}@${OPEN_DESIGN_COMMIT}`;
 
@@ -402,11 +402,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     name: "Notion Illustration",
     description:
       "Zero-native illustration style for hand-drawn product spot illustrations with simple ink contours and soft backgrounds.",
-    source: sourceRef(
-      VM0_SKILLS_REPO,
-      NOTION_ILLUSTRATION_COMMIT,
-      "notion-illustration",
-    ),
+    source: sourceRef(VM0_SKILLS_REPO, VM0_SKILLS_REF, "notion-illustration"),
     targets: ["image", "website", "poster", "presentation", "report"],
     tags: ["image", "illustration", "notion", "spot", "hand-drawn", "product"],
     triggers: [
@@ -563,7 +559,7 @@ export function selectOpenDesignCandidates(options: {
       },
       {
         repo: VM0_SKILLS_REPO,
-        commit: NOTION_ILLUSTRATION_COMMIT,
+        commit: VM0_SKILLS_REF,
       },
     ],
     candidates: {


### PR DESCRIPTION
## Summary
- update the Notion Illustration registry source ref to use the vm0-skills main branch
- use repo-level `VM0_SKILLS_REF` for the vm0-skills ref instead of a style-specific constant
- update the styled image metadata test expectation to main

## Validation
- `git diff --check`
- `pnpm exec prettier --check apps/cli/src/commands/zero/shared/open-design-registry.ts apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/cli check-types`
- `env -u ZERO_TOKEN -u VM0_TOKEN pnpm exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts`