### PR TITLE
fix: require window screenshots for coordinate clicks

### DIFF
--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -168,6 +168,8 @@ interface ComputerUseSnapshotMetadata {
   readonly snapshotId: string;
   readonly elementIdsByIndex?: readonly string[];
   readonly focusedElementIndex?: number;
+  readonly windowId?: number;
+  readonly windowFrame?: ComputerUseCoordinateBounds;
   readonly screenshotWidth: number;
   readonly screenshotHeight: number;
   readonly screenshotSource: "window" | "screen";
@@ -1446,6 +1448,12 @@ async function getAppState(
     ...(indexed.focusedElementIndex !== undefined
       ? { focusedElementIndex: indexed.focusedElementIndex }
       : {}),
+    ...(indexed.snapshot.windowId !== undefined
+      ? { windowId: indexed.snapshot.windowId }
+      : {}),
+    ...(indexed.snapshot.windowFrame
+      ? { windowFrame: indexed.snapshot.windowFrame }
+      : {}),
     screenshotWidth: screenshot.width,
     screenshotHeight: screenshot.height,
     screenshotSource: screenshot.source,
@@ -1489,6 +1497,11 @@ function mapScreenshotPointToScreen(args: {
   | { readonly screenX: number; readonly screenY: number }
   | ComputerUseCommandFailure {
   const { metadata } = args;
+  if (metadata.screenshotSource !== "window") {
+    return unsupportedCommand(
+      `Snapshot is not a target-window screenshot: ${metadata.snapshotId}`,
+    );
+  }
   if (!metadata.sourceBounds) {
     return unsupportedCommand(
       `Snapshot source bounds are unavailable: ${metadata.snapshotId}`,

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1146,6 +1146,12 @@ describe("computer use desktop runtime", () => {
       },
     );
     expect(state.status).toBe("succeeded");
+    expect(snapshotStore.get("Safari", "snap_1")).toMatchObject({
+      screenshotSource: "window",
+      sourceBounds: { x: 100, y: 200, width: 1600, height: 1200 },
+      windowId: 123,
+      windowFrame: { x: 100, y: 200, width: 1600, height: 1200 },
+    });
 
     const click = await executeComputerUseCommand(
       {
@@ -1191,6 +1197,48 @@ describe("computer use desktop runtime", () => {
       button: "right",
       clickCount: 2,
     });
+  });
+
+  it("rejects coordinate clicks against non-window screenshot snapshots", async () => {
+    const snapshotStore = new ComputerUseSnapshotStore();
+    const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
+    snapshotStore.set({
+      app: "Safari",
+      snapshotId: "screen_snap",
+      screenshotWidth: 800,
+      screenshotHeight: 600,
+      screenshotSource: "screen",
+      screenshotSourceName: "Built-in Display",
+      sourceBounds: { x: 0, y: 0, width: 1440, height: 900 },
+    });
+
+    const result = await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "element.click",
+        payload: {
+          app: "Safari",
+          snapshotId: "screen_snap",
+          x: 400,
+          y: 300,
+        },
+      },
+      { accessibility: true, screenRecording: false },
+      {
+        platform: "darwin",
+        snapshotStore,
+        nativeBackend: createNativeBackend({ clickPoint }),
+      },
+    );
+
+    expect(result).toStrictEqual({
+      status: "failed",
+      error: {
+        code: "unsupported_command",
+        message: "Snapshot is not a target-window screenshot: screen_snap",
+      },
+    });
+    expect(clickPoint).not.toHaveBeenCalled();
   });
 
   it("uses fresh native app state for coordinate clicks without a cached snapshot", async () => {


### PR DESCRIPTION
## Summary

- persist native target window id/frame in the Computer Use snapshot cache
- reject coordinate clicks when a cached snapshot is not a target-window screenshot
- add regression coverage so display/screen metadata cannot be used for coordinate mapping

## Validation

- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop build`
- `pnpm exec prettier --check --ignore-unknown apps/desktop/src/computer-use-accessibility.ts apps/desktop/src/window-policy.test.ts`

Fixes #14937
Refs #14933
