### PR TITLE
fix: align connector feature gate follow-ups

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
@@ -119,4 +119,20 @@ describe("POST /api/zero/connectors/:type/sessions", () => {
 
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "github" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
 });

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -12,7 +12,6 @@ import type {
 import {
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthCredentials,
-  isConnectorAuthMethodAvailable,
   isOAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -36,7 +35,7 @@ import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { settle } from "../utils";
 import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
+import { userConnectorAvailability } from "./connector-availability.service";
 import {
   upsertOAuthConnector$,
   zeroConnectorByType,
@@ -681,12 +680,12 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return resolvedType;
     }
 
-    const overrides = await get(
-      userFeatureSwitchOverrides(args.orgId, args.userId),
+    const availability = await get(
+      userConnectorAvailability(args.orgId, args.userId),
     );
     signal.throwIfAborted();
 
-    if (!isConnectorAuthMethodAvailable(resolvedType, "oauth", overrides)) {
+    if (!availability.isAuthMethodAvailable(resolvedType, "oauth")) {
       return connectorOauthDeviceAuthDisabled;
     }
 
@@ -786,12 +785,12 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       return resolvedType;
     }
 
-    const overrides = await get(
-      userFeatureSwitchOverrides(args.orgId, args.userId),
+    const availability = await get(
+      userConnectorAvailability(args.orgId, args.userId),
     );
     signal.throwIfAborted();
 
-    if (!isConnectorAuthMethodAvailable(resolvedType, "oauth", overrides)) {
+    if (!availability.isAuthMethodAvailable(resolvedType, "oauth")) {
       return connectorOauthDeviceAuthDisabled;
     }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -93,16 +93,24 @@ describe("directed authorize page", () => {
   });
 
   it("does not render an actionable card for feature-disabled connectors", async () => {
+    const disabledConnectorType = "bentoml" satisfies ConnectorType;
+    const disabledConnectorLabel = CONNECTOR_TYPES[disabledConnectorType].label;
+
     detachedSetupPage({
       context,
-      path: `/connectors/slock/authorize?agentId=${AGENT_ID}`,
+      path: `/connectors/${disabledConnectorType}/authorize?agentId=${AGENT_ID}`,
     });
 
-    await context.store.get(allConnectorTypes$);
+    const connectors = await context.store.get(allConnectorTypes$);
+    expect(
+      connectors.some((connector) => {
+        return connector.type === disabledConnectorType;
+      }),
+    ).toBeFalsy();
 
     await waitFor(() => {
       expect(
-        screen.queryByText("Zero needs Slock to proceed"),
+        screen.queryByText(`Zero needs ${disabledConnectorLabel} to proceed`),
       ).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -117,13 +117,24 @@ describe("directed connect page", () => {
   });
 
   it("does not render an actionable card for feature-disabled connectors", async () => {
-    detachedSetupPage({ context, path: "/connectors/slock/connect" });
+    const disabledConnectorType = "bentoml" satisfies ConnectorType;
+    const disabledConnectorLabel = CONNECTOR_TYPES[disabledConnectorType].label;
 
-    await context.store.get(allConnectorTypes$);
+    detachedSetupPage({
+      context,
+      path: `/connectors/${disabledConnectorType}/connect`,
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    expect(
+      connectors.some((connector) => {
+        return connector.type === disabledConnectorType;
+      }),
+    ).toBeFalsy();
 
     await waitFor(() => {
       expect(
-        screen.queryByText("Zero needs Slock to proceed"),
+        screen.queryByText(`Zero needs ${disabledConnectorLabel} to proceed`),
       ).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- align OAuth device-auth connector feature checks with shared userConnectorAvailability
- make directed connect/authorize disabled-connector tests use a truly feature-gated connector
- cover connector session creation when an authenticated request has no active org

## Tests
- pnpm --dir turbo -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts --reporter=verbose
- pnpm --dir turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx --reporter=verbose
- pnpm --dir turbo -F api check-types
- pnpm --dir turbo -F api lint
- pnpm --dir turbo -F @vm0/app check-types
- pnpm --dir turbo -F @vm0/app lint
- pnpm --dir turbo exec prettier --check apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts apps/api/src/signals/services/connector-oauth-device-auth.service.ts apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx

Note: local pre-commit was blocked by existing repo-wide knip output (`drizzle-kit packages/db/package.json` and configuration hints), so the commit was created with LEFTHOOK=0 after the targeted checks above passed.