### PR TITLE
fix: harden mitm network policy matching

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -878,7 +878,7 @@ def match_compiled_firewall_request(
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
       FirewallBlock — permission denied, unknown endpoint blocked, or matched
-        malformed firewall config failed closed
+        malformed firewall/network policy config failed closed
       None — no base URL match (not a firewall request)
 
     ``unknownPolicy="ask"`` is treated as block at the proxy layer.
@@ -1030,7 +1030,8 @@ def match_firewall_request(
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
-      FirewallBlock — base URL matched but permission denied or unknown blocked
+      FirewallBlock — base URL matched but permission denied, unknown blocked,
+        or malformed network policy failed closed
       None — no base URL match (not a firewall request)
     """
     if not vm_firewalls:

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -3,6 +3,8 @@
 Pure functions with no module-level state or I/O.
 """
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Literal, NamedTuple
 from urllib.parse import urlsplit
 
@@ -80,6 +82,21 @@ class _CompiledFirewall(NamedTuple):
 
 class CompiledFirewallSet(NamedTuple):
     firewalls: tuple[_CompiledFirewall, ...]
+
+
+UnknownPolicy = Literal["allow", "deny", "ask"]
+
+
+class _CompiledNetworkPolicy(NamedTuple):
+    blocked_permissions: frozenset[str]
+    unknown_policy: UnknownPolicy
+    permission_malformed: bool
+    unknown_policy_malformed: bool
+
+
+class CompiledNetworkPolicies(NamedTuple):
+    policies: Mapping[str, _CompiledNetworkPolicy]
+    top_level_malformed: bool
 
 
 def _split_base_match_url(
@@ -731,6 +748,68 @@ def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
     return CompiledFirewallSet(tuple(compiled_firewalls))
 
 
+def _compile_permission_set(raw_value: object | None) -> tuple[frozenset[str], bool]:
+    if raw_value is None:
+        return frozenset(), False
+    if not isinstance(raw_value, list):
+        return frozenset(), True
+    if not all(isinstance(item, str) for item in raw_value):
+        return frozenset(), True
+    return frozenset(raw_value), False
+
+
+def compile_network_policies(raw_network_policies: object | None) -> CompiledNetworkPolicies:
+    """Compile raw networkPolicies into immutable matcher-side data."""
+    if raw_network_policies is None:
+        return CompiledNetworkPolicies(MappingProxyType({}), False)
+    if not isinstance(raw_network_policies, dict):
+        return CompiledNetworkPolicies(MappingProxyType({}), True)
+
+    compiled: dict[str, _CompiledNetworkPolicy] = {}
+    for fw_name, grant in raw_network_policies.items():
+        if not isinstance(fw_name, str):
+            continue
+
+        if not isinstance(grant, dict):
+            compiled[fw_name] = _CompiledNetworkPolicy(
+                frozenset(),
+                "allow",
+                True,
+                False,
+            )
+            continue
+
+        deny, deny_malformed = _compile_permission_set(grant.get("deny"))
+        ask, ask_malformed = _compile_permission_set(grant.get("ask"))
+
+        raw_unknown_policy = grant.get("unknownPolicy")
+        unknown_policy: UnknownPolicy = "allow"
+        unknown_policy_malformed = False
+        if raw_unknown_policy is None:
+            unknown_policy = "allow"
+        elif raw_unknown_policy in ("allow", "deny", "ask"):
+            unknown_policy = raw_unknown_policy
+        else:
+            unknown_policy_malformed = True
+
+        compiled[fw_name] = _CompiledNetworkPolicy(
+            deny | ask,
+            unknown_policy,
+            deny_malformed or ask_malformed,
+            unknown_policy_malformed,
+        )
+
+    return CompiledNetworkPolicies(MappingProxyType(compiled), False)
+
+
+def _ensure_compiled_network_policies(
+    network_policies: object | None,
+) -> CompiledNetworkPolicies:
+    if isinstance(network_policies, CompiledNetworkPolicies):
+        return network_policies
+    return compile_network_policies(network_policies)
+
+
 class FirewallAllow(NamedTuple):
     """Base URL matched and auth headers should be injected.
 
@@ -773,6 +852,7 @@ FirewallBlockReason = Literal[
     "permission_denied",
     "unknown_endpoint",
     "malformed_firewall_config",
+    "malformed_network_policy",
 ]
 
 
@@ -787,44 +867,11 @@ class FirewallBlock(NamedTuple):
     reason: FirewallBlockReason
 
 
-def _build_block_set(
-    fw_name: str,
-    network_policies: dict,
-) -> set:
-    """Build a set of denied/asked permission names for a firewall name.
-
-    Only reads ``deny`` and ``ask`` fields — the ``allow`` field is not
-    consumed by the proxy (it exists for frontend display only).
-
-    Returns empty set when name is absent from the map (fully permissive —
-    consistent with the frontend contract where absent names are treated
-    as all-granted + allow-unknown).
-    """
-    grant = network_policies.get(fw_name)
-    if grant is None:
-        return set()
-    return set(grant.get("deny", [])) | set(grant.get("ask", []))
-
-
-def _get_unknown_policy(
-    fw_name: str,
-    network_policies: dict,
-) -> str:
-    """Get the policy for unknown endpoints (no rule match).
-
-    Returns "allow", "deny", or "ask".
-    """
-    grant = network_policies.get(fw_name)
-    if grant is None:
-        return "allow"
-    return grant.get("unknownPolicy", "allow")
-
-
 def match_compiled_firewall_request(
     url: str,
     method: str,
     compiled_firewalls: CompiledFirewallSet | None,
-    network_policies: dict | None = None,
+    network_policies: object | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
     """Match request against production precompiled firewall permissions.
 
@@ -843,8 +890,7 @@ def match_compiled_firewall_request(
     if url_parts is None:
         return None
 
-    if network_policies is None:
-        network_policies = {}
+    compiled_network_policies = _ensure_compiled_network_policies(network_policies)
 
     blocked_match: tuple[str, str, str, dict, dict] | None = None
 
@@ -853,9 +899,10 @@ def match_compiled_firewall_request(
     denied_match: tuple[str, str, str, str] | None = None
     denied_perm_names: list[str] = []
     malformed_match: tuple[str, str, str, str] | None = None
+    malformed_policy_match: tuple[str, str, str, str] | None = None
 
     for fw_entry in compiled_firewalls.firewalls:
-        block_set = _build_block_set(fw_entry.name, network_policies)
+        policy = compiled_network_policies.policies.get(fw_entry.name)
 
         for api_entry in fw_entry.apis:
             base_result = _match_compiled_base_url_parts(url_parts, api_entry.base)
@@ -874,6 +921,17 @@ def match_compiled_firewall_request(
                 )
             if api_entry.has_malformed_rules and malformed_match is None:
                 malformed_match = (api_entry.base.raw, fw_entry.name, upper_method, rel_path)
+            if compiled_network_policies.top_level_malformed or (
+                policy is not None and policy.permission_malformed
+            ):
+                if malformed_policy_match is None:
+                    malformed_policy_match = (
+                        api_entry.base.raw,
+                        fw_entry.name,
+                        upper_method,
+                        rel_path,
+                    )
+                continue
 
             if not api_entry.permissions:
                 continue
@@ -888,7 +946,7 @@ def match_compiled_firewall_request(
                     if params is not None:
                         all_params = {**base_params, **params}
 
-                        if perm.name not in block_set:
+                        if policy is None or perm.name not in policy.blocked_permissions:
                             return _permission_allow(
                                 api_entry.raw_api_entry,
                                 name=fw_entry.name,
@@ -917,9 +975,29 @@ def match_compiled_firewall_request(
                 tuple(denied_perm_names),
                 "permission_denied",
             )
+        if malformed_policy_match is not None:
+            return FirewallBlock(*malformed_policy_match, (), "malformed_network_policy")
         if malformed_match is not None:
             return FirewallBlock(*malformed_match, (), "malformed_firewall_config")
-        if _get_unknown_policy(blocked_name, network_policies) == "allow":
+
+        blocked_policy = compiled_network_policies.policies.get(blocked_name)
+        if blocked_policy is None:
+            return _unknown_allow(
+                first_matched_api_entry,
+                name=blocked_name,
+                params=base_params,
+                rel_path=blocked_rel_path,
+            )
+        if blocked_policy.unknown_policy_malformed:
+            return FirewallBlock(
+                blocked_base,
+                blocked_name,
+                upper_method,
+                blocked_rel_path,
+                (),
+                "malformed_network_policy",
+            )
+        if blocked_policy.unknown_policy == "allow":
             return _unknown_allow(
                 first_matched_api_entry,
                 name=blocked_name,
@@ -941,13 +1019,14 @@ def match_firewall_request(
     url: str,
     method: str,
     vm_firewalls: list | None,
-    network_policies: dict | None = None,
+    network_policies: object | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
     """Match request against firewall permissions with three-level matching.
 
     The compiled matcher is the production-authoritative path. This legacy
-    matcher is kept for direct raw-config comparisons and does not fail closed
-    on malformed compiled config.
+    matcher is kept for direct raw-config comparisons. It shares compiled
+    network policy handling but does not fail closed on malformed firewall
+    rules.
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
@@ -957,8 +1036,7 @@ def match_firewall_request(
     if not vm_firewalls:
         return None
 
-    if network_policies is None:
-        network_policies = {}
+    compiled_network_policies = _ensure_compiled_network_policies(network_policies)
 
     # Track the first matched base URL and api_entry for unknown endpoint auth.
     blocked_match: tuple[str, str, str, dict, dict] | None = None
@@ -970,10 +1048,11 @@ def match_firewall_request(
     # because a later permission may be granted for the same endpoint.
     denied_match: tuple[str, str, str, str] | None = None  # (base, name, method, path)
     denied_perm_names: list[str] = []
+    malformed_policy_match: tuple[str, str, str, str] | None = None
 
     for fw_entry in vm_firewalls:
         fw_name = fw_entry.get("name", "")
-        block_set = _build_block_set(fw_name, network_policies)
+        policy = compiled_network_policies.policies.get(fw_name)
 
         for api_entry in fw_entry.get("apis", []):
             base = api_entry.get("base", "").rstrip("/")
@@ -989,6 +1068,13 @@ def match_firewall_request(
             # Base URL matched
             if blocked_match is None:
                 blocked_match = (base, fw_name, rel_path, api_entry, base_params)
+
+            if compiled_network_policies.top_level_malformed or (
+                policy is not None and policy.permission_malformed
+            ):
+                if malformed_policy_match is None:
+                    malformed_policy_match = (base, fw_name, upper_method, rel_path)
+                continue
 
             permissions = api_entry.get("permissions")
             if not permissions:
@@ -1012,7 +1098,7 @@ def match_firewall_request(
                         all_params = {**base_params, **params}
 
                         # Three-level: not in deny/ask → allowed
-                        if perm_name not in block_set:
+                        if policy is None or perm_name not in policy.blocked_permissions:
                             return _permission_allow(
                                 api_entry,
                                 name=fw_name,
@@ -1039,9 +1125,29 @@ def match_firewall_request(
                 tuple(denied_perm_names),
                 "permission_denied",
             )
+        if malformed_policy_match is not None:
+            return FirewallBlock(*malformed_policy_match, (), "malformed_network_policy")
         # No permission rule matched — this is an "unknown" endpoint.
         # "ask" is treated as "deny" at the proxy level (same as ask permissions).
-        if _get_unknown_policy(blocked_name, network_policies) == "allow":
+
+        blocked_policy = compiled_network_policies.policies.get(blocked_name)
+        if blocked_policy is None:
+            return _unknown_allow(
+                first_matched_api_entry,
+                name=blocked_name,
+                params=base_params,
+                rel_path=blocked_rel_path,
+            )
+        if blocked_policy.unknown_policy_malformed:
+            return FirewallBlock(
+                blocked_base,
+                blocked_name,
+                upper_method,
+                blocked_rel_path,
+                (),
+                "malformed_network_policy",
+            )
+        if blocked_policy.unknown_policy == "allow":
             return _unknown_allow(
                 first_matched_api_entry,
                 name=blocked_name,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -231,7 +231,7 @@ async def request(flow: http.HTTPFlow) -> None:
     if not vm_context:
         # Not a registered VM, pass through without proxying
         return
-    vm_info, compiled_firewalls = vm_context
+    vm_info, compiled_firewalls, compiled_network_policies = vm_context
 
     run_id = vm_info.get("runId", "")
 
@@ -283,20 +283,23 @@ async def request(flow: http.HTTPFlow) -> None:
         # --- Step 2: Firewall match with permission check ---
         # Match base URL, then check permission rules before injecting auth headers.
         if compiled_firewalls:
-            network_policies = vm_info.get("networkPolicies") or {}
             result = matching.match_compiled_firewall_request(
                 original_url,
                 flow.request.method,
                 compiled_firewalls,
-                network_policies,
+                compiled_network_policies,
             )
             if isinstance(result, matching.FirewallBlock):
                 proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+                block_message = (
+                    "malformed network policy"
+                    if result.reason == "malformed_network_policy"
+                    else "no matching permission"
+                )
                 log_proxy_entry(
                     proxy_log_path,
                     "warn",
-                    "Firewall "
-                    f"{result.name}: no matching permission for {result.method} {result.path}",
+                    f"Firewall {result.name}: {block_message} for {result.method} {result.path}",
                     type="firewall_block",
                     name=result.name,
                     reason=result.reason,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -296,6 +296,11 @@ async def request(flow: http.HTTPFlow) -> None:
                     if result.reason == "malformed_network_policy"
                     else "no matching permission"
                 )
+                response_message = (
+                    "Request blocked: malformed network policy"
+                    if result.reason == "malformed_network_policy"
+                    else "Request blocked: no matching permission rule"
+                )
                 log_proxy_entry(
                     proxy_log_path,
                     "warn",
@@ -310,7 +315,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 error_body = json.dumps(
                     {
                         "error": "permission_denied",
-                        "message": "Request blocked: no matching permission rule",
+                        "message": response_message,
                         "method": result.method,
                         "path": result.path,
                         "name": result.name,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -8,9 +8,16 @@ from mitmproxy import ctx
 import matching
 from auth import evict_stale_cache_keys
 
+VmContext = tuple[
+    dict,
+    matching.CompiledFirewallSet | None,
+    matching.CompiledNetworkPolicies,
+]
+
 # Cache for proxy registry (invalidated by file stat change).
 _registry_cache: dict = {}
 _registry_compiled_cache: dict[str, matching.CompiledFirewallSet] = {}
+_registry_compiled_policy_cache: dict[str, matching.CompiledNetworkPolicies] = {}
 _registry_cache_key: tuple[int, int] = (0, 0)
 # One-shot guard for stat-path failures: no cache key is available in that
 # branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
@@ -22,22 +29,32 @@ _registry_load_error_logged = False
 
 def reset_cache_for_tests() -> None:
     """Reset module cache state between tests."""
-    global _registry_cache, _registry_compiled_cache, _registry_cache_key
+    global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
+    global _registry_cache_key
     global _registry_load_error_logged
     _registry_cache = {}
     _registry_compiled_cache = {}
+    _registry_compiled_policy_cache = {}
     _registry_cache_key = (0, 0)
     _registry_load_error_logged = False
 
 
-def _compile_registry(new_registry: dict) -> dict[str, matching.CompiledFirewallSet]:
-    compiled: dict[str, matching.CompiledFirewallSet] = {}
+def _compile_registry(
+    new_registry: dict,
+) -> tuple[
+    dict[str, matching.CompiledFirewallSet],
+    dict[str, matching.CompiledNetworkPolicies],
+]:
+    compiled_firewall_registry: dict[str, matching.CompiledFirewallSet] = {}
+    compiled_policy_registry: dict[str, matching.CompiledNetworkPolicies] = {}
     for client_ip, vm in new_registry.items():
         firewalls = vm.get("firewalls") if isinstance(vm, dict) else None
         compiled_firewalls = matching.compile_firewalls(firewalls)
         if compiled_firewalls is not None:
-            compiled[client_ip] = compiled_firewalls
-    return compiled
+            compiled_firewall_registry[client_ip] = compiled_firewalls
+        network_policies = vm.get("networkPolicies") if isinstance(vm, dict) else None
+        compiled_policy_registry[client_ip] = matching.compile_network_policies(network_policies)
+    return compiled_firewall_registry, compiled_policy_registry
 
 
 def _normalize_registry_vms(raw_registry: object) -> tuple[dict, int]:
@@ -50,7 +67,8 @@ def _normalize_registry_vms(raw_registry: object) -> tuple[dict, int]:
 
 def load_registry(registry_path: str) -> dict:
     """Load the proxy registry from file, with stat-based cache invalidation."""
-    global _registry_cache, _registry_compiled_cache, _registry_cache_key
+    global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
+    global _registry_cache_key
     global _registry_load_error_logged
 
     path = Path(registry_path)
@@ -72,7 +90,7 @@ def load_registry(registry_path: str) -> dict:
         new_registry, malformed_vm_count = _normalize_registry_vms(raw_registry)
         if malformed_vm_count:
             ctx.log.warn(f"Skipped {malformed_vm_count} malformed proxy registry VM entries")
-        new_compiled_registry = _compile_registry(new_registry)
+        new_compiled_registry, new_compiled_policy_registry = _compile_registry(new_registry)
 
         # Evict cache entries for runs no longer in the registry.
         active_run_ids = {
@@ -84,6 +102,7 @@ def load_registry(registry_path: str) -> dict:
 
         _registry_cache = new_registry
         _registry_compiled_cache = new_compiled_registry
+        _registry_compiled_policy_cache = new_compiled_policy_registry
         _registry_load_error_logged = False
     except Exception as e:
         if not _registry_load_error_logged:
@@ -104,9 +123,14 @@ def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
 def get_vm_context(
     client_ip: str,
     registry_path: str,
-) -> tuple[dict, matching.CompiledFirewallSet | None] | None:
-    """Look up raw VM info with its compiled firewall matcher sidecar."""
+) -> VmContext | None:
+    """Look up raw VM info with compiled firewall and policy matcher sidecars."""
     vm_info = load_registry(registry_path).get(client_ip)
     if vm_info is None:
         return None
-    return vm_info, _registry_compiled_cache.get(client_ip)
+    compiled_network_policies = _registry_compiled_policy_cache.get(client_ip)
+    if compiled_network_policies is None:
+        compiled_network_policies = matching.compile_network_policies(
+            vm_info.get("networkPolicies")
+        )
+    return vm_info, _registry_compiled_cache.get(client_ip), compiled_network_policies

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -313,6 +313,52 @@ class TestCompiledFirewallMatching:
         assert compiled.name == "specific"
         assert compiled.permission == "items-read"
 
+    def test_later_allowed_firewall_wins_after_earlier_malformed_policy_match(self):
+        fws = [
+            {
+                "name": "broad",
+                "apis": [
+                    {
+                        "base": "https://api.example.com",
+                        "auth": {"headers": {"Authorization": "Bearer broad"}},
+                        "permissions": [
+                            {"name": "broad-read", "rules": ["GET /items/{id}"]},
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "specific",
+                "apis": [
+                    {
+                        "base": "https://api.example.com",
+                        "auth": {"headers": {"Authorization": "Bearer specific"}},
+                        "permissions": [
+                            {"name": "items-read", "rules": ["GET /items/{id}"]},
+                        ],
+                    }
+                ],
+            },
+        ]
+        policies = {
+            "broad": "denied",
+            "specific": {"allow": ["items-read"], "deny": [], "unknownPolicy": "deny"},
+        }
+        url = "https://api.example.com/items/123"
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, matching.FirewallAllow)
+        assert compiled.name == "specific"
+        assert compiled.permission == "items-read"
+
     def test_preserves_raw_rule_order_for_any_before_exact_method(self):
         api_entry = {
             "base": "https://api.github.com",

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -2,11 +2,27 @@
 
 from unittest.mock import patch
 
+import pytest
+
 import matching
 from tests.firewall_helpers import wrap_firewalls
 
 
 class TestCompiledFirewallMatching:
+    def _github_firewalls(self):
+        return wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+
     def _compiled(self, firewalls):
         compiled = matching.compile_firewalls(firewalls)
         assert compiled is not None
@@ -579,3 +595,106 @@ class TestCompiledFirewallMatching:
 
         assert isinstance(result, matching.FirewallAllow)
         assert spy.call_count == 1
+
+    @pytest.mark.parametrize(
+        "policies",
+        [
+            {"github": {"deny": None, "ask": [], "unknownPolicy": "deny"}},
+            {"github": {"deny": [], "ask": None, "unknownPolicy": "deny"}},
+        ],
+    )
+    def test_null_permission_lists_behave_as_empty(self, policies):
+        fws = self._github_firewalls()
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            matching.compile_network_policies(policies),
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "repo-read"
+
+    @pytest.mark.parametrize(
+        "policies",
+        [
+            {"github": None},
+            {"github": "denied"},
+            {"github": {"deny": "repo-read", "ask": [], "unknownPolicy": "allow"}},
+            {"github": {"deny": [], "ask": "repo-read", "unknownPolicy": "allow"}},
+            {"github": {"deny": [123], "ask": [], "unknownPolicy": "allow"}},
+            {"github": {"deny": [], "ask": [None], "unknownPolicy": "allow"}},
+        ],
+    )
+    def test_malformed_permission_policy_fails_closed_after_base_match(self, policies):
+        fws = self._github_firewalls()
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            matching.compile_network_policies(policies),
+        )
+
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ()
+        assert result.reason == "malformed_network_policy"
+
+    def test_invalid_unknown_policy_only_blocks_unknown_endpoint_branch(self):
+        fws = self._github_firewalls()
+        policies = {"github": {"deny": [], "ask": [], "unknownPolicy": "broken"}}
+        compiled_policies = matching.compile_network_policies(policies)
+        compiled_firewalls = self._compiled(fws)
+
+        allowed = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+        blocked = matching.match_compiled_firewall_request(
+            "https://api.github.com/users/octocat",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+
+        assert isinstance(allowed, matching.FirewallAllow)
+        assert allowed.permission == "repo-read"
+        assert isinstance(blocked, matching.FirewallBlock)
+        assert blocked.reason == "malformed_network_policy"
+
+    def test_unrelated_malformed_policy_does_not_block_other_firewall(self):
+        fws = self._github_firewalls()
+        policies = {"slack": {"deny": "channels-read"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            matching.compile_network_policies(policies),
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "repo-read"
+
+    def test_top_level_malformed_policy_fails_closed_only_after_base_match(self):
+        fws = self._github_firewalls()
+        compiled_policies = matching.compile_network_policies("broken")
+        compiled_firewalls = self._compiled(fws)
+
+        unrelated = matching.match_compiled_firewall_request(
+            "https://api.example.com/repos/org/repo",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+        matched = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+
+        assert unrelated is None
+        assert isinstance(matched, matching.FirewallBlock)
+        assert matched.reason == "malformed_network_policy"

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -1034,6 +1034,25 @@ class TestThreeLevelMatching:
         assert result.permissions == ()
         assert result.reason == "malformed_network_policy"
 
+    def test_top_level_malformed_network_policy_fails_closed_after_base_match(self):
+        unrelated = matching.match_firewall_request(
+            "https://api.example.com/foo",
+            "GET",
+            self._firewalls(),
+            network_policies="denied",
+        )
+        matched = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies="denied",
+        )
+
+        assert unrelated is None
+        assert isinstance(matched, matching.FirewallBlock)
+        assert matched.permissions == ()
+        assert matched.reason == "malformed_network_policy"
+
     def test_invalid_unknown_policy_only_blocks_unknown_endpoint_branch(self):
         policies = {"github": {"deny": [], "ask": [], "unknownPolicy": "broken"}}
 

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -1,5 +1,7 @@
 """Tests for raw firewall request matching."""
 
+import pytest
+
 import matching
 from tests.firewall_helpers import grant_all, wrap_firewalls
 
@@ -992,6 +994,66 @@ class TestThreeLevelMatching:
             network_policies=None,
         )
         assert isinstance(result, matching.FirewallAllow)
+
+    @pytest.mark.parametrize(
+        "policies",
+        [
+            {"github": {"deny": None, "ask": [], "unknownPolicy": "deny"}},
+            {"github": {"deny": [], "ask": None, "unknownPolicy": "deny"}},
+        ],
+    )
+    def test_null_permission_lists_behave_as_empty(self, policies):
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=policies,
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "repo-read"
+
+    @pytest.mark.parametrize(
+        "policies",
+        [
+            {"github": None},
+            {"github": "denied"},
+            {"github": {"deny": "repo-read", "ask": [], "unknownPolicy": "allow"}},
+            {"github": {"deny": [], "ask": [None], "unknownPolicy": "allow"}},
+        ],
+    )
+    def test_malformed_permission_policy_fails_closed_after_base_match(self, policies):
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=policies,
+        )
+
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ()
+        assert result.reason == "malformed_network_policy"
+
+    def test_invalid_unknown_policy_only_blocks_unknown_endpoint_branch(self):
+        policies = {"github": {"deny": [], "ask": [], "unknownPolicy": "broken"}}
+
+        allowed = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=policies,
+        )
+        blocked = matching.match_firewall_request(
+            "https://api.github.com/users/octocat",
+            "GET",
+            self._firewalls(),
+            network_policies=policies,
+        )
+
+        assert isinstance(allowed, matching.FirewallAllow)
+        assert allowed.permission == "repo-read"
+        assert isinstance(blocked, matching.FirewallBlock)
+        assert blocked.reason == "malformed_network_policy"
 
     def test_empty_permissions_with_unknown_policy_allow(self, headers):
         """Firewall with no permission rules + unknownPolicy=allow allows all."""

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -406,16 +406,17 @@ class TestGetVmContext:
         context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert context is not None
-        vm_info, compiled_firewalls = context
+        vm_info, compiled_firewalls, compiled_network_policies = context
         assert vm_info["runId"] == "run-abc-123"
         assert registry.get_vm_info("10.200.0.1", str(path)) is vm_info
         assert compiled_firewalls is not None
+        assert compiled_network_policies is not None
 
         result = matching.match_compiled_firewall_request(
             "https://api.example.com/items",
             "GET",
             compiled_firewalls,
-            vm_info["networkPolicies"],
+            compiled_network_policies,
         )
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry is vm_info["firewalls"][0]["apis"][0]
@@ -443,23 +444,24 @@ class TestGetVmContext:
         _write_firewall_registry(path, rule="/items")
         first_context = registry.get_vm_context("10.200.0.1", str(path))
         assert first_context is not None
-        first_vm_info, first_compiled = first_context
+        first_vm_info, first_compiled, first_compiled_policies = first_context
         assert first_compiled is not None
 
         _write_firewall_registry(path, rule="/other-resource")
         second_context = registry.get_vm_context("10.200.0.1", str(path))
         assert second_context is not None
-        second_vm_info, second_compiled = second_context
+        second_vm_info, second_compiled, second_compiled_policies = second_context
 
         assert second_vm_info is not first_vm_info
         assert second_compiled is not None
         assert second_compiled is not first_compiled
+        assert second_compiled_policies is not first_compiled_policies
         assert isinstance(
             matching.match_compiled_firewall_request(
                 "https://api.example.com/items",
                 "GET",
                 second_compiled,
-                second_vm_info["networkPolicies"],
+                second_compiled_policies,
             ),
             matching.FirewallBlock,
         )
@@ -468,7 +470,7 @@ class TestGetVmContext:
                 "https://api.example.com/other-resource",
                 "GET",
                 second_compiled,
-                second_vm_info["networkPolicies"],
+                second_compiled_policies,
             ),
             matching.FirewallAllow,
         )
@@ -478,7 +480,7 @@ class TestGetVmContext:
         _write_firewall_registry(path)
         first_context = registry.get_vm_context("10.200.0.1", str(path))
         assert first_context is not None
-        _, first_compiled = first_context
+        _, first_compiled, first_compiled_policies = first_context
         assert first_compiled is not None
 
         path.write_text(
@@ -503,15 +505,16 @@ class TestGetVmContext:
 
         second_context = registry.get_vm_context("10.200.0.1", str(path))
         assert second_context is not None
-        _, second_compiled = second_context
+        _, second_compiled, second_compiled_policies = second_context
         assert second_compiled is None
+        assert second_compiled_policies is not first_compiled_policies
 
     def test_parse_failure_preserves_compiled_context(self, tmp_path):
         path = tmp_path / "registry.json"
         _write_firewall_registry(path)
         context = registry.get_vm_context("10.200.0.1", str(path))
         assert context is not None
-        vm_info, compiled_firewalls = context
+        vm_info, compiled_firewalls, compiled_network_policies = context
         assert compiled_firewalls is not None
 
         path.write_text("{ broken")
@@ -519,15 +522,16 @@ class TestGetVmContext:
             preserved_context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert preserved_context is not None
-        preserved_vm_info, preserved_compiled = preserved_context
+        preserved_vm_info, preserved_compiled, preserved_compiled_policies = preserved_context
         assert preserved_vm_info is vm_info
         assert preserved_compiled is compiled_firewalls
+        assert preserved_compiled_policies is compiled_network_policies
         assert isinstance(
             matching.match_compiled_firewall_request(
                 "https://api.example.com/items",
                 "GET",
                 preserved_compiled,
-                preserved_vm_info["networkPolicies"],
+                preserved_compiled_policies,
             ),
             matching.FirewallAllow,
         )
@@ -537,7 +541,7 @@ class TestGetVmContext:
         _write_firewall_registry(path)
         context = registry.get_vm_context("10.200.0.1", str(path))
         assert context is not None
-        vm_info, compiled_firewalls = context
+        vm_info, compiled_firewalls, compiled_network_policies = context
         assert compiled_firewalls is not None
 
         path.unlink()
@@ -545,18 +549,40 @@ class TestGetVmContext:
             preserved_context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert preserved_context is not None
-        preserved_vm_info, preserved_compiled = preserved_context
+        preserved_vm_info, preserved_compiled, preserved_compiled_policies = preserved_context
         assert preserved_vm_info is vm_info
         assert preserved_compiled is compiled_firewalls
+        assert preserved_compiled_policies is compiled_network_policies
         assert isinstance(
             matching.match_compiled_firewall_request(
                 "https://api.example.com/items",
                 "GET",
                 preserved_compiled,
-                preserved_vm_info["networkPolicies"],
+                preserved_compiled_policies,
             ),
             matching.FirewallAllow,
         )
+
+    def test_malformed_network_policy_shape_compiles_without_load_failure(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+        data = json.loads(path.read_text())
+        data["vms"]["10.200.0.1"]["networkPolicies"] = {"example": "denied"}
+        path.write_text(json.dumps(data))
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        _, compiled_firewalls, compiled_network_policies = context
+        assert compiled_firewalls is not None
+        result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            compiled_firewalls,
+            compiled_network_policies,
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "malformed_network_policy"
 
 
 class TestLogNetworkEntry:

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -938,6 +938,53 @@ class TestRequestHandler:
         assert proxy_log_entry["type"] == "firewall_block"
         assert proxy_log_entry["reason"] == "malformed_firewall_config"
 
+    async def test_firewall_malformed_network_policy_block_reports_reason(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        """Malformed network policy blocks fail closed instead of raising."""
+        vm_info = _single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "read-repos",
+                        "rules": ["GET /repos/{owner}/{repo}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["read-repos"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        )
+        vm_info["networkPolicies"] = {"github": "denied"}
+        reg_path = _write_registry(tmp_path, vm_info=vm_info)
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos/org/repo",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        assert flow.metadata["firewall_action"] == "DENY"
+        body = json.loads(flow.response.content)
+        assert body["permissions"] == []
+        assert body["reason"] == "malformed_network_policy"
+        proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        assert proxy_log_entry["type"] == "firewall_block"
+        assert proxy_log_entry["reason"] == "malformed_network_policy"
+        assert "networkPolicies" not in proxy_log_entry
+
     async def test_firewall_permission_denied_block_reports_reason(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -986,6 +986,54 @@ class TestRequestHandler:
         assert proxy_log_entry["reason"] == "malformed_network_policy"
         assert "networkPolicies" not in proxy_log_entry
 
+    async def test_firewall_top_level_malformed_network_policy_block_reports_reason(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        """Top-level malformed network policy blocks fail closed after base match."""
+        vm_info = _single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "read-repos",
+                        "rules": ["GET /repos/{owner}/{repo}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["read-repos"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        )
+        vm_info["networkPolicies"] = "denied"
+        reg_path = _write_registry(tmp_path, vm_info=vm_info)
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos/org/repo",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        assert flow.metadata["firewall_action"] == "DENY"
+        body = json.loads(flow.response.content)
+        assert body["permissions"] == []
+        assert body["message"] == "Request blocked: malformed network policy"
+        assert body["reason"] == "malformed_network_policy"
+        proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        assert proxy_log_entry["type"] == "firewall_block"
+        assert proxy_log_entry["reason"] == "malformed_network_policy"
+        assert "networkPolicies" not in proxy_log_entry
+
     async def test_firewall_permission_denied_block_reports_reason(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler.py
@@ -979,6 +979,7 @@ class TestRequestHandler:
         assert flow.metadata["firewall_action"] == "DENY"
         body = json.loads(flow.response.content)
         assert body["permissions"] == []
+        assert body["message"] == "Request blocked: malformed network policy"
         assert body["reason"] == "malformed_network_policy"
         proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
         assert proxy_log_entry["type"] == "firewall_block"


### PR DESCRIPTION
## Summary
- compile mitm networkPolicies into a registry-side matcher model alongside compiled firewalls
- fail closed with malformed_network_policy for present malformed policy data after a relevant firewall base match
- keep absent policy data permissive and preserve path-sensitive unknownPolicy behavior

## Tests
- cd crates/runner/mitm-addon && ruff format --check src tests/test_compiled_firewall_matching.py tests/test_firewall_matching.py tests/test_registry.py tests/test_request_handler.py
- cd crates/runner/mitm-addon && ruff check src tests/test_compiled_firewall_matching.py tests/test_firewall_matching.py tests/test_registry.py tests/test_request_handler.py
- cd crates/runner/mitm-addon && basedpyright src tests/test_compiled_firewall_matching.py tests/test_firewall_matching.py tests/test_registry.py tests/test_request_handler.py
- cd crates/runner/mitm-addon && pytest tests/

Closes #14934