### PR TITLE
feat: update notion illustration resource path

### DIFF
--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -311,7 +311,7 @@ describe("zero built-in generate image command", () => {
               source: expect.objectContaining({
                 repo: "vm0-ai/vm0-skills",
                 commit: "main",
-                path: "notion-illustration",
+                path: "illustration-template/notion-illustration",
               }),
             }),
           ]),

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -402,7 +402,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     name: "Notion Illustration",
     description:
       "Zero-native illustration style for hand-drawn product spot illustrations with simple ink contours and soft backgrounds.",
-    source: sourceRef(VM0_SKILLS_REPO, VM0_SKILLS_REF, "notion-illustration"),
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/notion-illustration",
+    ),
     targets: ["image", "website", "poster", "presentation", "report"],
     tags: ["image", "illustration", "notion", "spot", "hand-drawn", "product"],
     triggers: [


### PR DESCRIPTION
## Summary
- update the Notion illustration Open Design registry source path to `illustration-template/notion-illustration`
- keep the existing registry ID `vm0:image-style:notion-illustration` unchanged
- update styled image selection test expectations

## Paired PR
- vm0-skills: https://github.com/vm0-ai/vm0-skills/pull/206

## Validation
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts`
- registry selection smoke returns `vm0:image-style:notion-illustration` first with source path `illustration-template/notion-illustration`
