### PR TITLE
fix: validate model provider env placeholders in runner

### DIFF
--- a/crates/api-contracts/src/generated/model_providers.rs
+++ b/crates/api-contracts/src/generated/model_providers.rs
@@ -15,3 +15,22 @@ pub mod codex_oauth_token {
         pub const CHATGPT_REFRESH_TOKEN: &str = "rt_VM0_PLACEHOLDER_DO_NOT_TRUST";
     }
 }
+
+pub mod model_provider_env {
+    pub mod placeholders {
+        pub const ANTHROPIC_API_KEY: &str = "sk-ant-api03-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA";
+
+        pub const ANTHROPIC_AUTH_TOKEN: &str = "sk-CoffeeSafeLocalCoffeeSafeLocalCo";
+
+        pub const CHATGPT_ACCESS_TOKEN: &str =
+            "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal";
+
+        pub const CHATGPT_ACCOUNT_ID: &str = "ws_VM0_PLACEHOLDER_DO_NOT_TRUST";
+
+        pub const CHATGPT_REFRESH_TOKEN: &str = "rt_VM0_PLACEHOLDER_DO_NOT_TRUST";
+
+        pub const CLAUDE_CODE_OAUTH_TOKEN: &str = "sk-ant-oat01-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA";
+
+        pub const OPENAI_API_KEY: &str = "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca";
+    }
+}

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -34,6 +34,8 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use api_contracts::generated::model_providers::model_provider_env::placeholders as model_provider_placeholders;
+
 use crate::ids::RunId;
 
 /// Maximum wall-clock time for a single job (2 hours).
@@ -261,25 +263,35 @@ pub async fn execute_job(
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
-    let outcome = match execute_new_sandbox(
-        factory,
-        &context,
-        dispatch,
-        config,
-        params,
-        &mut telemetry,
-        cancel,
-    )
-    .await
-    {
-        Ok(outcome) => outcome,
-        Err(e) => ExecuteOutcome {
-            failure: Some(ExecutionFailure::from_error(e.to_string())),
+    let outcome = if let Err(error) = validate_model_provider_env_placeholders(&context) {
+        ExecuteOutcome {
+            failure: Some(ExecutionFailure::from_error(error)),
             sandbox: None,
             source_ip: String::new(),
             network_log_session: None,
             guest_session_id: None,
-        },
+        }
+    } else {
+        match execute_new_sandbox(
+            factory,
+            &context,
+            dispatch,
+            config,
+            params,
+            &mut telemetry,
+            cancel,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(e) => ExecuteOutcome {
+                failure: Some(ExecutionFailure::from_error(e.to_string())),
+                sandbox: None,
+                source_ip: String::new(),
+                network_log_session: None,
+                guest_session_id: None,
+            },
+        }
     };
 
     (outcome, telemetry)
@@ -312,16 +324,26 @@ pub async fn execute_job_reuse(
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
-    let outcome = execute_reused_sandbox(
-        sandbox,
-        &source_ip,
-        &context,
-        config,
-        &prev_storage,
-        &mut telemetry,
-        cancel,
-    )
-    .await;
+    let outcome = if let Err(error) = validate_model_provider_env_placeholders(&context) {
+        ExecuteOutcome {
+            failure: Some(ExecutionFailure::from_error(error)),
+            sandbox: Some(sandbox),
+            source_ip,
+            network_log_session: None,
+            guest_session_id: None,
+        }
+    } else {
+        execute_reused_sandbox(
+            sandbox,
+            &source_ip,
+            &context,
+            config,
+            &prev_storage,
+            &mut telemetry,
+            cancel,
+        )
+        .await
+    };
 
     (outcome, telemetry)
 }
@@ -381,6 +403,78 @@ fn elapsed_since_api_start_ms(api_start_ms: u64, now_ms: u64) -> Option<Duration
     }
 
     Some(Duration::from_millis(now_ms.saturating_sub(api_start_ms)))
+}
+
+struct ModelProviderPlaceholderEnvKey {
+    name: &'static str,
+    placeholder: &'static str,
+}
+
+const CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ModelProviderPlaceholderEnvKey] = &[
+    ModelProviderPlaceholderEnvKey {
+        name: "ANTHROPIC_API_KEY",
+        placeholder: model_provider_placeholders::ANTHROPIC_API_KEY,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "ANTHROPIC_AUTH_TOKEN",
+        placeholder: model_provider_placeholders::ANTHROPIC_AUTH_TOKEN,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CLAUDE_CODE_OAUTH_TOKEN",
+        placeholder: model_provider_placeholders::CLAUDE_CODE_OAUTH_TOKEN,
+    },
+];
+
+const CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ModelProviderPlaceholderEnvKey] = &[
+    ModelProviderPlaceholderEnvKey {
+        name: "OPENAI_API_KEY",
+        placeholder: model_provider_placeholders::OPENAI_API_KEY,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CHATGPT_ACCESS_TOKEN",
+        placeholder: model_provider_placeholders::CHATGPT_ACCESS_TOKEN,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CHATGPT_ACCOUNT_ID",
+        placeholder: model_provider_placeholders::CHATGPT_ACCOUNT_ID,
+    },
+    ModelProviderPlaceholderEnvKey {
+        name: "CHATGPT_REFRESH_TOKEN",
+        placeholder: model_provider_placeholders::CHATGPT_REFRESH_TOKEN,
+    },
+];
+
+const MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[&[ModelProviderPlaceholderEnvKey]] = &[
+    CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS,
+    CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS,
+];
+
+fn validate_model_provider_env_placeholders(context: &ExecutionContext) -> Result<(), String> {
+    let Some(environment) = &context.environment else {
+        return Ok(());
+    };
+
+    let invalid_keys: Vec<&str> = MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS
+        .iter()
+        .flat_map(|protected_keys| protected_keys.iter())
+        .filter_map(|protected_key| {
+            let value = environment.get(protected_key.name)?;
+            if value.is_empty() || value == protected_key.placeholder {
+                None
+            } else {
+                Some(protected_key.name)
+            }
+        })
+        .collect();
+
+    if invalid_keys.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "model provider environment contains non-placeholder values for: {}",
+        invalid_keys.join(", ")
+    ))
 }
 
 /// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM
@@ -2272,6 +2366,128 @@ mod tests {
             billable_firewalls: vec![],
             model_usage_provider: None,
         }
