### PR TITLE
chore: move data migration scripts to db package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 - **main branch is always stable** - All code merged to main has passed CI (build + tests). If your branch fails to build or pass tests, the issue is in your branch code, not main.
 - **Use dev-tunnel for local development** - Run `/dev-tunnel` to start a local server accessible by sandbox webhooks. Without this, webhooks cannot reach your local server.
-- **Run `pnpm db:migrate` to sync database** - After pulling new changes, run this command in the `turbo` directory to apply the latest migrations.
+- **Run `pnpm -F @vm0/db db:migrate` to sync database** - After pulling new changes, run this command in the `turbo` directory to apply the latest migrations.
 - **Run `script/sync-env.sh` to sync environment variables** - If missing required environment variables, ask the user to run this script to sync `.env.local`.
 - **Run `scripts/prepare.sh` when local dev or tests fail unexpectedly** - Before debugging test failures, verify your environment is set up correctly. This script checks Node.js, pnpm, PostgreSQL, syncs env files, installs dependencies, runs migrations, and seeds dev data.
 - **API migration is in progress** - `apps/web` API traffic is migrating to `apps/api`; read https://github.com/vm0-ai/vm0/issues/12290 before API work. New or migrated endpoint routes should be implemented in `apps/api`, not as new `apps/web/app/api/**/route.ts` handlers. When a web-compatible path is still needed, route it back to the API backend through `apps/web/next.config.js` Next rewrites instead of adding thin web proxy routes. For routes that still have implementations in both `apps/web` and `apps/api`, bug fixes and behavior or logic changes must update both implementations together until the route is fully API-authoritative.

--- a/turbo/.prettierignore
+++ b/turbo/.prettierignore
@@ -13,4 +13,4 @@ Caddyfile
 **/codereviews/**
 apps/web/src/db/migrations/
 packages/db/src/migrations/
-apps/web/scripts/migrations/
+packages/db/scripts/migrations/

--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -139,16 +139,7 @@ export default [
     },
   },
   {
-    ignores: [
-      "custom-eslint/**",
-      "public/**",
-      "scripts/migrations/001-backfill-clerk-orgs/**",
-      "scripts/migrations/002-backfill-clerk-metadata/**",
-      "scripts/migrations/003-sync-clerk-slugs/**",
-      "scripts/migrations/004-backfill-default-agent/**",
-      "scripts/migrations/005-backfill-clerk-metadata/**",
-      "scripts/migrations/006-cleanup-orphaned-orgs/**",
-    ],
+    ignores: ["custom-eslint/**", "public/**"],
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
 ];

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1053.0",
     "@aws-sdk/s3-request-presigner": "^3.1053.0",
-    "@clerk/backend": "^3.4.13",
     "@clerk/nextjs": "^7.2.7",
     "@neondatabase/serverless": "^1.0.2",
     "@opentelemetry/api": "^1.9.0",

--- a/turbo/apps/web/tsconfig.json
+++ b/turbo/apps/web/tsconfig.json
@@ -17,13 +17,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "scripts/migrations/001-backfill-clerk-orgs",
-    "scripts/migrations/002-backfill-clerk-metadata",
-    "scripts/migrations/003-sync-clerk-slugs",
-    "scripts/migrations/004-backfill-default-agent",
-    "scripts/migrations/005-backfill-clerk-metadata",
-    "scripts/migrations/006-cleanup-orphaned-orgs"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -176,11 +176,7 @@
     "scripts/analyze-react-renders.mjs",
     "scripts/analyze-rewind-cause.mjs",
     "scripts/analyze-rewind.mjs",
-    "scripts/dump-rewind-chains.mjs",
-    "apps/web/scripts/migrations/001-backfill-clerk-orgs/**",
-    "apps/web/scripts/migrations/002-backfill-clerk-metadata/**",
-    "apps/web/scripts/migrations/003-sync-clerk-slugs/**",
-    "apps/web/scripts/migrations/004-backfill-default-agent/**"
+    "scripts/dump-rewind-chains.mjs"
   ],
   "ignoreDependencies": ["@commitlint/cli", "@vm0/firewalls-generator"],
   "ignoreWorkspaces": [],

--- a/turbo/packages/db/.oxlintrc.json
+++ b/turbo/packages/db/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
   "extends": ["../../.oxlintrc.json"],
+  "ignorePatterns": ["scripts/migrations/**"],
   "overrides": [
     {
       "files": ["drizzle.config.ts", "eslint.config.mjs", "vitest.config.ts"],

--- a/turbo/packages/db/eslint.config.mjs
+++ b/turbo/packages/db/eslint.config.mjs
@@ -3,7 +3,7 @@ import { config, oxlint } from "@vm0/eslint-config/base";
 export default [
   ...config,
   {
-    ignores: ["**/dist/**"],
+    ignores: ["**/dist/**", "scripts/migrations/**"],
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
 ];

--- a/turbo/packages/db/package.json
+++ b/turbo/packages/db/package.json
@@ -29,6 +29,7 @@
     "test:migration-consistency": "tsx scripts/test-migration-consistency-schema.ts"
   },
   "dependencies": {
+    "@clerk/backend": "^3.4.13",
     "@vm0/api-contracts": "workspace:*",
     "@vm0/connectors": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/turbo/packages/db/scripts/migrations/001-backfill-clerk-orgs/README.md
+++ b/turbo/packages/db/scripts/migrations/001-backfill-clerk-orgs/README.md
@@ -22,7 +22,7 @@ unblocking Phase 3's `NOT NULL` constraint.
 
 - Node.js 18+
 - `pnpm install` completed in the `turbo` directory
-- Database migrations applied (`pnpm db:migrate`)
+- Database migrations applied (`pnpm -F @vm0/db db:migrate`)
 - Phase 1 + 2 deployed (PR #3592 merged)
 
 ## Environment Variables
@@ -34,20 +34,20 @@ unblocking Phase 3's `NOT NULL` constraint.
 
 ## Usage
 
-Run from the `turbo/apps/web` directory:
+Run from the `turbo/packages/db` directory:
 
 ```bash
 # Dry run (default) — preview which scopes need backfilling
-tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts
+pnpm exec tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts
 
 # Dry run for a single user
-tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts --user-id=user_xxx
+pnpm exec tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts --user-id=user_xxx
 
 # Actual migration for a single user first
-tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts --migrate --user-id=user_xxx
+pnpm exec tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts --migrate --user-id=user_xxx
 
 # Full migration
-tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts --migrate
+pnpm exec tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts --migrate
 ```
 
 ## Options

--- a/turbo/packages/db/scripts/migrations/001-backfill-clerk-orgs/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/001-backfill-clerk-orgs/backfill.ts
@@ -8,7 +8,7 @@
  * back to the row. After this completes, Phase 3 can add a NOT NULL constraint.
  *
  * Usage:
- *   tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts [--migrate] [--user-id=<clerkUserId>]
+ *   pnpm exec tsx scripts/migrations/001-backfill-clerk-orgs/backfill.ts [--migrate] [--user-id=<clerkUserId>]
  *
  * Environment:
  *   DATABASE_URL        — Required
@@ -16,6 +16,7 @@
  */
 
 import { parseArgs } from "node:util";
