### PR TITLE
feat: register vm0:image-style:mellow-pop in Open Design

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2795,6 +2795,15 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     desc: "Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art with white-filled interiors, a soft rounded color backdrop, transparent output, and simple iconic metaphors for product states.",
     source: { path: "illustration-template/vm0-illustration" },
   },
+  {
+    id: "vm0:image-style:mellow-pop",
+    kind: "image-style",
+    name: "Mellow Pop",
+    description:
+      "Chill flat-vector editorial poster of a serene recurring character on a fully saturated solid color background, with a signature pop of bright leaf-green and a scene-as-metaphor composition.",
+    desc: 'Mellow-pop flat-vector editorial illustration: a recurring chill character with closed-eye smile, tiny nose hint, and short dark bobbed hair, posed inside a scene-as-metaphor composition on a single fully saturated solid color background, with a signature pop of bright leaf-green woven into every piece (hero prop, plants, motifs, or sweater). Thin uniform black outlines, flat solid fills only, no gradients or texture. Five dials per brief: palette, scene metaphor, complexity (L1/L2/L3), pose, outfit accent. Trigger when user says /mellow-pop, asks for a "mellow-pop illustration", "chill flat-vector poster", or briefs with a scene metaphor + palette + complexity.',
+    source: { path: "illustration-template/mellow-pop" },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:mellow-pop` in the Open Design registry, pointing at `illustration-template/mellow-pop` in `vm0-ai/vm0-skills@main`. The resource lives on the companion PR vm0-ai/vm0-skills#222.

Mellow Pop is a chill flat-vector editorial poster style — a recurring character (closed-eye smile, tiny nose hint, short dark bobbed hair) posed inside a scene-as-metaphor composition on a fully saturated solid color background, with a signature pop of bright leaf-green woven into every piece. Five variable dials per brief: palette, scene metaphor, complexity (L1/L2/L3), pose, outfit accent.

## Change

Adds one entry to `OPEN_DESIGN_REGISTRY` in `turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts`:

```typescript
{
  id: "vm0:image-style:mellow-pop",
  kind: "image-style",
  name: "Mellow Pop",
  description: "Chill flat-vector editorial poster of a serene recurring character on a fully saturated solid color background, with a signature pop of bright leaf-green and a scene-as-metaphor composition.",
  desc: "...full selection blurb with trigger phrases and dial list...",
  source: { path: "illustration-template/mellow-pop" },
},
```

No other code changes — existing image-style tests assert against specific style IDs (notion-illustration, vm0-illustration) with toHaveLength(1) after filtering, so they remain green.

## Test plan

- [x] pnpm --filter @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts → 13/13 passing
- [x] Local smoke test: zero built-in generate image --style vm0:image-style:mellow-pop --json filters candidates.imageStyles to the new entry pointing at illustration-template/mellow-pop.
- [ ] Once vm0-ai/vm0-skills#222 merges to main, the registry source path will resolve and live --style vm0:image-style:mellow-pop generations will pull the SKILL.md + 9 reference images.

## Companion PR

Resource (SKILL.md + 9 reference images): vm0-ai/vm0-skills#222