### PR TITLE
feat(cli): require --style or --skip-style on built-in generate image

### DIFF
--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -80,6 +80,7 @@ describe("zero built-in generate image command", () => {
       "cli",
       "generate",
       "image",
+      "--skip-style",
       "--prompt",
       "A watercolor fox",
       "--quality",
@@ -142,6 +143,7 @@ describe("zero built-in generate image command", () => {
       "cli",
       "generate",
       "image",
+      "--skip-style",
       "--model",
       "flux-pro-1.1",
       "--prompt",
@@ -196,6 +198,7 @@ describe("zero built-in generate image command", () => {
       "cli",
       "generate",
       "image",
+      "--skip-style",
       "--model",
       "flux-pro-1.1",
       "--prompt",
@@ -237,6 +240,7 @@ describe("zero built-in generate image command", () => {
       "cli",
       "generate",
       "image",
+      "--skip-style",
       "--prompt",
       "JSON please",
       "--json",
@@ -260,35 +264,39 @@ describe("zero built-in generate image command", () => {
     });
   });
 
-  it("should print styled image resource selection instructions with --styled", async () => {
+  it("should print styled image resource selection instructions with --style", async () => {
     await zeroBuiltInCommand.parseAsync([
       "node",
       "cli",
       "generate",
       "image",
-      "--styled",
+      "--style",
+      "vm0:image-style:notion-illustration",
       "--prompt",
       "Notion illustration of a product manager mapping a launch plan",
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(stdout).toContain("# Zero built-in generate image --styled");
+    expect(stdout).toContain(
+      "# Zero built-in generate image --style vm0:image-style:notion-illustration",
+    );
     expect(stdout).toContain("federated generation resource-selection packet");
-    expect(stdout).toContain("## Stage 1: Resource Selection");
-    expect(stdout).toContain("## Candidate Registry Slice");
+    expect(stdout).toContain("## Selected Image Style");
     expect(stdout).toContain("vm0:image-style:notion-illustration");
+    expect(stdout).toContain("## Candidate Registry Slice");
     expect(stdout).toContain("vm0-ai/vm0-skills");
     expect(stdout).toContain("notion-illustration");
     expect(stdout).toContain("## Stage 3: Generate Image");
   });
 
-  it("should print styled image JSON resource selection metadata", async () => {
+  it("should lock the selected style in the JSON packet candidate slice", async () => {
     await zeroBuiltInCommand.parseAsync([
       "node",
       "cli",
       "generate",
       "image",
-      "--styled",
+      "--style",
+      "vm0:image-style:notion-illustration",
       "--prompt",
       "Notion illustration of a product manager mapping a launch plan",
       "--json",
@@ -302,19 +310,17 @@ describe("zero built-in generate image command", () => {
       prompt: "Notion illustration of a product manager mapping a launch plan",
       outputDir: "./opendesign/images",
     });
-    expect(parsed.selection).toEqual(
+    const selection = parsed.selection as {
+      candidates: { imageStyles: { id: string }[] };
+    };
+    expect(selection.candidates.imageStyles).toHaveLength(1);
+    expect(selection.candidates.imageStyles[0]).toEqual(
       expect.objectContaining({
-        candidates: expect.objectContaining({
-          imageStyles: expect.arrayContaining([
-            expect.objectContaining({
-              id: "vm0:image-style:notion-illustration",
-              source: expect.objectContaining({
-                repo: "vm0-ai/vm0-skills",
-                commit: "main",
-                path: "illustration-template/notion-illustration",
-              }),
-            }),
-          ]),
+        id: "vm0:image-style:notion-illustration",
+        source: expect.objectContaining({
+          repo: "vm0-ai/vm0-skills",
+          commit: "main",
+          path: "illustration-template/notion-illustration",
         }),
       }),
     );
@@ -323,13 +329,14 @@ describe("zero built-in generate image command", () => {
     );
   });
 
-  it("should include vm0 illustration style for in-app spot prompts", async () => {
+  it("should lock vm0 illustration when selected via --style", async () => {
     await zeroBuiltInCommand.parseAsync([
       "node",
       "cli",
       "generate",
       "image",
-      "--styled",
+      "--style",
+      "vm0:image-style:vm0-illustration",
       "--prompt",
       "vm0 style in-app illustration for an empty billing state",
       "--json",
@@ -337,22 +344,78 @@ describe("zero built-in generate image command", () => {
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed.selection).toEqual(
+    const selection = parsed.selection as {
+      candidates: { imageStyles: { id: string }[] };
+    };
+    expect(selection.candidates.imageStyles).toHaveLength(1);
+    expect(selection.candidates.imageStyles[0]).toEqual(
       expect.objectContaining({
-        candidates: expect.objectContaining({
-          imageStyles: expect.arrayContaining([
-            expect.objectContaining({
-              id: "vm0:image-style:vm0-illustration",
-              source: expect.objectContaining({
-                repo: "vm0-ai/vm0-skills",
-                commit: "main",
-                path: "illustration-template/vm0-illustration",
-              }),
-            }),
-          ]),
+        id: "vm0:image-style:vm0-illustration",
+        source: expect.objectContaining({
+          repo: "vm0-ai/vm0-skills",
+          commit: "main",
+          path: "illustration-template/vm0-illustration",
         }),
       }),
     );
+  });
+
+  it("should fail with style listing when neither --style nor --skip-style is provided", async () => {
+    await expect(async () => {
+      await zeroBuiltInCommand.parseAsync([
+        "node",
+        "cli",
+        "generate",
+        "image",
+        "--prompt",
+        "Anything",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("--style <id> or --skip-style is required");
+    expect(stderr).toContain("vm0:image-style:notion-illustration");
+    expect(stderr).toContain("vm0:image-style:vm0-illustration");
+  });
+
+  it("should fail with style listing when --style id is unknown", async () => {
+    await expect(async () => {
+      await zeroBuiltInCommand.parseAsync([
+        "node",
+        "cli",
+        "generate",
+        "image",
+        "--style",
+        "vm0:image-style:does-not-exist",
+        "--prompt",
+        "Anything",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain(
+      "Unknown image style: vm0:image-style:does-not-exist",
+    );
+    expect(stderr).toContain("vm0:image-style:notion-illustration");
+  });
+
+  it("should reject combining --style with --skip-style", async () => {
+    await expect(async () => {
+      await zeroBuiltInCommand.parseAsync([
+        "node",
+        "cli",
+        "generate",
+        "image",
+        "--style",
+        "vm0:image-style:notion-illustration",
+        "--skip-style",
+        "--prompt",
+        "Anything",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("--style and --skip-style cannot be combined");
   });
 
   it("should wait for an accepted async generation result", async () => {
@@ -400,6 +463,7 @@ describe("zero built-in generate image command", () => {
       "cli",
       "generate",
       "image",
+      "--skip-style",
       "--prompt",
       "Async please",
     ]);
@@ -434,12 +498,19 @@ describe("zero built-in generate image command", () => {
     expect(helpOutput).toContain("--safety-tolerance");
     expect(helpOutput).toContain("--image-url");
     expect(helpOutput).toContain("--image-prompt-strength");
-    expect(helpOutput).toContain("--styled");
+    expect(helpOutput).toContain("--style <id>");
+    expect(helpOutput).toContain("--skip-style");
+    expect(helpOutput).not.toContain("--styled ");
     expect(helpOutput).toContain("provider");
     expect(helpOutput).toContain("default");
     expect(helpOutput).toContain("not support transparent");
     expect(helpOutput).toContain("backgrounds");
     expect(helpOutput).toContain("Image-to-image");
+    expect(helpOutput).toContain("Image Styles:");
+    expect(helpOutput).toContain("vm0:image-style:notion-illustration");
+    expect(helpOutput).toContain("Notion-editorial-style hand-drawn");
+    expect(helpOutput).toContain("vm0:image-style:vm0-illustration");
+    expect(helpOutput).toContain("Generate vm0-style vm0 in-app");
   });
 
   it("should surface API errors", async () => {
@@ -463,6 +534,7 @@ describe("zero built-in generate image command", () => {
         "cli",
         "generate",
         "image",
+        "--skip-style",
         "--prompt",
         "hello",
       ]);

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/image.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/image.ts
@@ -3,10 +3,10 @@ import { createImageGenerateCommand } from "../../shared/image-generate";
 export const imageCommand = createImageGenerateCommand({
   name: "image",
   usageCommand: "zero built-in generate image",
-  examples: `  Generate image:        zero built-in generate image --prompt "A watercolor fox"
-  Pipe prompt:           cat prompt.txt | zero built-in generate image
-  Styled image:          zero built-in generate image --styled --prompt "A product manager mapping a launch plan"
-  GPT Image model:       zero built-in generate image --model gpt-image-1.5 --prompt "A poster" --size 1024x1536 --quality high
-  Flux model:            zero built-in generate image --model flux-pro-1.1 --prompt "A product hero shot" --seed 42
-  Image-to-image:        zero built-in generate image --model flux-pro-1.1 --image-url https://example.com/mockup.png --prompt "Turn this mockup into a polished product shot"`,
+  examples: `  Styled image:          zero built-in generate image --style vm0:image-style:notion-illustration --prompt "A product manager mapping a launch plan"
+  Skip style:            zero built-in generate image --skip-style --prompt "A watercolor fox"
+  Pipe prompt:           cat prompt.txt | zero built-in generate image --skip-style
+  GPT Image model:       zero built-in generate image --skip-style --model gpt-image-1.5 --prompt "A poster" --size 1024x1536 --quality high
+  Flux model:            zero built-in generate image --skip-style --model flux-pro-1.1 --prompt "A product hero shot" --seed 42
+  Image-to-image:        zero built-in generate image --skip-style --model flux-pro-1.1 --image-url https://example.com/mockup.png --prompt "Turn this mockup into a polished product shot"`,
 });

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -4,6 +4,11 @@ import chalk from "chalk";
 import { generateWebImage } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { createStyledImageAuthoringPacket } from "./image-style-authoring";
+import {
+  findImageStyle,
+  listImageStyles,
+  type OpenDesignRegistryEntry,
+} from "./open-design-registry";
 
 interface ImageOptions {
   prompt?: string;
@@ -21,7 +26,8 @@ interface ImageOptions {
   maskImageUrl?: string;
   inputFidelity?: string;
   imagePromptStrength?: string;
-  styled?: boolean;
+  style?: string;
+  skipStyle?: boolean;
   json?: boolean;
 }
 
@@ -29,6 +35,49 @@ interface ImageGenerateCommandConfig {
   name: string;
   usageCommand: string;
   examples: string;
+}
+
+function formatStyleListing(
+  styles: readonly OpenDesignRegistryEntry[],
+): string {
+  if (styles.length === 0) {
+    return "  (no image styles registered)";
+  }
+  return styles
+    .map((style) => {
+      const desc = style.desc ?? style.description;
+      return `  ${style.id}\n    ${desc}`;
+    })
+    .join("\n\n");
+}
+
+function requireStyleError(usageCommand: string): Error {
+  const styles = listImageStyles();
+  const message = [
+    "--style <id> or --skip-style is required",
+    "",
+    "Available styles:",
+    formatStyleListing(styles),
+    "",
+    `Examples:`,
+    `  ${usageCommand} --style ${styles[0]?.id ?? "<style-id>"} --prompt "..."`,
+    `  ${usageCommand} --skip-style --prompt "..."`,
+  ].join("\n");
+  return new Error(message);
+}
+
+function unknownStyleError(id: string, usageCommand: string): Error {
+  const styles = listImageStyles();
+  const message = [
+    `Unknown image style: ${id}`,
+    "",
+    "Available styles:",
+    formatStyleListing(styles),
+    "",
+    `Example:`,
+    `  ${usageCommand} --style ${styles[0]?.id ?? "<style-id>"} --prompt "..."`,
+  ].join("\n");
+  return new Error(message);
 }
 
 function readPrompt(options: ImageOptions, usageCommand: string): string {
@@ -152,19 +201,24 @@ export function createImageGenerateCommand(
       "Reference strength override for Flux Redux",
     )
     .option(
-      "--styled",
-      "Print a resource-selection packet for styled image generation",
+      "--style <id>",
+      "Image style id from the registry (see Image Styles below)",
+    )
+    .option(
+      "--skip-style",
+      "Opt out of styled image generation for this invocation",
     )
     .option("--json", "Print metadata as JSON")
-    .addHelpText(
-      "after",
-      `
+    .addHelpText("after", () => {
+      const styles = listImageStyles();
+      return `
 Examples:
 ${config.examples}
 
 Output:
-  Prints the generated /f/ image file URL and metadata. With --styled, prints
-  an Open Design resource-selection packet for the current agent.
+  Prints the generated /f/ image file URL and metadata. With --style <id>,
+  prints an Open Design resource-selection packet for the current agent
+  with the selected style locked in.
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
@@ -181,6 +235,8 @@ Models:
 
 Options:
   - Prompt: required, up to 32,000 characters; stdin is supported.
+  - Style: required. Pass --style <id> to generate in a registered style
+    or --skip-style to bypass styled generation entirely.
   - Size: gpt-image-2 accepts auto or WIDTHxHEIGHT. Popular sizes include
     1024x1024,
     1536x1024, 1024x1536, 2048x2048, 2048x1152, 3840x2160,
@@ -200,15 +256,29 @@ Options:
     Flux Redux accepts --image-prompt-strength to override the provider
     default; GPT edit models accept --input-fidelity and supported models
     accept --mask-image-url.
-  - Styled mode: pass --styled to select an image style resource first. In this
-    mode the agent resolves the selected style source and generates the image.`,
-    )
+
+Image Styles:
+${formatStyleListing(styles)}`;
+    })
     .action(
       withErrorHandler(async (options: ImageOptions, command: Command) => {
+        if (options.style && options.skipStyle) {
+          throw new Error("--style and --skip-style cannot be combined");
+        }
+        if (!options.style && !options.skipStyle) {
+          throw requireStyleError(config.usageCommand);
+        }
+
         const prompt = readPrompt(options, config.usageCommand);
-        if (options.styled) {
+        if (options.style) {
+          const style = findImageStyle(options.style);
+          if (!style) {
+            throw unknownStyleError(options.style, config.usageCommand);
+          }
+
           const packet = createStyledImageAuthoringPacket({
             prompt,
+            style,
             details: [
               `Model preference if direct image generation is used: ${options.model}`,
               `Requested size: ${options.size}`,

--- a/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
@@ -1,12 +1,14 @@
 import {
   type GenerationOutputKind,
   type OpenDesignCandidateSlice,
+  type OpenDesignRegistryEntry,
   selectOpenDesignCandidates,
 } from "./open-design-registry";
 
 interface StyledImageAuthoringOptions {
   readonly prompt: string;
   readonly details: readonly string[];
+  readonly style: OpenDesignRegistryEntry;
 }
 
 interface StyledImageAuthoringPacket {
@@ -46,7 +48,6 @@ interface StyledImageAuthoringPacket {
 
 const outputDir = "./opendesign/images";
 const artifactRules = [
-  "Select the image style that best matches the prompt before generation.",
   "Resolve the selected style source before generating the image.",
   "Use the style skill's referenced assets and generation path when it provides one.",
   "Produce a single final image file and keep any temporary metadata under the output directory.",
@@ -55,10 +56,17 @@ const artifactRules = [
 export function createStyledImageAuthoringPacket(
   options: StyledImageAuthoringOptions,
 ): StyledImageAuthoringPacket {
-  const candidateSlice = selectOpenDesignCandidates({
+  const baseSlice = selectOpenDesignCandidates({
     target: "image",
     prompt: [options.prompt, ...options.details, ...artifactRules].join("\n"),
   });
+  const candidateSlice: OpenDesignCandidateSlice = {
+    ...baseSlice,
+    candidates: {
+      ...baseSlice.candidates,
+      imageStyles: [options.style],
+    },
+  };
   const selectionSchema = {
     imageStyle: "string",
     skills: "string[]",
@@ -81,18 +89,20 @@ export function createStyledImageAuthoringPacket(
     outputDir,
   } as const;
   const instructions = [
-    "# Zero built-in generate image --styled",
+    `# Zero built-in generate image --style ${options.style.id}`,
     "",
     "This is a federated generation resource-selection packet for the current agent.",
-    "Zero is not generating this image on the server yet. You select resources, resolve them, and generate the styled image.",
+    "Zero is not generating this image on the server yet. The image style has already been selected by the caller — resolve it and generate the styled image.",
     "",
     "## User Prompt",
     options.prompt,
     "",
-    "## Stage 1: Resource Selection",
-    "- Choose an image style from the bundled federated registry slice below.",
+    "## Selected Image Style",
+    `- \`${options.style.id}\` — ${options.style.name}`,
+    "",
+    "## Stage 1: Supporting Resource Selection",
+    "- The image style is locked. Optionally pick supporting skills/templates from the candidate slice below.",
     "- Choose only IDs present in this packet; do not invent registry IDs.",
-    "- Prefer image-style resources with matching triggers, but the user prompt is the highest-priority signal.",
     "- Treat the selection JSON as internal working state, then continue to generation.",
     "",
     "## Selection Output Schema",

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -61,6 +61,7 @@ export interface OpenDesignRegistryEntry {
   readonly kind: OpenDesignResourceKind;
   readonly name: string;
   readonly description: string;
+  readonly desc?: string;
   readonly source: OpenDesignSourceRef;
   readonly targets: readonly OpenDesignTarget[];
   readonly tags: readonly string[];
@@ -402,6 +403,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     name: "Notion Illustration",
     description:
       "Zero-native illustration style for hand-drawn product spot illustrations with simple ink contours and soft backgrounds.",
+    desc: 'Notion-editorial-style hand-drawn spot illustration. Black brush-pen ink on white, tapered confident strokes, solid-black curly hair, solid-black pants/shoes, 3/4 face turned toward viewer with closed-eye smile and soft nose hint, open breathing body outlines, and 1-3 supporting scene props + ambient marks that frame the moment. Trigger when user says /notion-illustration, asks for a "Notion-style illustration", "Notion spot illustration", or a new piece in this hand-drawn brush-pen Notion editorial style.',
     source: sourceRef(
       VM0_SKILLS_REPO,
       VM0_SKILLS_REF,
@@ -435,6 +437,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     name: "vm0 Illustration",
     description:
       "vm0 in-app spot illustration style with bold hand-drawn ink line art, white-filled interiors, and a soft rounded color backdrop.",
+    desc: "Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art with white-filled interiors, a soft rounded color backdrop, transparent output, and simple iconic metaphors for product states.",
     source: sourceRef(
       VM0_SKILLS_REPO,
       VM0_SKILLS_REF,
@@ -471,6 +474,20 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     priority: 19,
   },
 ];
+
+export function listImageStyles(): readonly OpenDesignRegistryEntry[] {
+  return OPEN_DESIGN_REGISTRY.filter((entry) => {
+    return entry.kind === "image-style" && entry.status !== "hidden";
+  });
+}
+
+export function findImageStyle(
+  id: string,
+): OpenDesignRegistryEntry | undefined {
+  return listImageStyles().find((entry) => {
+    return entry.id === id;
+  });
+}
 
 export function toOpenDesignTarget(value: string): OpenDesignTarget {
   if (value === "dashboard") {


### PR DESCRIPTION
## Summary

- Make `--style <id>` required on `zero built-in generate image`, with `--skip-style` as the explicit opt-out. The old boolean `--styled` flag is gone.
- When neither flag is passed, the command errors with the full list of registered image styles + agent-facing descriptions so an agent (or human) can pick one. The same listing is now part of `--help` under a new "Image Styles" section.
- Add a `desc` field to `OpenDesignRegistryEntry`, populated verbatim from each skill's `SKILL.md` description. The registry-author `description` is kept for human-readable summaries; `desc` is the rich trigger text used for selection.
- When `--style <id>` is passed, the resource-selection packet locks the `imageStyles` candidate slice to just the selected entry — the agent no longer re-selects a style, only resolves it and generates.

### Behavior changes for agents

Before:
\`\`\`
zero built-in generate image --prompt "..."          # ran with no style
zero built-in generate image --styled --prompt "..." # agent picked a style
\`\`\`

After:
\`\`\`
zero built-in generate image --style vm0:image-style:notion-illustration --prompt "..."
zero built-in generate image --skip-style --prompt "..."
\`\`\`

If you forget both, you get:
\`\`\`
✗ --style <id> or --skip-style is required

Available styles:
  vm0:image-style:notion-illustration
    Notion-editorial-style hand-drawn spot illustration. Black brush-pen ink on white, ...

  vm0:image-style:vm0-illustration
    Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art, ...
\`\`\`

## Test plan

- [x] \`pnpm -F @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts\` — 13/13 pass (added: missing-flag error, unknown-id error, conflicting flags, --skip-style direct generation, locked-style packet shape, help listing)
- [x] \`pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/generate.test.ts\` — 15/15 pass (doctor \`-h\` invocations unaffected)
- [x] \`pnpm -F @vm0/cli exec eslint\` on touched files — clean
- [x] \`pnpm -F @vm0/cli exec tsc --noEmit\` — clean
- [x] \`pnpm exec prettier --write\` on touched files
- [ ] CI green