### PR TITLE
feat: register flat-poster image-style resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2795,6 +2795,15 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     desc: "Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art with white-filled interiors, a soft rounded color backdrop, transparent output, and simple iconic metaphors for product states.",
     source: { path: "illustration-template/vm0-illustration" },
   },
+  {
+    id: "vm0:image-style:flat-poster",
+    kind: "image-style",
+    name: "Flat Poster",
+    description:
+      "Vertical flat-color editorial poster style — saturated solid background, one centered hand-drawn vector subject in bold deep-navy outlines with strict two-tone fill, headline pinned top-left, wordmark pinned bottom-right.",
+    desc: 'Flat Poster — a vertical flat-color editorial poster style for brand benefit cards, marketing posters, and in-app campaign visuals. Portrait 2:3 canvas filled edge-to-edge with one saturated hue; a single centered hand-drawn vector subject in deep-navy outlines with strict two-tone fill (pure white plus one darker bg-tint accent); a bold rounded sans-serif headline pinned top-left; a short wordmark (default VM0) pinned bottom-right; small floating accent marks around the subject; no body copy. Six creative dials: palette, subject archetype, composition preset, accent marks, headline voice, mood. Trigger when the user says /flat-poster, asks for a "flat-color editorial poster", a "brand benefit card", a "marketing card in the bold outline + flat color style", or briefs with a palette + subject + headline shape.',
+    source: { path: "illustration-template/flat-poster" },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers a new Open Design image-style resource: **`vm0:image-style:flat-poster`** — a vertical flat-color editorial poster style for brand benefit cards, marketing posters, and in-app campaign visuals.

**Locked visual frame:**
- Portrait 2:3 canvas filled edge-to-edge with one saturated hue
- One centered hand-drawn vector subject in deep-navy outlines (~7px)
- Strict two-tone fill: pure white + one darker bg-tint accent
- Bold rounded sans-serif headline pinned top-left
- Short wordmark (default `VM0`) pinned bottom-right
- 4-10 small floating accent marks around the subject
- No body copy, no caption, no subtitle

**Six creative dials:** palette · subject archetype · composition preset · accent marks · headline voice · mood.

## Companion PR

Skill + reference assets live in: vm0-ai/vm0-skills#221

## Files changed

- `turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts` — append one new entry after `vm0:image-style:vm0-illustration`

## Test plan

- [ ] `pnpm -F @vm0/cli exec vitest -- open-design` passes
- [ ] Selection: a flat-poster-shaped prompt returns `vm0:image-style:flat-poster` as a candidate
- [ ] Selection: a watercolor blog-cover prompt does NOT return this resource
- [ ] End-to-end: generate one fresh piece via the registered style and confirm the locked frame holds