### PR TITLE
feat: register postcard-illustration styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1421,42 +1421,7 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Hand-drawn editorial postcard / travel-journal illustration with fine black ink linework, flat saturated gouache fills, sharp edges, dense small repeated ink patterns, paper-grain texture, sparse white speckles, and a tall portrait composition.",
     desc: 'Hand-drawn editorial postcard illustration style. Fine black marker/pen ink linework over flat saturated gouache color fills with sharp edges, dense small repeated ink patterns on surfaces (rows of windows, shingle curves, hatching, stippling), subtle paper-grain background texture, tiny scattered white speckles (snow / petals / sparkle), and a tall portrait composition with a layered foreground-midground-background. Travel-journal / urban-sketcher aesthetic. Trigger when the user says /postcard-illustration, asks for a "postcard illustration", "travel illustration", "urban sketcher style", or briefs a palette + scene archetype + complexity.',
-    source: sourceRef(
-      VM0_SKILLS_REPO,
-      VM0_SKILLS_REF,
-      "illustration-template/postcard-illustration",
-    ),
-    targets: ["image", "website", "poster", "presentation", "report"],
-    tags: [
-      "image",
-      "illustration",
-      "postcard",
-      "travel",
-      "urban-sketcher",
-      "hand-drawn",
-      "editorial",
-    ],
-    triggers: [
-      "postcard illustration",
-      "travel illustration",
-      "urban sketcher",
-      "travel journal",
-      "city scene illustration",
-      "hand drawn postcard",
-    ],
-    bestFor: [
-      "travel and destination artwork",
-      "cityscape and landmark illustrations",
-      "editorial blog covers with a sense of place",
-      "botanical close-up postcards",
-    ],
-    outputKinds: ["image"],
-    primaryOutputKind: "image",
-    executorHints: ["skill-authored", "built-in-image"],
-    previewHint: "image",
-    remixHint: "prompt-with-resource-hints",
-    status: "experimental",
-    priority: 20,
+    source: { path: "illustration-template/postcard-illustration" },
   },
 ];
 

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1414,6 +1414,50 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     status: "experimental",
     priority: 19,
   },
+  {
+    id: "vm0:image-style:postcard-illustration",
+    kind: "image-style",
+    name: "Postcard Illustration",
+    description:
+      "Hand-drawn editorial postcard / travel-journal illustration with fine black ink linework, flat saturated gouache fills, sharp edges, dense small repeated ink patterns, paper-grain texture, sparse white speckles, and a tall portrait composition.",
+    desc: 'Hand-drawn editorial postcard illustration style. Fine black marker/pen ink linework over flat saturated gouache color fills with sharp edges, dense small repeated ink patterns on surfaces (rows of windows, shingle curves, hatching, stippling), subtle paper-grain background texture, tiny scattered white speckles (snow / petals / sparkle), and a tall portrait composition with a layered foreground-midground-background. Travel-journal / urban-sketcher aesthetic. Trigger when the user says /postcard-illustration, asks for a "postcard illustration", "travel illustration", "urban sketcher style", or briefs a palette + scene archetype + complexity.',
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/postcard-illustration",
+    ),
+    targets: ["image", "website", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "postcard",
+      "travel",
+      "urban-sketcher",
+      "hand-drawn",
+      "editorial",
+    ],
+    triggers: [
+      "postcard illustration",
+      "travel illustration",
+      "urban sketcher",
+      "travel journal",
+      "city scene illustration",
+      "hand drawn postcard",
+    ],
+    bestFor: [
+      "travel and destination artwork",
+      "cityscape and landmark illustrations",
+      "editorial blog covers with a sense of place",
+      "botanical close-up postcards",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 20,
+  },
 ];
 
 export function listImageStyles(): readonly OpenDesignRegistryEntry[] {


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:postcard-illustration` in the Open Design registry. The source points at the new resource in `vm0-ai/vm0-skills@main` under `illustration-template/postcard-illustration`.

Adds a registry entry only — no behavior or test changes. The new style appears in the image-style listing alongside `notion-illustration` and `vm0-illustration`.

## Paired PR

- vm0-skills resource and locked reference anchors: vm0-ai/vm0-skills#208

## Style overview

Hand-drawn editorial postcard / travel-journal illustration:

- Tall portrait composition
- Fine confident black marker / technical pen ink linework
- Flat saturated gouache fills with sharp edges (NOT watercolor wash)
- Dense small repeated ink patterns on surfaces — windows, shingles, hatching, stippling
- Subtle paper-grain background texture
- Sparse white speckles (snow / petals / sparkle / rain)
- Travel-journal / urban-sketcher aesthetic

Seven dial-able knobs: palette, scene archetype, subject, complexity (L1/L2/L3), atmosphere, sky treatment, surface-pattern density, cast.

## Test plan

- [ ] `pnpm --filter @vm0/cli test -- open-design` passes (no test assertions change since existing tests substring-check the two pre-existing image-style IDs only)
- [ ] `zero built-in generate image --help` lists `vm0:image-style:postcard-illustration`
- [ ] Registry candidate selection includes the new ID for postcard / travel / urban-sketcher prompts
- [ ] Generation smoke test produces a usable output that matches the locked style axes