### PR TITLE
refactor: simplify connector auth method lookup

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -22,7 +22,7 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
-  deriveConnectedManualCredentialMethods,
+  deriveConnectedManualGrantMethods,
   getConnectorEnvironmentMapping,
   getConnectorProvidedSecretNames,
 } from "@vm0/connectors/connector-utils";
@@ -771,14 +771,14 @@ function missingEnvironmentReferences(args: {
   return [...missingVars, ...missingSecrets];
 }
 
-function allowedManualCredentialConnectorTypes(args: {
-  readonly manualCredentialTypes: readonly ConnectorType[];
+function allowedManualGrantConnectorTypes(args: {
+  readonly manualGrantTypes: readonly ConnectorType[];
   readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
 }): readonly ConnectorType[] {
   if (!args.allowedConnectorTypes) {
-    return args.manualCredentialTypes;
+    return args.manualGrantTypes;
   }
-  return args.manualCredentialTypes.filter((type) => {
+  return args.manualGrantTypes.filter((type) => {
     return args.allowedConnectorTypes?.includes(type);
   });
 }
@@ -1336,13 +1336,13 @@ async function loadReferencedSecrets(
         return ref.name;
       })
     : [];
-  const manualCredentialTypes = await loadManualCredentialConnectorTypes(db, {
+  const manualGrantTypes = await loadManualGrantConnectorTypes(db, {
     orgId: args.orgId,
     userId: args.userId,
   });
   const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
-    allowedManualCredentialConnectorTypes({
-      manualCredentialTypes,
+    allowedManualGrantConnectorTypes({
+      manualGrantTypes,
       allowedConnectorTypes: args.allowedConnectorTypes,
     }),
   );
@@ -1351,7 +1351,7 @@ async function loadReferencedSecrets(
   }
 
   // Load all user secrets, not only those named in the compose environment:
-  // Manual connector credentials are consumed by firewall auth templates,
+  // Manual grant secrets are consumed by firewall auth templates,
   // which the compose environment never references. Connector-owned secrets
   // are still scoped by filterDbSecretsByConnectorPermissions below.
   const rows = await db
@@ -1385,7 +1385,7 @@ async function loadReferencedSecrets(
 
   const filteredSecrets = filterDbSecretsByConnectorPermissions({
     dbSecrets: { ...orgSecrets, ...userSecrets },
-    allManualCredentialTypes: manualCredentialTypes,
+    allManualGrantTypes: manualGrantTypes,
     allowedConnectorTypes: args.allowedConnectorTypes,
   });
   const connectorSecrets =
@@ -1396,7 +1396,7 @@ async function loadReferencedSecrets(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-async function loadManualCredentialConnectorTypes(
+async function loadManualGrantConnectorTypes(
   db: Db,
   args: {
     readonly orgId: string;
@@ -1422,7 +1422,7 @@ async function loadManualCredentialConnectorTypes(
       ),
   ]);
 
-  return deriveConnectedManualCredentialMethods(
+  return deriveConnectedManualGrantMethods(
     new Set(
       secretRows.map((row) => {
         return row.name;
@@ -1440,7 +1440,7 @@ async function loadManualCredentialConnectorTypes(
 
 function filterDbSecretsByConnectorPermissions(args: {
   readonly dbSecrets: Record<string, string>;
-  readonly allManualCredentialTypes: readonly ConnectorType[];
+  readonly allManualGrantTypes: readonly ConnectorType[];
   readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
 }): Record<string, string> | undefined {
   if (Object.keys(args.dbSecrets).length === 0) {
@@ -1451,15 +1451,13 @@ function filterDbSecretsByConnectorPermissions(args: {
   }
 
   const allConnectorSecretNames = getConnectorProvidedSecretNames([
-    ...args.allManualCredentialTypes,
+    ...args.allManualGrantTypes,
   ]);
-  const allowedManualCredentialTypes = args.allManualCredentialTypes.filter(
-    (type) => {
-      return args.allowedConnectorTypes?.includes(type);
-    },
-  );
+  const allowedManualGrantTypes = args.allManualGrantTypes.filter((type) => {
+    return args.allowedConnectorTypes?.includes(type);
+  });
   const allowedConnectorSecretNames = getConnectorProvidedSecretNames(
-    allowedManualCredentialTypes,
+    allowedManualGrantTypes,
   );
   const filtered: Record<string, string> = {};
 
@@ -3169,7 +3167,7 @@ async function loadRunConnectorContexts(
 }> {
   const [
     oauthConnectorContext,
-    manualCredentialConnectorTypes,
+    manualGrantConnectorTypes,
     customConnectorContext,
   ] = await Promise.all([
     loadOauthConnectorContext(db, {
@@ -3178,7 +3176,7 @@ async function loadRunConnectorContexts(
       allowedConnectorTypes: args.allowedConnectorTypes,
       featureSwitchContext,
     }),
-    loadManualCredentialConnectorTypes(db, {
+    loadManualGrantConnectorTypes(db, {
       orgId: args.orgId,
       userId: args.userId,
     }),
@@ -3189,18 +3187,18 @@ async function loadRunConnectorContexts(
       featureSwitchContext,
     }),
   ]);
-  const allowedManualCredentialTypes = args.allowedConnectorTypes
-    ? manualCredentialConnectorTypes.filter((type) => {
+  const allowedManualGrantTypes = args.allowedConnectorTypes
+    ? manualGrantConnectorTypes.filter((type) => {
         return args.allowedConnectorTypes?.includes(type);
       })
-    : manualCredentialConnectorTypes;
+    : manualGrantConnectorTypes;
   return {
     connectorContext: {
       ...oauthConnectorContext,
       connectorTypes: [
         ...new Set([
           ...oauthConnectorContext.connectorTypes,
-          ...allowedManualCredentialTypes,
+          ...allowedManualGrantTypes,
         ]),
       ],
     },

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -7,18 +7,18 @@ import type {
 import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   connectorAuthMethodHasOAuthGrant,
-  deriveConnectedManualCredentialMethod,
-  deriveConnectedManualCredentialMethods,
+  deriveConnectedManualGrantMethod,
+  deriveConnectedManualGrantMethods,
   getAvailableConnectorAuthMethods,
-  getConnectorManualCredentialFields,
+  getConnectorManualGrantFields,
   getConnectorOAuthCredentials,
   getConnectorProvidedSecretNames,
   getConnectorSecretNames,
   getRuntimeAvailableConnectorTypes,
   getScopeDiff,
   isConnectorAuthMethodAvailable,
-  type ManualCredentialAuthMethod,
-  type ManualCredentialFieldNames,
+  type ConnectedManualGrantMethod,
+  type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
@@ -124,8 +124,8 @@ function storedConnectorTypeIsVisible(
   );
 }
 
-function manualCredentialConnectorResponse(
-  method: ManualCredentialAuthMethod,
+function manualGrantConnectorResponse(
+  method: ConnectedManualGrantMethod,
 ): ConnectorResponse {
   return {
     id: null,
@@ -141,7 +141,7 @@ function manualCredentialConnectorResponse(
   };
 }
 
-async function loadUserManualCredentialNameSets(
+async function loadUserManualGrantFieldNameSets(
   db: Db | ReadonlyDb,
   args: {
     readonly orgId: string;
@@ -184,16 +184,16 @@ async function loadUserManualCredentialNameSets(
   };
 }
 
-function manualCredentialConnectorMethods(args: {
+function manualGrantConnectorMethods(args: {
   readonly orgId: string;
   readonly userId: string;
-}): Computed<Promise<readonly ManualCredentialAuthMethod[]>> {
+}): Computed<Promise<readonly ConnectedManualGrantMethod[]>> {
   return computed(
-    async (get): Promise<readonly ManualCredentialAuthMethod[]> => {
+    async (get): Promise<readonly ConnectedManualGrantMethod[]> => {
       const db = get(db$);
       const { secretNames, variableNames } =
-        await loadUserManualCredentialNameSets(db, args);
-      return deriveConnectedManualCredentialMethods(secretNames, variableNames);
+        await loadUserManualGrantFieldNameSets(db, args);
+      return deriveConnectedManualGrantMethods(secretNames, variableNames);
     },
   );
 }
@@ -225,7 +225,7 @@ export function zeroConnectorList(args: {
             eq(connectors.userId, args.userId),
           ),
         ),
-      get(manualCredentialConnectorMethods(args)),
+      get(manualGrantConnectorMethods(args)),
       get(userFeatureSwitchOverrides(args.orgId, args.userId)),
     ]);
     const featureStates = getAllFeatureStates({
@@ -265,7 +265,7 @@ export function zeroConnectorList(args: {
         );
       })
       .map((method) => {
-        return manualCredentialConnectorResponse(method);
+        return manualGrantConnectorResponse(method);
       });
 
     const connectorList = [...dbConnectors, ...derivedConnectors];
@@ -324,16 +324,16 @@ function storedConnectorByType(args: {
   });
 }
 
-function manualCredentialMethodByType(args: {
+function manualGrantMethodByType(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly type: ConnectorType;
-}): Computed<Promise<ManualCredentialAuthMethod | null>> {
-  return computed(async (get): Promise<ManualCredentialAuthMethod | null> => {
+}): Computed<Promise<ConnectedManualGrantMethod | null>> {
+  return computed(async (get): Promise<ConnectedManualGrantMethod | null> => {
     const db = get(db$);
     const { secretNames, variableNames } =
-      await loadUserManualCredentialNameSets(db, args);
-    return deriveConnectedManualCredentialMethod(
+      await loadUserManualGrantFieldNameSets(db, args);
+    return deriveConnectedManualGrantMethod(
       args.type,
       secretNames,
       variableNames,
@@ -365,22 +365,20 @@ export function zeroConnectorByType(args: {
         return storedConnector;
       }
     }
-    const manualCredentialMethod = await get(
-      manualCredentialMethodByType(args),
-    );
-    if (!manualCredentialMethod) {
+    const manualGrantMethod = await get(manualGrantMethodByType(args));
+    if (!manualGrantMethod) {
       return null;
     }
     if (
       !isConnectorAuthMethodAvailable(
         args.type,
-        manualCredentialMethod.authMethod,
+        manualGrantMethod.authMethod,
         featureStates,
       )
     ) {
       return null;
     }
-    return manualCredentialConnectorResponse(manualCredentialMethod);
+    return manualGrantConnectorResponse(manualGrantMethod);
   });
 }
 
@@ -439,11 +437,11 @@ async function revokeExistingConnectorToken(args: {
   args.signal.throwIfAborted();
 }
 
-async function hasManualCredentialConnectorLocalState(args: {
+async function hasManualGrantConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: ManualCredentialFieldNames | null;
+  readonly fields: ManualGrantFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
   if (!args.fields) {
@@ -490,11 +488,11 @@ async function hasManualCredentialConnectorLocalState(args: {
   return false;
 }
 
-async function deleteManualCredentialConnectorLocalState(args: {
+async function deleteManualGrantConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: ManualCredentialFieldNames | null;
+  readonly fields: ManualGrantFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
   if (!args.fields) {
@@ -571,17 +569,17 @@ export const deleteZeroConnectorLocalState$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const fields = getConnectorManualCredentialFields(args.type);
-    const hasManualCredentialState = existing
+    const fields = getConnectorManualGrantFields(args.type);
+    const hasManualGrantState = existing
       ? false
-      : await hasManualCredentialConnectorLocalState({
+      : await hasManualGrantConnectorLocalState({
           db: writeDb,
           orgId: args.orgId,
           userId: args.userId,
           fields,
           signal,
         });
-    if (!existing && !hasManualCredentialState) {
+    if (!existing && !hasManualGrantState) {
       return false;
     }
 
@@ -631,7 +629,7 @@ export const deleteZeroConnectorLocalState$ = command(
     }
 
     deleted =
-      (await deleteManualCredentialConnectorLocalState({
+      (await deleteManualGrantConnectorLocalState({
         db: writeDb,
         orgId: args.orgId,
         userId: args.userId,
@@ -806,9 +804,7 @@ export const upsertOAuthConnector$ = command(
         ? secretMetadata.refreshSecretName
         : undefined,
     });
-    const manualCredentialFields = getConnectorManualCredentialFields(
-      args.type,
-    );
+    const manualGrantFields = getConnectorManualGrantFields(args.type);
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,
@@ -891,11 +887,11 @@ export const upsertOAuthConnector$ = command(
       throw new Error("Failed to upsert connector");
     }
 
-    await deleteManualCredentialConnectorLocalState({
+    await deleteManualGrantConnectorLocalState({
       db: writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      fields: manualCredentialFields,
+      fields: manualGrantFields,
       signal,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -10,16 +10,15 @@ import {
   deriveConnectedManualCredentialMethod,
   deriveConnectedManualCredentialMethods,
   getAvailableConnectorAuthMethods,
-  getConnectorManualCredentialAuthMethods,
+  getConnectorManualCredentialFields,
   getConnectorOAuthCredentials,
   getConnectorProvidedSecretNames,
   getConnectorSecretNames,
   getRuntimeAvailableConnectorTypes,
   getScopeDiff,
   isConnectorAuthMethodAvailable,
-  type ConnectedManualCredentialMethod,
   type ManualCredentialAuthMethod,
-  type RequiredManualCredentialFieldNames,
+  type ManualCredentialFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
@@ -126,7 +125,7 @@ function storedConnectorTypeIsVisible(
 }
 
 function manualCredentialConnectorResponse(
-  method: ConnectedManualCredentialMethod,
+  method: ManualCredentialAuthMethod,
 ): ConnectorResponse {
   return {
     id: null,
@@ -185,41 +184,12 @@ async function loadUserManualCredentialNameSets(
   };
 }
 
-function mergeRequiredManualCredentialFields(
-  methods: readonly ManualCredentialAuthMethod[],
-): RequiredManualCredentialFieldNames | null {
-  const secretsSet = new Set<string>();
-  const variablesSet = new Set<string>();
-  for (const method of methods) {
-    for (const name of method.requiredFields.secrets) {
-      secretsSet.add(name);
-    }
-    for (const name of method.requiredFields.variables) {
-      variablesSet.add(name);
-    }
-  }
-  const secretsList = [...secretsSet];
-  const variablesList = [...variablesSet];
-  if (secretsList.length === 0 && variablesList.length === 0) {
-    return null;
-  }
-  return { secrets: secretsList, variables: variablesList };
-}
-
-function requiredManualCredentialFieldsByType(
-  type: ConnectorType,
-): RequiredManualCredentialFieldNames | null {
-  return mergeRequiredManualCredentialFields(
-    getConnectorManualCredentialAuthMethods(type),
-  );
-}
-
 function manualCredentialConnectorMethods(args: {
   readonly orgId: string;
   readonly userId: string;
-}): Computed<Promise<readonly ConnectedManualCredentialMethod[]>> {
+}): Computed<Promise<readonly ManualCredentialAuthMethod[]>> {
   return computed(
-    async (get): Promise<readonly ConnectedManualCredentialMethod[]> => {
+    async (get): Promise<readonly ManualCredentialAuthMethod[]> => {
       const db = get(db$);
       const { secretNames, variableNames } =
         await loadUserManualCredentialNameSets(db, args);
@@ -358,19 +328,17 @@ function manualCredentialMethodByType(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly type: ConnectorType;
-}): Computed<Promise<ConnectedManualCredentialMethod | null>> {
-  return computed(
-    async (get): Promise<ConnectedManualCredentialMethod | null> => {
-      const db = get(db$);
-      const { secretNames, variableNames } =
-        await loadUserManualCredentialNameSets(db, args);
-      return deriveConnectedManualCredentialMethod(
-        args.type,
-        secretNames,
-        variableNames,
-      );
-    },
-  );
+}): Computed<Promise<ManualCredentialAuthMethod | null>> {
+  return computed(async (get): Promise<ManualCredentialAuthMethod | null> => {
+    const db = get(db$);
+    const { secretNames, variableNames } =
+      await loadUserManualCredentialNameSets(db, args);
+    return deriveConnectedManualCredentialMethod(
+      args.type,
+      secretNames,
+      variableNames,
+    );
+  });
 }
 
 export function zeroConnectorByType(args: {
@@ -475,14 +443,14 @@ async function hasManualCredentialConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly requiredFields: RequiredManualCredentialFieldNames | null;
+  readonly fields: ManualCredentialFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  if (!args.requiredFields) {
+  if (!args.fields) {
     return false;
   }
 
-  if (args.requiredFields.secrets.length > 0) {
+  if (args.fields.secrets.length > 0) {
     const [secret] = await args.db
       .select({ id: secrets.id })
       .from(secrets)
@@ -491,7 +459,7 @@ async function hasManualCredentialConnectorLocalState(args: {
           eq(secrets.orgId, args.orgId),
           eq(secrets.userId, args.userId),
           eq(secrets.type, "user"),
-          inArray(secrets.name, [...args.requiredFields.secrets]),
+          inArray(secrets.name, [...args.fields.secrets]),
         ),
       )
       .limit(1);
@@ -501,7 +469,7 @@ async function hasManualCredentialConnectorLocalState(args: {
     }
   }
 
-  if (args.requiredFields.variables.length > 0) {
+  if (args.fields.variables.length > 0) {
     const [variable] = await args.db
       .select({ id: variables.id })
       .from(variables)
@@ -509,7 +477,7 @@ async function hasManualCredentialConnectorLocalState(args: {
         and(
           eq(variables.orgId, args.orgId),
           eq(variables.userId, args.userId),
-          inArray(variables.name, [...args.requiredFields.variables]),
+          inArray(variables.name, [...args.fields.variables]),
         ),
       )
       .limit(1);
@@ -526,15 +494,15 @@ async function deleteManualCredentialConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly requiredFields: RequiredManualCredentialFieldNames | null;
+  readonly fields: ManualCredentialFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  if (!args.requiredFields) {
+  if (!args.fields) {
     return false;
   }
 
   let deleted = false;
-  for (const name of args.requiredFields.secrets) {
+  for (const name of args.fields.secrets) {
     const result = await args.db
       .delete(secrets)
       .where(
@@ -550,7 +518,7 @@ async function deleteManualCredentialConnectorLocalState(args: {
     deleted = deleted || result.length > 0;
   }
 
-  for (const name of args.requiredFields.variables) {
+  for (const name of args.fields.variables) {
     const result = await args.db
       .delete(variables)
       .where(
@@ -603,14 +571,14 @@ export const deleteZeroConnectorLocalState$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const requiredFields = requiredManualCredentialFieldsByType(args.type);
+    const fields = getConnectorManualCredentialFields(args.type);
     const hasManualCredentialState = existing
       ? false
       : await hasManualCredentialConnectorLocalState({
           db: writeDb,
           orgId: args.orgId,
           userId: args.userId,
-          requiredFields,
+          fields,
           signal,
         });
     if (!existing && !hasManualCredentialState) {
@@ -667,7 +635,7 @@ export const deleteZeroConnectorLocalState$ = command(
         db: writeDb,
         orgId: args.orgId,
         userId: args.userId,
-        requiredFields,
+        fields,
         signal,
       })) || deleted;
 
@@ -838,7 +806,7 @@ export const upsertOAuthConnector$ = command(
         ? secretMetadata.refreshSecretName
         : undefined,
     });
-    const requiredManualCredentialFields = requiredManualCredentialFieldsByType(
+    const manualCredentialFields = getConnectorManualCredentialFields(
       args.type,
     );
 
@@ -927,7 +895,7 @@ export const upsertOAuthConnector$ = command(
       db: writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      requiredFields: requiredManualCredentialFields,
+      fields: manualCredentialFields,
       signal,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -19,7 +19,7 @@ import {
   isConnectorAuthMethodAvailable,
   type ConnectedManualCredentialMethod,
   type ManualCredentialAuthMethod,
-  type ManualCredentialFieldNames,
+  type RequiredManualCredentialFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
@@ -185,16 +185,16 @@ async function loadUserManualCredentialNameSets(
   };
 }
 
-function mergeManualCredentialFields(
+function mergeRequiredManualCredentialFields(
   methods: readonly ManualCredentialAuthMethod[],
-): ManualCredentialFieldNames | null {
+): RequiredManualCredentialFieldNames | null {
   const secretsSet = new Set<string>();
   const variablesSet = new Set<string>();
   for (const method of methods) {
-    for (const name of method.fields.secrets) {
+    for (const name of method.requiredFields.secrets) {
       secretsSet.add(name);
     }
-    for (const name of method.fields.variables) {
+    for (const name of method.requiredFields.variables) {
       variablesSet.add(name);
     }
   }
@@ -206,10 +206,10 @@ function mergeManualCredentialFields(
   return { secrets: secretsList, variables: variablesList };
 }
 
-function manualCredentialFieldsByType(
+function requiredManualCredentialFieldsByType(
   type: ConnectorType,
-): ManualCredentialFieldNames | null {
-  return mergeManualCredentialFields(
+): RequiredManualCredentialFieldNames | null {
+  return mergeRequiredManualCredentialFields(
     getConnectorManualCredentialAuthMethods(type),
   );
 }
@@ -475,14 +475,14 @@ async function hasManualCredentialConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: ManualCredentialFieldNames | null;
+  readonly requiredFields: RequiredManualCredentialFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  if (!args.fields) {
+  if (!args.requiredFields) {
     return false;
   }
 
-  if (args.fields.secrets.length > 0) {
+  if (args.requiredFields.secrets.length > 0) {
     const [secret] = await args.db
       .select({ id: secrets.id })
       .from(secrets)
@@ -491,7 +491,7 @@ async function hasManualCredentialConnectorLocalState(args: {
           eq(secrets.orgId, args.orgId),
           eq(secrets.userId, args.userId),
           eq(secrets.type, "user"),
-          inArray(secrets.name, [...args.fields.secrets]),
+          inArray(secrets.name, [...args.requiredFields.secrets]),
         ),
       )
       .limit(1);
@@ -501,7 +501,7 @@ async function hasManualCredentialConnectorLocalState(args: {
     }
   }
 
-  if (args.fields.variables.length > 0) {
+  if (args.requiredFields.variables.length > 0) {
     const [variable] = await args.db
       .select({ id: variables.id })
       .from(variables)
@@ -509,7 +509,7 @@ async function hasManualCredentialConnectorLocalState(args: {
         and(
           eq(variables.orgId, args.orgId),
           eq(variables.userId, args.userId),
-          inArray(variables.name, [...args.fields.variables]),
+          inArray(variables.name, [...args.requiredFields.variables]),
         ),
       )
       .limit(1);
@@ -526,15 +526,15 @@ async function deleteManualCredentialConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: ManualCredentialFieldNames | null;
+  readonly requiredFields: RequiredManualCredentialFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  if (!args.fields) {
+  if (!args.requiredFields) {
     return false;
   }
 
   let deleted = false;
-  for (const name of args.fields.secrets) {
+  for (const name of args.requiredFields.secrets) {
     const result = await args.db
       .delete(secrets)
       .where(
@@ -550,7 +550,7 @@ async function deleteManualCredentialConnectorLocalState(args: {
     deleted = deleted || result.length > 0;
   }
 
-  for (const name of args.fields.variables) {
+  for (const name of args.requiredFields.variables) {
     const result = await args.db
       .delete(variables)
       .where(
@@ -603,14 +603,14 @@ export const deleteZeroConnectorLocalState$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const fields = manualCredentialFieldsByType(args.type);
+    const requiredFields = requiredManualCredentialFieldsByType(args.type);
     const hasManualCredentialState = existing
       ? false
       : await hasManualCredentialConnectorLocalState({
           db: writeDb,
           orgId: args.orgId,
           userId: args.userId,
-          fields,
+          requiredFields,
           signal,
         });
     if (!existing && !hasManualCredentialState) {
@@ -667,7 +667,7 @@ export const deleteZeroConnectorLocalState$ = command(
         db: writeDb,
         orgId: args.orgId,
         userId: args.userId,
-        fields,
+        requiredFields,
         signal,
       })) || deleted;
 
@@ -838,7 +838,9 @@ export const upsertOAuthConnector$ = command(
         ? secretMetadata.refreshSecretName
         : undefined,
     });
-    const manualCredentialFields = manualCredentialFieldsByType(args.type);
+    const requiredManualCredentialFields = requiredManualCredentialFieldsByType(
+      args.type,
+    );
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,
@@ -925,7 +927,7 @@ export const upsertOAuthConnector$ = command(
       db: writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      fields: manualCredentialFields,
+      requiredFields: requiredManualCredentialFields,
       signal,
     });
     signal.throwIfAborted();

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -16,6 +16,8 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorConfig,
   type ConnectorInvalidDefaultAuthMethodType,
+  type ConnectorManualGrantFieldConfig,
+  type ConnectorType,
   type OAuthAuthCodeConnectorType,
 } from "../connectors";
 import {
@@ -35,10 +37,9 @@ import {
   getConnectorOAuthCredentials,
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthScopes,
-  getConnectorManualGrantFields,
   getConnectorManualCredentialAuthMethods,
-  getConnectorManualCredentialFields,
-  getConnectorManualCredentialFieldStorageType,
+  getApiTokenFieldStorageType,
+  getApiTokenFieldsByType,
   getEligibleConnectorTypes,
   getRuntimeAvailableConnectorTypes,
   getConnectorSecretNames,
@@ -62,6 +63,16 @@ import {
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../auth-providers/oauth/google-connectors";
 import { buildGoogleAuthorizationUrl } from "../auth-providers/oauth/google";
 import { getConnectorFirewall } from "../firewalls";
+
+function getApiTokenManualGrantFields(
+  type: ConnectorType,
+): Record<string, ConnectorManualGrantFieldConfig> | undefined {
+  const method = getConnectorAuthMethod(type, "api-token");
+  if (method?.grant.kind !== "manual") {
+    return undefined;
+  }
+  return method.grant.fields;
+}
 
 const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
@@ -328,37 +339,23 @@ describe("connector auth method config", () => {
   });
 
   it("returns manual credential field storage types with secret default", () => {
-    expect(
-      getConnectorManualCredentialFieldStorageType(
-        "zendesk",
-        "api-token",
-        "ZENDESK_EMAIL",
-      ),
-    ).toBe("variable");
-    expect(
-      getConnectorManualCredentialFieldStorageType(
-        "zendesk",
-        "api-token",
-        "ZENDESK_API_TOKEN",
-      ),
-    ).toBe("secret");
-    expect(
-      getConnectorManualCredentialFieldStorageType(
-        "zendesk",
-        "api-token",
-        "UNKNOWN_FIELD",
-      ),
-    ).toBe("secret");
+    expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_EMAIL")).toBe(
+      "variable",
+    );
+    expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_API_TOKEN")).toBe(
+      "secret",
+    );
+    expect(getApiTokenFieldStorageType("zendesk", "UNKNOWN_FIELD")).toBe(
+      "secret",
+    );
   });
 
   it("groups required manual credential fields by storage", () => {
-    expect(
-      getConnectorManualCredentialFields("atlassian", "api-token"),
-    ).toStrictEqual({
+    expect(getApiTokenFieldsByType("atlassian")).toStrictEqual({
       secrets: ["ATLASSIAN_TOKEN"],
       variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
     });
-    expect(getConnectorManualCredentialFields("github", "oauth")).toBeNull();
+    expect(getApiTokenFieldsByType("github")).toBeNull();
   });
 
   it("lists only manual credential auth methods", () => {
@@ -366,7 +363,7 @@ describe("connector auth method config", () => {
       {
         type: "atlassian",
         authMethod: "api-token",
-        fields: {
+        requiredFields: {
           secrets: ["ATLASSIAN_TOKEN"],
           variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
         },
@@ -1611,7 +1608,7 @@ describe("getConnectorEnvironmentMapping", () => {
       );
 
       // api-token (if exists): exactly one secret XXX_TOKEN
-      const apiTokenFields = getConnectorManualGrantFields(type, "api-token");
+      const apiTokenFields = getApiTokenManualGrantFields(type);
       if (apiTokenFields) {
         expect(
           Object.keys(apiTokenFields),
@@ -1624,7 +1621,7 @@ describe("getConnectorEnvironmentMapping", () => {
   it("api-token-only connectors expose all secrets via environmentMapping with same name", () => {
     for (const type of connectorTypeSchema.options) {
       if (getConnectorOAuthGrantConfigIfSupported(type)) continue;
-      const fields = getConnectorManualGrantFields(type, "api-token");
+      const fields = getApiTokenManualGrantFields(type);
       if (!fields) continue;
 
       const fieldNames = Object.keys(fields);

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -37,7 +37,7 @@ import {
   getConnectorOAuthCredentials,
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthScopes,
-  getConnectorManualCredentialAuthMethods,
+  getConnectorManualCredentialFields,
   getApiTokenFieldStorageType,
   getApiTokenFieldsByType,
   getEligibleConnectorTypes,
@@ -350,7 +350,7 @@ describe("connector auth method config", () => {
     );
   });
 
-  it("groups required manual credential fields by storage", () => {
+  it("groups required api-token credential fields by storage", () => {
     expect(getApiTokenFieldsByType("atlassian")).toStrictEqual({
       secrets: ["ATLASSIAN_TOKEN"],
       variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
@@ -358,21 +358,17 @@ describe("connector auth method config", () => {
     expect(getApiTokenFieldsByType("github")).toBeNull();
   });
 
-  it("lists only manual credential auth methods", () => {
-    expect(getConnectorManualCredentialAuthMethods("atlassian")).toStrictEqual([
-      {
-        type: "atlassian",
-        authMethod: "api-token",
-        requiredFields: {
-          secrets: ["ATLASSIAN_TOKEN"],
-          variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
-        },
-      },
-    ]);
-    expect(getConnectorManualCredentialAuthMethods("github")).toStrictEqual([]);
-    expect(getConnectorManualCredentialAuthMethods("computer")).toStrictEqual(
-      [],
-    );
+  it("groups all manual credential fields by storage", () => {
+    expect(getConnectorManualCredentialFields("atlassian")).toStrictEqual({
+      secrets: ["ATLASSIAN_TOKEN"],
+      variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
+    });
+    expect(getConnectorManualCredentialFields("gitlab")).toStrictEqual({
+      secrets: ["GITLAB_TOKEN"],
+      variables: ["GITLAB_HOST"],
+    });
+    expect(getConnectorManualCredentialFields("github")).toBeNull();
+    expect(getConnectorManualCredentialFields("computer")).toBeNull();
   });
 
   it("derives connected manual credential methods from required fields", () => {
@@ -381,13 +377,17 @@ describe("connector auth method config", () => {
         new Set(["ATLASSIAN_TOKEN"]),
         new Set(["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"]),
       ),
-    ).toContainEqual({ type: "atlassian", authMethod: "api-token" });
+    ).toContainEqual(
+      expect.objectContaining({ type: "atlassian", authMethod: "api-token" }),
+    );
     expect(
       deriveConnectedManualCredentialMethods(
         new Set(["ATLASSIAN_TOKEN"]),
         new Set(["ATLASSIAN_EMAIL"]),
       ),
-    ).not.toContainEqual({ type: "atlassian", authMethod: "api-token" });
+    ).not.toContainEqual(
+      expect.objectContaining({ type: "atlassian", authMethod: "api-token" }),
+    );
     const connected = deriveConnectedManualCredentialMethods(
       new Set(["GITHUB_ACCESS_TOKEN", "COMPUTER_CONNECTOR_BRIDGE_TOKEN"]),
       new Set(),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -23,7 +23,7 @@ import {
 import {
   getAvailableConnectorAuthMethods,
   getConfiguredConnectorAuthMethods,
-  deriveConnectedManualCredentialMethods,
+  deriveConnectedManualGrantMethods,
   hasRequiredScopes,
   getConnectorAuthCodeGrantConfigIfSupported,
   getConnectorAuthMethod,
@@ -37,7 +37,7 @@ import {
   getConnectorOAuthCredentials,
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthScopes,
-  getConnectorManualCredentialFields,
+  getConnectorManualGrantFields,
   getApiTokenFieldStorageType,
   getApiTokenFieldsByType,
   getEligibleConnectorTypes,
@@ -338,7 +338,7 @@ describe("connector auth method config", () => {
     ]);
   });
 
-  it("returns manual credential field storage types with secret default", () => {
+  it("returns manual grant field storage types with secret default", () => {
     expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_EMAIL")).toBe(
       "variable",
     );
@@ -358,22 +358,22 @@ describe("connector auth method config", () => {
     expect(getApiTokenFieldsByType("github")).toBeNull();
   });
 
-  it("groups all manual credential fields by storage", () => {
-    expect(getConnectorManualCredentialFields("atlassian")).toStrictEqual({
+  it("groups all manual grant fields by storage", () => {
+    expect(getConnectorManualGrantFields("atlassian")).toStrictEqual({
       secrets: ["ATLASSIAN_TOKEN"],
       variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
     });
-    expect(getConnectorManualCredentialFields("gitlab")).toStrictEqual({
+    expect(getConnectorManualGrantFields("gitlab")).toStrictEqual({
       secrets: ["GITLAB_TOKEN"],
       variables: ["GITLAB_HOST"],
     });
-    expect(getConnectorManualCredentialFields("github")).toBeNull();
-    expect(getConnectorManualCredentialFields("computer")).toBeNull();
+    expect(getConnectorManualGrantFields("github")).toBeNull();
+    expect(getConnectorManualGrantFields("computer")).toBeNull();
   });
 
-  it("derives connected manual credential methods from required fields", () => {
+  it("derives connected manual grant methods from required fields", () => {
     expect(
-      deriveConnectedManualCredentialMethods(
+      deriveConnectedManualGrantMethods(
         new Set(["ATLASSIAN_TOKEN"]),
         new Set(["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"]),
       ),
@@ -381,14 +381,14 @@ describe("connector auth method config", () => {
       expect.objectContaining({ type: "atlassian", authMethod: "api-token" }),
     );
     expect(
-      deriveConnectedManualCredentialMethods(
+      deriveConnectedManualGrantMethods(
         new Set(["ATLASSIAN_TOKEN"]),
         new Set(["ATLASSIAN_EMAIL"]),
       ),
     ).not.toContainEqual(
       expect.objectContaining({ type: "atlassian", authMethod: "api-token" }),
     );
-    const connected = deriveConnectedManualCredentialMethods(
+    const connected = deriveConnectedManualGrantMethods(
       new Set(["GITHUB_ACCESS_TOKEN", "COMPUTER_CONNECTOR_BRIDGE_TOKEN"]),
       new Set(),
     );

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -102,20 +102,33 @@ function getManualGrantFields(
   return method.grant.fields;
 }
 
-export interface RequiredManualCredentialFieldNames {
+export interface ManualCredentialFieldNames {
   readonly secrets: readonly string[];
   readonly variables: readonly string[];
 }
 
+export type RequiredManualCredentialFieldNames = ManualCredentialFieldNames;
+
 export interface ManualCredentialAuthMethod {
   readonly type: ConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
+  readonly fields: ManualCredentialFieldNames;
   readonly requiredFields: RequiredManualCredentialFieldNames;
 }
 
-export interface ConnectedManualCredentialMethod {
-  readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+function manualCredentialFieldNames(
+  fields: Record<string, ConnectorManualGrantFieldConfig>,
+): ManualCredentialFieldNames {
+  const secretNames: string[] = [];
+  const variableNames: string[] = [];
+  for (const [name, cfg] of Object.entries(fields)) {
+    if (cfg.storage === "variable") {
+      variableNames.push(name);
+    } else {
+      secretNames.push(name);
+    }
+  }
+  return { secrets: secretNames, variables: variableNames };
 }
 
 function requiredManualCredentialFieldNames(
@@ -159,52 +172,62 @@ function getConnectorManualCredentialFieldStorageType(
   return fieldConfig?.storage ?? "secret";
 }
 
-export function getConnectorManualCredentialAuthMethods(
+export function getConnectorManualCredentialFields(
   type: ConnectorType,
-): ManualCredentialAuthMethod[] {
-  const manualMethods: ManualCredentialAuthMethod[] = [];
-
+): ManualCredentialFieldNames | null {
+  const secretNames = new Set<string>();
+  const variableNames = new Set<string>();
   for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
     const method = getConnectorAuthMethod(type, authMethod);
-    switch (method?.grant.kind) {
-      case "manual":
-        manualMethods.push({
-          type,
-          authMethod,
-          requiredFields: requiredManualCredentialFieldNames(
-            method.grant.fields,
-          ),
-        });
-        break;
-      case "managed":
-      case "auth-code":
-      case "device-auth":
-      case "interactive-pairing":
-      case undefined:
-        break;
+    if (method?.grant.kind !== "manual") {
+      continue;
     }
+    const fields = manualCredentialFieldNames(method.grant.fields);
+    fields.secrets.forEach((name) => {
+      secretNames.add(name);
+    });
+    fields.variables.forEach((name) => {
+      variableNames.add(name);
+    });
   }
 
-  return manualMethods;
+  if (secretNames.size === 0 && variableNames.size === 0) {
+    return null;
+  }
+  return { secrets: [...secretNames], variables: [...variableNames] };
 }
 
 export function deriveConnectedManualCredentialMethod(
   type: ConnectorType,
   userSecretNames: Set<string>,
   userVariableNames?: Set<string>,
-): ConnectedManualCredentialMethod | null {
+): ManualCredentialAuthMethod | null {
   const varNames = userVariableNames ?? new Set<string>();
 
-  for (const method of getConnectorManualCredentialAuthMethods(type)) {
-    if (!hasRequiredManualCredentialFields(method.requiredFields)) continue;
-    const secretsOk = method.requiredFields.secrets.every((name) => {
+  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+    const method = getConnectorAuthMethod(type, authMethod);
+    if (method?.grant.kind !== "manual") {
+      continue;
+    }
+    const requiredFields = requiredManualCredentialFieldNames(
+      method.grant.fields,
+    );
+    if (!hasRequiredManualCredentialFields(requiredFields)) {
+      continue;
+    }
+    const secretsOk = requiredFields.secrets.every((name) => {
       return userSecretNames.has(name);
     });
-    const variablesOk = method.requiredFields.variables.every((name) => {
+    const variablesOk = requiredFields.variables.every((name) => {
       return varNames.has(name);
     });
     if (secretsOk && variablesOk) {
-      return { type, authMethod: method.authMethod };
+      return {
+        type,
+        authMethod,
+        fields: manualCredentialFieldNames(method.grant.fields),
+        requiredFields,
+      };
     }
   }
 
@@ -214,8 +237,8 @@ export function deriveConnectedManualCredentialMethod(
 export function deriveConnectedManualCredentialMethods(
   userSecretNames: Set<string>,
   userVariableNames?: Set<string>,
-): ConnectedManualCredentialMethod[] {
-  const connected: ConnectedManualCredentialMethod[] = [];
+): ManualCredentialAuthMethod[] {
+  const connected: ManualCredentialAuthMethod[] = [];
 
   for (const type of CONNECTOR_TYPE_KEYS) {
     const method = deriveConnectedManualCredentialMethod(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -102,14 +102,7 @@ function getManualGrantFields(
   return method.grant.fields;
 }
 
-export function getConnectorManualGrantFields(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): Record<string, ConnectorManualGrantFieldConfig> | undefined {
-  return getManualGrantFields(getConnectorAuthMethod(type, authMethod));
-}
-
-export interface ManualCredentialFieldNames {
+export interface RequiredManualCredentialFieldNames {
   readonly secrets: readonly string[];
   readonly variables: readonly string[];
 }
@@ -117,7 +110,7 @@ export interface ManualCredentialFieldNames {
 export interface ManualCredentialAuthMethod {
   readonly type: ConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
-  readonly fields: ManualCredentialFieldNames;
+  readonly requiredFields: RequiredManualCredentialFieldNames;
 }
 
 export interface ConnectedManualCredentialMethod {
@@ -125,9 +118,9 @@ export interface ConnectedManualCredentialMethod {
   readonly authMethod: ConnectorAuthMethodId;
 }
 
-function manualCredentialFieldNames(
+function requiredManualCredentialFieldNames(
   fields: Record<string, ConnectorManualGrantFieldConfig>,
-): ManualCredentialFieldNames {
+): RequiredManualCredentialFieldNames {
   const secretNames: string[] = [];
   const variableNames: string[] = [];
   for (const [name, cfg] of Object.entries(fields)) {
@@ -142,20 +135,20 @@ function manualCredentialFieldNames(
 }
 
 function hasRequiredManualCredentialFields(
-  fields: ManualCredentialFieldNames,
+  fields: RequiredManualCredentialFieldNames,
 ): boolean {
   return fields.secrets.length > 0 || fields.variables.length > 0;
 }
 
-export function getConnectorManualCredentialFields(
+function getConnectorRequiredManualCredentialFields(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
-): ManualCredentialFieldNames | null {
+): RequiredManualCredentialFieldNames | null {
   const fields = getManualGrantFields(getConnectorAuthMethod(type, authMethod));
-  return fields ? manualCredentialFieldNames(fields) : null;
+  return fields ? requiredManualCredentialFieldNames(fields) : null;
 }
 
-export function getConnectorManualCredentialFieldStorageType(
+function getConnectorManualCredentialFieldStorageType(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
   name: string,
@@ -178,7 +171,9 @@ export function getConnectorManualCredentialAuthMethods(
         manualMethods.push({
           type,
           authMethod,
-          fields: manualCredentialFieldNames(method.grant.fields),
+          requiredFields: requiredManualCredentialFieldNames(
+            method.grant.fields,
+          ),
         });
         break;
       case "managed":
@@ -201,11 +196,11 @@ export function deriveConnectedManualCredentialMethod(
   const varNames = userVariableNames ?? new Set<string>();
 
   for (const method of getConnectorManualCredentialAuthMethods(type)) {
-    if (!hasRequiredManualCredentialFields(method.fields)) continue;
-    const secretsOk = method.fields.secrets.every((name) => {
+    if (!hasRequiredManualCredentialFields(method.requiredFields)) continue;
+    const secretsOk = method.requiredFields.secrets.every((name) => {
       return userSecretNames.has(name);
     });
-    const variablesOk = method.fields.variables.every((name) => {
+    const variablesOk = method.requiredFields.variables.every((name) => {
       return varNames.has(name);
     });
     if (secretsOk && variablesOk) {
@@ -899,10 +894,10 @@ export function getConnectorTypeForSecretName(
 
 export function getApiTokenFieldsByType(
   type: ConnectorType,
-): ManualCredentialFieldNames | null {
+): RequiredManualCredentialFieldNames | null {
   // Compatibility wrapper for legacy API-token callers. New state inference
   // should use manual credential helpers so the method id is preserved.
-  return getConnectorManualCredentialFields(type, "api-token");
+  return getConnectorRequiredManualCredentialFields(type, "api-token");
 }
 
 export function getApiTokenFieldStorageType(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -70,7 +70,10 @@ export function getConnectorAuthMethods(
   return CONNECTOR_TYPES[type].authMethods;
 }
 
-function lookupConnectorAuthMethod(
+/**
+ * Get one auth method config for a connector type.
+ */
+export function getConnectorAuthMethod(
   type: ConnectorType,
   authMethod: string,
 ): ConnectorAuthMethodConfig | undefined {
@@ -82,16 +85,6 @@ function lookupConnectorAuthMethod(
     }
   }
   return undefined;
-}
-
-/**
- * Get one auth method config for a connector type.
- */
-export function getConnectorAuthMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): ConnectorAuthMethodConfig | undefined {
-  return lookupConnectorAuthMethod(type, authMethod);
 }
 
 function connectorAuthMethodValues(
@@ -314,7 +307,7 @@ export function connectorAuthMethodHasOAuthGrant(
   type: ConnectorType,
   authMethod: string,
 ): boolean {
-  const method = lookupConnectorAuthMethod(type, authMethod);
+  const method = getConnectorAuthMethod(type, authMethod);
   switch (method?.grant.kind) {
     case "auth-code":
     case "device-auth":
@@ -658,9 +651,7 @@ export function getConnectorSecretNames(
   type: ConnectorType,
   authMethod: string,
 ): string[] {
-  return connectorMethodSecretNames(
-    lookupConnectorAuthMethod(type, authMethod),
-  );
+  return connectorMethodSecretNames(getConnectorAuthMethod(type, authMethod));
 }
 
 function connectorMethodSecretNames(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -107,13 +107,10 @@ export interface ManualCredentialFieldNames {
   readonly variables: readonly string[];
 }
 
-export type RequiredManualCredentialFieldNames = ManualCredentialFieldNames;
-
 export interface ManualCredentialAuthMethod {
   readonly type: ConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
   readonly fields: ManualCredentialFieldNames;
-  readonly requiredFields: RequiredManualCredentialFieldNames;
 }
 
 function manualCredentialFieldNames(
@@ -133,7 +130,7 @@ function manualCredentialFieldNames(
 
 function requiredManualCredentialFieldNames(
   fields: Record<string, ConnectorManualGrantFieldConfig>,
-): RequiredManualCredentialFieldNames {
+): ManualCredentialFieldNames {
   const secretNames: string[] = [];
   const variableNames: string[] = [];
   for (const [name, cfg] of Object.entries(fields)) {
@@ -148,7 +145,7 @@ function requiredManualCredentialFieldNames(
 }
 
 function hasRequiredManualCredentialFields(
-  fields: RequiredManualCredentialFieldNames,
+  fields: ManualCredentialFieldNames,
 ): boolean {
   return fields.secrets.length > 0 || fields.variables.length > 0;
 }
@@ -156,7 +153,7 @@ function hasRequiredManualCredentialFields(
 function getConnectorRequiredManualCredentialFields(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
-): RequiredManualCredentialFieldNames | null {
+): ManualCredentialFieldNames | null {
   const fields = getManualGrantFields(getConnectorAuthMethod(type, authMethod));
   return fields ? requiredManualCredentialFieldNames(fields) : null;
 }
@@ -226,7 +223,6 @@ export function deriveConnectedManualCredentialMethod(
         type,
         authMethod,
         fields: manualCredentialFieldNames(method.grant.fields),
-        requiredFields,
       };
     }
   }
@@ -917,7 +913,7 @@ export function getConnectorTypeForSecretName(
 
 export function getApiTokenFieldsByType(
   type: ConnectorType,
-): RequiredManualCredentialFieldNames | null {
+): ManualCredentialFieldNames | null {
   // Compatibility wrapper for legacy API-token callers. New state inference
   // should use manual credential helpers so the method id is preserved.
   return getConnectorRequiredManualCredentialFields(type, "api-token");

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -96,18 +96,10 @@ function connectorAuthMethodValues(
 function getManualGrantFields(
   method: ConnectorAuthMethodConfig | undefined,
 ): Record<string, ConnectorManualGrantFieldConfig> | undefined {
-  if (!method) {
+  if (!method || method.grant.kind !== "manual") {
     return undefined;
   }
-  switch (method.grant.kind) {
-    case "manual":
-      return method.grant.fields;
-    case "managed":
-    case "auth-code":
-    case "device-auth":
-    case "interactive-pairing":
-      return undefined;
-  }
+  return method.grant.fields;
 }
 
 export function getConnectorManualGrantFields(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -102,20 +102,19 @@ function getManualGrantFields(
   return method.grant.fields;
 }
 
-export interface ManualCredentialFieldNames {
+export interface ManualGrantFieldNames {
   readonly secrets: readonly string[];
   readonly variables: readonly string[];
 }
 
-export interface ManualCredentialAuthMethod {
+export interface ConnectedManualGrantMethod {
   readonly type: ConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
-  readonly fields: ManualCredentialFieldNames;
 }
 
-function manualCredentialFieldNames(
+function manualGrantFieldNames(
   fields: Record<string, ConnectorManualGrantFieldConfig>,
-): ManualCredentialFieldNames {
+): ManualGrantFieldNames {
   const secretNames: string[] = [];
   const variableNames: string[] = [];
   for (const [name, cfg] of Object.entries(fields)) {
@@ -128,9 +127,9 @@ function manualCredentialFieldNames(
   return { secrets: secretNames, variables: variableNames };
 }
 
-function requiredManualCredentialFieldNames(
+function requiredManualGrantFieldNames(
   fields: Record<string, ConnectorManualGrantFieldConfig>,
-): ManualCredentialFieldNames {
+): ManualGrantFieldNames {
   const secretNames: string[] = [];
   const variableNames: string[] = [];
   for (const [name, cfg] of Object.entries(fields)) {
@@ -144,21 +143,19 @@ function requiredManualCredentialFieldNames(
   return { secrets: secretNames, variables: variableNames };
 }
 
-function hasRequiredManualCredentialFields(
-  fields: ManualCredentialFieldNames,
-): boolean {
+function hasRequiredManualGrantFields(fields: ManualGrantFieldNames): boolean {
   return fields.secrets.length > 0 || fields.variables.length > 0;
 }
 
-function getConnectorRequiredManualCredentialFields(
+function getConnectorRequiredManualGrantFields(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
-): ManualCredentialFieldNames | null {
+): ManualGrantFieldNames | null {
   const fields = getManualGrantFields(getConnectorAuthMethod(type, authMethod));
-  return fields ? requiredManualCredentialFieldNames(fields) : null;
+  return fields ? requiredManualGrantFieldNames(fields) : null;
 }
 
-function getConnectorManualCredentialFieldStorageType(
+function getConnectorManualGrantFieldStorageType(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
   name: string,
@@ -169,9 +166,9 @@ function getConnectorManualCredentialFieldStorageType(
   return fieldConfig?.storage ?? "secret";
 }
 
-export function getConnectorManualCredentialFields(
+export function getConnectorManualGrantFields(
   type: ConnectorType,
-): ManualCredentialFieldNames | null {
+): ManualGrantFieldNames | null {
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
   for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
@@ -179,7 +176,7 @@ export function getConnectorManualCredentialFields(
     if (method?.grant.kind !== "manual") {
       continue;
     }
-    const fields = manualCredentialFieldNames(method.grant.fields);
+    const fields = manualGrantFieldNames(method.grant.fields);
     fields.secrets.forEach((name) => {
       secretNames.add(name);
     });
@@ -194,11 +191,11 @@ export function getConnectorManualCredentialFields(
   return { secrets: [...secretNames], variables: [...variableNames] };
 }
 
-export function deriveConnectedManualCredentialMethod(
+export function deriveConnectedManualGrantMethod(
   type: ConnectorType,
   userSecretNames: Set<string>,
   userVariableNames?: Set<string>,
-): ManualCredentialAuthMethod | null {
+): ConnectedManualGrantMethod | null {
   const varNames = userVariableNames ?? new Set<string>();
 
   for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
@@ -206,10 +203,8 @@ export function deriveConnectedManualCredentialMethod(
     if (method?.grant.kind !== "manual") {
       continue;
     }
-    const requiredFields = requiredManualCredentialFieldNames(
-      method.grant.fields,
-    );
-    if (!hasRequiredManualCredentialFields(requiredFields)) {
+    const requiredFields = requiredManualGrantFieldNames(method.grant.fields);
+    if (!hasRequiredManualGrantFields(requiredFields)) {
       continue;
     }
     const secretsOk = requiredFields.secrets.every((name) => {
@@ -222,7 +217,6 @@ export function deriveConnectedManualCredentialMethod(
       return {
         type,
         authMethod,
-        fields: manualCredentialFieldNames(method.grant.fields),
       };
     }
   }
@@ -230,14 +224,14 @@ export function deriveConnectedManualCredentialMethod(
   return null;
 }
 
-export function deriveConnectedManualCredentialMethods(
+export function deriveConnectedManualGrantMethods(
   userSecretNames: Set<string>,
   userVariableNames?: Set<string>,
-): ManualCredentialAuthMethod[] {
-  const connected: ManualCredentialAuthMethod[] = [];
+): ConnectedManualGrantMethod[] {
+  const connected: ConnectedManualGrantMethod[] = [];
 
   for (const type of CONNECTOR_TYPE_KEYS) {
-    const method = deriveConnectedManualCredentialMethod(
+    const method = deriveConnectedManualGrantMethod(
       type,
       userSecretNames,
       userVariableNames,
@@ -913,10 +907,10 @@ export function getConnectorTypeForSecretName(
 
 export function getApiTokenFieldsByType(
   type: ConnectorType,
-): ManualCredentialFieldNames | null {
+): ManualGrantFieldNames | null {
   // Compatibility wrapper for legacy API-token callers. New state inference
-  // should use manual credential helpers so the method id is preserved.
-  return getConnectorRequiredManualCredentialFields(type, "api-token");
+  // should use manual grant helpers so the method id is preserved.
+  return getConnectorRequiredManualGrantFields(type, "api-token");
 }
 
 export function getApiTokenFieldStorageType(
@@ -924,8 +918,8 @@ export function getApiTokenFieldStorageType(
   name: string,
 ): "secret" | "variable" {
   // Unknown fields preserve the historical form-submit behavior and are treated
-  // as encrypted secrets by the manual credential storage helper.
-  return getConnectorManualCredentialFieldStorageType(type, "api-token", name);
+  // as encrypted secrets by the manual grant storage helper.
+  return getConnectorManualGrantFieldStorageType(type, "api-token", name);
 }
 
 export function deriveApiTokenConnectedTypes(
@@ -934,10 +928,7 @@ export function deriveApiTokenConnectedTypes(
 ): ConnectorType[] {
   // Compatibility wrapper for legacy API-token callers. The config-driven
   // helper carries authMethod for production state inference.
-  return deriveConnectedManualCredentialMethods(
-    userSecretNames,
-    userVariableNames,
-  )
+  return deriveConnectedManualGrantMethods(userSecretNames, userVariableNames)
     .filter((method) => {
       return method.authMethod === "api-token";
     })


### PR DESCRIPTION
## Summary
- remove the private connector auth method lookup wrapper
- let getConnectorAuthMethod accept string IDs directly and return undefined for unknown methods

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- pre-commit: pnpm check-types via lefthook