### PR TITLE
test: verify mitmproxy billing e2e

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -797,7 +797,7 @@ jobs:
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           WEB_API_ENV_FILE: ${{ steps.web-build-env.outputs.file }}
-          DEV_MODEL_ANTHROPIC_KEY: fake-key
+          DEV_MODEL_ANTHROPIC_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY || 'fake-key' }}
           DEV_MODEL_DEEPSEEK_KEY: fake-key
         run: |
           while IFS= read -r line; do

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -50,6 +50,7 @@ _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
+_usage_flush_requested = threading.Event()
 _usage_flush_signal_lock = threading.Lock()
 
 # ============================================================================
@@ -107,29 +108,49 @@ def configure(updated: set[str]) -> None:
 
 def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
     del signum
+    _usage_flush_requested.set()
+    _start_usage_flush_worker()
+
+
+def _start_usage_flush_worker() -> None:
+    if not _usage_flush_signal_lock.acquire(blocking=False):
+        return
+
     thread = threading.Thread(
-        target=_flush_usage_for_runner_request,
+        target=_run_usage_flush_worker,
         name="usage-flush-request",
         daemon=True,
     )
-    thread.start()
+    started = False
+    try:
+        thread.start()
+        started = True
+    finally:
+        if not started:
+            _usage_flush_signal_lock.release()
+
+
+def _run_usage_flush_worker() -> None:
+    try:
+        while True:
+            _usage_flush_requested.clear()
+            _flush_usage_for_runner_request()
+            if not _usage_flush_requested.is_set():
+                return
+    finally:
+        _usage_flush_signal_lock.release()
+        if _usage_flush_requested.is_set():
+            _start_usage_flush_worker()
 
 
 def _flush_usage_for_runner_request() -> None:
-    if not _usage_flush_signal_lock.acquire(blocking=False):
-        return
+    flush_request_id = usage.read_usage_flush_request_id()
     try:
-        flush_request_id = usage.read_usage_flush_request_id()
-        try:
-            usage.flush_usage_events(trigger="runner")
-        except Exception as exc:
-            ctx.log.warn(
-                f"Failed to flush usage events after runner request ({type(exc).__name__})"
-            )
-        finally:
-            usage.write_pending_snapshot(flush_request_id=flush_request_id)
+        usage.flush_usage_events(trigger="runner")
+    except Exception as exc:
+        ctx.log.warn(f"Failed to flush usage events after runner request ({type(exc).__name__})")
     finally:
-        _usage_flush_signal_lock.release()
+        usage.write_pending_snapshot(flush_request_id=flush_request_id)
 
 
 def get_api_url() -> str:

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -15,6 +15,17 @@ from tests.pending_helpers import assert_pending
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
+def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
+    acquired = mitm_addon._usage_flush_signal_lock.acquire(timeout=timeout)
+    assert acquired
+    mitm_addon._usage_flush_signal_lock.release()
+
+
+def reset_runner_usage_flush_state() -> None:
+    mitm_addon._usage_flush_requested.clear()
+    wait_for_usage_flush_worker_to_stop()
+
+
 class TestDoneHook:
     """Tests for the done() graceful shutdown hook."""
 
@@ -80,8 +91,7 @@ class TestDoneHook:
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
         ):
-            runner_thread = threading.Thread(target=mitm_addon._flush_usage_for_runner_request)
-            runner_thread.start()
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
             assert runner_flush_started.wait(timeout=1)
 
             done_thread = threading.Thread(target=mitm_addon.done)
@@ -90,10 +100,8 @@ class TestDoneHook:
             assert not shutdown_called.is_set()
 
             release_runner_flush.set()
-            runner_thread.join(timeout=1)
             done_thread.join(timeout=1)
 
-        assert not runner_thread.is_alive()
         assert not done_thread.is_alive()
         assert calls == ["flush:runner", "flush:shutdown", "shutdown:True"]
 
