### PR TITLE
fix: gate marketing pixels to production

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1014,6 +1014,7 @@ jobs:
           skip-finish: "true"
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
+            VITE_VERCEL_ENV=production
             VITE_API_URL=https://www.vm0.ai
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL }}
             VITE_ZERO_HOST_DOMAIN=${{ vars.ZERO_HOST_DOMAIN }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1182,6 +1182,7 @@ jobs:
           deployment-env: app
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
+            VITE_VERCEL_ENV=preview
             VITE_API_URL=${{ needs.prepare.outputs.web-preview-url }}
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL_DEV || vars.PUBLIC_ARTIFACTS_BASE_URL }}
             VITE_ZERO_HOST_DOMAIN=${{ vars.ZERO_HOST_DOMAIN }}

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -3,41 +3,43 @@
   <head>
     <title>Zero</title>
     <meta charset="UTF-8" />
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=AW-18144854014"
-    ></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "AW-18144854014");
-    </script>
-    <!-- LinkedIn Insight Tag -->
-    <script>
-      _linkedin_partner_id = "9378804";
-      window._linkedin_data_partner_ids =
-        window._linkedin_data_partner_ids || [];
-      window._linkedin_data_partner_ids.push(_linkedin_partner_id);
-    </script>
-    <script>
-      (function (l) {
-        if (!l) {
-          window.lintrk = function (a, b) {
-            window.lintrk.q.push([a, b]);
-          };
-          window.lintrk.q = [];
-        }
-        var s = document.getElementsByTagName("script")[0];
-        var b = document.createElement("script");
-        b.type = "text/javascript";
-        b.async = true;
-        b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-        s.parentNode.insertBefore(b, s);
-      })(window.lintrk);
+      (function () {
+        if ("%VITE_VERCEL_ENV%" !== "production") return;
+
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () {
+          window.dataLayer.push(arguments);
+        };
+        window.gtag("js", new Date());
+        window.gtag("config", "AW-18144854014");
+
+        var gtagScript = document.createElement("script");
+        gtagScript.async = true;
+        gtagScript.src =
+          "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
+        document.head.appendChild(gtagScript);
+
+        var linkedInPartnerId = "9378804";
+        window._linkedin_data_partner_ids =
+          window._linkedin_data_partner_ids || [];
+        window._linkedin_data_partner_ids.push(linkedInPartnerId);
+
+        (function (l) {
+          if (!l) {
+            window.lintrk = function (a, b) {
+              window.lintrk.q.push([a, b]);
+            };
+            window.lintrk.q = [];
+          }
+          var s = document.getElementsByTagName("script")[0];
+          var b = document.createElement("script");
+          b.type = "text/javascript";
+          b.async = true;
+          b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+          s.parentNode.insertBefore(b, s);
+        })(window.lintrk);
+      })();
     </script>
     <script>
       // Mark <head> parse start as early as possible so we can measure the
@@ -184,14 +186,5 @@
       crossorigin="anonymous"
       defer
     ></script>
-    <noscript>
-      <img
-        height="1"
-        width="1"
-        style="display: none"
-        alt=""
-        src="https://px.ads.linkedin.com/collect/?pid=9378804&fmt=gif"
-      />
-    </noscript>
   </body>
 </html>

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -19,3 +19,18 @@ describe("platform index.html translation opt-out", () => {
     );
   });
 });
+
+describe("platform index.html marketing scripts", () => {
+  it("gates Google Ads and LinkedIn pixels to production deployments", () => {
+    expect(indexHtml).toContain('"%VITE_VERCEL_ENV%" !== "production"');
+    expect(indexHtml).not.toMatch(
+      /<script[^>]*\bsrc="https:\/\/www\.googletagmanager\.com\/gtag\/js/,
+    );
+    expect(indexHtml).not.toMatch(
+      /<script[^>]*\bsrc="https:\/\/snap\.licdn\.com\/li\.lms-analytics\/insight\.min\.js/,
+    );
+    expect(indexHtml).not.toMatch(
+      /<noscript[\s\S]*px\.ads\.linkedin\.com\/collect/,
+    );
+  });
+});

