### PR TITLE
feat: register iso-scene styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1414,6 +1414,52 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     status: "experimental",
     priority: 19,
   },
+  {
+    id: "vm0:image-style:iso-scene",
+    kind: "image-style",
+    name: "Isometric Editorial Scene",
+    description:
+      "Isometric editorial-magazine scene illustration with ultra-fine hairline outlines, flat fills, a saturated monochromatic background, and a scene-as-metaphor composition built from theme-native props.",
+    desc: 'Isometric editorial-magazine scene illustration in a locked flat-vector style — ultra-fine hairline outlines, monochromatic saturated background filling the canvas, and a single composed scene whose props themselves embody the theme. Trigger when users say /iso-scene, ask for an "isometric editorial illustration", a "scene illustration in the editorial machine style", or brief with palette + scene archetype + complexity.',
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/iso-scene",
+    ),
+    targets: ["image", "website", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "isometric",
+      "editorial",
+      "magazine",
+      "flat-vector",
+      "scene",
+    ],
+    triggers: [
+      "isometric illustration",
+      "isometric scene",
+      "iso scene",
+      "iso-scene",
+      "editorial scene illustration",
+      "construction machine style",
+      "monocle illustration",
+      "bloomberg illustration",
+    ],
+    bestFor: [
+      "editorial cover art",
+      "blog post hero illustrations",
+      "marketing campaign visuals",
+      "thematic scene metaphors",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 18,
+  },
 ];
 
 export function listImageStyles(): readonly OpenDesignRegistryEntry[] {


### PR DESCRIPTION
## Summary

Registers the `iso-scene` image-style resource in the Open Design registry. Pairs with [vm0-ai/vm0-skills#211](https://github.com/vm0-ai/vm0-skills/pull/211), which adds the template content and reference assets.

## Registry entry

- **ID:** `vm0:image-style:iso-scene`
- **Kind:** `image-style`
- **Source:** `vm0-ai/vm0-skills@main:illustration-template/iso-scene`
- **Targets:** image, website, poster, presentation, report
- **Status:** experimental, priority 18

## Style summary

Isometric editorial-magazine scene illustration in a locked flat-vector style:

- Ultra-fine hairline outlines (~0.5pt ink-pen)
- Flat colour fills, no gradients
- Saturated monochromatic background filling the entire canvas
- **Scene IS the metaphor** — props come from the theme itself, never a generic filing-cabinet box with relabelled folder tabs

Four customisable axes — palette (presets: green/blue/coral/yellow/terracotta/lavender/mint/sunset/sky, or custom hex), scene archetype, complexity (L1/L2/L3), optional silhouette modules.

## Companion PR

vm0-skills resource: https://github.com/vm0-ai/vm0-skills/pull/211

## Test plan

- [ ] `pnpm --filter @vm0/cli test -- open-design` — registry selection tests pass
- [ ] `zero built-in generate website --prompt "isometric editorial scene of a sky garden" --json | jq '.selection.candidates'` returns the new entry
- [ ] Local generation against the resource produces output matching the linework, background-fill, and scene-as-metaphor axes shown in the reference renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)