### PR TITLE
feat: register vm0 illustration image style

### DIFF
--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -310,7 +310,7 @@ describe("zero built-in generate image command", () => {
               id: "vm0:image-style:notion-illustration",
               source: expect.objectContaining({
                 repo: "vm0-ai/vm0-skills",
-                commit: "b35373eb12112b1e7a0caa372a5cafe02e214dd1",
+                commit: "main",
                 path: "notion-illustration",
               }),
             }),
@@ -320,6 +320,38 @@ describe("zero built-in generate image command", () => {
     );
     expect(parsed.instructions).toEqual(
       expect.stringContaining("## Stage 2: Resolve Selected Resources"),
+    );
+  });
+
+  it("should include vm0 illustration style for in-app spot prompts", async () => {
+    await zeroBuiltInCommand.parseAsync([
+      "node",
+      "cli",
+      "generate",
+      "image",
+      "--styled",
+      "--prompt",
+      "vm0 style in-app illustration for an empty billing state",
+      "--json",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(parsed.selection).toEqual(
+      expect.objectContaining({
+        candidates: expect.objectContaining({
+          imageStyles: expect.arrayContaining([
+            expect.objectContaining({
+              id: "vm0:image-style:vm0-illustration",
+              source: expect.objectContaining({
+                repo: "vm0-ai/vm0-skills",
+                commit: "main",
+                path: "illustration-template/vm0-illustration",
+              }),
+            }),
+          ]),
+        }),
+      }),
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -102,7 +102,7 @@ export interface OpenDesignCandidateSlice {
 const OPEN_DESIGN_REPO = "vm0-ai/open-design";
 const OPEN_DESIGN_COMMIT = "d021b04720ace133f1d6133d1487326f5fc28f07";
 const VM0_SKILLS_REPO = "vm0-ai/vm0-skills";
-const NOTION_ILLUSTRATION_COMMIT = "b35373eb12112b1e7a0caa372a5cafe02e214dd1";
+const VM0_SKILLS_REF = "main";
 
 const OPEN_DESIGN_REGISTRY_VERSION = `federated:${OPEN_DESIGN_REPO}@${OPEN_DESIGN_COMMIT}`;
 
@@ -402,11 +402,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     name: "Notion Illustration",
     description:
       "Zero-native illustration style for hand-drawn product spot illustrations with simple ink contours and soft backgrounds.",
-    source: sourceRef(
-      VM0_SKILLS_REPO,
-      NOTION_ILLUSTRATION_COMMIT,
-      "notion-illustration",
-    ),
+    source: sourceRef(VM0_SKILLS_REPO, VM0_SKILLS_REF, "notion-illustration"),
     targets: ["image", "website", "poster", "presentation", "report"],
     tags: ["image", "illustration", "notion", "spot", "hand-drawn", "product"],
     triggers: [
@@ -428,6 +424,47 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     remixHint: "prompt-with-resource-hints",
     status: "experimental",
     priority: 18,
+  },
+  {
+    id: "vm0:image-style:vm0-illustration",
+    kind: "image-style",
+    name: "vm0 Illustration",
+    description:
+      "vm0 in-app spot illustration style with bold hand-drawn ink line art, white-filled interiors, and a soft rounded color backdrop.",
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/vm0-illustration",
+    ),
+    targets: ["image", "website", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "spot",
+      "in-app",
+      "empty-state",
+      "hand-drawn",
+      "vm0",
+    ],
+    triggers: [
+      "vm0 style",
+      "in-app illustration",
+      "empty state illustration",
+      "vm0 illustration",
+      "soft rounded color backdrop",
+    ],
+    bestFor: [
+      "in-app empty states",
+      "billing and permission illustrations",
+      "small product state artwork",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 19,
   },
 ];
 
@@ -563,7 +600,7 @@ export function selectOpenDesignCandidates(options: {
       },
       {
         repo: VM0_SKILLS_REPO,
-        commit: NOTION_ILLUSTRATION_COMMIT,
+        commit: VM0_SKILLS_REF,
       },
     ],
     candidates: {


### PR DESCRIPTION
## Summary
- add `vm0:image-style:vm0-illustration` as a separate image-style registry entry
- keep `vm0:image-style:notion-illustration` as a separate entry, but follow #14944 by using shared `VM0_SKILLS_REF = "main"` for vm0-skills sources
- point vm0 Illustration source at `vm0-ai/vm0-skills@main/illustration-template/vm0-illustration`
- add a styled image selection test for vm0 Illustration prompts

## Linked PRs
- vm0-skills resource PR: https://github.com/vm0-ai/vm0-skills/pull/204 (merged)
- smoke follow-up for stricter fill guidance: https://github.com/vm0-ai/vm0-skills/pull/205
- supersedes closed PR: https://github.com/vm0-ai/vm0/pull/14944

## Validation
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts` ✅ 10/10
- registry selection smoke for `vm0 style in-app illustration for an empty billing state` returned `vm0:image-style:vm0-illustration` first
- Notion prompt still returns `vm0:image-style:notion-illustration` first
- `vm0-ai/vm0-skills@main/illustration-template/vm0-illustration/SKILL.md` resolves with HTTP 200
- generation smoke produced a 1024x1024 RGBA PNG artifact: https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/933b07f8-5f25-4ffb-875d-27880f7996ff/image-933b07f8.png
- alpha smoke showed transparent corners/background; visual smoke showed object interior too gray/dark, so #205 tightens pure-white fill guidance