### PR TITLE
fix: validate model provider env placeholders in runner

### DIFF
--- a/crates/api-contracts/src/generated/model_providers.rs
+++ b/crates/api-contracts/src/generated/model_providers.rs
@@ -15,3 +15,22 @@ pub mod codex_oauth_token {
         pub const CHATGPT_REFRESH_TOKEN: &str = "rt_VM0_PLACEHOLDER_DO_NOT_TRUST";
     }
 }
+
+pub mod model_provider_env {
+    pub mod placeholders {
+        pub const ANTHROPIC_API_KEY: &str = "sk-ant-api03-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA";
+
+        pub const ANTHROPIC_AUTH_TOKEN: &str = "sk-CoffeeSafeLocalCoffeeSafeLocalCo";
+
+        pub const CHATGPT_ACCESS_TOKEN: &str =
+            "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal";
+
+        pub const CHATGPT_ACCOUNT_ID: &str = "ws_VM0_PLACEHOLDER_DO_NOT_TRUST";
+
+        pub const CHATGPT_REFRESH_TOKEN: &str = "rt_VM0_PLACEHOLDER_DO_NOT_TRUST";
+
+        pub const CLAUDE_CODE_OAUTH_TOKEN: &str = "sk-ant-oat01-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA";
+
+        pub const OPENAI_API_KEY: &str = "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca";
+    }
+}

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -34,6 +34,8 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use api_contracts::generated::model_providers::model_provider_env::placeholders as model_provider_placeholders;
+
 use crate::ids::RunId;
 
 /// Maximum wall-clock time for a single job (2 hours).
@@ -261,25 +263,35 @@ pub async fn execute_job(
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
-    let outcome = match execute_new_sandbox(
-        factory,
-        &context,
-        dispatch,
-        config,
-        params,
-        &mut telemetry,
-        cancel,
-    )
-    .await
-    {
-        Ok(outcome) => outcome,
-        Err(e) => ExecuteOutcome {
-            failure: Some(ExecutionFailure::from_error(e.to_string())),
+    let outcome = if let Err(error) = validate_model_provider_env_placeholders(&context) {
+        ExecuteOutcome {
+            failure: Some(ExecutionFailure::from_error(error)),
             sandbox: None,
             source_ip: String::new(),
             network_log_session: None,
             guest_session_id: None,
-        },
+        }
+    } else {
+        match execute_new_sandbox(
+            factory,
+            &context,
+            dispatch,
+            config,
+            params,
+            &mut telemetry,
+            cancel,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(e) => ExecuteOutcome {
+                failure: Some(ExecutionFailure::from_error(e.to_string())),
+                sandbox: None,
+                source_ip: String::new(),
+                network_log_session: None,
+                guest_session_id: None,
+            },
+        }
     };
 
     (outcome, telemetry)
@@ -312,16 +324,26 @@ pub async fn execute_job_reuse(
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
-    let outcome = execute_reused_sandbox(
-        sandbox,
-        &source_ip,
-        &context,
-        config,
-        &prev_storage,
-        &mut telemetry,
-        cancel,
-    )
-    .await;
+    let outcome = if let Err(error) = validate_model_provider_env_placeholders(&context) {
+        ExecuteOutcome {
+            failure: Some(ExecutionFailure::from_error(error)),
+            sandbox: Some(sandbox),
+            source_ip,
+            network_log_session: None,
+            guest_session_id: None,
+        }
+    } else {
+        execute_reused_sandbox(
+            sandbox,
+            &source_ip,
+            &context,
+            config,
+            &prev_storage,
+            &mut telemetry,
+            cancel,
+        )
+        .await
+    };
 
     (outcome, telemetry)
 }
@@ -381,6 +403,78 @@ fn elapsed_since_api_start_ms(api_start_ms: u64, now_ms: u64) -> Option<Duration
     }
 
     Some(Duration::from_millis(now_ms.saturating_sub(api_start_ms)))
+}
+
+struct ModelProviderPlaceholderEnvKey {
+    name: &'static str,
+    placeholder: &'static str,
+}
+
+const CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ModelProviderPlaceholderEnvKey] = &[
+    ModelProviderPlaceholderEnvKey {
+        name: "ANTHROPIC_API_KEY",
+        placeholder: model_provider_placeholders::ANTHROPIC_API_KEY,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "ANTHROPIC_AUTH_TOKEN",
+        placeholder: model_provider_placeholders::ANTHROPIC_AUTH_TOKEN,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CLAUDE_CODE_OAUTH_TOKEN",
+        placeholder: model_provider_placeholders::CLAUDE_CODE_OAUTH_TOKEN,
+    },
+];
+
+const CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ModelProviderPlaceholderEnvKey] = &[
+    ModelProviderPlaceholderEnvKey {
+        name: "OPENAI_API_KEY",
+        placeholder: model_provider_placeholders::OPENAI_API_KEY,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CHATGPT_ACCESS_TOKEN",
+        placeholder: model_provider_placeholders::CHATGPT_ACCESS_TOKEN,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CHATGPT_ACCOUNT_ID",
+        placeholder: model_provider_placeholders::CHATGPT_ACCOUNT_ID,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CHATGPT_REFRESH_TOKEN",
+        placeholder: model_provider_placeholders::CHATGPT_REFRESH_TOKEN,
+    },
+];
+
+const MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[&[ModelProviderPlaceholderEnvKey]] = &[
+    CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS,
+    CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS,
+];
+
+fn validate_model_provider_env_placeholders(context: &ExecutionContext) -> Result<(), String> {
+    let Some(environment) = &context.environment else {
+        return Ok(());
+    };
+
+    let invalid_keys: Vec<&str> = MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS
+        .iter()
+        .flat_map(|protected_keys| protected_keys.iter())
+        .filter_map(|protected_key| {
+            let value = environment.get(protected_key.name)?;
+            if value.is_empty() || value == protected_key.placeholder {
+                None
+            } else {
+                Some(protected_key.name)
+            }
+        })
+        .collect();
+
+    if invalid_keys.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "model provider environment contains non-placeholder values for: {}",
+        invalid_keys.join(", ")
+    ))
 }
 
 /// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM
