### PR TITLE
feat(desktop): add local computer use runtime session

### DIFF
--- a/turbo/apps/desktop/bin/vm0-computer
+++ b/turbo/apps/desktop/bin/vm0-computer
@@ -1,0 +1,3 @@
+#!/bin/sh
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec node "$DIR/vm0-computer.mjs" "$@"

--- a/turbo/apps/desktop/bin/vm0-computer.mjs
+++ b/turbo/apps/desktop/bin/vm0-computer.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const defaultHelperPath = path.join(
+  appRoot,
+  "native",
+  "dist",
+  "native",
+  "computer-use-helper",
+);
+const helperCandidates = [
+  process.env.VM0_COMPUTER_HELPER_PATH,
+  defaultHelperPath,
+  path.join(
+    appRoot,
+    "native",
+    "computer-use-helper",
+    ".build",
+    "release",
+    "computer-use-helper",
+  ),
+].filter(Boolean);
+
+const zeroCommands = new Map([
+  ["list-apps", "apps.list"],
+  ["get-app-state", "app.state"],
+  ["open-app", "app.open"],
+  ["click", "element.click"],
+  ["scroll", "element.scroll"],
+  ["set-value", "element.set_value"],
+  ["perform-action", "element.perform_action"],
+  ["type-text", "keyboard.type_text"],
+  ["press-key", "keyboard.press_key"],
+]);
+
+function usage() {
+  return `Usage:
+  vm0-computer serve [--helper-path PATH]
+  vm0-computer run JSON [--helper-path PATH]
+  vm0-computer list-apps [--helper-path PATH]
+  vm0-computer get-app-state --app APP [--helper-path PATH]
+  vm0-computer open-app --app APP [--helper-path PATH]
+  vm0-computer click --app APP (--element-index N | --element ID | --x X --y Y) [--snapshot-id ID] [--button left|right|middle] [--click-count N]
+  vm0-computer scroll --app APP (--element-index N | --element ID) --direction up|down|left|right [--snapshot-id ID] [--pages N]
+  vm0-computer set-value --app APP (--element-index N | --element ID) --value VALUE [--snapshot-id ID]
+  vm0-computer perform-action --app APP (--element-index N | --element ID) --action ACTION [--snapshot-id ID]
+  vm0-computer type-text --app APP --text TEXT
+  vm0-computer press-key --app APP --key KEY`;
+}
+
+function fail(message, code = 1) {
+  console.error(message);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  const positional = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      positional.push(arg);
+      continue;
+    }
+    const inlineValueIndex = arg.indexOf("=");
+    if (inlineValueIndex !== -1) {
+      values.set(
+        arg.slice(2, inlineValueIndex),
+        arg.slice(inlineValueIndex + 1),
+      );
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      values.set(key, "true");
+      continue;
+    }
+    values.set(key, next);
+    index += 1;
+  }
+  return { positional, values };
+}
+
+function helperPathFrom(values) {
+  const explicit = values.get("helper-path");
+  if (explicit) {
+    return explicit;
+  }
+  const helperPath = helperCandidates.find((candidate) =>
+    existsSync(candidate),
+  );
+  return helperPath ?? defaultHelperPath;
+}
+
+function stringValue(values, key) {
+  const value = values.get(key);
+  return value && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function numberValue(values, key) {
+  const value = stringValue(values, key);
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    fail(`Invalid numeric value for --${key}: ${value}`);
+  }
+  return parsed;
+}
+
+function commandFromArgs(kind, values) {
+  const payload = {};
+  const app = stringValue(values, "app");
+  const snapshotId = stringValue(values, "snapshot-id");
+  const elementId =
+    stringValue(values, "element-id") ?? stringValue(values, "element");
+  const elementIndex = numberValue(values, "element-index");
+  const x = numberValue(values, "x");
+  const y = numberValue(values, "y");
+  const pages = numberValue(values, "pages");
+  const clickCount = numberValue(values, "click-count");
+  if (app) payload.app = app;
+  if (snapshotId) payload.snapshotId = snapshotId;
+  if (elementId) payload.elementId = elementId;
+  if (elementIndex !== undefined) payload.elementIndex = elementIndex;
+  if (x !== undefined) payload.x = x;
+  if (y !== undefined) payload.y = y;
+  if (pages !== undefined) payload.pages = pages;
+  if (clickCount !== undefined) payload.clickCount = clickCount;
+
+  for (const [option, field] of [
+    ["button", "button"],
+    ["direction", "direction"],
+    ["value", "value"],
+    ["text", "text"],
+    ["key", "key"],
+    ["action", "action"],
+  ]) {
+    const value = stringValue(values, option);
+    if (value) payload[field] = value;
+  }
+  return { kind, payload };
+}
+
+class RuntimeClient {
+  constructor(helperPath) {
+    this.child = spawn(helperPath, ["serve"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.buffer = "";
+    this.counter = 0;
+    this.pending = new Map();
+    this.stderr = "";
+
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk) => this.handleStdout(chunk));
+    this.child.stderr.setEncoding("utf8");
+    this.child.stderr.on("data", (chunk) => {
+      this.stderr += chunk;
+    });
+    this.child.on("close", (code) => {
+      for (const pending of this.pending.values()) {
+        pending.reject(
+          new Error(
+            this.stderr.trim() ||
+              `computer-use-helper exited with status ${code ?? "null"}`,
+          ),
+        );
+      }
+      this.pending.clear();
+    });
+  }
+
+  send(command) {
+    const id = `cli_${(this.counter += 1).toString()}`;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(
+        `${JSON.stringify({ id, ...command })}\n`,
+        (error) => {
+          if (error) {
+            this.pending.delete(id);
+            reject(error);
+          }
+        },
+      );
+    });
+  }
+
+  close() {
+    this.child.stdin.end();
+  }
+
+  handleStdout(chunk) {
+    this.buffer += chunk;
+    while (this.buffer.includes("\n")) {
+      const index = this.buffer.indexOf("\n");
+      const line = this.buffer.slice(0, index).trim();
+      this.buffer = this.buffer.slice(index + 1);
+      if (line.length > 0) {
+        this.handleLine(line);
+      }
+    }
+  }
+
+  handleLine(line) {
+    const response = JSON.parse(line);
+    const pending = this.pending.get(response.id);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(response.id);
+    pending.resolve(response);
+  }
+}
+
+async function runServe(helperPath) {
+  const child = spawn(helperPath, ["serve"], { stdio: "inherit" });
+  const code = await new Promise((resolve) => {
+    child.on("close", resolve);
+  });
+  process.exit(typeof code === "number" ? code : 1);
+}
+
+async function runCommands(helperPath, commands, outputArray) {
+  const client = new RuntimeClient(helperPath);
+  try {
+    const responses = [];
+    for (const command of commands) {
+      responses.push(await client.send(command));
+    }
+    process.stdout.write(
+      `${JSON.stringify(outputArray ? responses : responses[0], null, 2)}\n`,
+    );
+  } finally {
+    client.close();
+  }
+}
+
+const { positional, values } = parseArgs(process.argv.slice(2));
+const command = positional[0];
+if (!command || command === "--help" || command === "help") {
+  console.log(usage());
+  process.exit(command ? 0 : 1);
+}
+
+const helperPath = helperPathFrom(values);
+if (command === "serve") {
+  await runServe(helperPath);
+} else if (command === "run") {
+  const raw = positional[1];
+  if (!raw) {
+    fail("vm0-computer run requires a JSON command or command array");
+  }
+  const parsed = JSON.parse(raw);
+  const commands = Array.isArray(parsed) ? parsed : [parsed];
+  await runCommands(helperPath, commands, Array.isArray(parsed));
+} else if (zeroCommands.has(command)) {
+  await runCommands(
+    helperPath,
+    [commandFromArgs(zeroCommands.get(command), values)],
+    false,
+  );
+} else {
+  fail(`Unknown vm0-computer command: ${command}\n\n${usage()}`);
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -52,6 +52,139 @@ let visibleCollectionChildSources = [
     ChildSource(attribute: "AXContents", prefix: "c"),
 ]
 
+func appSnapshotKey(_ appName: String) -> String {
+    return appName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+}
+
+func snapshotStorageKey(appName: String, snapshotId: String) -> String {
+    return "\(appSnapshotKey(appName))\u{0}\(snapshotId)"
+}
+
+final class ComputerUseRuntimeSession {
+    private var snapshots: [String: [String: Any]] = [:]
+    private var snapshotOrder: [String] = []
+    private var latestByApp: [String: String] = [:]
+    private let maxSnapshots = 50
+
+    func recordSnapshot(_ response: [String: Any]) {
+        guard let appName = response["app"] as? String,
+              let snapshotId = response["snapshotId"] as? String
+        else {
+            return
+        }
+
+        let key = snapshotStorageKey(appName: appName, snapshotId: snapshotId)
+        var metadata: [String: Any] = [
+            "app": appName,
+            "snapshotId": snapshotId,
+        ]
+        for field in [
+            "elementIdsByIndex",
+            "focusedElementIndex",
+            "windowId",
+            "windowFrame",
+            "screenshotSource",
+            "screenshotWidth",
+            "screenshotHeight",
+            "screenshotSourceBounds",
+        ] {
+            if let value = response[field] {
+                metadata[field] = value
+            }
+        }
+
+        snapshots[key] = metadata
+        latestByApp[appSnapshotKey(appName)] = key
+        snapshotOrder.removeAll { existingKey in
+            existingKey == key
+        }
+        snapshotOrder.append(key)
+
+        while snapshotOrder.count > maxSnapshots {
+            let removedKey = snapshotOrder.removeFirst()
+            snapshots.removeValue(forKey: removedKey)
+            for (appKey, snapshotKey) in latestByApp where snapshotKey == removedKey {
+                latestByApp.removeValue(forKey: appKey)
+            }
+        }
+    }
+
+    func snapshot(appName: String, snapshotId: String?) throws -> [String: Any] {
+        let key: String?
+        if let snapshotId {
+            key = snapshotStorageKey(appName: appName, snapshotId: snapshotId)
+        } else {
+            key = latestByApp[appSnapshotKey(appName)]
+        }
+
+        guard let key, let metadata = snapshots[key] else {
+            let target = snapshotId.map { "\(appName): \($0)" } ?? appName
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "No app state snapshot is available for \(target)"
+            )
+        }
+        return metadata
+    }
+
+    func elementId(
+        appName: String,
+        snapshotId: String?,
+        elementIndex: Int,
+        commandName: String
+    ) throws -> String {
+        let metadata = try snapshot(appName: appName, snapshotId: snapshotId)
+        let storedSnapshotId = (metadata["snapshotId"] as? String) ?? snapshotId ?? "latest"
+        guard let elementIdsByIndex = metadata["elementIdsByIndex"] as? [String],
+              elementIndex >= 0,
+              elementIndex < elementIdsByIndex.count
+        else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Element index \(elementIndex) was not found in snapshot \(storedSnapshotId)"
+            )
+        }
+        let elementId = elementIdsByIndex[elementIndex]
+        guard !elementId.isEmpty else {
+            throw HelperFailure(
+                code: "unsupported_command",
+                message: "Element index \(elementIndex) was not found in snapshot \(storedSnapshotId)"
+            )
+        }
+        return elementId
+    }
+
+    func requestWithPointMetadata(_ request: [String: Any]) throws -> [String: Any] {
+        if request["screenshotSource"] != nil,
+           request["screenshotWidth"] != nil,
+           request["screenshotHeight"] != nil,
+           request["sourceBounds"] != nil || request["screenshotSourceBounds"] != nil
+        {
+            return request
+        }
+
+        let appName = try requiredString(request, "app")
+        let metadata = try snapshot(appName: appName, snapshotId: optionalString(request, "snapshotId"))
+        var enriched = request
+        for field in [
+            "snapshotId",
+            "screenshotSource",
+            "screenshotWidth",
+            "screenshotHeight",
+            "windowId",
+            "windowFrame",
+        ] {
+            if enriched[field] == nil, let value = metadata[field] {
+                enriched[field] = value
+            }
+        }
+        if enriched["sourceBounds"] == nil {
+            enriched["sourceBounds"] = metadata["screenshotSourceBounds"]
+        }
+        return enriched
+    }
+}
+
 let keyModifierDefinitions = [
     KeyModifierDefinition(
         name: "command",
@@ -1487,6 +1620,74 @@ func resolveElement(appName: String, elementId: String) throws -> AXUIElement {
     return resolved
 }
 
+func indexedSnapshotElements(_ elements: [[String: Any]]) -> (
+    elements: [[String: Any]],
+    elementIdsByIndex: [String],
+    focusedElementIndex: Int?
+) {
+    var nextIndex = 0
+    var elementIdsByIndex: [String] = []
+    var focusedElementIndex: Int?
+
+    func indexElement(_ element: [String: Any]) -> [String: Any] {
+        let index = nextIndex
+        nextIndex += 1
+        elementIdsByIndex.append((element["id"] as? String) ?? "")
+        if focusedElementIndex == nil,
+           let focused = element["focused"] as? Bool,
+           focused
+        {
+            focusedElementIndex = index
+        }
+
+        var indexed = element
+        indexed["index"] = index
+        if let children = element["children"] as? [[String: Any]], !children.isEmpty {
+            indexed["children"] = children.map { child in
+                indexElement(child)
+            }
+        }
+        return indexed
+    }
+
+    return (
+        elements.map { element in
+            indexElement(element)
+        },
+        elementIdsByIndex,
+        focusedElementIndex
+    )
+}
+
+func resolveElementId(
+    _ request: [String: Any],
+    session: ComputerUseRuntimeSession?,
+    commandName: String
+) throws -> String {
+    if let elementId = optionalString(request, "elementId") {
+        return elementId
+    }
+    guard let elementIndex = optionalInt(request, "elementIndex") else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "\(commandName) requires elementId or elementIndex"
+        )
+    }
+    guard let session else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "\(commandName) with elementIndex requires a runtime session snapshot"
+        )
+    }
+    let appName = try requiredString(request, "app")
+    return try session.elementId(
+        appName: appName,
+        snapshotId: optionalString(request, "snapshotId"),
+        elementIndex: elementIndex,
+        commandName: commandName
+    )
+}
+
 func handleAppsList() -> [String: Any] {
     var names = Set<String>()
     for app in NSWorkspace.shared.runningApplications {
@@ -1519,9 +1720,9 @@ func handlePermissionsRequestAccessibility() -> [String: Any] {
     return computerUsePermissionState()
 }
 
-func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
+func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let snapshotId = try requiredString(request, "snapshotId")
+    let snapshotId = optionalString(request, "snapshotId") ?? UUID().uuidString.lowercased()
 
     guard let runningApp = findRunningApp(named: appName) else {
         throw HelperFailure(
@@ -1560,6 +1761,8 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
     {
         elements.append(menuBarSnapshot)
     }
+    let indexed = indexedSnapshotElements(elements)
+    elements = indexed.elements
 
     var response: [String: Any] = [
         "app": appName,
@@ -1567,10 +1770,14 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
         "pid": Int(runningApp.processIdentifier),
         "snapshotId": snapshotId,
         "elements": elements,
+        "elementIdsByIndex": indexed.elementIdsByIndex,
         "nodeCount": nodeCount,
         "truncated": !truncationReasons.isEmpty,
         "truncationReasons": truncationReasons,
     ]
+    if let focusedElementIndex = indexed.focusedElementIndex {
+        response["focusedElementIndex"] = focusedElementIndex
+    }
     if let bundleId = runningApp.bundleIdentifier {
         response["bundleId"] = bundleId
     }
@@ -1601,6 +1808,7 @@ func handleAppState(_ request: [String: Any]) throws -> [String: Any] {
     response["screenshotWidth"] = screenshot.width
     response["screenshotHeight"] = screenshot.height
     response["screenshotSourceBounds"] = sourceBounds
+    session?.recordSnapshot(response)
     return response
 }
 
@@ -1624,9 +1832,13 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
     }
 }
 
-func handleElementClick(_ request: [String: Any]) throws -> [String: Any] {
+func handleElementClick(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let elementId = try requiredString(request, "elementId")
+    let hasElementTarget = optionalString(request, "elementId") != nil || optionalInt(request, "elementIndex") != nil
+    if !hasElementTarget, request["x"] != nil || request["y"] != nil {
+        return try handleElementClickPoint(request, session: session)
+    }
+    let elementId = try resolveElementId(request, session: session, commandName: "element.click")
     let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
     let app = try resolveRunningApp(named: appName)
     return try withFrontmostPreservation(
@@ -1758,25 +1970,29 @@ func parseKeyPress(_ key: String) throws -> ParsedKeyPress {
     )
 }
 
-func handleElementClickPoint(_ request: [String: Any]) throws -> [String: Any] {
-    let appName = try requiredString(request, "app")
-    let snapshotId = try requiredString(request, "snapshotId")
-    let x = try requiredNumber(request, "x")
-    let y = try requiredNumber(request, "y")
-    let screenshotSource = try requiredString(request, "screenshotSource")
+func handleElementClickPoint(
+    _ request: [String: Any],
+    session: ComputerUseRuntimeSession?
+) throws -> [String: Any] {
+    let preparedRequest = try session?.requestWithPointMetadata(request) ?? request
+    let appName = try requiredString(preparedRequest, "app")
+    let snapshotId = try requiredString(preparedRequest, "snapshotId")
+    let x = try requiredNumber(preparedRequest, "x")
+    let y = try requiredNumber(preparedRequest, "y")
+    let screenshotSource = try requiredString(preparedRequest, "screenshotSource")
     guard screenshotSource == "window" else {
         throw HelperFailure(
             code: "unsupported_command",
             message: "Snapshot is not a target-window screenshot: \(snapshotId)"
         )
     }
-    let screenshotWidth = try requiredNumber(request, "screenshotWidth")
-    let screenshotHeight = try requiredNumber(request, "screenshotHeight")
-    let sourceBounds = try rectPayload(request, "sourceBounds")
-    let windowFrame = try optionalRectPayload(request, "windowFrame")
-    let windowId = optionalInt(request, "windowId")
-    let button = optionalString(request, "button") ?? "left"
-    let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
+    let screenshotWidth = try requiredNumber(preparedRequest, "screenshotWidth")
+    let screenshotHeight = try requiredNumber(preparedRequest, "screenshotHeight")
+    let sourceBounds = try rectPayload(preparedRequest, "sourceBounds")
+    let windowFrame = try optionalRectPayload(preparedRequest, "windowFrame")
+    let windowId = optionalInt(preparedRequest, "windowId")
+    let button = optionalString(preparedRequest, "button") ?? "left"
+    let clickCount = max(1, min(optionalInt(preparedRequest, "clickCount", default: 1), 3))
     let config = try mouseEventConfig(button: button)
     let point = try screenPointFromScreenshotPoint(
         x: x,
@@ -1830,9 +2046,9 @@ func handleElementClickPoint(_ request: [String: Any]) throws -> [String: Any] {
     }
 }
 
-func handleElementSetValue(_ request: [String: Any]) throws -> [String: Any] {
+func handleElementSetValue(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let elementId = try requiredString(request, "elementId")
+    let elementId = try resolveElementId(request, session: session, commandName: "element.set_value")
     let value = try requiredString(request, "value")
     let app = try resolveRunningApp(named: appName)
     return try withFrontmostPreservation(
@@ -1846,9 +2062,9 @@ func handleElementSetValue(_ request: [String: Any]) throws -> [String: Any] {
     }
 }
 
-func handleElementPerformAction(_ request: [String: Any]) throws -> [String: Any] {
+func handleElementPerformAction(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let elementId = try requiredString(request, "elementId")
+    let elementId = try resolveElementId(request, session: session, commandName: "element.perform_action")
     let action = try requiredString(request, "action")
     let app = try resolveRunningApp(named: appName)
     return try withFrontmostPreservation(
@@ -1938,9 +2154,9 @@ func handlePressKey(_ request: [String: Any]) throws -> [String: Any] {
     }
 }
 
-func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {
+func handleScrollElement(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
-    let elementId = try requiredString(request, "elementId")
+    let elementId = try resolveElementId(request, session: session, commandName: "element.scroll")
     let direction = try requiredString(request, "direction")
     let pages = request["pages"] as? NSNumber
     let step = pages?.doubleValue ?? 1
@@ -1971,7 +2187,21 @@ func handleScrollElement(_ request: [String: Any]) throws -> [String: Any] {
     }
 }
 
-func handle(_ request: [String: Any]) throws -> [String: Any] {
+func commandRequest(from request: [String: Any]) throws -> [String: Any] {
+    var command = (request["payload"] as? [String: Any]) ?? request
+    if let kind = request["kind"] {
+        command["kind"] = kind
+    }
+    guard command["kind"] != nil else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Native Computer Use helper requires a command kind"
+        )
+    }
+    return command
+}
+
+func handle(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let kind = try requiredString(request, "kind")
     switch kind {
     case "permissions.state":
@@ -1981,23 +2211,23 @@ func handle(_ request: [String: Any]) throws -> [String: Any] {
     case "apps.list":
         return handleAppsList()
     case "app.state":
-        return try handleAppState(request)
+        return try handleAppState(request, session: session)
     case "app.open":
         return try handleAppOpen(request)
     case "element.click":
-        return try handleElementClick(request)
+        return try handleElementClick(request, session: session)
     case "element.click_point":
-        return try handleElementClickPoint(request)
+        return try handleElementClickPoint(request, session: session)
     case "element.set_value":
-        return try handleElementSetValue(request)
+        return try handleElementSetValue(request, session: session)
     case "element.perform_action":
-        return try handleElementPerformAction(request)
+        return try handleElementPerformAction(request, session: session)
     case "keyboard.type_text":
         return try handleTypeText(request)
     case "keyboard.press_key":
         return try handlePressKey(request)
     case "element.scroll":
-        return try handleScrollElement(request)
+        return try handleScrollElement(request, session: session)
     default:
         throw HelperFailure(
             code: "unsupported_command",
@@ -2012,21 +2242,55 @@ func writeJSONObject(_ object: [String: Any]) throws {
     FileHandle.standardOutput.write(Data("\n".utf8))
 }
 
-func run() {
+func responseObject(for request: [String: Any], session: ComputerUseRuntimeSession?) -> [String: Any] {
+    var response: [String: Any]
     do {
-        let input = FileHandle.standardInput.readDataToEndOfFile()
-        let parsed = try JSONSerialization.jsonObject(with: input, options: [])
-        guard let request = isRecord(parsed) else {
-            throw HelperFailure(
-                code: "unsupported_command",
-                message: "Native Computer Use helper requires a JSON object request"
-            )
-        }
-        let result = try handle(request)
-        try writeJSONObject([
+        let command = try commandRequest(from: request)
+        let result = try handle(command, session: session)
+        response = [
             "status": "succeeded",
             "result": result,
-        ])
+        ]
+    } catch let failure as HelperFailure {
+        response = [
+            "status": "failed",
+            "error": [
+                "code": failure.code,
+                "message": failure.message,
+            ],
+        ]
+    } catch {
+        response = [
+            "status": "failed",
+            "error": [
+                "code": "accessibility_unavailable",
+                "message": String(describing: error),
+            ],
+        ]
+    }
+
+    if let id = request["id"] {
+        response["id"] = id
+    }
+    return response
+}
+
+func parseRequestData(_ data: Data) throws -> [String: Any] {
+    let parsed = try JSONSerialization.jsonObject(with: data, options: [])
+    guard let request = isRecord(parsed) else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Native Computer Use helper requires a JSON object request"
+        )
+    }
+    return request
+}
+
+func runOneShot() {
+    do {
+        let input = FileHandle.standardInput.readDataToEndOfFile()
+        let request = try parseRequestData(input)
+        try writeJSONObject(responseObject(for: request, session: nil))
     } catch let failure as HelperFailure {
         try? writeJSONObject([
             "status": "failed",
@@ -2044,6 +2308,45 @@ func run() {
             ],
         ])
     }
+}
+
+func runStdioSession() {
+    let session = ComputerUseRuntimeSession()
+    while let line = readLine(strippingNewline: true) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            continue
+        }
+        do {
+            let request = try parseRequestData(Data(trimmed.utf8))
+            try writeJSONObject(responseObject(for: request, session: session))
+        } catch let failure as HelperFailure {
+            try? writeJSONObject([
+                "status": "failed",
+                "error": [
+                    "code": failure.code,
+                    "message": failure.message,
+                ],
+            ])
+        } catch {
+            try? writeJSONObject([
+                "status": "failed",
+                "error": [
+                    "code": "accessibility_unavailable",
+                    "message": String(describing: error),
+                ],
+            ])
+        }
+    }
+}
+
+func run() {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    if arguments.contains("serve") || arguments.contains("--stdio") {
+        runStdioSession()
+        return
+    }
+    runOneShot()
 }
 
 run()

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -5,6 +5,9 @@
   "productName": "Zero",
   "description": "Zero desktop shell",
   "main": "dist/main.js",
+  "bin": {
+    "vm0-computer": "bin/vm0-computer"
+  },
   "scripts": {
     "build": "pnpm build:native && pnpm build:electron && pnpm build:renderer",
     "build:electron": "tsup src/main.ts src/preload.ts --format cjs --platform node --target node20 --out-dir dist --sourcemap --clean --external electron",
@@ -17,7 +20,8 @@
     "make": "pnpm build && electron-forge make --platform darwin",
     "package": "pnpm build && electron-forge package --platform darwin",
     "start": "electron-forge start",
-    "test": "vitest run"
+    "test": "vitest run",
+    "vm0-computer": "node bin/vm0-computer.mjs"
   },
   "dependencies": {
     "@tabler/icons-react": "^3.36.1",

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -94,6 +94,7 @@ export interface AccessibilityAppStateSnapshot {
   readonly windowFrame?: ComputerUseCoordinateBounds;
   readonly snapshotId: string;
   readonly elements: readonly AccessibilityElementSnapshot[];
+  readonly elementIdsByIndex?: readonly string[];
   readonly focusedElementIndex?: number;
   readonly nodeCount?: number;
   readonly truncated?: boolean;
@@ -183,7 +184,7 @@ interface IndexedAccessibilitySnapshot {
 }
 
 interface ComputerUseElementTarget {
-  readonly elementId: string;
+  readonly elementId?: string;
   readonly elementIndex?: number;
   readonly snapshotId?: string;
 }
@@ -751,6 +752,30 @@ function indexAccessibilitySnapshot(
   };
 }
 
+function nativeIndexedAccessibilitySnapshot(
+  snapshot: AccessibilityAppStateSnapshot,
+): IndexedAccessibilitySnapshot | null {
+  if (!snapshot.elementIdsByIndex) {
+    return null;
+  }
+  return {
+    snapshot,
+    elementIdsByIndex: snapshot.elementIdsByIndex,
+    ...(snapshot.focusedElementIndex !== undefined
+      ? { focusedElementIndex: snapshot.focusedElementIndex }
+      : {}),
+  };
+}
+
+function indexedAccessibilitySnapshot(
+  snapshot: AccessibilityAppStateSnapshot,
+): IndexedAccessibilitySnapshot {
+  return (
+    nativeIndexedAccessibilitySnapshot(snapshot) ??
+    indexAccessibilitySnapshot(snapshot)
+  );
+}
+
 const ROLE_LABELS: Readonly<Record<string, string>> = Object.freeze({
   AXButton: "button",
   AXCheckBox: "checkbox",
@@ -1003,7 +1028,7 @@ function focusedElementLine(
 export function renderAccessibilityTree(
   snapshot: AccessibilityAppStateSnapshot,
 ): string {
-  const indexed = indexAccessibilitySnapshot(snapshot).snapshot;
+  const indexed = indexedAccessibilitySnapshot(snapshot).snapshot;
   const appName = indexed.appDisplayName ?? indexed.app;
   const appIdentity = indexed.appPath ?? appName;
   const appDetails = [
@@ -1174,7 +1199,7 @@ async function getAppState(
   const snapshot = normalizeAccessibilitySnapshot(
     await nativeBackend.getAppState(app, id),
   );
-  const indexed = indexAccessibilitySnapshot(snapshot);
+  const indexed = indexedAccessibilitySnapshot(snapshot);
   const screenshot = nativeAppStateScreenshot(indexed.snapshot);
   if ("status" in screenshot) {
     return screenshot;
@@ -1315,14 +1340,7 @@ function resolveElementTarget(args: {
   if ("status" in snapshot) {
     return snapshot;
   }
-  const elementId = snapshot.elementIdsByIndex?.[args.elementIndex];
-  if (!elementId) {
-    return unsupportedCommand(
-      `Element index ${args.elementIndex} was not found in snapshot ${snapshot.snapshotId}`,
-    );
-  }
   return {
-    elementId,
     elementIndex: args.elementIndex,
     snapshotId: snapshot.snapshotId,
   };
@@ -1337,13 +1355,13 @@ function elementTargetResult(
       ...(target.snapshotId ? { snapshotId: target.snapshotId } : {}),
     };
   }
-  return { elementId: target.elementId };
+  return target.elementId ? { elementId: target.elementId } : {};
 }
 
 function elementTargetText(target: ComputerUseElementTarget): string {
   return target.elementIndex !== undefined
     ? `elementIndex=${target.elementIndex}`
-    : target.elementId;
+    : (target.elementId ?? "element");
 }
 
 async function clickElement(args: {
@@ -1377,7 +1395,11 @@ async function clickElement(args: {
     }
     const nativeResult = await args.nativeBackend.clickElement({
       app: args.app,
-      elementId: target.elementId,
+      ...(target.elementId ? { elementId: target.elementId } : {}),
+      ...(target.elementIndex !== undefined
+        ? { elementIndex: target.elementIndex }
+        : {}),
+      ...(target.snapshotId ? { snapshotId: target.snapshotId } : {}),
       button: args.button,
       clickCount: args.clickCount,
     });
@@ -1444,7 +1466,11 @@ async function setElementValue(
 ): Promise<ComputerUseCommandSuccess> {
   const nativeResult = await nativeBackend.setElementValue({
     app,
-    elementId: target.elementId,
+    ...(target.elementId ? { elementId: target.elementId } : {}),
+    ...(target.elementIndex !== undefined
+      ? { elementIndex: target.elementIndex }
+      : {}),
+    ...(target.snapshotId ? { snapshotId: target.snapshotId } : {}),
     value,
   });
   return {
@@ -1466,7 +1492,11 @@ async function performElementAction(
 ): Promise<ComputerUseCommandSuccess> {
   const nativeResult = await nativeBackend.performElementAction({
     app,
-    elementId: target.elementId,
+    ...(target.elementId ? { elementId: target.elementId } : {}),
+    ...(target.elementIndex !== undefined
+      ? { elementIndex: target.elementIndex }
+      : {}),
+    ...(target.snapshotId ? { snapshotId: target.snapshotId } : {}),
     action,
   });
   return {
@@ -1524,7 +1554,11 @@ async function scrollElement(
 ): Promise<ComputerUseCommandSuccess> {
   const nativeResult = await nativeBackend.scrollElement({
     app,
-    elementId: target.elementId,
+    ...(target.elementId ? { elementId: target.elementId } : {}),
+    ...(target.elementIndex !== undefined
+      ? { elementIndex: target.elementIndex }
+      : {}),
+    ...(target.snapshotId ? { snapshotId: target.snapshotId } : {}),
     direction,
     pages,
   });

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -1,8 +1,17 @@
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { createComputerUseNativeBackend } from "./computer-use-native";
+
+const execFileAsync = promisify(execFile);
+const desktopRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 
 async function createHelper(
   response: unknown,
@@ -23,6 +32,95 @@ process.stdin.on("end", () => {
   return { dir, helperPath };
 }
 
+async function createSessionHelper(): Promise<{
+  readonly dir: string;
+  readonly helperPath: string;
+  readonly requestLogPath: string;
+}> {
+  const dir = await mkdtemp(path.join(tmpdir(), "computer-use-helper-"));
+  const helperPath = path.join(dir, "helper");
+  const requestLogPath = path.join(dir, "requests.ndjson");
+  await writeFile(
+    helperPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const requestLogPath = ${JSON.stringify(requestLogPath)};
+let buffer = "";
+
+function responseFor(request) {
+  if (request.kind === "app.state") {
+    return {
+      id: request.id,
+      status: "succeeded",
+      result: {
+        app: request.payload.app,
+        snapshotId: request.payload.snapshotId,
+        elements: [
+          {
+            index: 0,
+            role: "AXWindow",
+            children: [{ index: 1, role: "AXButton", name: "Open" }]
+          }
+        ],
+        elementIdsByIndex: ["w0", "w0.e0"],
+        screenshot: "data:image/png;base64,abc123",
+        screenshotSource: "window",
+        screenshotSourceName: "Example",
+        screenshotWidth: 800,
+        screenshotHeight: 600,
+        screenshotSourceBounds: { x: 0, y: 0, width: 800, height: 600 }
+      }
+    };
+  }
+  if (request.kind === "element.click") {
+    if (request.payload.x !== undefined && request.payload.y !== undefined) {
+      return {
+        id: request.id,
+        status: "succeeded",
+        result: {
+          snapshotId: request.payload.snapshotId,
+          screenX: 400,
+          screenY: 300,
+          button: request.payload.button
+        }
+      };
+    }
+    return {
+      id: request.id,
+      status: "succeeded",
+      result: {
+        snapshotId: request.payload.snapshotId,
+        elementIndex: request.payload.elementIndex,
+        button: request.payload.button
+      }
+    };
+  }
+  return { id: request.id, status: "succeeded", result: {} };
+}
+
+function handleLine(line) {
+  if (line.trim().length === 0) return;
+  const request = JSON.parse(line);
+  fs.appendFileSync(requestLogPath, JSON.stringify(request) + "\\n");
+  process.stdout.write(JSON.stringify(responseFor(request)) + "\\n");
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (buffer.includes("\\n")) {
+    const index = buffer.indexOf("\\n");
+    const line = buffer.slice(0, index);
+    buffer = buffer.slice(index + 1);
+    handleLine(line);
+  }
+});
+`,
+  );
+  await chmod(helperPath, 0o755);
+  return { dir, helperPath, requestLogPath };
+}
+
 describe("computer use native backend", () => {
   it("reads permissions from the native helper", async () => {
     const helper = await createHelper({
@@ -33,6 +131,7 @@ describe("computer use native backend", () => {
     try {
       const backend = createComputerUseNativeBackend({
         helperPath: helper.helperPath,
+        mode: "oneshot",
       });
 
       await expect(backend.getPermissions()).resolves.toEqual({
@@ -53,6 +152,7 @@ describe("computer use native backend", () => {
     try {
       const backend = createComputerUseNativeBackend({
         helperPath: helper.helperPath,
+        mode: "oneshot",
       });
 
       await expect(backend.requestAccessibilityPermission()).resolves.toEqual({
@@ -78,6 +178,7 @@ describe("computer use native backend", () => {
     try {
       const backend = createComputerUseNativeBackend({
         helperPath: helper.helperPath,
+        mode: "oneshot",
       });
 
       await expect(
@@ -120,6 +221,7 @@ describe("computer use native backend", () => {
     try {
       const backend = createComputerUseNativeBackend({
         helperPath: helper.helperPath,
+        mode: "oneshot",
       });
 
       await expect(backend.openApp("Things")).resolves.toEqual({
@@ -146,6 +248,7 @@ describe("computer use native backend", () => {
     try {
       const backend = createComputerUseNativeBackend({
         helperPath: helper.helperPath,
+        mode: "oneshot",
       });
 
       await expect(
@@ -172,6 +275,7 @@ describe("computer use native backend", () => {
     try {
       const backend = createComputerUseNativeBackend({
         helperPath: helper.helperPath,
+        mode: "oneshot",
       });
 
       await expect(backend.openApp("Things")).rejects.toMatchObject({
@@ -181,5 +285,267 @@ describe("computer use native backend", () => {
     } finally {
       await rm(helper.dir, { recursive: true, force: true });
     }
+  });
+
+  it("uses a session runtime for multiple commands in one helper process", async () => {
+    const helper = await createSessionHelper();
+    const backend = createComputerUseNativeBackend({
+      helperPath: helper.helperPath,
+    });
+
+    try {
+      await expect(
+        backend.getAppState("Safari", "snap_1"),
+      ).resolves.toMatchObject({
+        app: "Safari",
+        snapshotId: "snap_1",
+        elementIdsByIndex: ["w0", "w0.e0"],
+      });
+      await expect(
+        backend.clickElement({
+          app: "Safari",
+          snapshotId: "snap_1",
+          elementIndex: 1,
+          button: "left",
+          clickCount: 1,
+        }),
+      ).resolves.toEqual({
+        snapshotId: "snap_1",
+        elementIndex: 1,
+        button: "left",
+      });
+      await expect(
+        backend.clickPoint({
+          app: "Safari",
+          snapshotId: "snap_1",
+          x: 200,
+          y: 150,
+          screenshotSource: "window",
+          screenshotWidth: 800,
+          screenshotHeight: 600,
+          sourceBounds: { x: 0, y: 0, width: 800, height: 600 },
+          button: "right",
+          clickCount: 1,
+        }),
+      ).resolves.toEqual({
+        snapshotId: "snap_1",
+        screenX: 400,
+        screenY: 300,
+        button: "right",
+      });
+
+      const requests = (await readFile(helper.requestLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          return JSON.parse(line) as Record<string, unknown>;
+        });
+      expect(requests).toHaveLength(3);
+      expect(requests[0]).toMatchObject({
+        kind: "app.state",
+        payload: { app: "Safari", snapshotId: "snap_1" },
+      });
+      expect(requests[1]).toMatchObject({
+        kind: "element.click",
+        payload: {
+          app: "Safari",
+          snapshotId: "snap_1",
+          elementIndex: 1,
+          button: "left",
+          clickCount: 1,
+        },
+      });
+      expect(requests[2]).toMatchObject({
+        kind: "element.click",
+        payload: {
+          app: "Safari",
+          snapshotId: "snap_1",
+          x: 200,
+          y: 150,
+          screenshotSource: "window",
+          button: "right",
+        },
+      });
+    } finally {
+      backend.dispose();
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the same runtime contract from the vm0-computer CLI", async () => {
+    const helper = await createSessionHelper();
+    const commandInput = [
+      { kind: "app.state", payload: { app: "Safari", snapshotId: "snap_1" } },
+      {
+        kind: "element.click",
+        payload: {
+          app: "Safari",
+          snapshotId: "snap_1",
+          elementIndex: 1,
+          button: "left",
+          clickCount: 1,
+        },
+      },
+    ];
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          path.join(desktopRoot, "bin", "vm0-computer.mjs"),
+          "run",
+          JSON.stringify(commandInput),
+          "--helper-path",
+          helper.helperPath,
+        ],
+        { cwd: desktopRoot },
+      );
+      const responses = JSON.parse(stdout) as readonly Record<
+        string,
+        unknown
+      >[];
+      expect(responses).toHaveLength(2);
+      expect(responses[0]).toMatchObject({
+        status: "succeeded",
+        result: {
+          app: "Safari",
+          snapshotId: "snap_1",
+          elementIdsByIndex: ["w0", "w0.e0"],
+        },
+      });
+      expect(responses[1]).toMatchObject({
+        status: "succeeded",
+        result: {
+          snapshotId: "snap_1",
+          elementIndex: 1,
+          button: "left",
+        },
+      });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("maps Zero CLI command names through vm0-computer", async () => {
+    const helper = await createSessionHelper();
+    const cliPath = path.join(desktopRoot, "bin", "vm0-computer.mjs");
+    const commandArgs = [
+      ["list-apps"],
+      ["get-app-state", "--app", "Safari"],
+      ["open-app", "--app", "Safari"],
+      [
+        "click",
+        "--app",
+        "Safari",
+        "--snapshot-id",
+        "snap_1",
+        "--element",
+        "w0.e0",
+        "--button",
+        "right",
+        "--click-count",
+        "2",
+      ],
+      [
+        "scroll",
+        "--app",
+        "Safari",
+        "--snapshot-id",
+        "snap_1",
+        "--element-index",
+        "1",
+        "--direction",
+        "down",
+        "--pages",
+        "2",
+      ],
+      [
+        "set-value",
+        "--app",
+        "Safari",
+        "--snapshot-id",
+        "snap_1",
+        "--element-index",
+        "1",
+        "--value",
+        "hello",
+      ],
+      [
+        "perform-action",
+        "--app",
+        "Safari",
+        "--snapshot-id",
+        "snap_1",
+        "--element-index",
+        "1",
+        "--action",
+        "AXShowMenu",
+      ],
+      ["type-text", "--app", "Safari", "--text", "hello"],
+      ["press-key", "--app", "Safari", "--key", "Escape"],
+    ];
+
+    try {
+      for (const args of commandArgs) {
+        await execFileAsync(
+          process.execPath,
+          [cliPath, ...args, "--helper-path", helper.helperPath],
+          { cwd: desktopRoot },
+        );
+      }
+
+      const requests = (await readFile(helper.requestLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          return JSON.parse(line) as {
+            readonly kind: string;
+            readonly payload?: Record<string, unknown>;
+          };
+        });
+      expect(requests.map((request) => request.kind)).toStrictEqual([
+        "apps.list",
+        "app.state",
+        "app.open",
+        "element.click",
+        "element.scroll",
+        "element.set_value",
+        "element.perform_action",
+        "keyboard.type_text",
+        "keyboard.press_key",
+      ]);
+      expect(requests[3]?.payload).toMatchObject({
+        app: "Safari",
+        snapshotId: "snap_1",
+        elementId: "w0.e0",
+        button: "right",
+        clickCount: 2,
+      });
+      expect(requests[4]?.payload).toMatchObject({
+        elementIndex: 1,
+        direction: "down",
+        pages: 2,
+      });
+      expect(requests[5]?.payload).toMatchObject({ value: "hello" });
+      expect(requests[6]?.payload).toMatchObject({ action: "AXShowMenu" });
+      expect(requests[7]?.payload).toMatchObject({ text: "hello" });
+      expect(requests[8]?.payload).toMatchObject({ key: "Escape" });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not expose native command kinds as vm0-computer commands", async () => {
+    const cliPath = path.join(desktopRoot, "bin", "vm0-computer.mjs");
+
+    await expect(
+      execFileAsync(
+        process.execPath,
+        [cliPath, "app.state", "--app", "Safari", "--helper-path", "/missing"],
+        { cwd: desktopRoot },
+      ),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("Unknown vm0-computer command"),
+    });
   });
 });

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type {
@@ -44,6 +45,7 @@ export type ComputerUseNativeTypeTextResult = ComputerUseNativeActionResult & {
 };
 
 export interface ComputerUseNativeBackend {
+  readonly dispose: () => void;
   readonly getPermissions: () => Promise<ComputerUsePermissionState>;
   readonly requestAccessibilityPermission: () => Promise<ComputerUsePermissionState>;
   readonly listApps: () => Promise<readonly string[]>;
@@ -54,7 +56,9 @@ export interface ComputerUseNativeBackend {
   readonly openApp: (app: string) => Promise<ComputerUseNativeActionResult>;
   readonly clickElement: (args: {
     readonly app: string;
-    readonly elementId: string;
+    readonly elementId?: string;
+    readonly elementIndex?: number;
+    readonly snapshotId?: string;
     readonly button: ComputerUseMouseButton;
     readonly clickCount: number;
   }) => Promise<ComputerUseNativeActionResult>;
@@ -63,12 +67,16 @@ export interface ComputerUseNativeBackend {
   ) => Promise<ComputerUseNativeClickPointResult>;
   readonly setElementValue: (args: {
     readonly app: string;
-    readonly elementId: string;
+    readonly elementId?: string;
+    readonly elementIndex?: number;
+    readonly snapshotId?: string;
     readonly value: string;
   }) => Promise<ComputerUseNativeActionResult>;
   readonly performElementAction: (args: {
     readonly app: string;
-    readonly elementId: string;
+    readonly elementId?: string;
+    readonly elementIndex?: number;
+    readonly snapshotId?: string;
     readonly action: string;
   }) => Promise<ComputerUseNativeActionResult>;
   readonly typeText: (args: {
@@ -81,7 +89,9 @@ export interface ComputerUseNativeBackend {
   }) => Promise<ComputerUseNativePressKeyResult>;
   readonly scrollElement: (args: {
     readonly app: string;
-    readonly elementId: string;
+    readonly elementId?: string;
+    readonly elementIndex?: number;
+    readonly snapshotId?: string;
     readonly direction: string;
     readonly pages: number;
   }) => Promise<ComputerUseNativeActionResult>;
@@ -116,6 +126,7 @@ interface ResolveComputerUseHelperPathOptions {
 
 interface RunComputerUseHelperOptions {
   readonly helperPath?: string;
+  readonly mode?: "serve" | "oneshot";
 }
 
 export class ComputerUseNativeHelperError extends Error {
@@ -351,16 +362,199 @@ async function runComputerUseHelper(
   });
 }
 
+interface PendingRuntimeRequest {
+  readonly kind: string;
+  readonly resolve: (result: Record<string, unknown>) => void;
+  readonly reject: (error: Error) => void;
+}
+
+function runtimePayload(
+  request: ComputerUseNativeRequest,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(request)) {
+    if (key !== "kind" && value !== undefined) {
+      payload[key] = value;
+    }
+  }
+  return payload;
+}
+
+class ComputerUseNativeRuntimeClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private stdoutBuffer = "";
+  private requestCounter = 0;
+  private closed = false;
+  private stderr = "";
+  private readonly pending = new Map<string, PendingRuntimeRequest>();
+
+  constructor(private readonly helperPath: string) {}
+
+  request(request: ComputerUseNativeRequest): Promise<Record<string, unknown>> {
+    if (this.closed) {
+      return Promise.reject(
+        new ComputerUseNativeHelperError(
+          "accessibility_unavailable",
+          "Native Computer Use runtime is closed",
+        ),
+      );
+    }
+    const child = this.ensureChild();
+    const id = `desktop_${(this.requestCounter += 1).toString()}`;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { kind: request.kind, resolve, reject });
+      child.stdin.write(
+        `${JSON.stringify({ id, kind: request.kind, payload: runtimePayload(request) })}\n`,
+        (error) => {
+          if (error) {
+            this.pending.delete(id);
+            reject(
+              new ComputerUseNativeHelperError(
+                "accessibility_unavailable",
+                `Unable to write to native Computer Use runtime: ${error.message}`,
+              ),
+            );
+          }
+        },
+      );
+    });
+  }
+
+  dispose(): void {
+    this.closed = true;
+    for (const pending of this.pending.values()) {
+      pending.reject(
+        new ComputerUseNativeHelperError(
+          "accessibility_unavailable",
+          "Native Computer Use runtime was closed",
+        ),
+      );
+    }
+    this.pending.clear();
+    this.child?.kill();
+    this.child = null;
+  }
+
+  private ensureChild(): ChildProcessWithoutNullStreams {
+    if (this.child) {
+      return this.child;
+    }
+    const child = spawn(this.helperPath, ["serve"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child = child;
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      this.handleStdout(chunk);
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      this.stderr += chunk;
+    });
+    child.on("error", (error) => {
+      this.rejectAll(
+        new ComputerUseNativeHelperError(
+          "accessibility_unavailable",
+          `Unable to start native Computer Use runtime: ${error.message}`,
+        ),
+      );
+    });
+    child.on("close", (code) => {
+      this.child = null;
+      if (!this.closed) {
+        this.rejectAll(
+          new ComputerUseNativeHelperError(
+            "accessibility_unavailable",
+            this.stderr.trim() ||
+              `Native Computer Use runtime exited with status ${code ?? "null"}`,
+          ),
+        );
+      }
+    });
+    return child;
+  }
+
+  private handleStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    while (true) {
+      const newlineIndex = this.stdoutBuffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+      const line = this.stdoutBuffer.slice(0, newlineIndex).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line.length > 0) {
+        this.handleResponseLine(line);
+      }
+    }
+  }
+
+  private handleResponseLine(line: string): void {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isRecord(parsed) || typeof parsed.id !== "string") {
+        throw new ComputerUseNativeHelperError(
+          "accessibility_unavailable",
+          "Native Computer Use runtime returned an uncorrelated response",
+        );
+      }
+      const pending = this.pending.get(parsed.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(parsed.id);
+      const response = parseHelperResponse(line);
+      if (response.status === "failed") {
+        pending.reject(
+          new ComputerUseNativeHelperError(
+            responseErrorCode(response.error?.code),
+            responseErrorMessage(response.error?.message),
+          ),
+        );
+        return;
+      }
+      pending.resolve(resultRecord(response.result ?? {}, pending.kind));
+    } catch (error) {
+      const helperError =
+        error instanceof Error
+          ? error
+          : new ComputerUseNativeHelperError(
+              "accessibility_unavailable",
+              String(error),
+            );
+      this.rejectAll(helperError);
+    }
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) {
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
 export function createComputerUseNativeBackend(
   options: RunComputerUseHelperOptions = {},
 ): ComputerUseNativeBackend {
+  const helperPath = options.helperPath ?? resolveComputerUseHelperPath();
+  const runtime =
+    options.mode === "oneshot"
+      ? null
+      : new ComputerUseNativeRuntimeClient(helperPath);
   const run = async (
     request: ComputerUseNativeRequest,
   ): Promise<Record<string, unknown>> => {
-    return await runComputerUseHelper(request, options);
+    return runtime
+      ? await runtime.request(request)
+      : await runComputerUseHelper(request, { ...options, helperPath });
   };
 
   return {
+    dispose: () => {
+      runtime?.dispose();
+    },
     getPermissions: async () => {
       const result = await run({ kind: "permissions.state" });
       return resultPermissions(result);
@@ -384,7 +578,7 @@ export function createComputerUseNativeBackend(
       return await run({ kind: "element.click", ...args });
     },
     clickPoint: async (args) => {
-      const result = await run({ kind: "element.click_point", ...args });
+      const result = await run({ kind: "element.click", ...args });
       return {
         ...result,
         screenX: resultRequiredNumber(result, "screenX"),

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -1,4 +1,7 @@
-import { createComputerUseNativeBackend } from "./computer-use-native";
+import {
+  createComputerUseNativeBackend,
+  type ComputerUseNativeBackend,
+} from "./computer-use-native";
 import type { ComputerUsePermissionState } from "./computer-use-types";
 
 const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
@@ -7,19 +10,31 @@ const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
     screenRecording: false,
   });
 
-const nativeBackend = createComputerUseNativeBackend();
+let nativeBackend: ComputerUseNativeBackend | null = null;
 let currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
+
+export function setComputerUsePermissionNativeBackend(
+  backend: ComputerUseNativeBackend,
+): void {
+  nativeBackend = backend;
+}
+
+function getNativeBackend(): ComputerUseNativeBackend {
+  nativeBackend ??= createComputerUseNativeBackend();
+  return nativeBackend;
+}
 
 export function getComputerUsePermissionState(): ComputerUsePermissionState {
   return currentPermissionState;
 }
 
 export async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
-  currentPermissionState = await nativeBackend.getPermissions();
+  currentPermissionState = await getNativeBackend().getPermissions();
   return currentPermissionState;
 }
 
 export async function requestComputerUseAccessibilityPermission(): Promise<ComputerUsePermissionState> {
-  currentPermissionState = await nativeBackend.requestAccessibilityPermission();
+  currentPermissionState =
+    await getNativeBackend().requestAccessibilityPermission();
   return currentPermissionState;
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -32,7 +32,9 @@ import {
   getComputerUsePermissionState,
   refreshComputerUsePermissionState,
   requestComputerUseAccessibilityPermission,
+  setComputerUsePermissionNativeBackend,
 } from "./computer-use-permissions";
+import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
 import {
@@ -90,6 +92,8 @@ let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let desktopAuthToken: string | null = null;
 let desktopAuthTokenRefresh: Promise<string | null> | null = null;
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
+const computerUseNativeBackend = createComputerUseNativeBackend();
+setComputerUsePermissionNativeBackend(computerUseNativeBackend);
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -227,6 +231,7 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
       getPermissions: refreshComputerUsePermissionState,
       executeCommand: (command, permissions) => {
         return executeComputerUseCommand(command, permissions, {
+          nativeBackend: computerUseNativeBackend,
           snapshotStore: computerUseSnapshotStore,
         });
       },
@@ -752,11 +757,13 @@ if (!hasSingleInstanceLock) {
   app.on("before-quit", (event) => {
     appIsQuitting = true;
     if (!computerUseRuntime || computerUseQuitStopStarted) {
+      computerUseNativeBackend.dispose();
       return;
     }
     computerUseQuitStopStarted = true;
     event.preventDefault();
     void stopComputerUseRuntimeForQuit().finally(() => {
+      computerUseNativeBackend.dispose();
       app.quit();
     });
   });

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -45,6 +45,7 @@ function createNativeBackend(
   overrides: Partial<ComputerUseNativeBackend> = {},
 ): ComputerUseNativeBackend {
   const defaults: ComputerUseNativeBackend = {
+    dispose: () => {},
     getPermissions: async () => {
       return { accessibility: true, screenRecording: true };
     },
@@ -1212,7 +1213,7 @@ describe("computer use desktop runtime", () => {
     expect(result.result.visibleText).toContain("Can you see this?");
   });
 
-  it("maps model-facing element indexes back to internal element ids", async () => {
+  it("passes model-facing element indexes to the native runtime session", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
     clickElement.mockResolvedValue(
@@ -1302,7 +1303,8 @@ describe("computer use desktop runtime", () => {
     expect(click.status).toBe("succeeded");
     expect(clickElement).toHaveBeenCalledWith({
       app: "Safari",
-      elementId: "w0.e0",
+      snapshotId,
+      elementIndex: 1,
       button: "left",
       clickCount: 1,
     });


### PR DESCRIPTION
## Summary
- promote the native Computer Use helper into a session-based local runtime that owns app snapshots and element-index resolution
- add a local vm0-computer debug CLI matching the public zero computer-use command surface
- reuse one Desktop native backend session for permissions and command execution to avoid spawning one helper per command

## Validation
- pnpm -F @vm0/desktop build
- pnpm -F @vm0/desktop test
- pnpm knip --workspace @vm0/desktop
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm format
- node --check apps/desktop/bin/vm0-computer.mjs && sh -n apps/desktop/bin/vm0-computer
- apps/desktop/bin/vm0-computer list-apps

Fixes #14978