### PR TITLE
fix: demote expected exec cancel terminal logs

### DIFF
--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -2871,6 +2871,7 @@ mod tests {
     use std::os::fd::AsRawFd;
     use std::sync::atomic::AtomicU32;
     use std::sync::{Arc, Mutex};
+    use tokio::io::AsyncReadExt;
     use tracing::field::{Field, Visit};
     use tracing::{Event, Level, Subscriber};
     use tracing_subscriber::layer::{Context, Layer};
@@ -3033,6 +3034,24 @@ mod tests {
         value
             .parse()
             .unwrap_or_else(|err| panic!("invalid u128 field {field}={value:?}: {err}"))
+    }
+
+    async fn read_exec_operation_frame(stream: &mut tokio::net::UnixStream) -> RawMessage {
+        let mut header = [0u8; vsock_proto::HEADER_SIZE];
+        stream.read_exact(&mut header).await.unwrap();
+        let body_len = u32::from_be_bytes(header) as usize;
+        assert!(
+            (vsock_proto::MIN_BODY_SIZE..=vsock_proto::MAX_MESSAGE_SIZE).contains(&body_len),
+            "invalid message body length: {body_len}",
+        );
+
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).await.unwrap();
+        RawMessage {
+            msg_type: body[0],
+            seq: u32::from_be_bytes(body[1..vsock_proto::MIN_BODY_SIZE].try_into().unwrap()),
+            payload: body[vsock_proto::MIN_BODY_SIZE..].to_vec(),
+        }
     }
 
     #[test]
@@ -3482,6 +3501,65 @@ mod tests {
             result_rx.try_recv().unwrap().unwrap().termination,
             ExecTermination::Cancelled
         );
+    }
+
+    #[tokio::test]
+    async fn one_shot_cancel_handle_marks_terminal_result_as_host_requested_cancel() {
+        let (result_tx, result_rx) = oneshot::channel();
+        let (shared, mut read_stream, diagnostic) = shared_with_logged_operation(
+            ExecOperationLifecycle::OneShot,
+            "one-shot-cancel-marker-terminal-log",
+            result_tx,
+            false,
+        );
+        let handle = ExecOperationHandle {
+            shared: Arc::clone(&shared),
+            seq: Some(7),
+            diagnostic,
+            result_rx: Some(result_rx),
+            stream_rx: None,
+        };
+
+        let cancel_task = tokio::spawn(async move {
+            handle
+                .cancel_and_wait_for_terminal_status(Duration::from_secs(5))
+                .await
+        });
+        let cancel = read_exec_operation_frame(&mut read_stream).await;
+        assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+        assert_eq!(cancel.seq, 7);
+        vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
+
+        let payload = vsock_proto::encode_exec_result(
+            ExecTermination::Cancelled,
+            10,
+            ExecCapturedOutput::Discarded,
+            ExecCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        let msg = RawMessage {
+            msg_type: MSG_EXEC_RESULT,
+            seq: 7,
+            payload,
+        };
+
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            dispatch_result(&shared, &msg).unwrap();
+        });
+
+        let events = captured.events();
+        assert_eq!(events.len(), 1, "captured events: {events:#?}");
+        assert_eq!(events[0].level, Level::INFO);
+        assert_terminal_log_field(&events[0], "termination", "Cancelled");
+        assert_terminal_log_field(&events[0], "host_cancel_requested", "true");
+
+        let wait_result = cancel_task.await.unwrap().unwrap();
+        assert_eq!(wait_result.cancel_seq, Some(7));
+        assert_eq!(wait_result.result.termination, ExecTermination::Cancelled);
     }
 
     #[test]

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -3685,6 +3685,29 @@ mod tests {
     }
 
     #[test]
