### PR TITLE
fix(web): align docs home title and sidebar with sub-pages

### DIFF
--- a/turbo/apps/web/app/[locale]/docs/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/page.tsx
@@ -103,14 +103,12 @@ export default async function DocsIndexPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
       <Particles />
-      <section className="docs-hero">
-        <div className="container">
+      <DocsShell navigation={navigation} homeLabel={t("home")} draft={draft}>
+        <header className="docs-article-header">
           <p className="docs-kicker">{t("kicker")}</p>
           <h1 className="docs-title">{t("title")}</h1>
           <p className="docs-description">{t("description")}</p>
-        </div>
-      </section>
-      <DocsShell navigation={navigation} homeLabel={t("home")} draft={draft}>
+        </header>
         {pages.length > 0 ? (
           <div className="docs-index-grid">
             {pages.map((page) => {

--- a/turbo/apps/web/app/docs.css
+++ b/turbo/apps/web/app/docs.css
@@ -1,16 +1,10 @@
 /* ===== DOCS LAYOUT ===== */
 
-.docs-hero {
-  padding: calc(var(--total-header-height) + 72px) 0 36px;
-  position: relative;
-  z-index: 1;
-}
-
 .docs-shell {
   width: 100%;
   max-width: 1180px;
   margin: 0 auto;
-  padding: 0 30px 96px;
+  padding: calc(var(--total-header-height) + 48px) 30px 96px;
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
@@ -176,7 +170,6 @@
 }
 
 .docs-article-header {
-  padding-top: calc(var(--total-header-height) + 48px);
   margin-bottom: 42px;
 }
 
@@ -197,6 +190,7 @@
   .docs-shell {
     grid-template-columns: 1fr;
     gap: 32px;
+    padding-top: calc(var(--total-header-height) + 24px);
     padding-bottom: 72px;
   }
 
@@ -211,17 +205,9 @@
   .docs-index-grid {
     grid-template-columns: 1fr;
   }
-
-  .docs-article-header {
-    padding-top: 24px;
-  }
 }
 
 @media (max-width: 768px) {
-  .docs-hero {
-    padding: calc(var(--total-header-height) + 48px) 0 28px;
-  }
-
   .docs-title {
     font-size: 36px;
     line-height: 1.2;


### PR DESCRIPTION
## Summary
- Render the docs home page title inside `DocsShell` as `docs-article-header` instead of a standalone `docs-hero` section, so the home and sub-pages share one layout and the home page no longer renders without an article title.
- Move the top header offset onto `.docs-shell` (and drop it from `.docs-article-header`) so the sticky `Docs home` sidebar link aligns with `Back to docs` / the kicker on sub-pages. Previously the sidebar sat 24px higher than the article header on every doc page.
- Drop the now-unused `.docs-hero` rules and its mobile override.

## Before
- Clicking **Docs home** from a sub-page caused a visible jump: the hero shifted the sidebar down and the home page rendered without a title in the main column.
- `Docs home` in the sidebar was visibly higher than `Back to docs` and the article kicker (header+24px vs header+48px).

## After
- `Docs home` in the sidebar lines up with the article header on every page.
- Navigating between home and sub-pages keeps the sidebar and main column in the same place.

## Test plan
- [ ] Run `pnpm --filter web dev` and open `/en/docs`, confirm the title sits inside the main column at the same vertical position as a sub-page's kicker.
- [ ] Navigate Channels → Docs home → Chat and confirm no layout jump.
- [ ] Confirm sticky `Docs home` link aligns with `Back to docs` on each sub-page.
- [ ] Resize to <=960px and <=768px, confirm mobile layout still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)