### PR TITLE
fix: stop dual-writing stored secrets

### DIFF
--- a/turbo/apps/api/src/scripts/__tests__/backfill-secret-kms-encryption.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/backfill-secret-kms-encryption.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
+
+import { clearMockedEnv, mockEnv } from "../../lib/env";
+import {
+  encryptSecretValue,
+  encryptStoredSecretValueWithMode,
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+  type SecretKmsClient,
+} from "../../signals/services/crypto.utils";
+import {
+  filterStoredSecretMigrationRows,
+  type EncryptedRow,
+} from "../backfill-secret-kms-encryption";
+
+type MockKmsCommand = GenerateDataKeyCommand | DecryptCommand;
+type MockKmsResponse = GenerateDataKeyCommandOutput | DecryptCommandOutput;
+
+const DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+function createFakeKmsClient(): SecretKmsClient {
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(command: MockKmsCommand): Promise<MockKmsResponse> {
+    if (command instanceof GenerateDataKeyCommand) {
+      return Promise.resolve({
+        $metadata: {},
+        KeyId: command.input.KeyId,
+        CiphertextBlob: Buffer.from(
+          `encrypted-data-key:${command.input.KeyId}`,
+          "utf8",
+        ),
+        Plaintext: DATA_KEY,
+      });
+    }
+
+    return Promise.resolve({
+      $metadata: {},
+      Plaintext: DATA_KEY,
+    });
+  }
+
+  return { send };
+}
+
+function ids(rows: readonly EncryptedRow[]): readonly string[] {
+  return rows.map((row) => {
+    return row.id;
+  });
+}
+
+describe("stored secret KMS backfill", () => {
+  afterEach(() => {
+    clearMockedEnv();
+    resetSecretKmsClientForTests();
+  });
+
+  it("selects only legacy rows when writing dual envelopes", async () => {
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+    setSecretKmsClientForTests(createFakeKmsClient());
+    const legacy = encryptSecretValue("legacy");
+    const dual = await encryptStoredSecretValueWithMode("dual", "dual");
+    const kms = await encryptStoredSecretValueWithMode("kms", "kms");
+
+    expect(
+      ids(
+        filterStoredSecretMigrationRows(
+          [
+            { id: "legacy", encrypted: legacy },
+            { id: "dual", encrypted: dual },
+            { id: "kms", encrypted: kms },
+            { id: "empty", encrypted: null },
+          ],
+          "dual",
+        ),
+      ),
+    ).toStrictEqual(["legacy"]);
+  });
+
+  it("selects legacy and dual rows when writing KMS-only envelopes", async () => {
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+    setSecretKmsClientForTests(createFakeKmsClient());
+    const legacy = encryptSecretValue("legacy");
+    const dual = await encryptStoredSecretValueWithMode("dual", "dual");
+    const kms = await encryptStoredSecretValueWithMode("kms", "kms");
+
+    expect(
+      ids(
+        filterStoredSecretMigrationRows(
+          [
+            { id: "legacy", encrypted: legacy },
+            { id: "dual", encrypted: dual },
+            { id: "kms", encrypted: kms },
+            { id: "empty", encrypted: null },
+          ],
+          "kms",
+        ),
+      ),
+    ).toStrictEqual(["legacy", "dual"]);
+  });
+});

--- a/turbo/apps/api/src/scripts/backfill-secret-kms-encryption.ts
+++ b/turbo/apps/api/src/scripts/backfill-secret-kms-encryption.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 
-import { and, eq, isNotNull, like, not } from "drizzle-orm";
+import { and, asc, eq, gt, isNotNull } from "drizzle-orm";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { secrets } from "@vm0/db/schema/secret";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
@@ -10,35 +10,48 @@ import {
   decryptStoredSecretValueWithMode,
   encryptStoredSecretValueWithMode,
   inspectStoredSecretCiphertext,
-  STORED_SECRET_ENVELOPE_PREFIX,
   type StoredSecretCiphertextFormat,
   type StoredSecretWriteMode,
 } from "../signals/services/crypto.utils";
 import { settle } from "../signals/utils";
 
