### PR TITLE
refactor(runner): deduplicate completion retry call

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -218,19 +218,23 @@ impl JobProvider for ApiProvider {
             }
         };
 
-        if let Err(e) = self
-            .api
-            .complete(&token, run_id, exit_code, error, sandbox_id, reuse_result)
-            .await
-        {
-            warn!(run_id = %run_id, error = %e, "completion report failed, retrying");
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            if let Err(e) = self
+        const MAX_ATTEMPTS: usize = 2;
+        const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            match self
                 .api
                 .complete(&token, run_id, exit_code, error, sandbox_id, reuse_result)
                 .await
             {
-                error!(run_id = %run_id, error = %e, "failed to report completion after retry");
+                Ok(()) => return,
+                Err(e) if attempt < MAX_ATTEMPTS => {
+                    warn!(run_id = %run_id, error = %e, "completion report failed, retrying");
+                    tokio::time::sleep(RETRY_DELAY).await;
+                }
+                Err(e) => {
+                    error!(run_id = %run_id, error = %e, "failed to report completion after retry");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace the hand-unrolled completion retry in `ApiProvider::complete` with a local two-attempt loop.
- Keep the existing retry behavior unchanged: first attempt is immediate, one retry happens after a 2-second delay, and the original warn/error log messages are preserved.

Closes #14925

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner api_provider_complete`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`, `commitlint`