+import { createClerkClient } from "@clerk/backend";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { and, eq, isNull, asc, sql } from "drizzle-orm";
 import postgres from "postgres";
@@ -205,7 +206,6 @@ async function main() {
     if (!clerkSecretKey) {
       throw new Error("CLERK_SECRET_KEY is required for --migrate");
     }
-    const { createClerkClient } = await import("@clerk/backend");
     clerkClient = createClerkClient({ secretKey: clerkSecretKey });
   }
 

--- a/turbo/packages/db/scripts/migrations/002-backfill-clerk-metadata/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/002-backfill-clerk-metadata/backfill.ts
@@ -7,7 +7,7 @@
  * publicMetadata.
  *
  * Usage:
- *   tsx scripts/migrations/002-backfill-clerk-metadata/backfill.ts [--migrate]
+ *   pnpm exec tsx scripts/migrations/002-backfill-clerk-metadata/backfill.ts [--migrate]
  *
  * Environment:
  *   DATABASE_URL        — Required
@@ -15,6 +15,7 @@
  */
 
 import { parseArgs } from "node:util";
+import { createClerkClient } from "@clerk/backend";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { asc } from "drizzle-orm";
 import postgres from "postgres";
@@ -182,7 +183,6 @@ async function main() {
     if (!clerkSecretKey) {
       throw new Error("CLERK_SECRET_KEY is required for --migrate");
     }
-    const { createClerkClient } = await import("@clerk/backend");
     client = createClerkClient({ secretKey: clerkSecretKey });
   }
 

--- a/turbo/packages/db/scripts/migrations/003-sync-clerk-slugs/sync.ts
+++ b/turbo/packages/db/scripts/migrations/003-sync-clerk-slugs/sync.ts
@@ -7,7 +7,7 @@
  * In migrate mode, updates Clerk org slugs to match the database (DB is source of truth).
  *
  * Usage:
- *   tsx scripts/migrations/003-sync-clerk-slugs/sync.ts [--migrate]
+ *   pnpm exec tsx scripts/migrations/003-sync-clerk-slugs/sync.ts [--migrate]
  *
  * Environment:
  *   DATABASE_URL        — Required

--- a/turbo/packages/db/scripts/migrations/004-backfill-default-agent/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/004-backfill-default-agent/backfill.ts
@@ -7,7 +7,7 @@
  * to the corresponding Clerk org's publicMetadata.default_agent_compose_id.
  *
  * Usage:
- *   tsx scripts/migrations/004-backfill-default-agent/backfill.ts [--migrate]
+ *   pnpm exec tsx scripts/migrations/004-backfill-default-agent/backfill.ts [--migrate]
  *
  * Environment:
  *   DATABASE_URL        — Required

