### PR TITLE
feat: register ink-mascot styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2795,6 +2795,15 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     desc: "Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art with white-filled interiors, a soft rounded color backdrop, transparent output, and simple iconic metaphors for product states.",
     source: { path: "illustration-template/vm0-illustration" },
   },
+  {
+    id: "vm0:image-style:ink-mascot",
+    kind: "image-style",
+    name: "Ink Mascot",
+    description:
+      "Vintage editorial marketing card. Bold serif headline and short serif descriptor over a hand-drawn black-ink anthropomorphic mascot (stick limbs, chunky white sneakers) on a single solid saturated flat color background.",
+    desc: 'Generate a 3:5 portrait editorial marketing card in a locked vintage-textbook style. Bold serif headline plus an optional short serif descriptor sit on a single solid saturated flat color background (no gradient, no divider, no ground line). A hand-drawn black-ink anthropomorphic hero object — paint bucket, magnifying glass, envelope, notebook, funnel, megaphone, rocket, seedling, gift box, compass, etc. — stands with two thin stick arms, two stick legs, and chunky white sneakers with black laces (the signature detail). Crosshatch and stipple shading on rounded surfaces; floating ink doodles (sparkles, arrows, hearts, percent or dollar signs, motion lines) at the requested density. Dialable along six axes: concept, palette, hero object, action, doodle density (L1 minimal, L2 balanced, L3 packed), and type layout (A title-top, B headline-bottom, C headline-only, D big-word + tiny-descriptor). Trigger when user says /ink-mascot, asks for a "marketing card illustration", a "retro editorial mascot poster", or briefs with a marketing concept plus palette plus character.',
+    source: { path: "illustration-template/ink-mascot" },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:ink-mascot` in the Open Design registry. Source points at `illustration-template/ink-mascot` in `vm0-ai/vm0-skills` (federated, ref `main`).

## Style

3:5 portrait editorial marketing card in a locked vintage-textbook look:

- Bold serif headline + optional short serif descriptor
- Hand-drawn black-ink anthropomorphic mascot (paint bucket, magnifying glass, envelope, funnel, rocket, seedling, etc.) with stick arms/legs and **chunky white sneakers with black laces** (the signature detail)
- Single solid saturated flat color filling the canvas — no gradient, no divider, no ground line, no border
- Floating ink doodles (sparkles, arrows, motion lines, hearts, currency signs) orbit the mascot
- Crosshatch and stipple shading restrained to rounded surfaces

Reads like a chapter opener from a 1970s marketing primer.

## Dialable axes

| Axis | Values |
| --- | --- |
| **Concept** | Branding, SEO, Email marketing, Conversion, Loyalty, Retention, Launch, Growth, Pricing, Positioning, Storytelling, Community, Referrals, Targeting, Analytics, ... |
| **Palette** | Single saturated hex — mint, coral, lavender, terracotta, sage, plum, tangerine, forest, mustard, cobalt, rose, rust, slate, etc. |
| **Hero** | Theme-native anthropomorphic object — paint bucket, magnifying glass, envelope, notebook, funnel, megaphone, rocket, seedling, gift box, compass, lighthouse, stamp |
| **Action** | holding, pressing, launching, painting, catching, pointing, running, peering, juggling, building, planting |
| **Doodle density** | L1 minimal (0-2 props), L2 balanced (3-5), L3 packed (6-8) |
| **Type layout** | A title-top, B headline-bottom, C headline-only, D big-word + tiny-descriptor |

## Paired vm0-skills PR

This PR ships alongside the resource itself in vm0-ai/vm0-skills:

- vm0-skills PR: https://github.com/vm0-ai/vm0-skills/pull/220

That PR contains `illustration-template/ink-mascot/SKILL.md` and 8 canonical reference outputs across the dial range (Branding mint, SEO coral, Email lavender, Content terracotta, Conversion sage, Loyalty plum, Launch tangerine, Growth forest).

## Files

- `turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts` — appends one entry under the image-style block, after `vm0:image-style:vm0-illustration`.

## Validation

- Registry entry matches the existing schema (id, kind, name, description, desc, source.path).
- Source path resolves to vm0-ai/vm0-skills@main:illustration-template/ink-mascot (validated in the paired PR).
- Skill already authored in the org via zero skill create ink-mascot.

Generated with Claude Code.