-interface MigrationArgs {
+export interface MigrationArgs {
   readonly dryRun: boolean;
   readonly reportOnly: boolean;
   readonly mode: Exclude<StoredSecretWriteMode, "legacy">;
   readonly batchSize: number;
 }
 
-interface CiphertextCounts {
+export interface CiphertextCounts {
   readonly legacy: number;
   readonly dual: number;
   readonly kms: number;
 }
 
-interface MigrationReport {
+export interface MigrationReport {
   readonly name: string;
   readonly before: CiphertextCounts;
   readonly migrated: number;
   readonly after: CiphertextCounts;
 }
 
-type EncryptedRow = {
+type CiphertextRow = {
   readonly encrypted: string | null;
 };
+
+export type EncryptedRow = CiphertextRow & {
+  readonly id: string;
+};
+
+type SelectBatch = (
+  cursor: string | undefined,
+  batchSize: number,
+) => Promise<readonly EncryptedRow[]>;
+
+type UpdateEncryptedRow = (
+  row: EncryptedRow,
+  encrypted: string,
+) => Promise<number>;
 
 const DEFAULT_BATCH_SIZE = 100;
 
@@ -56,7 +69,7 @@ function incrementCount(
   };
 }
 
-function countCiphertexts(rows: readonly EncryptedRow[]): CiphertextCounts {
+function countCiphertexts(rows: readonly CiphertextRow[]): CiphertextCounts {
   return rows.reduce((counts, row) => {
     if (!row.encrypted) {
       return counts;
@@ -66,6 +79,30 @@ function countCiphertexts(rows: readonly EncryptedRow[]): CiphertextCounts {
       inspectStoredSecretCiphertext(row.encrypted).format,
     );
   }, emptyCounts());
+}
+
+function needsMigration(
+  encrypted: string | null,
+  mode: Exclude<StoredSecretWriteMode, "legacy">,
+): boolean {
+  if (!encrypted) {
+    return false;
+  }
+
+  const format = inspectStoredSecretCiphertext(encrypted).format;
+  if (mode === "dual") {
+    return format === "legacy";
+  }
+  return format !== "kms";
+}
+
+export function filterStoredSecretMigrationRows(
+  rows: readonly EncryptedRow[],
+  mode: Exclude<StoredSecretWriteMode, "legacy">,
+): readonly EncryptedRow[] {
+  return rows.filter((row) => {
+    return needsMigration(row.encrypted, mode);
+  });
 }
 
 function parseMode(
@@ -135,171 +172,140 @@ async function reencryptCiphertext(
   return encryptStoredSecretValueWithMode(plaintext, mode);
 }
 
-async function migrateSecretsTable(args: MigrationArgs): Promise<number> {
+async function migrateEncryptedRows(
+  args: MigrationArgs,
+  selectBatch: SelectBatch,
+  updateRow: UpdateEncryptedRow,
+): Promise<number> {
   let migrated = 0;
-  const database = db();
+  let cursor: string | undefined;
 
   while (!args.reportOnly) {
-    const rows = await database
-      .select({ id: secrets.id, encrypted: secrets.encryptedValue })
-      .from(secrets)
-      .where(
-        not(like(secrets.encryptedValue, `${STORED_SECRET_ENVELOPE_PREFIX}%`)),
-      )
-      .limit(args.batchSize);
+    const rows = await selectBatch(cursor, args.batchSize);
 
     if (rows.length === 0) {
       return migrated;
     }
+    cursor = rows[rows.length - 1]?.id;
 
-    for (const row of rows) {
+    for (const row of filterStoredSecretMigrationRows(rows, args.mode)) {
+      if (!row.encrypted) {
+        continue;
+      }
       const encryptedValue = await reencryptCiphertext(
         row.encrypted,
         args.mode,
       );
       if (!args.dryRun) {
-        const updatedRows = await database
-          .update(secrets)
-          .set({ encryptedValue })
-          .where(
-            and(
-              eq(secrets.id, row.id),
-              eq(secrets.encryptedValue, row.encrypted),
-            ),
-          )
-          .returning({ id: secrets.id });
-        migrated += updatedRows.length;
+        migrated += await updateRow(row, encryptedValue);
       } else {
         migrated += 1;
       }
     }
-
-    if (args.dryRun) {
-      return migrated;
-    }
   }
 
   return migrated;
+}
+
+async function migrateSecretsTable(args: MigrationArgs): Promise<number> {
+  const database = db();
+  return await migrateEncryptedRows(
+    args,
+    async (cursor, batchSize) => {
+      return await database
+        .select({ id: secrets.id, encrypted: secrets.encryptedValue })
+        .from(secrets)
+        .where(cursor ? gt(secrets.id, cursor) : undefined)
+        .orderBy(asc(secrets.id))
+        .limit(batchSize);
+    },
+    async (row, encryptedValue) => {
+      const updatedRows = await database
+        .update(secrets)
+        .set({ encryptedValue })
+        .where(
+          and(
+            eq(secrets.id, row.id),
+            eq(secrets.encryptedValue, row.encrypted!),
+          ),
+        )
+        .returning({ id: secrets.id });
+      return updatedRows.length;
+    },
+  );
 }
 
 async function migrateOrgCustomConnectorSecretsTable(
   args: MigrationArgs,
 ): Promise<number> {
-  let migrated = 0;
   const database = db();
-
-  while (!args.reportOnly) {
-    const rows = await database
-      .select({
-        id: orgCustomConnectorSecrets.id,
-        encrypted: orgCustomConnectorSecrets.encryptedValue,
-      })
-      .from(orgCustomConnectorSecrets)
-      .where(
-        not(
-          like(
-            orgCustomConnectorSecrets.encryptedValue,
-            `${STORED_SECRET_ENVELOPE_PREFIX}%`,
+  return await migrateEncryptedRows(
+    args,
+    async (cursor, batchSize) => {
+      return await database
+        .select({
+          id: orgCustomConnectorSecrets.id,
+          encrypted: orgCustomConnectorSecrets.encryptedValue,
+        })
+        .from(orgCustomConnectorSecrets)
+        .where(cursor ? gt(orgCustomConnectorSecrets.id, cursor) : undefined)
+        .orderBy(asc(orgCustomConnectorSecrets.id))
+        .limit(batchSize);
+    },
+    async (row, encryptedValue) => {
+      const updatedRows = await database
+        .update(orgCustomConnectorSecrets)
+        .set({ encryptedValue })
+        .where(
+          and(
+            eq(orgCustomConnectorSecrets.id, row.id),
+            eq(orgCustomConnectorSecrets.encryptedValue, row.encrypted!),
           ),
-        ),
-      )
-      .limit(args.batchSize);
-
-    if (rows.length === 0) {
-      return migrated;
-    }
-
-    for (const row of rows) {
-      const encryptedValue = await reencryptCiphertext(
-        row.encrypted,
-        args.mode,
-      );
-      if (!args.dryRun) {
-        const updatedRows = await database
-          .update(orgCustomConnectorSecrets)
-          .set({ encryptedValue })
-          .where(
-            and(
-              eq(orgCustomConnectorSecrets.id, row.id),
-              eq(orgCustomConnectorSecrets.encryptedValue, row.encrypted),
-            ),
-          )
-          .returning({ id: orgCustomConnectorSecrets.id });
-        migrated += updatedRows.length;
-      } else {
-        migrated += 1;
-      }
-    }
-
-    if (args.dryRun) {
-      return migrated;
-    }
-  }
-
-  return migrated;
+        )
+        .returning({ id: orgCustomConnectorSecrets.id });
+      return updatedRows.length;
+    },
+  );
 }
 
 async function migrateZeroAgentSchedulesTable(
   args: MigrationArgs,
 ): Promise<number> {
-  let migrated = 0;
   const database = db();
-
-  while (!args.reportOnly) {
-    const rows = await database
-      .select({
-        id: zeroAgentSchedules.id,
-        encrypted: zeroAgentSchedules.encryptedSecrets,
-      })
-      .from(zeroAgentSchedules)
-      .where(
-        and(
-          isNotNull(zeroAgentSchedules.encryptedSecrets),
-          not(
-            like(
-              zeroAgentSchedules.encryptedSecrets,
-              `${STORED_SECRET_ENVELOPE_PREFIX}%`,
-            ),
+  return await migrateEncryptedRows(
+    args,
+    async (cursor, batchSize) => {
+      return await database
+        .select({
+          id: zeroAgentSchedules.id,
+          encrypted: zeroAgentSchedules.encryptedSecrets,
+        })
+        .from(zeroAgentSchedules)
+        .where(
+          cursor
+            ? and(
+                isNotNull(zeroAgentSchedules.encryptedSecrets),
+                gt(zeroAgentSchedules.id, cursor),
+              )
+            : isNotNull(zeroAgentSchedules.encryptedSecrets),
+        )
+        .orderBy(asc(zeroAgentSchedules.id))
+        .limit(batchSize);
+    },
+    async (row, encryptedSecrets) => {
+      const updatedRows = await database
+        .update(zeroAgentSchedules)
+        .set({ encryptedSecrets })
+        .where(
+          and(
+            eq(zeroAgentSchedules.id, row.id),
+            eq(zeroAgentSchedules.encryptedSecrets, row.encrypted!),
           ),
-        ),
-      )
-      .limit(args.batchSize);
-
-    if (rows.length === 0) {
-      return migrated;
-    }
-
-    for (const row of rows) {
-      if (!row.encrypted) {
-        continue;
-      }
-      const encryptedSecrets = await reencryptCiphertext(
-        row.encrypted,
-        args.mode,
-      );
-      if (!args.dryRun) {
-        const updatedRows = await database
-          .update(zeroAgentSchedules)
-          .set({ encryptedSecrets })
-          .where(
-            and(
-              eq(zeroAgentSchedules.id, row.id),
-              eq(zeroAgentSchedules.encryptedSecrets, row.encrypted),
-            ),
-          )
-          .returning({ id: zeroAgentSchedules.id });
-        migrated += updatedRows.length;
-      } else {
-        migrated += 1;
-      }
-    }
-
-    if (args.dryRun) {
-      return migrated;
-    }
-  }
-
-  return migrated;
+        )
+        .returning({ id: zeroAgentSchedules.id });
+      return updatedRows.length;
+    },
+  );
 }
 
 async function countSecretsTable(): Promise<CiphertextCounts> {
@@ -335,10 +341,10 @@ function printReport(report: MigrationReport): void {
   );
 }
 
-async function run(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
-
-  const reports: MigrationReport[] = [
+export async function runStoredSecretKmsBackfill(
+  args: MigrationArgs,
+): Promise<readonly MigrationReport[]> {
+  return [
     {
       name: "secrets.encrypted_value",
       before: await countSecretsTable(),
@@ -358,6 +364,11 @@ async function run(): Promise<void> {
       after: await countZeroAgentSchedulesTable(),
     },
   ];
+}
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const reports = await runStoredSecretKmsBackfill(args);
 
   process.stdout.write(
     `mode=${args.mode} dryRun=${String(args.dryRun)} batchSize=${
@@ -369,8 +380,10 @@ async function run(): Promise<void> {
   }
 }
 
-const result = await settle(run());
-await closeDbPool();
-if (!result.ok) {
-  throw result.error;
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = await settle(run());
+  await closeDbPool();
+  if (!result.ok) {
+    throw result.error;
+  }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts
@@ -1,0 +1,44 @@
+import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
+
+import type { SecretKmsClient } from "../../../services/crypto.utils";
+
+type MockKmsCommand = GenerateDataKeyCommand | DecryptCommand;
+type MockKmsResponse = GenerateDataKeyCommandOutput | DecryptCommandOutput;
+
+const dataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+export function fakeKmsClient(): {
+  readonly calls: readonly MockKmsCommand[];
+  readonly client: SecretKmsClient;
+} {
+  const calls: MockKmsCommand[] = [];
+
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(command: MockKmsCommand): Promise<MockKmsResponse> {
+    calls.push(command);
+
+    if (command instanceof GenerateDataKeyCommand) {
+      return Promise.resolve({
+        $metadata: {},
+        KeyId: command.input.KeyId,
+        CiphertextBlob: Buffer.from(
+          `encrypted-data-key:${command.input.KeyId}`,
+          "utf8",
+        ),
+        Plaintext: dataKey,
+      });
+    }
+
+    return Promise.resolve({ $metadata: {}, Plaintext: dataKey });
+  }
+
+  return { calls, client: { send } };
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
@@ -10,9 +10,16 @@ import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import {
+  decryptSecretValue,
+  inspectPersistentSecretCiphertext,
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+} from "../../services/crypto.utils";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -126,6 +133,8 @@ describe("Claude Code device auth routes", () => {
   const fixtures: { readonly userId: string; readonly orgId: string }[] = [];
 
   afterEach(async () => {
+    clearMockedEnv();
+    resetSecretKmsClientForTests();
     while (fixtures.length > 0) {
       const fixture = fixtures.pop();
       if (fixture) {
@@ -144,6 +153,9 @@ describe("Claude Code device auth routes", () => {
 
   it("starts Claude Code device auth and returns setup-token OAuth details", async () => {
     const { userId, orgId } = setupUser();
+    const kms = fakeKmsClient();
+    setSecretKmsClientForTests(kms.client);
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const response = await accept(
       client().start({
@@ -171,6 +183,15 @@ describe("Claude Code device auth routes", () => {
     await expect(
       claudeCodeDeviceAuthSessions(userId, orgId),
     ).resolves.toHaveLength(1);
+    const [session] = await claudeCodeDeviceAuthSessions(userId, orgId);
+    expect(
+      inspectPersistentSecretCiphertext(session!.encryptedProviderState!),
+    ).toStrictEqual({
+      format: "dual",
+      hasLegacy: true,
+      hasKms: true,
+    });
+    expect(kms.calls).toHaveLength(1);
   });
 
   it("cancels pending Claude Code device auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts
@@ -10,10 +10,17 @@ import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import {
+  decryptSecretValue,
+  inspectPersistentSecretCiphertext,
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+} from "../../services/crypto.utils";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -219,6 +226,8 @@ describe("Codex device auth routes", () => {
   const fixtures: { readonly userId: string; readonly orgId: string }[] = [];
 
   afterEach(async () => {
+    clearMockedEnv();
+    resetSecretKmsClientForTests();
     while (fixtures.length > 0) {
       const fixture = fixtures.pop();
       if (fixture) {
@@ -256,6 +265,9 @@ describe("Codex device auth routes", () => {
 
   it("starts Codex device auth and returns browser confirmation details", async () => {
     const { userId, orgId } = setupUser();
+    const kms = fakeKmsClient();
+    setSecretKmsClientForTests(kms.client);
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
     const calls = mockCodexDeviceAuthHttp();
 
     const response = await accept(
@@ -290,6 +302,14 @@ describe("Codex device auth routes", () => {
       errorMessage: null,
     });
     expect(sessions[0]?.encryptedProviderState).toBeTruthy();
+    expect(
+      inspectPersistentSecretCiphertext(sessions[0]!.encryptedProviderState!),
+    ).toStrictEqual({
+      format: "dual",
+      hasLegacy: true,
+      hasKms: true,
+    });
+    expect(kms.calls).toHaveLength(1);
   });
 
   it("cancels pending device auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -14,13 +14,19 @@ import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
 import { now, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import {
+  decryptPersistentSecretValue,
   decryptSecretValue,
   encryptSecretValue,
+  inspectPersistentSecretCiphertext,
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
 } from "../../services/crypto.utils";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -395,6 +401,8 @@ describe("OAuth device authorization connector routes", () => {
   const users: { readonly userId: string; readonly orgId: string }[] = [];
 
   afterEach(async () => {
+    clearMockedEnv();
+    resetSecretKmsClientForTests();
     testOauthDeviceProvider.grant.pollDeviceAuth = originalPollDeviceAuth;
     while (users.length > 0) {
       const user = users.pop();
@@ -416,6 +424,9 @@ describe("OAuth device authorization connector routes", () => {
 
   it("starts a session and stores only encrypted provider state plus a token hash", async () => {
     const { userId, orgId } = await setupUser();
+    const kms = fakeKmsClient();
+    setSecretKmsClientForTests(kms.client);
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,
     );
@@ -449,12 +460,25 @@ describe("OAuth device authorization connector routes", () => {
       sessionTokenHash(response.body.sessionToken),
     );
     expect(session.encryptedProviderState).not.toContain("test-device:");
-    expect(decryptSecretValue(session.encryptedProviderState)).toContain(
+    expect(
+      inspectPersistentSecretCiphertext(session.encryptedProviderState),
+    ).toStrictEqual({
+      format: "dual",
+      hasLegacy: true,
+      hasKms: true,
+    });
+    const decryptedProviderState = await decryptPersistentSecretValue(
+      session.encryptedProviderState,
+      {
+        orgId,
+        userId,
+      },
+    );
+    expect(decryptedProviderState).toContain(
       "test-device:test-oauth-device-client:read",
     );
-    expect(decryptSecretValue(session.encryptedProviderState)).not.toContain(
-      "scopes",
-    );
+    expect(decryptedProviderState).not.toContain("scopes");
+    expect(kms.calls).toHaveLength(2);
   });
 
   it("marks the previous active session as superseded when a new session starts", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -347,7 +347,7 @@ describe("POST /api/zero/secrets", () => {
       throw new Error("Expected secret row to be written");
     }
     const envelope = storedSecretEnvelope(row.encryptedValue);
-    expect(envelope.legacy).toBeTruthy();
+    expect(envelope.legacy).toBeUndefined();
     expect(envelope.kms?.encryptedDataKey).toBeTruthy();
   });
 

--- a/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
@@ -126,14 +126,14 @@ describe("stored secret encryption", () => {
     expect(fakeKmsClient.calls).toHaveLength(0);
   });
 
-  it("dual-writes legacy AES and reads AWS KMS material by default when KMS env is set", async () => {
+  it("writes and reads KMS-only material by default when KMS env is set", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = await encryptStoredSecretValue("secret-value");
 
     expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
-      format: "dual",
-      hasLegacy: true,
+      format: "kms",
+      hasLegacy: false,
       hasKms: true,
     });
 
@@ -143,6 +143,32 @@ describe("stored secret encryption", () => {
     expect(fakeKmsClient.calls).toHaveLength(2);
     expect(fakeKmsClient.calls[0]).toBeInstanceOf(GenerateDataKeyCommand);
     expect(fakeKmsClient.calls[1]).toBeInstanceOf(DecryptCommand);
+  });
+
+  it("reads existing dual ciphertext by default when KMS env is set", async () => {
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+
+    const encrypted = await encryptStoredSecretValueWithMode(
+      "secret-value",
+      "dual",
+    );
+
+    expect(inspectStoredSecretCiphertext(encrypted)).toMatchObject({
+      format: "dual",
+    });
+    await expect(decryptStoredSecretValue(encrypted)).resolves.toBe(
+      "secret-value",
+    );
+  });
+
+  it("keeps reading legacy-only ciphertext by default until cleanup finishes", async () => {
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+
+    const encrypted = encryptSecretValue("secret-value");
+
+    await expect(decryptStoredSecretValue(encrypted)).resolves.toBe(
+      "secret-value",
+    );
   });
 
   it("can write and strictly read KMS-only ciphertext", async () => {
@@ -196,7 +222,7 @@ describe("stored secret encryption", () => {
     ).rejects.toThrow("Stored secret ciphertext does not include KMS data");
   });
 
-  it("dual-writes stored secrets maps when KMS env is set", async () => {
+  it("writes stored secrets maps as KMS-only when KMS env is set", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = await encryptStoredSecretsMap({ API_KEY: "secret" });
@@ -206,7 +232,7 @@ describe("stored secret encryption", () => {
       throw new Error("Expected encrypted secrets map");
     }
     expect(inspectStoredSecretCiphertext(encrypted)).toMatchObject({
-      format: "dual",
+      format: "kms",
     });
   });
 

--- a/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
@@ -17,7 +17,12 @@ import {
   safeSync,
   settle,
 } from "../utils";
-import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
+import {
+  decryptPersistentSecretValue,
+  decryptSecretValue,
+  encryptPersistentSecretValue,
+  encryptSecretValue,
+} from "./crypto.utils";
 import {
   upsertOrgModelProvider$,
   upsertUserModelProvider$,
@@ -139,10 +144,14 @@ function encodeSession(payload: ClaudeCodeDeviceAuthSessionToken): string {
   return encryptSecretValue(JSON.stringify(payload));
 }
 
-function encodeProviderState(
+async function encodeProviderState(
   payload: ClaudeCodeDeviceAuthProviderState,
-): string {
-  return encryptSecretValue(JSON.stringify(payload));
+  session: ConnectorCliAuthSession,
+): Promise<string> {
+  return await encryptPersistentSecretValue(JSON.stringify(payload), {
+    orgId: session.orgId,
+    userId: session.userId,
+  });
 }
 
 function decodeSession(token: string): ClaudeCodeDeviceAuthSessionToken | null {
@@ -158,15 +167,25 @@ function decodeSession(token: string): ClaudeCodeDeviceAuthSessionToken | null {
   return decoded.ok;
 }
 
-function decodeProviderState(
+async function decodeProviderState(
   encryptedProviderState: string | null,
-): ClaudeCodeDeviceAuthProviderState | null {
+  session: ConnectorCliAuthSession,
+): Promise<ClaudeCodeDeviceAuthProviderState | null> {
   if (!encryptedProviderState) {
+    return null;
+  }
+  const decrypted = await settle(
+    decryptPersistentSecretValue(encryptedProviderState, {
+      orgId: session.orgId,
+      userId: session.userId,
+    }),
+  );
+  if (!decrypted.ok) {
     return null;
   }
   const decoded = safeSync(() => {
     const parsed = claudeCodeDeviceAuthProviderStateSchema.safeParse(
-      safeJsonParse(decryptSecretValue(encryptedProviderState)),
+      safeJsonParse(decrypted.value),
     );
     return parsed.success ? parsed.data : null;
   });
@@ -387,13 +406,16 @@ async function moveSessionToAwaitingApproval(args: {
       status: "awaiting_user_approval",
       approvalUrl: args.approvalUrl,
       verificationCode: null,
-      encryptedProviderState: encodeProviderState({
-        version: 1,
-        type: "claude-code",
-        scope: args.scope,
-        state: args.state,
-        codeVerifier: args.codeVerifier,
-      }),
+      encryptedProviderState: await encodeProviderState(
+        {
+          version: 1,
+          type: "claude-code",
+          scope: args.scope,
+          state: args.state,
+          codeVerifier: args.codeVerifier,
+        },
+        args.session,
+      ),
       updatedAt: nowDate(),
     })
     .where(eq(connectorCliAuthSessions.id, args.session.id))
@@ -732,7 +754,10 @@ async function completeLoadedClaudeCodeDeviceAuth(args: {
     };
   }
 
-  const providerState = decodeProviderState(session.encryptedProviderState);
+  const providerState = await decodeProviderState(
+    session.encryptedProviderState,
+    session,
+  );
   if (!providerState) {
     return {
       status: "error",

--- a/turbo/apps/api/src/signals/services/codex-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-device-auth.service.ts
@@ -15,7 +15,12 @@ import {
   safeSync,
   settle,
 } from "../utils";
-import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
+import {
+  decryptPersistentSecretValue,
+  decryptSecretValue,
+  encryptPersistentSecretValue,
+  encryptSecretValue,
+} from "./crypto.utils";
 import { handleCodexAuthJsonPaste } from "./codex-auth-json-paste-handler";
 import {
   upsertOrgMultiAuthModelProvider$,
@@ -185,8 +190,14 @@ function encodeSession(payload: CodexDeviceAuthSessionToken): string {
   return encryptSecretValue(JSON.stringify(payload));
 }
 
-function encodeProviderState(payload: CodexDeviceAuthProviderState): string {
-  return encryptSecretValue(JSON.stringify(payload));
+async function encodeProviderState(
+  payload: CodexDeviceAuthProviderState,
+  session: ConnectorCliAuthSession,
+): Promise<string> {
+  return await encryptPersistentSecretValue(JSON.stringify(payload), {
+    orgId: session.orgId,
+    userId: session.userId,
+  });
 }
 
 function decodeSession(token: string): CodexDeviceAuthSessionToken | null {
@@ -202,15 +213,25 @@ function decodeSession(token: string): CodexDeviceAuthSessionToken | null {
   return decoded.ok;
 }
 
-function decodeProviderState(
+async function decodeProviderState(
   encryptedProviderState: string | null,
-): CodexDeviceAuthProviderState | null {
+  session: ConnectorCliAuthSession,
+): Promise<CodexDeviceAuthProviderState | null> {
   if (!encryptedProviderState) {
+    return null;
+  }
+  const decrypted = await settle(
+    decryptPersistentSecretValue(encryptedProviderState, {
+      orgId: session.orgId,
+      userId: session.userId,
+    }),
+  );
+  if (!decrypted.ok) {
     return null;
   }
   const decoded = safeSync(() => {
     const parsed = codexDeviceAuthProviderStateSchema.safeParse(
-      safeJsonParse(decryptSecretValue(encryptedProviderState)),
+      safeJsonParse(decrypted.value),
     );
     return parsed.success ? parsed.data : null;
   });
@@ -428,13 +449,16 @@ async function moveSessionToAwaitingApproval(args: {
       status: "awaiting_user_approval",
       approvalUrl: CODEX_DEVICE_AUTH_VERIFICATION_URL,
       verificationCode: args.userCode,
-      encryptedProviderState: encodeProviderState({
-        version: 1,
-        type: "codex",
-        scope: args.scope,
-        deviceAuthId: args.deviceAuthId,
-        userCode: args.userCode,
-      }),
+      encryptedProviderState: await encodeProviderState(
+        {
+          version: 1,
+          type: "codex",
+          scope: args.scope,
+          deviceAuthId: args.deviceAuthId,
+          userCode: args.userCode,
+        },
+        args.session,
+      ),
       updatedAt: nowDate(),
     })
     .where(eq(connectorCliAuthSessions.id, args.session.id))
@@ -891,7 +915,10 @@ async function completeLoadedCodexDeviceAuth(args: {
     };
   }
 
-  const providerState = decodeProviderState(session.encryptedProviderState);
+  const providerState = await decodeProviderState(
+    session.encryptedProviderState,
+    session,
+  );
   if (!providerState) {
     return {
       status: "error",

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -34,7 +34,10 @@ import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { settle } from "../utils";
-import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
+import {
+  decryptPersistentSecretValue,
+  encryptPersistentSecretValue,
+} from "./crypto.utils";
 import { userConnectorAvailability } from "./connector-availability.service";
 import {
   upsertOAuthConnector$,
@@ -381,12 +384,19 @@ async function claimSession(args: {
   return claimedSession ?? null;
 }
 
-function parseEncryptedProviderState(args: {
+async function parseEncryptedProviderState(args: {
   readonly session: DeviceAuthSessionRow;
   readonly type: OAuthDeviceAuthConnectorType;
-}): EncryptedProviderState {
+}): Promise<EncryptedProviderState> {
+  const decrypted = await decryptPersistentSecretValue(
+    args.session.encryptedProviderState,
+    {
+      orgId: args.session.orgId,
+      userId: args.session.userId,
+    },
+  );
   const providerState = encryptedProviderStateSchema.parse(
-    JSON.parse(decryptSecretValue(args.session.encryptedProviderState)),
+    JSON.parse(decrypted) as unknown,
   );
   if (providerState.connectorType !== args.type) {
     throw new Error("OAuth device provider state connector type mismatch");
@@ -581,7 +591,7 @@ async function completeSessionResponse(args: {
 async function runClaimedSession(
   args: PollClaimedSessionArgs,
 ): Promise<PollSuccess> {
-  const providerState = parseEncryptedProviderState({
+  const providerState = await parseEncryptedProviderState({
     session: args.session,
     type: args.type,
   });
@@ -705,12 +715,17 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       startResult.interval ?? DEFAULT_POLL_INTERVAL_SECONDS;
     const now = nowDate();
     const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
-    const encryptedProviderState = encryptSecretValue(
+    const encryptedProviderState = await encryptPersistentSecretValue(
       JSON.stringify({
         connectorType: resolvedType,
         deviceCode: startResult.deviceCode,
       }),
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+      },
     );
+    signal.throwIfAborted();
 
     const [session] = await set(writeDb$).transaction(async (tx) => {
       await lockDeviceAuthSessionOwner({

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -343,7 +343,7 @@ export async function encryptStoredSecretValue(
     return encryptSecretValue(plaintext);
   }
 
-  return await encryptStoredSecretValueWithMode(plaintext, "dual");
+  return await encryptStoredSecretValueWithMode(plaintext, "kms");
 }
 
 export async function decryptStoredSecretValue(


### PR DESCRIPTION
## Summary

Part of #13967.

This rollout cleanup PR now covers both stored-secret write cleanup and the provider-state bypass found during production investigation:

- stop new stored-secret writes from producing dual envelopes when `SECRETS_KMS_KEY_ID` is configured
- keep default stored-secret reads on `prefer-kms` until production cleanup removes the remaining legacy-only rows
- keep legacy and dual envelope parsing available for existing data and cleanup tooling
- update `backfill-secret-kms-encryption.ts` so `--mode kms` selects both legacy-only and dual rows, then rewrites them as KMS-only
- move Codex device auth, Claude Code device auth, and OAuth device auth provider-state writes from direct legacy encryption to `encryptPersistentSecretValue`
- keep short-lived session tokens on direct symmetric encryption because they are not DB backfill targets
- add focused coverage for KMS-only stored writes, legacy-compatible reads, cleanup candidate selection, and KMS-configured provider-state writes

Production report before this update found remaining legacy-only rows, so this PR intentionally does not switch stored-secret reads to `kms-only` yet.

## Production Report

Report-only, no writes:

Stored-secret targets:

- `secrets.encrypted_value`: `legacy=6 dual=755 kms=0 invalid=0`
- `org_custom_connector_secrets.encrypted_value`: `legacy=0 dual=4 kms=0 invalid=0`
- `zero_agent_schedules.encrypted_secrets`: `legacy=0 dual=5 kms=0 invalid=0`

Persistent-secret targets:

- `slack_org_installations.encrypted_bot_token`: `legacy=0 dual=16 kms=0 invalid=0`
- `telegram_installations.encrypted_bot_token`: `legacy=0 dual=4 kms=0 invalid=0`
- `github_installations.encrypted_access_token`: `legacy=0 dual=1 kms=0 invalid=0`
- `agent_run_callbacks.encrypted_secret`: `legacy=0 dual=26013 kms=0 invalid=0`
- `connector_cli_auth_sessions.encrypted_provider_state`: `legacy=1 dual=0 kms=0 invalid=0`
- `agent_run_queue.encrypted_params`: `legacy=0 dual=0 kms=0 invalid=0`
- `runner_job_queue.execution_context.encrypted_secrets`: `legacy=0 dual=6 kms=0 invalid=0`

Legacy-only concentration check:

- `secrets.encrypted_value`: all 6 legacy-only rows were connector token secrets; 5 were created before the stored-secret write switch landed and 1 Google Ads access token was created after it
- `connector_cli_auth_sessions.encrypted_provider_state`: the legacy-only row was a Codex device-auth provider state created after the switches were removed, which pointed to a direct encryption bypass now fixed in this PR

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/codex-device-auth.service.ts apps/api/src/signals/services/claude-code-device-auth.service.ts apps/api/src/signals/services/connector-oauth-device-auth.service.ts apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/zero-codex-device-auth.test.ts src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/services/__tests__/crypto.utils.test.ts src/scripts/__tests__/backfill-secret-kms-encryption.test.ts src/signals/routes/__tests__/zero-secrets.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/zero-codex-device-auth.test.ts src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts`

Local setup note: I also ran `pnpm -F @vm0/db db:migrate` after refreshing workspace dependency symlinks because the local test database was missing `connector_oauth_device_authorization_sessions`.