### PR TITLE
feat: register sticker-sheet image style

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2795,6 +2795,15 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     desc: "Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art with white-filled interiors, a soft rounded color backdrop, transparent output, and simple iconic metaphors for product states.",
     source: { path: "illustration-template/vm0-illustration" },
   },
+  {
+    id: "vm0:image-style:sticker-sheet",
+    kind: "image-style",
+    name: "Sticker Sheet",
+    description:
+      "Hand-painted gouache sticker-sheet illustration with ~20 themed objects floating on white, punchy saturated palette, wobbly hand-drawn ink overlay, and tiny decorative marks on every item.",
+    desc: 'Sticker Sheet — hand-painted gouache sticker-sheet illustration. ~20 small floating themed objects on pure white, punchy saturated palette (coral, mustard, sage, dusty pink, navy, cream, warm brown), flat brushy gouache fills with wobbly hand-drawn ink linework and tiny decorative marks (dots, hatches, squiggles) on every object. Each object slightly tilted, no drop shadows, cheerful cozy lifestyle journal mood. Trigger when user says /sticker-sheet, asks for a "sticker sheet illustration", "hand-painted gouache sticker pack", "themed object sheet", or briefs with a scene theme + object count in this house style.',
+    source: { path: "illustration-template/sticker-sheet" },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:sticker-sheet` in the Open Design registry. Points at `illustration-template/sticker-sheet/` in vm0-ai/vm0-skills (resource PR linked below).

## Style

Hand-painted gouache sticker-sheet illustration — a curated sheet of ~20 themed objects floating on pure white. Flat brushy gouache fills, wobbly hand-drawn black ink overlay, small decorative ink marks on every object (dots, hatches, squiggles, hand-lettered labels). Punchy saturated palette (coral / mustard / sage / dusty pink / navy / cream / warm brown). Cheerful cozy lifestyle-journal mood.

## Variable dials

- **Theme** — cozy desk / kitchen breakfast / weekend travel / indoor jungle / self-care reset / reading nook / stationery / camping / holiday / picnic / etc.
- **Object list** — ~18-22 concrete items with specific details
- **Accent palette weighting** — which 3-4 colors lead vs. support per theme

## Validation

Style validated through 5 generations with Marketing (1 anchor + 4 theme tests). All four theme tests held style cleanly. Documented model preference: nano-banana i2i (preserves the brushy ink + wobbly hand-drawn quality); GPT-Image-1.5 explicitly rejected as muted/pastel/faintly-3D in the SKILL.md.

## Paired PR

Resource lives at: https://github.com/vm0-ai/vm0-skills/pull/219

## Test plan

- [ ] `cd turbo && pnpm -F @vm0/cli exec vitest run image.test` passes (existing image-style tests filter by `--style`, so the new entry should not break length assertions)
- [ ] `zero built-in generate image --style vm0:image-style:sticker-sheet --prompt "..."` returns a selection packet pointing at the new resource path

🤖 Generated with [Claude Code](https://claude.com/claude-code)