### PR TITLE
refactor: move computer use input semantics to native helper

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -52,6 +52,152 @@ let visibleCollectionChildSources = [
     ChildSource(attribute: "AXContents", prefix: "c"),
 ]
 
+let keyModifierDefinitions = [
+    KeyModifierDefinition(
+        name: "command",
+        displayName: "Command",
+        keyCode: 55,
+        flag: Int(CGEventFlags.maskCommand.rawValue)
+    ),
+    KeyModifierDefinition(
+        name: "control",
+        displayName: "Control",
+        keyCode: 59,
+        flag: Int(CGEventFlags.maskControl.rawValue)
+    ),
+    KeyModifierDefinition(
+        name: "option",
+        displayName: "Option",
+        keyCode: 58,
+        flag: Int(CGEventFlags.maskAlternate.rawValue)
+    ),
+    KeyModifierDefinition(
+        name: "shift",
+        displayName: "Shift",
+        keyCode: 56,
+        flag: Int(CGEventFlags.maskShift.rawValue)
+    ),
+]
+
+let keyModifierAliases = [
+    "alt": "option",
+    "cmd": "command",
+    "command": "command",
+    "control": "control",
+    "ctrl": "control",
+    "meta": "command",
+    "option": "option",
+    "shift": "shift",
+    "super": "command",
+]
+
+let keyCodes = [
+    "'": 39,
+    ",": 43,
+    "-": 27,
+    ".": 47,
+    "/": 44,
+    "0": 29,
+    "1": 18,
+    "2": 19,
+    "3": 20,
+    "4": 21,
+    "5": 23,
+    "6": 22,
+    "7": 26,
+    "8": 28,
+    "9": 25,
+    ";": 41,
+    "=": 24,
+    "[": 33,
+    "\\": 42,
+    "]": 30,
+    "`": 50,
+    "a": 0,
+    "b": 11,
+    "backspace": 51,
+    "c": 8,
+    "d": 2,
+    "delete": 51,
+    "down": 125,
+    "downarrow": 125,
+    "e": 14,
+    "end": 119,
+    "enter": 36,
+    "esc": 53,
+    "escape": 53,
+    "f": 3,
+    "f1": 122,
+    "f2": 120,
+    "f3": 99,
+    "f4": 118,
+    "f5": 96,
+    "f6": 97,
+    "f7": 98,
+    "f8": 100,
+    "f9": 101,
+    "f10": 109,
+    "f11": 103,
+    "f12": 111,
+    "forwarddelete": 117,
+    "g": 5,
+    "h": 4,
+    "home": 115,
+    "i": 34,
+    "j": 38,
+    "k": 40,
+    "l": 37,
+    "left": 123,
+    "leftarrow": 123,
+    "m": 46,
+    "n": 45,
+    "o": 31,
+    "p": 35,
+    "pagedown": 121,
+    "pageup": 116,
+    "q": 12,
+    "r": 15,
+    "return": 36,
+    "right": 124,
+    "rightarrow": 124,
+    "s": 1,
+    "space": 49,
+    "spacebar": 49,
+    "t": 17,
+    "tab": 48,
+    "u": 32,
+    "up": 126,
+    "uparrow": 126,
+    "v": 9,
+    "w": 13,
+    "x": 7,
+    "y": 16,
+    "z": 6,
+]
+
+let keyDisplayNames = [
+    "backspace": "Backspace",
+    "delete": "Backspace",
+    "down": "Down",
+    "downarrow": "Down",
+    "enter": "Return",
+    "esc": "Escape",
+    "escape": "Escape",
+    "forwarddelete": "ForwardDelete",
+    "left": "Left",
+    "leftarrow": "Left",
+    "pagedown": "PageDown",
+    "pageup": "PageUp",
+    "return": "Return",
+    "right": "Right",
+    "rightarrow": "Right",
+    "space": "Space",
+    "spacebar": "Space",
+    "tab": "Tab",
+    "up": "Up",
+    "uparrow": "Up",
+]
+
 struct WindowTarget {
     let pid: pid_t
     let windowNumber: Int
@@ -77,6 +223,20 @@ struct CGWindowCandidate {
     let title: String?
     let frame: CGRect
     let area: Double
+}
+
+struct KeyModifierDefinition {
+    let name: String
+    let displayName: String
+    let keyCode: Int
+    let flag: Int
+}
+
+struct ParsedKeyPress {
+    let keyCode: Int
+    let modifiers: [KeyModifierDefinition]
+    let flags: Int
+    let normalizedKey: String
 }
 
 final class LaunchResultBox: @unchecked Sendable {
@@ -299,16 +459,6 @@ func requiredNumber(_ request: [String: Any], _ key: String) throws -> Double {
     return value.doubleValue
 }
 
-func requiredInt(_ request: [String: Any], _ key: String) throws -> Int {
-    guard let value = request[key] as? NSNumber else {
-        throw HelperFailure(
-            code: "unsupported_command",
-            message: "Missing required payload field: \(key)"
-        )
-    }
-    return value.intValue
-}
-
 func optionalString(_ request: [String: Any], _ key: String) -> String? {
     guard let value = request[key] as? String else {
         return nil
@@ -317,8 +467,46 @@ func optionalString(_ request: [String: Any], _ key: String) -> String? {
     return trimmed.isEmpty ? nil : trimmed
 }
 
+func optionalInt(_ request: [String: Any], _ key: String) -> Int? {
+    return (request[key] as? NSNumber)?.intValue
+}
+
 func optionalInt(_ request: [String: Any], _ key: String, default defaultValue: Int) -> Int {
     return (request[key] as? NSNumber)?.intValue ?? defaultValue
+}
+
+func rectPayload(_ request: [String: Any], _ key: String) throws -> CGRect {
+    guard let record = request[key] as? [String: Any],
+          let x = record["x"] as? NSNumber,
+          let y = record["y"] as? NSNumber,
+          let width = record["width"] as? NSNumber,
+          let height = record["height"] as? NSNumber
+    else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Missing required payload field: \(key)"
+        )
+    }
+    let rect = CGRect(
+        x: x.doubleValue,
+        y: y.doubleValue,
+        width: width.doubleValue,
+        height: height.doubleValue
+    )
+    guard rect.width > 0, rect.height > 0 else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Invalid bounds payload field: \(key)"
+        )
+    }
+    return rect
+}
+
+func optionalRectPayload(_ request: [String: Any], _ key: String) throws -> CGRect? {
+    if request[key] == nil {
+        return nil
+    }
+    return try rectPayload(request, key)
 }
 
 func findRunningApp(named appName: String) -> NSRunningApplication? {
@@ -729,6 +917,73 @@ func waitForWindowTarget(app: NSRunningApplication, timeout: TimeInterval = 3) -
 
 func backgroundTargetUnavailableMessage(appName: String) -> String {
     return "Unable to resolve a background window target for \(appName)"
+}
+
+func roundScreenCoordinate(_ value: CGFloat) -> Double {
+    return (Double(value) * 100).rounded() / 100
+}
+
+func screenPointFromScreenshotPoint(
+    x: Double,
+    y: Double,
+    screenshotWidth: Double,
+    screenshotHeight: Double,
+    sourceBounds: CGRect
+) throws -> CGPoint {
+    guard screenshotWidth > 0, screenshotHeight > 0 else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Snapshot dimensions are invalid"
+        )
+    }
+    return CGPoint(
+        x: roundScreenCoordinate(
+            sourceBounds.minX + (x / screenshotWidth) * sourceBounds.width
+        ),
+        y: roundScreenCoordinate(
+            sourceBounds.minY + (y / screenshotHeight) * sourceBounds.height
+        )
+    )
+}
+
+func snapshotWindowTarget(
+    appName: String,
+    snapshotId: String,
+    preferredScreenPoint: CGPoint,
+    windowId: Int?,
+    windowFrame: CGRect?
+) throws -> WindowTarget {
+    let app = try resolveRunningApp(named: appName)
+    if let windowId {
+        guard let candidate = cgWindowCandidates(pid: app.processIdentifier).first(where: { candidate in
+            candidate.windowNumber == windowId
+        }) else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Snapshot target window is no longer available: \(snapshotId)"
+            )
+        }
+        if let windowFrame, rectDistance(candidate.frame, windowFrame) > 4 {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Snapshot target window moved or resized: \(snapshotId)"
+            )
+        }
+        return WindowTarget(
+            pid: app.processIdentifier,
+            windowNumber: candidate.windowNumber,
+            title: candidate.title,
+            frame: candidate.frame
+        )
+    }
+
+    guard let target = resolveWindowTarget(app: app, preferredScreenPoint: preferredScreenPoint) else {
+        throw HelperFailure(
+            code: "accessibility_unavailable",
+            message: backgroundTargetUnavailableMessage(appName: appName)
+        )
+    }
+    return target
 }
 
 func performWithRequiredBackgroundTarget<T>(
@@ -1312,40 +1567,154 @@ func mouseEventConfig(button: String) throws -> (
     )
 }
 