@@ -119,6 +127,7 @@ class TestRunnerUsageFlushSignal:
     """Tests for runner-triggered usage buffer flush requests."""
 
     def test_signal_handler_flushes_usage_in_background(self, tmp_path):
+        reset_runner_usage_flush_state()
         flushed = threading.Event()
         snapshotted = threading.Event()
         pending_path = tmp_path / "usage-pending"
@@ -159,6 +168,7 @@ class TestRunnerUsageFlushSignal:
                 mitm_addon._handle_runner_usage_flush_signal(0, None)
                 assert flushed.wait(timeout=1)
                 assert snapshotted.wait(timeout=1)
+                wait_for_usage_flush_worker_to_stop()
 
             assert_pending(
                 pending_path,
@@ -171,6 +181,7 @@ class TestRunnerUsageFlushSignal:
             usage.set_pending_path("")
 
     def test_signal_handler_writes_snapshot_when_flush_fails(self, tmp_path):
+        reset_runner_usage_flush_state()
         snapshotted = threading.Event()
         pending_path = tmp_path / "usage-pending"
         request_path = tmp_path / "usage-flush-request"
@@ -208,6 +219,7 @@ class TestRunnerUsageFlushSignal:
             ):
                 mitm_addon._handle_runner_usage_flush_signal(0, None)
                 assert snapshotted.wait(timeout=1)
