### PR TITLE
fix: make webchat image previews linkable

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -58,19 +58,23 @@ describe("zero chat thread page display - attachment image preview", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
-    const previewButton = await waitFor(() => {
+    const previewLink = await waitFor(() => {
       return screen.getByLabelText("Preview photo.png");
     });
-    const previewImage = within(previewButton).getByAltText("photo.png");
+    expect(previewLink).toHaveAttribute(
+      "href",
+      "https://example.com/photo.png",
+    );
+    const previewImage = within(previewLink).getByAltText("photo.png");
     expect(previewImage).toBeInTheDocument();
     expect(
-      within(previewButton).getByTestId("chat-image-preview-loading"),
+      within(previewLink).getByTestId("chat-image-preview-loading"),
     ).toBeInTheDocument();
 
     fireEvent.load(previewImage);
     await waitFor(() => {
       expect(
-        within(previewButton).queryByTestId("chat-image-preview-loading"),
+        within(previewLink).queryByTestId("chat-image-preview-loading"),
       ).not.toBeInTheDocument();
     });
   });
@@ -481,8 +485,11 @@ describe("zero chat thread page display - body link document preview", () => {
   });
 
   it("renders bare platform image file urls as image previews", async () => {
+    const user = userEvent.setup();
     const imageUrl =
       "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/chart.png";
+    const publicImageUrl =
+      "https://cdn.vm7.io/artifacts/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/chart.png";
     server.use(
       http.get(imageUrl, () => {
         return new HttpResponse("png", {
@@ -503,8 +510,15 @@ describe("zero chat thread page display - body link document preview", () => {
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
-      expect(screen.getByAltText("chart.png")).toBeInTheDocument();
+      expect(screen.getByLabelText("Preview chart.png")).toBeInTheDocument();
     });
+    const previewLink = screen.getByLabelText("Preview chart.png");
+    expect(previewLink).toHaveAttribute("href", publicImageUrl);
+    expect(within(previewLink).getByAltText("chart.png")).toBeInTheDocument();
+
+    await user.click(previewLink);
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(lightbox).toBeInTheDocument();
   });
 
   it("renders json body links inline and supports collapse for platform file urls", async () => {
@@ -1170,7 +1184,11 @@ describe("zero chat thread page display - artifacts drawer", () => {
       expect(screen.getByText("Artifacts")).toBeInTheDocument();
     });
     expect(artifactsRequests).toBeGreaterThan(0);
-    expect(screen.getByLabelText("Preview chart.png")).toBeInTheDocument();
+    const previewLink = screen.getByLabelText("Preview chart.png");
+    expect(previewLink).toHaveAttribute(
+      "href",
+      "https://example.com/chart.png",
+    );
     expect(
       document.querySelectorAll('img[src="https://example.com/chart.png"]')
         .length,
@@ -1197,7 +1215,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(deckButton).toBeInTheDocument();
     expect(within(deckButton).getByText("PPTX")).toBeInTheDocument();
 
-    await user.click(screen.getByLabelText("Preview chart.png"));
+    await user.click(previewLink);
 
     const lightbox = await screen.findByTestId("attachment-lightbox");
     await user.click(within(lightbox).getByLabelText("Close"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -298,9 +298,9 @@ describe("zero chat thread page - insufficient credits card", () => {
   });
 });
 
-// CHAT-I-049 / CHAT-I-050: Image preview button opens ImageLightbox
+// CHAT-I-049 / CHAT-I-050: Image preview link opens ImageLightbox
 describe("zero chat thread page - image attachment opens lightbox", () => {
-  it("clicking image preview button opens ImageLightbox (CHAT-I-049, CHAT-I-050)", async () => {
+  it("clicking image preview link opens ImageLightbox (CHAT-I-049, CHAT-I-050)", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -318,8 +318,9 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
       expect(screen.getByAltText("photo.png")).toBeInTheDocument();
     });
 
-    const imageButton = screen.getByAltText("photo.png").closest("button")!;
-    click(imageButton);
+    const imageLink = screen.getByLabelText("Preview photo.png");
+    expect(imageLink).toHaveAttribute("href", "https://example.com/photo.png");
+    click(imageLink);
 
     await waitFor(() => {
       const lightboxImg = screen.getAllByRole("img").find((img) => {
@@ -361,10 +362,11 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const imageButton = await waitFor(() => {
-      return screen.getByAltText("photo.png").closest("button")!;
+    const imageLink = await waitFor(() => {
+      return screen.getByLabelText("Preview photo.png");
     });
-    click(imageButton);
+    expect(imageLink).toHaveAttribute("href", imageUrl);
+    click(imageLink);
 
     const downloadButton = await waitFor(() => {
       return screen.getByLabelText("Download");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1045,40 +1045,55 @@ function ArtifactBulkActionsMenu({
   );
 }
 
-type ChatImagePreviewButtonProps = {
+type ChatImagePreviewLinkProps = {
   alt: string;
   ariaLabel: string;
-  buttonClassName: string;
   imageClassName: string;
+  linkClassName: string;
   onPreview: () => void;
   placeholderClassName: string;
   url: string;
 };
 
-function ChatImagePreviewButton({
+function ChatImagePreviewLink({
   alt,
   ariaLabel,
-  buttonClassName,
   imageClassName,
+  linkClassName,
   onPreview,
   placeholderClassName,
   url,
-}: ChatImagePreviewButtonProps) {
+}: ChatImagePreviewLinkProps) {
   const imageLoadStatuses = useGet(imageLoadStatusByKey$);
   const imageLoadStatusRef = useSet(imageLoadStatusRef$);
   const setImageLoadStatus = useSet(setImageLoadStatus$);
-  const imageLoadKey = `chat-image-preview:${url}`;
+  const imageUrl = publicAttachmentUrl(url);
+  const imageLoadKey = `chat-image-preview:${imageUrl}`;
   const imageStatus = imageLoadStatuses[imageLoadKey] ?? "loading";
 
   const showPlaceholder = imageStatus !== "loaded";
 
+  const openPreview = (event: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.button !== 0
+    ) {
+      return;
+    }
+    event.preventDefault();
+    onPreview();
+  };
+
   return (
-    <button
-      type="button"
-      onClick={onPreview}
+    <a
+      href={imageUrl}
+      onClick={openPreview}
       className={cn(
-        "group/image-preview relative overflow-hidden",
-        buttonClassName,
+        "group/image-preview relative inline-block overflow-hidden",
+        linkClassName,
       )}
       aria-label={ariaLabel}
     >
@@ -1100,7 +1115,7 @@ function ChatImagePreviewButton({
       <img
         key={imageLoadKey}
         ref={imageLoadStatusRef}
-        src={url}
+        src={imageUrl}
         alt={alt}
         data-image-load-key={imageLoadKey}
         loading="lazy"
@@ -1121,7 +1136,7 @@ function ChatImagePreviewButton({
           className="text-white opacity-0 drop-shadow transition-opacity group-hover/image-preview:opacity-100"
         />
       </span>
-    </button>
+    </a>
   );
 }
 
@@ -1198,11 +1213,11 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
 
   if (previewKind === "image") {
     return (
-      <ChatImagePreviewButton
+      <ChatImagePreviewLink
         alt={`Preview ${file.filename}`}
         ariaLabel={`Preview ${file.filename}`}
-        buttonClassName="flex h-full w-full items-center justify-center bg-muted"
         imageClassName="h-full w-full object-contain"
+        linkClassName="flex h-full w-full items-center justify-center bg-muted"
         onPreview={() => {
           openImageLightbox(file.url);
         }}
@@ -2473,12 +2488,12 @@ function BodyContentBlocks({
 
         if (block.preview.kind === "image") {
           return (
-            <ChatImagePreviewButton
+            <ChatImagePreviewLink
               key={block.id}
               alt={block.preview.filename}
               ariaLabel={`Preview ${block.preview.filename}`}
-              buttonClassName="w-fit max-w-full rounded-lg border border-foreground/10"
               imageClassName="max-h-48 max-w-full object-contain"
+              linkClassName="w-fit max-w-full rounded-lg border border-foreground/10"
               onPreview={() => {
                 openLightbox(block.preview.url);
               }}
@@ -3180,12 +3195,12 @@ function UserMessageAttachments({
       {attachments.map((a) => {
         if (a.isImage) {
           return (
-            <ChatImagePreviewButton
+            <ChatImagePreviewLink
               key={a.url}
               alt={a.filename}
               ariaLabel={`Preview ${a.filename}`}
-              buttonClassName="rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
               imageClassName="h-9 max-w-[72px] object-cover"
+              linkClassName="rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
               onPreview={() => {
                 onImageClick(a.url);
               }}


### PR DESCRIPTION
## Summary
- render chat image previews as anchors with hrefs so users can copy/open image URLs with native browser actions
- preserve normal click behavior by opening the existing image lightbox
- cover generated/platform image previews, artifact image previews, and interaction tests with link assertions

Fixes #14899

## Tests
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pre-commit: turbo run check-types --concurrency=1