### PR TITLE
test: temporarily disable dynamic firewall e2e

### DIFF
--- a/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
+++ b/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
@@ -12,6 +12,8 @@
 load '../../helpers/setup'
 
 setup_file() {
+    skip "Temporarily disabled pending firewall dynamic base URL E2E stabilization"
+
     if [[ -z "$VM0_API_URL" ]]; then
         echo "VM0_API_URL not set" >&2
         return 1


### PR DESCRIPTION
## Summary
- Temporarily skip the dynamic firewall base URL E2E file in setup_file before it creates any CLI resources.

## Testing
- `git diff --check`
- Not run: `bats e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats` (`bats` is not installed in this environment).
