### PR TITLE
feat: expose slock connector without feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -77,21 +77,6 @@ async function enableTestOauthDevice(userId: string, orgId: string) {
     });
 }
 
-async function enableSlock(userId: string, orgId: string) {
-  await store
-    .set(writeDb$)
-    .insert(userFeatureSwitches)
-    .values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.SlockConnector]: true },
-    })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches: { [FeatureSwitchKey.SlockConnector]: true } },
-    });
-}
-
 async function cleanupUser(userId: string, orgId: string) {
   const db = store.set(writeDb$);
   await db
@@ -883,7 +868,6 @@ describe("OAuth device authorization connector routes", () => {
     const orgId = `org_${randomUUID()}`;
     users.push({ userId, orgId });
     mocks.clerk.session(userId, orgId);
-    await enableSlock(userId, orgId);
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,
     );
@@ -979,7 +963,6 @@ describe("OAuth device authorization connector routes", () => {
     const orgId = `org_${randomUUID()}`;
     users.push({ userId, orgId });
     mocks.clerk.session(userId, orgId);
-    await enableSlock(userId, orgId);
     const session = await createSession({
       userId,
       orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -280,32 +280,8 @@ describe("GET /api/zero/connectors/search", () => {
     expect(connector?.authMethods).toStrictEqual(["oauth"]);
   });
 
-  it("hides Slock when the feature is disabled", async () => {
+  it("shows Slock as an OAuth connector without a feature switch", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
-
-    const client = setupApp({ context })(zeroConnectorsSearchContract);
-    const response = await accept(
-      client.search({
-        query: { keyword: "slock" },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    const connector = response.body.connectors.find((c) => {
-      return c.id === "slock";
-    });
-    expect(connector).toBeUndefined();
-  });
-
-  it("shows Slock as an OAuth connector when the feature is enabled", async () => {
-    const userId = `user_${randomUUID()}`;
-    const orgId = `org_${randomUUID()}`;
-    seededFeatureSwitches.push({ orgId, userId });
-    await enableFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.SlockConnector]: true,
-    });
-    mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1391,13 +1391,6 @@ describe("POST /api/zero/runs", () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
     const agent = await seedRunnableZeroAgent({ fixture: fx });
-    await db.insert(userFeatureSwitches).values({
-      orgId: fx.orgId,
-      userId: fx.userId,
-      switches: {
-        [FeatureSwitchKey.SlockConnector]: true,
-      },
-    });
     await db.insert(userConnectors).values({
       orgId: fx.orgId,
       userId: fx.userId,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1308,13 +1308,10 @@ describe("getAvailableConnectorAuthMethods", () => {
     ]);
   });
 
-  it("exposes Slock OAuth only when its switch is enabled", () => {
-    expect(getAvailableConnectorAuthMethods("slock", {})).toStrictEqual([]);
-    expect(
-      getAvailableConnectorAuthMethods("slock", {
-        [FeatureSwitchKey.SlockConnector]: true,
-      }),
-    ).toStrictEqual(["oauth"]);
+  it("exposes Slock OAuth without a feature switch", () => {
+    expect(getAvailableConnectorAuthMethods("slock", {})).toStrictEqual([
+      "oauth",
+    ]);
   });
 
   it("exposes Lark API-token auth only when its switch is enabled", () => {

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 const SLOCK_API_BASE_URL = "https://api.slock.ai";
 
@@ -11,7 +10,6 @@ export const slock = {
       "Connect your Slock account to let agents access Slock agents, machines, channels, and messages.",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.SlockConnector,
         label: "OAuth Device Authorization",
         helpText: "Sign in with Slock using a device code.",
         grant: {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -19,7 +19,6 @@ export enum FeatureSwitchKey {
   RedditConnector = "redditConnector",
   SupabaseConnector = "supabaseConnector",
   WebflowConnector = "webflowConnector",
-  SlockConnector = "slockConnector",
   CloseConnector = "closeConnector",
   OutlookMailConnector = "outlookMailConnector",
   OutlookCalendarConnector = "outlookCalendarConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -114,11 +114,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Webflow site management connector",
     enabled: false,
   },
-  [FeatureSwitchKey.SlockConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Slock connector for user-auth control API access.",
-    enabled: false,
-  },
   [FeatureSwitchKey.OutlookMailConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Outlook Mail connector",


### PR DESCRIPTION
## Summary
- Remove the Slock connector feature switch gate from the connector auth method.
- Remove the obsolete slockConnector feature switch key and registry entry.
- Update connector/API tests so Slock is available without per-user switch setup.

## Verification
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F api check-types
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip
- pnpm test -- --maxWorkers=4

Note: an initial plain pnpm test run hit local ENOMEM while importing two app suites; rerunning those two suites directly passed, and the full retry passed 753 files / 9158 tests.