### PR TITLE
fix(desktop): polish computer use renderer layout

### DIFF
--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import {
+  IconActivityHeartbeat,
   IconAlertCircle,
   IconBuilding,
   IconChevronDown,
@@ -412,7 +413,7 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
     startLoadable.state === "loading";
 
   return (
-    <Panel title="Runtime">
+    <Panel title="Runtime" icon={<IconActivityHeartbeat size={18} />}>
       <div className="runtime-grid">
         <div>
           <span>Status</span>
@@ -892,9 +893,6 @@ function AccountMenu({
   }
 
   const workspaceLabel = authState.organization?.name ?? "Select workspace";
-  const workspaceMeta = authState.organization?.slug
-    ? `/${authState.organization.slug}`
-    : "No active workspace";
 
   return (
     <details className="account-menu">
@@ -902,15 +900,6 @@ function AccountMenu({
         <IconUserCircle size={17} />
         <span className="account-copy">
           <span className="account-email">{authState.user.email}</span>
-          <span
-            className={
-              authState.organization
-                ? "account-workspace"
-                : "account-workspace account-workspace-missing"
-            }
-          >
-            {workspaceLabel}
-          </span>
         </span>
         <IconChevronDown size={14} />
       </summary>
@@ -922,7 +911,6 @@ function AccountMenu({
         <div className="account-popover-heading">
           <span>Workspace</span>
           <strong>{workspaceLabel}</strong>
-          <small>{workspaceMeta}</small>
         </div>
         <button
           type="button"

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -146,33 +146,18 @@ button {
 
 .account-copy {
   min-width: 0;
-  display: grid;
-  gap: 1px;
-}
-
-.account-email,
-.account-workspace {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: block;
 }
 
 .account-email {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: #202631;
   font-size: 12px;
-  line-height: 1.15;
+  line-height: 1.2;
   font-weight: 650;
-}
-
-.account-workspace {
-  color: #667085;
-  font-size: 11px;
-  line-height: 1.1;
-  font-weight: 500;
-}
-
-.account-workspace-missing {
-  color: #b54708;
 }
 
 .account-popover {
@@ -245,6 +230,7 @@ button {
   padding: 18px 20px 32px;
   display: grid;
   justify-items: center;
+  align-content: start;
   gap: 14px;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -278,9 +264,10 @@ button {
 
 .panel {
   border-radius: 8px;
-  padding: 16px;
+  padding: 14px 16px;
   display: grid;
-  gap: 14px;
+  align-content: start;
+  gap: 10px;
 }
 
 .panel-heading {


### PR DESCRIPTION
## Summary
- tighten Desktop renderer panel spacing so section headers sit closer to their content
- add the Runtime section icon for consistency with Permissions and Command Log
- simplify the account menu summary and workspace block by removing the secondary workspace/slug lines

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop build:renderer
- pnpm -F @vm0/desktop test
- pnpm knip

## Notes
- pnpm vitest was attempted locally, but the repo-wide web global setup is blocked by missing local DATABASE_URL/env values. scripts/prepare.sh was also attempted and failed because 1Password CLI is unavailable and the required env files are not synced on this machine.
- This supersedes #15001, whose codex/* head ref did not generate GitHub Actions runs.