--- a/turbo/packages/db/scripts/migrations/005-backfill-clerk-metadata/README.md
+++ b/turbo/packages/db/scripts/migrations/005-backfill-clerk-metadata/README.md
@@ -33,7 +33,7 @@ their metadata to the corresponding DB tables:
 
 - Node.js 18+
 - `pnpm install` completed in the `turbo` directory
-- Database migrations applied (`pnpm db:migrate`)
+- Database migrations applied (`pnpm -F @vm0/db db:migrate`)
 
 ## Environment Variables
 
@@ -44,14 +44,14 @@ their metadata to the corresponding DB tables:
 
 ## Usage
 
-Run from the `turbo/apps/web` directory:
+Run from the `turbo/packages/db` directory:
 
 ```bash
 # Dry run (default) — preview what would be backfilled
-tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts
+pnpm exec tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts
 
 # Actual migration
-tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts --migrate
+pnpm exec tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts --migrate
 ```
 
 ## Options

--- a/turbo/packages/db/scripts/migrations/005-backfill-clerk-metadata/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/005-backfill-clerk-metadata/backfill.ts
@@ -7,9 +7,9 @@
  * org_metadata, org_members_metadata, and users tables. Ensures complete
  * data coverage beyond what lazy migration (#5591) achieves.
  *
- * Usage (from turbo/apps/web):
- *   tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts
- *   tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts --migrate
+ * Usage (from turbo/packages/db):
+ *   pnpm exec tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts
+ *   pnpm exec tsx scripts/migrations/005-backfill-clerk-metadata/backfill.ts --migrate
  *
  * Environment:
  *   DATABASE_URL        — Required

--- a/turbo/packages/db/scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts
+++ b/turbo/packages/db/scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts
@@ -12,10 +12,10 @@
  *   Phase 2: S3 storage objects
  *   Phase 3: Database records
  *
- * Usage (from turbo/apps/web):
- *   dotenv -e .env.local -- tsx scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts
- *   dotenv -e .env.local -- tsx scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts --migrate
- *   dotenv -e .env.local -- tsx scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts --migrate --org-id=org_xxx
+ * Usage (from turbo/packages/db):
+ *   pnpm exec tsx scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts
+ *   pnpm exec tsx scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts --migrate
+ *   pnpm exec tsx scripts/migrations/006-cleanup-orphaned-orgs/cleanup.ts --migrate --org-id=org_xxx
  *
  * Environment:
  *   DATABASE_URL        — Required
@@ -23,13 +23,13 @@
  */
 
 import { parseArgs } from "node:util";
-import { createRequire } from "node:module";
+import { createClerkClient } from "@clerk/backend";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { sql } from "drizzle-orm";
 import postgres from "postgres";
 
 // ---------------------------------------------------------------------------
-// Clerk client (CJS require — ESM export is broken under tsx runner)
+// Clerk client
 // ---------------------------------------------------------------------------
 
 type ClerkClient = {
@@ -39,11 +39,6 @@ type ClerkClient = {
       offset: number;
     }) => Promise<{ data: Array<{ id: string }>; totalCount: number }>;
   };
-};
-
-const require = createRequire(import.meta.url);
-const { createClerkClient } = require("@clerk/nextjs/server") as {
-  createClerkClient: (opts: { secretKey: string }) => ClerkClient;
 };
 
 // ---------------------------------------------------------------------------

--- a/turbo/packages/db/tsconfig.json
+++ b/turbo/packages/db/tsconfig.json
@@ -5,5 +5,5 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*", "scripts/**/*", "drizzle.config.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "scripts/migrations"]
 }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -674,9 +674,6 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1053.0
         version: 3.1053.0
-      '@clerk/backend':
-        specifier: ^3.4.13
-        version: 3.4.13(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/nextjs':
         specifier: ^7.2.7
         version: 7.2.7(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -966,6 +963,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@clerk/backend':
+        specifier: ^3.4.13
+        version: 3.4.13(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vm0/api-contracts':
         specifier: workspace:*
         version: link:../api-contracts


### PR DESCRIPTION
## Summary
- move one-time data migration scripts from apps/web to packages/db
- clean up web-only lint/type/knip/prettier ignores and move the historical-script ignores to db
- move @clerk/backend ownership to @vm0/db and update migration command docs

Follow-up to #14868.

## Validation
- pnpm -F @vm0/db check-types
- pnpm -F @vm0/db lint
- pnpm knip --workspace @vm0/db
- pnpm -F web check-types
- pnpm -F web lint
- pnpm knip --workspace web
- pnpm knip
- pnpm -F @vm0/db test:migration-consistency
- pnpm -F @vm0/db exec tsx -e 'import { createClerkClient } from "@clerk/backend"; if (typeof createClerkClient !== "function") throw new Error("createClerkClient is not a function");'\n- git diff --check