### PR TITLE
fix(web): dedupe docs article title rendering

### DIFF
--- a/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
@@ -35,7 +35,8 @@ function titlesMatch(a: string, b: string): boolean {
 
 function stripDuplicateLeadingHeading(content: string, title: string): string {
   const match = content.match(/^\s*#{1,3}\s+(.+?)\s*\n+/);
-  if (match && titlesMatch(match[1], title)) {
+  const heading = match?.[1];
+  if (match && heading && titlesMatch(heading, title)) {
     return content.slice(match[0].length);
   }
   return content;

--- a/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
@@ -29,6 +29,18 @@ function pathFromSlug(slug: string[]): string {
   return slug.join("/");
 }
 
+function titlesMatch(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function stripDuplicateLeadingHeading(content: string, title: string): string {
+  const match = content.match(/^\s*#{1,3}\s+(.+?)\s*\n+/);
+  if (match && titlesMatch(match[1], title)) {
+    return content.slice(match[0].length);
+  }
+  return content;
+}
+
 export async function generateMetadata({
   params,
   searchParams,
@@ -102,6 +114,8 @@ export default async function DocsPage({
   const t = await getTranslations({ locale, namespace: "docs" });
   const navigation = await getDocsNavigation(locale, { draft });
   const pageUrl = `${getDocsBaseUrl()}/${locale}/docs/${page.path}`;
+  const showKicker = !titlesMatch(page.section.title, page.title);
+  const articleContent = stripDuplicateLeadingHeading(page.content, page.title);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -181,7 +195,9 @@ export default async function DocsPage({
             </svg>
             {t("backToDocs")}
           </Link>
-          <span className="docs-kicker">{page.section.title}</span>
+          {showKicker && (
+            <span className="docs-kicker">{page.section.title}</span>
+          )}
           <h1 className="docs-title">{page.title}</h1>
           {page.description && (
             <p className="docs-description">{page.description}</p>
@@ -203,7 +219,7 @@ export default async function DocsPage({
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeHighlight]}
           >
-            {page.content}
+            {articleContent}
           </ReactMarkdown>
         </article>
       </DocsShell>


### PR DESCRIPTION
## Summary
- Hide the section kicker when it matches the page title (e.g. section "Channels" + page "Channels")
- Strip a leading H1-H3 from the markdown body when it duplicates the page title
- Result: the title no longer appears three times on docs pages where the section, page, and body heading share a name

## Before
Section kicker "CHANNELS", H1 "Channels", and a body heading "Channels" all stacked on the same page.

## Test plan
- [ ] Visit a docs page where section title == page title (e.g. Channels) and confirm only the H1 renders, no kicker, no duplicate body heading
- [ ] Visit a docs page where section title != page title and confirm the kicker still renders
- [ ] Visit a docs page whose markdown body does not lead with a duplicate heading and confirm content is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)