### PR TITLE
feat: register folk-muse styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1414,6 +1414,58 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     status: "experimental",
     priority: 19,
   },
+  {
+    id: "vm0:image-style:folk-muse",
+    kind: "image-style",
+    name: "Folk Muse",
+    description:
+      "Flat folk-art gouache portrait style — a single contemplative chest-up figure framed by an asymmetric botanical surround, with painted irises, smooth flat hair, a hand against the cheek, and a patterned robe.",
+    desc: 'Flat folk-art gouache portrait illustration in the contemporary editorial style of Carson Ellis, Maja Tomljanovic, and Bodil Jane. A single chest-up figure with an elongated mannerist oval face, tiny almond half-lidded eyes, smooth flat hair, one hand pressed against the face, a patterned robe filling the lower frame, and an asymmetric botanical surround filling the background edge-to-edge. Hand-painted matte gouache texture, flat color blocks, no harsh outlines, no photorealism. Calm, slightly melancholic, contemplative mood. Trigger when the user says /folk-muse, asks for a "folk-art portrait", "gouache portrait", "Carson Ellis style portrait", or any new piece in this contemplative folk-portrait style.',
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/folk-muse",
+    ),
+    targets: ["image", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "portrait",
+      "folk-art",
+      "gouache",
+      "hand-painted",
+      "editorial",
+      "botanical",
+    ],
+    triggers: [
+      "folk muse",
+      "folk-art portrait",
+      "gouache portrait",
+      "carson ellis style",
+      "maja tomljanovic style",
+      "bodil jane style",
+      "contemplative portrait",
+      "botanical portrait illustration",
+    ],
+    bestFor: [
+      "editorial covers and feature artwork",
+      "blog hero portraits",
+      "poster art with a single figure",
+      "calm, contemplative brand imagery",
+    ],
+    avoidFor: [
+      "product spot illustrations or empty states",
+      "multi-figure scenes",
+      "children's book artwork",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 20,
+  },
 ];
 
 export function listImageStyles(): readonly OpenDesignRegistryEntry[] {


### PR DESCRIPTION
## Summary
Wire the new **Folk Muse** image style into the Open Design registry so it can be selected via:

```
zero built-in generate image --style vm0:image-style:folk-muse --prompt "..."
```

Folk Muse is a flat folk-art gouache portrait style — a single contemplative chest-up figure framed by an asymmetric botanical surround. Six creative dials drive variation (palette, character, pose, robe motif, surrounding botanicals, optional companion); the rest of the style is locked.

Targets editorial covers, portrait posters, and contemplative brand imagery.

## Source resource
- Repo: vm0-ai/vm0-skills
- Ref: main (follows the latest published resource)
- Path: illustration-template/folk-muse
- Paired PR: vm0-ai/vm0-skills#216

## Registry entry
- id: vm0:image-style:folk-muse
- kind: image-style
- name: Folk Muse
- targets: image, poster, presentation, report
- priority: 20
- status: experimental
- executorHints: skill-authored, built-in-image
- Tags: image, illustration, portrait, folk-art, gouache, hand-painted, editorial, botanical

## Validation

- [x] Existing image.test.ts assertions are all `toContain` for notion-illustration / vm0-illustration — adding a third entry does not break them.
- [x] **Registry-selection smoke test passed.** `node dist/zero.js built-in generate image --style vm0:image-style:folk-muse --prompt "..." --json` returns exactly one imageStyles candidate with id `vm0:image-style:folk-muse` pointing at `vm0-ai/vm0-skills@main:illustration-template/folk-muse`. The new style also appears in the default `--help` / "Image Styles:" listing.
- [x] **Generation smoke test passed.** Built a brief from the SKILL.md template exercising the Forest Folk dial set (older man, warm olive skin, salt-and-pepper curls, hand at temple, ochre-mustard daisy + fern robe, deep sage background with mullein + ferns + daisies + foxglove). Ran via `zero built-in generate image --model seedream4 --size 1024x1536 --skip-style`. Output hits every locked axis (elongated mannerist face, almond half-lidded eyes with painted irises, single nose line, pink blush dot, flat hair, repeating robe motif, asymmetric botanicals): https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/d0547615-8e12-4730-8cb4-c927d942d0eb/image-d0547615.png

## Note on local test run
`pnpm --filter @vm0/cli test -- open-design` failed at the transform layer for every test file (`Failed to load tsconfig for '../../packages/connectors/src/connectors.ts'`) — this is a repo-wide environment issue unrelated to this change. The same failure reproduces against `main` without any of my edits. The built CLI runs fine and was used for the smoke tests above.
