### PR TITLE
fix(platform): restore workspace switcher without manage action

### DIFF
--- a/turbo/apps/platform/src/signals/select-org/org-switcher-ui.ts
+++ b/turbo/apps/platform/src/signals/select-org/org-switcher-ui.ts
@@ -1,0 +1,23 @@
+import { command, computed, state } from "ccstate";
+
+const internalCreatingOrg$ = state(false);
+
+export const creatingOrg$ = computed((get) => {
+  return get(internalCreatingOrg$);
+});
+
+export const setCreatingOrg$ = command(({ set }, value: boolean) => {
+  set(internalCreatingOrg$, value);
+});
+
+const internalAcceptingInvitationId$ = state<string | null>(null);
+
+export const acceptingInvitationId$ = computed((get) => {
+  return get(internalAcceptingInvitationId$);
+});
+
+export const setAcceptingInvitationId$ = command(
+  ({ set }, value: string | null) => {
+    set(internalAcceptingInvitationId$, value);
+  },
+);

--- a/turbo/apps/platform/src/signals/user-invitations.ts
+++ b/turbo/apps/platform/src/signals/user-invitations.ts
@@ -1,0 +1,29 @@
+import { command, computed, state } from "ccstate";
+import { clerk$ } from "./auth.ts";
+
+const reloadInvitations$ = state(0);
+
+/**
+ * Pending organization invitations for the current user.
+ * Re-fetches when `refreshUserInvitations$` is called or the poll loop ticks.
+ */
+export const userInvitations$ = computed(async (get) => {
+  get(reloadInvitations$);
+  const clerk = await get(clerk$);
+  const user = clerk.user;
+  if (!user) {
+    return [];
+  }
+
+  const result = await user.getOrganizationInvitations({ status: "pending" });
+  return result.data;
+});
+
+/**
+ * Trigger an immediate re-fetch of the user invitations signal.
+ */
+export const refreshUserInvitations$ = command(({ set }) => {
+  set(reloadInvitations$, (x) => {
+    return x + 1;
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -1,0 +1,450 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  fireClerkListeners,
+  mockedClerk,
+  mockOrganization,
+} from "../../../__tests__/mock-auth.ts";
+import { setMockOrg, resetMockOrg } from "../../../mocks/handlers/api-org.ts";
+
+const context = testContext();
+
+beforeEach(() => {
+  resetMockOrg();
+});
+
+describe("zero org switcher - current org avatar and name render (SIDEBAR-D-054)", () => {
+  it("displays the current organization name in the sidebar trigger", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Acme Corp" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - organization slug renders (SIDEBAR-D-055)", () => {
+  it("displays the organization slug in the dropdown header", async () => {
+    setMockOrg({
+      id: "org_1",
+      slug: "acme-corp",
+      name: "Acme Corp",
+      role: "admin",
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Acme Corp" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    });
+    click(screen.getByText("Acme Corp"));
+
+    await waitFor(() => {
+      expect(screen.getByText("acme-corp")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - pending invitations badge shows count (SIDEBAR-D-056)", () => {
+  it("shows a red dot badge when there are pending invitations", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [{ id: "org_1" }],
+        pendingInvitations: [
+          {
+            id: "inv_1",
+            publicOrganizationData: {
+              id: "org_invited",
+              name: "Invited Org",
+              imageUrl: "",
+            },
+            accept: () => {
+              return Promise.resolve({});
+            },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("pending-invitations-badge"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - pending invitations list renders (SIDEBAR-D-057)", () => {
+  it("shows pending invitation items when dropdown is opened", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [{ id: "org_1" }],
+        pendingInvitations: [
+          {
+            id: "inv_1",
+            publicOrganizationData: {
+              id: "org_invited",
+              name: "Invited Org",
+              imageUrl: "",
+            },
+            accept: () => {
+              return Promise.resolve({});
+            },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Current Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invited Org")).toBeInTheDocument();
+      expect(screen.getByText("Join")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - other org memberships list renders (SIDEBAR-D-058)", () => {
+  it("shows other organizations the user belongs to when dropdown is opened", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [
+          { id: "org_1", organization: { id: "org_1", name: "Current Org" } },
+          { id: "org_2", organization: { id: "org_2", name: "Other Org" } },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Current Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Other Org")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - dropdown opens (SIDEBAR-D-059)", () => {
+  it("shows workspace actions without the Manage shortcut", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+    mockedClerk.user!.createOrganizationEnabled = true;
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Current Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Create workspace")).toBeInTheDocument();
+    });
+    expect(within(screen.getByRole("menu")).queryByText("Manage")).toBeNull();
+  });
+});
+
+describe("zero org switcher - org switch menu item switches organization (SIDEBAR-D-061)", () => {
+  it("calls setActive with the selected org and closes the dropdown", async () => {
+    // Simulate the production behavior: setActive updates the active org in Clerk
+    // and fires the org-change listener. In production, watchOrgSwitch$ detects
+    // the change and navigates to "/" for a full page reload with the new org
+    // context. Here we verify the component correctly hands off to Clerk and the
+    // dropdown closes as the visible UI outcome.
+    mockedClerk.setActive.mockImplementation(
+      ({ organization }: { organization: string }) => {
+        mockOrganization({
+          activeOrg: { id: organization, name: "Other Org" },
+          memberships: [
+            {
+              id: "org_1",
+              organization: { id: "org_1", name: "Current Org" },
+            },
+            {
+              id: "org_2",
+              organization: { id: "org_2", name: "Other Org" },
+            },
+          ],
+        });
+        fireClerkListeners();
+        return Promise.resolve();
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [
+          { id: "org_1", organization: { id: "org_1", name: "Current Org" } },
+          { id: "org_2", organization: { id: "org_2", name: "Other Org" } },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Current Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Other Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Other Org"));
+
+    // Dropdown closes after selection (visible UI outcome)
+    await waitFor(() => {
+      expect(screen.queryByText("Create workspace")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - join button accepts invitation (SIDEBAR-D-062)", () => {
+  it("removes the invitation from the list after Join is clicked", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [{ id: "org_1" }],
+        pendingInvitations: [
+          {
+            id: "inv_1",
+            publicOrganizationData: {
+              id: "org_invited",
+              name: "Invited Org",
+              imageUrl: "",
+            },
+            accept: () => {
+              // Simulate acceptance clearing the invitation from the server
+              mockOrganization({
+                activeOrg: { id: "org_1", name: "Current Org" },
+                memberships: [{ id: "org_1" }],
+                pendingInvitations: [],
+              });
+              return Promise.resolve({});
+            },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Current Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Join")).toBeInTheDocument();
+    });
+    click(screen.getByText("Join"));
+
+    // After acceptance, the invitation is refreshed and removed from the list
+    await waitFor(() => {
+      expect(screen.queryByText("Join")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - create workspace item starts creation flow (SIDEBAR-D-063)", () => {
+  it("closes the dropdown after creating a new workspace", async () => {
+    // Simulate the production behavior: createOrganization creates the org, then
+    // setActive activates it. In production, watchOrgSwitch$ detects the active
+    // org change and navigates to "/" for a full page reload with the new workspace
+    // context. Here we verify the dropdown closes as the visible UI outcome.
+    mockedClerk.setActive.mockImplementation(
+      ({ organization }: { organization: string }) => {
+        mockOrganization({
+          activeOrg: { id: organization, name: "New Workspace" },
+          memberships: [
+            { id: "org_1", organization: { id: "org_1", name: "Current Org" } },
+            {
+              id: organization,
+              organization: { id: organization, name: "New Workspace" },
+            },
+          ],
+        });
+        fireClerkListeners();
+        return Promise.resolve();
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+    mockedClerk.user!.createOrganizationEnabled = true;
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("Current Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Create workspace")).toBeInTheDocument();
+    });
+    click(screen.getByText("Create workspace"));
+
+    // Dropdown closes after activation (visible UI outcome)
+    await waitFor(() => {
+      expect(screen.queryByText("Create workspace")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero org switcher - pending invitations badge hidden when none (SIDEBAR-D-064)", () => {
+  it("should not show red dot when there are no pending invitations", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "Current Org" },
+        memberships: [{ id: "org_1" }],
+        pendingInvitations: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Current Org")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("pending-invitations-badge"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("zero org switcher - sidebar re-renders on Clerk listener event", () => {
+  it("updates the sidebar avatar and name when Clerk mutates the active org in place", async () => {
+    // Reproduces the bug fixed by this PR: Clerk's SDK mutates
+    // `clerk.organization.imageUrl` in place after `reload()`, and
+    // components reading the Clerk object directly never re-rendered.
+    // The fix routes reads through `currentOrgInfo$`, which re-emits a
+    // fresh snapshot on every Clerk listener event.
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: {
+          id: "org_1",
+          name: "Original Name",
+          imageUrl: "https://example.com/original.png",
+          hasImage: true,
+        },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+
+    // Initial render uses the original name + avatar
+    const initialImg = await waitFor(() => {
+      const img = screen.getByAltText("Original Name") as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      return img;
+    });
+    expect(initialImg.src).toBe("https://example.com/original.png");
+
+    // Simulate Clerk's in-place mutation after `organization.reload()`
+    mockOrganization({
+      activeOrg: {
+        id: "org_1",
+        name: "Renamed Workspace",
+        imageUrl: "https://example.com/updated.png",
+        hasImage: true,
+      },
+      memberships: [{ id: "org_1" }],
+    });
+    fireClerkListeners();
+
+    // Sidebar must reflect both the new name and the new logo without a page reload
+    await waitFor(() => {
+      const updatedImg = screen.getByAltText(
+        "Renamed Workspace",
+      ) as HTMLImageElement;
+      expect(updatedImg).toBeInTheDocument();
+      expect(updatedImg.src).toBe("https://example.com/updated.png");
+    });
+    expect(screen.getByText("Renamed Workspace")).toBeInTheDocument();
+  });
+});
+
+describe("zero org switcher - create workspace visibility based on createOrganizationEnabled", () => {
+  it("hides create workspace when createOrganizationEnabled is false", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "My Org" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("My Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("My Org"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Create workspace")).not.toBeInTheDocument();
+  });
+
+  it("shows create workspace when createOrganizationEnabled is true", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "My Org" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+    mockedClerk.user!.createOrganizationEnabled = true;
+
+    await waitFor(() => {
+      expect(screen.getByText("My Org")).toBeInTheDocument();
+    });
+    click(screen.getByText("My Org"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Create workspace")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -1,0 +1,291 @@
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@vm0/ui";
+import { IconChevronDown, IconPlus, IconMail } from "@tabler/icons-react";
+import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
+import {
+  bestEffort,
+  detach,
+  onDomEventFn,
+  Reason,
+} from "../../signals/utils.ts";
+import { org$ } from "../../signals/org.ts";
+import {
+  userInvitations$,
+  refreshUserInvitations$,
+} from "../../signals/user-invitations.ts";
+import {
+  creatingOrg$,
+  setCreatingOrg$,
+  acceptingInvitationId$,
+  setAcceptingInvitationId$,
+} from "../../signals/select-org/org-switcher-ui.ts";
+
+function OrgAvatar({
+  name,
+  imageUrl,
+  size = "sm",
+}: {
+  name: string;
+  imageUrl?: string | null;
+  size?: "sm" | "lg";
+}) {
+  const dim = size === "lg" ? "h-10 w-10" : "h-6 w-6";
+  const radius = size === "lg" ? "rounded-xl" : "rounded-md";
+  const textSize = size === "lg" ? "text-base" : "text-[11px]";
+  const initial = name.charAt(0).toUpperCase();
+
+  if (imageUrl) {
+    return (
+      <img
+        src={imageUrl}
+        alt={name}
+        className={`${dim} ${radius} object-cover shrink-0`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${dim} ${radius} bg-[hsl(var(--gray-200))] text-[hsl(var(--primary-700))] flex items-center justify-center ${textSize} font-bold shrink-0`}
+    >
+      {initial}
+    </div>
+  );
+}
+
+function InvitationRow({
+  invitation,
+}: {
+  invitation: {
+    id: string;
+    publicOrganizationData: { name: string; imageUrl: string };
+    accept: () => Promise<unknown>;
+  };
+}) {
+  const acceptingId = useGet(acceptingInvitationId$);
+  const setAcceptingId = useSet(setAcceptingInvitationId$);
+  const refreshInvitations = useSet(refreshUserInvitations$);
+  const isAccepting = acceptingId === invitation.id;
+
+  const handleAccept = onDomEventFn(async () => {
+    setAcceptingId(invitation.id);
+    await bestEffort(
+      (async () => {
+        await invitation.accept();
+        refreshInvitations();
+      })(),
+    );
+    setAcceptingId(null);
+  });
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5">
+      <OrgAvatar
+        name={invitation.publicOrganizationData.name}
+        imageUrl={invitation.publicOrganizationData.imageUrl}
+      />
+      <span className="min-w-0 flex-1 text-sm truncate">
+        {invitation.publicOrganizationData.name}
+      </span>
+      <button
+        type="button"
+        disabled={isAccepting}
+        onClick={handleAccept}
+        className="shrink-0 flex items-center gap-1 px-2 h-7 rounded-md text-xs font-medium text-muted-foreground border border-border hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
+      >
+        <IconMail size={13} />
+        {isAccepting ? "Joining…" : "Join"}
+      </button>
+    </div>
+  );
+}
+
+function CreateWorkspaceItem() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const creatingOrg = useGet(creatingOrg$);
+  const setCreating = useSet(setCreatingOrg$);
+
+  const handleCreateOrg = onDomEventFn(async () => {
+    if (!clerk) {
+      return;
+    }
+    setCreating(true);
+    const slug = `workspace-${crypto.randomUUID().slice(0, 8)}`;
+    await bestEffort(
+      (async () => {
+        const org = await clerk.createOrganization({ name: slug, slug });
+        await clerk.setActive({ organization: org.id });
+      })(),
+    );
+    setCreating(false);
+  });
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        onClick={handleCreateOrg}
+        disabled={clerk === null || creatingOrg}
+        className="gap-3 px-3 py-2.5 rounded-lg"
+      >
+        <IconPlus
+          size={18}
+          stroke={1.5}
+          className="shrink-0 text-muted-foreground"
+        />
+        <span>{creatingOrg ? "Creating…" : "Create workspace"}</span>
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+function OtherMembershipsList() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const memberships = clerk?.user?.organizationMemberships ?? [];
+  const currentOrgId = clerk?.organization?.id;
+
+  const otherMemberships = memberships.filter((m) => {
+    return m.organization && m.organization.id !== currentOrgId;
+  });
+
+  if (otherMemberships.length === 0) {
+    return null;
+  }
+
+  const handleSwitchOrg = (orgId: string) => {
+    detach(clerk?.setActive({ organization: orgId }), Reason.DomCallback);
+  };
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      {otherMemberships.map((membership) => {
+        return (
+          <DropdownMenuItem
+            key={membership.organization.id}
+            onClick={() => {
+              handleSwitchOrg(membership.organization.id);
+            }}
+            className="gap-3 px-3 py-2.5 rounded-lg"
+          >
+            <OrgAvatar
+              name={membership.organization.name}
+              imageUrl={membership.organization.imageUrl}
+            />
+            <span className="truncate flex-1">
+              {membership.organization.name}
+            </span>
+          </DropdownMenuItem>
+        );
+      })}
+    </>
+  );
+}
+
+function OrgDropdownContent() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const orgData = useLastResolved(org$);
+  const pendingInvitations = useLastResolved(userInvitations$);
+  const currentOrg = useLastResolved(currentOrgInfo$);
+
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const orgName = currentOrg?.name ?? "Organization";
+  const orgSlug = orgData?.slug;
+
+  const hasPendingInvitations =
+    pendingInvitations !== undefined && pendingInvitations.length > 0;
+  const canCreateOrg = clerk?.user?.createOrganizationEnabled ?? false;
+
+  return (
+    <DropdownMenuContent align="start" className="w-72">
+      <div className="flex items-center gap-3 px-2 py-1.5">
+        <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} size="lg" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-tight truncate text-foreground">
+            {orgName}
+          </p>
+          {orgSlug && (
+            <p className="text-xs text-muted-foreground truncate mt-0.5">
+              {orgSlug}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <OtherMembershipsList />
+
+      {/* Pending invitations */}
+      {hasPendingInvitations && (
+        <>
+          <DropdownMenuSeparator />
+          {pendingInvitations.map((invitation) => {
+            return (
+              <InvitationRow key={invitation.id} invitation={invitation} />
+            );
+          })}
+        </>
+      )}
+
+      {canCreateOrg && <CreateWorkspaceItem />}
+    </DropdownMenuContent>
+  );
+}
+
+function PendingInvitationsBadge() {
+  const pendingInvitations = useLastResolved(userInvitations$);
+  const hasPendingInvitations =
+    pendingInvitations !== undefined && pendingInvitations.length > 0;
+  if (!hasPendingInvitations) {
+    return null;
+  }
+  return (
+    <span
+      data-testid="pending-invitations-badge"
+      className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-destructive ring-2 ring-sidebar"
+    />
+  );
+}
+
+export function ZeroOrgSwitcher() {
+  const currentOrg = useLastResolved(currentOrgInfo$);
+  const orgName = currentOrg?.name ?? "Organization";
+
+  return (
+    <div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-sidebar-accent text-sidebar-foreground transition-colors"
+          >
+            <span className="relative shrink-0">
+              <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />
+              <PendingInvitationsBadge />
+            </span>
+            <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">
+              {orgName}
+            </span>
+            <IconChevronDown
+              size={16}
+              className="ml-auto shrink-0 text-muted-foreground"
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <OrgDropdownContent />
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -49,6 +49,7 @@ import {
   manageSectionCollapsed$,
   setManageSectionCollapsed$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
+import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
 import { Link } from "../router/link.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { slackOrgScopeMismatch$ } from "../../signals/zero-page/zero-slack.ts";
@@ -391,7 +392,10 @@ function ExpandedHeader() {
   return (
     <div className="zero-sidebar-header shrink-0 px-2 pb-0">
       <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
-      <div className="zero-desktop-no-drag flex items-center justify-end gap-2 rounded-lg py-0.5">
+      <div className="zero-desktop-no-drag flex items-center justify-between gap-2 rounded-lg py-0.5">
+        <div className="min-w-0 flex-1">
+          <ZeroOrgSwitcher />
+        </div>
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Restore the expanded-sidebar workspace switcher so users can switch workspaces, accept invitations, and create workspaces.
- Remove only the Manage shortcut from the workspace menu.
- Restore and update the workspace switcher coverage to assert Manage stays absent.

## Checks
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip
- pnpm test
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-org-switcher.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app test
- pnpm knip --workspace @vm0/app