### PR TITLE
refactor: clarify manual grant field names

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
@@ -111,6 +111,25 @@ async function seedAtlassianApiTokenState(
   ]);
 }
 
+async function seedGitlabApiTokenState(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(secrets).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "GITLAB_TOKEN",
+    encryptedValue: "encrypted_gitlab_token",
+    type: "user",
+  });
+  await writeDb.insert(variables).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "GITLAB_HOST",
+    value: "gitlab.example.com",
+  });
+}
+
 async function remainingConnectorCount(
   fixture: OrgMembershipFixture,
 ): Promise<number> {
@@ -256,6 +275,29 @@ describe("DELETE /api/zero/connectors/:type", () => {
     const response = await accept(
       client.delete({
         params: { type: "atlassian" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+    await expect(
+      remainingSecretAndVariableState(fixture),
+    ).resolves.toStrictEqual({
+      secrets: 0,
+      variables: 0,
+    });
+  });
+
+  it("deletes optional manual grant variables", async () => {
+    const fixture = await track(seedFixture());
+    await seedGitlabApiTokenState(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({
+        params: { type: "gitlab" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [204],

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -10,7 +10,7 @@ import {
   deriveConnectedManualGrantMethod,
   deriveConnectedManualGrantMethods,
   getAvailableConnectorAuthMethods,
-  getConnectorManualGrantFields,
+  getConnectorManualGrantFieldNames,
   getConnectorOAuthCredentials,
   getConnectorProvidedSecretNames,
   getConnectorSecretNames,
@@ -569,7 +569,7 @@ export const deleteZeroConnectorLocalState$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const fields = getConnectorManualGrantFields(args.type);
+    const fields = getConnectorManualGrantFieldNames(args.type);
     const hasManualGrantState = existing
       ? false
       : await hasManualGrantConnectorLocalState({
@@ -804,7 +804,7 @@ export const upsertOAuthConnector$ = command(
         ? secretMetadata.refreshSecretName
         : undefined,
     });
-    const manualGrantFields = getConnectorManualGrantFields(args.type);
+    const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -37,7 +37,7 @@ import {
   getConnectorOAuthCredentials,
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthScopes,
-  getConnectorManualGrantFields,
+  getConnectorManualGrantFieldNames,
   getApiTokenFieldStorageType,
   getApiTokenFieldsByType,
   getEligibleConnectorTypes,
@@ -358,17 +358,17 @@ describe("connector auth method config", () => {
     expect(getApiTokenFieldsByType("github")).toBeNull();
   });
 
-  it("groups all manual grant fields by storage", () => {
-    expect(getConnectorManualGrantFields("atlassian")).toStrictEqual({
+  it("groups all manual grant field names by storage", () => {
+    expect(getConnectorManualGrantFieldNames("atlassian")).toStrictEqual({
       secrets: ["ATLASSIAN_TOKEN"],
       variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
     });
-    expect(getConnectorManualGrantFields("gitlab")).toStrictEqual({
+    expect(getConnectorManualGrantFieldNames("gitlab")).toStrictEqual({
       secrets: ["GITLAB_TOKEN"],
       variables: ["GITLAB_HOST"],
     });
-    expect(getConnectorManualGrantFields("github")).toBeNull();
-    expect(getConnectorManualGrantFields("computer")).toBeNull();
+    expect(getConnectorManualGrantFieldNames("github")).toBeNull();
+    expect(getConnectorManualGrantFieldNames("computer")).toBeNull();
   });
 
   it("derives connected manual grant methods from required fields", () => {
@@ -377,17 +377,13 @@ describe("connector auth method config", () => {
         new Set(["ATLASSIAN_TOKEN"]),
         new Set(["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"]),
       ),
-    ).toContainEqual(
-      expect.objectContaining({ type: "atlassian", authMethod: "api-token" }),
-    );
+    ).toContainEqual({ type: "atlassian", authMethod: "api-token" });
     expect(
       deriveConnectedManualGrantMethods(
         new Set(["ATLASSIAN_TOKEN"]),
         new Set(["ATLASSIAN_EMAIL"]),
       ),
-    ).not.toContainEqual(
-      expect.objectContaining({ type: "atlassian", authMethod: "api-token" }),
-    );
+    ).not.toContainEqual({ type: "atlassian", authMethod: "api-token" });
     const connected = deriveConnectedManualGrantMethods(
       new Set(["GITHUB_ACCESS_TOKEN", "COMPUTER_CONNECTOR_BRIDGE_TOKEN"]),
       new Set(),

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -147,7 +147,7 @@ function hasRequiredManualGrantFields(fields: ManualGrantFieldNames): boolean {
   return fields.secrets.length > 0 || fields.variables.length > 0;
 }
 
-function getConnectorRequiredManualGrantFields(
+function getConnectorRequiredManualGrantFieldNames(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
 ): ManualGrantFieldNames | null {
@@ -166,7 +166,7 @@ function getConnectorManualGrantFieldStorageType(
   return fieldConfig?.storage ?? "secret";
 }
 
-export function getConnectorManualGrantFields(
+export function getConnectorManualGrantFieldNames(
   type: ConnectorType,
 ): ManualGrantFieldNames | null {
   const secretNames = new Set<string>();
@@ -910,7 +910,7 @@ export function getApiTokenFieldsByType(
 ): ManualGrantFieldNames | null {
   // Compatibility wrapper for legacy API-token callers. New state inference
   // should use manual grant helpers so the method id is preserved.
-  return getConnectorRequiredManualGrantFields(type, "api-token");
+  return getConnectorRequiredManualGrantFieldNames(type, "api-token");
 }
 
 export function getApiTokenFieldStorageType(


### PR DESCRIPTION
## Summary
- rename the manual grant helper to make it clear it returns field names, not field configs
- add a GitLab disconnect regression test for optional manual grant variables

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
- pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api check-types
- pnpm -F api lint