### PR TITLE
chore: move dev seed script to api

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -843,7 +843,7 @@ jobs:
 
             cd turbo
             DATABASE_URL="$DATABASE_URL" pnpm -F @vm0/db db:migrate
-            DATABASE_URL="$DATABASE_URL" pnpm -F web db:dev-seed
+            DATABASE_URL="$DATABASE_URL" pnpm -F api db:dev-seed
             echo "Neon branch ready"
           ) > /tmp/neon-log 2>&1 &
           NEON_PID=$!

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -841,9 +841,14 @@ jobs:
             fi
             echo "$DATABASE_URL" > /tmp/neon-database-url
 
+            API_SEED_WEB_URL="${VM0_WEB_URL:-${{ needs.prepare.outputs.web-preview-url }}}"
+            if [ -z "$API_SEED_WEB_URL" ]; then
+              API_SEED_WEB_URL="https://www.vm0.ai"
+            fi
+
             cd turbo
             DATABASE_URL="$DATABASE_URL" pnpm -F @vm0/db db:migrate
-            DATABASE_URL="$DATABASE_URL" pnpm -F api db:dev-seed
+            ENV=preview VM0_WEB_URL="$API_SEED_WEB_URL" DATABASE_URL="$DATABASE_URL" pnpm -F api db:dev-seed
             echo "Neon branch ready"
           ) > /tmp/neon-log 2>&1 &
           NEON_PID=$!

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -59,7 +59,7 @@ from .x_tlds import IANA_TLDS
 
 # Permission → default bucket.  The default matches the majority of
 # paths in the scope; outliers go in `_PATH_OVERRIDES`.  Prices are
-# defined in turbo/apps/web/scripts/dev-seed.ts.
+# defined in turbo/apps/api/src/scripts/dev-seed.ts.
 _PERMISSION_TO_BUCKET: dict[str, str] = {
     # — Writes with an unambiguous single bucket —
     "tweet.moderate.write": "content.manage",

--- a/crates/runner/mitm-addon/tests/test_x_billing.py
+++ b/crates/runner/mitm-addon/tests/test_x_billing.py
@@ -350,7 +350,7 @@ class TestOverrideClassification:
 
 class TestSeedConsistency:
     """Every bucket the classifier can emit must have a pricing row in
-    ``turbo/apps/web/scripts/dev-seed.ts``.  Without that, the billing
+    ``turbo/apps/api/src/scripts/dev-seed.ts``.  Without that, the billing
     processor would stamp ``billing_error = 'missing_pricing'`` and
     charge $0 for legitimate requests.
     """
@@ -360,7 +360,8 @@ class TestSeedConsistency:
             pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent
             / "turbo"
             / "apps"
-            / "web"
+            / "api"
+            / "src"
             / "scripts"
             / "dev-seed.ts"
         )

--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "dev": "bash scripts/dev.sh",
     "start": "tsx src/server.ts",
+    "db:dev-seed": "dotenv -e .env.local -- tsx src/scripts/dev-seed.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' && eslint . --max-warnings 0",

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -1,16 +1,22 @@
 #!/usr/bin/env tsx
 
-import postgres from "postgres";
-import { drizzle } from "drizzle-orm/postgres-js";
 import { eq, sql } from "drizzle-orm";
 import { getEligibleConnectorTypes } from "@vm0/connectors/connector-utils";
 import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-providers";
 import { resolveSkillRef } from "@vm0/core/github-url";
 import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