+    }
+
+    fn context_with_env(environment: HashMap<String, String>) -> ExecutionContext {
+        let mut ctx = minimal_context();
+        ctx.environment = Some(environment);
+        ctx
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_env_without_protected_keys() {
+        let ctx = context_with_env(HashMap::from([("PROJECT_ID".into(), "vm0".into())]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_anthropic_api_key_placeholder() {
+        let ctx = context_with_env(HashMap::from([(
+            "ANTHROPIC_API_KEY".into(),
+            model_provider_placeholders::ANTHROPIC_API_KEY.into(),
+        )]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_anthropic_api_key() {
+        let secret = "sk-ant-api03-real-secret-value";
+        let ctx = context_with_env(HashMap::from([("ANTHROPIC_API_KEY".into(), secret.into())]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("ANTHROPIC_API_KEY"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_empty_anthropic_api_key_with_auth_token() {
+        let ctx = context_with_env(HashMap::from([
+            ("ANTHROPIC_API_KEY".into(), String::new()),
+            (
+                "ANTHROPIC_AUTH_TOKEN".into(),
+                model_provider_placeholders::ANTHROPIC_AUTH_TOKEN.into(),
+            ),
+        ]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_anthropic_auth_token() {
+        let secret = "sk-real-openrouter-token";
+        let ctx = context_with_env(HashMap::from([(
+            "ANTHROPIC_AUTH_TOKEN".into(),
+            secret.into(),
+        )]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("ANTHROPIC_AUTH_TOKEN"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_claude_oauth_placeholder() {
+        let ctx = context_with_env(HashMap::from([(
+            "CLAUDE_CODE_OAUTH_TOKEN".into(),
+            model_provider_placeholders::CLAUDE_CODE_OAUTH_TOKEN.into(),
+        )]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_openai_api_key_placeholder() {
+        let ctx = context_with_env(HashMap::from([(
+            "OPENAI_API_KEY".into(),
+            model_provider_placeholders::OPENAI_API_KEY.into(),
+        )]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_openai_api_key() {
+        let secret = "sk-proj-real-openai-secret";
+        let ctx = context_with_env(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("OPENAI_API_KEY"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_accepts_codex_oauth_placeholders() {
+        let ctx = context_with_env(HashMap::from([
+            (
+                "CHATGPT_ACCESS_TOKEN".into(),
+                model_provider_placeholders::CHATGPT_ACCESS_TOKEN.into(),
+            ),
+            (
+                "CHATGPT_ACCOUNT_ID".into(),
+                model_provider_placeholders::CHATGPT_ACCOUNT_ID.into(),
+            ),
+        ]));
+
+        assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_chatgpt_access_token() {
+        let secret = "ey-real-chatgpt-access-token";
+        let ctx = context_with_env(HashMap::from([(
+            "CHATGPT_ACCESS_TOKEN".into(),
+            secret.into(),
+        )]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("CHATGPT_ACCESS_TOKEN"));
+        assert!(!error.contains(secret));
     }
 
     #[test]
@@ -4947,6 +5163,41 @@ mod tests {
         assert!(outcome.sandbox.is_none());
     }
 
+    #[tokio::test]
+    async fn execute_job_model_provider_env_validation_failure_returns_run_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let secret = "sk-proj-real-openai-secret";
+        let mut ctx = minimal_context();
+        ctx.environment = Some(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::NoSessionId,
+            },
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(error.contains("OPENAI_API_KEY"));
+        assert!(!error.contains(secret));
+        assert!(outcome.sandbox.is_none());
+        assert!(
+            overrides.create_configs().is_empty(),
+            "fresh sandbox must not be created after env validation failure"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Keep-alive VM reuse integration tests
     // -----------------------------------------------------------------------
@@ -4983,6 +5234,35 @@ mod tests {
         assert_eq!(reuse_outcome.exit_code(), 0);
         assert!(reuse_outcome.error().is_none());
         assert!(reuse_outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_model_provider_env_validation_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let source_ip = sandbox.source_ip().to_string();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+        let secret = "sk-proj-real-openai-secret";
+        let mut ctx = minimal_context();
+        ctx.environment = Some(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, cancel).await;
+
+        assert_eq!(reuse_outcome.exit_code(), 1);
+        let error = reuse_outcome.error().unwrap();
+        assert!(error.contains("OPENAI_API_KEY"));
+        assert!(!error.contains(secret));
+        assert!(reuse_outcome.sandbox.is_some());
+        assert!(reuse_outcome.network_log_session.is_none());
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "reused sandbox must not start a process after env validation failure"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2471,6 +2471,10 @@ mod tests {
                 "CHATGPT_ACCOUNT_ID".into(),
                 model_provider_placeholders::CHATGPT_ACCOUNT_ID.into(),
             ),
+            (
+                "CHATGPT_REFRESH_TOKEN".into(),
+                model_provider_placeholders::CHATGPT_REFRESH_TOKEN.into(),
+            ),
         ]));
 
         assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
@@ -2487,6 +2491,20 @@ mod tests {
         let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
 
         assert!(error.contains("CHATGPT_ACCESS_TOKEN"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_real_chatgpt_refresh_token() {
+        let secret = "rt_real_chatgpt_refresh_token";
+        let ctx = context_with_env(HashMap::from([(
+            "CHATGPT_REFRESH_TOKEN".into(),
+            secret.into(),
+        )]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("CHATGPT_REFRESH_TOKEN"));
         assert!(!error.contains(secret));
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -405,46 +405,50 @@ fn elapsed_since_api_start_ms(api_start_ms: u64, now_ms: u64) -> Option<Duration
     Some(Duration::from_millis(now_ms.saturating_sub(api_start_ms)))
 }
 
-struct ModelProviderPlaceholderEnvKey {
+struct ProtectedModelProviderEnvKey {
     name: &'static str,
-    placeholder: &'static str,
+    placeholder: Option<&'static str>,
 }
 
-const CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ModelProviderPlaceholderEnvKey] = &[
-    ModelProviderPlaceholderEnvKey {
+const CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ProtectedModelProviderEnvKey] = &[
+    ProtectedModelProviderEnvKey {
         name: "ANTHROPIC_API_KEY",
-        placeholder: model_provider_placeholders::ANTHROPIC_API_KEY,
+        placeholder: Some(model_provider_placeholders::ANTHROPIC_API_KEY),
     },
-    ModelProviderPlaceholderEnvKey {
+    ProtectedModelProviderEnvKey {
         name: "ANTHROPIC_AUTH_TOKEN",
-        placeholder: model_provider_placeholders::ANTHROPIC_AUTH_TOKEN,
+        placeholder: Some(model_provider_placeholders::ANTHROPIC_AUTH_TOKEN),
     },
-    ModelProviderPlaceholderEnvKey {
+    ProtectedModelProviderEnvKey {
         name: "CLAUDE_CODE_OAUTH_TOKEN",
-        placeholder: model_provider_placeholders::CLAUDE_CODE_OAUTH_TOKEN,
+        placeholder: Some(model_provider_placeholders::CLAUDE_CODE_OAUTH_TOKEN),
     },
 ];
 
-const CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ModelProviderPlaceholderEnvKey] = &[
-    ModelProviderPlaceholderEnvKey {
+const CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[ProtectedModelProviderEnvKey] = &[
+    ProtectedModelProviderEnvKey {
         name: "OPENAI_API_KEY",
-        placeholder: model_provider_placeholders::OPENAI_API_KEY,
+        placeholder: Some(model_provider_placeholders::OPENAI_API_KEY),
     },
-    ModelProviderPlaceholderEnvKey {
+    ProtectedModelProviderEnvKey {
         name: "CHATGPT_ACCESS_TOKEN",
-        placeholder: model_provider_placeholders::CHATGPT_ACCESS_TOKEN,
+        placeholder: Some(model_provider_placeholders::CHATGPT_ACCESS_TOKEN),
     },
-    ModelProviderPlaceholderEnvKey {
+    ProtectedModelProviderEnvKey {
         name: "CHATGPT_ACCOUNT_ID",
-        placeholder: model_provider_placeholders::CHATGPT_ACCOUNT_ID,
+        placeholder: Some(model_provider_placeholders::CHATGPT_ACCOUNT_ID),
     },
-    ModelProviderPlaceholderEnvKey {
+    ProtectedModelProviderEnvKey {
         name: "CHATGPT_REFRESH_TOKEN",
-        placeholder: model_provider_placeholders::CHATGPT_REFRESH_TOKEN,
+        placeholder: Some(model_provider_placeholders::CHATGPT_REFRESH_TOKEN),
+    },
+    ProtectedModelProviderEnvKey {
+        name: "CHATGPT_ID_TOKEN",
+        placeholder: None,
     },
 ];
 
-const MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[&[ModelProviderPlaceholderEnvKey]] = &[
+const MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS: &[&[ProtectedModelProviderEnvKey]] = &[
     CLAUDE_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS,
     CODEX_MODEL_PROVIDER_PLACEHOLDER_ENV_KEYS,
 ];
@@ -459,7 +463,11 @@ fn validate_model_provider_env_placeholders(context: &ExecutionContext) -> Resul
         .flat_map(|protected_keys| protected_keys.iter())
         .filter_map(|protected_key| {
             let value = environment.get(protected_key.name)?;
-            if value.is_empty() || value == protected_key.placeholder {
+            if value.is_empty()
+                || protected_key
+                    .placeholder
+                    .is_some_and(|placeholder| value == placeholder)
+            {
                 None
             } else {
                 Some(protected_key.name)
@@ -2505,6 +2513,17 @@ mod tests {
         let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
 
         assert!(error.contains("CHATGPT_REFRESH_TOKEN"));
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn model_provider_env_placeholder_validation_rejects_chatgpt_id_token() {
+        let secret = "hdr.real-chatgpt-id-token.sig";
+        let ctx = context_with_env(HashMap::from([("CHATGPT_ID_TOKEN".into(), secret.into())]));
+
+        let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+        assert!(error.contains("CHATGPT_ID_TOKEN"));
         assert!(!error.contains(secret));
     }
 

--- a/e2e/helpers/audit-sandbox.bash
+++ b/e2e/helpers/audit-sandbox.bash
@@ -44,7 +44,9 @@ After running, output exactly:
 EOF
 )
 
-    run "$VM0_CLI" run "$agent_name" -- "$prompt"
+    run "$VM0_CLI" run "$agent_name" \
+        --model-provider-type "codex-oauth-token" \
+        -- "$prompt"
     if [ "$status" -ne 0 ]; then
         echo "Agent run failed (status=$status):" >&2
         echo "$output" >&2

--- a/e2e/helpers/audit-sandbox.bash
+++ b/e2e/helpers/audit-sandbox.bash
@@ -20,12 +20,12 @@
 #
 # Side effects:
 #   Sets AUDIT_JSON env var on success. Returns non-zero on failure.
-audit_sandbox_via_agent() {
+audit_chatgpt_oauth_sandbox_via_agent() {
     local agent_name="$1"
     local artifact_path="${2:-/artifacts/audit-runner.sh}"
 
     if [ -z "${CHATGPT_AUDIT_FORBIDDEN_ACCESS_TOKEN:-}" ]; then
-        echo "audit_sandbox_via_agent: CHATGPT_AUDIT_FORBIDDEN_* env vars not set" >&2
+        echo "audit_chatgpt_oauth_sandbox_via_agent: CHATGPT_AUDIT_FORBIDDEN_* env vars not set" >&2
         return 1
     fi
 
@@ -62,7 +62,7 @@ EOF
     ' | tr -d '\n' | sed 's/^ *//;s/ *$//')
 
     if [ -z "$AUDIT_JSON" ]; then
-        echo "audit_sandbox_via_agent: could not extract audit JSON from agent output" >&2
+        echo "audit_chatgpt_oauth_sandbox_via_agent: could not extract audit JSON from agent output" >&2
         echo "Agent output was:" >&2
         echo "$output" >&2
         return 1
@@ -70,7 +70,7 @@ EOF
 
     # Validate parseable JSON.
     if ! echo "$AUDIT_JSON" | jq . >/dev/null 2>&1; then
-        echo "audit_sandbox_via_agent: extracted output is not valid JSON" >&2
+        echo "audit_chatgpt_oauth_sandbox_via_agent: extracted output is not valid JSON" >&2
         echo "Extracted: $AUDIT_JSON" >&2
         return 1
     fi

--- a/e2e/tests/03-runner/t-codex-event-mapping.bats
+++ b/e2e/tests/03-runner/t-codex-event-mapping.bats
@@ -39,7 +39,7 @@ agents:
     description: "Codex event-mapping fixture-driver agent"
     framework: codex
     environment:
-      OPENAI_API_KEY: "\${{ secrets.OPENAI_API_KEY }}"
+      OPENAI_API_KEY: ""
       MOCK_CODEX_FIXTURE: "\${{ vars.MOCK_CODEX_FIXTURE }}"
     volumes:
       - codex-files:/home/user/.codex
@@ -61,7 +61,6 @@ teardown_file() {
 
 @test "t-codex-event-mapping-1: rich fixture renders all item types" {
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=mock-not-validated-by-mock-codex" \
         --vars "MOCK_CODEX_FIXTURE=event-mapping-rich" \
         "drive the rich fixture"
 
@@ -91,7 +90,6 @@ teardown_file() {
 
 @test "t-codex-event-mapping-2: turn-failed fixture renders Codex Failed" {
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=mock-not-validated-by-mock-codex" \
         --vars "MOCK_CODEX_FIXTURE=turn-failed" \
         "drive the turn-failed fixture"
 
@@ -105,7 +103,6 @@ teardown_file() {
 
 @test "t-codex-event-mapping-3: error-event fixture renders Codex Failed" {
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=mock-not-validated-by-mock-codex" \
         --vars "MOCK_CODEX_FIXTURE=error-event" \
         "drive the error-event fixture"
 

--- a/e2e/tests/03-runner/t-codex-real-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-real-smoke.bats
@@ -3,9 +3,9 @@
 # Real Codex smoke test — verifies actual codex CLI execution (not mock).
 #
 # Mirrors t27-real-claude-smoke.bats but for the codex framework. Requires
-# `OPENAI_API_KEY` in the host environment and uses --debug-no-mock-codex
-# to suppress USE_MOCK_CODEX forwarding so the real codex binary runs
-# inside the sandbox.
+# `OPENAI_API_KEY` in the host environment. The test configures it as an
+# org model provider, so the sandbox receives only the model-provider
+# placeholder and mitmproxy performs the egress-time replacement.
 #
 # OPENAI_API_KEY is mandatory — CI injects it via secrets.OPENAI_API_KEY and
 # local runs must export it. There is no skip path: if the key is missing,
@@ -28,6 +28,8 @@ VOLEOF
     $VM0_CLI volume push >/dev/null
     cd - >/dev/null
 
+    $ZERO_CLI org model-provider setup --type "openai-api-key" --secret "$OPENAI_API_KEY" >/dev/null
+
     cat > "$TEST_DIR/vm0-basic.yaml" <<EOF
 version: "1.0"
 agents:
@@ -35,7 +37,6 @@ agents:
     description: "Real codex smoke test"
     framework: codex
     environment:
-      OPENAI_API_KEY: "\${{ secrets.OPENAI_API_KEY }}"
       OPENAI_MODEL: "gpt-5.4-mini"
     volumes:
       - codex-files:/home/user/.codex
@@ -55,9 +56,15 @@ teardown_file() {
     fi
 }
 
+ensure_openai_model_provider() {
+    $ZERO_CLI org model-provider setup --type "openai-api-key" --secret "$OPENAI_API_KEY" >/dev/null
+}
+
 @test "t-codex-real-smoke-0: print sandbox codex version" {
+    ensure_openai_model_provider
+
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=$OPENAI_API_KEY" \
+        --model-provider-type "openai-api-key" \
         --debug-no-mock-codex \
         "Run 'codex --version' with the shell tool and include the exact output"
 
@@ -67,8 +74,10 @@ teardown_file() {
 }
 
 @test "t-codex-real-smoke-1: basic run with real codex" {
+    ensure_openai_model_provider
+
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=$OPENAI_API_KEY" \
+        --model-provider-type "openai-api-key" \
         --debug-no-mock-codex \
         "Compute 123+456 and reply with exactly: RESULT=<answer>"
 

--- a/e2e/tests/03-runner/t-codex-resume.bats
+++ b/e2e/tests/03-runner/t-codex-resume.bats
@@ -32,7 +32,7 @@ agents:
     description: "Codex resume test agent"
     framework: codex
     environment:
-      OPENAI_API_KEY: "\${{ secrets.OPENAI_API_KEY }}"
+      OPENAI_API_KEY: ""
     volumes:
       - codex-files:/home/user/.codex
     working_dir: /home/user/workspace
@@ -54,7 +54,6 @@ teardown_file() {
 @test "t-codex-resume-1: continue resumes codex thread from session" {
     # Initial turn: creates a codex thread and writes the session file.
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=mock-not-validated-by-mock-codex" \
         "first turn"
     assert_success
     assert_output --partial "▷ Codex Started"
@@ -77,7 +76,6 @@ teardown_file() {
     # codex thread_id from the prior session, mock-codex appends to the
     # existing session file, and a new turn renders.
     run $VM0_CLI run continue "$session_id" \
-        --secrets "OPENAI_API_KEY=mock-not-validated-by-mock-codex" \
         "second turn"
     assert_success
     assert_output --partial "▷ Codex Started"

--- a/e2e/tests/03-runner/t-codex-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-smoke.bats
@@ -37,7 +37,7 @@ agents:
     description: "Codex smoke test agent"
     framework: codex
     environment:
-      OPENAI_API_KEY: "\${{ secrets.OPENAI_API_KEY }}"
+      OPENAI_API_KEY: ""
     volumes:
       - codex-files:/home/user/.codex
     working_dir: /home/user/workspace
@@ -58,7 +58,6 @@ teardown_file() {
 
 @test "t-codex-smoke-1: basic codex run renders codex markers" {
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "OPENAI_API_KEY=mock-not-validated-by-mock-codex" \
         "echo from codex"
 
     assert_success

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -78,7 +78,6 @@ teardown_file() {
     if [[ -n "${THREAD_ID:-}" ]]; then
         _codex_zero_curl "/api/zero/chat-threads/$THREAD_ID" -X DELETE >/dev/null 2>&1 || true
     fi
-    $ZERO_CLI org model-provider remove "openai-api-key" 2>/dev/null || true
     disable_codex_beta
     if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
         rm -rf "$TEST_DIR"

--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -2,6 +2,8 @@
 
 # Real Claude smoke tests — verify actual LLM execution (not mock).
 # Requires ANTHROPIC_API_KEY set in CI via secrets.CI_ANTHROPIC_API_KEY.
+# The key is configured as an org model provider; the sandbox receives only
+# the model-provider placeholder and mitmproxy performs the replacement.
 #
 # Test 0 (version): print sandbox Claude Code version for debugging
 # Test 1 (basic): baseline LLM execution — math prompt, verify correct answer
@@ -37,16 +39,15 @@ VOLEOF
     $VM0_CLI volume push >/dev/null
     cd - >/dev/null
 
+    $ZERO_CLI org model-provider setup --type "anthropic-api-key" --secret "$ANTHROPIC_API_KEY" >/dev/null
+
     # Compose agents separately (only one agent per compose is supported)
-    # ANTHROPIC_API_KEY is passed via --secrets at run time (not via model-provider)
     cat > "$TEST_DIR/vm0-basic.yaml" <<EOF
 version: "1.0"
 agents:
   ${AGENT_NAME}:
     description: "Real Claude smoke test"
     framework: claude-code
-    environment:
-      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -62,8 +63,6 @@ agents:
   ${AGENT_NAME}-flags:
     description: "Real Claude flags test"
     framework: claude-code
-    environment:
-      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -79,8 +78,6 @@ agents:
   ${AGENT_NAME}-settings:
     description: "Real Claude settings test"
     framework: claude-code
-    environment:
-      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -96,8 +93,6 @@ agents:
   ${AGENT_NAME}-slash:
     description: "Real Claude slash-command no-history test"
     framework: claude-code
-    environment:
-      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -119,15 +114,21 @@ teardown_file() {
     fi
 }
 
+ensure_anthropic_model_provider() {
+    $ZERO_CLI org model-provider setup --type "anthropic-api-key" --secret "$ANTHROPIC_API_KEY" >/dev/null
+}
+
 # Test 0: Print sandbox Claude Code version for debugging
 @test "t27-0: print sandbox claude version" {
     if [ -z "$ANTHROPIC_API_KEY" ]; then
         skip "ANTHROPIC_API_KEY not set"
     fi
 
+    ensure_anthropic_model_provider
+
     # Run claude --version inside the sandbox to confirm which binary is installed
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+        --model-provider-type "anthropic-api-key" \
         --debug-no-mock-claude \
         "Run 'claude --version' with the Bash tool and include the exact output"
 
@@ -143,8 +144,10 @@ teardown_file() {
         skip "ANTHROPIC_API_KEY not set"
     fi
 
+    ensure_anthropic_model_provider
+
     run $VM0_CLI run "$AGENT_NAME" \
-        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+        --model-provider-type "anthropic-api-key" \
         --debug-no-mock-claude \
         "Compute 123+456 and reply with exactly: RESULT=<answer>"
 
@@ -163,10 +166,12 @@ teardown_file() {
         skip "ANTHROPIC_API_KEY not set"
     fi
 
+    ensure_anthropic_model_provider
+
     # "--" separates variadic --disallowed-tools from the prompt
     # (Commander.js <tools...> would otherwise swallow subsequent args)
     run $VM0_CLI run "${AGENT_NAME}-flags" \
-        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+        --model-provider-type "anthropic-api-key" \
         --debug-no-mock-claude \
         --append-system-prompt "Always end your final response with SIGNATURE=smoke-test" \
         --disallowed-tools CronCreate CronList CronDelete \
@@ -189,12 +194,14 @@ teardown_file() {
         skip "ANTHROPIC_API_KEY not set"
     fi
 
+    ensure_anthropic_model_provider
+
     # PreToolUse hook: write sentinel file before each Bash tool invocation.
     # Claude will read this file to prove the hook fired inside the sandbox.
     local settings='{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo SETTINGS_HOOK_OK > /tmp/hook_sentinel.txt"}]}]}}'
 
     run $VM0_CLI run "${AGENT_NAME}-settings" \
-        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+        --model-provider-type "anthropic-api-key" \
         --debug-no-mock-claude \
         --settings "$settings" \
         -- "Step 1: run 'echo hello'. Step 2: run 'cat /tmp/hook_sentinel.txt'. Include the exact output of step 2 in your response."
@@ -212,8 +219,10 @@ teardown_file() {
         skip "ANTHROPIC_API_KEY not set"
     fi
 
+    ensure_anthropic_model_provider
+
     run $VM0_CLI run "${AGENT_NAME}-slash" \
-        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+        --model-provider-type "anthropic-api-key" \
         --debug-no-mock-claude \
         "/help"
 

--- a/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
+++ b/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
@@ -72,20 +72,15 @@ setup_file() {
         "$CHATGPT_AUDIT_FORBIDDEN_ID_TOKEN"
 
     # Compose codex-framework agent that mounts the audit artifact.
-    # OPENAI_API_KEY env declaration satisfies validateFrameworkApiKey for the
-    # codex framework. The placeholder value is never used at runtime — the
-    # codex-oauth-token firewall injects real auth headers at egress —
-    # but the validator requires the env key to be present (or the provider
-    # to be a single-secret provider whose secretName matches; codex-oauth-
-    # token is multi-auth so getSecretNameForType returns undefined).
+    # Do not declare OPENAI_API_KEY here: direct runs without a framework API
+    # key resolve the seeded codex-oauth-token provider, which injects only
+    # ChatGPT placeholders into the sandbox and performs real auth at egress.
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 agents:
   ${AGENT_NAME}:
     description: "ChatGPT OAuth sandbox audit agent"
     framework: codex
-    environment:
-      OPENAI_API_KEY: "ignored-when-using-codex-oauth-token-provider"
     artifacts:
       - ${AUDIT_ARTIFACT_NAME}:/artifacts
     working_dir: /home/user/workspace
@@ -106,6 +101,7 @@ teardown_file() {
 # (per plan phase Q1 decision: A2 — synthetic + MSW for CI).
 @test "t54-1: codex agent run completes with codex-oauth provider" {
     run $VM0_CLI run "$AGENT_NAME" \
+        --model-provider-type "codex-oauth-token" \
         -- "Reply with exactly RESULT=579"
 
     assert_success
@@ -185,7 +181,9 @@ teardown_file() {
 
     seed_codex_oauth_via_authjson "$raw_json"
 
-    run $VM0_CLI run "$AGENT_NAME" -- "Reply with exactly RESULT=579"
+    run $VM0_CLI run "$AGENT_NAME" \
+        --model-provider-type "codex-oauth-token" \
+        -- "Reply with exactly RESULT=579"
 
     assert_success
     assert_output --partial "RESULT=579"
@@ -244,6 +242,7 @@ teardown_file() {
     fi
 
     run $VM0_CLI run "$AGENT_NAME" \
+        --model-provider-type "codex-oauth-token" \
         --debug-no-mock-codex \
         -- "Run this exact Bash command and include its output:
 curl -sS -m 10 -o /tmp/curl-out.txt -w 'HTTP_CODE=%{http_code} EXIT=%{exitcode}' https://auth.openai.com/oauth/token; echo

--- a/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
+++ b/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
@@ -130,7 +130,7 @@ teardown_file() {
         skip "Requires REAL ChatGPT account tokens (synthetic seed produces 401 from real codex; mock codex doesn't invoke Bash tool). Placeholder claims covered by Rust tests in crates/guest-agent/src/codex_auth.rs. Run with E2E_CHATGPT_REAL_ACCOUNT_TOKENS=1 in nightly real-account job."
     fi
 
-    audit_sandbox_via_agent "$AGENT_NAME"
+    audit_chatgpt_oauth_sandbox_via_agent "$AGENT_NAME"
 
     # The guest-agent's auth.json fabrication put the sandbox in ChatGPT
     # mode with placeholder JWT claims (Epic SC #4). All three ChatGPT-mode
@@ -216,7 +216,7 @@ teardown_file() {
 
     seed_codex_oauth_via_authjson "$raw_json"
 
-    audit_sandbox_via_agent "$AGENT_NAME"
+    audit_chatgpt_oauth_sandbox_via_agent "$AGENT_NAME"
 
     assert_chatgpt_auth_mode
     assert_placeholder_account_id

--- a/e2e/tests/03-runner/t55-codex-oauth-refresh.bats
+++ b/e2e/tests/03-runner/t55-codex-oauth-refresh.bats
@@ -44,16 +44,14 @@ setup_file() {
     # triggers a refresh on any in-sandbox request.
     seed_codex_oauth "$INITIAL_AT" "$INITIAL_RT" "$INITIAL_ACC" "id-tok" -60
 
-    # OPENAI_API_KEY placeholder satisfies validateFrameworkApiKey for codex
-    # framework — see t54-codex-oauth-sandbox.bats for the full rationale.
+    # Do not declare OPENAI_API_KEY here: direct runs without a framework API
+    # key resolve the seeded codex-oauth-token provider.
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 agents:
   ${AGENT_NAME}:
     description: "ChatGPT OAuth refresh rotation test"
     framework: codex
-    environment:
-      OPENAI_API_KEY: "ignored-when-using-codex-oauth-token-provider"
     working_dir: /home/user/workspace
 EOF
     $VM0_CLI compose "$TEST_DIR/vm0.yaml" >/dev/null
@@ -80,6 +78,7 @@ teardown_file() {
     # regression in the firewall webhook pipeline and should be triaged
     # before disabling this test.
     run $VM0_CLI run "$AGENT_NAME" \
+        --model-provider-type "codex-oauth-token" \
         -- "Reply with exactly RESULT=ok"
 
     # Two acceptable outcomes:
@@ -126,7 +125,9 @@ teardown_file() {
 
     seed_codex_oauth_via_authjson "$raw_json" -60
 
-    run $VM0_CLI run "$AGENT_NAME" -- "Reply with exactly RESULT=ok"
+    run $VM0_CLI run "$AGENT_NAME" \
+        --model-provider-type "codex-oauth-token" \
+        -- "Reply with exactly RESULT=ok"
 
     if [ "$status" -eq 0 ]; then
         assert_output --partial "RESULT=ok"

--- a/e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
+++ b/e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
@@ -154,13 +154,13 @@ agents:
   ${agent_name}:
     description: "ChatGPT OAuth stale-rejection test"
     framework: codex
-    environment:
-      OPENAI_API_KEY: "ignored-when-using-codex-oauth-token-provider"
     working_dir: /home/user/workspace
 EOF
     $VM0_CLI compose "$test_dir/vm0.yaml" >/dev/null
 
-    run $VM0_CLI run "$agent_name" -- "test"
+    run $VM0_CLI run "$agent_name" \
+        --model-provider-type "codex-oauth-token" \
+        -- "test"
 
     # Run MUST fail with a stale-provider signal. Tolerant to the exact
     # error code/message shape Wave 3 ships — match on any of:

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -351,6 +351,26 @@ describe("POST /api/agent/runs", () => {
     expect(response.body.error.message).toContain("prompt");
   });
 
+  it("rejects vm0 provider pinning on direct runs", async () => {
+    await fixture();
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: randomUUID(),
+          prompt: "test",
+          modelProviderType: "vm0",
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain(
+      "vm0 model provider is only supported by zero runs",
+    );
+  });
+
   it("creates a pending run, session, and runner job", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -867,6 +867,59 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.modelUsageProvider).toBeUndefined();
   });
 
+  it("injects a Codex gateway provider with the OPENAI_API_KEY placeholder", async () => {
+    const fx = await fixture();
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fx.orgId,
+        type: "openrouter-codex",
+        isDefault: true,
+        secretName: "OPENROUTER_API_KEY",
+      },
+      context.signal,
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fx.orgId }));
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: { framework: "codex", environment: {} },
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use codex provider",
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly cliAgentType: string;
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.cliAgentType).toBe("codex");
+    expect(executionContext.environment).toMatchObject({
+      OPENAI_API_KEY: modelProviderSecretPlaceholder(
+        "openrouter-codex",
+        "OPENROUTER_API_KEY",
+      ),
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+      OPENAI_MODEL: "openai/gpt-5.5",
+    });
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      OPENROUTER_API_KEY: "test-secret-value",
+    });
+  });
+
   it("persists requested artifacts plus memory on the new session", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
@@ -651,7 +651,7 @@ describe("POST /api/test/slack-state", () => {
         "e2e-slack-agent": {
           framework: "claude-code",
           environment: {
-            ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
+            ANTHROPIC_API_KEY: "",
           },
         },
       },

--- a/turbo/apps/api/src/signals/routes/agent-runs-create.ts
+++ b/turbo/apps/api/src/signals/routes/agent-runs-create.ts
@@ -26,6 +26,7 @@ const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       orgId: auth.orgId,
       body: body.data,
       apiStartTime,
+      modelProviderType: body.data.modelProviderType,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -312,7 +312,7 @@ function defaultAgentContent(name: string) {
       [name]: {
         framework: "claude-code",
         environment: {
-          ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
+          ANTHROPIC_API_KEY: "",
         },
       },
     },

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -326,7 +326,7 @@ function defaultAgentContent(name: string) {
       [name]: {
         framework: "claude-code",
         environment: {
-          ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
+          ANTHROPIC_API_KEY: "",
         },
       },
     },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3079,9 +3079,9 @@ async function resolveRunModelProvider(
   );
   const hasProviderOverride =
     args.modelProviderId !== undefined ||
-    args.modelProviderCredentialScope !== undefined;
-  const shouldResolveModelProvider =
-    hasProviderOverride || !hasFrameworkKey || args.modelProviderType === "vm0";
+    args.modelProviderCredentialScope !== undefined ||
+    args.modelProviderType !== undefined;
+  const shouldResolveModelProvider = hasProviderOverride || !hasFrameworkKey;
   const modelProvider = shouldResolveModelProvider
     ? await resolveModelProviderEnvironment(db, {
         orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3079,9 +3079,9 @@ async function resolveRunModelProvider(
   );
   const hasProviderOverride =
     args.modelProviderId !== undefined ||
-    args.modelProviderCredentialScope !== undefined ||
-    args.modelProviderType !== undefined;
-  const shouldResolveModelProvider = hasProviderOverride || !hasFrameworkKey;
+    args.modelProviderCredentialScope !== undefined;
+  const shouldResolveModelProvider =
+    hasProviderOverride || !hasFrameworkKey || args.modelProviderType === "vm0";
   const modelProvider = shouldResolveModelProvider
     ? await resolveModelProviderEnvironment(db, {
         orgId: args.orgId,

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -154,6 +154,38 @@ describe("run command", () => {
       });
     });
 
+    it("should pass hidden model provider type to create run", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--model-provider-type",
+        "openai-api-key",
+      ]);
+
+      expect(capturedBody).toEqual({
+        agentComposeId: testUuid,
+        prompt: "test prompt",
+        vars: undefined,
+        secrets: undefined,
+        volumeVersions: undefined,
+        conversationId: undefined,
+        modelProviderType: "openai-api-key",
+      });
+    });
+
     it("should accept and resolve agent names", async () => {
       let capturedBody: unknown;
       server.use(

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -186,6 +186,24 @@ describe("run command", () => {
       });
     });
 
+    it("should reject vm0 hidden model provider type", async () => {
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          testUuid,
+          "test prompt",
+          "--model-provider-type",
+          "vm0",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid model provider type: vm0"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should accept and resolve agent names", async () => {
       let capturedBody: unknown;
       server.use(

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -1,8 +1,8 @@
 import { Command, Option } from "commander";
 import {
-  modelProviderTypeSchema,
-  type ModelProviderType,
-} from "@vm0/api-contracts/contracts/model-providers";
+  directRunModelProviderTypeSchema,
+  type DirectRunModelProviderType,
+} from "@vm0/api-contracts/contracts/runs";
 import {
   getComposeById,
   getComposeByName,
@@ -34,11 +34,11 @@ declare const __CLI_VERSION__: string;
 
 function parseModelProviderType(
   value: string | undefined,
-): ModelProviderType | undefined {
+): DirectRunModelProviderType | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const parsed = modelProviderTypeSchema.safeParse(value);
+  const parsed = directRunModelProviderTypeSchema.safeParse(value);
   if (!parsed.success) {
     throw new Error(`Invalid model provider type: ${value}`);
   }

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -1,5 +1,9 @@
 import { Command, Option } from "commander";
 import {
+  modelProviderTypeSchema,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
   getComposeById,
   getComposeByName,
   getComposeVersion,
@@ -27,6 +31,19 @@ import {
 import { withErrorHandler } from "../../lib/command";
 
 declare const __CLI_VERSION__: string;
+
+function parseModelProviderType(
+  value: string | undefined,
+): ModelProviderType | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = modelProviderTypeSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Invalid model provider type: ${value}`);
+  }
+  return parsed.data;
+}
 
 export const mainRunCommand = new Command()
   .name("run")
@@ -101,6 +118,7 @@ export const mainRunCommand = new Command()
   )
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .addOption(new Option("--debug-no-mock-codex").hideHelp())
+  .addOption(new Option("--model-provider-type <type>").hideHelp())
   .addOption(new Option("--no-auto-update").hideHelp())
   .action(
     withErrorHandler(
@@ -128,6 +146,7 @@ export const mainRunCommand = new Command()
           captureNetworkBodies?: boolean;
           debugNoMockClaude?: boolean;
           debugNoMockCodex?: boolean;
+          modelProviderType?: string;
           autoUpdate?: boolean;
         },
       ) => {
@@ -223,6 +242,7 @@ export const mainRunCommand = new Command()
           captureNetworkBodies: options.captureNetworkBodies || undefined,
           debugNoMockClaude: options.debugNoMockClaude || undefined,
           debugNoMockCodex: options.debugNoMockCodex || undefined,
+          modelProviderType: parseModelProviderType(options.modelProviderType),
         });
 
         // 7. Check for immediate failure (e.g., missing secrets)

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -8,6 +8,7 @@ import {
   type CancelRunResponse,
   type QueueResponse,
 } from "@vm0/api-contracts/contracts/runs";
+import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import { getClientConfig, handleError } from "../core/client-factory";
 import type { CreateRunResponse, GetEventsResponse } from "../core/types";
@@ -56,6 +57,8 @@ export async function createRun(body: {
   settings?: string;
   // Per-permission policies
   permissionPolicies?: FirewallPolicies;
+  // Internal: pin provider type for direct CLI runs used by E2E
+  modelProviderType?: ModelProviderType;
   // Required
   prompt: string;
 }): Promise<CreateRunResponse> {

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -4,11 +4,11 @@ import {
   runEventsContract,
   runsCancelContract,
   runsQueueContract,
+  type DirectRunModelProviderType,
   type RunsListResponse,
   type CancelRunResponse,
   type QueueResponse,
 } from "@vm0/api-contracts/contracts/runs";
-import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import { getClientConfig, handleError } from "../core/client-factory";
 import type { CreateRunResponse, GetEventsResponse } from "../core/types";
@@ -57,8 +57,9 @@ export async function createRun(body: {
   settings?: string;
   // Per-permission policies
   permissionPolicies?: FirewallPolicies;
-  // Internal: pin provider type for direct CLI runs used by E2E
-  modelProviderType?: ModelProviderType;
+  // Internal: pin provider type for direct CLI runs used by E2E.
+  // vm0 is excluded; zero runs own vm0 credit enforcement.
+  modelProviderType?: DirectRunModelProviderType;
   // Required
   prompt: string;
 }): Promise<CreateRunResponse> {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -27,6 +27,7 @@ import {
   SUPPORTED_RUN_MODELS,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
   MODEL_PROVIDER_TYPES,
   modelProviderTypeSchema,
   modelProviderFrameworkSchema,
@@ -35,6 +36,28 @@ import {
 import { findMatchingPermissions } from "@vm0/connectors/firewall-rule-matcher";
 
 describe("model-first canonical catalog", () => {
+  it("exposes canonical model provider env placeholders", () => {
+    expect(Object.keys(MODEL_PROVIDER_ENV_PLACEHOLDERS).sort()).toEqual([
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_AUTH_TOKEN",
+      "CHATGPT_ACCESS_TOKEN",
+      "CHATGPT_ACCOUNT_ID",
+      "CHATGPT_REFRESH_TOKEN",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "OPENAI_API_KEY",
+    ]);
+    expect(MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY).toMatch(
+      /^sk-ant-api03-/,
+    );
+    expect(MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN).toMatch(
+      /^sk-ant-oat01-/,
+    );
+    expect(MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY).toMatch(/^sk-proj-/);
+    expect(
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN.split("."),
+    ).toHaveLength(1);
+  });
+
   it("exposes the curated flat model list only", () => {
     expect(SUPPORTED_RUN_MODELS).toEqual([
       "claude-opus-4-7",
@@ -410,6 +433,74 @@ describe("firewall base URL scoped to /v1/messages (#9560)", () => {
   );
 });
 
+describe("model provider firewall placeholders", () => {
+  it.each([
+    [
+      "anthropic-api-key",
+      "ANTHROPIC_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
+    ],
+    [
+      "claude-code-oauth-token",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
+    ],
+    [
+      "openrouter-api-key",
+      "OPENROUTER_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "moonshot-api-key",
+      "MOONSHOT_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "minimax-api-key",
+      "MINIMAX_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "deepseek-api-key",
+      "DEEPSEEK_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "zai-api-key",
+      "ZAI_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "vercel-ai-gateway",
+      "VERCEL_AI_GATEWAY_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    ],
+    [
+      "openrouter-codex",
+      "OPENROUTER_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    ],
+    [
+      "vercel-ai-gateway-codex",
+      "VERCEL_AI_GATEWAY_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    ],
+    [
+      "openai-api-key",
+      "OPENAI_API_KEY",
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    ],
+  ] as const)(
+    "%s uses the canonical placeholder for %s",
+    (type, secretName, placeholder) => {
+      const config = MODEL_PROVIDER_FIREWALL_CONFIGS[type];
+      expect(config.placeholders).toMatchObject({
+        [secretName]: placeholder,
+      });
+    },
+  );
+});
+
 describe("codex-oauth-token codex provider", () => {
   it("declares codex framework", () => {
     expect(getFrameworkForType("codex-oauth-token")).toBe("codex");
@@ -589,9 +680,10 @@ describe("codex-oauth-token codex provider", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
     expect(config.placeholders).toEqual({
       CHATGPT_ACCESS_TOKEN:
-        "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
-      CHATGPT_ACCOUNT_ID: "ws_VM0_PLACEHOLDER_DO_NOT_TRUST",
-      CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+      CHATGPT_ACCOUNT_ID: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
+      CHATGPT_REFRESH_TOKEN:
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
     });
   });
 

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -936,6 +936,33 @@ type FirewallSupportedProvider = Exclude<
   HiddenProviderType | "vm0"
 >;
 
+export const MODEL_PROVIDER_ENV_PLACEHOLDERS = {
+  // Placeholder: sk-ant-api03-{93 word/hyphen chars}AA (108 chars total)
+  // Source: Semgrep regex \Bsk-ant-api03-[\w\-]{93}AA\B
+  //   https://semgrep.dev/blog/2025/secrets-story-and-prefixed-secrets/
+  ANTHROPIC_API_KEY:
+    "sk-ant-api03-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+  // Placeholder: sk-ant-oat01-{93 word/hyphen chars}AA (108 chars total)
+  // Source: same structure as API key; prefix from claude setup-token output
+  //   https://github.com/anthropics/claude-code/issues/18340
+  //   Example: sk-ant-oat01-xxxxx...xxxxx (1-year OAuth token)
+  CLAUDE_CODE_OAUTH_TOKEN:
+    "sk-ant-oat01-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+  // Generic bearer-token marker for Claude-compatible gateways that map
+  // provider-specific secrets into ANTHROPIC_AUTH_TOKEN.
+  ANTHROPIC_AUTH_TOKEN: "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+  // Placeholder: sk-proj-{chars}T3BlbkFJ{chars} (typical project key shape)
+  // Source: matches turbo/packages/connectors/src/firewalls/openai.generated.ts
+  OPENAI_API_KEY:
+    "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca",
+  // Opaque fake marker, not a JWT. Codex ChatGPT mode reads auth.json, while
+  // firewall auth substitutes this marker at egress.
+  CHATGPT_ACCESS_TOKEN:
+    "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
+  CHATGPT_ACCOUNT_ID: "ws_VM0_PLACEHOLDER_DO_NOT_TRUST",
+  CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
+} as const;
+
 /**
  * Get provider types available for user selection.
  * Excludes providers that are hidden from the UI (e.g., those without token replacement support).
@@ -1037,94 +1064,69 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
   FirewallSupportedProvider,
   ExpandedFirewallConfig
 > = {
-  // Placeholder: sk-ant-api03-{93 word/hyphen chars}AA (108 chars total)
-  // Source: Semgrep regex \Bsk-ant-api03-[\w\-]{93}AA\B
-  //   https://semgrep.dev/blog/2025/secrets-story-and-prefixed-secrets/
   "anthropic-api-key": mpFirewall(
     "anthropic-api-key",
     { name: "x-api-key" },
-    "sk-ant-api03-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
   ),
-  // Placeholder: sk-ant-oat01-{93 word/hyphen chars}AA (108 chars total)
-  // Source: same structure as API key; prefix from claude setup-token output
-  //   https://github.com/anthropics/claude-code/issues/18340
-  //   Example: sk-ant-oat01-xxxxx...xxxxx (1-year OAuth token)
   "claude-code-oauth-token": mpFirewall(
     "claude-code-oauth-token",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-ant-oat01-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCofAA",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
   ),
-  // Placeholder: sk-or-v1-{64 hex chars} (73 chars total)
-  // Source: real key observed in GitHub issue
-  //   https://github.com/continuedev/continue/issues/6191
-  //   Example: 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
   "openrouter-api-key": mpFirewall(
     "openrouter-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "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",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 chars} (35 chars total)
-  // Source: no authoritative format documentation found; using generic sk- prefix
   "moonshot-api-key": mpFirewall(
     "moonshot-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: eyJ... (JWT-style, variable length)
-  // Source: no authoritative format documentation found; MiniMax docs do not disclose key format
-  //   https://platform.minimax.io/docs/api-reference/api-overview
   "minimax-api-key": mpFirewall(
     "minimax-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "eyCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffe",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 hex chars} (35 chars total)
-  // Source: Semgrep regex \bsk-[a-f0-9]{32}\b
-  //   https://semgrep.dev/blog/2025/secrets-story-and-prefixed-secrets/
   "deepseek-api-key": mpFirewall(
     "deepseek-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-c0ffee5afe10ca1c0ffee5afe10ca1c0",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 chars} (35 chars total)
-  // Source: no authoritative format documentation found; using generic sk- prefix
   "zai-api-key": mpFirewall(
     "zai-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Placeholder: sk-{32 chars} (35 chars total)
-  // Source: no authoritative format documentation found; Vercel gateway proxies upstream providers
   "vercel-ai-gateway": mpFirewall(
     "vercel-ai-gateway",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
   ),
-  // Codex-framework twin of openrouter-api-key. Same key shape as the
-  // claude-code entry; the difference is the firewall base URL — codex
-  // SDK hits OpenAI-compatible paths (/chat/completions, /responses)
-  // under https://openrouter.ai/api/v1, derived from the OPENAI_BASE_URL
-  // mapping by getFirewallBaseUrl.
+  // Codex-framework twin of openrouter-api-key. It reuses the same stored
+  // OpenRouter secret, but the sandbox env key is OPENAI_API_KEY because codex
+  // SDK hits OpenAI-compatible paths (/chat/completions, /responses) under
+  // https://openrouter.ai/api/v1, derived from the OPENAI_BASE_URL mapping by
+  // getFirewallBaseUrl.
   "openrouter-codex": mpFirewall(
     "openrouter-codex",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "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",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
-  // Codex-framework twin of vercel-ai-gateway. Same placeholder format
-  // (Vercel gateway proxies upstream); base URL scoped to /v1 prefix by
-  // getFirewallBaseUrl so codex can use either /chat/completions or
-  // /responses paths the gateway exposes.
+  // Codex-framework twin of vercel-ai-gateway. It reuses the same stored Vercel
+  // secret, but the sandbox env key is OPENAI_API_KEY. Base URL is scoped to
+  // the /v1 prefix by getFirewallBaseUrl so codex can use either
+  // /chat/completions or /responses paths the gateway exposes.
   "vercel-ai-gateway-codex": mpFirewall(
     "vercel-ai-gateway-codex",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
-  // Placeholder: sk-proj-{156 chars}T3BlbkFJ{156 chars} (typical project key shape)
-  // Source: matches turbo/packages/connectors/src/firewalls/openai.generated.ts
   "openai-api-key": mpFirewall(
     "openai-api-key",
     { name: "Authorization", valuePrefix: "Bearer" },
-    "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca",
+    MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
   // ChatGPT OAuth provider — multi-header injection + auth.openai.com deny.
   // Sandbox holds placeholder strings; firewall replaces them with real
@@ -1176,14 +1178,15 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
     },
     placeholders: {
       CHATGPT_ACCESS_TOKEN:
-        "chatgpt-token-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
-      CHATGPT_ACCOUNT_ID: "ws_VM0_PLACEHOLDER_DO_NOT_TRUST",
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+      CHATGPT_ACCOUNT_ID: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
       // refresh_token written by guest-agent into ~/.codex/auth.json (#12077).
       // Kept in this map so the firewall can substitute it on egress if codex
       // ever tries to use it directly — defense-in-depth alongside
       // CODEX_REFRESH_TOKEN_URL_OVERRIDE which redirects refresh attempts to
       // localhost. The sandbox never gets the real refresh_token (#7365).
-      CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
+      CHATGPT_REFRESH_TOKEN:
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
     },
   },
 };

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -2,11 +2,22 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import { firewallPoliciesSchema } from "@vm0/connectors/firewall-types";
-import { modelProviderTypeSchema } from "./model-providers";
+import {
+  modelProviderTypeSchema,
+  type ModelProviderType,
+} from "./model-providers";
 import { triggerSourceSchema } from "./logs";
 import { orgTierSchema } from "./orgs";
 
 const c = initContract();
+export type DirectRunModelProviderType = Exclude<ModelProviderType, "vm0">;
+
+const directRunModelProviderTypeSchema = modelProviderTypeSchema.refine(
+  (type) => {
+    return type !== "vm0";
+  },
+  { message: "vm0 model provider is only supported by zero runs" },
+);
 
 // Stored in Postgres `integer` columns. Keep request validation aligned with
 // the DB range so malformed sandbox payloads fail as 400s instead of DB errors.
@@ -114,7 +125,9 @@ const unifiedRunRequestSchema = z
     permissionPolicies: firewallPoliciesSchema.optional(),
 
     // Internal: pin provider type for direct CLI runs used by E2E.
-    modelProviderType: modelProviderTypeSchema.optional(),
+    // vm0 is intentionally excluded here because only zero runs enforce
+    // vm0-managed-provider credits.
+    modelProviderType: directRunModelProviderTypeSchema.optional(),
   })
   .strict();
 
@@ -739,6 +752,7 @@ export type RunsQueueContract = typeof runsQueueContract;
 // Export schemas for reuse
 export {
   runStatusSchema,
+  directRunModelProviderTypeSchema,
   unifiedRunRequestSchema,
   createRunResponseSchema,
   getRunResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import { firewallPoliciesSchema } from "@vm0/connectors/firewall-types";
+import { modelProviderTypeSchema } from "./model-providers";
 import { triggerSourceSchema } from "./logs";
 import { orgTierSchema } from "./orgs";
 
@@ -111,6 +112,9 @@ const unifiedRunRequestSchema = z
 
     // Per-permission policies (e.g., { "github": { "actions:read": "allow" } })
     permissionPolicies: firewallPoliciesSchema.optional(),
+
+    // Internal: pin provider type for direct CLI runs used by E2E.
+    modelProviderType: modelProviderTypeSchema.optional(),
   })
   .strict();
 

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -31,6 +31,7 @@ const zeroRunRequestSchema = unifiedRunRequestSchema
     secrets: true,
     agentComposeId: true,
     appendSystemPrompt: true,
+    modelProviderType: true,
   })
   .extend({
     agentId: z.string().optional(),

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -7,7 +7,10 @@ import {
   type RustStringConstantBinding,
   rustStringConstantBindings,
 } from "../constants";
-import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "../../contracts/model-providers";
+import {
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
+  MODEL_PROVIDER_FIREWALL_CONFIGS,
+} from "../../contracts/model-providers";
 
 const codexOauthPlaceholders =
   MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"].placeholders!;
@@ -27,6 +30,41 @@ const expectedBindings = [
     rustModulePath: ["codex_oauth_token", "placeholders"],
     rustConstName: "CHATGPT_REFRESH_TOKEN",
     value: codexOauthPlaceholders.CHATGPT_REFRESH_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "ANTHROPIC_API_KEY",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "ANTHROPIC_AUTH_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CLAUDE_CODE_OAUTH_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "OPENAI_API_KEY",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CHATGPT_ACCESS_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CHATGPT_ACCOUNT_ID",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
+  },
+  {
+    rustModulePath: ["model_provider_env", "placeholders"],
+    rustConstName: "CHATGPT_REFRESH_TOKEN",
+    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
   },
 ] as const;
 
@@ -74,9 +112,14 @@ describe("Rust string constant bindings", () => {
 
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod codex_oauth_token {");
+    expect(firstRender).toContain("pub mod model_provider_env {");
     expect(firstRender).toContain("pub mod placeholders {");
     expect(firstRender).toContain(
       `pub const CHATGPT_ACCOUNT_ID: &str = "${codexOauthPlaceholders.CHATGPT_ACCOUNT_ID}";`,
+    );
+    expect(firstRender).toContain("pub const OPENAI_API_KEY: &str =");
+    expect(firstRender).toContain(
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
     );
     expect(firstRender).toContain(
       `pub const CHATGPT_REFRESH_TOKEN: &str = "${codexOauthPlaceholders.CHATGPT_REFRESH_TOKEN}";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -1,4 +1,7 @@
-import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "../contracts/model-providers";
+import {
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
+  MODEL_PROVIDER_FIREWALL_CONFIGS,
+} from "../contracts/model-providers";
 
 export interface RustStringConstantBinding {
   readonly rustModulePath: readonly string[];
@@ -14,8 +17,26 @@ const codexOauthPlaceholderNames = [
 
 type CodexOauthPlaceholderName = (typeof codexOauthPlaceholderNames)[number];
 
+const modelProviderEnvPlaceholderNames = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "CHATGPT_ACCESS_TOKEN",
+  "CHATGPT_ACCOUNT_ID",
+  "CHATGPT_REFRESH_TOKEN",
+] as const;
+
+type ModelProviderEnvPlaceholderName =
+  (typeof modelProviderEnvPlaceholderNames)[number];
+
 const codexOauthPlaceholderModule = [
   "codex_oauth_token",
+  "placeholders",
+] as const;
+
+const modelProviderEnvPlaceholderModule = [
+  "model_provider_env",
   "placeholders",
 ] as const;
 
@@ -33,12 +54,29 @@ function codexOauthPlaceholder(name: CodexOauthPlaceholderName): string {
   return value;
 }
 
-export const rustStringConstantBindings = codexOauthPlaceholderNames.map(
-  (name) => {
+function modelProviderEnvPlaceholder(
+  name: ModelProviderEnvPlaceholderName,
+): string {
+  const value = MODEL_PROVIDER_ENV_PLACEHOLDERS[name];
+  if (value.length === 0) {
+    throw new Error(`model provider env placeholder ${name} is empty`);
+  }
+  return value;
+}
+
+export const rustStringConstantBindings = [
+  ...codexOauthPlaceholderNames.map((name) => {
     return {
       rustModulePath: codexOauthPlaceholderModule,
       rustConstName: name,
       value: codexOauthPlaceholder(name),
     };
-  },
-) satisfies readonly RustStringConstantBinding[];
+  }),
+  ...modelProviderEnvPlaceholderNames.map((name) => {
+    return {
+      rustModulePath: modelProviderEnvPlaceholderModule,
+      rustConstName: name,
+      value: modelProviderEnvPlaceholder(name),
+    };
+  }),
+] satisfies readonly RustStringConstantBinding[];

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -698,13 +698,14 @@ function renderStringConstant(
 ): string[] {
   const literal = rustStringLiteral(constant.value);
   const singleLine = `${indent}pub const ${constant.rustConstName}: &str = ${literal};`;
-  if (singleLine.length <= 100) {
+  const splitValueLine = `${indent}    ${literal};`;
+  if (singleLine.length <= 100 || splitValueLine.length > 100) {
     return [singleLine];
   }
 
   return [
     `${indent}pub const ${constant.rustConstName}: &str =`,
-    `${indent}    ${literal};`,
+    splitValueLine,
   ];
 }
 


### PR DESCRIPTION
## Summary

- centralize model provider runtime env placeholders and export them to generated Rust constants
- validate protected Claude/Codex env keys in the runner before launching sandbox processes
- keep Rust string constant generation stable under `cargo fmt`
- add API and Rust coverage for canonical placeholders, safe failures, and Codex gateway env mapping

Closes #14992

## Tests

- `pnpm -F @vm0/api-contracts generate:rust && git diff --exit-code -- ../crates/api-contracts/src/generated`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner model_provider_env`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts`
- pre-commit hook: `pnpm check-types`, `pnpm knip`, cargo doc/clippy