### PR TITLE
chore(connectors): remove managed grant fields

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
@@ -56,10 +56,6 @@ describe("firewall secret name consistency", () => {
               }
               break;
             case "managed":
-              for (const name of Object.keys(method.grant.fields ?? {})) {
-                connectorSecretNames.add(name);
-              }
-              break;
             case "auth-code":
             case "device-auth":
             case "interactive-pairing":

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -88,7 +88,6 @@ function getManualGrantFields(
     case "manual":
       return method.grant.fields;
     case "managed":
-      return method.grant.fields;
     case "auth-code":
     case "device-auth":
     case "interactive-pairing":

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -371,7 +371,6 @@ export interface ConnectorInteractivePairingGrantConfig {
 
 export interface ConnectorManagedGrantConfig {
   readonly kind: "managed";
-  readonly fields?: Record<string, ConnectorManualGrantFieldConfig>;
 }
 
 export type ConnectorGrantConfig =

--- a/turbo/packages/connectors/src/connectors/computer.ts
+++ b/turbo/packages/connectors/src/connectors/computer.ts
@@ -12,23 +12,7 @@ export const computer = {
         featureFlag: FeatureSwitchKey.ComputerConnector,
         label: "API",
         helpText: "Server-provisioned ngrok tunnel credentials.",
-        grant: {
-          kind: "managed",
-          fields: {
-            COMPUTER_CONNECTOR_BRIDGE_TOKEN: {
-              label: "Bridge Token",
-              required: true,
-            },
-            COMPUTER_CONNECTOR_DOMAIN_ID: {
-              label: "Domain ID",
-              required: true,
-            },
-            COMPUTER_CONNECTOR_DOMAIN: {
-              label: "Tunnel Domain",
-              required: true,
-            },
-          },
-        },
+        grant: { kind: "managed" },
         access: {
           kind: "managed",
           outputs: {


### PR DESCRIPTION
## Summary
- remove the unused `fields` property from managed connector grant config
- stop treating managed grant config as a manual field source
- simplify the computer connector managed grant metadata

## Testing
- `pnpm -F @vm0/connectors test`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm exec prettier --check packages/connectors/src/connectors.ts packages/connectors/src/connector-utils.ts packages/connectors/src/connectors/computer.ts packages/connectors/src/__tests__/firewall-secret-consistency.test.ts`
- pre-commit: `pnpm knip`
- pre-commit: `pnpm check-types`