-import { schema } from "@vm0/db";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { skills } from "@vm0/db/schema/skill";
+
+import { closeDbPool, db } from "../lib/db";
+import { optionalEnv } from "../lib/env";
+import { nowDate } from "../lib/time";
+import { settle } from "../signals/utils";
+
+function writeLine(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
 
 /**
  * Dev seed: populate usage_pricing, vm0_api_keys, and skills tables.
@@ -62,7 +68,7 @@ function buildSeedSkillValues(
   });
 }
 
-const USAGE_PRICING: (typeof usagePricing.$inferInsert)[] = [
+const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
   // Model usage in the unified usage_event ledger.
   ...usageGroup("model", "claude-sonnet-4-6", [
     ["tokens.input", usd(3), 1_000_000],
@@ -236,7 +242,7 @@ const USAGE_PRICING: (typeof usagePricing.$inferInsert)[] = [
 
   // BytePlus ModelArk video generation with a 200% provider-price multiplier.
   ...usageGroup("video", "dreamina-seedance-2-0-260128", [
-    ["output_video_tokens.480p_720p.no_video", usd(7.0 * 2), 1_000_000],
+    ["output_video_tokens.480p_720p.no_video", usd(7 * 2), 1_000_000],
     ["output_video_tokens.480p_720p.with_video", usd(4.3 * 2), 1_000_000],
     ["output_video_tokens.1080p.no_video", usd(7.7 * 2), 1_000_000],
     ["output_video_tokens.1080p.with_video", usd(4.7 * 2), 1_000_000],
@@ -254,7 +260,7 @@ const USAGE_PRICING: (typeof usagePricing.$inferInsert)[] = [
   // $0.015/minute cost with 20% gross margin = $0.01875/minute,
   // rounded to 19 credits/minute.
   ...usageGroup("audio", "gpt-4o-mini-tts", [
-    ["output_audio_seconds", usd(0.01875), 60],
+    ["output_audio_seconds", usd(0.018_75), 60],
   ]),
 ];
 
@@ -278,13 +284,15 @@ function buildVm0ApiKeys(): (typeof vm0ApiKeys.$inferInsert)[] {
     const envVars = vendor === "openai" ? [envVar, "OPENAI_API_KEY"] : [envVar];
     const apiKey = envVars
       .map((name) => {
-        return process.env[name];
+        return optionalEnv(name);
       })
       .find((value): value is string => {
         return typeof value === "string" && value.length > 0;
       });
     if (!apiKey) {
-      console.log(`  ⚠ ${envVars.join(" or ")} not set, skipping ${vendor}`);
+      writeLine(
+        `Skipping ${vendor}: ${envVars.join(" or ")} is not configured`,
+      );
       continue;
     }
     for (const model of models) {
@@ -295,70 +303,71 @@ function buildVm0ApiKeys(): (typeof vm0ApiKeys.$inferInsert)[] {
 }
 
 async function devSeed() {
-  if (!process.env.DATABASE_URL) {
+  if (!optionalEnv("DATABASE_URL")) {
     throw new Error("DATABASE_URL environment variable is not set");
   }
 
-  const client = postgres(process.env.DATABASE_URL, { max: 1 });
-  const db = drizzle(client, { schema });
+  const database = db();
 
-  try {
-    // --- usage_pricing (batch upsert) ---
-    console.log("Seeding usage_pricing...");
-    for (const p of USAGE_PRICING) {
-      await db
-        .insert(usagePricing)
-        .values(p)
-        .onConflictDoUpdate({
-          target: [
-            usagePricing.kind,
-            usagePricing.provider,
-            usagePricing.category,
-          ],
-          set: {
-            unitPrice: sql`excluded.unit_price`,
-            unitSize: sql`excluded.unit_size`,
-            updatedAt: new Date(),
-          },
-        });
-      console.log(
-        `  ${p.kind}/${p.provider}/${p.category}: ${p.unitPrice} credits per ${p.unitSize}`,
-      );
-    }
-    console.log(`✅ Seeded ${USAGE_PRICING.length} usage pricing entries`);
-
-    // --- vm0_api_keys (transactional replace) ---
-    console.log("Seeding vm0_api_keys...");
-    const apiKeys = buildVm0ApiKeys();
-    await db.transaction(async (tx) => {
-      await tx.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, "dev-seed"));
-      if (apiKeys.length > 0) {
-        await tx.insert(vm0ApiKeys).values(apiKeys);
-      }
-    });
-    for (const k of apiKeys) {
-      console.log(`  ${k.vendor}/${k.model}`);
-    }
-    console.log(`✅ Seeded ${apiKeys.length} vm0 API key entries`);
-
-    // --- skills (seed skills + common connectors, batch insert) ---
-    console.log("Seeding skills...");
-    const eligibleConnectorTypes = getEligibleConnectorTypes();
-    const skillValues = buildSeedSkillValues([
-      ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),
-    ]);
-    const inserted = await db
-      .insert(skills)
-      .values(skillValues)
-      .onConflictDoNothing()
-      .returning({ id: skills.id });
-    const seededCount = inserted.length;
-    console.log(
-      `✅ Seeded skills: ${seededCount} new, ${skillValues.length - seededCount} already existed`,
+  // --- usage_pricing (batch upsert) ---
+  writeLine("Seeding usage_pricing");
+  for (const p of USAGE_PRICING) {
+    await database
+      .insert(usagePricing)
+      .values(p)
+      .onConflictDoUpdate({
+        target: [
+          usagePricing.kind,
+          usagePricing.provider,
+          usagePricing.category,
+        ],
+        set: {
+          unitPrice: sql`excluded.unit_price`,
+          unitSize: sql`excluded.unit_size`,
+          updatedAt: nowDate(),
+        },
+      });
+    writeLine(
+      `Seeded usage pricing entry: ${p.kind}/${p.provider}/${p.category}`,
     );
-  } finally {
-    await client.end();
   }
+  writeLine(`Seeded ${USAGE_PRICING.length} usage pricing entries`);
+
+  // --- vm0_api_keys (transactional replace) ---
+  writeLine("Seeding vm0_api_keys");
+  const apiKeys = buildVm0ApiKeys();
+  await database.transaction(async (tx) => {
+    await tx.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, "dev-seed"));
+    if (apiKeys.length > 0) {
+      await tx.insert(vm0ApiKeys).values(apiKeys);
+    }
+  });
+  for (const k of apiKeys) {
+    writeLine(`Seeded vm0 API key entry: ${k.vendor}/${k.model}`);
+  }
+  writeLine(`Seeded ${apiKeys.length} vm0 API key entries`);
+
+  // --- skills (seed skills + common connectors, batch insert) ---
+  writeLine("Seeding skills");
+  const eligibleConnectorTypes = getEligibleConnectorTypes();
+  const skillValues = buildSeedSkillValues([
+    ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),
+  ]);
+  const inserted = await database
+    .insert(skills)
+    .values(skillValues)
+    .onConflictDoNothing()
+    .returning({ id: skills.id });
+  const seededCount = inserted.length;
+  writeLine(
+    `Seeded ${seededCount} new skills and kept ${
+      skillValues.length - seededCount
+    } existing skills`,
+  );
 }
 
-await devSeed();
+const result = await settle(devSeed());
+await closeDbPool();
+if (!result.ok) {
+  throw result.error;
+}

--- a/turbo/apps/web/app/[locale]/models/data.ts
+++ b/turbo/apps/web/app/[locale]/models/data.ts
@@ -7,7 +7,7 @@
 //     (VM0_MODEL_TO_PROVIDER, MODEL_PROVIDER_TYPES)
 //   - turbo/apps/platform/.../settings/provider-ui-config.ts
 //     (VM0_MODEL_CREDIT_MULTIPLIER)
-//   - turbo/apps/web/scripts/dev-seed.ts (MODEL_PRICING. USD per 1M tokens)
+//   - turbo/apps/api/src/scripts/dev-seed.ts (MODEL_PRICING. USD per 1M tokens)
 //
 // Generation models (image, video, audio): per-unit pricing mirrors the same
 // dev-seed.ts table (USD per image / megapixel / video-second / audio-second).

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -13,7 +13,7 @@
     "check-types": "next typegen && tsc --noEmit",
     "db:migrate": "pnpm -F @vm0/db db:migrate",
     "db:generate": "pnpm -F @vm0/db db:generate",
-    "db:dev-seed": "dotenv -e .env.local -- tsx scripts/dev-seed.ts",
+    "db:dev-seed": "dotenv -e .env.local -- pnpm -F api db:dev-seed",
     "db:studio": "pnpm -F @vm0/db db:studio",
     "db:reset": "pnpm -F @vm0/db db:reset"
   },
@@ -38,7 +38,6 @@
     "next": "^16.2.6",
     "next-intl": "^4.11.0",
     "pg": "^8.16.3",
-    "postgres": "^3.4.9",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",
@@ -69,7 +68,6 @@
     "oxlint": "^1.57.0",
     "oxlint-tsgolint": "0.23.0",
     "postcss": "^8.5.6",
-    "tsx": "^4.21.0",
     "typescript": "5.9.3",
     "vitest": "^4.1.7"
   }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -10,7 +10,6 @@
         "proxy.cors.ts",
         "i18n.ts",
         "navigation.ts",
-        "scripts/**/*.{ts,tsx}",
         "**/__tests__/**/*.{test,spec}.{ts,tsx}",
         "**/*.{test,spec}.{ts,tsx}",
         "src/__tests__/api-test-helpers/index.ts",
@@ -21,8 +20,7 @@
         "!**/__tests__/**!",
         "!**/*.{test,spec}.{ts,tsx}!",
         "!src/lib/test-endpoints/**!",
-        "!src/mocks/**!",
-        "scripts/**/*.ts"
+        "!src/mocks/**!"
       ],
       "ignoreDependencies": [
         "@vm0/ui",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/api:
     dependencies:
@@ -304,7 +304,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cli:
     dependencies:
@@ -395,7 +395,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -459,7 +459,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/host-worker:
     devDependencies:
@@ -664,7 +664,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -728,9 +728,6 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.20.0
-      postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -816,15 +813,12 @@ importers:
       postcss:
         specifier: '>=8.5.10'
         version: 8.5.10
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/api-contracts:
     dependencies:
@@ -864,7 +858,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/api-services:
     devDependencies:
@@ -888,7 +882,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/connectors:
     dependencies:
@@ -925,7 +919,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/core:
     dependencies:
@@ -959,7 +953,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/db:
     dependencies:
@@ -1014,7 +1008,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -1068,7 +1062,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1178,7 +1172,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -9983,7 +9977,6 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -14867,7 +14860,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14883,7 +14876,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -14903,7 +14896,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@vitest/browser': 4.1.7(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.7)
 
@@ -14952,7 +14945,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -20130,7 +20123,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -20160,7 +20153,18 @@ snapshots:
       '@vitest/ui': 4.1.7(vitest@4.1.7)
       happy-dom: 20.9.0
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary
- move the dev database seed script from `apps/web` to `apps/api/src/scripts`
- run the seed through API database/env helpers and keep the web script as a compatibility wrapper
- update the migration CI job and knip config now that web has no TypeScript scripts
- update mitm X billing seed consistency checks for the new API-owned seed path
- pass the minimal API env needed for the web deploy Neon seed step

## Validation
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace web`
- `pnpm knip`
- `pnpm -F api db:dev-seed`
- `pnpm -F web db:dev-seed`
- `python3 -m ruff format src/usage/providers/connectors/x_billing.py tests/test_x_billing.py`
- `python3 -m ruff check src/usage/providers/connectors/x_billing.py tests/test_x_billing.py`
- `python3 -m pytest tests/test_x_billing.py -v`
- `python3 -m pytest tests/ -v`
- pre-commit: `pnpm knip --cache`, `pnpm check-types`, ruff format/check