+                wait_for_usage_flush_worker_to_stop()
 
             assert_pending(
                 pending_path,
@@ -237,6 +249,63 @@ class TestRunnerUsageFlushSignal:
         message = log.warn.call_args.args[0]
         assert "RuntimeError" in message
         assert "secret-token" not in message
+
+    def test_signal_during_active_flush_runs_follow_up_flush(self):
+        reset_runner_usage_flush_state()
+        first_flush_started = threading.Event()
+        release_first_flush = threading.Event()
+        second_flush_completed = threading.Event()
+        worker_timed_out = threading.Event()
+        flush_triggers: list[str] = []
+
+        def flush_usage_events(*, trigger: str) -> int:
+            flush_triggers.append(trigger)
+            if len(flush_triggers) == 1:
+                first_flush_started.set()
+                if not release_first_flush.wait(timeout=2):
+                    worker_timed_out.set()
+            else:
+                second_flush_completed.set()
+            return 0
+
+        with patch.object(usage, "flush_usage_events", side_effect=flush_usage_events):
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            assert first_flush_started.wait(timeout=1)
+
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            release_first_flush.set()
+
+            assert second_flush_completed.wait(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+        assert not worker_timed_out.is_set()
+        assert flush_triggers == ["runner", "runner"]
+
+    def test_failed_signal_flush_releases_worker_for_later_signal(self, mitm_ctx):
+        reset_runner_usage_flush_state()
+        second_flush_completed = threading.Event()
+        flush_triggers: list[str] = []
+
+        def flush_usage_events(*, trigger: str) -> int:
+            flush_triggers.append(trigger)
+            if len(flush_triggers) == 1:
+                raise RuntimeError("flush failed")
+            second_flush_completed.set()
+            return 0
+
+        with (
+            mitm_ctx() as log,
+            patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
+        ):
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            wait_for_usage_flush_worker_to_stop()
+
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            assert second_flush_completed.wait(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+        log.warn.assert_called_once()
+        assert flush_triggers == ["runner", "runner"]
 
 
 class TestTlsClienthello:

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use agent_diagnostics::{FailureClass, FailureDiagnostic, FailureReason};
 use futures_util::FutureExt;
 use sandbox::SandboxId;
+use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -63,6 +64,8 @@ pub(super) struct SpawnContext {
     /// This eliminates the up-to-10s blind spot where the server doesn't know
     /// which runner holds a newly-parked session.
     pub(super) park_notify: Arc<tokio::sync::Notify>,
+    /// Best-effort signal for the main loop to ask mitmproxy to flush usage.
+    pub(super) usage_flush_tx: mpsc::Sender<()>,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
     #[cfg(test)]
     pub(super) outer_job_panic: Option<OuterJobPanicPoint>,
@@ -118,6 +121,7 @@ pub(super) fn spawn_job(
     let status = Arc::clone(&ctx.status);
     let idle_pool = Arc::clone(&ctx.idle_pool);
     let park_notify = Arc::clone(&ctx.park_notify);
+    let usage_flush_tx = ctx.usage_flush_tx.clone();
     let parking_gate = ctx.parking_gate.clone();
     let factory_for_cleanup = Arc::clone(&factory);
     let cleanup_state = RunCleanupState::new();
@@ -280,6 +284,12 @@ pub(super) fn spawn_job(
             .await;
 
             // Structural guarantee: claim (in provider) is always paired with complete.
+            match usage_flush_tx.try_send(()) {
+                Ok(()) | Err(mpsc::error::TrySendError::Full(())) => {}
+                Err(mpsc::error::TrySendError::Closed(())) => {
+                    warn!(run_id = %run_id, "proxy usage flush signal channel closed before completion");
+                }
+            }
             let ownership = OwnershipTransitions::new(status.as_ref());
             completion_ready
                 .complete_and_release(provider.as_ref(), &ownership, &cleanup_state_for_body)

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -578,6 +578,7 @@ enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     IdleCleanupProcessed { expired_count: usize },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
+    UsageFlushRequested,
 }
 
 #[cfg(test)]
@@ -682,6 +683,10 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
     }
 
+    fn notify_usage_flush_requested(&self) {
+        self.record(StartLoopEvent::UsageFlushRequested);
+    }
+
     async fn wait_budget_exhausted_reactor(&self, timeout: Duration) {
         self.wait_for(timeout, "budget-exhausted reactor entry", |event| {
             matches!(event, StartLoopEvent::BudgetExhaustedReactorEntered).then_some(())
@@ -714,6 +719,13 @@ impl StartLoopTestObserver {
                 _ => None,
             },
         )
+        .await
+    }
+
+    async fn wait_usage_flush_requested(&self, timeout: Duration) {
+        self.wait_for(timeout, "usage flush request", |event| {
+            matches!(event, StartLoopEvent::UsageFlushRequested).then_some(())
+        })
         .await
     }
 }
@@ -939,6 +951,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // immediate heartbeat after parking a VM, so the server learns about the
     // new heldSession without waiting for the next 10-second tick.
     let park_notify = Arc::new(tokio::sync::Notify::new());
+    let (usage_flush_tx, mut usage_flush_rx) = tokio::sync::mpsc::channel(1);
     let orphaned_active_runs = OrphanedActiveRuns::new();
     let mut orphan_reap_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + Duration::from_secs(10),
@@ -966,6 +979,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         orphaned_active_runs: orphaned_active_runs.clone(),
         parking_gate: parking_gate.clone(),
         park_notify: Arc::clone(&park_notify),
+        usage_flush_tx,
         device_rate_limits: device_rate_limits.clone(),
         #[cfg(test)]
         outer_job_panic,
@@ -1111,6 +1125,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     ).await;
                 }
             }
+            Some(()) = usage_flush_rx.recv() => {
+                #[cfg(test)]
+                test_observer.notify_usage_flush_requested();
+                mitm.request_usage_flush();
+            }
             // Reconcile active runs left visible after an outer job-task panic.
             _ = orphan_reap_tick.tick(), if !orphaned_active_runs.is_empty() => {
                 reap_orphaned_active_runs(
@@ -1226,6 +1245,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             orphan_reap_process_discovery.as_ref(),
                         ).await;
                     }
+                }
+                Some(()) = usage_flush_rx.recv() => {
+                    #[cfg(test)]
+                    test_observer.notify_usage_flush_requested();
+                    mitm.request_usage_flush();
                 }
                 Some(result) = destroy_tasks.join_next() => {
                     if let Err(e) = result {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -4,11 +4,84 @@ use super::support::{
     mock_run_config_with_api_url, mock_run_config_with_delay, mock_run_config_with_overrides,
     push_job, shutdown, test_profiles, wait_budget_count, wait_budget_exhausted_reactor,
     wait_cancel_token, wait_cancel_token_removed, wait_discover_entered, wait_parking_state,
-    wait_status_mode,
+    wait_status_mode, wait_usage_flush_requested,
 };
 
 use super::super::signals::{SignalController, SignalHandlerTask, handle_resume_signal};
 use crate::idle_pool::ParkingState;
+
+fn usage_pending_path(base_dir: &std::path::Path) -> std::path::PathBuf {
+    base_dir.join("mitm-addon").join("usage-pending")
+}
+
+fn usage_test_now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn write_usage_pending_state(
+    base_dir: &std::path::Path,
+    usage_state_id: &str,
+    flows: u32,
+    buffered: u32,
+    reports: u32,
+) {
+    let addon_dir = base_dir.join("mitm-addon");
+    std::fs::create_dir_all(&addon_dir).unwrap();
+    std::fs::write(
+        usage_pending_path(base_dir),
+        serde_json::json!({
+            "pid": std::process::id(),
+            "usageStateId": usage_state_id,
+            "updatedAtMs": usage_test_now_millis(),
+            "flows": flows,
+            "buffered": buffered,
+            "reports": reports,
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+async fn install_usage_flush_child(config: &mut RunConfig) {
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::io::AsyncBufReadExt;
+
+    let script = config.base_dir.join("usage-flush-child.sh");
+    std::fs::write(
+        &script,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+fifo="$0.fifo"
+mkfifo "$fifo"
+exec 3<>"$fifo"
+trap ':' USR1
+trap 'exit 0' TERM
+echo ready
+while true; do read -r _ <&3 || true; done
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut child = tokio::process::Command::new(&script)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut ready_lines = tokio::io::BufReader::new(stdout).lines();
+    let ready = tokio::time::timeout(Duration::from_secs(2), ready_lines.next_line())
+        .await
+        .expect("usage flush child did not print ready")
+        .unwrap()
+        .expect("usage flush child stdout closed before ready");
+    assert_eq!(ready, "ready");
+    config.mitm.set_child_for_test(child);
+}
 
 // -----------------------------------------------------------------------
 // Test 1: Normal discover → claim → execute → complete
@@ -31,6 +104,34 @@ async fn main_loop_discover_claim_execute_complete() {
     assert_eq!(c.exit_code, 0);
     assert!(c.error.is_none());
 
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn job_completion_requests_proxy_usage_flush_without_waiting() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    install_usage_flush_child(&mut config).await;
+    let usage_state_id = config.mitm.usage_state_id_for_test().to_string();
+    write_usage_pending_state(&config.base_dir, &usage_state_id, 0, 0, 1);
+    let base_dir = config.base_dir.clone();
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        completion.is_some(),
+        "job completion must not wait for proxy usage drain"
+    );
+    wait_usage_flush_requested(&env, Duration::from_secs(5)).await;
+
+    write_usage_pending_state(&base_dir, &usage_state_id, 0, 0, 0);
     shutdown(&env, run_handle).await;
 }
 

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -55,9 +55,20 @@ async fn install_usage_flush_child(config: &mut RunConfig) {
         r#"#!/usr/bin/env bash
 set -euo pipefail
 fifo="$0.fifo"
+base_dir="$(dirname "$0")"
+request="$base_dir/mitm-addon/usage-flush-request"
+pending="$base_dir/mitm-addon/usage-pending"
+write_pending_snapshot() {
+  [[ -f "$request" ]] || return 0
+  flush_id="$(sed -n 's/.*"flushRequestId":"\([^"]*\)".*/\1/p' "$request")"
+  state_id="$(sed -n 's/.*"usageStateId":"\([^"]*\)".*/\1/p' "$request")"
+  [[ -n "$flush_id" && -n "$state_id" ]] || return 0
+  now_ms="$(date +%s%3N)"
+  printf '{"pid":%s,"usageStateId":"%s","updatedAtMs":%s,"flows":0,"buffered":0,"reports":0,"flushRequestId":"%s"}' "$$" "$state_id" "$now_ms" "$flush_id" > "$pending"
+}
 mkfifo "$fifo"
 exec 3<>"$fifo"
-trap ':' USR1
+trap write_pending_snapshot USR1
 trap 'exit 0' TERM
 echo ready
 while true; do read -r _ <&3 || true; done

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -22,5 +22,5 @@ pub(super) use self::wait::{
     assert_run_exits_within, wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token,
     wait_cancel_token_removed, wait_discover_entered,
     wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len, wait_idle_pool_sessions,
-    wait_parking_state, wait_sandbox_lifecycle_counts,
+    wait_parking_state, wait_sandbox_lifecycle_counts, wait_usage_flush_requested,
 };

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -202,3 +202,7 @@ pub(in super::super) async fn wait_idle_cleanup_processed_with_expired_entries(
         .wait_idle_cleanup_processed_with_expired_entries(timeout)
         .await
 }
+
+pub(in super::super) async fn wait_usage_flush_requested(env: &MockRunEnv, timeout: Duration) {
+    env.start_observer.wait_usage_flush_requested(timeout).await;
+}

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -651,6 +651,14 @@ impl MitmProxy {
             crash_rx,
         )
     }
+
+    pub fn usage_state_id_for_test(&self) -> &str {
+        &self.usage_state_id
+    }
+
+    pub fn set_child_for_test(&mut self, child: tokio::process::Child) {
+        self.child = Some(child);
+    }
 }
 
 impl Drop for MitmProxy {

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -133,6 +133,35 @@ zero_curl() {
     curl -fsS "${hdrs[@]}" "$@" "$base$path"
 }
 
+zero_usage_runs_response() {
+    local run_id="$1"
+    zero_curl "/api/zero/usage/runs?runId=$run_id&pageSize=1"
+}
+
+wait_for_zero_usage_run() {
+    local run_id="$1"
+    local timeout="${2:-60}"
+    local interval="${ZERO_USAGE_POLL_INTERVAL_S:-2}"
+    local start=$SECONDS
+    local body=""
+    local count=""
+
+    while (( SECONDS - start < timeout )); do
+        if body=$(zero_usage_runs_response "$run_id" 2>&1); then
+            count=$(printf '%s' "$body" | jq -r '.runs | length')
+            if [[ "$count" == "1" ]]; then
+                printf '%s' "$body" | jq -c '.runs[0]'
+                return 0
+            fi
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for usage run $run_id" >&2
+    echo "# Last usage response: $body" >&2
+    return 1
+}
+
 zero_model_provider_id_by_type() {
     local provider_type="$1"
     local body provider_id

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -138,6 +138,41 @@ zero_usage_runs_response() {
     zero_curl "/api/zero/usage/runs?runId=$run_id&pageSize=1"
 }
 
+zero_run_response() {
+    local run_id="$1"
+    zero_curl "/api/zero/runs/$run_id"
+}
+
+wait_for_zero_run_completed() {
+    local run_id="$1"
+    local timeout="${2:-100}"
+    local interval="${ZERO_RUN_POLL_INTERVAL_S:-2}"
+    local start=$SECONDS
+    local body=""
+    local status_value=""
+
+    while (( SECONDS - start < timeout )); do
+        if body=$(zero_run_response "$run_id" 2>&1); then
+            status_value=$(printf '%s' "$body" | jq -r '.status // ""')
+            case "$status_value" in
+                completed)
+                    return 0
+                    ;;
+                failed|timeout|cancelled)
+                    echo "# Run $run_id reached terminal status: $status_value" >&2
+                    echo "# Run response: $body" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for run $run_id to complete" >&2
+    echo "# Last run response: $body" >&2
+    return 1
+}
+
 wait_for_zero_usage_run() {
     local run_id="$1"
     local timeout="${2:-60}"
@@ -159,6 +194,7 @@ wait_for_zero_usage_run() {
 
     echo "# Timed out (${timeout}s) waiting for usage run $run_id" >&2
     echo "# Last usage response: $body" >&2
+    echo "# Run response: $(zero_run_response "$run_id" 2>&1 || true)" >&2
     return 1
 }
 

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -11,6 +11,8 @@
 
 load '../../helpers/setup'
 
+export BATS_TEST_TIMEOUT=180
+
 setup_file() {
     if [ -z "$ANTHROPIC_API_KEY" ]; then
         skip "ANTHROPIC_API_KEY not set — required for real Claude calls"
@@ -65,6 +67,7 @@ teardown_file() {
         return 1
     }
 
+    wait_for_zero_run_completed "$RUN_ID"
     WAIT_FOR_LOG_TIMEOUT=60 wait_for_log "$RUN_ID" --network -- "[model-provider:anthropic-api-key]"
     refute_output --partial '[model-provider:anthropic-api-key $]'
 
@@ -89,6 +92,7 @@ teardown_file() {
         return 1
     }
 
+    wait_for_zero_run_completed "$RUN_ID"
     WAIT_FOR_LOG_TIMEOUT=60 wait_for_log "$RUN_ID" --network -- '[model-provider:anthropic-api-key $]'
 
     usage_run=$(wait_for_zero_usage_run "$RUN_ID")

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -67,6 +67,9 @@ teardown_file() {
 
     WAIT_FOR_LOG_TIMEOUT=60 wait_for_log "$RUN_ID" --network -- "[model-provider:anthropic-api-key]"
     refute_output --partial '[model-provider:anthropic-api-key $]'
+
+    usage_body=$(zero_usage_runs_response "$RUN_ID")
+    assert_equal "$(printf '%s' "$usage_body" | jq -r '.runs | length')" "0"
 }
 
 @test "t54-1: vm0 meta-provider — firewall billable" {
@@ -87,4 +90,11 @@ teardown_file() {
     }
 
     WAIT_FOR_LOG_TIMEOUT=60 wait_for_log "$RUN_ID" --network -- '[model-provider:anthropic-api-key $]'
+
+    usage_run=$(wait_for_zero_usage_run "$RUN_ID")
+    assert_equal "$(printf '%s' "$usage_run" | jq -r '.runId')" "$RUN_ID"
+    assert_equal "$(printf '%s' "$usage_run" | jq -r '.model')" "claude-sonnet-4-6"
+    jq -e '.inputTokens > 0' <<<"$usage_run" >/dev/null
+    jq -e '.outputTokens > 0' <<<"$usage_run" >/dev/null
+    jq -e '.creditsCharged > 0' <<<"$usage_run" >/dev/null
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
@@ -244,6 +244,23 @@ describe("GET /api/zero/usage/runs", () => {
     });
   });
 
+  it("rejects invalid runId format", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { runId: "not-a-uuid" },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
   it("returns empty result for runId without processed usage", async () => {
     mockClerkUserLookup();
     const fixture = await track(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
@@ -180,6 +180,137 @@ describe("GET /api/zero/usage/runs", () => {
     expect(response.body.runs[1]?.creditsCharged).toBe(50);
   });
 
+  it("filters by runId", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const included = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId, createdAt: createdAt(2) },
+      context.signal,
+    );
+    const excluded = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId, createdAt: createdAt(1) },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: included.runId,
+        inputTokens: 123,
+        outputTokens: 45,
+        creditsCharged: 67,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: excluded.runId,
+        inputTokens: 999,
+        outputTokens: 999,
+        creditsCharged: 999,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { runId: included.runId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.pagination).toStrictEqual({
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]).toMatchObject({
+      runId: included.runId,
+      model: "claude-sonnet-4-6",
+      inputTokens: 123,
+      outputTokens: 45,
+      creditsCharged: 67,
+    });
+  });
+
+  it("returns empty result for runId without processed usage", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const run = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { runId: run.runId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      runs: [],
+      pagination: { page: 1, pageSize: 20, total: 0 },
+    });
+  });
+
+  it("does not leak another org's runId", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const otherFixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const otherRun = await store.set(
+      seedRun$,
+      { orgId: otherFixture.orgId, userId: otherFixture.userId },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: otherFixture.orgId,
+        userId: otherFixture.userId,
+        runId: otherRun.runId,
+        inputTokens: 100,
+        outputTokens: 50,
+        creditsCharged: 25,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { runId: otherRun.runId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      runs: [],
+      pagination: { page: 1, pageSize: 20, total: 0 },
+    });
+  });
+
   it("paginates results correctly", async () => {
     mockClerkUserLookup();
     const fixture = await track(

--- a/turbo/apps/api/src/signals/routes/zero-usage-runs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-runs.ts
@@ -44,6 +44,7 @@ const getUsageRunsInner$ = command(
         orgId: auth.orgId,
         page: query.page,
         pageSize: query.pageSize,
+        runId: query.runId,
         agentId: query.agentId,
         userIds: parseUserIds(query.userIds),
         dateFrom: query.dateFrom,

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -96,6 +96,7 @@ interface UsageRunsArgs {
   readonly orgId: string;
   readonly page: number;
   readonly pageSize: number;
+  readonly runId?: string;
   readonly agentId?: string;
   readonly userIds?: readonly string[];
   readonly dateFrom?: string;
@@ -112,6 +113,9 @@ export const zeroUsageRuns$ = command(
     const eventUsage = buildUsageEventRunUsageTotalsSubquery(db, args.orgId);
     const conditions = [eq(agentRuns.orgId, args.orgId)];
 
+    if (args.runId) {
+      conditions.push(eq(agentRuns.id, args.runId));
+    }
     if (args.agentId) {
       conditions.push(eq(agentComposes.id, args.agentId));
     }

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-daily.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-daily.ts
@@ -42,7 +42,7 @@ export const zeroUsageRunsContract = c.router({
     query: z.object({
       page: z.coerce.number().int().positive().default(1),
       pageSize: z.coerce.number().int().positive().max(100).default(20),
-      runId: z.string().optional(),
+      runId: z.string().uuid().optional(),
       agentId: z.string().optional(),
       // Comma-separated list of user IDs to filter by. Empty string = no filter.
       userIds: z.string().optional(),
@@ -51,6 +51,7 @@ export const zeroUsageRunsContract = c.router({
     }),
     responses: {
       200: usageRunsResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-daily.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-daily.ts
@@ -42,6 +42,7 @@ export const zeroUsageRunsContract = c.router({
     query: z.object({
       page: z.coerce.number().int().positive().default(1),
       pageSize: z.coerce.number().int().positive().max(100).default(20),
+      runId: z.string().optional(),
       agentId: z.string().optional(),
       // Comma-separated list of user IDs to filter by. Empty string = no filter.
       userIds: z.string().optional(),


### PR DESCRIPTION
## Summary
- request a best-effort mitmproxy usage flush signal when runner jobs complete without waiting on billing drain
- add runId filtering to the zero usage runs API for run-scoped assertions
- extend the billable firewall e2e test to assert BYOK is not billed and managed usage is billed

Closes #14926

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-runs.test.ts
- pnpm -F api check-types
- git diff --check