@@ -2272,6 +2366,128 @@ mod tests {
             billable_firewalls: vec![],
             model_usage_provider: None,
         }
+    }
+
+    fn context_with_env(environment: HashMap<String, String>) -> ExecutionContext {
+        let mut ctx = minimal_context();
+        ctx.environment = Some(environment);
+        ctx
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_env_without_protected_keys() {
+        let ctx = context_with_env(HashMap::from([("PROJECT_ID".into(), "vm0".into())]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_anthropic_api_key_placeholder() {
+        let ctx = context_with_env(HashMap::from([(
+            "ANTHROPIC_API_KEY".into(),
+            model_provider_placeholders::ANTHROPIC_API_KEY.into(),
+        )]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_anthropic_api_key() {
+        let secret = "sk-ant-api03-real-secret-value";
+        let ctx = context_with_env(HashMap::from([("ANTHROPIC_API_KEY".into(), secret.into())]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("ANTHROPIC_API_KEY"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_empty_anthropic_api_key_with_auth_token() {
+        let ctx = context_with_env(HashMap::from([
+            ("ANTHROPIC_API_KEY".into(), String::new()),
+            (
+                "ANTHROPIC_AUTH_TOKEN".into(),
+                model_provider_placeholders::ANTHROPIC_AUTH_TOKEN.into(),
+            ),
+        ]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_anthropic_auth_token() {
+        let secret = "sk-real-openrouter-token";
+        let ctx = context_with_env(HashMap::from([(
+            "ANTHROPIC_AUTH_TOKEN".into(),
+            secret.into(),
+        )]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("ANTHROPIC_AUTH_TOKEN"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_claude_oauth_placeholder() {
+        let ctx = context_with_env(HashMap::from([(
+            "CLAUDE_CODE_OAUTH_TOKEN".into(),
+            model_provider_placeholders::CLAUDE_CODE_OAUTH_TOKEN.into(),
+        )]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_openai_api_key_placeholder() {
+        let ctx = context_with_env(HashMap::from([(
+            "OPENAI_API_KEY".into(),
+            model_provider_placeholders::OPENAI_API_KEY.into(),
+        )]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_openai_api_key() {
+        let secret = "sk-proj-real-openai-secret";
+        let ctx = context_with_env(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("OPENAI_API_KEY"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_codex_oauth_placeholders() {
+        let ctx = context_with_env(HashMap::from([
+            (
+                "CHATGPT_ACCESS_TOKEN".into(),
+                model_provider_placeholders::CHATGPT_ACCESS_TOKEN.into(),
+            ),
+            (
+                "CHATGPT_ACCOUNT_ID".into(),
+                model_provider_placeholders::CHATGPT_ACCOUNT_ID.into(),
+            ),
+        ]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_chatgpt_access_token() {
+        let secret = "ey-real-chatgpt-access-token";
+        let ctx = context_with_env(HashMap::from([(
+            "CHATGPT_ACCESS_TOKEN".into(),
+            secret.into(),
+        )]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("CHATGPT_ACCESS_TOKEN"));
+        assert!(!error.contains(secret));
     }
 
     #[test]
@@ -4947,6 +5163,41 @@ mod tests {
         assert!(outcome.sandbox.is_none());
     }
 
+    #[tokio::test]
+    async fn execute_job_model_provider_env_validation_failure_returns_run_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let secret = "sk-proj-real-openai-secret";
+        let mut ctx = minimal_context();
+        ctx.environment = Some(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::NoSessionId,
+            },
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(error.contains("OPENAI_API_KEY"));
+        assert!(!error.contains(secret));
+        assert!(outcome.sandbox.is_none());
+        assert!(
+            overrides.create_configs().is_empty(),
+            "fresh sandbox must not be created after env validation failure"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Keep-alive VM reuse integration tests
     // -----------------------------------------------------------------------
@@ -4983,6 +5234,35 @@ mod tests {
         assert_eq!(reuse_outcome.exit_code(), 0);
         assert!(reuse_outcome.error().is_none());
         assert!(reuse_outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_model_provider_env_validation_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let source_ip = sandbox.source_ip().to_string();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+        let secret = "sk-proj-real-openai-secret";
+        let mut ctx = minimal_context();
+        ctx.environment = Some(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, cancel).await;
+
+        assert_eq!(reuse_outcome.exit_code(), 1);
+        let error = reuse_outcome.error().unwrap();
+        assert!(error.contains("OPENAI_API_KEY"));
+        assert!(!error.contains(secret));
+        assert!(reuse_outcome.sandbox.is_some());
+        assert!(reuse_outcome.network_log_session.is_none());
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "reused sandbox must not start a process after env validation failure"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2471,6 +2471,10 @@ mod tests {
                 "CHATGPT_ACCOUNT_ID".into(),
                 model_provider_placeholders::CHATGPT_ACCOUNT_ID.into(),
             ),
+            (
+                "CHATGPT_REFRESH_TOKEN".into(),
+                model_provider_placeholders::CHATGPT_REFRESH_TOKEN.into(),
+            ),
         ]));
 
         assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
@@ -2487,6 +2491,20 @@ mod tests {
         let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
 
         assert!(error.contains("CHATGPT_ACCESS_TOKEN"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_chatgpt_refresh_token() {
+        let secret = "rt_real_chatgpt_refresh_token";
+        let ctx = context_with_env(HashMap::from([(
+            "CHATGPT_REFRESH_TOKEN".into(),
+            secret.into(),
+        )]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("CHATGPT_REFRESH_TOKEN"));
         assert!(!error.contains(secret));
     }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -867,6 +867,59 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.modelUsageProvider).toBeUndefined();
   });
 
+  it("injects a Codex gateway provider with the OPENAI_API_KEY placeholder", async () => {
+    const fx = await fixture();
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fx.orgId,
+        type: "openrouter-codex",
+        isDefault: true,
+        secretName: "OPENROUTER_API_KEY",
+      },
+      context.signal,
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fx.orgId }));
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: { framework: "codex", environment: {} },
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use codex provider",
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly cliAgentType: string;
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.cliAgentType).toBe("codex");
+    expect(executionContext.environment).toMatchObject({
+      OPENAI_API_KEY: modelProviderSecretPlaceholder(
+        "openrouter-codex",
+        "OPENROUTER_API_KEY",
+      ),
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+      OPENAI_MODEL: "openai/gpt-5.5",
+    });
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      OPENROUTER_API_KEY: "test-secret-value",
+    });
+  });
+
   it("persists requested artifacts plus memory on the new session", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -27,6 +27,7 @@ import {
   SUPPORTED_RUN_MODELS,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
   MODEL_PROVIDER_TYPES,
   modelProviderTypeSchema,
   modelProviderFrameworkSchema,
@@ -35,6 +36,28 @@ import {
 import { findMatchingPermissions } from "@vm0/connectors/firewall-rule-matcher";
 
 describe("model-first canonical catalog", () => {
+  it("exposes canonical model provider env placeholders", () => {
+    expect(Object.keys(MODEL_PROVIDER_ENV_PLACEHOLDERS).sort()).toEqual([
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_AUTH_TOKEN",
+      "CHATGPT_ACCESS_TOKEN",
+      "CHATGPT_ACCOUNT_ID",
+      "CHATGPT_REFRESH_TOKEN",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "OPENAI_API_KEY",
+    ]);
+    expect(MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY).toMatch(
+      /^sk-ant-api03-/,
+    );
+    expect(MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN).toMatch(
+      /^sk-ant-oat01-/,
+    );
+    expect(MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY).toMatch(/^sk-proj-/);
+    expect(
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN.split("."),
+    ).toHaveLength(1);
+  });
+
   it("exposes the curated flat model list only", () => {
     expect(SUPPORTED_RUN_MODELS).toEqual([
       "claude-opus-4-7",
@@ -410,6 +433,74 @@ describe("firewall base URL scoped to /v1/messages (#9560)", () => {
   );
 });
 
+describe("model provider firewall placeholders", () => {
+  it.each([
+    [
+      "anthropic-api-key",
+      "ANTHROPIC_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
+    ],
+    [
+      "claude-code-oauth-token",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
+    ],
+    [
+      "openrouter-api-key",
+      "OPENROUTER_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "moonshot-api-key",
+      "MOONSHOT_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "minimax-api-key",
+      "MINIMAX_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "deepseek-api-key",
+      "DEEPSEEK_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "zai-api-key",
+      "ZAI_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "vercel-ai-gateway",
+      "VERCEL_AI_GATEWAY_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "openrouter-codex",
+      "OPENROUTER_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    ],
+    [
+      "vercel-ai-gateway-codex",
+      "VERCEL_AI_GATEWAY_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    ],
+    [
+      "openai-api-key",
+      "OPENAI_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    ],
+  ] as const)(
+    "%s uses the canonical placeholder for %s",
+    (type, secretName, placeholder) => {
+      const config = MODEL_PROVIDER_FIREWALL_CONFIGS[type];
+      expect(config.placeholders).toMatchObject({
+        [secretName]: placeholder,
+      });
+    },
+  );
+});
+
 describe("codex-oauth-token codex provider", () => {
   it("declares codex framework", () => {
     expect(getFrameworkForType("codex-oauth-token")).toBe("codex");
@@ -589,9 +680,10 @@ describe("codex-oauth-token codex provider", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
     expect(config.placeholders).toEqual({
       CHATGPT_ACCESS_TOKEN:
-        "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
-      CHATGPT_ACCOUNT_ID: "ws_VM0_PLACEHOLDER_DO_NOT_TRUST",
-      CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+      CHATGPT_ACCOUNT_ID: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
+      CHATGPT_REFRESH_TOKEN:
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
     });
   });
 

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -936,6 +936,33 @@ type FirewallSupportedProvider = Exclude<
   HiddenProviderType | "vm0"
 >;
 
+export const MODEL_PROVIDER_ENV_PLACEHOLDERS = {
+  // Placeholder: sk-ant-api03-{93 word/hyphen chars}AA (108 chars total)
+  // Source: Semgrep regex \Bsk-ant-api03-[\w\-]{93}AA\B
+  //   https://semgrep.dev/blog/2025/secrets-story-and-prefixed-secrets/
+  ANTHROPIC_API_KEY:
+    "sk-ant-api03-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+  // Placeholder: sk-ant-oat01-{93 word/hyphen chars}AA (108 chars total)
+  // Source: same structure as API key; prefix from claude setup-token output
+  //   https://github.com/anthropics/claude-code/issues/18340
+  //   Example: sk-ant-oat01-xxxxx...xxxxx (1-year OAuth token)
+  CLAUDE_CODE_OAUTH_TOKEN:
+    "sk-ant-oat01-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+  // Generic bearer-token marker for Claude-compatible gateways that map
+  // provider-specific secrets into ANTHROPIC_AUTH_TOKEN.
+  ANTHROPIC_AUTH_TOKEN: "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+  // Placeholder: sk-proj-{chars}T3BlbkFJ{chars} (typical project key shape)
+  // Source: matches turbo/packages/connectors/src/firewalls/openai.generated.ts
+  OPENAI_API_KEY:
+    "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca",
+  // Opaque fake marker, not a JWT. Codex ChatGPT mode reads auth.json, while
+  // firewall auth substitutes this marker at egress.
+  CHATGPT_ACCESS_TOKEN:
+    "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
+  CHATGPT_ACCOUNT_ID: "ws_VM0_PLACEHOLDER_DO_NOT_TRUST",
+  CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
+} as const;
+
 /**
  * Get provider types available for user selection.
  * Excludes providers that are hidden from the UI (e.g., those without token replacement support).
@@ -1037,94 +1064,69 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
   FirewallSupportedProvider,
   ExpandedFirewallConfig
 > = {
-  // Placeholder: sk-ant-api03-{93 word/hyphen chars}AA (108 chars total)
-  // Source: Semgrep regex \Bsk-ant-api03-[\w\-]{93}AA\B
-  //   https://semgrep.dev/blog/2025/secrets-story-and-prefixed-secrets/
   "anthropic-api-key": mpFirewall(
     "anthropic-api-key",
     { name: "x-api-key" },
-    "sk-ant-api03-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
   ),
-  // Placeholder: sk-ant-oat01-{93 word/hyphen chars}AA (108 chars total)
-  // Source: same structure as API key; prefix from claude setup-token output
-  //   https://github.com/anthropics/claude-code/issues/18340
-  //   Example: sk-ant-oat01-xxxxx...xxxxx (1-year OAuth token)
   "claude-code-oauth-token": mpFirewall(
     "claude-code-oauth-token",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-ant-oat01-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
   ),
-  // Placeholder: sk-or-v1-{64 hex chars} (73 chars total)
-  // Source: real key observed in GitHub issue
-  //   https://github.com/continuedev/continue/issues/6191
-  //   Example: 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
   "openrouter-api-key": mpFirewall(
     "openrouter-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "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",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 chars} (35 chars total)
-  // Source: no authoritative format documentation found; using generic sk- prefix
   "moonshot-api-key": mpFirewall(
     "moonshot-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: eyJ... (JWT-style, variable length)
-  // Source: no authoritative format documentation found; MiniMax docs do not disclose key format
-  //   https://platform.minimax.io/docs/api-reference/api-overview
   "minimax-api-key": mpFirewall(
     "minimax-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "eyCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffe",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 hex chars} (35 chars total)
-  // Source: Semgrep regex \bsk-[a-f0-9]{32}\b
-  //   https://semgrep.dev/blog/2025/secrets-story-and-prefixed-secrets/
   "deepseek-api-key": mpFirewall(
     "deepseek-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-c0ffee5afe10ca1c0ffee5afe10ca1c0",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 chars} (35 chars total)
-  // Source: no authoritative format documentation found; using generic sk- prefix
   "zai-api-key": mpFirewall(
     "zai-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 chars} (35 chars total)
-  // Source: no authoritative format documentation found; Vercel gateway proxies upstream providers
   "vercel-ai-gateway": mpFirewall(
     "vercel-ai-gateway",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Codex-framework twin of openrouter-api-key. Same key shape as the
-  // claude-code entry; the difference is the firewall base URL — codex
-  // SDK hits OpenAI-compatible paths (/chat/completions, /responses)
-  // under https://openrouter.ai/api/v1, derived from the OPENAI_BASE_URL
-  // mapping by getFirewallBaseUrl.
+  // Codex-framework twin of openrouter-api-key. It reuses the same stored
+  // OpenRouter secret, but the sandbox env key is OPENAI_API_KEY because codex
+  // SDK hits OpenAI-compatible paths (/chat/completions, /responses) under
+  // https://openrouter.ai/api/v1, derived from the OPENAI_BASE_URL mapping by
+  // getFirewallBaseUrl.
   "openrouter-codex": mpFirewall(
     "openrouter-codex",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "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",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
-  // Codex-framework twin of vercel-ai-gateway. Same placeholder format
-  // (Vercel gateway proxies upstream); base URL scoped to /v1 prefix by
-  // getFirewallBaseUrl so codex can use either /chat/completions or
-  // /responses paths the gateway exposes.
+  // Codex-framework twin of vercel-ai-gateway. It reuses the same stored Vercel
+  // secret, but the sandbox env key is OPENAI_API_KEY. Base URL is scoped to
+  // the /v1 prefix by getFirewallBaseUrl so codex can use either
+  // /chat/completions or /responses paths the gateway exposes.
   "vercel-ai-gateway-codex": mpFirewall(
     "vercel-ai-gateway-codex",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
-  // Placeholder: sk-proj-{156 chars}T3BlbkFJ{156 chars} (typical project key shape)
-  // Source: matches turbo/packages/connectors/src/firewalls/openai.generated.ts
   "openai-api-key": mpFirewall(
     "openai-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
   // ChatGPT OAuth provider — multi-header injection + auth.openai.com deny.
   // Sandbox holds placeholder strings; firewall replaces them with real
@@ -1176,14 +1178,15 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
     },
     placeholders: {
       CHATGPT_ACCESS_TOKEN:
-        "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
-      CHATGPT_ACCOUNT_ID: "ws_VM0_PLACEHOLDER_DO_NOT_TRUST",
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+      CHATGPT_ACCOUNT_ID: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
       // refresh_token written by guest-agent into ~/.codex/auth.json (#12077).
       // Kept in this map so the firewall can substitute it on egress if codex
       // ever tries to use it directly — defense-in-depth alongside
       // CODEX_REFRESH_TOKEN_URL_OVERRIDE which redirects refresh attempts to
       // localhost. The sandbox never gets the real refresh_token (#7365).
-      CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
+      CHATGPT_REFRESH_TOKEN:
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
     },
   },
 };

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -7,7 +7,10 @@ import {
   type RustStringConstantBinding,
   rustStringConstantBindings,
 } from "../constants";
-import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "../../contracts/model-providers";
+import {
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
+  MODEL_PROVIDER_FIREWALL_CONFIGS,
+} from "../../contracts/model-providers";
 
 const codexOauthPlaceholders =
   MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"].placeholders!;
@@ -27,6 +30,41 @@ const expectedBindings = [
     rustModulePath: ["codex_oauth_token", "placeholders"],
     rustConstName: "CHATGPT_REFRESH_TOKEN",
     value: codexOauthPlaceholders.CHATGPT_REFRESH_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "ANTHROPIC_API_KEY",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "ANTHROPIC_AUTH_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CLAUDE_CODE_OAUTH_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "OPENAI_API_KEY",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CHATGPT_ACCESS_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CHATGPT_ACCOUNT_ID",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CHATGPT_REFRESH_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
   },
 ] as const;
 
@@ -74,9 +112,14 @@ describe("Rust string constant bindings", () => {
 
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod codex_oauth_token {");
+    expect(firstRender).toContain("pub mod model_provider_env {");
     expect(firstRender).toContain("pub mod placeholders {");
     expect(firstRender).toContain(
       `pub const CHATGPT_ACCOUNT_ID: &str = "${codexOauthPlaceholders.CHATGPT_ACCOUNT_ID}";`,
+    );
+    expect(firstRender).toContain("pub const OPENAI_API_KEY: &str =");
+    expect(firstRender).toContain(
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
     );
     expect(firstRender).toContain(
       `pub const CHATGPT_REFRESH_TOKEN: &str = "${codexOauthPlaceholders.CHATGPT_REFRESH_TOKEN}";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -1,4 +1,7 @@
-import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "../contracts/model-providers";
+import {
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
+  MODEL_PROVIDER_FIREWALL_CONFIGS,
+} from "../contracts/model-providers";
 
 export interface RustStringConstantBinding {
   readonly rustModulePath: readonly string[];
@@ -14,8 +17,26 @@ const codexOauthPlaceholderNames = [
 
 type CodexOauthPlaceholderName = (typeof codexOauthPlaceholderNames)[number];
 
+const modelProviderEnvPlaceholderNames = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "CHATGPT_ACCESS_TOKEN",
+  "CHATGPT_ACCOUNT_ID",
+  "CHATGPT_REFRESH_TOKEN",
+] as const;
+
+type ModelProviderEnvPlaceholderName =
+  (typeof modelProviderEnvPlaceholderNames)[number];
+
 const codexOauthPlaceholderModule = [
   "codex_oauth_token",
+  "placeholders",
+] as const;
+
+const modelProviderEnvPlaceholderModule = [
+  "model_provider_env",
   "placeholders",
 ] as const;
 
@@ -33,12 +54,29 @@ function codexOauthPlaceholder(name: CodexOauthPlaceholderName): string {
   return value;
 }
 
-export const rustStringConstantBindings = codexOauthPlaceholderNames.map(
-  (name) => {
+function modelProviderEnvPlaceholder(
+  name: ModelProviderEnvPlaceholderName,
+): string {
+  const value = MODEL_PROVIDER_ENV_PLACEHOLDERS[name];
+  if (value.length === 0) {
+    throw new Error(`model provider env placeholder ${name} is empty`);
+  }
+  return value;
+}
+
+export const rustStringConstantBindings = [
+  ...codexOauthPlaceholderNames.map((name) => {
     return {
       rustModulePath: codexOauthPlaceholderModule,
       rustConstName: name,
       value: codexOauthPlaceholder(name),
     };
-  },
-) satisfies readonly RustStringConstantBinding[];
+  }),
+  ...modelProviderEnvPlaceholderNames.map((name) => {
+    return {
+      rustModulePath: modelProviderEnvPlaceholderModule,
+      rustConstName: name,
+      value: modelProviderEnvPlaceholder(name),
+    };
+  }),
+] satisfies readonly RustStringConstantBinding[];

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -698,13 +698,14 @@ function renderStringConstant(
 ): string[] {
   const literal = rustStringLiteral(constant.value);
   const singleLine = `${indent}pub const ${constant.rustConstName}: &str = ${literal};`;
-  if (singleLine.length <= 100) {
+  const splitValueLine = `${indent}    ${literal};`;
+  if (singleLine.length <= 100 || splitValueLine.length > 100) {
     return [singleLine];
   }
 
   return [
     `${indent}pub const ${constant.rustConstName}: &str =`,
-    `${indent}    ${literal};`,
+    splitValueLine,
   ];
 }
 


### PR DESCRIPTION
## Summary

- centralize model provider runtime env placeholders and export them to generated Rust constants
- validate protected Claude/Codex env keys in the runner before launching sandbox processes
- keep Rust string constant generation stable under `cargo fmt`
- add API and Rust coverage for canonical placeholders, safe failures, and Codex gateway env mapping

Closes #14992

## Tests

- `pnpm -F @vm0/api-contracts generate:rust && git diff --exit-code -- ../crates/api-contracts/src/generated`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner model_provider_env`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts`
- pre-commit hook: `pnpm check-types`, `pnpm knip`, cargo doc/clippy
