### PR TITLE
fix: gate connector entry points by feature switches

### DIFF
--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -66,6 +66,13 @@ encode_test_email() {
     printf '%s' "$E2E_RUNNER_EMAIL" | sed 's/+/%2B/g; s/@/%40/g'
 }
 
+enable_test_oauth_feature_switch() {
+    zero_curl "/api/zero/feature-switches" \
+        -X POST \
+        -d '{"switches":{"testOauthConnector":true}}' \
+        >/dev/null
+}
+
 # Enable the test-oauth connector for a specific compose (user_connectors row).
 # Required for zero-run to pass it in allowedConnectorTypes.
 enable_test_oauth_for_compose() {
@@ -153,6 +160,8 @@ header_location() {
 
 connect_test_oauth_via_authorization_code() {
     local scenario="${1:-}"
+    enable_test_oauth_feature_switch || return 1
+
     local start_body
     start_body=$(zero_curl "/api/zero/connectors/test-oauth/oauth/start" -X POST -d '{}')
     local authorization_url

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-authorize.test.ts
@@ -1,13 +1,19 @@
 import { randomUUID } from "node:crypto";
 
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { describe, expect, it, beforeEach } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
+const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 const BASE_URL = "https://app.vm0.test";
@@ -36,6 +42,30 @@ async function requestAuthorize(
     method: "GET",
     headers: options.authenticated ? sessionHeaders() : undefined,
   });
+}
+
+async function requestAuthorizeWithFeature(
+  type: string,
+  featureKey: FeatureSwitchKey,
+): Promise<Response> {
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId,
+    userId,
+    switches: { [featureKey]: true },
+  });
+  mocks.clerk.session(userId, orgId);
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(authorizeUrl(type), {
+    method: "GET",
+    headers: sessionHeaders(),
+  });
+  await db
+    .delete(userFeatureSwitches)
+    .where(eq(userFeatureSwitches.orgId, orgId));
+  return response;
 }
 
 describe("GET /api/connectors/:type/authorize", () => {
@@ -142,6 +172,17 @@ describe("GET /api/connectors/:type/authorize", () => {
     ).toBeFalsy();
   });
 
+  it("rejects feature-disabled direct OAuth authorization", async () => {
+    const response = await requestAuthorize("docusign", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "docusign connector is not available",
+    });
+  });
+
   it("uses Slack user_scope rather than scope", async () => {
     const response = await requestAuthorize("slack", { authenticated: true });
 
@@ -158,9 +199,10 @@ describe("GET /api/connectors/:type/authorize", () => {
   });
 
   it("includes DocuSign OAuth parameters", async () => {
-    const response = await requestAuthorize("docusign", {
-      authenticated: true,
-    });
+    const response = await requestAuthorizeWithFeature(
+      "docusign",
+      FeatureSwitchKey.DocuSignConnector,
+    );
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
@@ -181,9 +223,10 @@ describe("GET /api/connectors/:type/authorize", () => {
   });
 
   it("includes Mercury OAuth parameters", async () => {
-    const response = await requestAuthorize("mercury", {
-      authenticated: true,
-    });
+    const response = await requestAuthorizeWithFeature(
+      "mercury",
+      FeatureSwitchKey.MercuryConnector,
+    );
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
@@ -221,7 +264,10 @@ describe("GET /api/connectors/:type/authorize", () => {
   });
 
   it("requests permanent Reddit authorization", async () => {
-    const response = await requestAuthorize("reddit", { authenticated: true });
+    const response = await requestAuthorizeWithFeature(
+      "reddit",
+      FeatureSwitchKey.RedditConnector,
+    );
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import type { ConnectorOAuthClientConfig } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { testOauthProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -88,6 +90,19 @@ const dynamicPublicClient = {
   clientType: "public",
   tokenEndpointAuthMethod: "none",
 } as const satisfies ConnectorOAuthClientConfig;
+
+async function enableConnectorFeature(
+  userId: string,
+  orgId: string,
+  featureKey: FeatureSwitchKey,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId,
+    userId,
+    switches: { [featureKey]: true },
+  });
+}
 
 function useDynamicTestOAuthAuthorize(): () => void {
   const grant = getConnectorAuthMethod("test-oauth", "oauth")?.grant;
@@ -182,9 +197,28 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
       if (orgId) {
         await db.delete(connectors).where(eq(connectors.orgId, orgId));
         await db.delete(secrets).where(eq(secrets.orgId, orgId));
+        await db
+          .delete(userFeatureSwitches)
+          .where(eq(userFeatureSwitches.orgId, orgId));
       }
     }
   });
+
+  async function requestAuthorizeWithFeature(
+    type: string,
+    featureKey: FeatureSwitchKey,
+  ): Promise<Response> {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    await enableConnectorFeature(userId, orgId, featureKey);
+    mocks.clerk.session(userId, orgId);
+    const app = createApp({ signal: context.signal });
+    return await app.request(authorizeUrl(type), {
+      method: "GET",
+      headers: sessionHeaders(),
+    });
+  }
 
   it("returns 400 for an unknown connector type", async () => {
     const response = await requestAuthorize("invalid");
@@ -260,6 +294,17 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
         return cookie.startsWith("connector_oauth_state=");
       }),
     ).toBeTruthy();
+  });
+
+  it("rejects auth-code OAuth authorization when the connector feature is disabled", async () => {
+    const response = await requestAuthorize("test-oauth", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "test-oauth connector is not available",
+    });
   });
 
   it("returns 400 when authorizing a device authorization connector", async () => {
@@ -345,9 +390,20 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
 
   it("allows dynamic public OAuth authorize without env credentials", async () => {
     restoreDynamicTestOAuthAuthorize = useDynamicTestOAuthAuthorize();
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    await enableConnectorFeature(
+      userId,
+      orgId,
+      FeatureSwitchKey.TestOauthConnector,
+    );
+    mocks.clerk.session(userId, orgId);
 
-    const response = await requestAuthorize("test-oauth", {
-      authenticated: true,
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(authorizeUrl("test-oauth"), {
+      method: "GET",
+      headers: sessionHeaders(),
     });
 
     expect(response.status).toBe(307);
@@ -409,9 +465,10 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
   });
 
   it("includes DocuSign PKCE parameters", async () => {
-    const response = await requestAuthorize("docusign", {
-      authenticated: true,
-    });
+    const response = await requestAuthorizeWithFeature(
+      "docusign",
+      FeatureSwitchKey.DocuSignConnector,
+    );
 
     const location = response.headers.get("location");
     expect(location).not.toBeNull();
@@ -426,7 +483,10 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
   });
 
   it("requests permanent Reddit authorization", async () => {
-    const response = await requestAuthorize("reddit", { authenticated: true });
+    const response = await requestAuthorizeWithFeature(
+      "reddit",
+      FeatureSwitchKey.RedditConnector,
+    );
 
     const location = response.headers.get("location");
     expect(location).not.toBeNull();
@@ -462,9 +522,10 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
   });
 
   it("requests offline Dropbox authorization", async () => {
-    const response = await requestAuthorize("dropbox", {
-      authenticated: true,
-    });
+    const response = await requestAuthorizeWithFeature(
+      "dropbox",
+      FeatureSwitchKey.DropboxConnector,
+    );
 
     const location = response.headers.get("location");
     expect(location).not.toBeNull();
@@ -703,8 +764,25 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
       if (orgId) {
         await db.delete(connectors).where(eq(connectors.orgId, orgId));
         await db.delete(secrets).where(eq(secrets.orgId, orgId));
+        await db
+          .delete(userFeatureSwitches)
+          .where(eq(userFeatureSwitches.orgId, orgId));
       }
     }
+  });
+
+  it("rejects auth-code OAuth start when the connector feature is disabled", async () => {
+    const response = await requestOauthStart("test-oauth", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "test-oauth connector is not available",
+        code: "FORBIDDEN",
+      },
+    });
   });
 
   it("creates a server-side OAuth handoff and returns the provider authorization URL", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-create.test.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroComputerConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -56,6 +58,18 @@ async function deleteFixture(fixture: OrgUserFixture): Promise<void> {
   const db = store.set(writeDb$);
   await db.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
   await db.delete(connectors).where(eq(connectors.orgId, fixture.orgId));
+  await db
+    .delete(userFeatureSwitches)
+    .where(eq(userFeatureSwitches.orgId, fixture.orgId));
+}
+
+async function enableComputerConnector(fixture: OrgUserFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ComputerConnector]: true },
+  });
 }
 
 function setupNgrokMocks(): NgrokCalls {
@@ -210,9 +224,30 @@ describe("POST /api/zero/connectors/computer", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("returns 403 when the computer connector feature is disabled", async () => {
+    const fixture = uniqueOrgUser("zcomp-disabled");
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "computer connector is not available",
+      code: "FORBIDDEN",
+    });
+  });
+
   it("returns 400 when ngrok is not configured", async () => {
     const fixture = uniqueOrgUser("zcomp-no-ngrok");
     fixtures.push(fixture);
+    await enableComputerConnector(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const client = setupApp({ context })(zeroComputerConnectorContract);
 
@@ -233,6 +268,7 @@ describe("POST /api/zero/connectors/computer", () => {
   it("creates a computer connector", async () => {
     const fixture = uniqueOrgUser("zcomp-create");
     fixtures.push(fixture);
+    await enableComputerConnector(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
     const ngrokCalls = setupNgrokMocks();
@@ -277,6 +313,7 @@ describe("POST /api/zero/connectors/computer", () => {
   it("returns 409 when the computer connector already exists", async () => {
     const fixture = uniqueOrgUser("zcomp-duplicate");
     fixtures.push(fixture);
+    await enableComputerConnector(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
     setupNgrokMocks();
@@ -307,6 +344,7 @@ describe("POST /api/zero/connectors/computer", () => {
   it("cleans up resources when endpoint creation fails", async () => {
     const fixture = uniqueOrgUser("zcomp-endpoint-fail");
     fixtures.push(fixture);
+    await enableComputerConnector(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
     const ngrokCalls = setupNgrokMocks();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-local-agent-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-local-agent-connect.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroLocalAgentConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectors } from "@vm0/db/schema/connector";
 import { localAgentHosts } from "@vm0/db/schema/local-agent";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -20,6 +22,15 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+async function enableLocalAgent(orgId: string, userId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId,
+    userId,
+    switches: { [FeatureSwitchKey.LocalAgentConnector]: true },
+  });
+}
 
 async function seedLocalAgentHost(args: {
   readonly orgId: string;
@@ -51,6 +62,14 @@ async function deleteLocalAgentConnectorFixture(
     writeDb
       .delete(localAgentHosts)
       .where(eq(localAgentHosts.orgId, fixture.orgId)),
+    writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      ),
   ]);
 }
 
@@ -73,6 +92,7 @@ describe("POST /api/zero/connectors/local-agent", () => {
     seededFixtures.push(
       await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
     );
+    await enableLocalAgent(orgId, userId);
     await seedLocalAgentHost({ orgId, userId, status: "online" });
     mocks.clerk.session(userId, orgId);
 
@@ -92,12 +112,34 @@ describe("POST /api/zero/connectors/local-agent", () => {
     });
   });
 
+  it("rejects connect when local-agent connector is disabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedLocalAgentHost({ orgId, userId, status: "online" });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroLocalAgentConnectorContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
   it("rejects connect when no linked host is online", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     seededFixtures.push(
       await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
     );
+    await enableLocalAgent(orgId, userId);
     await seedLocalAgentHost({ orgId, userId, status: "offline" });
     mocks.clerk.session(userId, orgId);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { zeroConnectorSessionsContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -72,6 +72,38 @@ describe("POST /api/zero/connectors/:type/sessions", () => {
       userId,
       status: "pending",
     });
+  });
+
+  it("rejects feature-disabled connector sessions without creating a row", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "docusign" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "docusign connector is not available",
+      code: "FORBIDDEN",
+    });
+
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({ id: connectorSessions.id })
+      .from(connectorSessions)
+      .where(
+        and(
+          eq(connectorSessions.userId, userId),
+          eq(connectorSessions.type, "docusign"),
+        ),
+      );
+    expect(rows).toStrictEqual([]);
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
@@ -446,6 +446,28 @@ describe("POST /api/zero/onboarding/setup", () => {
     ]);
   });
 
+  it("rejects disabled selected connectors before creating the default agent", async () => {
+    const fixture = await track(createFixture());
+    mockAdminSession(fixture);
+
+    const response = await accept(
+      apiClient().setup({
+        headers: authHeaders(),
+        body: {
+          displayName: "Zero",
+          selectedConnectors: ["slock"],
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toContain(
+      "Connector types are not available: slock",
+    );
+    await expect(countAgents(fixture.orgId)).resolves.toBe(0);
+  });
+
   it("authorizes connectors on a repeated setup call to an existing default agent", async () => {
     const fixture = await track(createFixture());
     mockAdminSession(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
@@ -455,7 +455,7 @@ describe("POST /api/zero/onboarding/setup", () => {
         headers: authHeaders(),
         body: {
           displayName: "Zero",
-          selectedConnectors: ["slock"],
+          selectedConnectors: ["bentoml"],
         },
       }),
       [403],
@@ -463,7 +463,7 @@ describe("POST /api/zero/onboarding/setup", () => {
 
     expect(response.body.error.code).toBe("FORBIDDEN");
     expect(response.body.error.message).toContain(
-      "Connector types are not available: slock",
+      "Connector types are not available: bentoml",
     );
     await expect(countAgents(fixture.orgId)).resolves.toBe(0);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts
@@ -146,6 +146,35 @@ describe("PUT /api/zero/agents/:id/user-connectors", () => {
     ).resolves.toStrictEqual(expect.arrayContaining(["github", "slack"]));
   });
 
+  it("rejects connector permissions for disabled connector types", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["slock"] },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+    expect(response.body.error.message).toContain(
+      "Connector types are not available: slock",
+    );
+    await expect(
+      getEnabledTypes(fixture.orgId, fixture.userId, agentId),
+    ).resolves.toStrictEqual([]);
+  });
+
   it("accepts a CLI token when updating connector permissions", async () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts
@@ -161,14 +161,14 @@ describe("PUT /api/zero/agents/:id/user-connectors", () => {
       apiClient().update({
         params: { id: agentId },
         headers: authHeaders(),
-        body: { enabledTypes: ["slock"] },
+        body: { enabledTypes: ["bentoml"] },
       }),
       [400],
     );
 
     expect(response.body.error.code).toBe("VALIDATION_ERROR");
     expect(response.body.error.message).toContain(
-      "Connector types are not available: slock",
+      "Connector types are not available: bentoml",
     );
     await expect(
       getEnabledTypes(fixture.orgId, fixture.userId, agentId),

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -9,7 +9,10 @@ import {
   type ZeroAgentVisibility,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import {
+  connectorTypeSchema,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -43,6 +46,10 @@ import {
   zeroAgentList,
   visibleJoinedZeroAgentCondition,
 } from "../services/zero-agent-data.service";
+import {
+  unavailableUserConnectorTypes,
+  userConnectorAvailability,
+} from "../services/connector-availability.service";
 import type { RouteEntry } from "../route";
 
 const PUBLIC_AGENT_LIMIT = 7;
@@ -920,19 +927,34 @@ const updateAgentUserConnectorsInner$ = command(
     }
 
     const uniqueTypes = Array.from(new Set(body.data.enabledTypes));
-    const invalidTypes = uniqueTypes.filter((t) => {
-      return !connectorTypeSchema.safeParse(t).success;
-    });
+    const parsedTypes: ConnectorType[] = [];
+    const invalidTypes: string[] = [];
+    for (const type of uniqueTypes) {
+      const parsed = connectorTypeSchema.safeParse(type);
+      if (parsed.success) {
+        parsedTypes.push(parsed.data);
+      } else {
+        invalidTypes.push(type);
+      }
+    }
     if (invalidTypes.length > 0) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message: `Invalid connector types: ${invalidTypes.join(", ")}`,
-            code: "VALIDATION_ERROR",
-          },
-        },
-      };
+      return validationError(
+        `Invalid connector types: ${invalidTypes.join(", ")}`,
+      );
+    }
+
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    const unavailableTypes = unavailableUserConnectorTypes(
+      availability,
+      parsedTypes,
+    );
+    if (unavailableTypes.length > 0) {
+      return validationError(
+        `Connector types are not available: ${unavailableTypes.join(", ")}`,
+      );
     }
 
     await writeDb.transaction(async (tx) => {
@@ -946,9 +968,9 @@ const updateAgentUserConnectorsInner$ = command(
           ),
         );
 
-      if (uniqueTypes.length > 0) {
+      if (parsedTypes.length > 0) {
         await tx.insert(userConnectors).values(
-          uniqueTypes.map((connectorType) => {
+          parsedTypes.map((connectorType) => {
             return {
               orgId: auth.orgId,
               userId: auth.userId,
@@ -974,7 +996,7 @@ const updateAgentUserConnectorsInner$ = command(
 
     return {
       status: 200 as const,
-      body: { enabledTypes: uniqueTypes },
+      body: { enabledTypes: parsedTypes },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -16,8 +16,6 @@ import {
   zeroLocalAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { and, eq } from "drizzle-orm";
@@ -43,7 +41,7 @@ import {
   zeroConnectorScopeDiff,
   zeroConnectorSearch,
 } from "../services/zero-connector-data.service";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { userConnectorAvailability } from "../services/connector-availability.service";
 import { connectLocalBrowserConnector$ } from "../services/zero-local-browser.service";
 import { connectLocalAgentConnector$ } from "../services/zero-local-agent.service";
 import { createComputerConnector$ } from "../services/zero-computer-connector.service";
@@ -98,16 +96,26 @@ const localBrowserDisabled = Object.freeze({
   }),
 });
 
-function isLocalBrowserEnabled(params: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly overrides: Record<string, boolean>;
-}): boolean {
-  return isFeatureEnabled(FeatureSwitchKey.LocalBrowserUse, {
-    orgId: params.orgId,
-    userId: params.userId,
-    overrides: params.overrides,
-  });
+const localAgentDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Local agent connector is not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+function connectorUnavailable(type: string) {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: `${type} connector is not available`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
 }
 
 function generateConnectorSessionCode(
@@ -131,6 +139,55 @@ function jsonResponse(body: unknown, status: number): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function appendConnectorOAuthCookie(
+  response: Response,
+  name: string,
+  value: string | undefined,
+): void {
+  if (!value) {
+    return;
+  }
+  response.headers.append(
+    "Set-Cookie",
+    buildConnectorOAuthCookieHeader(
+      name,
+      value,
+      CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+    ),
+  );
+}
+
+function connectorOAuthStartRedirectResponse(args: {
+  readonly url: string;
+  readonly state: string;
+  readonly codeVerifier?: string;
+  readonly oauthContext?: string;
+  readonly session?: string;
+}): Response {
+  const response = connectorOAuthRedirectResponse(args.url);
+  appendConnectorOAuthCookie(
+    response,
+    CONNECTOR_OAUTH_STATE_COOKIE_NAME,
+    args.state,
+  );
+  appendConnectorOAuthCookie(
+    response,
+    CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
+    args.codeVerifier,
+  );
+  appendConnectorOAuthCookie(
+    response,
+    CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
+    args.oauthContext,
+  );
+  appendConnectorOAuthCookie(
+    response,
+    CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
+    args.session,
+  );
+  return response;
 }
 
 function connectorDoesNotUseOAuthResponse(type: string) {
@@ -303,6 +360,14 @@ const searchConnectorsInner$ = computed(async (get) => {
 const connectLocalAgentConnectorInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (!availability.isAuthMethodAvailable("local-agent", "api")) {
+      return localAgentDisabled;
+    }
+
     const result = await set(
       connectLocalAgentConnector$,
       { orgId: auth.orgId, userId: auth.userId },
@@ -321,17 +386,11 @@ const connectLocalAgentConnectorInner$ = command(
 const connectLocalBrowserConnectorInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
     );
     signal.throwIfAborted();
-    if (
-      !isLocalBrowserEnabled({
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
+    if (!availability.isAuthMethodAvailable("local-browser", "api")) {
       return localBrowserDisabled;
     }
 
@@ -421,6 +480,14 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (!availability.isAuthMethodAvailable(startType.type, "oauth")) {
+      return jsonResponse({ error: `${type} connector is not available` }, 403);
+    }
+
     const prepared = prepareResolvedConnectorOAuthStart({
       type: startType.type,
       origin,
@@ -444,46 +511,13 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     );
     signal.throwIfAborted();
 
-    const response = connectorOAuthRedirectResponse(authResult.url);
-    response.headers.append(
-      "Set-Cookie",
-      buildConnectorOAuthCookieHeader(
-        CONNECTOR_OAUTH_STATE_COOKIE_NAME,
-        prepared.state,
-        CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-      ),
-    );
-    if (authResult.codeVerifier) {
-      response.headers.append(
-        "Set-Cookie",
-        buildConnectorOAuthCookieHeader(
-          CONNECTOR_OAUTH_PKCE_COOKIE_NAME,
-          authResult.codeVerifier,
-          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-        ),
-      );
-    }
-    if (authResult.oauthContext) {
-      response.headers.append(
-        "Set-Cookie",
-        buildConnectorOAuthCookieHeader(
-          CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME,
-          authResult.oauthContext,
-          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-        ),
-      );
-    }
-    if (query.session) {
-      response.headers.append(
-        "Set-Cookie",
-        buildConnectorOAuthCookieHeader(
-          CONNECTOR_OAUTH_SESSION_COOKIE_NAME,
-          query.session,
-          CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-        ),
-      );
-    }
-    return response;
+    return connectorOAuthStartRedirectResponse({
+      url: authResult.url,
+      state: prepared.state,
+      codeVerifier: authResult.codeVerifier,
+      oauthContext: authResult.oauthContext,
+      session: query.session,
+    });
   });
 }
 
@@ -517,6 +551,14 @@ const startConnectorOauthInner$ = command(
       return badRequestMessage(
         "Explicit org context required — ensure active org in session",
       );
+    }
+
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (!availability.isAuthMethodAvailable(startType.type, "oauth")) {
+      return connectorUnavailable(type);
     }
 
     const origin = getConnectorOAuthOrigin(request);

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -619,8 +619,16 @@ const startConnectorOauthInner$ = command(
 
 const createConnectorSessionInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const auth = get(authContext$);
+    const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(zeroConnectorSessionsContract.create));
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (!availability.isAuthMethodAvailable(params.type, "oauth")) {
+      return connectorUnavailable(params.type);
+    }
+
     const code = generateConnectorSessionCode();
     const expiresAt = new Date(
       nowDate().getTime() + CONNECTOR_SESSION_TTL_SECONDS * 1000,
@@ -754,7 +762,7 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroConnectorSessionsContract.create,
-    handler: authRoute({}, createConnectorSessionInner$),
+    handler: authRoute(connectorWriteAuth, createConnectorSessionInner$),
   },
   {
     route: zeroConnectorsByTypeContract.get,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -263,6 +263,14 @@ const getComputerConnectorInner$ = computed(async (get) => {
 const createComputerConnectorInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    const availability = await get(
+      userConnectorAvailability(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (!availability.isAuthMethodAvailable("computer", "api")) {
+      return connectorUnavailable("computer");
+    }
+
     const result = await set(
       createComputerConnector$,
       { orgId: auth.orgId, userId: auth.userId },

--- a/turbo/apps/api/src/signals/services/connector-availability.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-availability.service.ts
@@ -1,0 +1,91 @@
+import { computed, type Computed } from "ccstate";
+import {
+  getAvailableConnectorAuthMethods,
+  isConnectorAuthMethodAvailable,
+  type AvailableConnectorAuthMethodsOptions,
+} from "@vm0/connectors/connector-utils";
+import type {
+  ConnectorAuthMethodId,
+  ConnectorType,
+} from "@vm0/connectors/connectors";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
+
+type ConnectorFeatureStates = ReturnType<typeof getAllFeatureStates>;
+
+const USER_CONNECTOR_AUTH_METHOD_OPTIONS = {
+  apiAuthMethodPolicy: "include",
+} as const satisfies AvailableConnectorAuthMethodsOptions;
+
+/**
+ * Feature-aware user availability for new connector actions.
+ *
+ * This is intentionally separate from runtime availability: disabling a
+ * feature switch should block new connect/authorize/write entry points, while
+ * existing runtime connector use remains a separate product policy.
+ */
+interface UserConnectorAvailability {
+  readonly featureStates: ConnectorFeatureStates;
+  readonly isAuthMethodAvailable: (
+    type: ConnectorType,
+    authMethod: ConnectorAuthMethodId,
+  ) => boolean;
+  readonly getAvailableAuthMethods: (
+    type: ConnectorType,
+    options?: AvailableConnectorAuthMethodsOptions,
+  ) => readonly ConnectorAuthMethodId[];
+  readonly isConnectorTypeAvailable: (
+    type: ConnectorType,
+    options?: AvailableConnectorAuthMethodsOptions,
+  ) => boolean;
+}
+
+function createUserConnectorAvailability(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly overrides: Record<string, boolean>;
+}): UserConnectorAvailability {
+  const featureStates = getAllFeatureStates(args);
+  return {
+    featureStates,
+    isAuthMethodAvailable(type, authMethod) {
+      return isConnectorAuthMethodAvailable(type, authMethod, featureStates);
+    },
+    getAvailableAuthMethods(
+      type,
+      options = USER_CONNECTOR_AUTH_METHOD_OPTIONS,
+    ) {
+      return getAvailableConnectorAuthMethods(type, featureStates, options);
+    },
+    isConnectorTypeAvailable(
+      type,
+      options = USER_CONNECTOR_AUTH_METHOD_OPTIONS,
+    ) {
+      return (
+        getAvailableConnectorAuthMethods(type, featureStates, options).length >
+        0
+      );
+    },
+  };
+}
+
+export function userConnectorAvailability(
+  orgId: string,
+  userId: string,
+): Computed<Promise<UserConnectorAvailability>> {
+  return computed(async (get): Promise<UserConnectorAvailability> => {
+    const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
+    return createUserConnectorAvailability({ orgId, userId, overrides });
+  });
+}
+
+export function unavailableUserConnectorTypes(
+  availability: UserConnectorAvailability,
+  types: readonly ConnectorType[],
+  options: AvailableConnectorAuthMethodsOptions = USER_CONNECTOR_AUTH_METHOD_OPTIONS,
+): ConnectorType[] {
+  return types.filter((type) => {
+    return !availability.isConnectorTypeAvailable(type, options);
+  });
+}

--- a/turbo/apps/api/src/signals/services/connector-availability.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-availability.service.ts
@@ -12,8 +12,6 @@ import { getAllFeatureStates } from "@vm0/core/feature-switch";
 
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
-type ConnectorFeatureStates = ReturnType<typeof getAllFeatureStates>;
-
 const USER_CONNECTOR_AUTH_METHOD_OPTIONS = {
   apiAuthMethodPolicy: "include",
 } as const satisfies AvailableConnectorAuthMethodsOptions;
@@ -26,15 +24,10 @@ const USER_CONNECTOR_AUTH_METHOD_OPTIONS = {
  * existing runtime connector use remains a separate product policy.
  */
 interface UserConnectorAvailability {
-  readonly featureStates: ConnectorFeatureStates;
   readonly isAuthMethodAvailable: (
     type: ConnectorType,
     authMethod: ConnectorAuthMethodId,
   ) => boolean;
-  readonly getAvailableAuthMethods: (
-    type: ConnectorType,
-    options?: AvailableConnectorAuthMethodsOptions,
-  ) => readonly ConnectorAuthMethodId[];
   readonly isConnectorTypeAvailable: (
     type: ConnectorType,
     options?: AvailableConnectorAuthMethodsOptions,
@@ -48,15 +41,8 @@ function createUserConnectorAvailability(args: {
 }): UserConnectorAvailability {
   const featureStates = getAllFeatureStates(args);
   return {
-    featureStates,
     isAuthMethodAvailable(type, authMethod) {
       return isConnectorAuthMethodAvailable(type, authMethod, featureStates);
-    },
-    getAvailableAuthMethods(
-      type,
-      options = USER_CONNECTOR_AUTH_METHOD_OPTIONS,
-    ) {
-      return getAvailableConnectorAuthMethods(type, featureStates, options);
     },
     isConnectorTypeAvailable(
       type,

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -19,6 +19,10 @@ import { db$, writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { settle, tapError } from "../utils";
 import { serverSideZeroAgentCompose$ } from "./agent-compose.service";
+import {
+  unavailableUserConnectorTypes,
+  userConnectorAvailability,
+} from "./connector-availability.service";
 import { upsertOrgNoSecretModelProvider$ } from "./zero-model-provider.service";
 
 const L = logger("onboarding.service");
@@ -47,9 +51,42 @@ interface OnboardingSetupArgs {
   readonly timezone?: string;
 }
 
-interface OnboardingSetupResponse {
-  readonly status: 200;
-  readonly body: { readonly agentId: string };
+type OnboardingSetupResponse =
+  | {
+      readonly status: 200;
+      readonly body: { readonly agentId: string };
+    }
+  | {
+      readonly status: 403;
+      readonly body: {
+        readonly error: {
+          readonly message: string;
+          readonly code: "FORBIDDEN";
+        };
+      };
+    };
+
+type OnboardingSetupForbiddenResponse = Extract<
+  OnboardingSetupResponse,
+  { readonly status: 403 }
+>;
+
+function unavailableSelectedConnectorsError(
+  unavailableTypes: readonly ConnectorType[],
+): OnboardingSetupForbiddenResponse | null {
+  if (unavailableTypes.length === 0) {
+    return null;
+  }
+
+  return {
+    status: 403,
+    body: {
+      error: {
+        message: `Connector types are not available: ${unavailableTypes.join(", ")}`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
 }
 
 function nameToSlug(name: string): string {
@@ -447,6 +484,21 @@ export const setupOnboarding$ = command(
     args: OnboardingSetupArgs,
     signal: AbortSignal,
   ): Promise<OnboardingSetupResponse> => {
+    const selectedConnectors = Array.from(new Set(args.selectedConnectors));
+    const unavailableTypes =
+      selectedConnectors.length === 0
+        ? []
+        : unavailableUserConnectorTypes(
+            await get(userConnectorAvailability(args.orgId, args.userId)),
+            selectedConnectors,
+          );
+    signal.throwIfAborted();
+    const availabilityError =
+      unavailableSelectedConnectorsError(unavailableTypes);
+    if (availabilityError) {
+      return availabilityError;
+    }
+
     const writeDb = set(writeDb$);
     const existingAgentId = await existingDefaultAgentId(writeDb, args.orgId);
     signal.throwIfAborted();
@@ -458,7 +510,7 @@ export const setupOnboarding$ = command(
         orgId: args.orgId,
         userId: args.userId,
         agentId: existingAgentId,
-        selectedConnectors: args.selectedConnectors,
+        selectedConnectors,
       });
       signal.throwIfAborted();
       return { status: 200 as const, body: { agentId: existingAgentId } };
@@ -557,7 +609,7 @@ export const setupOnboarding$ = command(
       orgId: args.orgId,
       userId: args.userId,
       agentId: composeResult.composeId,
-      selectedConnectors: args.selectedConnectors,
+      selectedConnectors,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -29,8 +29,12 @@ const connectedGithub = {
   updatedAt: "2025-01-01T00:00:00Z",
 };
 
-function stubConnector(body: Record<string, unknown>, status = 200) {
-  return http.get("http://localhost:3000/api/zero/connectors/:type", () => {
+function stubConnector(
+  body: Record<string, unknown>,
+  status = 200,
+  type = "github",
+) {
+  return http.get(`http://localhost:3000/api/zero/connectors/${type}`, () => {
     return HttpResponse.json(body, { status });
   });
 }
@@ -57,6 +61,21 @@ function stubUserConnectors(id: string, enabledTypes: string[]) {
       return HttpResponse.json({ enabledTypes });
     },
   );
+}
+
+function stubAvailableConnectors(types: string[]) {
+  return http.get("http://localhost:3000/api/zero/connectors/search", () => {
+    return HttpResponse.json({
+      connectors: types.map((type) => {
+        return {
+          id: type,
+          label: type,
+          description: type,
+          authMethods: ["oauth"],
+        };
+      }),
+    });
+  });
 }
 
 describe("zero connector status command", () => {
@@ -112,6 +131,25 @@ describe("zero connector status command", () => {
       expect(logCalls).not.toContain("Authorized:");
       expect(logCalls).not.toContain("Diagnose it with");
       expect(logCalls).not.toContain("zero doctor check-connector");
+    });
+
+    it("does not print connect guidance for unavailable connectors", async () => {
+      server.use(
+        stubAvailableConnectors([]),
+        stubConnector(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          404,
+        ),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "The github connector is not available for this account.",
+      );
+      expect(logCalls).not.toContain("[Connect github]");
+      expect(logCalls).not.toContain("/connectors/github/connect");
     });
 
     it("shows reconnect guidance when connector needs reconnect", async () => {

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import {
   CONNECTOR_TYPE_KEYS,
+  CONNECTOR_TYPES,
   type ConnectorType,
   connectorTypeSchema,
 } from "@vm0/connectors/connectors";
@@ -9,7 +10,7 @@ import {
   getScopeDiff,
   hasRequiredScopes,
 } from "@vm0/connectors/connector-utils";
-import { getZeroConnector } from "../../../lib/api";
+import { getZeroConnector, searchZeroConnectors } from "../../../lib/api";
 import { formatDateTime } from "../../../lib/domain/schedule-utils";
 import { withErrorHandler } from "../../../lib/command";
 import { resolveAgentContext } from "./agent-context";
@@ -21,6 +22,21 @@ type Connector = NonNullable<Awaited<ReturnType<typeof getZeroConnector>>>;
 type AgentContext = NonNullable<
   Awaited<ReturnType<typeof resolveAgentContext>>
 >;
+
+function isConnectorType(type: string): type is ConnectorType {
+  return type in CONNECTOR_TYPES;
+}
+
+async function availableConnectorTypes(): Promise<Set<ConnectorType>> {
+  const catalog = await searchZeroConnectors();
+  return new Set(
+    catalog.connectors
+      .map((connector) => {
+        return connector.id;
+      })
+      .filter(isConnectorType),
+  );
+}
 
 function printConnectorDetails(
   type: ConnectorType,
@@ -163,15 +179,22 @@ export const statusCommand = new Command()
         });
       }
 
-      const [connector, agentCtx] = await Promise.all([
+      const [connector, availableTypes, agentCtx] = await Promise.all([
         getZeroConnector(parseResult.data),
+        availableConnectorTypes(),
         resolveAgentContext(options.agent),
       ]);
+      const available = availableTypes.has(parseResult.data);
 
       console.log(`Connector: ${chalk.cyan(type)}`);
       console.log();
 
       printConnectorDetails(parseResult.data, connector);
+      if (!available) {
+        console.log();
+        console.log(`The ${type} connector is not available for this account.`);
+        return;
+      }
 
       if (agentCtx) {
         await printAgentAction(parseResult.data, connector, agentCtx);

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -54,6 +54,21 @@ const connectedResponse = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
+function stubAvailableConnectors(types: string[]) {
+  return http.get("https://app.vm0.ai/api/zero/connectors/search", () => {
+    return HttpResponse.json({
+      connectors: types.map((type) => {
+        return {
+          id: type,
+          label: type,
+          description: type,
+          authMethods: ["oauth"],
+        };
+      }),
+    });
+  });
+}
+
 /** Minimal run context response */
 const runContextResponse = {
   prompt: "test",
@@ -178,6 +193,48 @@ describe("zero doctor check-connector command", () => {
   });
 
   describe("step 2: connector status", () => {
+    it("should report unavailable connectors without connect or authorize guidance", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        stubAvailableConnectors([]),
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: [] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json(runContextResponse);
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        "The GitHub connector is not available for this account.",
+      );
+      expect(output).toContain(
+        "Skipped — the GitHub connector is not available for this account.",
+      );
+      expect(output).not.toContain("[Connect GitHub]");
+      expect(output).not.toContain("[Authorize GitHub]");
+    });
+
     it("should report connector not connected with a single authorize URL that covers both connect and authorize", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
@@ -57,6 +57,21 @@ function stubUserConnectors(enabledTypes: string[]) {
   );
 }
 
+function stubAvailableConnectors(types: string[]) {
+  return http.get("http://localhost:3000/api/zero/connectors/search", () => {
+    return HttpResponse.json({
+      connectors: types.map((type) => {
+        return {
+          id: type,
+          label: type,
+          description: type,
+          authMethods: ["api-token"],
+        };
+      }),
+    });
+  });
+}
+
 describe("zero doctor generate command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -206,6 +221,34 @@ describe("zero doctor generate command", () => {
         }),
       ]),
     });
+  });
+
+  it("does not mark runtime-configured but unavailable connectors as connectable", async () => {
+    server.use(
+      stubConnectorsWithConfiguredTypes([], ["bentoml"]),
+      stubAvailableConnectors([]),
+      stubUserConnectors([]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", "text", "--json"]);
+
+    const json = JSON.parse(output()) as {
+      otherCandidates: Array<{
+        type: string;
+        status: string;
+        reason: string;
+        actionUrl?: string;
+      }>;
+    };
+    const bentoml = json.otherCandidates.find((candidate) => {
+      return candidate.type === "bentoml";
+    });
+    expect(bentoml).toMatchObject({
+      type: "bentoml",
+      status: "not-available",
+      reason: "not available for this account",
+    });
+    expect(bentoml?.actionUrl).toBeUndefined();
   });
 
   it("suggests the built-in video command when no video connector is ready", async () => {

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -20,7 +20,10 @@ import type {
 } from "@vm0/connectors/firewall-types";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { getApiUrl } from "../../../lib/api/config";
-import { getZeroConnector } from "../../../lib/api/domains/zero-connectors";
+import {
+  getZeroConnector,
+  searchZeroConnectors,
+} from "../../../lib/api/domains/zero-connectors";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
 import { getZeroRunContext } from "../../../lib/api/domains/zero-runs";
 import { withErrorHandler } from "../../../lib/command";
@@ -38,6 +41,7 @@ interface DiagContext {
   envName: string;
   connectorType: string;
   label: string;
+  connectorAvailable: boolean;
   platformOrigin: string;
   agentId: string | undefined;
 }
@@ -47,6 +51,20 @@ interface UrlLookupResult {
   envName: string;
   matchedBase: string;
   relativePath: string;
+}
+
+function isConnectorType(type: string): type is ConnectorType {
+  return type in CONNECTOR_TYPES;
+}
+
+async function connectorTypeIsAvailable(type: string): Promise<boolean> {
+  if (!isConnectorType(type)) {
+    return false;
+  }
+  const catalog = await searchZeroConnectors();
+  return catalog.connectors.some((connector) => {
+    return connector.id === type;
+  });
 }
 
 /**
@@ -152,7 +170,11 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
     `### 2a: Connector status (user must configure via OAuth login or API key)`,
   );
   console.log("");
-  if (!isConnected) {
+  if (!ctx.connectorAvailable) {
+    console.log(
+      `The ${ctx.label} connector is not available for this account.`,
+    );
+  } else if (!isConnected) {
     console.log(`The ${ctx.label} connector is not connected.`);
     if (ctx.agentId && hasPermission) {
       const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect?agentId=${ctx.agentId}`;
@@ -180,7 +202,11 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
     `### 2b: Agent authorization (user must authorize agent to use this connector)`,
   );
   console.log("");
-  if (!ctx.agentId) {
+  if (!ctx.connectorAvailable) {
+    console.log(
+      `Skipped — the ${ctx.label} connector is not available for this account.`,
+    );
+  } else if (!ctx.agentId) {
     console.log("ZERO_AGENT_ID is not set — cannot check agent authorization.");
   } else if (isExpired) {
     // The /authorize page treats an expired connector as "already connected"
@@ -513,13 +539,17 @@ How connectors work:
       console.log("");
 
       const { label } = CONNECTOR_TYPES[connectorType as ConnectorType];
-      const apiUrl = await getApiUrl();
+      const [apiUrl, connectorAvailable] = await Promise.all([
+        getApiUrl(),
+        connectorTypeIsAvailable(connectorType),
+      ]);
       const platformUrl = toPlatformUrl(apiUrl);
 
       const ctx: DiagContext = {
         envName,
         connectorType,
         label,
+        connectorAvailable,
         platformOrigin: platformUrl.origin,
         agentId: process.env.ZERO_AGENT_ID || undefined,
       };

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -10,7 +10,10 @@ import {
 import { getConnectorGenerationTypes } from "@vm0/connectors/connector-utils";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
-import { listZeroConnectors } from "../../../lib/api/domains/zero-connectors";
+import {
+  listZeroConnectors,
+  searchZeroConnectors,
+} from "../../../lib/api/domains/zero-connectors";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
 
@@ -409,6 +412,23 @@ function getGenerationConnectors(
     });
 }
 
+function isConnectorType(type: string): type is ConnectorType {
+  return type in CONNECTOR_TYPES;
+}
+
+async function getFeatureAvailableConnectorTypes(): Promise<
+  Set<ConnectorType>
+> {
+  const catalog = await searchZeroConnectors();
+  return new Set(
+    catalog.connectors
+      .map((connector) => {
+        return connector.id;
+      })
+      .filter(isConnectorType),
+  );
+}
+
 function formatAccount(connector: ConnectedConnector): string | undefined {
   if (connector.externalUsername) return `@${connector.externalUsername}`;
   if (connector.externalEmail) return connector.externalEmail;
@@ -459,6 +479,7 @@ function toCandidate(params: {
   config: ConnectorConfig;
   connector: ConnectedConnector | undefined;
   configuredTypes: Set<ConnectorType>;
+  availableTypes: Set<ConnectorType>;
   authorizedTypes: Set<string> | null;
   agentId: string | undefined;
   platformOrigin: string;
@@ -468,6 +489,7 @@ function toCandidate(params: {
     config,
     connector,
     configuredTypes,
+    availableTypes,
     authorizedTypes,
     agentId,
     platformOrigin,
@@ -476,7 +498,10 @@ function toCandidate(params: {
   let status: CandidateStatus;
   let reason: string;
 
-  if (connector?.needsReconnect) {
+  if (!availableTypes.has(type)) {
+    status = "not-available";
+    reason = "not available for this account";
+  } else if (connector?.needsReconnect) {
     status = "needs-reconnect";
     reason = "connected, reconnect required";
   } else if (!connector) {
@@ -651,11 +676,13 @@ export const generateCommand = new Command()
       const connectorGenerationType =
         getConnectorGenerationType(generationType);
       const agentId = process.env.ZERO_AGENT_ID;
-      const [connectorList, enabledTypes, platformOrigin] = await Promise.all([
-        listZeroConnectors(),
-        agentId ? getZeroAgentUserConnectors(agentId) : Promise.resolve(null),
-        getPlatformOrigin(),
-      ]);
+      const [connectorList, availableTypes, enabledTypes, platformOrigin] =
+        await Promise.all([
+          listZeroConnectors(),
+          getFeatureAvailableConnectorTypes(),
+          agentId ? getZeroAgentUserConnectors(agentId) : Promise.resolve(null),
+          getPlatformOrigin(),
+        ]);
       const connectedMap = new Map(
         connectorList.connectors.map((connector) => {
           return [connector.type, connector];
@@ -671,6 +698,7 @@ export const generateCommand = new Command()
                 config,
                 connector: connectedMap.get(connectorType),
                 configuredTypes,
+                availableTypes,
                 authorizedTypes,
                 agentId,
                 platformOrigin,

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -96,6 +96,18 @@ export const apiHandlers = [
       { status: 200 },
     );
   }),
+  http.get("https://app.vm0.ai/api/zero/connectors/search", () => {
+    return HttpResponse.json(
+      { connectors: defaultAvailableConnectors() },
+      { status: 200 },
+    );
+  }),
+  http.get("https://www.vm0.ai/api/zero/connectors/search", () => {
+    return HttpResponse.json(
+      { connectors: defaultAvailableConnectors() },
+      { status: 200 },
+    );
+  }),
 
   // GET /api/zero/org - getZeroOrg
   http.get("http://localhost:3000/api/zero/org", () => {

--- a/turbo/apps/platform/src/mocks/handlers/api-local-agent.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-local-agent.ts
@@ -7,17 +7,24 @@ import { mockApi } from "../msw-contract.ts";
 import { upsertMockConnector } from "./api-connectors.ts";
 
 let mockLocalAgentHosts: LocalAgentHost[] = [];
+let mockLocalAgentHostsRequestCount = 0;
 
 export function setMockLocalAgentHosts(hosts: LocalAgentHost[]): void {
   mockLocalAgentHosts = hosts;
 }
 
+export function getMockLocalAgentHostsRequestCount(): number {
+  return mockLocalAgentHostsRequestCount;
+}
+
 export function resetMockLocalAgentHosts(): void {
   mockLocalAgentHosts = [];
+  mockLocalAgentHostsRequestCount = 0;
 }
 
 export const apiLocalAgentHandlers = [
   mockApi(zeroLocalAgentHostsContract.list, ({ respond }) => {
+    mockLocalAgentHostsRequestCount += 1;
     return respond(200, { hosts: mockLocalAgentHosts });
   }),
   mockApi(zeroLocalAgentConnectorContract.create, ({ respond }) => {

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -22,6 +22,7 @@ export interface ConnectorActionDescriptor {
 }
 
 export interface ConnectorActionSignals {
+  available$: Computed<Promise<boolean>>;
   connected$: Computed<Promise<boolean>>;
   authorized$: Computed<Promise<boolean>>;
   complete$: Computed<Promise<boolean>>;
@@ -114,6 +115,13 @@ export function createConnectorActionBlock(
     set(authorizedOverride$, true);
   });
 
+  const available$ = computed(async (get): Promise<boolean> => {
+    const allConnectors = await get(allConnectorTypes$);
+    return allConnectors.some((connector) => {
+      return connector.type === descriptor.connectorType;
+    });
+  });
+
   const connected$ = computed(async (get): Promise<boolean> => {
     if (
       get(connectedOverride$) ||
@@ -150,6 +158,12 @@ export function createConnectorActionBlock(
   });
 
   const activate$ = command(async ({ get, set }, signal: AbortSignal) => {
+    const available = await get(available$);
+    signal.throwIfAborted();
+    if (!available) {
+      return;
+    }
+
     const connected = await get(connected$);
     signal.throwIfAborted();
     if (connected) {
@@ -174,6 +188,7 @@ export function createConnectorActionBlock(
     type: "connector-action",
     id,
     ...descriptor,
+    available$,
     connected$,
     authorized$,
     complete$,

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -150,6 +150,11 @@ export function createConnectorActionBlock(
   });
 
   const complete$ = computed(async (get): Promise<boolean> => {
+    const available = await get(available$);
+    if (!available) {
+      return false;
+    }
+
     const [connected, authorized] = await Promise.all([
       get(connected$),
       get(authorized$),

--- a/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
@@ -113,6 +113,22 @@ describe("setupOnboardingPage$ — ?connector= consumption", () => {
     expect(gmailCount).toBe(1);
   });
 
+  it("ignores feature-disabled connectors from ?connector=", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?connector=slock,gmail",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    const selected = context.store.get(zeroSelectedConnectors$);
+    expect(selected).toContain("gmail");
+    expect(selected).not.toContain("slock");
+  });
+
   it("leaves selections untouched when ?connector= is absent", async () => {
     mockAdminOnboarding();
 

--- a/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
@@ -118,7 +118,7 @@ describe("setupOnboardingPage$ — ?connector= consumption", () => {
 
     detachedSetupPage({
       context,
-      path: "/onboarding?connector=slock,gmail",
+      path: "/onboarding?connector=bentoml,gmail",
       withoutRender: true,
     });
 
@@ -126,7 +126,7 @@ describe("setupOnboardingPage$ — ?connector= consumption", () => {
 
     const selected = context.store.get(zeroSelectedConnectors$);
     expect(selected).toContain("gmail");
-    expect(selected).not.toContain("slock");
+    expect(selected).not.toContain("bentoml");
   });
 
   it("leaves selections untouched when ?connector= is absent", async () => {

--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -1,8 +1,5 @@
 import { command } from "ccstate";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { createElement } from "react";
 import { OnboardingPage } from "../../views/onboarding-page/onboarding-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -15,6 +12,7 @@ import {
   zeroNeedsOnboarding$,
   zeroSelectedConnectors$,
 } from "../zero-page/zero-onboarding.ts";
+import { allConnectorTypes$ } from "../zero-page/settings/connectors.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 export const setupOnboardingPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -56,8 +54,15 @@ export const setupOnboardingPage$ = command(
     const params = get(searchParams$);
     const connectorParam = params.get("connector");
     if (connectorParam !== null) {
+      const availableConnectors = await get(allConnectorTypes$);
+      signal.throwIfAborted();
+      const availableTypes = new Set(
+        availableConnectors.map((connector) => {
+          return connector.type;
+        }),
+      );
       const isConnectorType = (id: string): id is ConnectorType => {
-        return id in CONNECTOR_TYPES;
+        return availableTypes.has(id as ConnectorType);
       };
       const alreadySelected = new Set<ConnectorType>(
         get(zeroSelectedConnectors$),

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { testContext } from "../../__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
 import { allConnectorTypes$ } from "../settings/connectors.ts";
 import { zeroAuthorizedConnectors$ } from "../zero-connectors.ts";
 import { authorizeConnector$ as directedAuthorizeConnector$ } from "../../connectors-page/directed-authorize-type.ts";
@@ -10,6 +13,7 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import { server } from "../../../mocks/server.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { createConnectorActionBlock } from "../../chat-page/connector-action-block.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -125,6 +129,33 @@ describe("connectors", () => {
     await expect(
       context.store.get(zeroAuthorizedConnectors$),
     ).resolves.toStrictEqual(["github"]);
+  });
+
+  it("keeps disabled chat connector action blocks non-actionable", async () => {
+    let authorizationRequests = 0;
+    server.use(
+      mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
+        authorizationRequests += 1;
+        return respond(200, { enabledTypes: ["slock"] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.SlockConnector]: false },
+      withoutRender: true,
+    });
+
+    const block = createConnectorActionBlock("connector-action-1", {
+      connectorType: "slock",
+      agentId: DEFAULT_AGENT_ID,
+      originalUrl: `https://app.vm0.ai/connectors/slock/authorize?agentId=${DEFAULT_AGENT_ID}`,
+    });
+
+    await expect(context.store.get(block.available$)).resolves.toBeFalsy();
+    await expect(context.store.get(block.complete$)).resolves.toBeFalsy();
+    expect(authorizationRequests).toBe(0);
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -136,21 +136,21 @@ describe("connectors", () => {
     server.use(
       mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
         authorizationRequests += 1;
-        return respond(200, { enabledTypes: ["slock"] });
+        return respond(200, { enabledTypes: ["bentoml"] });
       }),
     );
 
     await setupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.SlockConnector]: false },
+      featureSwitches: { [FeatureSwitchKey.BentomlConnector]: false },
       withoutRender: true,
     });
 
     const block = createConnectorActionBlock("connector-action-1", {
-      connectorType: "slock",
+      connectorType: "bentoml",
       agentId: DEFAULT_AGENT_ID,
-      originalUrl: `https://app.vm0.ai/connectors/slock/authorize?agentId=${DEFAULT_AGENT_ID}`,
+      originalUrl: `https://app.vm0.ai/connectors/bentoml/authorize?agentId=${DEFAULT_AGENT_ID}`,
     });
 
     await expect(context.store.get(block.available$)).resolves.toBeFalsy();

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/local-agent-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/local-agent-connector.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setupPage } from "../../../../__tests__/page-helper.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
-import { setMockLocalAgentHosts } from "../../../../mocks/handlers/api-local-agent.ts";
+import {
+  getMockLocalAgentHostsRequestCount,
+  setMockLocalAgentHosts,
+} from "../../../../mocks/handlers/api-local-agent.ts";
 import {
   allConnectorTypes$,
   connectLocalAgentConnector$,
@@ -12,6 +15,24 @@ import {
 const context = testContext();
 
 describe("local-agent connector", () => {
+  it("does not fetch local-agent hosts when the feature is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalAgentConnector]: false },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+
+    expect(
+      connectors.some((connector) => {
+        return connector.type === "local-agent";
+      }),
+    ).toBeFalsy();
+    expect(getMockLocalAgentHostsRequestCount()).toBe(0);
+  });
+
   it("shows online local-agent hosts without treating them as connected", async () => {
     setMockLocalAgentHosts([
       {
@@ -68,6 +89,7 @@ describe("local-agent connector", () => {
       context,
       path: "/",
       withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalAgentConnector]: true },
     });
 
     await context.store.set(

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -393,7 +393,11 @@ export function matchesConnectorSearch(
 export const allConnectorTypes$ = computed(async (get) => {
   const connectorListPromise = get(connectors$);
   const features = get(featureSwitch$);
-  const localAgentHostListPromise = get(localAgentHosts$);
+  const localAgentHostListPromise = features?.[
+    FeatureSwitchKey.LocalAgentConnector
+  ]
+    ? get(localAgentHosts$)
+    : Promise.resolve({ hosts: [] } satisfies LocalAgentHostListResponse);
   const localBrowserHostListPromise = features?.[
     FeatureSwitchKey.LocalBrowserUse
   ]

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -24,6 +24,7 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { allConnectorTypes$ } from "../../../signals/zero-page/settings/connectors.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -89,6 +90,21 @@ describe("directed authorize page", () => {
       screen.getByText(CONNECTOR_TYPES.gmail.helpText),
     ).toBeInTheDocument();
     expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+  });
+
+  it("does not render an actionable card for feature-disabled connectors", async () => {
+    detachedSetupPage({
+      context,
+      path: `/connectors/slock/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await context.store.get(allConnectorTypes$);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Zero needs Slock to proceed"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("shows authorized state after clicking authorize", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -34,6 +34,7 @@ import {
 } from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { allConnectorTypes$ } from "../../../signals/zero-page/settings/connectors.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -113,6 +114,18 @@ describe("directed connect page", () => {
       screen.getByText(CONNECTOR_TYPES.gmail.helpText),
     ).toBeInTheDocument();
     expect(screen.getByText("Connect")).toBeInTheDocument();
+  });
+
+  it("does not render an actionable card for feature-disabled connectors", async () => {
+    detachedSetupPage({ context, path: "/connectors/slock/connect" });
+
+    await context.store.get(allConnectorTypes$);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Zero needs Slock to proceed"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("shows connected state when connector is already connected", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2542,10 +2542,15 @@ function BodyContentBlocks({
 
 function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
   const pageSignal = useGet(pageSignal$);
+  const available = useLastResolved(block.available$) ?? false;
   const complete = useLastResolved(block.complete$) ?? false;
   const [activateLoadable, activate] = useLoadableSet(block.activate$);
   const activating = activateLoadable.state === "loading";
   const config = CONNECTOR_TYPES[block.connectorType];
+
+  if (!available) {
+    return null;
+  }
 
   return (
     <div

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -19,9 +19,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import {
-  isGoogleOAuthConnector,
-} from "@vm0/connectors/connector-utils";
+import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -20,7 +20,6 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConfiguredConnectorAuthMethods,
   isGoogleOAuthConnector,
 } from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
@@ -694,10 +693,12 @@ export function ZeroConnectorsPage() {
     const ct = allConnectors.find((c) => {
       return c.type === type;
     });
+    if (!ct) {
+      return;
+    }
     const launchMode = getConnectorConnectLaunchMode({
       type,
-      availableAuthMethods:
-        ct?.availableAuthMethods ?? getConfiguredConnectorAuthMethods(type),
+      availableAuthMethods: ct.availableAuthMethods,
       preferModalForGoogleOAuth: true,
     });
     if (launchMode === "modal") {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -1,6 +1,7 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   CONNECTOR_TYPES,
+  connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -69,47 +70,107 @@ function AuthorizeAction({
 // Main card
 // ---------------------------------------------------------------------------
 
-function DirectedAuthorizeCard() {
+function useDirectedAuthorizeParams(): {
+  readonly connectorType: ConnectorType;
+  readonly agentId: string;
+} | null {
   const type = useGet(directedAuthorizeType$);
   const agentId = useGet(directedAuthorizeAgentId$);
+  if (!type || !agentId) {
+    return null;
+  }
+  const parsed = connectorTypeSchema.safeParse(type);
+  if (!parsed.success) {
+    return null;
+  }
+  return { connectorType: parsed.data, agentId };
+}
+
+function useDirectedAuthorizeCatalogState(connectorType: ConnectorType | null) {
+  const justConnected = useGet(justConnectedTypes$);
+  const allLoadable = useLastLoadable(allConnectorTypes$);
+  const catalogLoaded = allLoadable.state === "hasData";
+  const allData = catalogLoaded ? allLoadable.data : [];
+  const item = connectorType
+    ? allData.find((connector) => {
+        return connector.type === connectorType;
+      })
+    : undefined;
+  const isConnected =
+    connectorType !== null &&
+    (justConnected.has(connectorType) || item?.connected === true);
+  return {
+    item,
+    isConnected,
+    catalogLoading:
+      connectorType !== null &&
+      !justConnected.has(connectorType) &&
+      allLoadable.state === "loading",
+    unavailable:
+      connectorType !== null && catalogLoaded && !item && !isConnected,
+  };
+}
+
+function useDirectedAuthorizePermissionState(
+  connectorType: ConnectorType | null,
+) {
+  const justAuthorized = useGet(justAuthorizedTypes$);
+  const enabledLoadable = useLastLoadable(agentEnabledTypes$);
+  const enabledTypes =
+    enabledLoadable.state === "hasData" ? enabledLoadable.data : [];
+  return {
+    isAuthorized:
+      connectorType !== null &&
+      (justAuthorized.has(connectorType) ||
+        enabledTypes.includes(connectorType)),
+    permissionLoading: enabledLoadable.state === "loading",
+  };
+}
+
+function canAuthorizeConnector(
+  connectorType: ConnectorType,
+  item: { readonly availableAuthMethods: readonly string[] } | undefined,
+  isConnected: boolean,
+): boolean {
+  return (
+    isConnected ||
+    (isOAuthAuthCodeConnectorType(connectorType) &&
+      (item?.availableAuthMethods.includes("oauth") ?? false))
+  );
+}
+
+function DirectedAuthorizeCard() {
+  const params = useDirectedAuthorizeParams();
   const agentNameLoadable = useLastLoadable(directedAuthorizeAgentName$);
   const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
-  const justConnected = useGet(justConnectedTypes$);
-  const justAuthorized = useGet(justAuthorizedTypes$);
-  const allLoadable = useLastLoadable(allConnectorTypes$);
-  const enabledLoadable = useLastLoadable(agentEnabledTypes$);
+  const connectorTypeForState = params?.connectorType ?? null;
+  const { item, isConnected, catalogLoading, unavailable } =
+    useDirectedAuthorizeCatalogState(connectorTypeForState);
+  const { isAuthorized, permissionLoading } =
+    useDirectedAuthorizePermissionState(connectorTypeForState);
 
-  if (!type || !(type in CONNECTOR_TYPES) || !agentId) {
+  if (!params) {
     return null;
   }
 
-  const connectorType = type as ConnectorType;
+  const { connectorType, agentId } = params;
   const config = CONNECTOR_TYPES[connectorType];
   const agentName =
     agentNameLoadable.state === "hasData" && agentNameLoadable.data
       ? agentNameLoadable.data
       : "Zero";
   const isConnecting = pollingType === connectorType;
-  const isLoading =
-    (!justConnected.has(connectorType) && allLoadable.state === "loading") ||
-    enabledLoadable.state === "loading";
+  if (unavailable) {
+    return null;
+  }
 
-  const isConnected =
-    justConnected.has(connectorType) ||
-    (allLoadable.state === "hasData" &&
-      allLoadable.data.some((c) => {
-        return c.type === connectorType && c.connected;
-      }));
-
-  const isAuthorized =
-    justAuthorized.has(connectorType) ||
-    (enabledLoadable.state === "hasData" &&
-      enabledLoadable.data.includes(connectorType));
-  const canAuthorize =
-    isConnected || isOAuthAuthCodeConnectorType(connectorType);
+  const isLoading = catalogLoading || permissionLoading;
+  const canAuthorize = canAuthorizeConnector(connectorType, item, isConnected);
+  const showGoogleOAuthNotice =
+    !isAuthorized && !isConnected && isGoogleOAuthConnector(connectorType);
 
   const handleAuthorize = () => {
     if (!canAuthorize) {
@@ -152,11 +213,7 @@ function DirectedAuthorizeCard() {
                 <p className="w-60 text-sm text-muted-foreground">
                   {config.helpText}
                 </p>
-                {!isAuthorized &&
-                  !isConnected &&
-                  isGoogleOAuthConnector(connectorType) && (
-                    <GoogleOAuthNotice />
-                  )}
+                {showGoogleOAuthNotice && <GoogleOAuthNotice />}
               </>
             )}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -8,7 +8,6 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConfiguredConnectorAuthMethods,
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
 } from "@vm0/connectors/connector-utils";
@@ -405,8 +404,17 @@ function DirectedConnectDialogs({
   );
 }
 
-function DirectedConnectCard() {
+function useDirectedConnectConnectorType(): ConnectorType | null {
   const type = useGet(directedConnectType$);
+  if (!type) {
+    return null;
+  }
+  const parsed = connectorTypeSchema.safeParse(type);
+  return parsed.success ? parsed.data : null;
+}
+
+function DirectedConnectCard() {
+  const connectorType = useDirectedConnectConnectorType();
   const agentId = useGet(directedConnectAgentId$);
   const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
   const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
@@ -421,16 +429,10 @@ function DirectedConnectCard() {
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelectedConnectorType = useSet(setSelectedConnectorType$);
 
-  if (!type) {
-    return null;
-  }
-  const parsedConnectorType = connectorTypeSchema.safeParse(type);
-
-  if (!parsedConnectorType.success) {
+  if (!connectorType) {
     return null;
   }
 
-  const connectorType = parsedConnectorType.data;
   const config = CONNECTOR_TYPES[connectorType];
   const agentName =
     agentNameLoadable.state === "hasData" && agentNameLoadable.data
@@ -441,15 +443,19 @@ function DirectedConnectCard() {
     pollingDeviceAuthType === connectorType;
   const isLoading =
     !justConnected.has(connectorType) && allLoadable.state === "loading";
-  const allData = allLoadable.state === "hasData" ? allLoadable.data : [];
+  const catalogLoaded = allLoadable.state === "hasData";
+  const allData = catalogLoaded ? allLoadable.data : [];
   const item = allData.find((c) => {
     return c.type === connectorType;
   });
+  const unavailable =
+    catalogLoaded && !item && !justConnected.has(connectorType);
+  if (unavailable) {
+    return null;
+  }
   const isConnected =
     justConnected.has(connectorType) || (item?.connected ?? false);
-  const authMethods =
-    item?.availableAuthMethods ??
-    getConfiguredConnectorAuthMethods(connectorType);
+  const authMethods = item?.availableAuthMethods ?? [];
   const manualCredentialMethod = getManualCredentialMethod(
     connectorType,
     authMethods,

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -11,15 +11,7 @@ import { getAvatarPresets } from "./zero-avatars.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import zeroAnimatedSrc from "./assets/zero-animated.webp";
 import { Button, Input } from "@vm0/ui";
-import {
-  CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import {
-  getConfiguredConnectorAuthMethods,
-  getConnectorTags,
-} from "@vm0/connectors/connector-utils";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   zeroWorkspaceName$,
@@ -154,18 +146,10 @@ function SelectConnectorsContent() {
   const toggleConnector = useSet(toggleZeroConnector$);
   const search = useGet(connectorSearch$);
   const setSearch = useSet(setConnectorSearch$);
+  const connectorEntries = useLastResolved(allConnectorTypes$) ?? [];
 
-  const connectorEntries = CONNECTOR_TYPE_KEYS.map((type) => {
-    return [type, CONNECTOR_TYPES[type]] as const;
-  });
-
-  const filtered = connectorEntries.filter(([type, config]) => {
-    return matchesConnectorSearch(search, {
-      label: config.label,
-      type,
-      helpText: config.helpText,
-      tags: getConnectorTags(type),
-    });
+  const filtered = connectorEntries.filter((connector) => {
+    return matchesConnectorSearch(search, connector);
   });
 
   const selectedSet = new Set(selectedConnectors);
@@ -198,16 +182,16 @@ function SelectConnectorsContent() {
         />
       </div>
       <div className="w-full grid grid-cols-2 sm:grid-cols-3 gap-3">
-        {filtered.map(([type, config]) => {
+        {filtered.map((connector) => {
           return (
             <OnboardingConnectorCard
-              key={type}
-              type={type}
-              label={config.label}
-              isSelected={selectedSet.has(type)}
+              key={connector.type}
+              type={connector.type}
+              label={connector.label}
+              isSelected={selectedSet.has(connector.type)}
               isPolling={false}
               onClick={() => {
-                return toggleConnector(type);
+                return toggleConnector(connector.type);
               }}
             />
           );
@@ -253,10 +237,8 @@ function ConnectStepContent() {
       }),
   );
 
-  const selectedEntries = CONNECTOR_TYPE_KEYS.map((type) => {
-    return [type, CONNECTOR_TYPES[type]] as const;
-  }).filter(([type]) => {
-    return effectiveConnectors.includes(type);
+  const selectedEntries = allConnectors.filter((connector) => {
+    return effectiveConnectors.includes(connector.type);
   });
 
   const handleConnect = (type: ConnectorType) => {
@@ -264,11 +246,12 @@ function ConnectStepContent() {
     if (connector?.connected) {
       return;
     }
+    if (!connector) {
+      return;
+    }
     const launchMode = getConnectorConnectLaunchMode({
       type,
-      availableAuthMethods:
-        connector?.availableAuthMethods ??
-        getConfiguredConnectorAuthMethods(type),
+      availableAuthMethods: connector.availableAuthMethods,
       preferModalForGoogleOAuth: true,
     });
     if (launchMode === "modal") {
@@ -298,7 +281,8 @@ function ConnectStepContent() {
       </p>
       {selectedEntries.length > 0 && (
         <div className="w-full flex flex-col gap-3">
-          {selectedEntries.map(([type, config]) => {
+          {selectedEntries.map((connector) => {
+            const type = connector.type;
             const isConnected = connectedSet.has(type);
             const isPolling =
               pollingAuthCodeType === type || pollingDeviceAuthType === type;
@@ -312,11 +296,11 @@ function ConnectStepContent() {
                 </span>
                 <div className="min-w-0 flex-1">
                   <span className="block text-sm font-medium text-foreground">
-                    {config.label}
+                    {connector.label}
                   </span>
-                  {"helpText" in config && config.helpText && (
+                  {connector.helpText && (
                     <span className="block text-xs text-muted-foreground mt-0.5 line-clamp-1">
-                      {(config.helpText as string)
+                      {connector.helpText
                         .replace(/^Connect your \w+ account to /, "")
                         .replace(/^Connect /, "")}
                     </span>
@@ -519,11 +503,10 @@ function getStepIllustration(stepKey: string): StepIllustration {
 function OrbitIllustration() {
   const selectedConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
+  const connectorEntries = useLastResolved(allConnectorTypes$) ?? [];
 
-  const entries = CONNECTOR_TYPE_KEYS.map((type) => {
-    return [type, CONNECTOR_TYPES[type]] as const;
-  }).filter(([type]) => {
-    return selectedConnectors.includes(type);
+  const entries = connectorEntries.filter((connector) => {
+    return selectedConnectors.includes(connector.type);
   });
 
   const innerRadius = 110;
@@ -566,7 +549,8 @@ function OrbitIllustration() {
       </div>
 
       {/* Inner orbit connectors */}
-      {inner.map(([type], i) => {
+      {inner.map((connector, i) => {
+        const type = connector.type;
         const angle =
           (i / Math.max(inner.length, 1)) * Math.PI * 2 - Math.PI / 2;
         const x = Math.cos(angle) * innerRadius;
@@ -586,7 +570,8 @@ function OrbitIllustration() {
       })}
 
       {/* Outer orbit connectors */}
-      {outer.map(([type], i) => {
+      {outer.map((connector, i) => {
+        const type = connector.type;
         const angle =
           (i / Math.max(outer.length, 1)) * Math.PI * 2 - Math.PI / 2 + 0.3;
         const x = Math.cos(angle) * outerRadius;

--- a/turbo/packages/api-contracts/src/contracts/connectors-type-authorize.ts
+++ b/turbo/packages/api-contracts/src/contracts/connectors-type-authorize.ts
@@ -14,6 +14,7 @@ export const connectorsTypeAuthorizeContract = c.router({
     responses: {
       307: c.noBody(),
       400: z.object({ error: z.string() }),
+      403: z.object({ error: z.string() }),
       500: z.object({ error: z.string() }),
     },
     summary: "Start connector OAuth authorization",

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -269,6 +269,7 @@ export const zeroComputerConnectorContract = c.router({
       200: computerConnectorCreateResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       409: apiErrorSchema,
     },
     summary: "Create computer connector (zero proxy)",

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -227,6 +227,7 @@ export const zeroConnectorSessionsContract = c.router({
       200: connectorSessionResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary: "Create connector session for device flow (zero proxy)",
   },

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -104,6 +104,7 @@ export const zeroConnectorAuthorizeContract = c.router({
       307: c.noBody(),
       400: z.object({ error: z.string() }),
       401: c.noBody(),
+      403: z.object({ error: z.string() }),
       500: z.object({ error: z.string() }),
     },
     summary: "Start connector OAuth authorization (zero proxy)",


### PR DESCRIPTION
## Summary
- add a shared API user connector availability helper and gate OAuth start/authorize, local-agent/local-browser connect, onboarding setup, and agent connector permission writes
- switch onboarding, directed connector pages, connector settings actions, and chat connector cards to feature-aware connector catalogs
- prevent CLI status/doctor commands from suggesting connect or authorize actions for feature-disabled connectors

Closes #14998

## Tests
- cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/zero-connectors-local-agent-connect.test.ts src/signals/routes/__tests__/zero-user-connectors-update.test.ts src/signals/routes/__tests__/zero-onboarding-setup.test.ts --run
- cd turbo && pnpm -F @vm0/cli exec vitest src/commands/zero/connector/__tests__/status.test.ts src/commands/zero/doctor/__tests__/generate.test.ts src/commands/zero/doctor/__tests__/check-connector.test.ts --run
- cd turbo && pnpm -F @vm0/app exec vitest src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts src/signals/zero-page/settings/__tests__/local-agent-connector.test.ts src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx src/views/zero-page/__tests__/zero-onboarding.test.tsx src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx --run
- cd turbo && pnpm -F api check-types
- cd turbo && pnpm -F @vm0/cli check-types
- cd turbo && pnpm -F @vm0/app check-types
- cd turbo && pnpm -F api lint
- cd turbo && pnpm -F @vm0/cli lint
- cd turbo && pnpm -F @vm0/app lint
- cd turbo && pnpm exec prettier --check <changed files>