--- a/turbo/apps/web/app/__tests__/root-layout-marketing-scripts.test.tsx
+++ b/turbo/apps/web/app/__tests__/root-layout-marketing-scripts.test.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import RootLayout from "../layout";
+import { reloadEnv } from "../../src/env";
+
+vi.mock("next/script", () => {
+  return {
+    default: ({
+      children,
+      id,
+      src,
+    }: {
+      children?: ReactNode;
+      id?: string;
+      src?: string;
+    }) => {
+      return (
+        <template data-script-id={id} data-script-src={src}>
+          {children}
+        </template>
+      );
+    },
+  };
+});
+
+vi.mock("next/font/google", () => {
+  const font = () => {
+    return { variable: "font-variable" };
+  };
+
+  return {
+    Fira_Code: font,
+    Fira_Mono: font,
+    JetBrains_Mono: font,
+    Noto_Sans: font,
+  };
+});
+
+vi.mock("next/dynamic", () => {
+  return {
+    default: () => {
+      return function DynamicComponent() {
+        return null;
+      };
+    },
+  };
+});
+
+vi.mock("@clerk/nextjs", () => {
+  return {
+    ClerkProvider: ({ children }: { children: ReactNode }) => {
+      return <>{children}</>;
+    },
+    GoogleOneTap: () => {
+      return null;
+    },
+  };
+});
+
+vi.mock("next-intl/server", () => {
+  return {
+    getLocale: () => {
+      return Promise.resolve("en");
+    },
+  };
+});
+
+async function renderRootLayoutHtml(): Promise<string> {
+  return renderToStaticMarkup(
+    await RootLayout({
+      children: <main>content</main>,
+    }),
+  );
+}
+
+describe("root layout marketing scripts", () => {
+  it("does not load ad pixels in preview deployments", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    reloadEnv();
+
+    const html = await renderRootLayoutHtml();
+
+    expect(html).not.toContain("www.googletagmanager.com/gtag/js");
+    expect(html).not.toContain("AW-18144854014");
+    expect(html).not.toContain(
+      "snap.licdn.com/li.lms-analytics/insight.min.js",
+    );
+    expect(html).not.toContain("px.ads.linkedin.com/collect");
+    expect(html).not.toContain("app.termly.io/resource-blocker");
+  });
+
+  it("loads ad pixels in production deployments", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    reloadEnv();
+
+    const html = await renderRootLayoutHtml();
+
+    expect(html).toContain("www.googletagmanager.com/gtag/js");
+    expect(html).toContain("AW-18144854014");
+    expect(html).toContain("snap.licdn.com/li.lms-analytics/insight.min.js");
+    expect(html).toContain("px.ads.linkedin.com/collect");
+    expect(html).toContain("app.termly.io/resource-blocker");
+  });
+});

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -144,6 +144,8 @@ export default async function RootLayout({
   // Drives the <html lang> attribute so non-English pages are indexed correctly.
   const htmlLang = await getLocale();
   const clerkFapiHost = getClerkFrontendApiHost();
+  const shouldLoadMarketingScripts = env().VERCEL_ENV === "production";
+
   return (
     <ClerkProvider
       publishableKey={getClerkPublishableKey()}
@@ -156,39 +158,43 @@ export default async function RootLayout({
       <SafeGoogleOneTap redirectUrl={getAppUrl()} />
       <html lang={htmlLang} data-theme="dark" suppressHydrationWarning>
         <head>
-          {/*
-            Google Consent Mode v2 default-denied. Must run synchronously in
-            <head> before gtag.js loads so Google itself respects consent and
-            withholds cookies + tracking pings until the user opts in. Inline
-            via dangerouslySetInnerHTML so it ships in SSR HTML with zero
-            network round-trip — any async strategy (incl. beforeInteractive
-            with src) loses the race against tag-manager bootstrap.
-          */}
-          <script
-            id="google-consent-default"
-            dangerouslySetInnerHTML={{
-              __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:'denied',wait_for_update:500});`,
-            }}
-          />
-          {/*
-            Termly resource-blocker. beforeInteractive ensures Next.js places
-            this in the SSR <head> ahead of client-injected tracking scripts
-            so Termly's MutationObserver is live before gtag.js mounts.
-            Previously loaded with afterInteractive, which raced gtag and let
-            the Google Ads pixel + _gcl_au cookie fire before consent.
-          */}
-          <Script
-            src="https://app.termly.io/resource-blocker/058a3478-08ac-4f2f-a9c4-5b357bbe7433"
-            strategy="beforeInteractive"
-          />
-          <Script
-            id="google-ads-tag"
-            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`}
-            strategy="afterInteractive"
-          />
-          <Script id="google-ads-init" strategy="afterInteractive">
-            {`gtag('js', new Date());gtag('config', '${GOOGLE_ADS_ID}');`}
-          </Script>
+          {shouldLoadMarketingScripts && (
+            <>
+              {/*
+                Google Consent Mode v2 default-denied. Must run synchronously in
+                <head> before gtag.js loads so Google itself respects consent and
+                withholds cookies + tracking pings until the user opts in. Inline
+                via dangerouslySetInnerHTML so it ships in SSR HTML with zero
+                network round-trip — any async strategy (incl. beforeInteractive
+                with src) loses the race against tag-manager bootstrap.
+              */}
+              <script
+                id="google-consent-default"
+                dangerouslySetInnerHTML={{
+                  __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:'denied',wait_for_update:500});`,
+                }}
+              />
+              {/*
+                Termly resource-blocker. beforeInteractive ensures Next.js places
+                this in the SSR <head> ahead of client-injected tracking scripts
+                so Termly's MutationObserver is live before gtag.js mounts.
+                Previously loaded with afterInteractive, which raced gtag and let
+                the Google Ads pixel + _gcl_au cookie fire before consent.
+              */}
+              <Script
+                src="https://app.termly.io/resource-blocker/058a3478-08ac-4f2f-a9c4-5b357bbe7433"
+                strategy="beforeInteractive"
+              />
+              <Script
+                id="google-ads-tag"
+                src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`}
+                strategy="afterInteractive"
+              />
+              <Script id="google-ads-init" strategy="afterInteractive">
+                {`gtag('js', new Date());gtag('config', '${GOOGLE_ADS_ID}');`}
+              </Script>
+            </>
+          )}
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
             rel="preconnect"
@@ -308,37 +314,41 @@ export default async function RootLayout({
             src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
             strategy="lazyOnload"
           />
-          <Script id="linkedin-insight-init" strategy="afterInteractive">
-            {`
-              _linkedin_partner_id = "${LINKEDIN_PARTNER_ID}";
-              window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
-              window._linkedin_data_partner_ids.push(_linkedin_partner_id);
-            `}
-          </Script>
-          <Script id="linkedin-insight-loader" strategy="afterInteractive">
-            {`
-              (function(l) {
-                if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
-                window.lintrk.q=[]}
-                var s = document.getElementsByTagName("script")[0];
-                var b = document.createElement("script");
-                b.type = "text/javascript";b.async = true;
-                b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-                s.parentNode.insertBefore(b, s);})(window.lintrk);
-            `}
-          </Script>
-          {/*
-            LinkedIn's no-JS tracking pixel must render as raw HTML inside
-            <noscript> — next/image and the @next/next/no-img-element rule
-            both rely on client-side JS, which by definition cannot run here.
-            dangerouslySetInnerHTML keeps the pixel in pure HTML and stays
-            consistent with the JSON-LD blocks above.
-          */}
-          <noscript
-            dangerouslySetInnerHTML={{
-              __html: `<img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=${LINKEDIN_PARTNER_ID}&fmt=gif" />`,
-            }}
-          />
+          {shouldLoadMarketingScripts && (
+            <>
+              <Script id="linkedin-insight-init" strategy="afterInteractive">
+                {`
+                  _linkedin_partner_id = "${LINKEDIN_PARTNER_ID}";
+                  window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+                  window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+                `}
+              </Script>
+              <Script id="linkedin-insight-loader" strategy="afterInteractive">
+                {`
+                  (function(l) {
+                    if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+                    window.lintrk.q=[]}
+                    var s = document.getElementsByTagName("script")[0];
+                    var b = document.createElement("script");
+                    b.type = "text/javascript";b.async = true;
+                    b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+                    s.parentNode.insertBefore(b, s);})(window.lintrk);
+                `}
+              </Script>
+              {/*
+                LinkedIn's no-JS tracking pixel must render as raw HTML inside
+                <noscript> — next/image and the @next/next/no-img-element rule
+                both rely on client-side JS, which by definition cannot run here.
+                dangerouslySetInnerHTML keeps the pixel in pure HTML and stays
+                consistent with the JSON-LD blocks above.
+              */}
+              <noscript
+                dangerouslySetInnerHTML={{
+                  __html: `<img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=${LINKEDIN_PARTNER_ID}&fmt=gif" />`,
+                }}
+              />
+            </>
+          )}
         </body>
       </html>
     </ClerkProvider>


### PR DESCRIPTION
## Summary
- gate web Google Ads, LinkedIn Insight, and Termly resource-blocker scripts to production only
- gate platform app Google Ads and LinkedIn script injection behind VITE_VERCEL_ENV=production
- pass VITE_VERCEL_ENV for app preview and production deployments and cover both apps with tests

## Tests
- pnpm -F @vm0/app exec vitest run src/__tests__/index-html.test.ts
- pnpm -F web exec vitest run app/__tests__/root-layout-marketing-scripts.test.tsx
- pnpm -F web check-types
- pnpm -F @vm0/app check-types
- pre-commit: prettier, knip, check-types
