### PR TITLE
refactor: derive manual credential connector state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { zeroConnectorsByTypeContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { afterEach } from "vitest";
@@ -42,7 +43,10 @@ async function seedConnector(args: {
 
 async function deleteConnectorsByOrg(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
-  await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+  await Promise.all([
+    writeDb.delete(connectors).where(eq(connectors.orgId, orgId)),
+    writeDb.delete(secrets).where(eq(secrets.orgId, orgId)),
+  ]);
 }
 
 describe("GET /api/zero/connectors/:type", () => {
@@ -122,6 +126,40 @@ describe("GET /api/zero/connectors/:type", () => {
     );
 
     expect(response.body.type).toBe("github");
+  });
+
+  it("returns a connector inferred from manual credential secrets", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId,
+      name: "OPENAI_TOKEN",
+      encryptedValue: "encrypted_openai_token",
+      type: "user",
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.get({
+        params: { type: "openai" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: null,
+      type: "openai",
+      authMethod: "api-token",
+      createdAt: "1970-01-01T00:00:00.000Z",
+      updatedAt: "1970-01-01T00:00:00.000Z",
+    });
   });
 
   it("allows access with a sandbox JWT carrying connector:read capability", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -3,7 +3,9 @@ import { randomUUID } from "node:crypto";
 import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { variables } from "@vm0/db/schema/variable";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { afterEach } from "vitest";
@@ -40,9 +42,11 @@ async function deleteConnectorsByOrg(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
   await Promise.all([
     writeDb.delete(connectors).where(eq(connectors.orgId, orgId)),
+    writeDb.delete(secrets).where(eq(secrets.orgId, orgId)),
     writeDb
       .delete(userFeatureSwitches)
       .where(eq(userFeatureSwitches.orgId, orgId)),
+    writeDb.delete(variables).where(eq(variables.orgId, orgId)),
   ]);
 }
 
@@ -113,6 +117,40 @@ describe("GET /api/zero/connectors", () => {
         return c.type === "github";
       }),
     ).toBeTruthy();
+  });
+
+  it("returns connectors inferred from manual credential secrets", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId,
+      name: "OPENAI_TOKEN",
+      encryptedValue: "encrypted_openai_token",
+      type: "user",
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsMainContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const openai = response.body.connectors.find((connector) => {
+      return connector.type === "openai";
+    });
+    expect(openai).toMatchObject({
+      id: null,
+      type: "openai",
+      authMethod: "api-token",
+      createdAt: "1970-01-01T00:00:00.000Z",
+      updatedAt: "1970-01-01T00:00:00.000Z",
+    });
   });
 
   it("hides connected local-browser connector when the feature is disabled", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -22,7 +22,7 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
-  deriveApiTokenConnectedTypes,
+  deriveConnectedManualCredentialMethods,
   getConnectorEnvironmentMapping,
   getConnectorProvidedSecretNames,
 } from "@vm0/connectors/connector-utils";
@@ -771,14 +771,14 @@ function missingEnvironmentReferences(args: {
   return [...missingVars, ...missingSecrets];
 }
 
-function allowedApiTokenConnectorTypes(args: {
-  readonly apiTokenTypes: readonly ConnectorType[];
+function allowedManualCredentialConnectorTypes(args: {
+  readonly manualCredentialTypes: readonly ConnectorType[];
   readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
 }): readonly ConnectorType[] {
   if (!args.allowedConnectorTypes) {
-    return args.apiTokenTypes;
+    return args.manualCredentialTypes;
   }
-  return args.apiTokenTypes.filter((type) => {
+  return args.manualCredentialTypes.filter((type) => {
     return args.allowedConnectorTypes?.includes(type);
   });
 }
@@ -1336,13 +1336,13 @@ async function loadReferencedSecrets(
         return ref.name;
       })
     : [];
-  const apiTokenTypes = await loadApiTokenConnectorTypes(db, {
+  const manualCredentialTypes = await loadManualCredentialConnectorTypes(db, {
     orgId: args.orgId,
     userId: args.userId,
   });
   const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
-    allowedApiTokenConnectorTypes({
-      apiTokenTypes,
+    allowedManualCredentialConnectorTypes({
+      manualCredentialTypes,
       allowedConnectorTypes: args.allowedConnectorTypes,
     }),
   );
@@ -1351,7 +1351,7 @@ async function loadReferencedSecrets(
   }
 
   // Load all user secrets, not only those named in the compose environment:
-  // api-token connector credentials are consumed by firewall auth templates,
+  // Manual connector credentials are consumed by firewall auth templates,
   // which the compose environment never references. Connector-owned secrets
   // are still scoped by filterDbSecretsByConnectorPermissions below.
   const rows = await db
@@ -1385,7 +1385,7 @@ async function loadReferencedSecrets(
 
   const filteredSecrets = filterDbSecretsByConnectorPermissions({
     dbSecrets: { ...orgSecrets, ...userSecrets },
-    allApiTokenTypes: apiTokenTypes,
+    allManualCredentialTypes: manualCredentialTypes,
     allowedConnectorTypes: args.allowedConnectorTypes,
   });
   const connectorSecrets =
@@ -1396,7 +1396,7 @@ async function loadReferencedSecrets(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-async function loadApiTokenConnectorTypes(
+async function loadManualCredentialConnectorTypes(
   db: Db,
   args: {
     readonly orgId: string;
@@ -1422,7 +1422,7 @@ async function loadApiTokenConnectorTypes(
       ),
   ]);
 
-  return deriveApiTokenConnectedTypes(
+  return deriveConnectedManualCredentialMethods(
     new Set(
       secretRows.map((row) => {
         return row.name;
@@ -1433,12 +1433,14 @@ async function loadApiTokenConnectorTypes(
         return row.name;
       }),
     ),
-  );
+  ).map((method) => {
+    return method.type;
+  });
 }
 
 function filterDbSecretsByConnectorPermissions(args: {
   readonly dbSecrets: Record<string, string>;
-  readonly allApiTokenTypes: readonly ConnectorType[];
+  readonly allManualCredentialTypes: readonly ConnectorType[];
   readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
 }): Record<string, string> | undefined {
   if (Object.keys(args.dbSecrets).length === 0) {
@@ -1449,13 +1451,16 @@ function filterDbSecretsByConnectorPermissions(args: {
   }
 
   const allConnectorSecretNames = getConnectorProvidedSecretNames([
-    ...args.allApiTokenTypes,
+    ...args.allManualCredentialTypes,
   ]);
-  const allowedApiTokenTypes = args.allApiTokenTypes.filter((type) => {
-    return args.allowedConnectorTypes?.includes(type);
-  });
-  const allowedConnectorSecretNames =
-    getConnectorProvidedSecretNames(allowedApiTokenTypes);
+  const allowedManualCredentialTypes = args.allManualCredentialTypes.filter(
+    (type) => {
+      return args.allowedConnectorTypes?.includes(type);
+    },
+  );
+  const allowedConnectorSecretNames = getConnectorProvidedSecretNames(
+    allowedManualCredentialTypes,
+  );
   const filtered: Record<string, string> = {};
 
   for (const [name, value] of Object.entries(args.dbSecrets)) {
@@ -3164,7 +3169,7 @@ async function loadRunConnectorContexts(
 }> {
   const [
     oauthConnectorContext,
-    apiTokenConnectorTypes,
+    manualCredentialConnectorTypes,
     customConnectorContext,
   ] = await Promise.all([
     loadOauthConnectorContext(db, {
@@ -3173,7 +3178,7 @@ async function loadRunConnectorContexts(
       allowedConnectorTypes: args.allowedConnectorTypes,
       featureSwitchContext,
     }),
-    loadApiTokenConnectorTypes(db, {
+    loadManualCredentialConnectorTypes(db, {
       orgId: args.orgId,
       userId: args.userId,
     }),
@@ -3184,18 +3189,18 @@ async function loadRunConnectorContexts(
       featureSwitchContext,
     }),
   ]);
-  const allowedApiTokenConnectorTypes = args.allowedConnectorTypes
-    ? apiTokenConnectorTypes.filter((type) => {
+  const allowedManualCredentialTypes = args.allowedConnectorTypes
+    ? manualCredentialConnectorTypes.filter((type) => {
         return args.allowedConnectorTypes?.includes(type);
       })
-    : apiTokenConnectorTypes;
+    : manualCredentialConnectorTypes;
   return {
     connectorContext: {
       ...oauthConnectorContext,
       connectorTypes: [
         ...new Set([
           ...oauthConnectorContext.connectorTypes,
-          ...allowedApiTokenConnectorTypes,
+          ...allowedManualCredentialTypes,
         ]),
       ],
     },

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -7,15 +7,19 @@ import type {
 import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   connectorAuthMethodHasOAuthGrant,
-  deriveApiTokenConnectedTypes,
-  getApiTokenFieldsByType,
+  deriveConnectedManualCredentialMethod,
+  deriveConnectedManualCredentialMethods,
   getAvailableConnectorAuthMethods,
+  getConnectorManualCredentialAuthMethods,
   getConnectorOAuthCredentials,
   getConnectorProvidedSecretNames,
   getConnectorSecretNames,
   getRuntimeAvailableConnectorTypes,
   getScopeDiff,
   isConnectorAuthMethodAvailable,
+  type ConnectedManualCredentialMethod,
+  type ManualCredentialAuthMethod,
+  type ManualCredentialFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
@@ -41,7 +45,7 @@ import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
-import { db$, type Db, writeDb$ } from "../external/db";
+import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import {
   deleteBotUser,
   deleteCloudEndpoint,
@@ -121,47 +125,107 @@ function storedConnectorTypeIsVisible(
   );
 }
 
-function apiTokenConnectorTypes(args: {
+function manualCredentialConnectorResponse(
+  method: ConnectedManualCredentialMethod,
+): ConnectorResponse {
+  return {
+    id: null,
+    type: method.type,
+    authMethod: method.authMethod,
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: null,
+    needsReconnect: false,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+  };
+}
+
+async function loadUserManualCredentialNameSets(
+  db: Db | ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<{
+  readonly secretNames: Set<string>;
+  readonly variableNames: Set<string>;
+}> {
+  const [userSecretRows, userVariableRows] = await Promise.all([
+    db
+      .select({ name: secrets.name })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, args.orgId),
+          eq(secrets.userId, args.userId),
+          eq(secrets.type, "user"),
+        ),
+      ),
+    db
+      .select({ name: variables.name })
+      .from(variables)
+      .where(
+        and(eq(variables.orgId, args.orgId), eq(variables.userId, args.userId)),
+      ),
+  ]);
+
+  return {
+    secretNames: new Set(
+      userSecretRows.map((row) => {
+        return row.name;
+      }),
+    ),
+    variableNames: new Set(
+      userVariableRows.map((row) => {
+        return row.name;
+      }),
+    ),
+  };
+}
+
+function mergeManualCredentialFields(
+  methods: readonly ManualCredentialAuthMethod[],
+): ManualCredentialFieldNames | null {
+  const secretsSet = new Set<string>();
+  const variablesSet = new Set<string>();
+  for (const method of methods) {
+    for (const name of method.fields.secrets) {
+      secretsSet.add(name);
+    }
+    for (const name of method.fields.variables) {
+      variablesSet.add(name);
+    }
+  }
+  const secretsList = [...secretsSet];
+  const variablesList = [...variablesSet];
+  if (secretsList.length === 0 && variablesList.length === 0) {
+    return null;
+  }
+  return { secrets: secretsList, variables: variablesList };
+}
+
+function manualCredentialFieldsByType(
+  type: ConnectorType,
+): ManualCredentialFieldNames | null {
+  return mergeManualCredentialFields(
+    getConnectorManualCredentialAuthMethods(type),
+  );
+}
+
+function manualCredentialConnectorMethods(args: {
   readonly orgId: string;
   readonly userId: string;
-}): Computed<Promise<readonly ConnectorType[]>> {
-  return computed(async (get): Promise<readonly ConnectorType[]> => {
-    const db = get(db$);
-    const [userSecretRows, userVariableRows] = await Promise.all([
-      db
-        .select({ name: secrets.name })
-        .from(secrets)
-        .where(
-          and(
-            eq(secrets.orgId, args.orgId),
-            eq(secrets.userId, args.userId),
-            eq(secrets.type, "user"),
-          ),
-        ),
-      db
-        .select({ name: variables.name })
-        .from(variables)
-        .where(
-          and(
-            eq(variables.orgId, args.orgId),
-            eq(variables.userId, args.userId),
-          ),
-        ),
-    ]);
-
-    return deriveApiTokenConnectedTypes(
-      new Set(
-        userSecretRows.map((row) => {
-          return row.name;
-        }),
-      ),
-      new Set(
-        userVariableRows.map((row) => {
-          return row.name;
-        }),
-      ),
-    );
-  });
+}): Computed<Promise<readonly ConnectedManualCredentialMethod[]>> {
+  return computed(
+    async (get): Promise<readonly ConnectedManualCredentialMethod[]> => {
+      const db = get(db$);
+      const { secretNames, variableNames } =
+        await loadUserManualCredentialNameSets(db, args);
+      return deriveConnectedManualCredentialMethods(secretNames, variableNames);
+    },
+  );
 }
 
 export function zeroConnectorList(args: {
@@ -170,7 +234,7 @@ export function zeroConnectorList(args: {
 }): Computed<Promise<ConnectorListResponse>> {
   return computed(async (get): Promise<ConnectorListResponse> => {
     const db = get(db$);
-    const [oauthRows, derivedTypes, overrides] = await Promise.all([
+    const [oauthRows, derivedMethods, overrides] = await Promise.all([
       db
         .select({
           id: connectors.id,
@@ -191,7 +255,7 @@ export function zeroConnectorList(args: {
             eq(connectors.userId, args.userId),
           ),
         ),
-      get(apiTokenConnectorTypes(args)),
+      get(manualCredentialConnectorMethods(args)),
       get(userFeatureSwitchOverrides(args.orgId, args.userId)),
     ]);
     const featureStates = getAllFeatureStates({
@@ -219,26 +283,19 @@ export function zeroConnectorList(args: {
     // Use a fixed timestamp for derived connectors — they are inferred from
     // secrets/variables rather than explicitly created, so a stable sentinel
     // value keeps shadow comparisons deterministic.
-    const derivedConnectors: ConnectorResponse[] = derivedTypes
-      .filter((type) => {
-        return !dbTypes.has(type);
+    const derivedConnectors: ConnectorResponse[] = derivedMethods
+      .filter((method) => {
+        return !dbTypes.has(method.type);
       })
-      .filter((type) => {
-        return isConnectorAuthMethodAvailable(type, "api-token", featureStates);
+      .filter((method) => {
+        return isConnectorAuthMethodAvailable(
+          method.type,
+          method.authMethod,
+          featureStates,
+        );
       })
-      .map((type) => {
-        return {
-          id: null,
-          type,
-          authMethod: "api-token",
-          externalId: null,
-          externalUsername: null,
-          externalEmail: null,
-          oauthScopes: null,
-          needsReconnect: false,
-          createdAt: "1970-01-01T00:00:00.000Z",
-          updatedAt: "1970-01-01T00:00:00.000Z",
-        };
+      .map((method) => {
+        return manualCredentialConnectorResponse(method);
       });
 
     const connectorList = [...dbConnectors, ...derivedConnectors];
@@ -297,81 +354,23 @@ function storedConnectorByType(args: {
   });
 }
 
-function apiTokenConnectorByType(args: {
+function manualCredentialMethodByType(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly type: ConnectorType;
-}): Computed<Promise<ConnectorResponse | null>> {
-  return computed(async (get): Promise<ConnectorResponse | null> => {
-    const db = get(db$);
-    const fields = getApiTokenFieldsByType(args.type);
-    if (
-      !fields ||
-      (fields.secrets.length === 0 && fields.variables.length === 0)
-    ) {
-      return null;
-    }
-
-    const [userSecretRows, userVariableRows] = await Promise.all([
-      fields.secrets.length > 0
-        ? db
-            .select({ name: secrets.name })
-            .from(secrets)
-            .where(
-              and(
-                eq(secrets.orgId, args.orgId),
-                eq(secrets.userId, args.userId),
-                eq(secrets.type, "user"),
-              ),
-            )
-        : Promise.resolve([]),
-      fields.variables.length > 0
-        ? db
-            .select({ name: variables.name })
-            .from(variables)
-            .where(
-              and(
-                eq(variables.orgId, args.orgId),
-                eq(variables.userId, args.userId),
-              ),
-            )
-        : Promise.resolve([]),
-    ]);
-
-    const secretNames = new Set(
-      userSecretRows.map((row) => {
-        return row.name;
-      }),
-    );
-    const variableNames = new Set(
-      userVariableRows.map((row) => {
-        return row.name;
-      }),
-    );
-    const secretsOk = fields.secrets.every((name) => {
-      return secretNames.has(name);
-    });
-    const variablesOk = fields.variables.every((name) => {
-      return variableNames.has(name);
-    });
-    if (!secretsOk || !variablesOk) {
-      return null;
-    }
-
-    // Use a fixed timestamp — this connector is inferred, not explicitly created.
-    return {
-      id: null,
-      type: args.type,
-      authMethod: "api-token",
-      externalId: null,
-      externalUsername: null,
-      externalEmail: null,
-      oauthScopes: null,
-      needsReconnect: false,
-      createdAt: "1970-01-01T00:00:00.000Z",
-      updatedAt: "1970-01-01T00:00:00.000Z",
-    };
-  });
+}): Computed<Promise<ConnectedManualCredentialMethod | null>> {
+  return computed(
+    async (get): Promise<ConnectedManualCredentialMethod | null> => {
+      const db = get(db$);
+      const { secretNames, variableNames } =
+        await loadUserManualCredentialNameSets(db, args);
+      return deriveConnectedManualCredentialMethod(
+        args.type,
+        secretNames,
+        variableNames,
+      );
+    },
+  );
 }
 
 export function zeroConnectorByType(args: {
@@ -398,12 +397,22 @@ export function zeroConnectorByType(args: {
         return storedConnector;
       }
     }
+    const manualCredentialMethod = await get(
+      manualCredentialMethodByType(args),
+    );
+    if (!manualCredentialMethod) {
+      return null;
+    }
     if (
-      !isConnectorAuthMethodAvailable(args.type, "api-token", featureStates)
+      !isConnectorAuthMethodAvailable(
+        args.type,
+        manualCredentialMethod.authMethod,
+        featureStates,
+      )
     ) {
       return null;
     }
-    return get(apiTokenConnectorByType(args));
+    return manualCredentialConnectorResponse(manualCredentialMethod);
   });
 }
 
@@ -462,14 +471,11 @@ async function revokeExistingConnectorToken(args: {
   args.signal.throwIfAborted();
 }
 
-async function hasApiTokenConnectorLocalState(args: {
+async function hasManualCredentialConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: {
-    readonly secrets: readonly string[];
-    readonly variables: readonly string[];
-  } | null;
+  readonly fields: ManualCredentialFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
   if (!args.fields) {
@@ -516,14 +522,11 @@ async function hasApiTokenConnectorLocalState(args: {
   return false;
 }
 
-async function deleteApiTokenConnectorLocalState(args: {
+async function deleteManualCredentialConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: {
-    readonly secrets: readonly string[];
-    readonly variables: readonly string[];
-  } | null;
+  readonly fields: ManualCredentialFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
   if (!args.fields) {
@@ -600,17 +603,17 @@ export const deleteZeroConnectorLocalState$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const fields = getApiTokenFieldsByType(args.type);
-    const hasApiTokenState = existing
+    const fields = manualCredentialFieldsByType(args.type);
+    const hasManualCredentialState = existing
       ? false
-      : await hasApiTokenConnectorLocalState({
+      : await hasManualCredentialConnectorLocalState({
           db: writeDb,
           orgId: args.orgId,
           userId: args.userId,
           fields,
           signal,
         });
-    if (!existing && !hasApiTokenState) {
+    if (!existing && !hasManualCredentialState) {
       return false;
     }
 
@@ -660,7 +663,7 @@ export const deleteZeroConnectorLocalState$ = command(
     }
 
     deleted =
-      (await deleteApiTokenConnectorLocalState({
+      (await deleteManualCredentialConnectorLocalState({
         db: writeDb,
         orgId: args.orgId,
         userId: args.userId,
@@ -835,7 +838,7 @@ export const upsertOAuthConnector$ = command(
         ? secretMetadata.refreshSecretName
         : undefined,
     });
-    const apiTokenFields = getApiTokenFieldsByType(args.type);
+    const manualCredentialFields = manualCredentialFieldsByType(args.type);
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,
@@ -918,11 +921,11 @@ export const upsertOAuthConnector$ = command(
       throw new Error("Failed to upsert connector");
     }
 
-    await deleteApiTokenConnectorLocalState({
+    await deleteManualCredentialConnectorLocalState({
       db: writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      fields: apiTokenFields,
+      fields: manualCredentialFields,
       signal,
     });
     signal.throwIfAborted();

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -19,9 +19,9 @@ import {
   type OAuthAuthCodeConnectorType,
 } from "../connectors";
 import {
-  getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
   getConfiguredConnectorAuthMethods,
+  deriveConnectedManualCredentialMethods,
   hasRequiredScopes,
   getConnectorAuthCodeGrantConfigIfSupported,
   getConnectorAuthMethod,
@@ -36,6 +36,9 @@ import {
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthScopes,
   getConnectorManualGrantFields,
+  getConnectorManualCredentialAuthMethods,
+  getConnectorManualCredentialFields,
+  getConnectorManualCredentialFieldStorageType,
   getEligibleConnectorTypes,
   getRuntimeAvailableConnectorTypes,
   getConnectorSecretNames,
@@ -324,16 +327,84 @@ describe("connector auth method config", () => {
     ]);
   });
 
-  it("returns api-token field storage types with secret default", () => {
-    expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_EMAIL")).toBe(
-      "variable",
+  it("returns manual credential field storage types with secret default", () => {
+    expect(
+      getConnectorManualCredentialFieldStorageType(
+        "zendesk",
+        "api-token",
+        "ZENDESK_EMAIL",
+      ),
+    ).toBe("variable");
+    expect(
+      getConnectorManualCredentialFieldStorageType(
+        "zendesk",
+        "api-token",
+        "ZENDESK_API_TOKEN",
+      ),
+    ).toBe("secret");
+    expect(
+      getConnectorManualCredentialFieldStorageType(
+        "zendesk",
+        "api-token",
+        "UNKNOWN_FIELD",
+      ),
+    ).toBe("secret");
+  });
+
+  it("groups required manual credential fields by storage", () => {
+    expect(
+      getConnectorManualCredentialFields("atlassian", "api-token"),
+    ).toStrictEqual({
+      secrets: ["ATLASSIAN_TOKEN"],
+      variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
+    });
+    expect(getConnectorManualCredentialFields("github", "oauth")).toBeNull();
+  });
+
+  it("lists only manual credential auth methods", () => {
+    expect(getConnectorManualCredentialAuthMethods("atlassian")).toStrictEqual([
+      {
+        type: "atlassian",
+        authMethod: "api-token",
+        fields: {
+          secrets: ["ATLASSIAN_TOKEN"],
+          variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
+        },
+      },
+    ]);
+    expect(getConnectorManualCredentialAuthMethods("github")).toStrictEqual([]);
+    expect(getConnectorManualCredentialAuthMethods("computer")).toStrictEqual(
+      [],
     );
-    expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_API_TOKEN")).toBe(
-      "secret",
+  });
+
+  it("derives connected manual credential methods from required fields", () => {
+    expect(
+      deriveConnectedManualCredentialMethods(
+        new Set(["ATLASSIAN_TOKEN"]),
+        new Set(["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"]),
+      ),
+    ).toContainEqual({ type: "atlassian", authMethod: "api-token" });
+    expect(
+      deriveConnectedManualCredentialMethods(
+        new Set(["ATLASSIAN_TOKEN"]),
+        new Set(["ATLASSIAN_EMAIL"]),
+      ),
+    ).not.toContainEqual({ type: "atlassian", authMethod: "api-token" });
+    const connected = deriveConnectedManualCredentialMethods(
+      new Set(["GITHUB_ACCESS_TOKEN", "COMPUTER_CONNECTOR_BRIDGE_TOKEN"]),
+      new Set(),
     );
-    expect(getApiTokenFieldStorageType("zendesk", "UNKNOWN_FIELD")).toBe(
-      "secret",
-    );
+    expect(
+      connected.some((method) => {
+        return method.type === "github";
+      }),
+    ).toBe(false);
+    expect(
+      connected.some((method) => {
+        return method.type === "computer";
+      }),
+    ).toBe(false);
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -55,8 +55,8 @@ export function getConfiguredConnectorAuthMethods(
  *   feature-switch filtering.
  * - Runtime available connector types are connector types the current server
  *   environment can offer as connection candidates.
- * - User connected connector types come from persisted OAuth rows or inferred
- *   api-token state from user secrets and variables.
+ * - User connected connector types come from persisted rows or inferred manual
+ *   credential state from user secrets and variables.
  * - Runtime injection happens later when a run receives env vars, secrets,
  *   variables, and firewall context.
  */
@@ -122,6 +122,133 @@ export function getConnectorManualGrantFields(
   authMethod: ConnectorAuthMethodId,
 ): Record<string, ConnectorManualGrantFieldConfig> | undefined {
   return getManualGrantFields(getConnectorAuthMethod(type, authMethod));
+}
+
+export interface ManualCredentialFieldNames {
+  readonly secrets: readonly string[];
+  readonly variables: readonly string[];
+}
+
+export interface ManualCredentialAuthMethod {
+  readonly type: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly fields: ManualCredentialFieldNames;
+}
+
+export interface ConnectedManualCredentialMethod {
+  readonly type: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+}
+
+function manualCredentialFieldNames(
+  fields: Record<string, ConnectorManualGrantFieldConfig>,
+): ManualCredentialFieldNames {
+  const secretNames: string[] = [];
+  const variableNames: string[] = [];
+  for (const [name, cfg] of Object.entries(fields)) {
+    if (!cfg.required) continue;
+    if (cfg.storage === "variable") {
+      variableNames.push(name);
+    } else {
+      secretNames.push(name);
+    }
+  }
+  return { secrets: secretNames, variables: variableNames };
+}
+
+function hasRequiredManualCredentialFields(
+  fields: ManualCredentialFieldNames,
+): boolean {
+  return fields.secrets.length > 0 || fields.variables.length > 0;
+}
+
+export function getConnectorManualCredentialFields(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+): ManualCredentialFieldNames | null {
+  const fields = getManualGrantFields(getConnectorAuthMethod(type, authMethod));
+  return fields ? manualCredentialFieldNames(fields) : null;
+}
+
+export function getConnectorManualCredentialFieldStorageType(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+  name: string,
+): "secret" | "variable" {
+  const fieldConfig = getManualGrantFields(
+    getConnectorAuthMethod(type, authMethod),
+  )?.[name];
+  return fieldConfig?.storage ?? "secret";
+}
+
+export function getConnectorManualCredentialAuthMethods(
+  type: ConnectorType,
+): ManualCredentialAuthMethod[] {
+  const manualMethods: ManualCredentialAuthMethod[] = [];
+
+  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+    const method = getConnectorAuthMethod(type, authMethod);
+    switch (method?.grant.kind) {
+      case "manual":
+        manualMethods.push({
+          type,
+          authMethod,
+          fields: manualCredentialFieldNames(method.grant.fields),
+        });
+        break;
+      case "managed":
+      case "auth-code":
+      case "device-auth":
+      case "interactive-pairing":
+      case undefined:
+        break;
+    }
+  }
+
+  return manualMethods;
+}
+
+export function deriveConnectedManualCredentialMethod(
+  type: ConnectorType,
+  userSecretNames: Set<string>,
+  userVariableNames?: Set<string>,
+): ConnectedManualCredentialMethod | null {
+  const varNames = userVariableNames ?? new Set<string>();
+
+  for (const method of getConnectorManualCredentialAuthMethods(type)) {
+    if (!hasRequiredManualCredentialFields(method.fields)) continue;
+    const secretsOk = method.fields.secrets.every((name) => {
+      return userSecretNames.has(name);
+    });
+    const variablesOk = method.fields.variables.every((name) => {
+      return varNames.has(name);
+    });
+    if (secretsOk && variablesOk) {
+      return { type, authMethod: method.authMethod };
+    }
+  }
+
+  return null;
+}
+
+export function deriveConnectedManualCredentialMethods(
+  userSecretNames: Set<string>,
+  userVariableNames?: Set<string>,
+): ConnectedManualCredentialMethod[] {
+  const connected: ConnectedManualCredentialMethod[] = [];
+
+  for (const type of CONNECTOR_TYPE_KEYS) {
+    const method = deriveConnectedManualCredentialMethod(
+      type,
+      userSecretNames,
+      userVariableNames,
+    );
+    if (method) {
+      connected.push(method);
+    }
+  }
+
+  return connected;
 }
 
 function connectorAccessOutputs(
@@ -787,75 +914,39 @@ export function getConnectorTypeForSecretName(
   return null;
 }
 
-/**
- * Get required field names grouped by storage type for a connector's api-token auth method.
- * Returns null if the connector type does not support api-token auth.
- */
 export function getApiTokenFieldsByType(
   type: ConnectorType,
-): { secrets: string[]; variables: string[] } | null {
-  const apiTokenConfig = getConnectorAuthMethod(type, "api-token");
-  const fields = getManualGrantFields(apiTokenConfig);
-  if (!fields) return null;
-
-  const secretNames: string[] = [];
-  const variableNames: string[] = [];
-  for (const [name, cfg] of Object.entries(fields)) {
-    if (!cfg.required) continue;
-    if (cfg.storage === "variable") {
-      variableNames.push(name);
-    } else {
-      secretNames.push(name);
-    }
-  }
-  return { secrets: secretNames, variables: variableNames };
+): ManualCredentialFieldNames | null {
+  // Compatibility wrapper for legacy API-token callers. New state inference
+  // should use manual credential helpers so the method id is preserved.
+  return getConnectorManualCredentialFields(type, "api-token");
 }
 
-/**
- * Return the storage target for a connector API-token field.
- *
- * Unknown fields preserve the historical form-submit behavior and are treated
- * as encrypted secrets.
- */
 export function getApiTokenFieldStorageType(
   type: ConnectorType,
   name: string,
 ): "secret" | "variable" {
-  const fieldConfig = getManualGrantFields(
-    getConnectorAuthMethod(type, "api-token"),
-  )?.[name];
-  return fieldConfig?.storage ?? "secret";
+  // Unknown fields preserve the historical form-submit behavior and are treated
+  // as encrypted secrets by the manual credential storage helper.
+  return getConnectorManualCredentialFieldStorageType(type, "api-token", name);
 }
 
-/**
- * Derive which connector types are "connected" via api-token based on present user secret and variable names.
- * A connector type is considered connected if all its required api-token fields exist
- * (secrets checked against userSecretNames, variables checked against userVariableNames).
- */
 export function deriveApiTokenConnectedTypes(
   userSecretNames: Set<string>,
   userVariableNames?: Set<string>,
 ): ConnectorType[] {
-  const allTypes = CONNECTOR_TYPE_KEYS;
-  const connected: ConnectorType[] = [];
-  const varNames = userVariableNames ?? new Set<string>();
-
-  for (const type of allTypes) {
-    const fields = getApiTokenFieldsByType(type);
-    if (!fields) continue;
-    if (fields.secrets.length === 0 && fields.variables.length === 0) continue;
-    const secretsOk = fields.secrets.every((name) => {
-      return userSecretNames.has(name);
+  // Compatibility wrapper for legacy API-token callers. The config-driven
+  // helper carries authMethod for production state inference.
+  return deriveConnectedManualCredentialMethods(
+    userSecretNames,
+    userVariableNames,
+  )
+    .filter((method) => {
+      return method.authMethod === "api-token";
+    })
+    .map((method) => {
+      return method.type;
     });
-    const variablesOk = fields.variables.every((name) => {
-      return varNames.has(name);
-    });
-    if (secretsOk && variablesOk) {
-      connected.push(type);
-    }
-  }
-
-  return connected;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add config-driven manual credential helpers that preserve the connected auth method
- migrate connector list/by-type/delete/OAuth cleanup and run context code off API-token-specific inference
- add connector utility and API route coverage for derived manual credential state

Closes #14965

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm check-types
