### PR TITLE
feat: register papernook image-style resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1414,6 +1414,50 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     status: "experimental",
     priority: 19,
   },
+  {
+    id: "vm0:image-style:papernook",
+    kind: "image-style",
+    name: "Papernook",
+    description:
+      "Hand-drawn editorial illustration set in a cozy cluttered personal-studio scene with warm cream paper, scratchy ink, painterly gouache fills, dot-eye character face, and dense edge-to-edge thematic props.",
+    desc: 'Hand-drawn editorial illustration in the spirit of a cluttered personal-studio scene. Loose scratchy black ink outlines that wobble, textured gouache fills with visible brush marks, warm cream paper background, simplified dot-eye character face, and a DENSE edge-to-edge composition where a centered character is orbited by thematic props that visually act out the scene metaphor. Default palette: dusty cornflower blue, soft coral pink, fresh sage green, charcoal, warm cream — no mustard, no burnt-orange. Trigger when user says /papernook, asks for a "papernook illustration", a "cozy cluttered editorial scene", a "warm-cream desk scene", or a new piece in this hand-drawn studio-clutter editorial style.',
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/papernook",
+    ),
+    targets: ["image", "website", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "editorial",
+      "hand-drawn",
+      "warm-cream",
+      "studio-clutter",
+      "papernook",
+    ],
+    triggers: [
+      "papernook",
+      "cozy cluttered illustration",
+      "warm cream desk scene",
+      "studio clutter illustration",
+      "editorial scene illustration",
+      "hand drawn editorial",
+    ],
+    bestFor: [
+      "blog cover art",
+      "magazine-style editorial illustration",
+      "persona / role illustrations",
+      "scene-as-metaphor concept art",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 20,
+  },
 ];
 
 export function listImageStyles(): readonly OpenDesignRegistryEntry[] {


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:papernook` in the Open Design registry, sourcing from `vm0-ai/vm0-skills@main:illustration-template/papernook`.

**Style:** hand-drawn editorial illustration set in a cozy cluttered personal-studio scene — warm cream paper, scratchy ink outlines, painterly gouache fills, dot-eye character face, and a dense edge-to-edge composition where a centered character is orbited by thematic props that visually act out the scene metaphor.

**Default palette:** dusty cornflower blue, soft coral pink, fresh sage green, charcoal black, warm cream — no mustard, no burnt-orange.

## Registry entry

| Field | Value |
|---|---|
| `id` | `vm0:image-style:papernook` |
| `kind` | `image-style` |
| `source` | `vm0-ai/vm0-skills@main:illustration-template/papernook` |
| `targets` | image, website, poster, presentation, report |
| `outputKinds` | image |
| `executorHints` | skill-authored, built-in-image |
| `previewHint` | image |
| `remixHint` | prompt-with-resource-hints |
| `status` | experimental |
| `priority` | 20 |

Triggers include: `papernook`, `cozy cluttered illustration`, `warm cream desk scene`, `studio clutter illustration`, `editorial scene illustration`, `hand drawn editorial`.

Best for: blog cover art, magazine-style editorial illustration, persona/role illustrations, scene-as-metaphor concept art.

## Paired skill PR

Skill resource + 5 reference assets land in **vm0-ai/vm0-skills#210**.

## Existing-test impact

The two existing image-style entries (`notion-illustration`, `vm0-illustration`) remain unchanged. Test assertions in `__tests__/image.test.ts` use `toContain` checks against those IDs, so adding `papernook` does not break them.

## Test plan

- [ ] `pnpm --filter @vm0/cli test -- open-design` passes locally
- [ ] `zero built-in generate image` `--help` lists papernook in the styles section
- [ ] Smoke generation with `--style vm0:image-style:papernook` produces a usable warm-cream illustration

🤖 Generated with [Claude Code](https://claude.com/claude-code)