### PR TITLE
feat(platform): restore org switcher without manage button

### DIFF
--- a/turbo/apps/platform/src/signals/select-org/org-switcher-ui.ts
+++ b/turbo/apps/platform/src/signals/select-org/org-switcher-ui.ts
@@ -1,0 +1,23 @@
+import { command, computed, state } from "ccstate";
+
+const internalCreatingOrg$ = state(false);
+
+export const creatingOrg$ = computed((get) => {
+  return get(internalCreatingOrg$);
+});
+
+export const setCreatingOrg$ = command(({ set }, value: boolean) => {
+  set(internalCreatingOrg$, value);
+});
+
+const internalAcceptingInvitationId$ = state<string | null>(null);
+
+export const acceptingInvitationId$ = computed((get) => {
+  return get(internalAcceptingInvitationId$);
+});
+
+export const setAcceptingInvitationId$ = command(
+  ({ set }, value: string | null) => {
+    set(internalAcceptingInvitationId$, value);
+  },
+);

--- a/turbo/apps/platform/src/signals/user-invitations.ts
+++ b/turbo/apps/platform/src/signals/user-invitations.ts
@@ -1,0 +1,29 @@
+import { command, computed, state } from "ccstate";
+import { clerk$ } from "./auth.ts";
+
+const reloadInvitations$ = state(0);
+
+/**
+ * Pending organization invitations for the current user.
+ * Re-fetches when `refreshUserInvitations$` is called or the poll loop ticks.
+ */
+export const userInvitations$ = computed(async (get) => {
+  get(reloadInvitations$);
+  const clerk = await get(clerk$);
+  const user = clerk.user;
+  if (!user) {
+    return [];
+  }
+
+  const result = await user.getOrganizationInvitations({ status: "pending" });
+  return result.data;
+});
+
+/**
+ * Trigger an immediate re-fetch of the user invitations signal.
+ */
+export const refreshUserInvitations$ = command(({ set }) => {
+  set(reloadInvitations$, (x) => {
+    return x + 1;
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -10,6 +10,7 @@ import {
   setOrgManageDialogOpen$,
 } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
+import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
 import { AccountDropdown } from "./zero-sidebar.tsx";
 import { Link } from "../router/link.tsx";
 
@@ -28,6 +29,9 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
         }}
       />
       <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
+        <div className="shrink-0 px-2 pt-1.5">
+          <ZeroOrgSwitcher />
+        </div>
         <div className="flex-1" />
         <div className="p-2">
           <AccountDropdown onAccountAction={onAccountAction} />

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -1,0 +1,285 @@
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@vm0/ui";
+import { IconChevronDown, IconPlus, IconMail } from "@tabler/icons-react";
+import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
+import { bestEffort, detach, onDomEventFn, Reason } from "../../signals/utils.ts";
+import { org$ } from "../../signals/org.ts";
+import {
+  userInvitations$,
+  refreshUserInvitations$,
+} from "../../signals/user-invitations.ts";
+import {
+  creatingOrg$,
+  setCreatingOrg$,
+  acceptingInvitationId$,
+  setAcceptingInvitationId$,
+} from "../../signals/select-org/org-switcher-ui.ts";
+
+function OrgAvatar({
+  name,
+  imageUrl,
+  size = "sm",
+}: {
+  name: string;
+  imageUrl?: string | null;
+  size?: "sm" | "lg";
+}) {
+  const dim = size === "lg" ? "h-10 w-10" : "h-6 w-6";
+  const radius = size === "lg" ? "rounded-xl" : "rounded-md";
+  const textSize = size === "lg" ? "text-base" : "text-[11px]";
+  const initial = name.charAt(0).toUpperCase();
+
+  if (imageUrl) {
+    return (
+      <img
+        src={imageUrl}
+        alt={name}
+        className={`${dim} ${radius} object-cover shrink-0`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${dim} ${radius} bg-[hsl(var(--gray-200))] text-[hsl(var(--primary-700))] flex items-center justify-center ${textSize} font-bold shrink-0`}
+    >
+      {initial}
+    </div>
+  );
+}
+
+function InvitationRow({
+  invitation,
+}: {
+  invitation: {
+    id: string;
+    publicOrganizationData: { name: string; imageUrl: string };
+    accept: () => Promise<unknown>;
+  };
+}) {
+  const acceptingId = useGet(acceptingInvitationId$);
+  const setAcceptingId = useSet(setAcceptingInvitationId$);
+  const refreshInvitations = useSet(refreshUserInvitations$);
+  const isAccepting = acceptingId === invitation.id;
+
+  const handleAccept = onDomEventFn(async () => {
+    setAcceptingId(invitation.id);
+    await bestEffort(
+      (async () => {
+        await invitation.accept();
+        refreshInvitations();
+      })(),
+    );
+    setAcceptingId(null);
+  });
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5">
+      <OrgAvatar
+        name={invitation.publicOrganizationData.name}
+        imageUrl={invitation.publicOrganizationData.imageUrl}
+      />
+      <span className="min-w-0 flex-1 text-sm truncate">
+        {invitation.publicOrganizationData.name}
+      </span>
+      <button
+        type="button"
+        disabled={isAccepting}
+        onClick={handleAccept}
+        className="shrink-0 flex items-center gap-1 px-2 h-7 rounded-md text-xs font-medium text-muted-foreground border border-border hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
+      >
+        <IconMail size={13} />
+        {isAccepting ? "Joining…" : "Join"}
+      </button>
+    </div>
+  );
+}
+
+function CreateWorkspaceItem() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const creatingOrg = useGet(creatingOrg$);
+  const setCreating = useSet(setCreatingOrg$);
+
+  const handleCreateOrg = onDomEventFn(async () => {
+    if (!clerk) {
+      return;
+    }
+    setCreating(true);
+    const slug = `workspace-${crypto.randomUUID().slice(0, 8)}`;
+    await bestEffort(
+      (async () => {
+        const org = await clerk.createOrganization({ name: slug, slug });
+        await clerk.setActive({ organization: org.id });
+      })(),
+    );
+    setCreating(false);
+  });
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        onClick={handleCreateOrg}
+        disabled={clerk === null || creatingOrg}
+        className="gap-3 px-3 py-2.5 rounded-lg"
+      >
+        <IconPlus
+          size={18}
+          stroke={1.5}
+          className="shrink-0 text-muted-foreground"
+        />
+        <span>{creatingOrg ? "Creating…" : "Create workspace"}</span>
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+function OtherMembershipsList() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const memberships = clerk?.user?.organizationMemberships ?? [];
+  const currentOrgId = clerk?.organization?.id;
+
+  const otherMemberships = memberships.filter((m) => {
+    return m.organization && m.organization.id !== currentOrgId;
+  });
+
+  if (otherMemberships.length === 0) {
+    return null;
+  }
+
+  const handleSwitchOrg = (orgId: string) => {
+    detach(clerk?.setActive({ organization: orgId }), Reason.DomCallback);
+  };
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      {otherMemberships.map((membership) => {
+        return (
+          <DropdownMenuItem
+            key={membership.organization.id}
+            onClick={() => {
+              handleSwitchOrg(membership.organization.id);
+            }}
+            className="gap-3 px-3 py-2.5 rounded-lg"
+          >
+            <OrgAvatar
+              name={membership.organization.name}
+              imageUrl={membership.organization.imageUrl}
+            />
+            <span className="truncate flex-1">
+              {membership.organization.name}
+            </span>
+          </DropdownMenuItem>
+        );
+      })}
+    </>
+  );
+}
+
+function OrgDropdownContent() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const orgData = useLastResolved(org$);
+  const pendingInvitations = useLastResolved(userInvitations$);
+  const currentOrg = useLastResolved(currentOrgInfo$);
+
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const orgName = currentOrg?.name ?? "Organization";
+  const orgSlug = orgData?.slug;
+
+  const hasPendingInvitations =
+    pendingInvitations !== undefined && pendingInvitations.length > 0;
+  const canCreateOrg = clerk?.user?.createOrganizationEnabled ?? false;
+
+  return (
+    <DropdownMenuContent align="start" className="w-72">
+      <div className="flex items-center gap-3 px-2 py-1.5">
+        <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} size="lg" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-tight truncate text-foreground">
+            {orgName}
+          </p>
+          {orgSlug && (
+            <p className="text-xs text-muted-foreground truncate mt-0.5">
+              {orgSlug}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <OtherMembershipsList />
+
+      {hasPendingInvitations && (
+        <>
+          <DropdownMenuSeparator />
+          {pendingInvitations.map((invitation) => {
+            return (
+              <InvitationRow key={invitation.id} invitation={invitation} />
+            );
+          })}
+        </>
+      )}
+
+      {canCreateOrg && <CreateWorkspaceItem />}
+    </DropdownMenuContent>
+  );
+}
+
+function PendingInvitationsBadge() {
+  const pendingInvitations = useLastResolved(userInvitations$);
+  const hasPendingInvitations =
+    pendingInvitations !== undefined && pendingInvitations.length > 0;
+  if (!hasPendingInvitations) {
+    return null;
+  }
+  return (
+    <span
+      data-testid="pending-invitations-badge"
+      className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-destructive ring-2 ring-sidebar"
+    />
+  );
+}
+
+export function ZeroOrgSwitcher() {
+  const currentOrg = useLastResolved(currentOrgInfo$);
+  const orgName = currentOrg?.name ?? "Organization";
+
+  return (
+    <div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-sidebar-accent text-sidebar-foreground transition-colors"
+          >
+            <span className="relative shrink-0">
+              <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />
+              <PendingInvitationsBadge />
+            </span>
+            <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">
+              {orgName}
+            </span>
+            <IconChevronDown
+              size={16}
+              className="ml-auto shrink-0 text-muted-foreground"
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <OrgDropdownContent />
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -53,6 +53,7 @@ import { Link } from "../router/link.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { slackOrgScopeMismatch$ } from "../../signals/zero-page/zero-slack.ts";
 import { BillingDialog } from "./billing-dialog.tsx";
+import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
 import { ManagePinnedAgentsDialog } from "./zero-sidebar-dialogs.tsx";
 
 import { AccountDropdown } from "./zero-sidebar-account.tsx";
@@ -391,7 +392,10 @@ function ExpandedHeader() {
   return (
     <div className="zero-sidebar-header shrink-0 px-2 pb-0">
       <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
-      <div className="zero-desktop-no-drag flex items-center justify-end gap-2 rounded-lg py-0.5">
+      <div className="zero-desktop-no-drag flex items-center justify-between gap-2 rounded-lg py-0.5">
+        <div className="min-w-0 flex-1">
+          <ZeroOrgSwitcher />
+        </div>
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

#14908 (Models settings redesign) removed the org switcher entirely as a side-effect — `zero-org-switcher.tsx`, its signals (`org-switcher-ui.ts`, `user-invitations.ts`), and the wiring in `zero-sidebar.tsx` / `zero-directed-shared.tsx` were all deleted.

This PR restores the org switcher so users can still switch workspaces, see the workspace name in the sidebar header, and accept pending invitations — but **drops the Manage button** from the dropdown header, which was the only intentional UX cut.

## Changes

- `signals/select-org/org-switcher-ui.ts`, `signals/user-invitations.ts` — restored verbatim.
- `views/zero-page/zero-org-switcher.tsx` — restored, with the Manage button (and its `IconSettings` icon, `openSettingsDialogAt$` + `pageSignal$` imports, and `handleManage` handler) removed from `OrgDropdownContent`.
- `views/zero-page/zero-sidebar.tsx` — `ExpandedHeader` again renders `<ZeroOrgSwitcher />` on the left of the collapse button (`justify-between`).
- `views/zero-page/zero-directed-shared.tsx` — `MinimalSidebarLayout` again renders `<ZeroOrgSwitcher />` at the top of the minimal sidebar.

## Not restored

The deleted `__tests__/zero-org-switcher.test.tsx` (493 lines) and the small assertion tweaks in `zero-sidebar.test.tsx` / `zero-sidebar-interaction.test.tsx`. Most of the old tests covered the now-intentionally-removed Manage button flow. Happy to re-add a slimmer test file for the no-Manage dropdown in a follow-up if desired.

## Test plan

- [ ] Expanded sidebar: workspace avatar + name show top-left; clicking opens the dropdown.
- [ ] Dropdown header shows workspace avatar, name, and slug — **no Manage button**.
- [ ] Other workspaces (if any) appear and switching activates them.
- [ ] Pending invitations show the red dot badge on the trigger and a "Join" row in the dropdown.
- [ ] "Create workspace" appears for users with `createOrganizationEnabled`.
- [ ] Minimal sidebar layout (org-management redirect / onboarding flows) again shows the switcher at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)