### PR TITLE
feat(platform): add URL-routed artifact sidebar behind ChatArtifactSidebar switch

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -6,6 +6,7 @@ import {
   searchParams$,
   updateSearchParams$,
 } from "../route.ts";
+import { classifyChatAttachment } from "../chat-page/parse-body-blocks.ts";
 import {
   openDocumentLightbox$ as openDocumentLightboxModal$,
   openImageLightbox$ as openImageLightboxModal$,
@@ -46,16 +47,6 @@ export type ArtifactRef =
       imageId: string;
     };
 
-interface ArtifactOpenInput {
-  url: string;
-  kind: ArtifactPreviewKind;
-  filename: string;
-}
-
-function encodeArtifactParam(input: ArtifactOpenInput): string {
-  return input.url;
-}
-
 function decodeArtifactParam(value: string): ArtifactRef | null {
   if (value.startsWith(IMAGE_ID_PREFIX)) {
     const imageId = value.slice(IMAGE_ID_PREFIX.length);
@@ -67,40 +58,14 @@ function decodeArtifactParam(value: string): ArtifactRef | null {
   return null;
 }
 
-// Open metadata that callers pass alongside the URL so the sidebar knows the
-// filename + kind without having to re-classify from a bare URL. Kept in
-// memory because the URL only carries the reference.
-interface ArtifactOpenMetadata {
-  filename: string;
-  kind: ArtifactPreviewKind;
-}
-
-const artifactOpenMetadataByUrl$ = state<
-  ReadonlyMap<string, ArtifactOpenMetadata>
->(new Map());
-
-const rememberArtifactMetadata$ = command(
-  ({ get, set }, input: ArtifactOpenInput) => {
-    const current = get(artifactOpenMetadataByUrl$);
-    const existing = current.get(input.url);
-    if (
-      existing &&
-      existing.filename === input.filename &&
-      existing.kind === input.kind
-    ) {
-      return;
-    }
-    const next = new Map(current);
-    next.set(input.url, { filename: input.filename, kind: input.kind });
-    set(artifactOpenMetadataByUrl$, next);
-  },
-);
-
 export const chatArtifactSidebarEnabled$ = computed((get) => {
   const features = get(featureSwitch$);
   return features[FeatureSwitchKey.ChatArtifactSidebar] ?? false;
 });
 
+// The URL alone is the source of truth: kind + filename are derived from
+// the URL itself via classifyChatAttachment, so deep-linking or refreshing
+// the page re-renders the right body without any in-memory metadata cache.
 export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
   const params = get(searchParams$);
   const raw = params.get(ARTIFACT_QUERY_PARAM);
@@ -110,13 +75,9 @@ export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
   if (raw.startsWith(IMAGE_ID_PREFIX)) {
     return decodeArtifactParam(raw);
   }
-  const metadata = get(artifactOpenMetadataByUrl$).get(raw);
-  return {
-    source: "url",
-    url: raw,
-    kind: metadata?.kind ?? "file",
-    filename: metadata?.filename ?? filenameFromUrl(raw),
-  };
+  const filename = filenameFromUrl(raw);
+  const kind = classifyChatAttachment({ filename, url: raw });
+  return { source: "url", url: raw, kind, filename };
 });
 
 function filenameFromUrl(url: string): string {
@@ -125,14 +86,11 @@ function filenameFromUrl(url: string): string {
   return last && last.length > 0 ? last : "file";
 }
 
-export const openArtifact$ = command(
-  ({ get, set }, input: ArtifactOpenInput) => {
-    set(rememberArtifactMetadata$, input);
-    const params = new URLSearchParams(get(searchParams$));
-    params.set(ARTIFACT_QUERY_PARAM, encodeArtifactParam(input));
-    set(updateSearchParams$, params);
-  },
-);
+const openArtifact$ = command(({ get, set }, url: string) => {
+  const params = new URLSearchParams(get(searchParams$));
+  params.set(ARTIFACT_QUERY_PARAM, url);
+  set(updateSearchParams$, params);
+});
 
 export const closeArtifact$ = command(({ get, set }) => {
   const params = new URLSearchParams(get(searchParams$));
@@ -169,11 +127,7 @@ export const toggleArtifactFullscreen$ = command(({ get, set }) => {
 export const openImageLightboxOrArtifact$ = command(
   ({ get, set }, url: string) => {
     if (get(chatArtifactSidebarEnabled$)) {
-      set(openArtifact$, {
-        url,
-        kind: "image",
-        filename: filenameFromUrl(url),
-      });
+      set(openArtifact$, url);
       return;
     }
     set(openImageLightboxModal$, url);
@@ -183,11 +137,7 @@ export const openImageLightboxOrArtifact$ = command(
 export const openVideoLightboxOrArtifact$ = command(
   ({ get, set }, value: { url: string; filename: string }) => {
     if (get(chatArtifactSidebarEnabled$)) {
-      set(openArtifact$, {
-        url: value.url,
-        kind: "video",
-        filename: value.filename,
-      });
+      set(openArtifact$, value.url);
       return;
     }
     set(openVideoLightboxModal$, value);
@@ -204,11 +154,7 @@ export const openDocumentLightboxOrArtifact$ = command(
     },
   ) => {
     if (get(chatArtifactSidebarEnabled$)) {
-      set(openArtifact$, {
-        url: value.url,
-        kind: value.kind,
-        filename: value.filename,
-      });
+      set(openArtifact$, value.url);
       return;
     }
     set(openDocumentLightboxModal$, value);

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -1,0 +1,216 @@
+import { command, computed, state } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import {
+  replaceSearchParams$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import {
+  openDocumentLightbox$ as openDocumentLightboxModal$,
+  openImageLightbox$ as openImageLightboxModal$,
+  openVideoLightbox$ as openVideoLightboxModal$,
+} from "./zero-attachment-chips.ts";
+
+// ---------------------------------------------------------------------------
+// Artifact sidebar — URL-routed page-level slot for previewing a single
+// attachment next to the chat thread area. Gated behind
+// FeatureSwitchKey.ChatArtifactSidebar; the OFF path keeps the old modal
+// lightbox in place.
+// ---------------------------------------------------------------------------
+
+const ARTIFACT_QUERY_PARAM = "artifact";
+const IMAGE_ID_PREFIX = "image:";
+
+export type ArtifactPreviewKind =
+  | "markdown"
+  | "text"
+  | "json"
+  | "csv"
+  | "html"
+  | "pdf"
+  | "image"
+  | "video"
+  | "audio"
+  | "file";
+
+export type ArtifactRef =
+  | {
+      source: "url";
+      url: string;
+      kind: ArtifactPreviewKind;
+      filename: string;
+    }
+  | {
+      source: "image-id";
+      imageId: string;
+    };
+
+interface ArtifactOpenInput {
+  url: string;
+  kind: ArtifactPreviewKind;
+  filename: string;
+}
+
+function encodeArtifactParam(input: ArtifactOpenInput): string {
+  return input.url;
+}
+
+function decodeArtifactParam(value: string): ArtifactRef | null {
+  if (value.startsWith(IMAGE_ID_PREFIX)) {
+    const imageId = value.slice(IMAGE_ID_PREFIX.length);
+    if (!imageId) {
+      return null;
+    }
+    return { source: "image-id", imageId };
+  }
+  return null;
+}
+
+// Open metadata that callers pass alongside the URL so the sidebar knows the
+// filename + kind without having to re-classify from a bare URL. Kept in
+// memory because the URL only carries the reference.
+interface ArtifactOpenMetadata {
+  filename: string;
+  kind: ArtifactPreviewKind;
+}
+
+const artifactOpenMetadataByUrl$ = state<
+  ReadonlyMap<string, ArtifactOpenMetadata>
+>(new Map());
+
+const rememberArtifactMetadata$ = command(
+  ({ get, set }, input: ArtifactOpenInput) => {
+    const current = get(artifactOpenMetadataByUrl$);
+    const existing = current.get(input.url);
+    if (
+      existing &&
+      existing.filename === input.filename &&
+      existing.kind === input.kind
+    ) {
+      return;
+    }
+    const next = new Map(current);
+    next.set(input.url, { filename: input.filename, kind: input.kind });
+    set(artifactOpenMetadataByUrl$, next);
+  },
+);
+
+export const chatArtifactSidebarEnabled$ = computed((get) => {
+  const features = get(featureSwitch$);
+  return features[FeatureSwitchKey.ChatArtifactSidebar] ?? false;
+});
+
+export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
+  const params = get(searchParams$);
+  const raw = params.get(ARTIFACT_QUERY_PARAM);
+  if (!raw) {
+    return null;
+  }
+  if (raw.startsWith(IMAGE_ID_PREFIX)) {
+    return decodeArtifactParam(raw);
+  }
+  const metadata = get(artifactOpenMetadataByUrl$).get(raw);
+  return {
+    source: "url",
+    url: raw,
+    kind: metadata?.kind ?? "file",
+    filename: metadata?.filename ?? filenameFromUrl(raw),
+  };
+});
+
+function filenameFromUrl(url: string): string {
+  const cleaned = url.split("?")[0].split("#")[0];
+  const last = cleaned.split("/").pop();
+  return last && last.length > 0 ? last : "file";
+}
+
+export const openArtifact$ = command(
+  ({ get, set }, input: ArtifactOpenInput) => {
+    set(rememberArtifactMetadata$, input);
+    const params = new URLSearchParams(get(searchParams$));
+    params.set(ARTIFACT_QUERY_PARAM, encodeArtifactParam(input));
+    set(updateSearchParams$, params);
+  },
+);
+
+export const closeArtifact$ = command(({ get, set }) => {
+  const params = new URLSearchParams(get(searchParams$));
+  if (!params.has(ARTIFACT_QUERY_PARAM)) {
+    return;
+  }
+  params.delete(ARTIFACT_QUERY_PARAM);
+  set(replaceSearchParams$, params);
+  set(internalArtifactFullscreen$, false);
+});
+
+// ---------------------------------------------------------------------------
+// Fullscreen toggle — the sidebar fills the viewport on demand. Lives in
+// memory (intentionally not URL-routed) so deep links open at the default
+// 50/50 size.
+// ---------------------------------------------------------------------------
+
+const internalArtifactFullscreen$ = state<boolean>(false);
+
+export const artifactFullscreen$ = computed((get) => {
+  return get(internalArtifactFullscreen$);
+});
+
+export const toggleArtifactFullscreen$ = command(({ get, set }) => {
+  set(internalArtifactFullscreen$, !get(internalArtifactFullscreen$));
+});
+
+// ---------------------------------------------------------------------------
+// Switch-aware open commands — the existing lightbox-open commands route
+// here when the sidebar feature switch is on, so every chip click site
+// participates without per-callsite branching.
+// ---------------------------------------------------------------------------
+
+export const openImageLightboxOrArtifact$ = command(
+  ({ get, set }, url: string) => {
+    if (get(chatArtifactSidebarEnabled$)) {
+      set(openArtifact$, {
+        url,
+        kind: "image",
+        filename: filenameFromUrl(url),
+      });
+      return;
+    }
+    set(openImageLightboxModal$, url);
+  },
+);
+
+export const openVideoLightboxOrArtifact$ = command(
+  ({ get, set }, value: { url: string; filename: string }) => {
+    if (get(chatArtifactSidebarEnabled$)) {
+      set(openArtifact$, {
+        url: value.url,
+        kind: "video",
+        filename: value.filename,
+      });
+      return;
+    }
+    set(openVideoLightboxModal$, value);
+  },
+);
+
+export const openDocumentLightboxOrArtifact$ = command(
+  (
+    { get, set },
+    value: {
+      kind: "markdown" | "text" | "json" | "csv" | "html" | "pdf";
+      url: string;
+      filename: string;
+    },
+  ) => {
+    if (get(chatArtifactSidebarEnabled$)) {
+      set(openArtifact$, {
+        url: value.url,
+        kind: value.kind,
+        filename: value.filename,
+      });
+      return;
+    }
+    set(openDocumentLightboxModal$, value);
+  },
+);

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -4,6 +4,7 @@ import MarkdownPreview, {
 import { IconLoader2, IconPhoto } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { openImageLightboxOrArtifact$ } from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
 import { theme$ } from "../../signals/theme.ts";
@@ -228,18 +229,18 @@ function PlainLink({ href, children, ...rest }: MarkdownAnchorProps) {
   );
 }
 
-function MediaImage({
-  src,
-  alt,
-  onImageClick,
-}: {
-  src: string;
-  alt: string;
-  onImageClick?: (url: string) => void;
-}) {
+function MediaImage({ src, alt }: { src: string; alt: string }) {
   const imageLoadStatuses = useGet(imageLoadStatusByKey$);
   const imageLoadStatusRef = useSet(imageLoadStatusRef$);
   const setImageLoadStatus = useSet(setImageLoadStatus$);
+  // Self-sourced lightbox handler so MediaImage doesn't need a callback
+  // prop chained from the Markdown caller. Removing the `onImageClick`
+  // prop chain is what lets the `components` map and the renderer
+  // functions live at module scope with stable identity — which in turn
+  // prevents React from tearing down the <video>/<img> subtree on every
+  // re-render of the parent (the previous behavior caused .mp4 metadata
+  // to refetch every time `?artifact=` was toggled).
+  const openImageLightbox = useSet(openImageLightboxOrArtifact$);
   const imageLoadKey = `markdown:${src}`;
   const imageStatus = imageLoadStatuses[imageLoadKey] ?? "loading";
   const showPlaceholder = imageStatus !== "loaded";
@@ -248,7 +249,7 @@ function MediaImage({
     <button
       type="button"
       onClick={() => {
-        onImageClick?.(src);
+        openImageLightbox(src);
       }}
       className="relative block max-w-full my-1 overflow-hidden rounded-lg border border-foreground/10 cursor-zoom-in"
     >
@@ -282,14 +283,7 @@ function MediaImage({
   );
 }
 
-function MediaLink({
-  href,
-  children,
-  onImageClick,
-  ...rest
-}: MarkdownAnchorProps & {
-  onImageClick?: (url: string) => void;
-}) {
+function MediaLink({ href, children, ...rest }: MarkdownAnchorProps) {
   if (!href || !isSafeMediaUrl(href)) {
     return (
       <PlainLink href={href} {...rest}>
@@ -300,7 +294,7 @@ function MediaLink({
 
   if (isImageUrl(href)) {
     const alt = typeof children === "string" ? children : "";
-    return <MediaImage src={href} alt={alt} onImageClick={onImageClick} />;
+    return <MediaImage src={href} alt={alt} />;
   }
 
   if (isVideoUrl(href)) {
@@ -320,73 +314,65 @@ function MediaLink({
   );
 }
 
-function MarkdownLinkRenderer(
-  props: { children?: ReactNode } & MarkdownAnchorProps & {
-      mediaPreview: boolean;
-      onImageClick: ((url: string) => void) | undefined;
-    },
+// Module-scope renderers passed into MarkdownPreview's `components` map.
+// Function identity is stable across renders, which keeps MarkdownPreview
+// from re-mounting the children at <a>/<img> positions on parent re-render.
+function PlainLinkRenderer(
+  props: { children?: ReactNode } & MarkdownAnchorProps,
 ) {
-  const { mediaPreview, onImageClick, children, ...rest } = props;
-  if (mediaPreview) {
-    return (
-      <MediaLink {...rest} onImageClick={onImageClick}>
-        {children}
-      </MediaLink>
-    );
-  }
+  const { children, ...rest } = props;
   return <PlainLink {...rest}>{children}</PlainLink>;
 }
 
-function MarkdownImageRenderer(
-  props: MarkdownImageProps & {
-    mediaPreview: boolean;
-    onImageClick: ((url: string) => void) | undefined;
-  },
+function MediaLinkRenderer(
+  props: { children?: ReactNode } & MarkdownAnchorProps,
 ) {
-  const { mediaPreview, onImageClick, src, alt, ...rest } = props;
-  const imageProps = omitMarkdownNodeProp(rest);
-  const hasSafeSrc = typeof src === "string" && isSafeMediaUrl(src);
-  if (mediaPreview && hasSafeSrc) {
-    return <MediaImage src={src} alt={alt ?? ""} onImageClick={onImageClick} />;
-  }
-  return <img {...imageProps} src={src} alt={alt} />;
+  const { children, ...rest } = props;
+  return <MediaLink {...rest}>{children}</MediaLink>;
 }
+
+function PlainImageRenderer(props: MarkdownImageProps) {
+  const { src, alt, ...rest } = props;
+  return <img {...omitMarkdownNodeProp(rest)} src={src} alt={alt} />;
+}
+
+function MediaImageRenderer(props: MarkdownImageProps) {
+  const { src, alt, ...rest } = props;
+  const hasSafeSrc = typeof src === "string" && isSafeMediaUrl(src);
+  if (hasSafeSrc) {
+    return <MediaImage src={src} alt={alt ?? ""} />;
+  }
+  return <img {...omitMarkdownNodeProp(rest)} src={src} alt={alt} />;
+}
+
+const PLAIN_MARKDOWN_COMPONENTS = {
+  table: ResponsiveTable,
+  a: PlainLinkRenderer,
+  img: PlainImageRenderer,
+} as const;
+
+const MEDIA_MARKDOWN_COMPONENTS = {
+  table: ResponsiveTable,
+  a: MediaLinkRenderer,
+  img: MediaImageRenderer,
+} as const;
 
 export function Markdown({
   className,
   style,
   mediaPreview = false,
   mathEnabled = false,
-  onImageClick,
   remarkPlugins,
   rehypePlugins,
   ...rest
 }: MarkdownPreviewProps & {
   mediaPreview?: boolean;
   mathEnabled?: boolean;
-  onImageClick?: (url: string) => void;
 }) {
   const theme = useGet(theme$);
-  const renderLink = (
-    props: { children?: ReactNode } & MarkdownAnchorProps,
-  ) => {
-    return (
-      <MarkdownLinkRenderer
-        {...props}
-        mediaPreview={mediaPreview}
-        onImageClick={onImageClick}
-      />
-    );
-  };
-  const renderImage = (props: MarkdownImageProps) => {
-    return (
-      <MarkdownImageRenderer
-        {...props}
-        mediaPreview={mediaPreview}
-        onImageClick={onImageClick}
-      />
-    );
-  };
+  const components = mediaPreview
+    ? MEDIA_MARKDOWN_COMPONENTS
+    : PLAIN_MARKDOWN_COMPONENTS;
   return (
     <MarkdownPreview
       className={`!bg-transparent !text-foreground text-sm ${className ?? ""}`}
@@ -405,11 +391,7 @@ export function Markdown({
       rehypePlugins={
         mathEnabled ? [rehypeKatex, ...(rehypePlugins ?? [])] : rehypePlugins
       }
-      components={{
-        table: ResponsiveTable,
-        a: renderLink,
-        img: renderImage,
-      }}
+      components={components}
       {...rest}
     />
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Integration tests for the ChatArtifactSidebar feature switch behavior.
+ *
+ * Covers the ON path that issue #15027 introduces: inline .txt/.md
+ * attachments collapse to anchor chips, clicking them writes the
+ * ?artifact= URL parameter, and the page-level slot then renders the
+ * sidebar component. The OFF path is covered by the existing
+ * zero-attachment-preview.test.tsx file.
+ */
+
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StoreProvider } from "ccstate-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { search } from "../../../signals/location.ts";
+import { setPageSignal$ } from "../../../signals/page-signal.ts";
+import { AttachmentPreview } from "../zero-attachment-preview.tsx";
+import {
+  ArtifactSidebarSlot,
+  ArtifactSidebar,
+} from "../zero-artifact-sidebar.tsx";
+import {
+  artifactFullscreen$,
+  currentArtifactRef$,
+} from "../../../signals/zero-page/zero-artifact-sidebar.ts";
+
+const context = testContext();
+
+function setup(path = "/chats/thread-1") {
+  detachedSetupPage({
+    context,
+    path,
+    featureSwitches: {
+      [FeatureSwitchKey.ChatArtifactSidebar]: true,
+    },
+    withoutRender: true,
+  });
+  // ArtifactSidebar reads pageSignal$ for fetch cancellation; tests render
+  // it outside of normal page setup, so we have to seed it explicitly.
+  context.store.set(setPageSignal$, context.signal);
+}
+
+function renderWithStore(node: React.ReactNode) {
+  return render(<StoreProvider value={context.store}>{node}</StoreProvider>);
+}
+
+describe("chatArtifactSidebar: inline anchor chip behavior", () => {
+  it("renders a .txt attachment as an anchor chip when the switch is on", () => {
+    setup();
+    renderWithStore(
+      <AttachmentPreview
+        attachment={{
+          filename: "notes.txt",
+          url: "https://example.com/notes.txt",
+        }}
+      />,
+    );
+
+    const chip = screen.getByTestId("attachment-preview-text");
+    expect(chip.tagName).toBe("A");
+    expect(chip).toHaveAttribute("href", "https://example.com/notes.txt");
+    // The inline <pre> body should NOT be present on the ON path.
+    expect(screen.queryByText(/notes\.txt/)).toBeInTheDocument();
+  });
+
+  it("renders a .md attachment as an anchor chip when the switch is on", () => {
+    setup();
+    renderWithStore(
+      <AttachmentPreview
+        attachment={{
+          filename: "readme.md",
+          url: "https://example.com/readme.md",
+        }}
+      />,
+    );
+
+    const chip = screen.getByTestId("attachment-preview-markdown");
+    expect(chip.tagName).toBe("A");
+    expect(chip).toHaveAttribute("href", "https://example.com/readme.md");
+  });
+
+  it("opens the artifact pane and writes ?artifact= on plain click", () => {
+    setup();
+    renderWithStore(
+      <AttachmentPreview
+        attachment={{
+          filename: "notes.txt",
+          url: "https://example.com/notes.txt",
+        }}
+      />,
+    );
+
+    const chip = screen.getByTestId("attachment-preview-text");
+    fireEvent.click(chip);
+
+    const ref = context.store.get(currentArtifactRef$);
+    expect(ref).toStrictEqual({
+      source: "url",
+      url: "https://example.com/notes.txt",
+      kind: "text",
+      filename: "notes.txt",
+    });
+    expect(search()).toContain(
+      "artifact=https%3A%2F%2Fexample.com%2Fnotes.txt",
+    );
+  });
+
+  it("does not intercept cmd+click (modifier-click navigates natively)", () => {
+    setup();
+    renderWithStore(
+      <AttachmentPreview
+        attachment={{
+          filename: "notes.txt",
+          url: "https://example.com/notes.txt",
+        }}
+      />,
+    );
+
+    const chip = screen.getByTestId("attachment-preview-text");
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+      button: 0,
+    });
+    chip.dispatchEvent(event);
+
+    // The URL param must NOT have been written; native anchor navigation
+    // (handled by the browser) is left intact.
+    expect(search()).not.toContain("artifact=");
+    expect(context.store.get(currentArtifactRef$)).toBeNull();
+  });
+});
+
+describe("chatArtifactSidebar: sidebar slot rendering", () => {
+  it("does not render the sidebar when the switch is off", () => {
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt",
+      withoutRender: true,
+    });
+    context.store.set(setPageSignal$, context.signal);
+    renderWithStore(<ArtifactSidebarSlot />);
+    expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
+  });
+
+  it("does not render the sidebar when no artifact param is present", () => {
+    setup();
+    renderWithStore(<ArtifactSidebarSlot />);
+    expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
+  });
+
+  it("renders the sidebar when switch is on and artifact param is set", () => {
+    setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt");
+    renderWithStore(<ArtifactSidebarSlot />);
+    expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+  });
+});
+
+describe("chatArtifactSidebar: fullscreen toggle", () => {
+  it("toggles fullscreen state when the fullscreen button is clicked", () => {
+    setup();
+    renderWithStore(
+      <ArtifactSidebar
+        artifactRef={{
+          source: "url",
+          url: "https://example.com/notes.txt",
+          kind: "text",
+          filename: "notes.txt",
+        }}
+      />,
+    );
+
+    expect(context.store.get(artifactFullscreen$)).toBeFalsy();
+
+    fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
+    expect(context.store.get(artifactFullscreen$)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
+    expect(context.store.get(artifactFullscreen$)).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -2,8 +2,9 @@ import type { ReactNode } from "react";
 import {
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
+  IconCopy,
   IconDownload,
-  IconLink,
+  IconExternalLink,
   IconLoader2,
   IconX,
 } from "@tabler/icons-react";
@@ -27,7 +28,6 @@ import {
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
-import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — page-level pane for previewing the artifact pointed to
@@ -61,7 +61,7 @@ export function ArtifactSidebar({ artifactRef }: { artifactRef: ArtifactRef }) {
         className={
           fullscreen
             ? "fixed inset-0 z-40 flex flex-col bg-background"
-            : "flex h-full min-h-0 flex-col border-l border-border/60 bg-background"
+            : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background"
         }
         data-testid="artifact-sidebar"
       >
@@ -83,7 +83,7 @@ export function ArtifactSidebar({ artifactRef }: { artifactRef: ArtifactRef }) {
       className={
         fullscreen
           ? "fixed inset-0 z-40 flex flex-col bg-background"
-          : "flex h-full min-h-0 flex-col border-l border-border/60 bg-background"
+          : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background"
       }
       data-testid="artifact-sidebar"
     >
@@ -151,58 +151,63 @@ function ArtifactSidebarHeader({
   onToggleFullscreen: () => void;
   onClose: () => void;
 }) {
+  const publicUrl = url ? publicAttachmentUrl(url) : undefined;
   return (
-    <div className="flex shrink-0 items-center gap-3 border-b border-border/60 px-4 py-3">
-      {kind && (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
-          <FilePreviewIcon
-            filename={title}
-            contentType={contentTypeForKind(kind)}
-            testId="artifact-sidebar-file-icon"
-          />
-        </div>
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-foreground">
+    <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-4 py-3">
+      {url ? (
+        <button
+          type="button"
+          onClick={() => {
+            detach(
+              copyAttachmentLinkToClipboard(url),
+              Reason.DomCallback,
+              "artifact copy link",
+            );
+          }}
+          aria-label="Copy artifact URL"
+          title={publicUrl}
+          className="group/copy-url flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1 text-left text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        >
+          <IconCopy size={14} className="shrink-0" />
+          <span className="min-w-0 flex-1 truncate font-mono text-xs">
+            {publicUrl}
+          </span>
+        </button>
+      ) : (
+        <div className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
           {title}
         </div>
-        {kind && (
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">
-            {kind}
-          </div>
-        )}
-      </div>
+      )}
       <div className="flex shrink-0 items-center gap-1">
         {url && (
           <>
-            <button
-              type="button"
-              onClick={() => {
-                detach(
-                  copyAttachmentLinkToClipboard(url),
-                  Reason.DomCallback,
-                  "artifact copy link",
-                );
-              }}
-              aria-label="Copy link"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            >
-              <IconLink size={16} />
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                detach(
-                  downloadAttachmentUrl(url, undefined, title),
-                  Reason.DomCallback,
-                  "artifact download",
-                );
-              }}
-              aria-label="Download"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            >
-              <IconDownload size={16} />
-            </button>
+            {kind === "html" ? (
+              <a
+                href={publicAttachmentUrl(url)}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open in new tab"
+                data-testid="artifact-sidebar-open-external"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              >
+                <IconExternalLink size={16} />
+              </a>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  detach(
+                    downloadAttachmentUrl(url, undefined, title),
+                    Reason.DomCallback,
+                    "artifact download",
+                  );
+                }}
+                aria-label="Download"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              >
+                <IconDownload size={16} />
+              </button>
+            )}
           </>
         )}
         <button
@@ -210,7 +215,7 @@ function ArtifactSidebarHeader({
           onClick={onToggleFullscreen}
           aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
           data-testid="artifact-sidebar-fullscreen-toggle"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          className="hidden xl:inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
         >
           {fullscreen ? (
             <IconArrowsDiagonalMinimize2 size={16} />
@@ -458,9 +463,13 @@ function ArtifactIframeBody({
   kind: "html" | "pdf";
   filename: string;
 }) {
+  // PDF Open Parameters: #navpanes=0 hides Chromium's built-in left rail
+  // (thumbnails / bookmarks) so the embedded preview shows just the page
+  // and toolbar by default. Firefox/PDF.js silently ignores it.
+  const src = kind === "pdf" ? `${url}#navpanes=0` : url;
   return (
     <iframe
-      src={url}
+      src={src}
       title={`${filename} preview`}
       sandbox={kind === "html" ? "allow-scripts" : undefined}
       className="h-full w-full bg-background"
@@ -476,23 +485,4 @@ function ArtifactGenericBody({ filename }: { filename: string }) {
       <p className="text-xs">{filename}</p>
     </div>
   );
-}
-
-const CONTENT_TYPE_BY_KIND: Readonly<
-  Record<ArtifactKindForBody, string | undefined>
-> = {
-  markdown: "text/markdown",
-  text: "text/plain",
-  json: "application/json",
-  csv: "text/csv",
-  html: "text/html",
-  pdf: "application/pdf",
-  image: "image/*",
-  video: "video/*",
-  audio: "audio/*",
-  file: undefined,
-};
-
-function contentTypeForKind(kind: ArtifactKindForBody): string | undefined {
-  return CONTENT_TYPE_BY_KIND[kind];
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1,0 +1,498 @@
+import type { ReactNode } from "react";
+import {
+  IconArrowsDiagonal,
+  IconArrowsDiagonalMinimize2,
+  IconDownload,
+  IconLink,
+  IconLoader2,
+  IconX,
+} from "@tabler/icons-react";
+import { useGet, useSet } from "ccstate-react";
+import {
+  artifactFullscreen$,
+  type ArtifactRef,
+  chatArtifactSidebarEnabled$,
+  closeArtifact$,
+  currentArtifactRef$,
+  toggleArtifactFullscreen$,
+} from "../../signals/zero-page/zero-artifact-sidebar.ts";
+import {
+  copyAttachmentLinkToClipboard,
+  CsvPreviewTable,
+  downloadAttachmentUrl,
+  parseCsvRows,
+  publicAttachmentUrl,
+  TextPreviewLoader,
+} from "./zero-attachment-chips.tsx";
+import { Markdown } from "../components/markdown.tsx";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
+import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
+
+// ---------------------------------------------------------------------------
+// ArtifactSidebar — page-level pane for previewing the artifact pointed to
+// by ?artifact=. Renders kind-specific bodies inline (no modal), with a
+// fullscreen toggle that swaps to a full-viewport layout. Mounted by the
+// chat thread page and gated by FeatureSwitchKey.ChatArtifactSidebar.
+// ---------------------------------------------------------------------------
+
+export function ArtifactSidebarSlot() {
+  const enabled = useGet(chatArtifactSidebarEnabled$);
+  const ref = useGet(currentArtifactRef$);
+
+  if (!enabled || !ref) {
+    return null;
+  }
+
+  return <ArtifactSidebar artifactRef={ref} />;
+}
+
+export function ArtifactSidebar({ artifactRef }: { artifactRef: ArtifactRef }) {
+  const fullscreen = useGet(artifactFullscreen$);
+  const close = useSet(closeArtifact$);
+  const toggleFullscreen = useSet(toggleArtifactFullscreen$);
+  const pageSignal = useGet(pageSignal$);
+
+  const display = resolveArtifactDisplay(artifactRef);
+
+  if (!display) {
+    return (
+      <div
+        className={
+          fullscreen
+            ? "fixed inset-0 z-40 flex flex-col bg-background"
+            : "flex h-full min-h-0 flex-col border-l border-border/60 bg-background"
+        }
+        data-testid="artifact-sidebar"
+      >
+        <ArtifactSidebarHeader
+          title="Artifact unavailable"
+          fullscreen={fullscreen}
+          onToggleFullscreen={toggleFullscreen}
+          onClose={close}
+        />
+        <div className="flex flex-1 items-center justify-center p-6 text-sm text-muted-foreground">
+          Unsupported artifact reference.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={
+        fullscreen
+          ? "fixed inset-0 z-40 flex flex-col bg-background"
+          : "flex h-full min-h-0 flex-col border-l border-border/60 bg-background"
+      }
+      data-testid="artifact-sidebar"
+    >
+      <ArtifactSidebarHeader
+        title={display.filename}
+        kind={display.kind}
+        url={display.url}
+        fullscreen={fullscreen}
+        onToggleFullscreen={toggleFullscreen}
+        onClose={close}
+      />
+      <div className="min-h-0 flex-1 overflow-hidden bg-background">
+        <ArtifactBody
+          url={display.url}
+          kind={display.kind}
+          filename={display.filename}
+          pageSignal={pageSignal}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ArtifactDisplay {
+  url: string;
+  kind: ArtifactKindForBody;
+  filename: string;
+}
+
+type ArtifactKindForBody =
+  | "markdown"
+  | "text"
+  | "json"
+  | "csv"
+  | "html"
+  | "pdf"
+  | "image"
+  | "video"
+  | "audio"
+  | "file";
+
+function resolveArtifactDisplay(ref: ArtifactRef): ArtifactDisplay | null {
+  if (ref.source !== "url") {
+    return null;
+  }
+  return {
+    url: ref.url,
+    kind: ref.kind,
+    filename: ref.filename,
+  };
+}
+
+function ArtifactSidebarHeader({
+  title,
+  kind,
+  url,
+  fullscreen,
+  onToggleFullscreen,
+  onClose,
+}: {
+  title: string;
+  kind?: ArtifactKindForBody;
+  url?: string;
+  fullscreen: boolean;
+  onToggleFullscreen: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-border/60 px-4 py-3">
+      {kind && (
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
+          <FilePreviewIcon
+            filename={title}
+            contentType={contentTypeForKind(kind)}
+            testId="artifact-sidebar-file-icon"
+          />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground">
+          {title}
+        </div>
+        {kind && (
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            {kind}
+          </div>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {url && (
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                detach(
+                  copyAttachmentLinkToClipboard(url),
+                  Reason.DomCallback,
+                  "artifact copy link",
+                );
+              }}
+              aria-label="Copy link"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            >
+              <IconLink size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                detach(
+                  downloadAttachmentUrl(url, undefined, title),
+                  Reason.DomCallback,
+                  "artifact download",
+                );
+              }}
+              aria-label="Download"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            >
+              <IconDownload size={16} />
+            </button>
+          </>
+        )}
+        <button
+          type="button"
+          onClick={onToggleFullscreen}
+          aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          data-testid="artifact-sidebar-fullscreen-toggle"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        >
+          {fullscreen ? (
+            <IconArrowsDiagonalMinimize2 size={16} />
+          ) : (
+            <IconArrowsDiagonal size={16} />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close artifact"
+          data-testid="artifact-sidebar-close"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        >
+          <IconX size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ArtifactBody({
+  url,
+  kind,
+  filename,
+  pageSignal,
+}: {
+  url: string;
+  kind: ArtifactKindForBody;
+  filename: string;
+  pageSignal: AbortSignal;
+}) {
+  if (kind === "markdown") {
+    return <ArtifactMarkdownBody url={url} signal={pageSignal} />;
+  }
+  if (kind === "text" || kind === "json") {
+    return <ArtifactPlainTextBody url={url} kind={kind} signal={pageSignal} />;
+  }
+  if (kind === "csv") {
+    return <ArtifactCsvBody url={url} signal={pageSignal} />;
+  }
+  if (kind === "image") {
+    return <ArtifactImageBody url={url} filename={filename} />;
+  }
+  if (kind === "video") {
+    return <ArtifactVideoBody url={url} filename={filename} />;
+  }
+  if (kind === "audio") {
+    return <ArtifactAudioBody url={url} filename={filename} />;
+  }
+  if (kind === "html" || kind === "pdf") {
+    return <ArtifactIframeBody url={url} kind={kind} filename={filename} />;
+  }
+  return <ArtifactGenericBody filename={filename} />;
+}
+
+function ArtifactSpinner() {
+  return (
+    <div className="flex h-full items-center justify-center text-muted-foreground">
+      <IconLoader2 size={20} className="animate-spin" />
+    </div>
+  );
+}
+
+function ArtifactBodyError({ message }: { message: string }): ReactNode {
+  return (
+    <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+      {message}
+    </div>
+  );
+}
+
+function ArtifactMarkdownBody({
+  url,
+  signal,
+}: {
+  url: string;
+  signal: AbortSignal;
+}) {
+  return (
+    <TextPreviewLoader url={url} signal={signal}>
+      {({ status, text }) => {
+        if (status === "loading") {
+          return <ArtifactSpinner />;
+        }
+        if (status === "error") {
+          return <ArtifactBodyError message="Markdown preview unavailable." />;
+        }
+        return (
+          <div className="h-full overflow-auto p-6">
+            <Markdown source={text} />
+          </div>
+        );
+      }}
+    </TextPreviewLoader>
+  );
+}
+
+function ArtifactPlainTextBody({
+  kind,
+  signal,
+  url,
+}: {
+  kind: "text" | "json";
+  signal: AbortSignal;
+  url: string;
+}) {
+  return (
+    <TextPreviewLoader url={url} signal={signal}>
+      {({ status, text }) => {
+        if (status === "loading") {
+          return <ArtifactSpinner />;
+        }
+        if (status === "error") {
+          return (
+            <ArtifactBodyError
+              message={
+                kind === "json"
+                  ? "JSON preview unavailable."
+                  : "Text preview unavailable."
+              }
+            />
+          );
+        }
+        const formatted = formatBodyText(kind, text);
+        return (
+          <pre
+            className="h-full overflow-auto whitespace-pre-wrap break-words p-6 text-sm text-foreground"
+            data-testid={`artifact-sidebar-body-${kind}`}
+          >
+            {formatted}
+          </pre>
+        );
+      }}
+    </TextPreviewLoader>
+  );
+}
+
+function formatBodyText(kind: "text" | "json", text: string): string {
+  if (kind === "json") {
+    const parsed = jsonParseOr<unknown>(text, null);
+    return parsed === null ? text : JSON.stringify(parsed, null, 2);
+  }
+  return text;
+}
+
+function ArtifactCsvBody({
+  url,
+  signal,
+}: {
+  url: string;
+  signal: AbortSignal;
+}) {
+  return (
+    <TextPreviewLoader url={url} signal={signal}>
+      {({ status, text }) => {
+        if (status === "loading") {
+          return <ArtifactSpinner />;
+        }
+        if (status === "error") {
+          return <ArtifactBodyError message="CSV preview unavailable." />;
+        }
+        const rows = parseCsvRows(text);
+        if (rows.length === 0) {
+          return <ArtifactBodyError message="Empty CSV." />;
+        }
+        return (
+          <div className="h-full overflow-auto p-6">
+            <CsvPreviewTable rows={rows} />
+          </div>
+        );
+      }}
+    </TextPreviewLoader>
+  );
+}
+
+function ArtifactImageBody({
+  url,
+  filename,
+}: {
+  url: string;
+  filename: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center bg-muted/20 p-4">
+      <img
+        src={url}
+        alt={filename}
+        className="max-h-full max-w-full object-contain"
+        data-testid="artifact-sidebar-body-image"
+      />
+    </div>
+  );
+}
+
+function ArtifactVideoBody({
+  url,
+  filename,
+}: {
+  url: string;
+  filename: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center bg-black/95 p-4">
+      <video
+        src={publicAttachmentUrl(url)}
+        controls
+        playsInline
+        className="max-h-full max-w-full"
+        aria-label={`Video preview for ${filename}`}
+        data-testid="artifact-sidebar-body-video"
+      />
+    </div>
+  );
+}
+
+function ArtifactAudioBody({
+  url,
+  filename,
+}: {
+  url: string;
+  filename: string;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-6">
+      <p className="text-sm text-muted-foreground">{filename}</p>
+      <audio
+        src={url}
+        controls
+        preload="metadata"
+        className="w-full max-w-md"
+        aria-label={`Audio preview for ${filename}`}
+        data-testid="artifact-sidebar-body-audio"
+      />
+    </div>
+  );
+}
+
+function ArtifactIframeBody({
+  url,
+  kind,
+  filename,
+}: {
+  url: string;
+  kind: "html" | "pdf";
+  filename: string;
+}) {
+  return (
+    <iframe
+      src={url}
+      title={`${filename} preview`}
+      sandbox={kind === "html" ? "allow-scripts" : undefined}
+      className="h-full w-full bg-background"
+      data-testid={`artifact-sidebar-body-${kind}`}
+    />
+  );
+}
+
+function ArtifactGenericBody({ filename }: { filename: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-muted-foreground">
+      <p className="text-sm">No inline preview available for this file.</p>
+      <p className="text-xs">{filename}</p>
+    </div>
+  );
+}
+
+const CONTENT_TYPE_BY_KIND: Readonly<
+  Record<ArtifactKindForBody, string | undefined>
+> = {
+  markdown: "text/markdown",
+  text: "text/plain",
+  json: "application/json",
+  csv: "text/csv",
+  html: "text/html",
+  pdf: "application/pdf",
+  image: "image/*",
+  video: "video/*",
+  audio: "audio/*",
+  file: undefined,
+};
+
+function contentTypeForKind(kind: ArtifactKindForBody): string | undefined {
+  return CONTENT_TYPE_BY_KIND[kind];
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -394,7 +394,9 @@ export async function downloadAttachmentUrl(
   }
 }
 
-async function copyAttachmentLinkToClipboard(url: string): Promise<void> {
+export async function copyAttachmentLinkToClipboard(
+  url: string,
+): Promise<void> {
   const copied = await writeToClipboard(publicAttachmentUrl(url));
   if (copied) {
     toast.success("Link copied");

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -17,11 +17,13 @@ import {
   textPreviewCollapsedByKey$,
   toggleTextPreviewCollapsed$,
 } from "../../signals/view-component-state.ts";
+import { lightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
-  lightboxUrl$,
-  openDocumentLightbox$,
-  openVideoLightbox$,
-} from "../../signals/zero-page/zero-attachment-chips.ts";
+  chatArtifactSidebarEnabled$,
+  openArtifact$,
+  openDocumentLightboxOrArtifact$,
+  openVideoLightboxOrArtifact$,
+} from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import {
   classifyChatAttachment,
   EMPTY_TEXT$,
@@ -100,7 +102,60 @@ type TextPreviewProps = {
   text$?: Computed<Promise<string>>;
 };
 
-function TextPreview({ filename, url, kind, text$ }: TextPreviewProps) {
+function TextPreview(props: TextPreviewProps) {
+  const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
+  if (sidebarEnabled) {
+    return (
+      <AttachmentAnchorChip
+        filename={props.filename}
+        url={props.url}
+        kind={props.kind}
+      />
+    );
+  }
+  return <TextPreviewInline {...props} />;
+}
+
+function AttachmentAnchorChip({
+  filename,
+  url,
+  kind,
+}: {
+  filename: string;
+  url: string;
+  kind: "text" | "json" | "markdown";
+}) {
+  const publicUrl = publicAttachmentUrl(url);
+  const openArtifact = useSet(openArtifact$);
+
+  return (
+    <a
+      href={publicUrl}
+      data-testid={`attachment-preview-${kind}`}
+      onClick={(event) => {
+        if (shouldUseNativeAnchorNavigation(event)) {
+          return;
+        }
+        event.preventDefault();
+        event.currentTarget.blur();
+        openArtifact({ url, kind, filename });
+      }}
+      aria-label={`Open ${kind} preview for ${filename}`}
+      title={filename}
+      className="group/anchor-chip inline-flex min-h-8 max-w-[min(100%,520px)] w-fit items-center gap-2 self-start rounded-full border border-foreground/10 bg-background px-2 py-1 pr-3 text-left align-top text-sm text-foreground no-underline transition-colors hover:border-foreground/20 hover:bg-muted/40"
+    >
+      <span
+        data-testid={`attachment-preview-${kind}-icon`}
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-foreground/10 bg-muted/40 text-muted-foreground transition-colors group-hover/anchor-chip:border-foreground/15 group-hover/anchor-chip:bg-muted/60 group-hover/anchor-chip:text-foreground"
+      >
+        <IconExternalLink size={13} stroke={1.8} />
+      </span>
+      <span className="min-w-0 truncate font-medium">{filename}</span>
+    </a>
+  );
+}
+
+function TextPreviewInline({ filename, url, kind, text$ }: TextPreviewProps) {
   const textPreviewCollapsedByKey = useGet(textPreviewCollapsedByKey$);
   const toggleTextPreviewCollapsed = useSet(toggleTextPreviewCollapsed$);
   const collapsedKey = `attachment-preview:${kind}:${filename}:${url}`;
@@ -190,9 +245,16 @@ function DocumentThumbnailPreview({
   url: string;
   kind: "markdown" | "csv" | "pdf" | "html";
 }) {
-  const openDocumentLightbox = useSet(openDocumentLightbox$);
+  const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
+  const openDocumentLightbox = useSet(openDocumentLightboxOrArtifact$);
   const lightboxOpen = useGet(lightboxUrl$) !== null;
   const publicUrl = publicAttachmentUrl(url);
+
+  if (sidebarEnabled && kind === "markdown") {
+    return (
+      <AttachmentAnchorChip filename={filename} url={url} kind="markdown" />
+    );
+  }
 
   if (kind === "html") {
     return (
@@ -379,7 +441,7 @@ function VideoThumbnailPreview({
   filename: string;
   url: string;
 }) {
-  const openVideoLightbox = useSet(openVideoLightbox$);
+  const openVideoLightbox = useSet(openVideoLightboxOrArtifact$);
   const lightboxOpen = useGet(lightboxUrl$) !== null;
   const videoUrl = publicAttachmentUrl(url);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -6,9 +6,12 @@ import {
   IconEye,
   IconExternalLink,
   IconFileMusic,
+  IconFileTypePdf,
   IconLoader2,
   IconPlayerPlay,
+  IconTable,
   IconVideo,
+  IconWorld,
 } from "@tabler/icons-react";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Computed } from "ccstate";
@@ -20,7 +23,6 @@ import {
 import { lightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
   chatArtifactSidebarEnabled$,
-  openArtifact$,
   openDocumentLightboxOrArtifact$,
   openVideoLightboxOrArtifact$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
@@ -116,6 +118,27 @@ function TextPreview(props: TextPreviewProps) {
   return <TextPreviewInline {...props} />;
 }
 
+type AttachmentAnchorChipKind =
+  | "text"
+  | "json"
+  | "markdown"
+  | "csv"
+  | "pdf"
+  | "html";
+
+function attachmentAnchorChipIcon(kind: AttachmentAnchorChipKind): ReactNode {
+  if (kind === "html") {
+    return <IconWorld size={13} stroke={1.8} />;
+  }
+  if (kind === "csv") {
+    return <IconTable size={13} stroke={1.8} />;
+  }
+  if (kind === "pdf") {
+    return <IconFileTypePdf size={13} stroke={1.8} />;
+  }
+  return <IconExternalLink size={13} stroke={1.8} />;
+}
+
 function AttachmentAnchorChip({
   filename,
   url,
@@ -123,10 +146,12 @@ function AttachmentAnchorChip({
 }: {
   filename: string;
   url: string;
-  kind: "text" | "json" | "markdown";
+  kind: AttachmentAnchorChipKind;
 }) {
   const publicUrl = publicAttachmentUrl(url);
-  const openArtifact = useSet(openArtifact$);
+  // Switch-aware open. html chips can render even when the sidebar feature is
+  // off, in which case this routes back to the legacy modal lightbox.
+  const openDocument = useSet(openDocumentLightboxOrArtifact$);
 
   return (
     <a
@@ -138,7 +163,7 @@ function AttachmentAnchorChip({
         }
         event.preventDefault();
         event.currentTarget.blur();
-        openArtifact({ url, kind, filename });
+        openDocument({ kind, url, filename });
       }}
       aria-label={`Open ${kind} preview for ${filename}`}
       title={filename}
@@ -148,7 +173,7 @@ function AttachmentAnchorChip({
         data-testid={`attachment-preview-${kind}-icon`}
         className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-foreground/10 bg-muted/40 text-muted-foreground transition-colors group-hover/anchor-chip:border-foreground/15 group-hover/anchor-chip:bg-muted/60 group-hover/anchor-chip:text-foreground"
       >
-        <IconExternalLink size={13} stroke={1.8} />
+        {attachmentAnchorChipIcon(kind)}
       </span>
       <span className="min-w-0 truncate font-medium">{filename}</span>
     </a>
@@ -248,40 +273,13 @@ function DocumentThumbnailPreview({
   const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
   const openDocumentLightbox = useSet(openDocumentLightboxOrArtifact$);
   const lightboxOpen = useGet(lightboxUrl$) !== null;
-  const publicUrl = publicAttachmentUrl(url);
 
-  if (sidebarEnabled && kind === "markdown") {
-    return (
-      <AttachmentAnchorChip filename={filename} url={url} kind="markdown" />
-    );
-  }
-
-  if (kind === "html") {
-    return (
-      <a
-        href={publicUrl}
-        data-testid="attachment-preview-html"
-        onClick={(event) => {
-          if (shouldUseNativeAnchorNavigation(event)) {
-            return;
-          }
-          event.preventDefault();
-          event.currentTarget.blur();
-          openDocumentLightbox({ kind, url, filename });
-        }}
-        aria-label={`Open html preview for ${filename}`}
-        title={filename}
-        className="group/html-preview inline-flex min-h-8 max-w-[min(100%,520px)] w-fit items-center gap-2 self-start rounded-full border border-foreground/10 bg-background px-2 py-1 pr-3 text-left align-top text-sm text-foreground no-underline transition-colors hover:border-foreground/20 hover:bg-muted/40"
-      >
-        <span
-          data-testid="attachment-preview-html-icon"
-          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-foreground/10 bg-muted/40 text-muted-foreground transition-colors group-hover/html-preview:border-foreground/15 group-hover/html-preview:bg-muted/60 group-hover/html-preview:text-foreground"
-        >
-          <IconExternalLink size={13} stroke={1.8} />
-        </span>
-        <span className="min-w-0 truncate font-medium">{filename}</span>
-      </a>
-    );
+  // html chip is always the collapsed anchor form (it has no body to inline);
+  // markdown/csv/pdf use the same chip when the artifact sidebar is on, and
+  // keep the full thumbnail card otherwise so legacy lightbox layouts still
+  // look right.
+  if (kind === "html" || sidebarEnabled) {
+    return <AttachmentAnchorChip filename={filename} url={url} kind={kind} />;
   }
 
   const accentClass =

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -90,6 +90,7 @@ import {
   publicAttachmentUrl,
   TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
+import { ArtifactSidebarSlot } from "./zero-artifact-sidebar.tsx";
 import {
   classifyChatAttachment,
   contentTypeForBodyPreviewKind,
@@ -107,12 +108,14 @@ import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
+import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
-  lightboxUrl$ as attachmentLightboxUrl$,
-  openDocumentLightbox$ as openAttachmentDocumentLightbox$,
-  openImageLightbox$ as openAttachmentImageLightbox$,
-  openVideoLightbox$ as openAttachmentVideoLightbox$,
-} from "../../signals/zero-page/zero-attachment-chips.ts";
+  chatArtifactSidebarEnabled$,
+  currentArtifactRef$,
+  openDocumentLightboxOrArtifact$ as openAttachmentDocumentLightbox$,
+  openImageLightboxOrArtifact$ as openAttachmentImageLightbox$,
+  openVideoLightboxOrArtifact$ as openAttachmentVideoLightbox$,
+} from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import {
   writeToClipboard,
   type ChatClipboardAttachment,
@@ -1667,6 +1670,9 @@ export function ZeroChatThreadPage() {
   const rightThread = useGet(currentRightThread$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
   const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
+  const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
+  const artifactRef = useGet(currentArtifactRef$);
+  const artifactSidebarOpen = sidebarEnabled && artifactRef !== null;
   // Lifted from ChatThread so the keyboard handler's sidebarChatThreads$
   // snapshot survives keyed ChatThread remounts during thread navigation.
   // Otherwise a second mod+shift+arrow press lands on a freshly mounted
@@ -1674,32 +1680,49 @@ export function ZeroChatThreadPage() {
   // empty threads list and a silently dropped keypress.
   const makeChatThreadKeyDown = useChatThreadKeyDownFactory();
 
+  const threadArea = (
+    <div
+      ref={setKeyboardScrollRoot}
+      className="flex flex-1 min-h-0 bg-transparent"
+    >
+      {leftThread && (
+        <ChatThread
+          key={leftThread.threadId}
+          thread={leftThread}
+          onKeyDown={makeChatThreadKeyDown(leftThread)}
+        />
+      )}
+      {rightThread && (
+        <>
+          <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
+          <ChatThread
+            key={rightThread.threadId}
+            thread={rightThread}
+            onKeyDown={makeChatThreadKeyDown(rightThread)}
+          />
+        </>
+      )}
+    </div>
+  );
+
   return (
     <>
-      <div
-        ref={setKeyboardScrollRoot}
-        className="flex flex-1 min-h-0 bg-transparent"
-      >
-        {leftThread && (
-          <ChatThread
-            key={leftThread.threadId}
-            thread={leftThread}
-            onKeyDown={makeChatThreadKeyDown(leftThread)}
-          />
-        )}
-        {rightThread && (
-          <>
-            <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
-            <ChatThread
-              key={rightThread.threadId}
-              thread={rightThread}
-              onKeyDown={makeChatThreadKeyDown(rightThread)}
-            />
-          </>
-        )}
-      </div>
-      {leftThread && <ChatArtifactsDrawer thread={leftThread} />}
-      {rightThread && (
+      {artifactSidebarOpen ? (
+        <div className="flex flex-1 min-h-0 bg-transparent">
+          <div className="flex flex-1 basis-0 min-w-0 min-h-0">
+            {threadArea}
+          </div>
+          <div className="flex flex-1 basis-0 min-w-0 min-h-0">
+            <ArtifactSidebarSlot />
+          </div>
+        </div>
+      ) : (
+        threadArea
+      )}
+      {!sidebarEnabled && leftThread && (
+        <ChatArtifactsDrawer thread={leftThread} />
+      )}
+      {!sidebarEnabled && rightThread && (
         <ChatArtifactsDrawer key={rightThread.threadId} thread={rightThread} />
       )}
       {lightboxUrl && <AttachmentLightbox />}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1707,18 +1707,29 @@ export function ZeroChatThreadPage() {
 
   return (
     <>
-      {artifactSidebarOpen ? (
-        <div className="flex flex-1 min-h-0 bg-transparent">
-          <div className="flex flex-1 basis-0 min-w-0 min-h-0">
-            {threadArea}
-          </div>
+      {/* Keep the wrapper structure stable across artifact open/close so the
+          thread area's React subtree (and its scroll/keyboard state) never
+          unmounts when the sidebar appears. Only the wrapper className and
+          the optional sidebar sibling change with state. Below xl: the
+          thread half hides so the sidebar fills the pane (no toggle, the
+          50/50 split needs each half ~640px to clear the composer's sm:
+          breakpoint, below which the model picker collapses to icons). */}
+      <div className="flex flex-1 min-h-0 bg-transparent">
+        <div
+          className={
+            artifactSidebarOpen
+              ? "hidden xl:flex flex-1 basis-0 min-w-0 min-h-0"
+              : "flex flex-1 min-w-0 min-h-0"
+          }
+        >
+          {threadArea}
+        </div>
+        {artifactSidebarOpen && (
           <div className="flex flex-1 basis-0 min-w-0 min-h-0">
             <ArtifactSidebarSlot />
           </div>
-        </div>
-      ) : (
-        threadArea
-      )}
+        )}
+      </div>
       {!sidebarEnabled && leftThread && (
         <ChatArtifactsDrawer thread={leftThread} />
       )}
@@ -2501,7 +2512,6 @@ function BodyContentBlocks({
               }
               mediaPreview
               mathEnabled
-              onImageClick={openLightbox}
             />
           );
         }

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -58,4 +58,5 @@ export enum FeatureSwitchKey {
   HostedSites = "hostedSites",
   SandboxIoLimiters = "sandboxIoLimiters",
   ZeroMaps = "zeroMaps",
+  ChatArtifactSidebar = "chatArtifactSidebar",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -322,6 +322,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatArtifactSidebar]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Replace the inline attachment text editor and modal lightbox with a single page-level artifact sidebar (50/50 with the chat thread area, URL-routed via ?artifact=, fullscreen-capable). When on, inline text/markdown attachments render as anchor chips, all preview chips route to the sidebar, and the artifacts drawer is hidden.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

Implements the redesign agreed in `deep-dive/issue-15027-inline-text-editor/innovate.md`: a single page-level artifact viewer pane on the right side of the chat-thread page (50/50 split), with the open artifact reference held in a `?artifact=` URL query parameter so the view is deep-linkable.

- Inline text/markdown attachment previews collapse to anchor chips (real `<a>`, so `cmd+click`, middle-click, and right-click → "copy link" all work natively).
- All preview chips (image, video, pdf, csv, html, markdown, text/json) route to the pane instead of the modal lightbox.
- Pane has a fullscreen toggle that expands it to fill the viewport.
- `ChatArtifactsDrawer` is suppressed on the new path.

All of the above is gated behind `FeatureSwitchKey.ChatArtifactSidebar` (staff-only during rollout). When the switch is off, today's behavior is preserved exactly: inline `TextPreview` `<pre>` body, `AttachmentLightbox` modal, `openDocumentLightbox$` / `openImageLightbox$` / `openVideoLightbox$` commands, and `ChatArtifactsDrawer` are all untouched.

Closes #15027

## What the bug becomes (under switch ON)

1. **Double vertical scrollbar** → gone (chip has no body; pane has a single scroll container per renderer).
2. **Height is not adjustable** → pane fills its slot; fullscreen toggle expands it further.
3. **Markdown is not rendered** → both the inline preview (anchor chip) and the pane render via the existing `Markdown` component.
4. **Download button is not a proper link** → chip is a real `<a href="…">`; pane header carries copy-link, download, fullscreen, and close affordances.

## Files

- New: `signals/zero-page/zero-artifact-sidebar.ts` — `?artifact=` URL signal, open/close commands, switch-aware variants of the existing `openImageLightbox$` / `openVideoLightbox$` / `openDocumentLightbox$` commands.
- New: `views/zero-page/zero-artifact-sidebar.tsx` — the pane shell plus kind-specific renderers (markdown / text / json / csv / image / video / audio / pdf / html / file).
- New: `views/zero-page/__tests__/zero-artifact-sidebar.test.tsx` — integration tests for the ON path (anchor chip rendering, click → URL write, cmd+click bypass, slot rendering, fullscreen toggle).
- Modified: `views/zero-page/zero-attachment-preview.tsx` — `TextPreview` returns the anchor chip on the ON path; `DocumentThumbnailPreview` returns an anchor chip for markdown on the ON path; chip click sites use the switch-aware open commands.
- Modified: `views/zero-page/zero-chat-thread-page.tsx` — layout wraps thread area + sidebar slot in a 50/50 row when the switch is on and an artifact is open; `ChatArtifactsDrawer` is suppressed on the ON path.
- Modified: `views/zero-page/zero-attachment-chips.tsx` — export `copyAttachmentLinkToClipboard` for the new pane header.
- Modified: `packages/connectors/src/feature-switch-key.ts`, `packages/core/src/feature-switch.ts` — register `ChatArtifactSidebar` switch (staff-only).

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run` for `zero-attachment-preview.test.tsx` (37 tests, OFF-path regression) and the new `zero-artifact-sidebar.test.tsx` (8 tests, ON-path coverage) — all pass.
- [x] `pnpm -F @vm0/app run lint` clean.
- [x] `pnpm -F @vm0/app run check-types` clean.
- [x] `pnpm -F @vm0/core run check-types` and `pnpm -F @vm0/connectors run check-types` clean.
- [ ] Visual smoke test on staging with the switch on (open chat with `.txt` / `.md` / image / pdf attachments; verify chip → pane → fullscreen → close → URL clears).
- [ ] Visual smoke test with the switch off — verify lightbox + drawer + inline `<pre>` body all behave as before.

## Risks / follow-ups

- **Three-pane layout** (dual-thread + sidebar): each thread sits at ~25% viewport width when the pane is open. Chat-thread internals (composer, bubbles, sticky headers) need eyeballing at that width; flagged in the innovate doc.
- **Same param, two reference forms**: encoding supports `image:<id>` token alongside raw-URL form, but no writer emits the `image:<id>` form yet — wired so it can be added without further schema changes.
- **Parallel OFF path**: every new attachment kind has to participate in both code paths until the switch is fully rolled out and the old `TextPreview` body + `AttachmentLightbox` + `ChatArtifactsDrawer` are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)