### PR TITLE
refactor: remove oauth token endpoint auth metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -201,7 +201,6 @@ function mockOAuthEnv(): void {
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
-  tokenEndpointAuthMethod: "none",
 } as const satisfies ConnectorOAuthClientConfig;
 
 type CapturedOAuthExchange = {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -288,7 +288,6 @@ async function seedExpiredTestOAuthConnector(
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
-  tokenEndpointAuthMethod: "none",
 } as const satisfies ConnectorOAuthClientConfig;
 
 type CapturedOAuthRefresh = {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -86,7 +86,6 @@ function mockOAuthEnv(): void {
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
-  tokenEndpointAuthMethod: "none",
 } as const satisfies ConnectorOAuthClientConfig;
 
 function useDynamicTestOAuthAuthorize(): () => void {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1756,7 +1756,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientIdEnv: "PUBLIC_OAUTH_CLIENT_ID",
       },
       (name) => {
@@ -1771,7 +1770,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       client: {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientIdEnv: "PUBLIC_OAUTH_CLIENT_ID",
       },
       clientId: "public-client-id",
@@ -1782,7 +1780,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     const client = {
       clientRegistration: "dynamic",
       clientType: "public",
-      tokenEndpointAuthMethod: "none",
     } as const;
 
     expect(
@@ -1818,7 +1815,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientId: "public-client-id",
       },
       emptyEnv,
@@ -1835,7 +1831,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     const dynamicClient = {
       clientRegistration: "dynamic",
       clientType: "public",
-      tokenEndpointAuthMethod: "none",
     } as const;
     const dynamicCredentials = resolveConnectorOAuthClientCredentials(
       dynamicClient,
@@ -1972,7 +1967,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       client: {
         clientRegistration: "static",
         clientType: "confidential",
-        tokenEndpointAuthMethod: "client_secret_post",
         clientIdEnv: "GH_OAUTH_CLIENT_ID",
         clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
       },
@@ -1989,7 +1983,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       client: {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientId: "test-oauth-device-client",
       },
       scopes: ["read"],
@@ -2003,7 +1996,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       client: {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientId: "base44_cli",
       },
       scopes: ["apps:read", "apps:write", "offline"],
@@ -2016,7 +2008,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
         client: {
           clientRegistration: "static",
           clientType: "public",
-          tokenEndpointAuthMethod: "none",
           clientId: "vm0",
         },
         scopes: [],
@@ -2081,7 +2072,6 @@ describe("connector OAuth device authorization config", () => {
       client: {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientId: "test-oauth-device-client",
       },
       scopes: ["read"],
@@ -2099,7 +2089,6 @@ describe("connector OAuth device authorization config", () => {
       client: {
         clientRegistration: "static",
         clientType: "public",
-        tokenEndpointAuthMethod: "none",
         clientId: "base44_cli",
       },
       scopes: ["apps:read", "apps:write", "offline"],
@@ -2116,7 +2105,6 @@ describe("connector OAuth device authorization config", () => {
         client: {
           clientRegistration: "static",
           clientType: "public",
-          tokenEndpointAuthMethod: "none",
           clientId: "vm0",
         },
         scopes: [],

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -266,37 +266,28 @@ export type ConnectorOAuthClientConfig =
   | {
       readonly clientRegistration: "static";
       readonly clientType: "confidential";
-      readonly tokenEndpointAuthMethod:
-        | "client_secret_basic"
-        | "client_secret_post";
       readonly clientIdEnv: string;
       readonly clientSecretEnv: string;
     }
   | {
       readonly clientRegistration: "static";
       readonly clientType: "confidential";
-      readonly tokenEndpointAuthMethod:
-        | "client_secret_basic"
-        | "client_secret_post";
       readonly clientId: string;
       readonly clientSecret: string;
     }
   | {
       readonly clientRegistration: "static";
       readonly clientType: "public";
-      readonly tokenEndpointAuthMethod: "none";
       readonly clientIdEnv: string;
     }
   | {
       readonly clientRegistration: "static";
       readonly clientType: "public";
-      readonly tokenEndpointAuthMethod: "none";
       readonly clientId: string;
     }
   | {
       readonly clientRegistration: "dynamic";
       readonly clientType: "public";
-      readonly tokenEndpointAuthMethod: "none";
     };
 
 export type StaticConfidentialConnectorOAuthClientConfig = Extract<

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -262,14 +262,6 @@ export interface ConnectorManualGrantFieldConfig {
   storage?: "secret" | "variable";
 }
 
-/**
- * OAuth configuration for connectors that support OAuth flow.
- */
-export type ConnectorOAuthTokenEndpointAuthMethod =
-  | "none"
-  | "client_secret_basic"
-  | "client_secret_post";
-
 export type ConnectorOAuthClientConfig =
   | {
       readonly clientRegistration: "static";

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -18,7 +18,6 @@ export const ahrefs = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "AHREFS_OAUTH_CLIENT_ID",
             clientSecretEnv: "AHREFS_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -16,7 +16,6 @@ export const airtable = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "AIRTABLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "AIRTABLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -16,7 +16,6 @@ export const asana = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "ASANA_OAUTH_CLIENT_ID",
             clientSecretEnv: "ASANA_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/base44.ts
+++ b/turbo/packages/connectors/src/connectors/base44.ts
@@ -17,7 +17,6 @@ export const base44 = {
           client: {
             clientRegistration: "static",
             clientType: "public",
-            tokenEndpointAuthMethod: "none",
             clientId: "base44_cli",
           },
           scopes: ["apps:read", "apps:write", "offline"],

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -18,7 +18,6 @@ export const canva = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "CANVA_OAUTH_CLIENT_ID",
             clientSecretEnv: "CANVA_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -18,7 +18,6 @@ export const close = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "CLOSE_OAUTH_CLIENT_ID",
             clientSecretEnv: "CLOSE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -18,7 +18,6 @@ export const deel = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "DEEL_OAUTH_CLIENT_ID",
             clientSecretEnv: "DEEL_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -18,7 +18,6 @@ export const docusign = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "DOCUSIGN_OAUTH_CLIENT_ID",
             clientSecretEnv: "DOCUSIGN_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -17,7 +17,6 @@ export const dropbox = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "DROPBOX_OAUTH_CLIENT_ID",
             clientSecretEnv: "DROPBOX_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -17,7 +17,6 @@ export const figma = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "FIGMA_OAUTH_CLIENT_ID",
             clientSecretEnv: "FIGMA_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -18,7 +18,6 @@ export const garminConnect = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
             clientSecretEnv: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -17,7 +17,6 @@ export const github = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GH_OAUTH_CLIENT_ID",
             clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -16,7 +16,6 @@ export const gmail = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -20,7 +20,6 @@ export const googleAds = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -17,7 +17,6 @@ export const googleCalendar = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -15,7 +15,6 @@ export const googleDocs = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -15,7 +15,6 @@ export const googleDrive = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -16,7 +16,6 @@ export const googleMeet = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -15,7 +15,6 @@ export const googleSheets = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
             clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -17,7 +17,6 @@ export const gumroad = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "GUMROAD_OAUTH_CLIENT_ID",
             clientSecretEnv: "GUMROAD_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -16,7 +16,6 @@ export const hubspot = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "HUBSPOT_OAUTH_CLIENT_ID",
             clientSecretEnv: "HUBSPOT_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -16,7 +16,6 @@ export const intervalsIcu = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "INTERVALS_ICU_OAUTH_CLIENT_ID",
             clientSecretEnv: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -16,7 +16,6 @@ export const linear = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "LINEAR_OAUTH_CLIENT_ID",
             clientSecretEnv: "LINEAR_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -18,7 +18,6 @@ export const mailchimp = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "MAILCHIMP_OAUTH_CLIENT_ID",
             clientSecretEnv: "MAILCHIMP_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -18,7 +18,6 @@ export const mercury = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "MERCURY_OAUTH_CLIENT_ID",
             clientSecretEnv: "MERCURY_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -18,7 +18,6 @@ export const metaAds = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "META_ADS_OAUTH_CLIENT_ID",
             clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -16,7 +16,6 @@ export const monday = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "MONDAY_OAUTH_CLIENT_ID",
             clientSecretEnv: "MONDAY_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -18,7 +18,6 @@ export const neon = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "NEON_OAUTH_CLIENT_ID",
             clientSecretEnv: "NEON_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -16,7 +16,6 @@ export const notion = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "NOTION_OAUTH_CLIENT_ID",
             clientSecretEnv: "NOTION_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -19,7 +19,6 @@ export const outlookCalendar = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
             clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -18,7 +18,6 @@ export const outlookMail = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
             clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -18,7 +18,6 @@ export const posthog = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "POSTHOG_OAUTH_CLIENT_ID",
             clientSecretEnv: "POSTHOG_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -18,7 +18,6 @@ export const reddit = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "REDDIT_OAUTH_CLIENT_ID",
             clientSecretEnv: "REDDIT_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -16,7 +16,6 @@ export const sentry = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "SENTRY_OAUTH_CLIENT_ID",
             clientSecretEnv: "SENTRY_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -16,7 +16,6 @@ export const slack = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "SLACK_CLIENT_ID",
             clientSecretEnv: "SLACK_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -19,7 +19,6 @@ export const slock = {
           client: {
             clientRegistration: "static",
             clientType: "public",
-            tokenEndpointAuthMethod: "none",
             clientId: "vm0",
           },
           scopes: [],

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -18,7 +18,6 @@ export const spotify = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "SPOTIFY_OAUTH_CLIENT_ID",
             clientSecretEnv: "SPOTIFY_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -16,7 +16,6 @@ export const strava = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "STRAVA_OAUTH_CLIENT_ID",
             clientSecretEnv: "STRAVA_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -19,7 +19,6 @@ export const stripe = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "STRIPE_OAUTH_CLIENT_ID",
             clientSecretEnv: "STRIPE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -18,7 +18,6 @@ export const supabase = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "SUPABASE_OAUTH_CLIENT_ID",
             clientSecretEnv: "SUPABASE_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -19,7 +19,6 @@ export const testOauthDevice = {
           client: {
             clientRegistration: "static",
             clientType: "public",
-            tokenEndpointAuthMethod: "none",
             clientId: "test-oauth-device-client",
           },
           scopes: ["read"],

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -18,7 +18,6 @@ export const testOauth = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientId: "test-oauth-client",
             clientSecret: "test-oauth-secret",
           },

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -16,7 +16,6 @@ export const todoist = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "TODOIST_OAUTH_CLIENT_ID",
             clientSecretEnv: "TODOIST_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -16,7 +16,6 @@ export const vercel = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
             clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -18,7 +18,6 @@ export const webflow = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "WEBFLOW_OAUTH_CLIENT_ID",
             clientSecretEnv: "WEBFLOW_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -16,7 +16,6 @@ export const x = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "X_OAUTH_CLIENT_ID",
             clientSecretEnv: "X_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -16,7 +16,6 @@ export const xero = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_post",
             clientIdEnv: "XERO_OAUTH_CLIENT_ID",
             clientSecretEnv: "XERO_OAUTH_CLIENT_SECRET",
           },

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -18,7 +18,6 @@ export const zoom = {
           client: {
             clientRegistration: "static",
             clientType: "confidential",
-            tokenEndpointAuthMethod: "client_secret_basic",
             clientIdEnv: "ZOOM_OAUTH_CLIENT_ID",
             clientSecretEnv: "ZOOM_OAUTH_CLIENT_SECRET",
           },


### PR DESCRIPTION
## Summary
- remove the unused `ConnectorOAuthTokenEndpointAuthMethod` type alias
- remove unused `tokenEndpointAuthMethod` metadata from connector OAuth client config and connector definitions
- update tests and fixtures that asserted the metadata field

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm check-types
