### PR TITLE
fix: keep model provider secrets out of sandbox env

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 
 import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
 import {
+  getModelProviderFirewall,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
@@ -49,6 +53,18 @@ import { encryptSecretForTests } from "./helpers/encrypt-secret";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+function modelProviderSecretPlaceholder(
+  type: ModelProviderType,
+  secretName: string,
+): string {
+  const placeholder =
+    getModelProviderFirewall(type)?.placeholders?.[secretName];
+  if (!placeholder) {
+    throw new Error(`Missing model provider placeholder for ${secretName}`);
+  }
+  return placeholder;
+}
 
 interface AgentConfig {
   readonly framework?: "claude-code" | "codex";
@@ -838,7 +854,10 @@ describe("POST /api/agent/runs", () => {
       readonly modelUsageProvider: string | undefined;
     };
     expect(executionContext.environment).toMatchObject({
-      ANTHROPIC_API_KEY: "test-secret-value",
+      ANTHROPIC_API_KEY: modelProviderSecretPlaceholder(
+        "anthropic-api-key",
+        "ANTHROPIC_API_KEY",
+      ),
       ANTHROPIC_MODEL: "claude-sonnet-4-6",
     });
     expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -6,6 +6,10 @@ import {
   runnersPollContract,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
+import {
+  getModelProviderFirewall,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
@@ -65,6 +69,18 @@ function runnerHeartbeatBody(runnerId: string) {
 
 function encryptedSecretsMap(values: Record<string, string>): string {
   return encryptSecretValue(JSON.stringify(values));
+}
+
+function modelProviderSecretPlaceholder(
+  type: ModelProviderType,
+  secretName: string,
+): string {
+  const placeholder =
+    getModelProviderFirewall(type)?.placeholders?.[secretName];
+  if (!placeholder) {
+    throw new Error(`Missing model provider placeholder for ${secretName}`);
+  }
+  return placeholder;
 }
 
 function storedExecutionContext(args?: {
@@ -722,6 +738,39 @@ describe("POST /api/runners/*", () => {
       contextOverrides: {
         encryptedSecrets: encryptedSecretsMap({ SECRET: "not-in-env" }),
         environment: { SOME_VAR: "other-value" },
+      },
+    });
+
+    const response = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: `Bearer ${pat.token}`,
+      status: 200,
+    });
+
+    expect(response.body).toMatchObject({ secretValues: [] });
+  });
+
+  it("does not return model provider secretValues when environment contains placeholders", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const pat = await seedPatFixture({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    patFixtures.push(pat);
+    const queued = await seedQueuedRun({
+      fixture,
+      contextOverrides: {
+        encryptedSecrets: encryptedSecretsMap({
+          ANTHROPIC_API_KEY: "real-model-provider-key",
+        }),
+        environment: {
+          ANTHROPIC_API_KEY: modelProviderSecretPlaceholder(
+            "anthropic-api-key",
+            "ANTHROPIC_API_KEY",
+          ),
+        },
       },
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  getModelProviderFirewall,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   agentComposes,
@@ -48,6 +52,18 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const ORG_SENTINEL_USER_ID = "__org__";
+
+function modelProviderSecretPlaceholder(
+  type: ModelProviderType,
+  secretName: string,
+): string {
+  const placeholder =
+    getModelProviderFirewall(type)?.placeholders?.[secretName];
+  if (!placeholder) {
+    throw new Error(`Missing model provider placeholder for ${secretName}`);
+  }
+  return placeholder;
+}
 
 interface ChatMessageFixture {
   readonly userId: string;
@@ -1182,13 +1198,17 @@ describe("POST /api/zero/chat/messages", () => {
       readonly billableFirewalls: readonly string[];
       readonly modelUsageProvider: string | undefined;
     };
+    const anthropicPlaceholder = modelProviderSecretPlaceholder(
+      "anthropic-api-key",
+      "ANTHROPIC_API_KEY",
+    );
     expect(executionContext.environment).toMatchObject({
-      ANTHROPIC_API_KEY: expect.any(String),
+      ANTHROPIC_API_KEY: anthropicPlaceholder,
       ANTHROPIC_MODEL: "claude-sonnet-4-6",
     });
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
-      ANTHROPIC_API_KEY: executionContext.environment.ANTHROPIC_API_KEY,
-    });
+    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    expect(decrypted?.ANTHROPIC_API_KEY).toStrictEqual(expect.any(String));
+    expect(decrypted?.ANTHROPIC_API_KEY).not.toBe(anthropicPlaceholder);
     expect(executionContext.billableFirewalls).toContain(
       "model-provider:anthropic-api-key",
     );
@@ -1234,7 +1254,10 @@ describe("POST /api/zero/chat/messages", () => {
       readonly encryptedSecrets: string | null;
     };
     expect(executionContext.environment).toMatchObject({
-      ANTHROPIC_AUTH_TOKEN: "selected-deepseek-key",
+      ANTHROPIC_AUTH_TOKEN: modelProviderSecretPlaceholder(
+        "deepseek-api-key",
+        "DEEPSEEK_API_KEY",
+      ),
       ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic",
       ANTHROPIC_MODEL: "deepseek-v4-pro",
     });
@@ -1346,7 +1369,7 @@ describe("POST /api/zero/chat/messages", () => {
       readonly encryptedSecrets: string | null;
     };
     expect(executionContext.environment.ANTHROPIC_AUTH_TOKEN).toBe(
-      "org-deepseek-key",
+      modelProviderSecretPlaceholder("deepseek-api-key", "DEEPSEEK_API_KEY"),
     );
     expect(executionContext.environment.ANTHROPIC_MODEL).toBe(
       "deepseek-v4-pro",
@@ -1464,6 +1487,9 @@ describe("POST /api/zero/chat/messages", () => {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
     };
+    expect(executionContext.environment.ANTHROPIC_API_KEY).toBe(
+      modelProviderSecretPlaceholder("anthropic-api-key", "ANTHROPIC_API_KEY"),
+    );
     expect(executionContext.environment.ANTHROPIC_MODEL).toBe(
       "claude-sonnet-4-6",
     );
@@ -1514,7 +1540,10 @@ describe("POST /api/zero/chat/messages", () => {
     };
     expect(executionContext.cliAgentType).toBe("codex");
     expect(executionContext.environment).toMatchObject({
-      OPENAI_API_KEY: "vm0-key-gpt-5.5",
+      OPENAI_API_KEY: modelProviderSecretPlaceholder(
+        "openai-api-key",
+        "OPENAI_API_KEY",
+      ),
       OPENAI_MODEL: "gpt-5.5",
     });
     expect(executionContext.environment.ANTHROPIC_API_KEY).toBeUndefined();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
 
+import {
+  getModelProviderFirewall,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { zeroRunsMainContract } from "@vm0/api-contracts/contracts/zero-runs";
 import type {
   FirewallPolicyValue,
@@ -65,6 +69,18 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const ORG_SENTINEL_USER_ID = "__org__";
+
+function modelProviderSecretPlaceholder(
+  type: ModelProviderType,
+  secretName: string,
+): string {
+  const placeholder =
+    getModelProviderFirewall(type)?.placeholders?.[secretName];
+  if (!placeholder) {
+    throw new Error(`Missing model provider placeholder for ${secretName}`);
+  }
+  return placeholder;
+}
 
 interface ZeroAgentSeed {
   readonly fixture: UsageInsightFixture;
@@ -708,20 +724,18 @@ describe("POST /api/zero/runs", () => {
       readonly modelUsageProvider: string | undefined;
     };
     expect(executionContext.environment).toMatchObject({
+      ANTHROPIC_API_KEY: modelProviderSecretPlaceholder(
+        "anthropic-api-key",
+        "ANTHROPIC_API_KEY",
+      ),
       ANTHROPIC_MODEL: "claude-opus-4-6",
     });
+    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
     // Local dev databases may already have dev-seeded exact keys.
     if (!hasExistingExactKey) {
-      expect(executionContext.environment.ANTHROPIC_API_KEY).toBe(
-        "sk-vm0-managed",
-      );
+      expect(decrypted?.ANTHROPIC_API_KEY).toBe("sk-vm0-managed");
     }
-    expect(executionContext.environment.ANTHROPIC_API_KEY).not.toBe(
-      "sk-vm0-fallback",
-    );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
-      ANTHROPIC_API_KEY: executionContext.environment.ANTHROPIC_API_KEY,
-    });
+    expect(decrypted?.ANTHROPIC_API_KEY).not.toBe("sk-vm0-fallback");
     expect(executionContext.billableFirewalls).toContain(
       "model-provider:anthropic-api-key",
     );
@@ -783,18 +797,19 @@ describe("POST /api/zero/runs", () => {
       readonly encryptedSecrets: string | null;
     };
     expect(executionContext.environment).toMatchObject({
+      ANTHROPIC_AUTH_TOKEN: modelProviderSecretPlaceholder(
+        "minimax-api-key",
+        "MINIMAX_API_KEY",
+      ),
       ANTHROPIC_MODEL: "MiniMax-M2.7",
       ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic",
     });
+    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
     // Local dev databases may already have dev-seeded vendor keys.
     if (existingVendorKeys.length === 0) {
-      expect(executionContext.environment.ANTHROPIC_AUTH_TOKEN).toBe(
-        "sk-vm0-fallback",
-      );
+      expect(decrypted?.MINIMAX_API_KEY).toBe("sk-vm0-fallback");
     }
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
-      MINIMAX_API_KEY: executionContext.environment.ANTHROPIC_AUTH_TOKEN,
-    });
+    expect(decrypted?.MINIMAX_API_KEY).toBeDefined();
   });
 
   it("injects multi-auth Codex OAuth model provider secrets and refresh metadata", async () => {
@@ -877,8 +892,14 @@ describe("POST /api/zero/runs", () => {
       readonly modelUsageProvider: string | undefined;
     };
     expect(executionContext.environment).toMatchObject({
-      CHATGPT_ACCESS_TOKEN: "chatgpt-access",
-      CHATGPT_ACCOUNT_ID: "workspace-id",
+      CHATGPT_ACCESS_TOKEN: modelProviderSecretPlaceholder(
+        "codex-oauth-token",
+        "CHATGPT_ACCESS_TOKEN",
+      ),
+      CHATGPT_ACCOUNT_ID: modelProviderSecretPlaceholder(
+        "codex-oauth-token",
+        "CHATGPT_ACCOUNT_ID",
+      ),
       OPENAI_MODEL: "gpt-5.4",
     });
     const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
@@ -972,7 +993,10 @@ describe("POST /api/zero/runs", () => {
       readonly billableFirewalls: readonly string[];
     };
     expect(executionContext.environment).toMatchObject({
-      ANTHROPIC_API_KEY: "test-secret-value",
+      ANTHROPIC_API_KEY: modelProviderSecretPlaceholder(
+        "anthropic-api-key",
+        "ANTHROPIC_API_KEY",
+      ),
       ANTHROPIC_MODEL: "claude-sonnet-4-6",
     });
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -1,5 +1,9 @@
 import { createHmac, randomBytes } from "node:crypto";
 
+import {
+  getModelProviderFirewall,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { createStore } from "ccstate";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
@@ -37,6 +41,18 @@ const EVENTS_PATH = "/api/zero/slack/events";
 const TEST_VM0_ANTHROPIC_KEY = "vm0-key-claude-sonnet-4-6";
 const TEST_VM0_DEEPSEEK_KEY = "vm0-key-deepseek-v4-pro";
 const TEST_VM0_OPENAI_KEY = "vm0-key-gpt-5.5";
+
+function modelProviderSecretPlaceholder(
+  type: ModelProviderType,
+  secretName: string,
+): string {
+  const placeholder =
+    getModelProviderFirewall(type)?.placeholders?.[secretName];
+  if (!placeholder) {
+    throw new Error(`Missing model provider placeholder for ${secretName}`);
+  }
+  return placeholder;
+}
 
 afterEach(async () => {
   const db = store.set(writeDb$);
@@ -1236,7 +1252,10 @@ describe("POST /api/zero/slack/events", () => {
     };
     expect(executionContext.cliAgentType).toBe("codex");
     expect(executionContext.environment).toMatchObject({
-      OPENAI_API_KEY: "vm0-key-gpt-5.5",
+      OPENAI_API_KEY: modelProviderSecretPlaceholder(
+        "openai-api-key",
+        "OPENAI_API_KEY",
+      ),
       OPENAI_MODEL: "gpt-5.5",
     });
     expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -858,41 +858,37 @@ function modelProviderEnvironment(
 
 function providerEnvironmentFromSecretRefs(
   type: ModelProviderType,
-  secretName: string | undefined,
-  secretValue: string | undefined,
+  secretName: string,
+  secretValue: string,
   selectedModel: string | null,
 ): Record<string, string> {
   const mapping = getEnvironmentMapping(type);
   if (!mapping) {
-    return secretName && secretValue
-      ? {
-          [secretName]: modelProviderEnvironmentSecretValue(
-            type,
-            secretName,
-            secretValue,
-          ),
-        }
-      : {};
+    return {
+      [secretName]: modelProviderEnvironmentSecretValue(
+        type,
+        secretName,
+        secretValue,
+      ),
+    };
   }
 
   const model = selectedModel ?? MODEL_PROVIDER_TYPES[type].defaultModel ?? "";
   const environment: Record<string, string> = {};
   for (const [key, value] of Object.entries(mapping)) {
     if (value === "$secret") {
-      if (secretName && secretValue) {
-        environment[key] = modelProviderEnvironmentSecretValue(
-          type,
-          secretName,
-          secretValue,
-        );
-      }
+      environment[key] = modelProviderEnvironmentSecretValue(
+        type,
+        secretName,
+        secretValue,
+      );
     } else if (value === "$model") {
       if (model) {
         environment[key] = model;
       }
     } else if (value.startsWith("$secrets.")) {
       const referencedSecret = value.slice("$secrets.".length);
-      if (referencedSecret === secretName && secretValue) {
+      if (referencedSecret === secretName) {
         environment[key] = modelProviderEnvironmentSecretValue(
           type,
           referencedSecret,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -817,6 +817,16 @@ function isSingleSecretModelProviderConfig(
   );
 }
 
+function modelProviderEnvironmentSecretValue(
+  type: ModelProviderType,
+  secretName: string,
+  secretValue: string,
+): string {
+  return getModelProviderFirewall(type)
+    ? `\${{ secrets.${secretName} }}`
+    : secretValue;
+}
+
 function modelProviderEnvironment(
   id: string | null,
   type: ModelProviderType,
@@ -825,10 +835,15 @@ function modelProviderEnvironment(
   selectedModel: string | null,
 ): ResolvedModelProviderEnvironment {
   const model = selectedModel ?? config.defaultModel ?? "";
+  const environmentSecret = modelProviderEnvironmentSecretValue(
+    type,
+    config.secretName,
+    secretValue,
+  );
   const environment: Record<string, string> = {};
   for (const [key, value] of Object.entries(config.environmentMapping)) {
     environment[key] = value
-      .replaceAll("$secret", secretValue)
+      .replaceAll("$secret", environmentSecret)
       .replaceAll("$model", model);
   }
 
@@ -849,15 +864,27 @@ function providerEnvironmentFromSecretRefs(
 ): Record<string, string> {
   const mapping = getEnvironmentMapping(type);
   if (!mapping) {
-    return secretName && secretValue ? { [secretName]: secretValue } : {};
+    return secretName && secretValue
+      ? {
+          [secretName]: modelProviderEnvironmentSecretValue(
+            type,
+            secretName,
+            secretValue,
+          ),
+        }
+      : {};
   }
 
   const model = selectedModel ?? MODEL_PROVIDER_TYPES[type].defaultModel ?? "";
   const environment: Record<string, string> = {};
   for (const [key, value] of Object.entries(mapping)) {
     if (value === "$secret") {
-      if (secretValue) {
-        environment[key] = secretValue;
+      if (secretName && secretValue) {
+        environment[key] = modelProviderEnvironmentSecretValue(
+          type,
+          secretName,
+          secretValue,
+        );
       }
     } else if (value === "$model") {
       if (model) {
@@ -866,7 +893,11 @@ function providerEnvironmentFromSecretRefs(
     } else if (value.startsWith("$secrets.")) {
       const referencedSecret = value.slice("$secrets.".length);
       if (referencedSecret === secretName && secretValue) {
-        environment[key] = secretValue;
+        environment[key] = modelProviderEnvironmentSecretValue(
+          type,
+          referencedSecret,
+          secretValue,
+        );
       }
     } else {
       environment[key] = value;
@@ -882,16 +913,28 @@ function providerEnvironmentFromSecretMap(
 ): Record<string, string> {
   const mapping = getEnvironmentMapping(type);
   if (!mapping) {
-    return providerSecrets;
+    return Object.fromEntries(
+      Object.entries(providerSecrets).map(([secretName, secretValue]) => {
+        return [
+          secretName,
+          modelProviderEnvironmentSecretValue(type, secretName, secretValue),
+        ];
+      }),
+    );
   }
 
-  const fallbackSecret = Object.values(providerSecrets)[0];
+  const fallbackSecret = Object.entries(providerSecrets)[0];
   const model = selectedModel ?? getDefaultModel(type) ?? "";
   const environment: Record<string, string> = {};
   for (const [key, value] of Object.entries(mapping)) {
     if (value === "$secret") {
       if (fallbackSecret) {
-        environment[key] = fallbackSecret;
+        const [secretName, secretValue] = fallbackSecret;
+        environment[key] = modelProviderEnvironmentSecretValue(
+          type,
+          secretName,
+          secretValue,
+        );
       }
     } else if (value === "$model") {
       if (model) {
@@ -901,7 +944,11 @@ function providerEnvironmentFromSecretMap(
       const secretName = value.slice("$secrets.".length);
       const secretValue = providerSecrets[secretName];
       if (secretValue) {
-        environment[key] = secretValue;
+        environment[key] = modelProviderEnvironmentSecretValue(
+          type,
+          secretName,
+          secretValue,
+        );
       }
     } else {
       environment[key] = value;


### PR DESCRIPTION
Closes #14979.

## Summary
- Keep firewall-backed model provider secrets out of the sandbox environment by preserving secret templates for placeholder expansion.
- Continue storing real model provider secret values only in `encryptedSecrets` so mitmproxy/firewall auth can replace placeholders at egress.
- Add coverage for zero run/chat model provider paths and runner claim `secretValues` filtering.

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/zero-chat-messages.test.ts src/signals/routes/__tests__/runners.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit: `pnpm knip`, `pnpm turbo run check-types --concurrency=1`
