### PR TITLE
refactor: move computer use permissions to native helper

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1152,6 +1152,25 @@ func handleAppsList() -> [String: Any] {
     return ["apps": Array(names).sorted()]
 }
 
+func computerUsePermissionState() -> [String: Any] {
+    return [
+        "accessibility": AXIsProcessTrusted(),
+        "screenRecording": CGPreflightScreenCaptureAccess(),
+    ]
+}
+
+func handlePermissionsState() -> [String: Any] {
+    return computerUsePermissionState()
+}
+
+func handlePermissionsRequestAccessibility() -> [String: Any] {
+    let options = [
+        "AXTrustedCheckOptionPrompt": true,
+    ] as CFDictionary
+    _ = AXIsProcessTrustedWithOptions(options)
+    return computerUsePermissionState()
+}
+
 func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let snapshotId = try requiredString(request, "snapshotId")
@@ -1450,6 +1469,10 @@ func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {
 func handle(_ request: [String: Any]) throws -> [String: Any] {
     let kind = try requiredString(request, "kind")
     switch kind {
+    case "permissions.state":
+        return handlePermissionsState()
+    case "permissions.request_accessibility":
+        return handlePermissionsRequestAccessibility()
     case "apps.list":
         return handleAppsList()
     case "app.state":

--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -11,7 +11,7 @@ interface ComputerUseIpcOptions {
 interface ComputerUseNativeApi {
   readonly getState: () => DesktopComputerUseState;
   readonly start: () => Promise<DesktopComputerUseState>;
-  readonly requestAccessibilityPermission: () => DesktopComputerUseState;
+  readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
 }
 
 export function notifyDesktopComputerUseChanged(): void {

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -19,13 +19,15 @@ export type ComputerUseHostFetch = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+type MaybePromise<T> = T | Promise<T>;
+
 interface ComputerUseHostRuntimeOptions {
   readonly platformUrl: URL;
   readonly displayName: string;
   readonly appVersion: string;
   readonly sessionFetch: ComputerUseHostFetch;
   readonly hostFetch: ComputerUseHostFetch;
-  readonly getPermissions: () => ComputerUsePermissionState;
+  readonly getPermissions: () => MaybePromise<ComputerUsePermissionState>;
   readonly executeCommand: (
     command: ComputerUseCommand,
     permissions: ComputerUsePermissionState,
@@ -87,7 +89,7 @@ export class ComputerUseHostRuntime {
   private readonly appVersion: string;
   private readonly sessionFetch: ComputerUseHostFetch;
   private readonly hostFetchRequest: ComputerUseHostFetch;
-  private readonly getPermissions: () => ComputerUsePermissionState;
+  private readonly getPermissions: ComputerUseHostRuntimeOptions["getPermissions"];
   private readonly executeCommand: ComputerUseHostRuntimeOptions["executeCommand"];
   private readonly onChange: () => void;
   private readonly scheduleTimeout: typeof setTimeout;
@@ -156,11 +158,11 @@ export class ComputerUseHostRuntime {
     return this.state;
   }
 
-  private runtimeBody(): Record<string, unknown> {
+  private async runtimeBody(): Promise<Record<string, unknown>> {
     return buildComputerUseRuntimeBody({
       displayName: this.displayName,
       appVersion: this.appVersion,
-      permissions: this.getPermissions(),
+      permissions: await this.getPermissions(),
     });
   }
 
@@ -265,7 +267,7 @@ export class ComputerUseHostRuntime {
       {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(this.runtimeBody()),
+        body: JSON.stringify(await this.runtimeBody()),
       },
     );
     if (response.status === 401) {
@@ -328,7 +330,7 @@ export class ComputerUseHostRuntime {
   private async heartbeat(): Promise<boolean> {
     const response = await this.hostFetch("/api/zero/computer-use/heartbeat", {
       method: "POST",
-      body: JSON.stringify(this.runtimeBody()),
+      body: JSON.stringify(await this.runtimeBody()),
     });
     if (response.status === 401) {
       this.hostToken = null;
@@ -417,7 +419,7 @@ export class ComputerUseHostRuntime {
     try {
       completed = await this.executeCommand(
         body.command,
-        this.getPermissions(),
+        await this.getPermissions(),
       );
     } catch (error) {
       const completedAtMs = Date.now();

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -24,6 +24,46 @@ process.stdin.on("end", () => {
 }
 
 describe("computer use native backend", () => {
+  it("reads permissions from the native helper", async () => {
+    const helper = await createHelper({
+      status: "succeeded",
+      result: { accessibility: true, screenRecording: false },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+      });
+
+      await expect(backend.getPermissions()).resolves.toEqual({
+        accessibility: true,
+        screenRecording: false,
+      });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("requests accessibility permission through the native helper", async () => {
+    const helper = await createHelper({
+      status: "succeeded",
+      result: { accessibility: true, screenRecording: true },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+      });
+
+      await expect(backend.requestAccessibilityPermission()).resolves.toEqual({
+        accessibility: true,
+        screenRecording: true,
+      });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     ["app_not_found", "Unable to open Things: Unable to find application"],
     ["app_open_failed", "Unable to open Things"],

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -6,6 +6,7 @@ import type {
   ComputerUseCommandFailure,
   ComputerUseMouseButton,
 } from "./computer-use-accessibility";
+import type { ComputerUsePermissionState } from "./computer-use-types";
 
 type ComputerUseNativeErrorCode = ComputerUseCommandFailure["error"]["code"];
 
@@ -23,6 +24,8 @@ export interface ComputerUseNativePressKeyRequest {
 }
 
 export interface ComputerUseNativeBackend {
+  readonly getPermissions: () => Promise<ComputerUsePermissionState>;
+  readonly requestAccessibilityPermission: () => Promise<ComputerUsePermissionState>;
   readonly listApps: () => Promise<readonly string[]>;
   readonly getAppState: (
     app: string,
@@ -194,6 +197,24 @@ function resultOptionalString(
     : undefined;
 }
 
+function resultPermissions(
+  result: Record<string, unknown>,
+): ComputerUsePermissionState {
+  if (
+    typeof result.accessibility === "boolean" &&
+    typeof result.screenRecording === "boolean"
+  ) {
+    return {
+      accessibility: result.accessibility,
+      screenRecording: result.screenRecording,
+    };
+  }
+  throw new ComputerUseNativeHelperError(
+    "accessibility_unavailable",
+    "Native Computer Use helper returned invalid permissions",
+  );
+}
+
 function helperPathCandidates(
   options: ResolveComputerUseHelperPathOptions,
 ): readonly [string, string, string] {
@@ -293,6 +314,14 @@ export function createComputerUseNativeBackend(
   };
 
   return {
+    getPermissions: async () => {
+      const result = await run({ kind: "permissions.state" });
+      return resultPermissions(result);
+    },
+    requestAccessibilityPermission: async () => {
+      const result = await run({ kind: "permissions.request_accessibility" });
+      return resultPermissions(result);
+    },
     listApps: async () => {
       const result = await run({ kind: "apps.list" });
       return resultStringArray(result, "apps");

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -1,17 +1,25 @@
-import { systemPreferences } from "electron";
+import { createComputerUseNativeBackend } from "./computer-use-native";
 import type { ComputerUsePermissionState } from "./computer-use-types";
 
+const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
+  Object.freeze({
+    accessibility: false,
+    screenRecording: false,
+  });
+
+const nativeBackend = createComputerUseNativeBackend();
+let currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
+
 export function getComputerUsePermissionState(): ComputerUsePermissionState {
-  return {
-    accessibility: systemPreferences.isTrustedAccessibilityClient(false),
-    screenRecording:
-      systemPreferences.getMediaAccessStatus("screen") === "granted",
-  };
+  return currentPermissionState;
 }
 
-export function requestComputerUseAccessibilityPermission(): ComputerUsePermissionState {
-  if (process.platform === "darwin") {
-    systemPreferences.isTrustedAccessibilityClient(true);
-  }
-  return getComputerUsePermissionState();
+export async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
+  currentPermissionState = await nativeBackend.getPermissions();
+  return currentPermissionState;
+}
+
+export async function requestComputerUseAccessibilityPermission(): Promise<ComputerUsePermissionState> {
+  currentPermissionState = await nativeBackend.requestAccessibilityPermission();
+  return currentPermissionState;
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -30,6 +30,7 @@ import {
 import type { DesktopAuthState } from "./desktop-bridge";
 import {
   getComputerUsePermissionState,
+  refreshComputerUsePermissionState,
   requestComputerUseAccessibilityPermission,
 } from "./computer-use-permissions";
 import { resolveDesktopConfig } from "./config";
@@ -223,7 +224,7 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
       hostFetch: (input, init) => {
         return fetch(input, init);
       },
-      getPermissions: getComputerUsePermissionState,
+      getPermissions: refreshComputerUsePermissionState,
       executeCommand: (command, permissions) => {
         return executeComputerUseCommand(command, permissions, {
           snapshotStore: computerUseSnapshotStore,
@@ -236,8 +237,8 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
   return getComputerUseBridgeState();
 }
 
-function requestComputerUsePermission(): DesktopComputerUseState {
-  requestComputerUseAccessibilityPermission();
+async function requestComputerUsePermission(): Promise<DesktopComputerUseState> {
+  await requestComputerUseAccessibilityPermission();
   notifyDesktopComputerUseChanged();
   return getComputerUseBridgeState();
 }
@@ -251,6 +252,16 @@ function installComputerUse(): void {
     },
     { rendererUrl: localRendererUrl },
   );
+}
+
+function refreshComputerUsePermissionsForState(): void {
+  void refreshComputerUsePermissionState()
+    .catch((error) => {
+      console.warn("Unable to refresh native Computer Use permissions", error);
+    })
+    .finally(() => {
+      notifyDesktopComputerUseChanged();
+    });
 }
 
 async function stopComputerUseRuntimeForQuit(): Promise<void> {
@@ -619,7 +630,9 @@ async function maybeStartComputerUseAfterAuth(): Promise<void> {
   computerUseRuntime = null;
   notifyDesktopAuthChanged();
   notifyDesktopComputerUseChanged();
-  if (hasRequiredComputerUsePermissions(getComputerUsePermissionState())) {
+  const permissions = await refreshComputerUsePermissionState();
+  notifyDesktopComputerUseChanged();
+  if (hasRequiredComputerUsePermissions(permissions)) {
     await startComputerUseRuntime();
   }
 }
@@ -754,6 +767,7 @@ if (!hasSingleInstanceLock) {
     registerDesktopAuthProtocol();
     installDesktopRendererProtocol();
     installComputerUse();
+    refreshComputerUsePermissionsForState();
     installDesktopAuth();
     queueDesktopAuthCallbackArgv(process.argv);
 

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -38,6 +38,12 @@ function createNativeBackend(
   overrides: Partial<ComputerUseNativeBackend> = {},
 ): ComputerUseNativeBackend {
   const defaults: ComputerUseNativeBackend = {
+    getPermissions: async () => {
+      return { accessibility: true, screenRecording: true };
+    },
+    requestAccessibilityPermission: async () => {
+      return { accessibility: true, screenRecording: true };
+    },
     listApps: async () => [],
     getAppState: async (app, snapshotId) => {
       return { app, snapshotId, elements: [] };


### PR DESCRIPTION
## Summary
- add native helper commands for Computer Use permission state and accessibility prompts
- route Desktop permission refresh/request flows through the helper instead of Electron systemPreferences
- allow the host runtime to refresh permissions asynchronously for start, heartbeat, and command execution

## Validation
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop build
- pnpm exec prettier --check --ignore-unknown apps/desktop/src/computer-use-native.ts apps/desktop/src/computer-use-permissions.ts apps/desktop/src/computer-use-electron.ts apps/desktop/src/computer-use-host.ts apps/desktop/src/main.ts apps/desktop/src/window-policy.test.ts apps/desktop/src/computer-use-native.test.ts
- git diff --check
- pnpm knip --workspace @vm0/desktop