+func normalizeKeyToken(_ value: String) -> String {
+    return value
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+        .filter { character in
+            !character.isWhitespace && character != "_" && character != "-"
+        }
+}
+
+func displayKeyToken(_ token: String) -> String {
+    if let displayName = keyDisplayNames[token] {
+        return displayName
+    }
+    if token.first == "f",
+       token.count <= 3,
+       Int(token.dropFirst()) != nil
+    {
+        return token.uppercased()
+    }
+    if token.count == 1 {
+        return token.uppercased()
+    }
+    return token
+}
+
+func parseKeyPress(_ key: String) throws -> ParsedKeyPress {
+    let rawParts = key.split(separator: "+", omittingEmptySubsequences: false).map { part in
+        String(part).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    if rawParts.isEmpty || rawParts.contains(where: { part in part.isEmpty }) {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "keyboard.press_key requires a non-empty key or key combination"
+        )
+    }
+
+    var modifierNames = Set<String>()
+    var keyCode: Int?
+    var displayKey: String?
+
+    for rawPart in rawParts {
+        let token = normalizeKeyToken(rawPart)
+        if let modifierName = keyModifierAliases[token] {
+            modifierNames.insert(modifierName)
+            continue
+        }
+        guard let code = keyCodes[token] else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Unsupported key specification: \(rawPart)"
+            )
+        }
+        if keyCode != nil {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "keyboard.press_key supports exactly one non-modifier key"
+            )
+        }
+        keyCode = code
+        displayKey = displayKeyToken(token)
+    }
+
+    guard let keyCode, let displayKey else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "keyboard.press_key requires a non-modifier key"
+        )
+    }
+
+    let activeModifiers = keyModifierDefinitions.filter { definition in
+        modifierNames.contains(definition.name)
+    }
+    let flags = activeModifiers.reduce(0) { partial, definition in
+        partial | definition.flag
+    }
+    let normalizedKey = (
+        activeModifiers.map { definition in definition.displayName } + [displayKey]
+    ).joined(separator: "+")
+
+    return ParsedKeyPress(
+        keyCode: keyCode,
+        modifiers: activeModifiers,
+        flags: flags,
+        normalizedKey: normalizedKey
+    )
+}
+
 func handleElementClickPoint(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
+    let snapshotId = try requiredString(request, "snapshotId")
     let x = try requiredNumber(request, "x")
     let y = try requiredNumber(request, "y")
+    let screenshotSource = try requiredString(request, "screenshotSource")
+    guard screenshotSource == "window" else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Snapshot is not a target-window screenshot: \(snapshotId)"
+        )
+    }
+    let screenshotWidth = try requiredNumber(request, "screenshotWidth")
+    let screenshotHeight = try requiredNumber(request, "screenshotHeight")
+    let sourceBounds = try rectPayload(request, "sourceBounds")
+    let windowFrame = try optionalRectPayload(request, "windowFrame")
+    let windowId = optionalInt(request, "windowId")
     let button = optionalString(request, "button") ?? "left"
     let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
     let config = try mouseEventConfig(button: button)