+    fn exec_terminal_log_severity_warns_for_host_cancel_with_failure_terminations() {
+        for termination in [
+            ExecTermination::TimedOut,
+            ExecTermination::StartFailed,
+            ExecTermination::WaitFailed,
+        ] {
+            let context = ExecTerminalLogContext {
+                host_cancel_requested: true,
+                ..clean_terminal_log_context(
+                    ExecTerminalLogLifecycle::Supervised,
+                    false,
+                    termination,
+                )
+            };
+
+            assert_eq!(
+                exec_terminal_log_severity(context),
+                Some(ExecTerminalLogSeverity::Warn)
+            );
+        }
+    }
+
+    #[test]
     fn exec_terminal_log_severity_warns_for_non_exit_terminations() {
         for lifecycle in [
             ExecTerminalLogLifecycle::OneShot,

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -3288,7 +3288,41 @@ mod tests {
         host_cancel_requested: bool,
     ) -> (Vec<CapturedEvent>, ExecOperationResult) {
         let (result_tx, mut result_rx) = oneshot::channel();
-        let (_read_stream, write_stream) = tokio::net::UnixStream::pair().unwrap();
+        let (shared, _read_stream, _diagnostic) =
+            shared_with_logged_operation(lifecycle, label, result_tx, host_cancel_requested);
+        let payload = vsock_proto::encode_exec_result(
+            termination,
+            10,
+            ExecCapturedOutput::Discarded,
+            ExecCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        let msg = RawMessage {
+            msg_type: MSG_EXEC_RESULT,
+            seq: 7,
+            payload,
+        };
+
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            dispatch_result(&shared, &msg).unwrap();
+        });
+
+        let events = captured.events();
+        let result = result_rx.try_recv().unwrap().unwrap();
+        (events, result)
+    }
+
+    fn shared_with_logged_operation(
+        lifecycle: ExecOperationLifecycle,
+        label: &str,
+        result_tx: oneshot::Sender<io::Result<ExecOperationResult>>,
+        host_cancel_requested: bool,
+    ) -> (Arc<Shared>, tokio::net::UnixStream, ExecOperationDiagnostic) {
+        let (read_stream, write_stream) = tokio::net::UnixStream::pair().unwrap();
         let fd = write_stream.as_raw_fd();
         let (_read_half, write_half) = write_stream.into_split();
         let shared = Arc::new(Shared {
@@ -3315,7 +3349,7 @@ mod tests {
                 ExecOperation {
                     normal_operation: None,
                     lifecycle,
-                    diagnostic,
+                    diagnostic: diagnostic.clone(),
                     result_tx,
                     stream_tx: None,
                     stdout_capture: ExecCaptureState::Discard,
@@ -3329,30 +3363,7 @@ mod tests {
                 },
             );
         }
-        let payload = vsock_proto::encode_exec_result(
-            termination,
-            10,
-            ExecCapturedOutput::Discarded,
-            ExecCapturedOutput::Discarded,
-            "",
-        )
-        .unwrap();
-        let msg = RawMessage {
-            msg_type: MSG_EXEC_RESULT,
-            seq: 7,
-            payload,
-        };
-
-        let captured = CapturedEvents::default();
-        let subscriber = tracing_subscriber::registry().with(captured.clone());
-        tracing::subscriber::with_default(subscriber, || {
-            tracing::callsite::rebuild_interest_cache();
-            dispatch_result(&shared, &msg).unwrap();
-        });
-
-        let events = captured.events();
-        let result = result_rx.try_recv().unwrap().unwrap();
-        (events, result)
+        (shared, read_stream, diagnostic)
     }
 
     #[tokio::test]
@@ -3421,6 +3432,56 @@ mod tests {
         assert_terminal_log_field(&events[0], "termination", "Cancelled");
         assert_terminal_log_field(&events[0], "host_cancel_requested", "true");
         assert_eq!(result.termination, ExecTermination::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn supervised_cancel_frame_marks_terminal_result_as_host_requested_cancel() {
+        let (result_tx, mut result_rx) = oneshot::channel();
+        let lifecycle = ExecOperationLifecycle::SupervisedStarted {
+            pid: 42,
+            control_nonce: None,
+        };
+        let (shared, _read_stream, diagnostic) = shared_with_logged_operation(
+            lifecycle,
+            "supervised-cancel-marker-terminal-log",
+            result_tx,
+            false,
+        );
+
+        send_supervised_exec_cancel_frame(&shared, 7, &diagnostic)
+            .await
+            .unwrap();
+
+        let payload = vsock_proto::encode_exec_result(
+            ExecTermination::Cancelled,
+            10,
+            ExecCapturedOutput::Discarded,
+            ExecCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        let msg = RawMessage {
+            msg_type: MSG_EXEC_RESULT,
+            seq: 7,
+            payload,
+        };
+
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            dispatch_result(&shared, &msg).unwrap();
+        });
+
+        let events = captured.events();
+        assert_eq!(events.len(), 1, "captured events: {events:#?}");
+        assert_eq!(events[0].level, Level::INFO);
+        assert_terminal_log_field(&events[0], "termination", "Cancelled");
+        assert_terminal_log_field(&events[0], "host_cancel_requested", "true");
+        assert_eq!(
+            result_rx.try_recv().unwrap().unwrap().termination,
+            ExecTermination::Cancelled
+        );
     }
 
     #[test]

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -260,6 +260,12 @@ impl Operations {
         self.operations.get_mut(&seq)
     }
 
+    fn mark_host_cancel_requested(&mut self, seq: u32) {
+        if let Some(operation) = self.operations.get_mut(&seq) {
+            operation.host_cancel_requested = true;
+        }
+    }
+
     fn insert_pending_control(
         &mut self,
         target_seq: u32,
@@ -328,6 +334,7 @@ struct ExecOperation {
     stderr_stream: Option<ExecStreamState>,
     expected_output_seq: u32,
     stream_overflowed: bool,
+    host_cancel_requested: bool,
     pending_controls: HashMap<u32, PendingExecControl>,
 }
 
@@ -462,6 +469,7 @@ struct ExecTerminalLogContext {
     stderr_truncated: bool,
     stream_overflowed: bool,
     diagnostic_present: bool,
+    host_cancel_requested: bool,
 }
 
 #[derive(Clone)]
@@ -621,6 +629,7 @@ impl ExecOperationDiagnostic {
         lifecycle: ExecTerminalLogLifecycle,
         result: &vsock_proto::DecodedExecResult<'_>,
         stream_overflowed: bool,
+        host_cancel_requested: bool,
     ) {
         let elapsed_ms = self.elapsed_ms();
         let slow = elapsed_ms >= EXEC_OPERATION_STAGE_SLOW_THRESHOLD.as_millis();
@@ -635,6 +644,7 @@ impl ExecOperationDiagnostic {
             stderr_truncated,
             stream_overflowed,
             diagnostic_present,
+            host_cancel_requested,
         }) else {
             return;
         };
@@ -651,6 +661,7 @@ impl ExecOperationDiagnostic {
                     stdout_truncated,
                     stderr_truncated,
                     diagnostic_present,
+                    host_cancel_requested,
                     "exec operation terminal result"
                 );
             }
@@ -665,6 +676,7 @@ impl ExecOperationDiagnostic {
                     stdout_truncated,
                     stderr_truncated,
                     diagnostic_present,
+                    host_cancel_requested,
                     "exec operation terminal result"
                 );
             }
@@ -773,7 +785,7 @@ impl ExecOperationHandle {
             &payload,
             Some(self.diagnostic.frame("cancel")),
             None,
-            FrameWriteObserver::default(),
+            exec_cancel_write_observer(&self.shared, seq),
         )
         .await?;
         tracing::info!(
@@ -1220,7 +1232,7 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     &payload,
                     Some(diagnostic.frame("drop-cancel")),
                     None,
-                    FrameWriteObserver::default(),
+                    exec_cancel_write_observer(&shared, seq),
                 ),
             )
             .await;
@@ -1259,6 +1271,21 @@ fn exec_operation_protocol_error(error: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, error.to_string())
 }
 
+fn exec_cancel_write_observer(shared: &Arc<Shared>, seq: u32) -> FrameWriteObserver {
+    let shared = Arc::clone(shared);
+    FrameWriteObserver::new(move || {
+        mark_exec_operation_host_cancel_requested(&shared, seq);
+        Ok(())
+    })
+}
+
+fn mark_exec_operation_host_cancel_requested(shared: &Arc<Shared>, seq: u32) {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    if let ConnectionState::Connected { operations, .. } = &mut *guard {
+        operations.mark_host_cancel_requested(seq);
+    }
+}
+
 async fn send_supervised_exec_cancel_frame(
     shared: &Arc<Shared>,
     seq: u32,
@@ -1272,7 +1299,7 @@ async fn send_supervised_exec_cancel_frame(
         &payload,
         Some(diagnostic.frame("cancel")),
         None,
-        FrameWriteObserver::default(),
+        exec_cancel_write_observer(shared, seq),
     )
     .await?;
     tracing::info!(
@@ -1341,6 +1368,15 @@ fn exec_termination_requires_low_level_warning(termination: ExecTermination) -> 
     }
 }
 
+fn exec_terminal_cancel_is_expected(context: ExecTerminalLogContext) -> bool {
+    matches!(context.termination, ExecTermination::Cancelled)
+        && context.host_cancel_requested
+        && !context.stdout_truncated
+        && !context.stderr_truncated
+        && !context.stream_overflowed
+        && !context.diagnostic_present
+}
+
 fn exec_terminal_log_lifecycle(lifecycle: &ExecOperationLifecycle) -> ExecTerminalLogLifecycle {
     match lifecycle {
         ExecOperationLifecycle::OneShot => ExecTerminalLogLifecycle::OneShot,
@@ -1350,6 +1386,10 @@ fn exec_terminal_log_lifecycle(lifecycle: &ExecOperationLifecycle) -> ExecTermin
 }
 
 fn exec_terminal_log_severity(context: ExecTerminalLogContext) -> Option<ExecTerminalLogSeverity> {
+    if exec_terminal_cancel_is_expected(context) {
+        return Some(ExecTerminalLogSeverity::Info);
+    }
+
     let notable = exec_termination_requires_low_level_warning(context.termination)
         || context.stdout_truncated
         || context.stderr_truncated
@@ -1717,7 +1757,15 @@ fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
 }
 
 fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let Some((diagnostic, result_tx, start_tx, log_lifecycle, stream_overflowed, decoded)) = ({
+    let Some((
+        diagnostic,
+        result_tx,
+        start_tx,
+        log_lifecycle,
+        stream_overflowed,
+        host_cancel_requested,
+        decoded,
+    )) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
@@ -1737,6 +1785,7 @@ fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
                     diagnostic,
                     result_tx,
                     stream_overflowed,
+                    host_cancel_requested,
                     ..
                 } = operation;
                 let log_lifecycle = exec_terminal_log_lifecycle(&lifecycle);
@@ -1756,16 +1805,23 @@ fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
                     start_tx,
                     log_lifecycle,
                     stream_overflowed,
+                    host_cancel_requested,
                     decoded,
                 ))
             }
             ConnectionState::Connected { .. } | ConnectionState::Closed => None,
         }
