### PR TITLE
feat: register mosaic-still-life styled template

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -1414,6 +1414,50 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     status: "experimental",
     priority: 19,
   },
+  {
+    id: "vm0:image-style:mosaic-still-life",
+    kind: "image-style",
+    name: "Mosaic Still Life",
+    description:
+      "Editorial still-life illustration in a mosaic-tile + painterly hybrid style — tessellated ground/sky/wall surfaces with crisp painterly objects, an animal companion, and a patterned textile peeking through.",
+    desc: 'Mosaic-tile + painterly hybrid editorial illustration. Tessellated/pointillist mosaic surfaces (grass, sky, sand, walls, floors) anchor the scene, with crisp painterly still-life objects rendered ON TOP. Always features a still-life centerpiece on a table, an animal companion at the heart of the scene, and at least one patterned textile peeking through. Cozy, nostalgic, bucolic mood. Trigger when user says /mosaic-still-life, asks for a "mosaic illustration", "mosaic-tile editorial illustration", "tessellated still life", or briefs with a palette + scene + animal in this style.',
+    source: sourceRef(
+      VM0_SKILLS_REPO,
+      VM0_SKILLS_REF,
+      "illustration-template/mosaic-still-life",
+    ),
+    targets: ["image", "website", "poster", "presentation", "report"],
+    tags: [
+      "image",
+      "illustration",
+      "mosaic",
+      "still-life",
+      "editorial",
+      "painterly",
+      "tessellated",
+    ],
+    triggers: [
+      "mosaic illustration",
+      "mosaic-tile editorial",
+      "tessellated still life",
+      "mosaic still life",
+      "painterly mosaic",
+      "ceramic-tile illustration",
+    ],
+    bestFor: [
+      "blog covers",
+      "editorial spreads",
+      "use-case page artwork",
+      "cozy storybook scenes",
+    ],
+    outputKinds: ["image"],
+    primaryOutputKind: "image",
+    executorHints: ["skill-authored", "built-in-image"],
+    previewHint: "image",
+    remixHint: "prompt-with-resource-hints",
+    status: "experimental",
+    priority: 17,
+  },
 ];
 
 export function listImageStyles(): readonly OpenDesignRegistryEntry[] {


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:mosaic-still-life` in the Open Design registry, pointing at the new template resource in `vm0-ai/vm0-skills@main:illustration-template/mosaic-still-life`.

The style is an editorial still-life illustration in a **mosaic-tile + painterly hybrid** hand: tessellated/pointillist surfaces (grass, sky, sand, walls, brick, pegboard, tile backsplash) carry the background, while crisp painterly objects with ink outlines sit on top. Every scene includes a still-life centerpiece, an animal companion, and a patterned textile peeking through.

## Registry entry

| Field | Value |
|---|---|
| ID | `vm0:image-style:mosaic-still-life` |
| Kind | `image-style` |
| Source | `vm0-ai/vm0-skills@main:illustration-template/mosaic-still-life` |
| Triggers | mosaic illustration, mosaic-tile editorial, tessellated still life, mosaic still life, painterly mosaic, ceramic-tile illustration |
| Best for | blog covers, editorial spreads, use-case page artwork, cozy storybook scenes |
| Priority | 17 |
| Status | experimental |

## User-adjustable dials (kept configurable)

1. **Palette** — 9 validated palettes, more allowed
2. **Scene** — outdoor (grass/sky/sand) or indoor (pegboard/color-swatch wall/tile backsplash/brick/checkered floor)
3. **Animal companion** — cat, dog, bunny, bird
4. **Mosaic grain** — fine, medium, chunky
5. **POV** — slight 3/4 angle, top-down

## Validation

- Existing image-style tests (`image.test.ts`) assert specific styles by ID and survive new entries unchanged
- No total-count assertions exist for `listImageStyles()`
- New entry follows the same shape as `vm0:image-style:notion-illustration` and `vm0:image-style:vm0-illustration`

## Test plan

- [ ] `pnpm --filter @vm0/cli test -- open-design` passes
- [ ] `zero built-in generate image --style vm0:image-style:mosaic-still-life --prompt "..."` returns the new resource in the candidate slice
- [ ] Live i2i generation with one of the reference images produces a recognizable mosaic-still-life output

Paired skill PR: https://github.com/vm0-ai/vm0-skills/pull/218