-    let point = CGPoint(x: x, y: y)
+    let point = try screenPointFromScreenshotPoint(
+        x: x,
+        y: y,
+        screenshotWidth: screenshotWidth,
+        screenshotHeight: screenshotHeight,
+        sourceBounds: sourceBounds
+    )
+    let target = try snapshotWindowTarget(
+        appName: appName,
+        snapshotId: snapshotId,
+        preferredScreenPoint: point,
+        windowId: windowId,
+        windowFrame: windowFrame
+    )
 
-    try performWithRequiredBackgroundTarget(appName: appName, preferredScreenPoint: point) { target in
-        let dispatcher = AddressedEventDispatcher(target: target)
-        for index in 1...clickCount {
-            try dispatcher.postMouse(
-                config.down,
-                at: point,
-                button: config.button,
-                clickState: Int64(index),
-                pressure: 1
-            )
-            usleep(30_000)
-            try dispatcher.postMouse(
-                config.up,
-                at: point,
-                button: config.button,
-                clickState: Int64(index),
-                pressure: 0
-            )
-            if index < clickCount {
-                usleep(50_000)
-            }
+    let dispatcher = AddressedEventDispatcher(target: target)
+    for index in 1...clickCount {
+        try dispatcher.postMouse(
+            config.down,
+            at: point,
+            button: config.button,
+            clickState: Int64(index),
+            pressure: 1
+        )
+        usleep(30_000)
+        try dispatcher.postMouse(
+            config.up,
+            at: point,
+            button: config.button,
+            clickState: Int64(index),
+            pressure: 0
+        )
+        if index < clickCount {
+            usleep(50_000)
         }
     }
 
-    return [:]
+    return [
+        "screenX": point.x,
+        "screenY": point.y,
+    ]
 }
 
 func handleElementSetValue(_ request: [String: Any]) throws -> [String: Any] {
@@ -1408,36 +1777,24 @@ func handleTypeText(_ request: [String: Any]) throws -> [String: Any] {
 
 func handlePressKey(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let keyCode = try requiredInt(request, "keyCode")
-    let flags = try requiredInt(request, "flags")
-    let modifierRecords = (request["modifiers"] as? [[String: Any]]) ?? []
-    let modifiers = try modifierRecords.map { record -> (keyCode: Int, flag: Int) in
-        guard let keyCode = record["keyCode"] as? NSNumber,
-              let flag = record["flag"] as? NSNumber
-        else {
-            throw HelperFailure(
-                code: "unsupported_command",
-                message: "Invalid keyboard modifier payload"
-            )
-        }
-        return (keyCode: keyCode.intValue, flag: flag.intValue)
-    }
+    let key = try requiredString(request, "key")
+    let parsed = try parseKeyPress(key)
 
     try performWithRequiredBackgroundTarget(appName: appName) { target in
         let dispatcher = AddressedEventDispatcher(target: target)
         var activeFlags = 0
-        for modifier in modifiers {
+        for modifier in parsed.modifiers {
             activeFlags |= modifier.flag
             try dispatcher.postKey(keyCode: modifier.keyCode, keyDown: true, flags: activeFlags)
         }
-        try dispatcher.postKey(keyCode: keyCode, keyDown: true, flags: flags)
-        try dispatcher.postKey(keyCode: keyCode, keyDown: false, flags: flags)
-        for modifier in modifiers.reversed() {
+        try dispatcher.postKey(keyCode: parsed.keyCode, keyDown: true, flags: parsed.flags)
+        try dispatcher.postKey(keyCode: parsed.keyCode, keyDown: false, flags: parsed.flags)
+        for modifier in parsed.modifiers.reversed() {
             activeFlags &= ~modifier.flag
             try dispatcher.postKey(keyCode: modifier.keyCode, keyDown: false, flags: activeFlags)
         }
     }
-    return [:]
+    return ["normalizedKey": parsed.normalizedKey]
 }
 
 func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -3,7 +3,6 @@ import {
   ComputerUseNativeHelperError,
   createComputerUseNativeBackend,
   type ComputerUseNativeBackend,
-  type ComputerUseNativePressKeyRequest,
 } from "./computer-use-native";
 
 export const SUPPORTED_COMPUTER_USE_CAPABILITIES = [
@@ -198,176 +197,6 @@ interface ComputerUseCommandExecutionDependencies {
 }
 
 const DEFAULT_SNAPSHOT_STORE_LIMIT = 50;
-const CG_EVENT_FLAG_SHIFT = 131_072;
-const CG_EVENT_FLAG_CONTROL = 262_144;
-const CG_EVENT_FLAG_OPTION = 524_288;
-const CG_EVENT_FLAG_COMMAND = 1_048_576;
-
-type ComputerUseKeyModifier = "command" | "control" | "option" | "shift";
-
-interface ComputerUseModifierDefinition {
-  readonly name: ComputerUseKeyModifier;
-  readonly displayName: string;
-  readonly keyCode: number;
-  readonly flag: number;
-}
-
-interface ParsedComputerUseKeyPress {
-  readonly keyCode: number;
-  readonly modifiers: readonly {
-    readonly keyCode: number;
-    readonly flag: number;
-  }[];
-  readonly flags: number;
-  readonly normalizedKey: string;
-}
-
-const MODIFIER_DEFINITIONS: readonly ComputerUseModifierDefinition[] = [
-  {
-    name: "command",
-    displayName: "Command",
-    keyCode: 55,
-    flag: CG_EVENT_FLAG_COMMAND,
-  },
-  {
-    name: "control",
-    displayName: "Control",
-    keyCode: 59,
-    flag: CG_EVENT_FLAG_CONTROL,
-  },
-  {
-    name: "option",
-    displayName: "Option",
-    keyCode: 58,
-    flag: CG_EVENT_FLAG_OPTION,
-  },
-  {
-    name: "shift",
-    displayName: "Shift",
-    keyCode: 56,
-    flag: CG_EVENT_FLAG_SHIFT,
-  },
-] as const;
-
-const MODIFIER_ALIASES: Readonly<Record<string, ComputerUseKeyModifier>> =
-  Object.freeze({
-    alt: "option",
-    cmd: "command",
-    command: "command",
-    control: "control",
-    ctrl: "control",
-    meta: "command",
-    option: "option",
-    shift: "shift",
-    super: "command",
-  });
-
-const KEY_CODES: Readonly<Record<string, number>> = Object.freeze({
-  "'": 39,
-  ",": 43,
-  "-": 27,
-  ".": 47,
-  "/": 44,
-  "0": 29,
-  "1": 18,
-  "2": 19,
-  "3": 20,
-  "4": 21,
-  "5": 23,
-  "6": 22,
-  "7": 26,
-  "8": 28,
-  "9": 25,
-  ";": 41,
-  "=": 24,
-  "[": 33,
-  "\\": 42,
-  "]": 30,
-  "`": 50,
-  a: 0,
-  b: 11,
-  backspace: 51,
-  c: 8,
-  d: 2,
-  delete: 51,
-  down: 125,
-  downarrow: 125,
-  e: 14,
-  end: 119,
-  enter: 36,
-  esc: 53,
-  escape: 53,
-  f: 3,
-  f1: 122,
-  f2: 120,
-  f3: 99,
-  f4: 118,
-  f5: 96,
-  f6: 97,
-  f7: 98,
-  f8: 100,
-  f9: 101,
-  f10: 109,
-  f11: 103,
-  f12: 111,
-  forwarddelete: 117,
-  g: 5,
-  h: 4,
-  home: 115,
-  i: 34,
-  j: 38,
-  k: 40,
-  l: 37,
-  left: 123,
-  leftarrow: 123,
-  m: 46,
-  n: 45,
-  o: 31,
-  p: 35,
-  pagedown: 121,
-  pageup: 116,
-  q: 12,
-  r: 15,
-  return: 36,
-  right: 124,
-  rightarrow: 124,
-  s: 1,
-  space: 49,
-  spacebar: 49,
-  t: 17,
-  tab: 48,
-  u: 32,
-  up: 126,
-  uparrow: 126,
-  v: 9,
-  w: 13,
-  x: 7,
-  y: 16,
-  z: 6,
-});
-
-const KEY_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.freeze({
-  backspace: "Backspace",
-  delete: "Backspace",
-  down: "Down",
-  downarrow: "Down",
-  enter: "Return",
-  esc: "Escape",
-  escape: "Escape",
-  forwarddelete: "ForwardDelete",
-  left: "Left",
-  leftarrow: "Left",
-  pagedown: "PageDown",
-  pageup: "PageUp",
-  return: "Return",
-  right: "Right",
-  rightarrow: "Right",
-  space: "Space",
-  spacebar: "Space",
-  tab: "Tab",
-  up: "Up",
-  uparrow: "Up",
-});
 
 class UnsupportedComputerUseCommandError extends Error {
   constructor(message: string) {
@@ -860,26 +689,6 @@ function renderAccessibilityVisibleText(
     .join("\n");
 }
 
-function normalizeKeyToken(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[\s_-]+/g, "");
-}
-
-function displayKeyToken(token: string): string {
-  if (KEY_DISPLAY_NAMES[token]) {
-    return KEY_DISPLAY_NAMES[token];
-  }
-  if (/^f\d{1,2}$/.test(token)) {
-    return token.toUpperCase();
-  }
-  if (token.length === 1) {
-    return token.toUpperCase();
-  }
-  return token;
-}
-
 function unsupportedCommand(message: string): ComputerUseCommandFailure {
   return {
     status: "failed",
@@ -897,77 +706,6 @@ function missingField(field: string): ComputerUseCommandFailure {
       code: "unsupported_command",
       message: `Missing required payload field: ${field}`,
     },
-  };
-}
-
-function parseComputerUseKeyPress(key: string): ParsedComputerUseKeyPress {
-  const rawParts = key.split("+").map((part) => {
-    return part.trim();
-  });
-  if (
-    rawParts.length === 0 ||
-    rawParts.some((part) => {
-      return part.length === 0;
-    })
-  ) {
-    throw new UnsupportedComputerUseCommandError(
-      "keyboard.press_key requires a non-empty key or key combination",
-    );
-  }
-
-  const modifiers = new Set<ComputerUseKeyModifier>();
-  let keyCode: number | null = null;
-  let displayKey: string | null = null;
-
-  for (const rawPart of rawParts) {
-    const token = normalizeKeyToken(rawPart);
-    const modifier = MODIFIER_ALIASES[token];
-    if (modifier) {
-      modifiers.add(modifier);
-      continue;
-    }
-
-    const code = KEY_CODES[token];
-    if (code === undefined) {
-      throw new UnsupportedComputerUseCommandError(
-        `Unsupported key specification: ${rawPart}`,
-      );
-    }
-    if (keyCode !== null) {
-      throw new UnsupportedComputerUseCommandError(
-        "keyboard.press_key supports exactly one non-modifier key",
-      );
-    }
-    keyCode = code;
-    displayKey = displayKeyToken(token);
-  }
-
-  if (keyCode === null || displayKey === null) {
-    throw new UnsupportedComputerUseCommandError(
-      "keyboard.press_key requires a non-modifier key",
-    );
-  }
-
-  const activeModifiers = MODIFIER_DEFINITIONS.filter((modifier) => {
-    return modifiers.has(modifier.name);
-  });
-  return {
-    keyCode,
-    modifiers: activeModifiers.map((modifier) => {
-      return {
-        keyCode: modifier.keyCode,
-        flag: modifier.flag,
-      };
-    }),
-    flags: activeModifiers.reduce((flags, modifier) => {
-      return flags | modifier.flag;
-    }, 0),
-    normalizedKey: [
-      ...activeModifiers.map((modifier) => {
-        return modifier.displayName;
-      }),
-      displayKey,
-    ].join("+"),
   };
 }
 
@@ -1532,46 +1270,6 @@ async function openApp(
   };
 }
 
-function roundScreenCoordinate(value: number): number {
-  return Number(value.toFixed(2));
-}
-
-function mapScreenshotPointToScreen(args: {
-  readonly metadata: ComputerUseSnapshotMetadata;
-  readonly x: number;
-  readonly y: number;
-}):
-  | { readonly screenX: number; readonly screenY: number }
-  | ComputerUseCommandFailure {
-  const { metadata } = args;
-  if (metadata.screenshotSource !== "window") {
-    return unsupportedCommand(
-      `Snapshot is not a target-window screenshot: ${metadata.snapshotId}`,
-    );
-  }
-  if (!metadata.sourceBounds) {
-    return unsupportedCommand(
-      `Snapshot source bounds are unavailable: ${metadata.snapshotId}`,
-    );
-  }
-  if (metadata.screenshotWidth <= 0 || metadata.screenshotHeight <= 0) {
-    return unsupportedCommand(
-      `Snapshot dimensions are invalid: ${metadata.snapshotId}`,
-    );
-  }
-
-  return {
-    screenX: roundScreenCoordinate(
-      metadata.sourceBounds.x +
-        (args.x / metadata.screenshotWidth) * metadata.sourceBounds.width,
-    ),
-    screenY: roundScreenCoordinate(
-      metadata.sourceBounds.y +
-        (args.y / metadata.screenshotHeight) * metadata.sourceBounds.height,
-    ),
-  };
-}
-
 function resolveClickSnapshot(args: {
   readonly app: string;
   readonly snapshotId: string | null;
@@ -1704,18 +1402,19 @@ async function clickElement(args: {
     if ("status" in snapshot) {
       return snapshot;
     }
-    const screenPoint = mapScreenshotPointToScreen({
-      metadata: snapshot,
+    const clickPoint = await args.nativeBackend.clickPoint({
+      app: args.app,
+      snapshotId: snapshot.snapshotId,
       x: args.x,
       y: args.y,
-    });
-    if ("status" in screenPoint) {
-      return screenPoint;
-    }
-    await args.nativeBackend.clickPoint({
-      app: args.app,
-      x: screenPoint.screenX,
-      y: screenPoint.screenY,
+      screenshotSource: snapshot.screenshotSource,
+      screenshotWidth: snapshot.screenshotWidth,
+      screenshotHeight: snapshot.screenshotHeight,
+      ...(snapshot.sourceBounds ? { sourceBounds: snapshot.sourceBounds } : {}),
+      ...(snapshot.windowId !== undefined
+        ? { windowId: snapshot.windowId }
+        : {}),
+      ...(snapshot.windowFrame ? { windowFrame: snapshot.windowFrame } : {}),
       button: args.button,
       clickCount: args.clickCount,
     });
@@ -1726,8 +1425,8 @@ async function clickElement(args: {
         snapshotId: snapshot.snapshotId,
         x: args.x,
         y: args.y,
-        screenX: screenPoint.screenX,
-        screenY: screenPoint.screenY,
+        screenX: clickPoint.screenX,
+        screenY: clickPoint.screenY,
         button: args.button,
         clickCount: args.clickCount,
         dispatchMode: "background_mouse_event",
@@ -1815,24 +1514,16 @@ async function pressKey(
   key: string,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  const parsed = parseComputerUseKeyPress(key);
-  const request: ComputerUseNativePressKeyRequest = {
-    app,
-    keyCode: parsed.keyCode,
-    modifiers: parsed.modifiers,
-    flags: parsed.flags,
-    normalizedKey: parsed.normalizedKey,
-  };
-  await nativeBackend.pressKey(request);
+  const result = await nativeBackend.pressKey({ app, key });
   return {
     status: "succeeded",
     result: {
       app,
-      key: parsed.normalizedKey,
+      key: result.normalizedKey,
       dispatchMode: "background_keyboard_event",
       dispatchTarget: "app_process",
       inputRisk: "background_app_shortcut",
-      text: `Pressed ${parsed.normalizedKey}`,
+      text: `Pressed ${result.normalizedKey}`,
     },
   };
 }

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -64,6 +64,57 @@ describe("computer use native backend", () => {
     }
   });
 
+  it("reads coordinate click screen points from the native helper", async () => {
+    const helper = await createHelper({
+      status: "succeeded",
+      result: { screenX: 900, screenY: 800 },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+      });
+
+      await expect(
+        backend.clickPoint({
+          app: "Safari",
+          snapshotId: "snap_1",
+          x: 400,
+          y: 300,
+          screenshotSource: "window",
+          screenshotWidth: 800,
+          screenshotHeight: 600,
+          sourceBounds: { x: 100, y: 200, width: 1600, height: 1200 },
+          windowId: 123,
+          windowFrame: { x: 100, y: 200, width: 1600, height: 1200 },
+          button: "right",
+          clickCount: 2,
+        }),
+      ).resolves.toEqual({ screenX: 900, screenY: 800 });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads normalized key names from the native helper", async () => {
+    const helper = await createHelper({
+      status: "succeeded",
+      result: { normalizedKey: "Command+K" },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+      });
+
+      await expect(
+        backend.pressKey({ app: "Safari", key: "cmd+k" }),
+      ).resolves.toEqual({ normalizedKey: "Command+K" });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     ["app_not_found", "Unable to open Things: Unable to find application"],
     ["app_open_failed", "Unable to open Things"],

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -4,22 +4,34 @@ import path from "node:path";
 import type {
   AccessibilityAppStateSnapshot,
   ComputerUseCommandFailure,
+  ComputerUseCoordinateBounds,
   ComputerUseMouseButton,
 } from "./computer-use-accessibility";
 import type { ComputerUsePermissionState } from "./computer-use-types";
 
 type ComputerUseNativeErrorCode = ComputerUseCommandFailure["error"]["code"];
 
-export interface ComputerUseNativeKeyModifier {
-  readonly keyCode: number;
-  readonly flag: number;
+export interface ComputerUseNativeClickPointRequest {
+  readonly app: string;
+  readonly snapshotId: string;
+  readonly x: number;
+  readonly y: number;
+  readonly screenshotSource: "window" | "screen";
+  readonly screenshotWidth: number;
+  readonly screenshotHeight: number;
+  readonly sourceBounds?: ComputerUseCoordinateBounds;
+  readonly windowId?: number;
+  readonly windowFrame?: ComputerUseCoordinateBounds;
+  readonly button: ComputerUseMouseButton;
+  readonly clickCount: number;
 }
 
-export interface ComputerUseNativePressKeyRequest {
-  readonly app: string;
-  readonly keyCode: number;
-  readonly modifiers: readonly ComputerUseNativeKeyModifier[];
-  readonly flags: number;
+export interface ComputerUseNativeClickPointResult {
+  readonly screenX: number;
+  readonly screenY: number;
+}
+
+export interface ComputerUseNativePressKeyResult {
   readonly normalizedKey: string;
 }
 
@@ -38,13 +50,9 @@ export interface ComputerUseNativeBackend {
     readonly button: ComputerUseMouseButton;
     readonly clickCount: number;
   }) => Promise<void>;
-  readonly clickPoint: (args: {
-    readonly app: string;
-    readonly x: number;
-    readonly y: number;
-    readonly button: ComputerUseMouseButton;
-    readonly clickCount: number;
-  }) => Promise<void>;
+  readonly clickPoint: (
+    args: ComputerUseNativeClickPointRequest,
+  ) => Promise<ComputerUseNativeClickPointResult>;
   readonly setElementValue: (args: {
     readonly app: string;
     readonly elementId: string;
@@ -59,7 +67,10 @@ export interface ComputerUseNativeBackend {
     readonly app: string;
     readonly text: string;
   }) => Promise<{ readonly role?: string; readonly description?: string }>;
-  readonly pressKey: (args: ComputerUseNativePressKeyRequest) => Promise<void>;
+  readonly pressKey: (args: {
+    readonly app: string;
+    readonly key: string;
+  }) => Promise<ComputerUseNativePressKeyResult>;
   readonly scrollElement: (args: {
     readonly app: string;
     readonly elementId: string;
@@ -195,6 +206,34 @@ function resultOptionalString(
   return typeof value === "string" && value.trim().length > 0
     ? value
     : undefined;
+}
+
+function resultRequiredString(
+  result: Record<string, unknown>,
+  key: string,
+): string {
+  const value = result[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  throw new ComputerUseNativeHelperError(
+    "accessibility_unavailable",
+    `Native Computer Use helper returned invalid ${key}`,
+  );
+}
+
+function resultRequiredNumber(
+  result: Record<string, unknown>,
+  key: string,
+): number {
+  const value = result[key];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  throw new ComputerUseNativeHelperError(
+    "accessibility_unavailable",
+    `Native Computer Use helper returned invalid ${key}`,
+  );
 }
 
 function resultPermissions(
@@ -337,7 +376,11 @@ export function createComputerUseNativeBackend(
       await run({ kind: "element.click", ...args });
     },
     clickPoint: async (args) => {
-      await run({ kind: "element.click_point", ...args });
+      const result = await run({ kind: "element.click_point", ...args });
+      return {
+        screenX: resultRequiredNumber(result, "screenX"),
+        screenY: resultRequiredNumber(result, "screenY"),
+      };
     },
     setElementValue: async (args) => {
       await run({ kind: "element.set_value", ...args });
@@ -353,7 +396,10 @@ export function createComputerUseNativeBackend(
       };
     },
     pressKey: async (args) => {
-      await run({ kind: "keyboard.press_key", ...args });
+      const result = await run({ kind: "keyboard.press_key", ...args });
+      return {
+        normalizedKey: resultRequiredString(result, "normalizedKey"),
+      };
     },
     scrollElement: async (args) => {
       await run({ kind: "element.scroll", ...args });

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -12,7 +12,6 @@ import {
   ComputerUseNativeHelperError,
   resolveComputerUseHelperPath,
   type ComputerUseNativeBackend,
-  type ComputerUseNativePressKeyRequest,
 } from "./computer-use-native";
 import {
   buildComputerUseRuntimeBody,
@@ -50,13 +49,17 @@ function createNativeBackend(
     },
     openApp: async () => {},
     clickElement: async () => {},
-    clickPoint: async () => {},
+    clickPoint: async (args) => {
+      return { screenX: args.x, screenY: args.y };
+    },
     setElementValue: async () => {},
     performElementAction: async () => {},
     typeText: async () => {
       return {};
     },
-    pressKey: async () => {},
+    pressKey: async (args) => {
+      return { normalizedKey: args.key };
+    },
     scrollElement: async () => {},
   };
   return { ...defaults, ...overrides };
@@ -1224,6 +1227,7 @@ describe("computer use desktop runtime", () => {
   it("maps screenshot coordinate clicks through cached snapshot bounds", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
+    clickPoint.mockResolvedValue({ screenX: 900, screenY: 800 });
     const nativeBackend = createNativeBackend({
       clickPoint,
       getAppState: async (app) => {
@@ -1314,16 +1318,29 @@ describe("computer use desktop runtime", () => {
     });
     expect(clickPoint).toHaveBeenCalledWith({
       app: "Safari",
-      x: 900,
-      y: 800,
+      snapshotId: "snap_1",
+      x: 400,
+      y: 300,
+      screenshotSource: "window",
+      screenshotWidth: 800,
+      screenshotHeight: 600,
+      sourceBounds: { x: 100, y: 200, width: 1600, height: 1200 },
+      windowId: 123,
+      windowFrame: { x: 100, y: 200, width: 1600, height: 1200 },
       button: "right",
       clickCount: 2,
     });
   });
 
-  it("rejects coordinate clicks against non-window screenshot snapshots", async () => {
+  it("surfaces native rejection for coordinate clicks against non-window snapshots", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
+    clickPoint.mockRejectedValue(
+      new ComputerUseNativeHelperError(
+        "unsupported_command",
+        "Snapshot is not a target-window screenshot: screen_snap",
+      ),
+    );
     snapshotStore.set({
       app: "Safari",
       snapshotId: "screen_snap",
@@ -1360,13 +1377,25 @@ describe("computer use desktop runtime", () => {
         message: "Snapshot is not a target-window screenshot: screen_snap",
       },
     });
-    expect(clickPoint).not.toHaveBeenCalled();
+    expect(clickPoint).toHaveBeenCalledWith({
+      app: "Safari",
+      snapshotId: "screen_snap",
+      x: 400,
+      y: 300,
+      screenshotSource: "screen",
+      screenshotWidth: 800,
+      screenshotHeight: 600,
+      sourceBounds: { x: 0, y: 0, width: 1440, height: 900 },
+      button: "left",
+      clickCount: 1,
+    });
   });
 
   it("uses fresh native app state for coordinate clicks without a cached snapshot", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     let stateCaptureCount = 0;
     const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
+    clickPoint.mockResolvedValue({ screenX: 440, screenY: 380 });
 
     const result = await executeComputerUseCommand(
       {
@@ -1434,8 +1463,15 @@ describe("computer use desktop runtime", () => {
     expect(stateCaptureCount).toBe(2);
     expect(clickPoint).toHaveBeenCalledWith({
       app: "Safari",
-      x: 440,
-      y: 380,
+      snapshotId: "snap_fresh",
+      x: 200,
+      y: 150,
+      screenshotSource: "window",
+      screenshotWidth: 400,
+      screenshotHeight: 300,
+      sourceBounds: { x: 40, y: 80, width: 800, height: 600 },
+      windowId: 123,
+      windowFrame: { x: 40, y: 80, width: 800, height: 600 },
       button: "left",
       clickCount: 1,
     });
@@ -1494,36 +1530,27 @@ describe("computer use desktop runtime", () => {
     });
   });
 
-  it("parses press-key combinations before posting background input", async () => {
+  it("passes press-key combinations to the native helper", async () => {
     const cases = [
       {
         key: "Command+K",
         normalizedKey: "Command+K",
-        keyCode: 40,
-        flags: 1_048_576,
-        modifiers: [{ keyCode: 55, flag: 1_048_576 }],
       },
       {
         key: "Control+K",
         normalizedKey: "Control+K",
-        keyCode: 40,
-        flags: 262_144,
-        modifiers: [{ keyCode: 59, flag: 262_144 }],
       },
       {
         key: "Command+Shift+S",
         normalizedKey: "Command+Shift+S",
-        keyCode: 1,
-        flags: 1_179_648,
-        modifiers: [
-          { keyCode: 55, flag: 1_048_576 },
-          { keyCode: 56, flag: 131_072 },
-        ],
       },
     ];
 
     for (const testCase of cases) {
-      const pressRequests: ComputerUseNativePressKeyRequest[] = [];
+      const pressRequests: Array<{
+        readonly app: string;
+        readonly key: string;
+      }> = [];
       const result = await executeComputerUseCommand(
         {
           id: "cmd_1",
@@ -1536,6 +1563,7 @@ describe("computer use desktop runtime", () => {
           nativeBackend: createNativeBackend({
             pressKey: async (request) => {
               pressRequests.push(request);
+              return { normalizedKey: testCase.normalizedKey };
             },
             getAppState: async (app, snapshotId) => {
               return nativeAppStateWithScreenshot(app, snapshotId);
@@ -1554,10 +1582,7 @@ describe("computer use desktop runtime", () => {
       expect(pressRequests).toStrictEqual([
         {
           app: "Safari",
-          keyCode: testCase.keyCode,
-          flags: testCase.flags,
-          modifiers: testCase.modifiers,
-          normalizedKey: testCase.normalizedKey,
+          key: testCase.key,
         },
       ]);
     }
@@ -1566,6 +1591,7 @@ describe("computer use desktop runtime", () => {
   it("posts press-key combinations to the target process without app activation", async () => {
     const openApp = vi.fn<ComputerUseNativeBackend["openApp"]>();
     const pressKey = vi.fn<ComputerUseNativeBackend["pressKey"]>();
+    pressKey.mockResolvedValue({ normalizedKey: "Command+K" });
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -1599,16 +1625,19 @@ describe("computer use desktop runtime", () => {
     });
     expect(pressKey).toHaveBeenCalledWith({
       app: "Safari",
-      keyCode: 40,
-      modifiers: [{ keyCode: 55, flag: 1_048_576 }],
-      flags: 1_048_576,
-      normalizedKey: "Command+K",
+      key: "Command+K",
     });
     expect(openApp).not.toHaveBeenCalled();
   });
 
-  it("rejects unsupported press-key syntax before dispatching input", async () => {
+  it("surfaces native press-key syntax rejections", async () => {
     const pressKey = vi.fn<ComputerUseNativeBackend["pressKey"]>();
+    pressKey.mockRejectedValue(
+      new ComputerUseNativeHelperError(
+        "unsupported_command",
+        "Unsupported key specification: Launchpad",
+      ),
+    );
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -1629,7 +1658,10 @@ describe("computer use desktop runtime", () => {
         message: "Unsupported key specification: Launchpad",
       },
     });
-    expect(pressKey).not.toHaveBeenCalled();
+    expect(pressKey).toHaveBeenCalledWith({
+      app: "Safari",
+      key: "Command+Launchpad",
+    });
   });
 
   it("rejects type-text when the target app has no focused editable element", async () => {


### PR DESCRIPTION
## Summary
- move screenshot-coordinate to screen-coordinate mapping into the Swift helper
- pass snapshot/window metadata into native coordinate clicks so the helper can reject non-window or stale-window snapshots
- move keyboard.press_key key parsing into the Swift helper and return the normalized key from native execution

## Validation
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop build
- pnpm exec prettier --check --ignore-unknown apps/desktop/src/computer-use-accessibility.ts apps/desktop/src/computer-use-native.ts apps/desktop/src/window-policy.test.ts apps/desktop/src/computer-use-native.test.ts
- git diff --check
- pnpm knip --workspace @vm0/desktop
- direct helper negative checks for unsupported key syntax and non-window coordinate snapshots