### PR TITLE
refactor: remove legacy connector auth method order

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -133,8 +133,6 @@ export interface ConnectorTypeWithStatus {
 
 type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
 
-export { getConfiguredConnectorAuthMethods };
-
 function getAvailableConnectorConnectAuthMethods(
   type: ConnectorType,
   featureStates: Record<string, boolean> | null | undefined,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -14,7 +14,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getConnectorAuthMethod,
   connectorAuthMethodHasOAuthGrant,
-  getConnectorAuthMethodPriority,
+  getConfiguredConnectorAuthMethods,
   getConnectorInteractivePairingGrantConfigIfSupported,
   getConnectorTags,
   hasRequiredScopes,
@@ -133,34 +133,7 @@ export interface ConnectorTypeWithStatus {
 
 type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
 
-function parseConnectorAuthMethodId(
-  authMethod: string,
-): ConnectorAuthMethodId | null {
-  switch (authMethod) {
-    case "oauth":
-    case "api-token":
-    case "api":
-    case "cli-auth": {
-      return authMethod;
-    }
-  }
-  return null;
-}
-
-export function getConfiguredConnectorAuthMethods(
-  type: ConnectorType,
-): ConnectorAuthMethodId[] {
-  return Object.keys(CONNECTOR_TYPES[type].authMethods)
-    .flatMap((authMethod) => {
-      const parsed = parseConnectorAuthMethodId(authMethod);
-      return parsed ? [parsed] : [];
-    })
-    .sort((a, b) => {
-      return (
-        getConnectorAuthMethodPriority(a) - getConnectorAuthMethodPriority(b)
-      );
-    });
-}
+export { getConfiguredConnectorAuthMethods };
 
 function getAvailableConnectorConnectAuthMethods(
   type: ConnectorType,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,7 +3,6 @@ import { delay } from "signal-timers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
-  CONNECTOR_LEGACY_AUTH_METHOD_ORDER,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorAuthMethodId,
@@ -15,6 +14,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getConnectorAuthMethod,
   connectorAuthMethodHasOAuthGrant,
+  getConnectorAuthMethodPriority,
   getConnectorInteractivePairingGrantConfigIfSupported,
   getConnectorTags,
   hasRequiredScopes,
@@ -147,13 +147,6 @@ function parseConnectorAuthMethodId(
   return null;
 }
 
-function getLegacyAuthMethodPriority(authMethod: string): number {
-  const index = CONNECTOR_LEGACY_AUTH_METHOD_ORDER.findIndex((method) => {
-    return method === authMethod;
-  });
-  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
-}
-
 export function getConfiguredConnectorAuthMethods(
   type: ConnectorType,
 ): ConnectorAuthMethodId[] {
@@ -163,7 +156,9 @@ export function getConfiguredConnectorAuthMethods(
       return parsed ? [parsed] : [];
     })
     .sort((a, b) => {
-      return getLegacyAuthMethodPriority(a) - getLegacyAuthMethodPriority(b);
+      return (
+        getConnectorAuthMethodPriority(a) - getConnectorAuthMethodPriority(b)
+      );
     });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -19,7 +19,10 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
+import {
+  getConfiguredConnectorAuthMethods,
+  isGoogleOAuthConnector,
+} from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
@@ -49,7 +52,6 @@ import {
   setPermissionDialogType$,
   isStandaloneMode,
   matchesConnectorSearch,
-  getConfiguredConnectorAuthMethods,
   getConnectorConnectLaunchMode,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -8,6 +8,7 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  getConfiguredConnectorAuthMethods,
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
 } from "@vm0/connectors/connector-utils";
@@ -22,7 +23,6 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
   connectConnectorOAuthAuthCode$,
-  getConfiguredConnectorAuthMethods,
   getConnectorConnectLaunchMode,
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -16,7 +16,10 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorTags } from "@vm0/connectors/connector-utils";
+import {
+  getConfiguredConnectorAuthMethods,
+  getConnectorTags,
+} from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   zeroWorkspaceName$,
@@ -51,7 +54,6 @@ import {
   selectedConnectorType$,
   setSelectedConnectorType$,
   setPermissionDialogType$,
-  getConfiguredConnectorAuthMethods,
   getConnectorConnectLaunchMode,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
+  getConfiguredConnectorAuthMethods,
   hasRequiredScopes,
   getConnectorAuthCodeGrantConfigIfSupported,
   getConnectorAuthMethod,
@@ -908,6 +909,17 @@ describe("isOAuthConnectorType", () => {
 });
 
 describe("getAvailableConnectorAuthMethods", () => {
+  it("returns configured auth methods without feature filtering", () => {
+    expect(getConfiguredConnectorAuthMethods("stripe")).toStrictEqual([
+      "oauth",
+      "api-token",
+      "cli-auth",
+    ]);
+    expect(getConfiguredConnectorAuthMethods("local-browser")).toStrictEqual([
+      "api",
+    ]);
+  });
+
   it("exposes Stripe CLI auth only when its switch is enabled", () => {
     expect(getAvailableConnectorAuthMethods("stripe", {})).toStrictEqual([
       "api-token",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -908,7 +908,7 @@ describe("isOAuthConnectorType", () => {
   });
 });
 
-describe("getAvailableConnectorAuthMethods", () => {
+describe("getConfiguredConnectorAuthMethods", () => {
   it("returns configured auth methods without feature filtering", () => {
     expect(getConfiguredConnectorAuthMethods("stripe")).toStrictEqual([
       "oauth",
@@ -919,7 +919,9 @@ describe("getAvailableConnectorAuthMethods", () => {
       "api",
     ]);
   });
+});
 
+describe("getAvailableConnectorAuthMethods", () => {
   it("exposes Stripe CLI auth only when its switch is enabled", () => {
     expect(getAvailableConnectorAuthMethods("stripe", {})).toStrictEqual([
       "api-token",

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -22,33 +22,32 @@ import {
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors";
 
+const CONNECTOR_AUTH_METHOD_PRIORITY = {
+  oauth: 0,
+  "api-token": 1,
+  api: 2,
+  "cli-auth": 3,
+} as const satisfies Record<ConnectorAuthMethodId, number>;
+
 function parseConnectorAuthMethodId(
   authMethod: string,
 ): ConnectorAuthMethodId | null {
-  switch (authMethod) {
-    case "oauth":
-    case "api-token":
-    case "api":
-    case "cli-auth": {
-      return authMethod;
-    }
+  if (isConnectorAuthMethodId(authMethod)) {
+    return authMethod;
   }
   return null;
+}
+
+function isConnectorAuthMethodId(
+  authMethod: string,
+): authMethod is ConnectorAuthMethodId {
+  return Object.hasOwn(CONNECTOR_AUTH_METHOD_PRIORITY, authMethod);
 }
 
 function getConnectorAuthMethodPriority(
   authMethod: ConnectorAuthMethodId,
 ): number {
-  switch (authMethod) {
-    case "oauth":
-      return 0;
-    case "api-token":
-      return 1;
-    case "api":
-      return 2;
-    case "cli-auth":
-      return 3;
-  }
+  return CONNECTOR_AUTH_METHOD_PRIORITY[authMethod];
 }
 
 export function getConfiguredConnectorAuthMethods(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,5 +1,4 @@
 import {
-  CONNECTOR_LEGACY_AUTH_METHOD_ORDER,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
@@ -23,8 +22,34 @@ import {
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors";
 
-type ConnectorLegacyAuthMethodId =
-  (typeof CONNECTOR_LEGACY_AUTH_METHOD_ORDER)[number];
+function parseConnectorAuthMethodId(
+  authMethod: string,
+): ConnectorAuthMethodId | null {
+  switch (authMethod) {
+    case "oauth":
+    case "api-token":
+    case "api":
+    case "cli-auth": {
+      return authMethod;
+    }
+  }
+  return null;
+}
+
+export function getConnectorAuthMethodPriority(
+  authMethod: ConnectorAuthMethodId,
+): number {
+  switch (authMethod) {
+    case "oauth":
+      return 0;
+    case "api-token":
+      return 1;
+    case "api":
+      return 2;
+    case "cli-auth":
+      return 3;
+  }
+}
 
 /**
  * Connector utility vocabulary:
@@ -298,11 +323,21 @@ export function getAvailableConnectorAuthMethods(
   type: ConnectorType,
   featureStates: ConnectorFeatureStates,
   options: AvailableConnectorAuthMethodsOptions = {},
-): ConnectorLegacyAuthMethodId[] {
+): ConnectorAuthMethodId[] {
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
-  const availableAuthMethods: ConnectorLegacyAuthMethodId[] = [];
+  const availableAuthMethods: ConnectorAuthMethodId[] = [];
+  const configuredAuthMethods = Object.keys(CONNECTOR_TYPES[type].authMethods)
+    .flatMap((authMethod) => {
+      const parsed = parseConnectorAuthMethodId(authMethod);
+      return parsed ? [parsed] : [];
+    })
+    .sort((a, b) => {
+      return (
+        getConnectorAuthMethodPriority(a) - getConnectorAuthMethodPriority(b)
+      );
+    });
 
-  for (const authMethod of CONNECTOR_LEGACY_AUTH_METHOD_ORDER) {
+  for (const authMethod of configuredAuthMethods) {
     const method = getConnectorAuthMethod(type, authMethod);
     switch (method?.grant.kind) {
       case "managed": {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -51,6 +51,21 @@ export function getConnectorAuthMethodPriority(
   }
 }
 
+export function getConfiguredConnectorAuthMethods(
+  type: ConnectorType,
+): ConnectorAuthMethodId[] {
+  return Object.keys(CONNECTOR_TYPES[type].authMethods)
+    .flatMap((authMethod) => {
+      const parsed = parseConnectorAuthMethodId(authMethod);
+      return parsed ? [parsed] : [];
+    })
+    .sort((a, b) => {
+      return (
+        getConnectorAuthMethodPriority(a) - getConnectorAuthMethodPriority(b)
+      );
+    });
+}
+
 /**
  * Connector utility vocabulary:
  *
@@ -326,16 +341,7 @@ export function getAvailableConnectorAuthMethods(
 ): ConnectorAuthMethodId[] {
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
   const availableAuthMethods: ConnectorAuthMethodId[] = [];
-  const configuredAuthMethods = Object.keys(CONNECTOR_TYPES[type].authMethods)
-    .flatMap((authMethod) => {
-      const parsed = parseConnectorAuthMethodId(authMethod);
-      return parsed ? [parsed] : [];
-    })
-    .sort((a, b) => {
-      return (
-        getConnectorAuthMethodPriority(a) - getConnectorAuthMethodPriority(b)
-      );
-    });
+  const configuredAuthMethods = getConfiguredConnectorAuthMethods(type);
 
   for (const authMethod of configuredAuthMethods) {
     const method = getConnectorAuthMethod(type, authMethod);

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -29,38 +29,20 @@ const CONNECTOR_AUTH_METHOD_PRIORITY = {
   "cli-auth": 3,
 } as const satisfies Record<ConnectorAuthMethodId, number>;
 
-function parseConnectorAuthMethodId(
-  authMethod: string,
-): ConnectorAuthMethodId | null {
-  if (isConnectorAuthMethodId(authMethod)) {
-    return authMethod;
-  }
-  return null;
-}
-
 function isConnectorAuthMethodId(
   authMethod: string,
 ): authMethod is ConnectorAuthMethodId {
   return Object.hasOwn(CONNECTOR_AUTH_METHOD_PRIORITY, authMethod);
 }
 
-function getConnectorAuthMethodPriority(
-  authMethod: ConnectorAuthMethodId,
-): number {
-  return CONNECTOR_AUTH_METHOD_PRIORITY[authMethod];
-}
-
 export function getConfiguredConnectorAuthMethods(
   type: ConnectorType,
 ): ConnectorAuthMethodId[] {
   return Object.keys(CONNECTOR_TYPES[type].authMethods)
-    .flatMap((authMethod) => {
-      const parsed = parseConnectorAuthMethodId(authMethod);
-      return parsed ? [parsed] : [];
-    })
+    .filter(isConnectorAuthMethodId)
     .sort((a, b) => {
       return (
-        getConnectorAuthMethodPriority(a) - getConnectorAuthMethodPriority(b)
+        CONNECTOR_AUTH_METHOD_PRIORITY[a] - CONNECTOR_AUTH_METHOD_PRIORITY[b]
       );
     });
 }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -36,7 +36,7 @@ function parseConnectorAuthMethodId(
   return null;
 }
 
-export function getConnectorAuthMethodPriority(
+function getConnectorAuthMethodPriority(
   authMethod: ConnectorAuthMethodId,
 ): number {
   switch (authMethod) {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -38,6 +38,7 @@ function isConnectorAuthMethodId(
 export function getConfiguredConnectorAuthMethods(
   type: ConnectorType,
 ): ConnectorAuthMethodId[] {
+  // Configured methods are raw registry entries; callers apply feature flags.
   return Object.keys(CONNECTOR_TYPES[type].authMethods)
     .filter(isConnectorAuthMethodId)
     .sort((a, b) => {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -455,17 +455,6 @@ export interface ConnectorAuthMethodConfig {
  */
 export type ConnectorAuthMethodId = "oauth" | "api-token" | "api" | "cli-auth";
 
-/**
- * Temporary ordering for auth method ids still handled by legacy key-based
- * API/UI paths. This is intentionally not exhaustive over ConnectorAuthMethodId.
- */
-export const CONNECTOR_LEGACY_AUTH_METHOD_ORDER = [
-  "oauth",
-  "api-token",
-  "api",
-  "cli-auth",
-] as const satisfies readonly ConnectorAuthMethodId[];
-
 type AssertNever<T extends never> = T;
 
 export type ConnectorDisplayCategory =


### PR DESCRIPTION
## Summary

- Remove the obsolete `CONNECTOR_LEGACY_AUTH_METHOD_ORDER` export and local `ConnectorLegacyAuthMethodId` alias.
- Derive available connector auth methods from each connector config's method keys, then sort by explicit current method priority.
- Reuse the same priority helper in platform fallback auth method ordering.

## Tests

- `pnpm prettier --write apps/platform/src/signals/zero-page/settings/connectors.ts packages/connectors/src/connector-utils.ts packages/connectors/src/connectors.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/connectors exec vitest --run src/__tests__/connectors.test.ts`
- equivalence script comparing old explicit order behavior with new config-key traversal returned `[]`

Note: local pre-commit hooks were skipped because current main has an unrelated knip failure: `drizzle-kit packages/db/package.json` is reported as an unlisted binary. I did not include a knip config change in this PR.