### PR TITLE
refactor: move computer use dispatch metadata to native helper

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1081,14 +1081,107 @@ func openApplicationWithoutActivation(named appName: String) throws -> NSRunning
     return launchResult.app
 }
 
-func restorePreviousFrontmostIfNeeded(previousApp: NSRunningApplication?, targetPID: pid_t) {
-    guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID,
-          let previousApp,
-          previousApp.processIdentifier != targetPID
+@discardableResult
+func restorePreviousFrontmostIfNeeded(previousApp: NSRunningApplication?, targetPID: pid_t) -> Bool {
+    guard let previousApp, previousApp.processIdentifier != targetPID else {
+        return false
+    }
+    var restored = false
+    var cleanChecks = 0
+    var attempts = 0
+    while cleanChecks < 2, attempts < 5 {
+        attempts += 1
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID {
+            _ = previousApp.activate(options: [.activateIgnoringOtherApps])
+            restored = true
+            cleanChecks = 0
+        } else {
+            cleanChecks += 1
+        }
+        if cleanChecks < 2, attempts < 5 {
+            usleep(50_000)
+        }
+    }
+    return restored
+}
+
+func runningAppRecord(_ app: NSRunningApplication?) -> [String: Any]? {
+    guard let app else {
+        return nil
+    }
+    var record: [String: Any] = [
+        "pid": app.processIdentifier,
+    ]
+    if let localizedName = app.localizedName, !localizedName.isEmpty {
+        record["localizedName"] = localizedName
+    }
+    if let bundleIdentifier = app.bundleIdentifier, !bundleIdentifier.isEmpty {
+        record["bundleIdentifier"] = bundleIdentifier
+    }
+    return record
+}
+
+@discardableResult
+func restorePreviousFrontmostIfChanged(previousApp: NSRunningApplication?) -> Bool {
+    guard let previousApp,
+          NSWorkspace.shared.frontmostApplication?.processIdentifier != previousApp.processIdentifier
     else {
-        return
+        return false
     }
     _ = previousApp.activate(options: [.activateIgnoringOtherApps])
+    return true
+}
+
+func nativeActionResult(
+    dispatchMode: String,
+    dispatchTarget: String,
+    inputRisk: String,
+    extra: [String: Any] = [:]
+) -> [String: Any] {
+    var result = extra
+    result["dispatchMode"] = dispatchMode
+    result["dispatchTarget"] = dispatchTarget
+    result["inputRisk"] = inputRisk
+    return result
+}
+
+func withFrontmostPreservation(
+    dispatchMode: String,
+    dispatchTarget: String,
+    inputRisk: String,
+    _ action: () throws -> (targetPID: pid_t?, result: [String: Any])
+) throws -> [String: Any] {
+    let before = NSWorkspace.shared.frontmostApplication
+    let actionResult: (targetPID: pid_t?, result: [String: Any])
+    do {
+        actionResult = try action()
+    } catch {
+        restorePreviousFrontmostIfChanged(previousApp: before)
+        throw error
+    }
+    let afterAction = NSWorkspace.shared.frontmostApplication
+    let restored = actionResult.targetPID.map { targetPID in
+        restorePreviousFrontmostIfNeeded(previousApp: before, targetPID: targetPID)
+    } ?? false
+    let after = NSWorkspace.shared.frontmostApplication
+
+    var result = nativeActionResult(
+        dispatchMode: dispatchMode,
+        dispatchTarget: dispatchTarget,
+        inputRisk: inputRisk,
+        extra: actionResult.result
+    )
+    if let frontmostBefore = runningAppRecord(before) {
+        result["frontmostBefore"] = frontmostBefore
+    }
+    if let frontmostAfterAction = runningAppRecord(afterAction) {
+        result["frontmostAfterAction"] = frontmostAfterAction
+    }
+    if let frontmostAfter = runningAppRecord(after) {
+        result["frontmostAfter"] = frontmostAfter
+    }
+    result["frontmostRestored"] = restored
+    return result
 }
 
 func titleElementText(_ element: AXUIElement) -> String? {
@@ -1513,38 +1606,49 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
 
 func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let previousApp = NSWorkspace.shared.frontmostApplication
-    if findRunningApp(named: appName) != nil {
-        return [:]
-    }
+    return try withFrontmostPreservation(
+        dispatchMode: "background_app_open",
+        dispatchTarget: "target_app",
+        inputRisk: "background_app_launch"
+    ) {
+        if let runningApp = findRunningApp(named: appName) {
+            return (targetPID: runningApp.processIdentifier, result: [:])
+        }
 
-    let launchedApp = try openApplicationWithoutActivation(named: appName) ??
-        waitForRunningApp(named: appName)
-    guard let launchedApp else {
-        throw HelperFailure(code: "app_open_failed", message: "Unable to find launched app: \(appName)")
+        let launchedApp = try openApplicationWithoutActivation(named: appName) ??
+            waitForRunningApp(named: appName)
+        guard let launchedApp else {
+            throw HelperFailure(code: "app_open_failed", message: "Unable to find launched app: \(appName)")
+        }
+        return (targetPID: launchedApp.processIdentifier, result: [:])
     }
-    restorePreviousFrontmostIfNeeded(previousApp: previousApp, targetPID: launchedApp.processIdentifier)
-    return [:]
 }
 
 func handleElementClick(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let elementId = try requiredString(request, "elementId")
     let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
-    let element = try resolveElement(appName: appName, elementId: elementId)
-    for index in 0..<clickCount {
-        let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
-        if error != .success {
-            throw HelperFailure(
-                code: "accessibility_unavailable",
-                message: "Unable to press \(elementId): \(error.rawValue)"
-            )
+    let app = try resolveRunningApp(named: appName)
+    return try withFrontmostPreservation(
+        dispatchMode: "accessibility_action",
+        dispatchTarget: "element",
+        inputRisk: "targeted_app_action"
+    ) {
+        let element = try resolveElement(appName: appName, elementId: elementId)
+        for index in 0..<clickCount {
+            let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
+            if error != .success {
+                throw HelperFailure(
+                    code: "accessibility_unavailable",
+                    message: "Unable to press \(elementId): \(error.rawValue)"
+                )
+            }
+            if index + 1 < clickCount {
+                usleep(50_000)
+            }
         }
-        if index + 1 < clickCount {
-            usleep(50_000)
-        }
+        return (targetPID: app.processIdentifier, result: [:])
     }
-    return [:]
 }
 
 func mouseEventConfig(button: String) throws -> (
@@ -1681,98 +1785,128 @@ func handleElementClickPoint(_ request: [String: Any]) throws -> [String: Any] {
         screenshotHeight: screenshotHeight,
         sourceBounds: sourceBounds
     )
-    let target = try snapshotWindowTarget(
-        appName: appName,
-        snapshotId: snapshotId,
-        preferredScreenPoint: point,
-        windowId: windowId,
-        windowFrame: windowFrame
-    )
+    return try withFrontmostPreservation(
+        dispatchMode: "background_mouse_event",
+        dispatchTarget: "app_process",
+        inputRisk: "background_app_pointer"
+    ) {
+        let target = try snapshotWindowTarget(
+            appName: appName,
+            snapshotId: snapshotId,
+            preferredScreenPoint: point,
+            windowId: windowId,
+            windowFrame: windowFrame
+        )
 
-    let dispatcher = AddressedEventDispatcher(target: target)
-    for index in 1...clickCount {
-        try dispatcher.postMouse(
-            config.down,
-            at: point,
-            button: config.button,
-            clickState: Int64(index),
-            pressure: 1
-        )
-        usleep(30_000)
-        try dispatcher.postMouse(
-            config.up,
-            at: point,
-            button: config.button,
-            clickState: Int64(index),
-            pressure: 0
-        )
-        if index < clickCount {
-            usleep(50_000)
+        let dispatcher = AddressedEventDispatcher(target: target)
+        for index in 1...clickCount {
+            try dispatcher.postMouse(
+                config.down,
+                at: point,
+                button: config.button,
+                clickState: Int64(index),
+                pressure: 1
+            )
+            usleep(30_000)
+            try dispatcher.postMouse(
+                config.up,
+                at: point,
+                button: config.button,
+                clickState: Int64(index),
+                pressure: 0
+            )
+            if index < clickCount {
+                usleep(50_000)
+            }
         }
-    }
 
-    return [
-        "screenX": point.x,
-        "screenY": point.y,
-    ]
+        return (
+            targetPID: target.pid,
+            result: [
+                "screenX": point.x,
+                "screenY": point.y,
+            ]
+        )
+    }
 }
 
 func handleElementSetValue(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let elementId = try requiredString(request, "elementId")
     let value = try requiredString(request, "value")
-    let element = try resolveElement(appName: appName, elementId: elementId)
-    try setAttribute(element, kAXValueAttribute as CFString, value as CFString)
-    return [:]
+    let app = try resolveRunningApp(named: appName)
+    return try withFrontmostPreservation(
+        dispatchMode: "accessibility_value",
+        dispatchTarget: "element",
+        inputRisk: "targeted_app_text"
+    ) {
+        let element = try resolveElement(appName: appName, elementId: elementId)
+        try setAttribute(element, kAXValueAttribute as CFString, value as CFString)
+        return (targetPID: app.processIdentifier, result: [:])
+    }
 }
 
 func handleElementPerformAction(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let elementId = try requiredString(request, "elementId")
     let action = try requiredString(request, "action")
-    let element = try resolveElement(appName: appName, elementId: elementId)
-    let error = AXUIElementPerformAction(element, action as CFString)
-    if error != .success {
-        throw HelperFailure(
-            code: "accessibility_unavailable",
-            message: "Unable to perform \(action) on \(elementId): \(error.rawValue)"
-        )
+    let app = try resolveRunningApp(named: appName)
+    return try withFrontmostPreservation(
+        dispatchMode: "accessibility_action",
+        dispatchTarget: "element",
+        inputRisk: "targeted_app_action"
+    ) {
+        let element = try resolveElement(appName: appName, elementId: elementId)
+        let error = AXUIElementPerformAction(element, action as CFString)
+        if error != .success {
+            throw HelperFailure(
+                code: "accessibility_unavailable",
+                message: "Unable to perform \(action) on \(elementId): \(error.rawValue)"
+            )
+        }
+        return (targetPID: app.processIdentifier, result: [:])
     }
-    return [:]
 }
 
 func handleTypeText(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let inputText = try requiredString(request, "text")
-    let root = try appElement(named: appName)
-    guard let element = axElementValue(attribute(root, kAXFocusedUIElementAttribute as CFString)) else {
-        throw HelperFailure(
-            code: "unsupported_command",
-            message: "keyboard.type_text requires a focused editable text element in \(appName)"
-        )
-    }
-    let role = role(element)
-    let editableRoles = Set([
-        "AXComboBox",
-        "AXSearchField",
-        "AXTextArea",
-        "AXTextField",
-        "AXTextView",
-    ])
-    guard let role, editableRoles.contains(role) else {
-        throw HelperFailure(
-            code: "unsupported_command",
-            message: "keyboard.type_text requires a focused editable text element in \(appName)"
-        )
-    }
+    let app = try resolveRunningApp(named: appName)
+    return try withFrontmostPreservation(
+        dispatchMode: "accessibility_value",
+        dispatchTarget: "focused_editable_element",
+        inputRisk: "targeted_app_text"
+    ) {
+        let root = AXUIElementCreateApplication(app.processIdentifier)
+        guard let element = axElementValue(attribute(root, kAXFocusedUIElementAttribute as CFString)) else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "keyboard.type_text requires a focused editable text element in \(appName)"
+            )
+        }
+        let role = role(element)
+        let editableRoles = Set([
+            "AXComboBox",
+            "AXSearchField",
+            "AXTextArea",
+            "AXTextField",
+            "AXTextView",
+        ])
+        guard let role, editableRoles.contains(role) else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "keyboard.type_text requires a focused editable text element in \(appName)"
+            )
+        }
 
-    let currentValue = stringValue(attribute(element, kAXValueAttribute as CFString)) ?? ""
-    try setAttribute(element, kAXValueAttribute as CFString, (currentValue + inputText) as CFString)
-    var result: [String: Any] = ["role": role]
-    if let description = stringValue(attribute(element, kAXDescriptionAttribute as CFString)) {
-        result["description"] = description
+        let currentValue = stringValue(attribute(element, kAXValueAttribute as CFString)) ?? ""
+        try setAttribute(element, kAXValueAttribute as CFString, (currentValue + inputText) as CFString)
+        var result: [String: Any] = ["role": role]
+        if let description = stringValue(attribute(element, kAXDescriptionAttribute as CFString)) {
+            result["description"] = description
+        }
+        return (targetPID: app.processIdentifier, result: result)
     }
-    return result
 }
 
 func handlePressKey(_ request: [String: Any]) throws -> [String: Any] {
@@ -1780,21 +1914,28 @@ func handlePressKey(_ request: [String: Any]) throws -> [String: Any] {
     let key = try requiredString(request, "key")
     let parsed = try parseKeyPress(key)
 
-    try performWithRequiredBackgroundTarget(appName: appName) { target in
-        let dispatcher = AddressedEventDispatcher(target: target)
-        var activeFlags = 0
-        for modifier in parsed.modifiers {
-            activeFlags |= modifier.flag
-            try dispatcher.postKey(keyCode: modifier.keyCode, keyDown: true, flags: activeFlags)
+    return try withFrontmostPreservation(
+        dispatchMode: "background_keyboard_event",
+        dispatchTarget: "app_process",
+        inputRisk: "background_app_shortcut"
+    ) {
+        let targetPID = try performWithRequiredBackgroundTarget(appName: appName) { target in
+            let dispatcher = AddressedEventDispatcher(target: target)
+            var activeFlags = 0
+            for modifier in parsed.modifiers {
+                activeFlags |= modifier.flag
+                try dispatcher.postKey(keyCode: modifier.keyCode, keyDown: true, flags: activeFlags)
+            }
+            try dispatcher.postKey(keyCode: parsed.keyCode, keyDown: true, flags: parsed.flags)
+            try dispatcher.postKey(keyCode: parsed.keyCode, keyDown: false, flags: parsed.flags)
+            for modifier in parsed.modifiers.reversed() {
+                activeFlags &= ~modifier.flag
+                try dispatcher.postKey(keyCode: modifier.keyCode, keyDown: false, flags: activeFlags)
+            }
+            return target.pid
         }
-        try dispatcher.postKey(keyCode: parsed.keyCode, keyDown: true, flags: parsed.flags)
-        try dispatcher.postKey(keyCode: parsed.keyCode, keyDown: false, flags: parsed.flags)
-        for modifier in parsed.modifiers.reversed() {
-            activeFlags &= ~modifier.flag
-            try dispatcher.postKey(keyCode: modifier.keyCode, keyDown: false, flags: activeFlags)
-        }
+        return (targetPID: targetPID, result: ["normalizedKey": parsed.normalizedKey])
     }
-    return ["normalizedKey": parsed.normalizedKey]
 }
 
 func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {
@@ -1807,20 +1948,27 @@ func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {
         ? "AXHorizontalScrollBar"
         : "AXVerticalScrollBar"
     let sign = direction == "up" || direction == "left" ? -1.0 : 1.0
-    let element = try resolveElement(appName: appName, elementId: elementId)
-    guard let scrollBar = attributeArray(element, kAXChildrenAttribute as CFString).first(where: { child in
-        role(child) == axis
-    }) else {
-        return [:]
+    let app = try resolveRunningApp(named: appName)
+    return try withFrontmostPreservation(
+        dispatchMode: "accessibility_action",
+        dispatchTarget: "element",
+        inputRisk: "targeted_app_action"
+    ) {
+        let element = try resolveElement(appName: appName, elementId: elementId)
+        guard let scrollBar = attributeArray(element, kAXChildrenAttribute as CFString).first(where: { child in
+            role(child) == axis
+        }) else {
+            return (targetPID: app.processIdentifier, result: [:])
+        }
+        if let current = numberValue(attribute(scrollBar, kAXValueAttribute as CFString)) {
+            try setAttribute(
+                scrollBar,
+                kAXValueAttribute as CFString,
+                NSNumber(value: current + sign * step)
+            )
+        }
+        return (targetPID: app.processIdentifier, result: [:])
     }
-    if let current = numberValue(attribute(scrollBar, kAXValueAttribute as CFString)) {
-        try setAttribute(
-            scrollBar,
-            kAXValueAttribute as CFString,
-            NSNumber(value: current + sign * step)
-        )
-    }
-    return [:]
 }
 
 func handle(_ request: [String: Any]) throws -> [String: Any] {

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1257,14 +1257,12 @@ async function openApp(
   app: string,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.openApp(app);
+  const nativeResult = await nativeBackend.openApp(app);
   return {
     status: "succeeded",
     result: {
       app,
-      dispatchMode: "background_app_open",
-      dispatchTarget: "target_app",
-      inputRisk: "background_app_launch",
+      ...nativeResult,
       text: `Opened ${app}`,
     },
   };
@@ -1377,7 +1375,7 @@ async function clickElement(args: {
     if ("status" in target) {
       return target;
     }
-    await args.nativeBackend.clickElement({
+    const nativeResult = await args.nativeBackend.clickElement({
       app: args.app,
       elementId: target.elementId,
       button: args.button,
@@ -1390,9 +1388,7 @@ async function clickElement(args: {
         ...elementTargetResult(target),
         button: args.button,
         clickCount: args.clickCount,
-        dispatchMode: "accessibility_action",
-        dispatchTarget: "element",
-        inputRisk: "targeted_app_action",
+        ...nativeResult,
         text: `Clicked ${elementTargetText(target)}`,
       },
     };
@@ -1418,6 +1414,7 @@ async function clickElement(args: {
       button: args.button,
       clickCount: args.clickCount,
     });
+    const { screenX, screenY, ...nativeResult } = clickPoint;
     return {
       status: "succeeded",
       result: {
@@ -1425,13 +1422,11 @@ async function clickElement(args: {
         snapshotId: snapshot.snapshotId,
         x: args.x,
         y: args.y,
-        screenX: clickPoint.screenX,
-        screenY: clickPoint.screenY,
+        screenX,
+        screenY,
         button: args.button,
         clickCount: args.clickCount,
-        dispatchMode: "background_mouse_event",
-        dispatchTarget: "app_process",
-        inputRisk: "background_app_pointer",
+        ...nativeResult,
         text: `Clicked ${args.x},${args.y}`,
       },
     };
@@ -1447,7 +1442,7 @@ async function setElementValue(
   value: string,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.setElementValue({
+  const nativeResult = await nativeBackend.setElementValue({
     app,
     elementId: target.elementId,
     value,
@@ -1457,9 +1452,7 @@ async function setElementValue(
     result: {
       app,
       ...elementTargetResult(target),
-      dispatchMode: "accessibility_value",
-      dispatchTarget: "element",
-      inputRisk: "targeted_app_text",
+      ...nativeResult,
       text: `Set ${elementTargetText(target)}`,
     },
   };
@@ -1471,7 +1464,7 @@ async function performElementAction(
   action: string,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.performElementAction({
+  const nativeResult = await nativeBackend.performElementAction({
     app,
     elementId: target.elementId,
     action,
@@ -1482,9 +1475,7 @@ async function performElementAction(
       app,
       ...elementTargetResult(target),
       action,
-      dispatchMode: "accessibility_action",
-      dispatchTarget: "element",
-      inputRisk: "targeted_app_action",
+      ...nativeResult,
       text: `Performed ${action}`,
     },
   };
@@ -1500,10 +1491,7 @@ async function typeText(
     status: "succeeded",
     result: {
       app,
-      dispatchMode: "accessibility_value",
-      dispatchTarget: "focused_editable_element",
-      inputRisk: "targeted_app_text",
-      role: result.role,
+      ...result,
       text: "Typed text",
     },
   };
@@ -1515,15 +1503,14 @@ async function pressKey(
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
   const result = await nativeBackend.pressKey({ app, key });
+  const { normalizedKey, ...nativeResult } = result;
   return {
     status: "succeeded",
     result: {
       app,
-      key: result.normalizedKey,
-      dispatchMode: "background_keyboard_event",
-      dispatchTarget: "app_process",
-      inputRisk: "background_app_shortcut",
-      text: `Pressed ${result.normalizedKey}`,
+      key: normalizedKey,
+      ...nativeResult,
+      text: `Pressed ${normalizedKey}`,
     },
   };
 }
@@ -1535,7 +1522,7 @@ async function scrollElement(
   pages: number,
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  await nativeBackend.scrollElement({
+  const nativeResult = await nativeBackend.scrollElement({
     app,
     elementId: target.elementId,
     direction,
@@ -1548,9 +1535,7 @@ async function scrollElement(
       ...elementTargetResult(target),
       direction,
       pages,
-      dispatchMode: "accessibility_action",
-      dispatchTarget: "element",
-      inputRisk: "targeted_app_action",
+      ...nativeResult,
       text: `Scrolled ${elementTargetText(target)}`,
     },
   };

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -67,7 +67,12 @@ describe("computer use native backend", () => {
   it("reads coordinate click screen points from the native helper", async () => {
     const helper = await createHelper({
       status: "succeeded",
-      result: { screenX: 900, screenY: 800 },
+      result: {
+        dispatchMode: "background_mouse_event",
+        frontmostRestored: true,
+        screenX: 900,
+        screenY: 800,
+      },
     });
 
     try {
@@ -90,7 +95,39 @@ describe("computer use native backend", () => {
           button: "right",
           clickCount: 2,
         }),
-      ).resolves.toEqual({ screenX: 900, screenY: 800 });
+      ).resolves.toEqual({
+        dispatchMode: "background_mouse_event",
+        frontmostRestored: true,
+        screenX: 900,
+        screenY: 800,
+      });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads app-open dispatch metadata from the native helper", async () => {
+    const helper = await createHelper({
+      status: "succeeded",
+      result: {
+        dispatchMode: "background_app_open",
+        dispatchTarget: "target_app",
+        inputRisk: "background_app_launch",
+        frontmostRestored: false,
+      },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+      });
+
+      await expect(backend.openApp("Things")).resolves.toEqual({
+        dispatchMode: "background_app_open",
+        dispatchTarget: "target_app",
+        inputRisk: "background_app_launch",
+        frontmostRestored: false,
+      });
     } finally {
       await rm(helper.dir, { recursive: true, force: true });
     }
@@ -99,7 +136,11 @@ describe("computer use native backend", () => {
   it("reads normalized key names from the native helper", async () => {
     const helper = await createHelper({
       status: "succeeded",
-      result: { normalizedKey: "Command+K" },
+      result: {
+        dispatchMode: "background_keyboard_event",
+        frontmostRestored: false,
+        normalizedKey: "Command+K",
+      },
     });
 
     try {
@@ -109,7 +150,11 @@ describe("computer use native backend", () => {
 
       await expect(
         backend.pressKey({ app: "Safari", key: "cmd+k" }),
-      ).resolves.toEqual({ normalizedKey: "Command+K" });
+      ).resolves.toEqual({
+        dispatchMode: "background_keyboard_event",
+        frontmostRestored: false,
+        normalizedKey: "Command+K",
+      });
     } finally {
       await rm(helper.dir, { recursive: true, force: true });
     }

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -26,14 +26,22 @@ export interface ComputerUseNativeClickPointRequest {
   readonly clickCount: number;
 }
 
-export interface ComputerUseNativeClickPointResult {
-  readonly screenX: number;
-  readonly screenY: number;
-}
+export type ComputerUseNativeActionResult = Record<string, unknown>;
 
-export interface ComputerUseNativePressKeyResult {
+export type ComputerUseNativeClickPointResult =
+  ComputerUseNativeActionResult & {
+    readonly screenX: number;
+    readonly screenY: number;
+  };
+
+export type ComputerUseNativePressKeyResult = ComputerUseNativeActionResult & {
   readonly normalizedKey: string;
-}
+};
+
+export type ComputerUseNativeTypeTextResult = ComputerUseNativeActionResult & {
+  readonly role?: string;
+  readonly description?: string;
+};
 
 export interface ComputerUseNativeBackend {
   readonly getPermissions: () => Promise<ComputerUsePermissionState>;
@@ -43,13 +51,13 @@ export interface ComputerUseNativeBackend {
     app: string,
     snapshotId: string,
   ) => Promise<AccessibilityAppStateSnapshot>;
-  readonly openApp: (app: string) => Promise<void>;
+  readonly openApp: (app: string) => Promise<ComputerUseNativeActionResult>;
   readonly clickElement: (args: {
     readonly app: string;
     readonly elementId: string;
     readonly button: ComputerUseMouseButton;
     readonly clickCount: number;
-  }) => Promise<void>;
+  }) => Promise<ComputerUseNativeActionResult>;
   readonly clickPoint: (
     args: ComputerUseNativeClickPointRequest,
   ) => Promise<ComputerUseNativeClickPointResult>;
@@ -57,16 +65,16 @@ export interface ComputerUseNativeBackend {
     readonly app: string;
     readonly elementId: string;
     readonly value: string;
-  }) => Promise<void>;
+  }) => Promise<ComputerUseNativeActionResult>;
   readonly performElementAction: (args: {
     readonly app: string;
     readonly elementId: string;
     readonly action: string;
-  }) => Promise<void>;
+  }) => Promise<ComputerUseNativeActionResult>;
   readonly typeText: (args: {
     readonly app: string;
     readonly text: string;
-  }) => Promise<{ readonly role?: string; readonly description?: string }>;
+  }) => Promise<ComputerUseNativeTypeTextResult>;
   readonly pressKey: (args: {
     readonly app: string;
     readonly key: string;
@@ -76,7 +84,7 @@ export interface ComputerUseNativeBackend {
     readonly elementId: string;
     readonly direction: string;
     readonly pages: number;
-  }) => Promise<void>;
+  }) => Promise<ComputerUseNativeActionResult>;
 }
 
 type ComputerUseNativeRequest = Record<string, unknown> & {
@@ -370,39 +378,44 @@ export function createComputerUseNativeBackend(
       return result as unknown as AccessibilityAppStateSnapshot;
     },
     openApp: async (app) => {
-      await run({ kind: "app.open", app });
+      return await run({ kind: "app.open", app });
     },
     clickElement: async (args) => {
-      await run({ kind: "element.click", ...args });
+      return await run({ kind: "element.click", ...args });
     },
     clickPoint: async (args) => {
       const result = await run({ kind: "element.click_point", ...args });
       return {
+        ...result,
         screenX: resultRequiredNumber(result, "screenX"),
         screenY: resultRequiredNumber(result, "screenY"),
       };
     },
     setElementValue: async (args) => {
-      await run({ kind: "element.set_value", ...args });
+      return await run({ kind: "element.set_value", ...args });
     },
     performElementAction: async (args) => {
-      await run({ kind: "element.perform_action", ...args });
+      return await run({ kind: "element.perform_action", ...args });
     },
     typeText: async (args) => {
       const result = await run({ kind: "keyboard.type_text", ...args });
+      const role = resultOptionalString(result, "role");
+      const description = resultOptionalString(result, "description");
       return {
-        role: resultOptionalString(result, "role"),
-        description: resultOptionalString(result, "description"),
+        ...result,
+        ...(role ? { role } : {}),
+        ...(description ? { description } : {}),
       };
     },
     pressKey: async (args) => {
       const result = await run({ kind: "keyboard.press_key", ...args });
       return {
+        ...result,
         normalizedKey: resultRequiredString(result, "normalizedKey"),
       };
     },
     scrollElement: async (args) => {
-      await run({ kind: "element.scroll", ...args });
+      return await run({ kind: "element.scroll", ...args });
     },
   };
 }

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -33,6 +33,14 @@ import {
 } from "./desktop-auth";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
+function nativeDispatchResult(
+  dispatchMode: string,
+  dispatchTarget: string,
+  inputRisk: string,
+): Record<string, unknown> {
+  return { dispatchMode, dispatchTarget, inputRisk };
+}
+
 function createNativeBackend(
   overrides: Partial<ComputerUseNativeBackend> = {},
 ): ComputerUseNativeBackend {
@@ -47,20 +55,69 @@ function createNativeBackend(
     getAppState: async (app, snapshotId) => {
       return { app, snapshotId, elements: [] };
     },
-    openApp: async () => {},
-    clickElement: async () => {},
-    clickPoint: async (args) => {
-      return { screenX: args.x, screenY: args.y };
+    openApp: async () => {
+      return nativeDispatchResult(
+        "background_app_open",
+        "target_app",
+        "background_app_launch",
+      );
     },
-    setElementValue: async () => {},
-    performElementAction: async () => {},
+    clickElement: async () => {
+      return nativeDispatchResult(
+        "accessibility_action",
+        "element",
+        "targeted_app_action",
+      );
+    },
+    clickPoint: async (args) => {
+      return {
+        ...nativeDispatchResult(
+          "background_mouse_event",
+          "app_process",
+          "background_app_pointer",
+        ),
+        screenX: args.x,
+        screenY: args.y,
+      };
+    },
+    setElementValue: async () => {
+      return nativeDispatchResult(
+        "accessibility_value",
+        "element",
+        "targeted_app_text",
+      );
+    },
+    performElementAction: async () => {
+      return nativeDispatchResult(
+        "accessibility_action",
+        "element",
+        "targeted_app_action",
+      );
+    },
     typeText: async () => {
-      return {};
+      return nativeDispatchResult(
+        "accessibility_value",
+        "focused_editable_element",
+        "targeted_app_text",
+      );
     },
     pressKey: async (args) => {
-      return { normalizedKey: args.key };
+      return {
+        ...nativeDispatchResult(
+          "background_keyboard_event",
+          "app_process",
+          "background_app_shortcut",
+        ),
+        normalizedKey: args.key,
+      };
     },
-    scrollElement: async () => {},
+    scrollElement: async () => {
+      return nativeDispatchResult(
+        "accessibility_action",
+        "element",
+        "targeted_app_action",
+      );
+    },
   };
   return { ...defaults, ...overrides };
 }
@@ -550,6 +607,22 @@ describe("computer use desktop runtime", () => {
 
   it("reports app open as a background launch without target preparation", async () => {
     const openApp = vi.fn<ComputerUseNativeBackend["openApp"]>();
+    openApp.mockResolvedValue({
+      ...nativeDispatchResult(
+        "background_app_open",
+        "target_app",
+        "background_app_launch",
+      ),
+      frontmostRestored: true,
+      frontmostBefore: {
+        localizedName: "Notes",
+        pid: 200,
+      },
+      frontmostAfter: {
+        localizedName: "Notes",
+        pid: 200,
+      },
+    });
     const result = await executeComputerUseCommand(
       { id: "cmd_1", kind: "app.open", payload: { app: "Safari" } },
       { accessibility: true, screenRecording: true },
@@ -574,6 +647,15 @@ describe("computer use desktop runtime", () => {
           dispatchMode: "background_app_open",
           dispatchTarget: "target_app",
           inputRisk: "background_app_launch",
+          frontmostRestored: true,
+          frontmostBefore: {
+            localizedName: "Notes",
+            pid: 200,
+          },
+          frontmostAfter: {
+            localizedName: "Notes",
+            pid: 200,
+          },
         },
       },
     });
@@ -1013,6 +1095,13 @@ describe("computer use desktop runtime", () => {
 
   it("resolves action element ids from non-uiElement child sources", async () => {
     const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
+    clickElement.mockResolvedValue(
+      nativeDispatchResult(
+        "accessibility_action",
+        "element",
+        "targeted_app_action",
+      ),
+    );
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -1053,6 +1142,13 @@ describe("computer use desktop runtime", () => {
 
   it("returns fresh app state and screenshot after element clicks", async () => {
     const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
+    clickElement.mockResolvedValue(
+      nativeDispatchResult(
+        "accessibility_action",
+        "element",
+        "targeted_app_action",
+      ),
+    );
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -1119,6 +1215,13 @@ describe("computer use desktop runtime", () => {
   it("maps model-facing element indexes back to internal element ids", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
+    clickElement.mockResolvedValue(
+      nativeDispatchResult(
+        "accessibility_action",
+        "element",
+        "targeted_app_action",
+      ),
+    );
     const nativeBackend = createNativeBackend({
       clickElement,
       getAppState: async (app, snapshotId) => {
@@ -1227,7 +1330,15 @@ describe("computer use desktop runtime", () => {
   it("maps screenshot coordinate clicks through cached snapshot bounds", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
-    clickPoint.mockResolvedValue({ screenX: 900, screenY: 800 });
+    clickPoint.mockResolvedValue({
+      ...nativeDispatchResult(
+        "background_mouse_event",
+        "app_process",
+        "background_app_pointer",
+      ),
+      screenX: 900,
+      screenY: 800,
+    });
     const nativeBackend = createNativeBackend({
       clickPoint,
       getAppState: async (app) => {
@@ -1395,7 +1506,15 @@ describe("computer use desktop runtime", () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     let stateCaptureCount = 0;
     const clickPoint = vi.fn<ComputerUseNativeBackend["clickPoint"]>();
-    clickPoint.mockResolvedValue({ screenX: 440, screenY: 380 });
+    clickPoint.mockResolvedValue({
+      ...nativeDispatchResult(
+        "background_mouse_event",
+        "app_process",
+        "background_app_pointer",
+      ),
+      screenX: 440,
+      screenY: 380,
+    });
 
     const result = await executeComputerUseCommand(
       {
@@ -1591,7 +1710,14 @@ describe("computer use desktop runtime", () => {
   it("posts press-key combinations to the target process without app activation", async () => {
     const openApp = vi.fn<ComputerUseNativeBackend["openApp"]>();
     const pressKey = vi.fn<ComputerUseNativeBackend["pressKey"]>();
-    pressKey.mockResolvedValue({ normalizedKey: "Command+K" });
+    pressKey.mockResolvedValue({
+      ...nativeDispatchResult(
+        "background_keyboard_event",
+        "app_process",
+        "background_app_shortcut",
+      ),
+      normalizedKey: "Command+K",
+    });
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",


### PR DESCRIPTION
## Summary
- return native dispatch metadata and frontmost-app records from the Computer Use helper for all write commands
- preserve the user's frontmost app around native write actions, including a short delayed-activation guard and error-path restoration
- make the Electron/TypeScript command layer merge native action metadata instead of hardcoding dispatch semantics

## Testing
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop build
- pnpm exec prettier --check --ignore-unknown apps/desktop/src/computer-use-accessibility.ts apps/desktop/src/computer-use-native.ts apps/desktop/src/computer-use-native.test.ts apps/desktop/src/window-policy.test.ts
- git diff --check
- pnpm knip --workspace @vm0/desktop
- printf '%s\n' '{"kind":"app.open","app":"Finder"}' | turbo/apps/desktop/native/computer-use-helper/.build/release/computer-use-helper