### PR TITLE
feat: register sunlit-gouache image-style resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1414,6 +1414,51 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     status: "experimental",
     priority: 19,
   },
+  {
+    id: "vm0:image-style:sunlit-gouache",
+    kind: "image-style",
+    name: "Sunlit Gouache",
+    description:
+      "Bright pastel travel-painting illustration in opaque gouache on textured paper with chunky flat brushstrokes, vertical one-point perspective, and figures walking into warm sunlight.",
+    desc: 'Sunlit Gouache travel-painting illustration. Opaque gouache on textured paper, visible chunky flat brushstrokes with dry-brush highlights, locked six-color palette (cream, butter-yellow, sky-blue, sage-green, terracotta, one small red accent), vertical 2:3 one-point-perspective composition drawing the eye into a bright sunlit focal point, figures seen from behind walking into the scene, an overhead band of hanging elements (awning, prayer flags, catenary, bunting, lanterns) creating depth, dappled painterly reflections on the ground, airy optimistic warm mood. Trigger when user says /sunlit-gouache, asks for a "sunlit gouache illustration", "painterly travel scene", "gouache café/market/temple/station scene", or a new piece in this bright pastel painted-light style.',
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/sunlit-gouache",
+    ),
+    targets: ["image", "website", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "gouache",
+      "painterly",
+      "travel",
+      "editorial",
+      "pastel",
+      "sunlit",
+    ],
+    triggers: [
+      "sunlit gouache",
+      "gouache illustration",
+      "painterly travel scene",
+      "gouache travel painting",
+      "painted travel illustration",
+      "pastel travel illustration",
+    ],
+    bestFor: [
+      "editorial cover art",
+      "travel narrative artwork",
+      "blog hero illustrations",
+      "presentation section dividers",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 18,
+  },
 ];
 
 export function listImageStyles(): readonly OpenDesignRegistryEntry[] {


### PR DESCRIPTION
## Summary

Adds the **Sunlit Gouache** image-style entry to the Open Design registry, pointing at the paired resource in `vm0-ai/vm0-skills@main`.

The style codifies a bright pastel gouache travel-painting recipe with:

- **Locked axes** — opaque gouache on textured paper with chunky flat brushstrokes; locked six-color palette (cream / butter-yellow / sky-blue / sage-green / terracotta / one red accent); vertical 2:3 one-point-perspective composition; figures seen from behind walking into a bright sunlit focal point; an overhead band of hanging elements (awning, prayer flags, catenary, bunting, lanterns) creating depth; dappled painterly ground reflections; airy optimistic warm mood.
- **Five variable dials** — scene archetype, light register, cast, overhead motif, cultural register.

## Registry entry

- **ID:** `vm0:image-style:sunlit-gouache`
- **Kind:** `image-style`
- **Source:** `vm0-ai/vm0-skills` @ `main` / `illustration-template/sunlit-gouache`
- **Targets:** image, website, poster, presentation, report
- **Triggers:** sunlit gouache · gouache illustration · painterly travel scene · gouache travel painting · painted travel illustration · pastel travel illustration
- **Best for:** editorial cover art, travel narrative artwork, blog hero illustrations, presentation section dividers
- **Status:** experimental
- **Priority:** 18

## Paired PR

- Resource definition: vm0-ai/vm0-skills#217

## Validation

- pnpm -F @vm0/cli check-types — clean
- pnpm -F @vm0/cli exec eslint src/commands/zero/shared/open-design-registry.ts — clean
- pnpm -F @vm0/cli exec prettier --check src/commands/zero/shared/open-design-registry.ts — clean
- pnpm -F @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts — 13/13 passed (existing notion-illustration / vm0-illustration assertions still pass with the new entry alongside them)

## Test plan

- [ ] CI lint + check-types + test pass
- [ ] zero built-in generate image --style vm0:image-style:sunlit-gouache returns the registered resource in the JSON candidate slice
- [ ] One end-to-end smoke generation with this style produces an output that passes the SKILL.md evaluation checklist (chunky gouache, six-color palette, vertical one-point perspective, figures from behind, single red accent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)