### PR TITLE
feat: show admin credit balance in account menu

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -196,7 +196,7 @@ describe("zero sidebar - account dropdown opens (SIDEBAR-D-013)", () => {
     });
   });
 
-  it("shows credit balance in the account dropdown for org admins", async () => {
+  it("shows credits in the account dropdown for org admins", async () => {
     setMockBillingStatus({ credits: 12_345 });
     mockBaseAPIs();
     detachedSetupPage({ context, path: "/" });
@@ -209,8 +209,11 @@ describe("zero sidebar - account dropdown opens (SIDEBAR-D-013)", () => {
 
     const menu = await screen.findByRole("menu");
     await waitFor(() => {
-      expect(within(menu).getByText("Credit balance")).toBeInTheDocument();
-      expect(within(menu).getByText(/12,345/)).toBeInTheDocument();
+      expect(
+        within(menu).getByRole("menuitem", {
+          name: /12,345 credits/,
+        }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -32,6 +32,8 @@ import {
 } from "../../../__tests__/mock-auth.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -192,6 +194,44 @@ describe("zero sidebar - account dropdown opens (SIDEBAR-D-013)", () => {
     await waitFor(() => {
       expect(screen.getByText("Sign out")).toBeInTheDocument();
     });
+  });
+
+  it("shows credit balance in the account dropdown for org admins", async () => {
+    setMockBillingStatus({ credits: 12_345 });
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Default Org")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Test User"));
+
+    const menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(within(menu).getByText("Credit balance")).toBeInTheDocument();
+      expect(within(menu).getByText(/12,345/)).toBeInTheDocument();
+    });
+  });
+
+  it("hides credit balance in the account dropdown for org members", async () => {
+    setMockOrg({ role: "member" });
+    setMockBillingStatus({ credits: 12_345 });
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Default Org")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Test User"));
+
+    const menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(within(menu).getByText("Settings")).toBeInTheDocument();
+    });
+    expect(within(menu).queryByText("Credit balance")).not.toBeInTheDocument();
+    expect(within(menu).queryByText(/12,345/)).not.toBeInTheDocument();
   });
 
   it("shows Lab entry in account dropdown when FeatureSwitchKey.Lab is on", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -210,10 +210,10 @@ describe("zero sidebar - account dropdown opens (SIDEBAR-D-013)", () => {
     const menu = await screen.findByRole("menu");
     await waitFor(() => {
       expect(
-        within(menu).getByRole("menuitem", {
-          name: /12,345 credits/,
+        queryAllByRoleFast("menuitem", menu).find((element) => {
+          return element.textContent?.includes("12,345 credits");
         }),
-      ).toBeInTheDocument();
+      ).toBeDefined();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -1,6 +1,12 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { useGet, useLoadable, useLastResolved, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLoadable,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import {
   IconLogout,
   IconPlus,
@@ -9,6 +15,7 @@ import {
   IconSwitchHorizontal,
   IconDatabaseExport,
   IconFlask,
+  IconCoins,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -35,6 +42,8 @@ import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { apiBaseForNavigation$ } from "../../signals/fetch.ts";
+import { isOrgAdmin$ } from "../../signals/org.ts";
+import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
 
 interface SessionAccount {
   sessionId: string;
@@ -184,6 +193,85 @@ function CurrentAccountHeader({
           </div>
         </div>
       </div>
+      <DropdownMenuSeparator />
+    </>
+  );
+}
+
+function AdminCreditBalanceCard({
+  onOpenCreditBalance,
+}: {
+  onOpenCreditBalance: () => void;
+}) {
+  const isAdminLoadable = useLastLoadable(isOrgAdmin$);
+  const isAdmin =
+    isAdminLoadable.state === "hasData" && isAdminLoadable.data === true;
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  return (
+    <AdminCreditBalanceCardContent onOpenCreditBalance={onOpenCreditBalance} />
+  );
+}
+
+function AdminCreditBalanceCardContent({
+  onOpenCreditBalance,
+}: {
+  onOpenCreditBalance: () => void;
+}) {
+  const billingLoadable = useLastLoadable(billingStatusAsync$);
+
+  const credits =
+    billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
+  const loading = billingLoadable.state === "loading" && credits === null;
+
+  return (
+    <>
+      <DropdownMenuItem
+        onClick={onOpenCreditBalance}
+        className="group mx-1 mb-1 gap-3 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-muted/20 px-3 py-2.5 focus:bg-muted/35"
+      >
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <IconCoins size={17} stroke={1.5} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[11px] font-medium leading-none text-muted-foreground">
+            Credit balance
+          </span>
+          {loading ? (
+            <span className="mt-2 block h-4 w-24 rounded bg-muted/60" />
+          ) : (
+            <span
+              className="mt-1 block text-[15px] font-semibold leading-snug text-foreground tabular-nums break-words"
+              title={
+                credits !== null
+                  ? `${credits.toLocaleString("en-US")} credits`
+                  : undefined
+              }
+            >
+              {credits !== null ? (
+                <>
+                  {credits.toLocaleString("en-US")}
+                  <span className="ml-1 text-xs font-medium text-muted-foreground">
+                    {credits === 1 ? "credit" : "credits"}
+                  </span>
+                </>
+              ) : (
+                <span className="text-xs font-medium text-muted-foreground">
+                  Unavailable
+                </span>
+              )}
+            </span>
+          )}
+        </span>
+        <IconChevronRight
+          size={14}
+          stroke={1.5}
+          className="shrink-0 text-muted-foreground/50 transition-colors group-hover:text-foreground/70"
+        />
+      </DropdownMenuItem>
       <DropdownMenuSeparator />
     </>
   );
@@ -416,6 +504,11 @@ export function AccountDropdown({
     detach(openSettings("preference", pageSignal), Reason.DomCallback);
   };
 
+  const handleOpenCreditBalance = () => {
+    setSidebarExpanded(false);
+    detach(openSettings("usage", pageSignal), Reason.DomCallback);
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -432,6 +525,11 @@ export function AccountDropdown({
           display={accountDisplay}
           visible={current !== undefined || user !== undefined}
         />
+        {!hidePreferences && (
+          <AdminCreditBalanceCard
+            onOpenCreditBalance={handleOpenCreditBalance}
+          />
+        )}
         {!hidePreferences && (
           <UnifiedSettingsGroup
             labEnabled={labEnabled}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -198,7 +198,7 @@ function CurrentAccountHeader({
   );
 }
 
-function AdminCreditBalanceCard({
+function AdminCreditBalanceItem({
   onOpenCreditBalance,
 }: {
   onOpenCreditBalance: () => void;
@@ -212,11 +212,11 @@ function AdminCreditBalanceCard({
   }
 
   return (
-    <AdminCreditBalanceCardContent onOpenCreditBalance={onOpenCreditBalance} />
+    <AdminCreditBalanceItemContent onOpenCreditBalance={onOpenCreditBalance} />
   );
 }
 
-function AdminCreditBalanceCardContent({
+function AdminCreditBalanceItemContent({
   onOpenCreditBalance,
 }: {
   onOpenCreditBalance: () => void;
@@ -226,51 +226,29 @@ function AdminCreditBalanceCardContent({
   const credits =
     billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
   const loading = billingLoadable.state === "loading" && credits === null;
+  const creditLabel =
+    credits !== null
+      ? `${credits.toLocaleString("en-US")} ${credits === 1 ? "credit" : "credits"}`
+      : null;
+
+  if (!loading && creditLabel === null) {
+    return null;
+  }
 
   return (
     <>
       <DropdownMenuItem
         onClick={onOpenCreditBalance}
-        className="group mx-1 mb-1 gap-3 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-muted/20 px-3 py-2.5 focus:bg-muted/35"
+        className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-          <IconCoins size={17} stroke={1.5} />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-[11px] font-medium leading-none text-muted-foreground">
-            Credit balance
-          </span>
+        <IconCoins size={18} stroke={1.5} className="text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-sm tabular-nums">
           {loading ? (
-            <span className="mt-2 block h-4 w-24 rounded bg-muted/60" />
+            <span className="block h-4 w-24 rounded bg-muted/60" />
           ) : (
-            <span
-              className="mt-1 block text-[15px] font-semibold leading-snug text-foreground tabular-nums break-words"
-              title={
-                credits !== null
-                  ? `${credits.toLocaleString("en-US")} credits`
-                  : undefined
-              }
-            >
-              {credits !== null ? (
-                <>
-                  {credits.toLocaleString("en-US")}
-                  <span className="ml-1 text-xs font-medium text-muted-foreground">
-                    {credits === 1 ? "credit" : "credits"}
-                  </span>
-                </>
-              ) : (
-                <span className="text-xs font-medium text-muted-foreground">
-                  Unavailable
-                </span>
-              )}
-            </span>
+            creditLabel
           )}
         </span>
-        <IconChevronRight
-          size={14}
-          stroke={1.5}
-          className="shrink-0 text-muted-foreground/50 transition-colors group-hover:text-foreground/70"
-        />
       </DropdownMenuItem>
       <DropdownMenuSeparator />
     </>
@@ -526,7 +504,7 @@ export function AccountDropdown({
           visible={current !== undefined || user !== undefined}
         />
         {!hidePreferences && (
-          <AdminCreditBalanceCard
+          <AdminCreditBalanceItem
             onOpenCreditBalance={handleOpenCreditBalance}
           />
         )}

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -29,6 +29,7 @@
         "require-in-the-middle",
         "cpu-features"
       ],
+      "ignoreBinaries": ["drizzle-kit"],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]
       }
@@ -130,7 +131,8 @@
         "src/**/*.{test,spec}.ts",
         "scripts/**/*.ts"
       ],
-      "project": ["src/**/*.ts", "scripts/**/*.ts", "drizzle.config.ts"]
+      "project": ["src/**/*.ts", "scripts/**/*.ts", "drizzle.config.ts"],
+      "ignoreBinaries": ["drizzle-kit"]
     },
     "packages/ui": {
       "entry": [


### PR DESCRIPTION
## Summary
- show an admin-only credit balance row in the bottom-left account dropdown
- style the row as a compact balance panel with icon, formatted total, loading/unavailable states, and a shortcut to Usage settings
- add sidebar dropdown tests for admin visibility and member hiding

## Testing
- pnpm -F web db:migrate
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm knip