-    }) else {
+    })
+    else {
         return Ok(());
     };
 
-    diagnostic.log_terminal(log_lifecycle, &decoded, stream_overflowed);
+    diagnostic.log_terminal(
+        log_lifecycle,
+        &decoded,
+        stream_overflowed,
+        host_cancel_requested,
+    );
     let result = owned_result(decoded, stream_overflowed);
     if let Some(start_tx) = start_tx {
         let message = if result.diagnostic.is_empty() {
@@ -2279,6 +2335,7 @@ async fn start_exec_operation_on_shared_with_tracking(
         stderr_stream: stream_state(request.stderr),
         expected_output_seq: 0,
         stream_overflowed: false,
+        host_cancel_requested: false,
         pending_controls: HashMap::new(),
     };
 
@@ -2415,6 +2472,7 @@ where
         stderr_stream: stream_state(request.stderr),
         expected_output_seq: 0,
         stream_overflowed: false,
+        host_cancel_requested: false,
         pending_controls: HashMap::new(),
     };
 
@@ -2903,6 +2961,7 @@ mod tests {
             stderr_stream: None,
             expected_output_seq: 0,
             stream_overflowed: false,
+            host_cancel_requested: false,
             pending_controls: HashMap::new(),
         }
     }
@@ -2931,7 +2990,7 @@ mod tests {
         result: &vsock_proto::DecodedExecResult<'_>,
         stream_overflowed: bool,
     ) -> Vec<Level> {
-        capture_terminal_log_events_with_context(lifecycle, slow, result, stream_overflowed)
+        capture_terminal_log_events_with_context(lifecycle, slow, result, stream_overflowed, false)
             .into_iter()
             .map(|event| event.level)
             .collect()
@@ -2942,6 +3001,7 @@ mod tests {
         slow: bool,
         result: &vsock_proto::DecodedExecResult<'_>,
         stream_overflowed: bool,
+        host_cancel_requested: bool,
     ) -> Vec<CapturedEvent> {
         let mut diagnostic = ExecOperationDiagnostic::new(7, "terminal-log");
         if slow {
@@ -2952,7 +3012,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         tracing::subscriber::with_default(subscriber, || {
             tracing::callsite::rebuild_interest_cache();
-            diagnostic.log_terminal(lifecycle, result, stream_overflowed);
+            diagnostic.log_terminal(lifecycle, result, stream_overflowed, host_cancel_requested);
         });
         captured.events()
     }
@@ -3031,6 +3091,7 @@ mod tests {
             true,
             &clean,
             false,
+            false,
         );
         assert_eq!(info_events.len(), 1, "captured events: {info_events:#?}");
         let info_event = &info_events[0];
@@ -3049,6 +3110,7 @@ mod tests {
         assert_terminal_log_field(info_event, "stdout_truncated", "false");
         assert_terminal_log_field(info_event, "stderr_truncated", "false");
         assert_terminal_log_field(info_event, "diagnostic_present", "false");
+        assert_terminal_log_field(info_event, "host_cancel_requested", "false");
 
         let warn_result = vsock_proto::DecodedExecResult {
             termination: ExecTermination::TimedOut,
@@ -3068,6 +3130,7 @@ mod tests {
             false,
             &warn_result,
             true,
+            false,
         );
         assert_eq!(warn_events.len(), 1, "captured events: {warn_events:#?}");
         let warn_event = &warn_events[0];
@@ -3082,6 +3145,27 @@ mod tests {
         assert_terminal_log_field(warn_event, "stdout_truncated", "true");
         assert_terminal_log_field(warn_event, "stderr_truncated", "true");
         assert_terminal_log_field(warn_event, "diagnostic_present", "true");
+        assert_terminal_log_field(warn_event, "host_cancel_requested", "false");
+    }
+
+    #[test]
+    fn exec_operation_diagnostic_logs_host_requested_cancel_as_info() {
+        let cancelled = vsock_proto::DecodedExecResult {
+            termination: ExecTermination::Cancelled,
+            ..clean_terminal_result()
+        };
+        let events = capture_terminal_log_events_with_context(
+            ExecTerminalLogLifecycle::Supervised,
+            false,
+            &cancelled,
+            false,
+            true,
+        );
+
+        assert_eq!(events.len(), 1, "captured events: {events:#?}");
+        assert_eq!(events[0].level, Level::INFO);
+        assert_terminal_log_field(&events[0], "termination", "Cancelled");
+        assert_terminal_log_field(&events[0], "host_cancel_requested", "true");
     }
 
     #[test]
@@ -3189,6 +3273,20 @@ mod tests {
         lifecycle: ExecOperationLifecycle,
         label: &str,
     ) -> (Vec<CapturedEvent>, ExecOperationResult) {
+        capture_dispatch_terminal_log_events_with_options(
+            lifecycle,
+            label,
+            ExecTermination::Exited { exit_code: 0 },
+            false,
+        )
+    }
+
+    fn capture_dispatch_terminal_log_events_with_options(
+        lifecycle: ExecOperationLifecycle,
+        label: &str,
+        termination: ExecTermination,
+        host_cancel_requested: bool,
+    ) -> (Vec<CapturedEvent>, ExecOperationResult) {
         let (result_tx, mut result_rx) = oneshot::channel();
         let (_read_stream, write_stream) = tokio::net::UnixStream::pair().unwrap();
         let fd = write_stream.as_raw_fd();
@@ -3226,12 +3324,13 @@ mod tests {
                     stderr_stream: None,
                     expected_output_seq: 0,
                     stream_overflowed: false,
+                    host_cancel_requested,
                     pending_controls: HashMap::new(),
                 },
             );
         }
         let payload = vsock_proto::encode_exec_result(
-            ExecTermination::Exited { exit_code: 0 },
+            termination,
             10,
             ExecCapturedOutput::Discarded,
             ExecCapturedOutput::Discarded,
@@ -3304,6 +3403,26 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn dispatch_result_logs_host_requested_cancel_as_info() {
+        let lifecycle = ExecOperationLifecycle::SupervisedStarted {
+            pid: 42,
+            control_nonce: None,
+        };
+        let (events, result) = capture_dispatch_terminal_log_events_with_options(
+            lifecycle,
+            "dispatch-host-cancelled-terminal-log",
+            ExecTermination::Cancelled,
+            true,
+        );
+
+        assert_eq!(events.len(), 1, "captured events: {events:#?}");
+        assert_eq!(events[0].level, Level::INFO);
+        assert_terminal_log_field(&events[0], "termination", "Cancelled");
+        assert_terminal_log_field(&events[0], "host_cancel_requested", "true");
+        assert_eq!(result.termination, ExecTermination::Cancelled);
+    }
+
     #[test]
     fn exec_terminal_log_lifecycle_maps_supervised_states() {
         let (start_tx, _start_rx) = oneshot::channel();
@@ -3343,6 +3462,7 @@ mod tests {
             stderr_truncated: false,
             stream_overflowed: false,
             diagnostic_present: false,
+            host_cancel_requested: false,
         }
     }
 
@@ -3508,6 +3628,59 @@ mod tests {
                     Some(ExecTerminalLogSeverity::Warn)
                 );
             }
+        }
+    }
+
+    #[test]
+    fn exec_terminal_log_severity_demotes_expected_host_cancel() {
+        for lifecycle in [
+            ExecTerminalLogLifecycle::OneShot,
+            ExecTerminalLogLifecycle::Supervised,
+        ] {
+            let context = ExecTerminalLogContext {
+                host_cancel_requested: true,
+                ..clean_terminal_log_context(lifecycle, false, ExecTermination::Cancelled)
+            };
+
+            assert_eq!(
+                exec_terminal_log_severity(context),
+                Some(ExecTerminalLogSeverity::Info)
+            );
+        }
+    }
+
+    #[test]
+    fn exec_terminal_log_severity_warns_for_expected_host_cancel_with_metadata() {
+        let clean_cancel = ExecTerminalLogContext {
+            host_cancel_requested: true,
+            ..clean_terminal_log_context(
+                ExecTerminalLogLifecycle::Supervised,
+                false,
+                ExecTermination::Cancelled,
+            )
+        };
+        for context in [
+            ExecTerminalLogContext {
+                stdout_truncated: true,
+                ..clean_cancel
+            },
+            ExecTerminalLogContext {
+                stderr_truncated: true,
+                ..clean_cancel
+            },
+            ExecTerminalLogContext {
+                stream_overflowed: true,
+                ..clean_cancel
+            },
+            ExecTerminalLogContext {
+                diagnostic_present: true,
+                ..clean_cancel
+            },
+        ] {
+            assert_eq!(
+                exec_terminal_log_severity(context),
+                Some(ExecTerminalLogSeverity::Warn)
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- track host-requested exec cancels through terminal result logging
- log clean host-requested `Cancelled` terminal results at info level
- keep unexpected cancels and cancels with diagnostics, truncation, or stream overflow at warn level

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`