### PR TITLE
fix: scope pinned chat threads to the requested agent

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-list.test.ts
@@ -963,14 +963,19 @@ describe("GET /api/zero/chat-threads (unified list, agentId omitted)", () => {
     expect(response.body.nextCursor).toBeNull();
   });
 
-  it("returns org pinned threads even when non-pinned results are agent-scoped", async () => {
+  it("scopes pinned threads to the requested agent when agentId is provided", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
 
     const scopedFixture = await track(
       store.set(
         seedZeroChatThread$,
-        { userId, orgId, title: "Scoped unpinned" },
+        {
+          userId,
+          orgId,
+          title: "Scoped pinned",
+          pinnedAt: new Date("2025-05-02T10:00:00.000Z"),
+        },
         context.signal,
       ),
     );
@@ -1008,18 +1013,14 @@ describe("GET /api/zero/chat-threads (unified list, agentId omitted)", () => {
       response.body.pinned.map((t) => {
         return t.id;
       }),
-    ).toStrictEqual([otherPinnedFixture.threadId]);
-    expect(
-      response.body.threads.map((t) => {
-        return t.id;
-      }),
     ).toStrictEqual([scopedFixture.threadId]);
-    expect(
-      allListedThreads(response.body).map((t) => {
-        return t.id;
-      }),
-    ).not.toContain(otherUnpinnedFixture.threadId);
-    expect(response.body.totalCount).toBe(1);
+    expect(response.body.threads).toStrictEqual([]);
+    const allIds = allListedThreads(response.body).map((t) => {
+      return t.id;
+    });
+    expect(allIds).not.toContain(otherPinnedFixture.threadId);
+    expect(allIds).not.toContain(otherUnpinnedFixture.threadId);
+    expect(response.body.totalCount).toBe(0);
   });
 
   it("caps the non-pinned segment at `limit` and reports hasMore + nextCursor when there's overflow", async () => {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -818,18 +818,17 @@ export function zeroChatThreadList(args: {
     const lastMessage = lastVisibleMessageSubquery(db);
     const projection = chatThreadListProjection(lastMessage);
 
-    const orgFilters = [
+    const scopedFilters = [
       eq(chatThreads.userId, args.userId),
       eq(zeroAgents.orgId, args.orgId),
     ];
-    const scopedFilters = [...orgFilters];
     if (args.agentComposeId) {
       scopedFilters.push(eq(chatThreads.agentComposeId, args.agentComposeId));
     }
 
     // Pinned segment is only returned on the first page (no cursor).
-    // Pinned threads are always returned in full for the caller's org — cap
-    // and agent-scoped pagination don't apply.
+    // Honours the same agent scope as the non-pinned segment so the sidebar
+    // never surfaces another agent's pinned threads while you're viewing one.
     const pinnedRows = cursor
       ? []
       : await db
@@ -837,7 +836,7 @@ export function zeroChatThreadList(args: {
           .from(chatThreads)
           .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
           .leftJoinLateral(lastMessage, sql`true`)
-          .where(and(...orgFilters, isNotNull(chatThreads.pinnedAt)))
+          .where(and(...scopedFilters, isNotNull(chatThreads.pinnedAt)))
           .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id));
 
     const nonPinnedFilters = [...scopedFilters, isNull(chatThreads.pinnedAt)];


### PR DESCRIPTION
## Summary
- Sidebar's pinned segment was returning every pinned thread in the org regardless of the agent in view, so opening any agent surfaced other agents' pinned threads (Ethan's report)
- `zeroChatThreadList` now applies the same `agentComposeId` filter to the pinned query that the non-pinned query already used; the `orgFilters` / `scopedFilters` split collapses into a single `scopedFilters`
- Flipped the regression test that previously locked in the org-wide pinned behavior — it now asserts pinned threads are agent-scoped when `agentId` is provided

## Test plan
- [ ] `pnpm -F @vm0/api exec vitest run zero-chat-threads-list`
- [ ] Manual: open Agent A → pin a thread → switch to Agent B → confirm the pinned thread does NOT appear in B's sidebar
- [ ] Manual: load `/chats` (no agent scope) — pinned threads from all agents should still show up there since `agentId` is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)