### PR TITLE
fix desktop local computer use readiness

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1052,6 +1052,13 @@ func backgroundTargetUnavailableMessage(appName: String) -> String {
     return "Unable to resolve a background window target for \(appName)"
 }
 
+func windowTargetUnavailableFailure(appName: String) -> HelperFailure {
+    return HelperFailure(
+        code: "window_unavailable",
+        message: backgroundTargetUnavailableMessage(appName: appName)
+    )
+}
+
 func roundScreenCoordinate(_ value: CGFloat) -> Double {
     return (Double(value) * 100).rounded() / 100
 }
@@ -1111,10 +1118,7 @@ func snapshotWindowTarget(
     }
 
     guard let target = resolveWindowTarget(app: app, preferredScreenPoint: preferredScreenPoint) else {
-        throw HelperFailure(
-            code: "accessibility_unavailable",
-            message: backgroundTargetUnavailableMessage(appName: appName)
-        )
+        throw windowTargetUnavailableFailure(appName: appName)
     }
     return target
 }
@@ -1126,28 +1130,10 @@ func performWithRequiredBackgroundTarget<T>(
 ) throws -> T {
     let app = try resolveRunningApp(named: appName)
     guard let target = resolveWindowTarget(app: app, preferredScreenPoint: preferredScreenPoint) else {
-        throw HelperFailure(
-            code: "accessibility_unavailable",
-            message: backgroundTargetUnavailableMessage(appName: appName)
-        )
+        throw windowTargetUnavailableFailure(appName: appName)
     }
 
     return try action(target)
-}
-
-func applicationURL(named appName: String) -> URL? {
-    if appName.hasPrefix("/") || appName.hasPrefix("~") {
-        let expanded = (appName as NSString).expandingTildeInPath
-        if FileManager.default.fileExists(atPath: expanded) {
-            return URL(fileURLWithPath: expanded)
-        }
-    }
-    if appName.contains("."),
-       let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appName)
-    {
-        return url
-    }
-    return nil
 }
 
 func waitForRunningApp(named appName: String, timeout: TimeInterval = 5) -> NSRunningApplication? {
@@ -1159,6 +1145,111 @@ func waitForRunningApp(named appName: String, timeout: TimeInterval = 5) -> NSRu
         usleep(100_000)
     } while Date() < deadline
     return findRunningApp(named: appName)
+}
+
+func applicationSearchRoots() -> [URL] {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return [
+        URL(fileURLWithPath: "/Applications", isDirectory: true),
+        URL(fileURLWithPath: "/System/Applications", isDirectory: true),
+        URL(fileURLWithPath: "/System/Library/CoreServices/Applications", isDirectory: true),
+        home.appendingPathComponent("Applications", isDirectory: true),
+    ]
+}
+
+func discoveredApplicationURLs() -> [URL] {
+    var urls: [URL] = []
+    var seen = Set<String>()
+    for root in applicationSearchRoots() where FileManager.default.fileExists(atPath: root.path) {
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey, .isPackageKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            continue
+        }
+
+        for case let url as URL in enumerator {
+            guard url.pathExtension.localizedCaseInsensitiveCompare("app") == .orderedSame else {
+                continue
+            }
+            let path = url.standardizedFileURL.path
+            if seen.insert(path).inserted {
+                urls.append(url)
+            }
+            enumerator.skipDescendants()
+        }
+    }
+    return urls
+}
+
+func applicationNames(for url: URL) -> [String] {
+    let bundle = Bundle(url: url)
+    let values = [
+        bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
+        bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String,
+        url.deletingPathExtension().lastPathComponent,
+    ]
+    var names: [String] = []
+    for value in values {
+        guard let name = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !name.isEmpty,
+              !names.contains(name)
+        else {
+            continue
+        }
+        names.append(name)
+    }
+    return names
+}
+
+func applicationURL(named appName: String) -> URL? {
+    let trimmed = appName.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+        return nil
+    }
+    if trimmed.hasPrefix("/") || trimmed.hasPrefix("~") {
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        if FileManager.default.fileExists(atPath: expanded) {
+            return URL(fileURLWithPath: expanded)
+        }
+    }
+    if trimmed.contains("."),
+       let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: trimmed)
+    {
+        return url
+    }
+
+    let candidates = discoveredApplicationURLs()
+    if let exactBundleID = candidates.first(where: { url in
+        Bundle(url: url)?.bundleIdentifier?.localizedCaseInsensitiveCompare(trimmed) == .orderedSame
+    }) {
+        return exactBundleID
+    }
+    if let exactName = candidates.first(where: { url in
+        applicationNames(for: url).contains { name in
+            name.localizedCaseInsensitiveCompare(trimmed) == .orderedSame
+        }
+    }) {
+        return exactName
+    }
+    return candidates.first { url in
+        applicationNames(for: url).contains { name in
+            name.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+}
+
+func applicationURL(for app: NSRunningApplication, fallbackName: String) -> URL? {
+    if let bundleURL = app.bundleURL {
+        return bundleURL
+    }
+    if let bundleIdentifier = app.bundleIdentifier,
+       let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+    {
+        return url
+    }
+    return applicationURL(named: fallbackName)
 }
 
 func openWithCommandInBackground(named appName: String) throws {
@@ -1189,14 +1280,9 @@ func openWithCommandInBackground(named appName: String) throws {
     }
 }
 
-func openApplicationWithoutActivation(named appName: String) throws -> NSRunningApplication? {
-    guard let url = applicationURL(named: appName) else {
-        try openWithCommandInBackground(named: appName)
-        return nil
-    }
-
+func openApplication(at url: URL, named appName: String, activates: Bool) throws -> NSRunningApplication? {
     let configuration = NSWorkspace.OpenConfiguration()
-    configuration.activates = false
+    configuration.activates = activates
     let semaphore = DispatchSemaphore(value: 0)
     let launchResult = LaunchResultBox()
     NSWorkspace.shared.openApplication(at: url, configuration: configuration) { app, error in
@@ -1212,6 +1298,15 @@ func openApplicationWithoutActivation(named appName: String) throws -> NSRunning
         )
     }
     return launchResult.app
+}
+
+func openApplicationWithoutActivation(named appName: String) throws -> NSRunningApplication? {
+    guard let url = applicationURL(named: appName) else {
+        try openWithCommandInBackground(named: appName)
+        return nil
+    }
+
+    return try openApplication(at: url, named: appName, activates: false)
 }
 
 @discardableResult
@@ -1720,6 +1815,11 @@ func handlePermissionsRequestAccessibility() -> [String: Any] {
     return computerUsePermissionState()
 }
 
+func handlePermissionsRequestScreenRecording() -> [String: Any] {
+    _ = CGRequestScreenCaptureAccess()
+    return computerUsePermissionState()
+}
+
 func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let snapshotId = optionalString(request, "snapshotId") ?? UUID().uuidString.lowercased()
@@ -1788,10 +1888,7 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
         response["windowTitle"] = windowTitle
     }
     guard let target = resolveWindowTarget(app: runningApp, root: root) else {
-        throw HelperFailure(
-            code: "accessibility_unavailable",
-            message: backgroundTargetUnavailableMessage(appName: appName)
-        )
+        throw windowTargetUnavailableFailure(appName: appName)
     }
     let screenshot = try BackgroundWindowScreenshot.capture(windowNumber: target.windowNumber)
     let sourceName = target.title ??
@@ -1819,16 +1916,44 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
         dispatchTarget: "target_app",
         inputRisk: "background_app_launch"
     ) {
-        if let runningApp = findRunningApp(named: appName) {
-            return (targetPID: runningApp.processIdentifier, result: [:])
+        let runningApp = findRunningApp(named: appName)
+        if let runningApp, resolveWindowTarget(app: runningApp) != nil {
+            return (targetPID: runningApp.processIdentifier, result: ["windowReady": true])
         }
 
-        let launchedApp = try openApplicationWithoutActivation(named: appName) ??
-            waitForRunningApp(named: appName)
-        guard let launchedApp else {
+        let appURL = runningApp.flatMap { app in
+            applicationURL(for: app, fallbackName: appName)
+        } ?? applicationURL(named: appName)
+
+        var targetApp: NSRunningApplication?
+        if let appURL {
+            targetApp = try openApplication(at: appURL, named: appName, activates: false) ??
+                runningApp ??
+                waitForRunningApp(named: appName)
+        } else {
+            try openWithCommandInBackground(named: appName)
+            targetApp = runningApp ?? waitForRunningApp(named: appName)
+        }
+
+        guard let launchedApp = targetApp else {
             throw HelperFailure(code: "app_open_failed", message: "Unable to find launched app: \(appName)")
         }
-        return (targetPID: launchedApp.processIdentifier, result: [:])
+
+        if waitForWindowTarget(app: launchedApp, timeout: 2) == nil {
+            if let appURL {
+                targetApp = try openApplication(at: appURL, named: appName, activates: true) ?? launchedApp
+            } else {
+                _ = launchedApp.activate(options: [.activateIgnoringOtherApps])
+            }
+        }
+
+        guard let appWithWindow = targetApp,
+              waitForWindowTarget(app: appWithWindow, timeout: 3) != nil
+        else {
+            throw windowTargetUnavailableFailure(appName: appName)
+        }
+
+        return (targetPID: appWithWindow.processIdentifier, result: ["windowReady": true])
     }
 }
 
@@ -2208,6 +2333,8 @@ func handle(_ request: [String: Any], session: ComputerUseRuntimeSession?) throw
         return handlePermissionsState()
     case "permissions.request_accessibility":
         return handlePermissionsRequestAccessibility()
+    case "permissions.request_screen_recording":
+        return handlePermissionsRequestScreenRecording()
     case "apps.list":
         return handleAppsList()
     case "app.state":

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -144,6 +144,7 @@ export interface ComputerUseCommandFailure {
     readonly code:
       | "permission_denied"
       | "accessibility_unavailable"
+      | "window_unavailable"
       | "screen_recording_unavailable"
       | "app_not_found"
       | "app_open_failed"

--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -10,8 +10,10 @@ interface ComputerUseIpcOptions {
 
 interface ComputerUseNativeApi {
   readonly getState: () => DesktopComputerUseState;
+  readonly refreshPermissions: () => Promise<DesktopComputerUseState>;
   readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
+  readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
 }
 
 export function notifyDesktopComputerUseChanged(): void {
@@ -41,6 +43,10 @@ export function installComputerUseIpc(
     assertComputerUsePage(event);
     return api.getState();
   });
+  ipcMain.handle(COMPUTER_USE_CHANNELS.refreshPermissions, (event) => {
+    assertComputerUsePage(event);
+    return api.refreshPermissions();
+  });
   ipcMain.handle(COMPUTER_USE_CHANNELS.start, async (event) => {
     assertComputerUsePage(event);
     return api.start();
@@ -50,6 +56,13 @@ export function installComputerUseIpc(
     (event) => {
       assertComputerUsePage(event);
       return api.requestAccessibilityPermission();
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.requestScreenRecordingPermission,
+    (event) => {
+      assertComputerUsePage(event);
+      return api.requestScreenRecordingPermission();
     },
   );
   ipcMain.handle(

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -1,7 +1,9 @@
 export const COMPUTER_USE_CHANNELS = {
   getState: "computer-use:get-state",
+  refreshPermissions: "computer-use:refresh-permissions",
   start: "computer-use:start",
   requestAccessibilityPermission: "computer-use:request-accessibility",
+  requestScreenRecordingPermission: "computer-use:request-screen-recording",
   openAccessibilitySettings: "computer-use:open-accessibility-settings",
   openScreenRecordingSettings: "computer-use:open-screen-recording-settings",
   changed: "computer-use:changed",

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -49,6 +49,17 @@ const requestLogPath = ${JSON.stringify(requestLogPath)};
 let buffer = "";
 
 function responseFor(request) {
+  if (
+    request.kind === "permissions.state" ||
+    request.kind === "permissions.request_accessibility" ||
+    request.kind === "permissions.request_screen_recording"
+  ) {
+    return {
+      id: request.id,
+      status: "succeeded",
+      result: { accessibility: true, screenRecording: true }
+    };
+  }
   if (request.kind === "app.state") {
     return {
       id: request.id,
@@ -169,6 +180,36 @@ describe("computer use native backend", () => {
     }
   });
 
+  it("requests screen recording permission through the native helper", async () => {
+    const helper = await createSessionHelper();
+    const backend = createComputerUseNativeBackend({
+      helperPath: helper.helperPath,
+    });
+
+    try {
+      await expect(backend.requestScreenRecordingPermission()).resolves.toEqual(
+        {
+          accessibility: true,
+          screenRecording: true,
+        },
+      );
+
+      const requests = (await readFile(helper.requestLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          return JSON.parse(line) as Record<string, unknown>;
+        });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        kind: "permissions.request_screen_recording",
+      });
+    } finally {
+      backend.dispose();
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
   it("reads coordinate click screen points from the native helper", async () => {
     const helper = await createHelper({
       status: "succeeded",
@@ -271,6 +312,7 @@ describe("computer use native backend", () => {
   it.each([
     ["app_not_found", "Unable to open Things: Unable to find application"],
     ["app_open_failed", "Unable to open Things"],
+    ["window_unavailable", "Unable to resolve a background window target"],
   ])("preserves %s helper failures", async (code, message) => {
     const helper = await createHelper({
       status: "failed",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -48,6 +48,7 @@ export interface ComputerUseNativeBackend {
   readonly dispose: () => void;
   readonly getPermissions: () => Promise<ComputerUsePermissionState>;
   readonly requestAccessibilityPermission: () => Promise<ComputerUsePermissionState>;
+  readonly requestScreenRecordingPermission: () => Promise<ComputerUsePermissionState>;
   readonly listApps: () => Promise<readonly string[]>;
   readonly getAppState: (
     app: string,
@@ -147,6 +148,7 @@ function responseErrorCode(value: unknown): ComputerUseNativeErrorCode {
   if (
     value === "permission_denied" ||
     value === "accessibility_unavailable" ||
+    value === "window_unavailable" ||
     value === "screen_recording_unavailable" ||
     value === "app_not_found" ||
     value === "app_open_failed" ||
@@ -561,6 +563,12 @@ export function createComputerUseNativeBackend(
     },
     requestAccessibilityPermission: async () => {
       const result = await run({ kind: "permissions.request_accessibility" });
+      return resultPermissions(result);
+    },
+    requestScreenRecordingPermission: async () => {
+      const result = await run({
+        kind: "permissions.request_screen_recording",
+      });
       return resultPermissions(result);
     },
     listApps: async () => {

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -38,3 +38,9 @@ export async function requestComputerUseAccessibilityPermission(): Promise<Compu
     await getNativeBackend().requestAccessibilityPermission();
   return currentPermissionState;
 }
+
+export async function requestComputerUseScreenRecordingPermission(): Promise<ComputerUsePermissionState> {
+  currentPermissionState =
+    await getNativeBackend().requestScreenRecordingPermission();
+  return currentPermissionState;
+}

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -35,8 +35,10 @@ export interface DesktopAuthApi {
 
 export interface DesktopComputerUseApi {
   readonly getState: () => Promise<DesktopComputerUseState>;
+  readonly refreshPermissions: () => Promise<DesktopComputerUseState>;
   readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
+  readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
   readonly openAccessibilitySettings: () => Promise<void>;
   readonly openScreenRecordingSettings: () => Promise<void>;
   readonly subscribe: (callback: () => void) => () => void;

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -32,11 +32,13 @@ import {
   getComputerUsePermissionState,
   refreshComputerUsePermissionState,
   requestComputerUseAccessibilityPermission,
+  requestComputerUseScreenRecordingPermission,
   setComputerUsePermissionNativeBackend,
 } from "./computer-use-permissions";
 import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
+import { headersWithSessionCookies } from "./desktop-session-cookies";
 import {
   installDesktopAuthIpc,
   notifyDesktopAuthChanged,
@@ -165,16 +167,21 @@ function signedOutDesktopAuthState(): DesktopAuthState {
   };
 }
 
-async function getDesktopAuthState(): Promise<DesktopAuthState> {
-  if (!desktopAuthToken) {
-    return signedOutDesktopAuthState();
+async function desktopAuthHeadersFor(requestUrl: URL): Promise<Headers> {
+  const headers = await headersWithSessionCookies(
+    session.fromPartition(config.sessionPartition),
+    [config.webUrl, config.platformUrl, requestUrl],
+  );
+  if (desktopAuthToken) {
+    headers.set("authorization", `Bearer ${desktopAuthToken}`);
   }
+  return headers;
+}
 
-  const authHeaders = {
-    authorization: `Bearer ${desktopAuthToken}`,
-  };
-  const meResponse = await fetch(`${desktopApiBaseUrl}${AUTH_ME_PATH}`, {
-    headers: authHeaders,
+async function getDesktopAuthState(): Promise<DesktopAuthState> {
+  const meUrl = new URL(AUTH_ME_PATH, desktopApiBaseUrl);
+  const meResponse = await fetch(meUrl, {
+    headers: await desktopAuthHeadersFor(meUrl),
   });
   if (meResponse.status === 401) {
     desktopAuthToken = null;
@@ -185,8 +192,9 @@ async function getDesktopAuthState(): Promise<DesktopAuthState> {
   }
 
   const user = (await meResponse.json()) as AuthMeResponse;
-  const orgResponse = await fetch(`${desktopApiBaseUrl}${ZERO_ORG_PATH}`, {
-    headers: authHeaders,
+  const orgUrl = new URL(ZERO_ORG_PATH, desktopApiBaseUrl);
+  const orgResponse = await fetch(orgUrl, {
+    headers: await desktopAuthHeadersFor(orgUrl),
   });
   if (orgResponse.status === 401) {
     desktopAuthToken = null;
@@ -248,12 +256,26 @@ async function requestComputerUsePermission(): Promise<DesktopComputerUseState> 
   return getComputerUseBridgeState();
 }
 
+async function requestComputerUseScreenRecording(): Promise<DesktopComputerUseState> {
+  await requestComputerUseScreenRecordingPermission();
+  notifyDesktopComputerUseChanged();
+  return getComputerUseBridgeState();
+}
+
+async function refreshComputerUsePermissions(): Promise<DesktopComputerUseState> {
+  await refreshComputerUsePermissionState();
+  notifyDesktopComputerUseChanged();
+  return getComputerUseBridgeState();
+}
+
 function installComputerUse(): void {
   installComputerUseIpc(
     {
       getState: getComputerUseBridgeState,
+      refreshPermissions: refreshComputerUsePermissions,
       start: startComputerUseRuntime,
       requestAccessibilityPermission: requestComputerUsePermission,
+      requestScreenRecordingPermission: requestComputerUseScreenRecording,
     },
     { rendererUrl: localRendererUrl },
   );

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -32,12 +32,20 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
   getState(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.getState);
   },
+  refreshPermissions(): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.refreshPermissions);
+  },
   start(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.start);
   },
   requestAccessibilityPermission(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(
       COMPUTER_USE_CHANNELS.requestAccessibilityPermission,
+    );
+  },
+  requestScreenRecordingPermission(): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.requestScreenRecordingPermission,
     );
   },
   openAccessibilitySettings(): Promise<void> {

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -33,6 +33,7 @@ import {
   openScreenRecordingSettings$,
   refreshComputerUse$,
   requestAccessibilityPermission$,
+  requestScreenRecordingPermission$,
   setupComputerUseBridge$,
   startComputerUse$,
 } from "./computer-use-state";
@@ -322,6 +323,8 @@ function PermissionsPanel({
   const [requestLoadable, requestPermission] = useLoadableSet(
     requestAccessibilityPermission$,
   );
+  const [screenRecordingRequestLoadable, requestScreenRecording] =
+    useLoadableSet(requestScreenRecordingPermission$);
   const [, openAccessibility] = useLoadableSet(openAccessibilitySettings$);
   const [, openScreenRecording] = useLoadableSet(openScreenRecordingSettings$);
   const accessibilityGranted = state.permissions.accessibility;
@@ -380,14 +383,25 @@ function PermissionsPanel({
                 Ready
               </span>
             ) : (
-              <IconButton
-                icon={<IconExternalLink size={15} />}
-                onClick={() => {
-                  void openScreenRecording();
-                }}
-              >
-                Settings
-              </IconButton>
+              <>
+                <IconButton
+                  icon={<IconShieldCheck size={15} />}
+                  onClick={() => {
+                    void requestScreenRecording();
+                  }}
+                  disabled={screenRecordingRequestLoadable.state === "loading"}
+                >
+                  Request
+                </IconButton>
+                <IconButton
+                  icon={<IconExternalLink size={15} />}
+                  onClick={() => {
+                    void openScreenRecording();
+                  }}
+                >
+                  Settings
+                </IconButton>
+              </>
             )}
           </div>
         </div>

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -60,10 +60,15 @@ export const desktopAuthData$ = computed((get): Promise<DesktopAuthState> => {
   return desktopAuthApi().getState();
 });
 
-export const refreshComputerUse$ = command(({ set }) => {
+const reloadComputerUse$ = command(({ set }) => {
   set(reloadComputerUseState$, (count) => {
     return count + 1;
   });
+});
+
+export const refreshComputerUse$ = command(async ({ set }) => {
+  await desktopComputerUseApi().refreshPermissions();
+  set(reloadComputerUse$);
 });
 
 const refreshDesktopAuth$ = command(({ set }) => {
@@ -75,12 +80,12 @@ const refreshDesktopAuth$ = command(({ set }) => {
 export const setupComputerUseBridge$ = command(
   ({ set }, signal: AbortSignal) => {
     const unsubscribeComputerUse = desktopComputerUseApi().subscribe(() => {
-      set(refreshComputerUse$);
+      set(reloadComputerUse$);
     });
     const unsubscribeAuth = window.vm0DesktopAuth?.subscribe(() => {
       set(autoStartAttempted$, false);
       set(refreshDesktopAuth$);
-      set(refreshComputerUse$);
+      set(reloadComputerUse$);
     });
 
     signal.addEventListener(
@@ -98,7 +103,7 @@ export const setupComputerUseBridge$ = command(
 
 export const startComputerUse$ = command(async ({ set }) => {
   await desktopComputerUseApi().start();
-  set(refreshComputerUse$);
+  set(reloadComputerUse$);
 });
 
 export const maybeAutoStartComputerUse$ = command(
@@ -108,13 +113,18 @@ export const maybeAutoStartComputerUse$ = command(
     }
     set(autoStartAttempted$, true);
     await desktopComputerUseApi().start();
-    set(refreshComputerUse$);
+    set(reloadComputerUse$);
   },
 );
 
 export const requestAccessibilityPermission$ = command(async ({ set }) => {
   await desktopComputerUseApi().requestAccessibilityPermission();
-  set(refreshComputerUse$);
+  set(reloadComputerUse$);
+});
+
+export const requestScreenRecordingPermission$ = command(async ({ set }) => {
+  await desktopComputerUseApi().requestScreenRecordingPermission();
+  set(reloadComputerUse$);
 });
 
 export const openAccessibilitySettings$ = command(async () => {
@@ -133,5 +143,5 @@ export const openDesktopOrgSelection$ = command(async ({ set }) => {
   await desktopAuthApi().openOrgSelection();
   set(autoStartAttempted$, false);
   set(refreshDesktopAuth$);
-  set(refreshComputerUse$);
+  set(reloadComputerUse$);
 });

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -52,6 +52,9 @@ function createNativeBackend(
     requestAccessibilityPermission: async () => {
       return { accessibility: true, screenRecording: true };
     },
+    requestScreenRecordingPermission: async () => {
+      return { accessibility: true, screenRecording: true };
+    },
     listApps: async () => [],
     getAppState: async (app, snapshotId) => {
       return { app, snapshotId, elements: [] };

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../zero-computer-use";
 
 describe("computer-use contract", () => {
-  it.each(["app_not_found", "app_open_failed"])(
+  it.each(["app_not_found", "app_open_failed", "window_unavailable"])(
     "accepts %s command failures",
     (code) => {
       expect(computerUseCommandErrorCodeSchema.parse(code)).toBe(code);

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -38,6 +38,7 @@ export const computerUseCommandErrorCodeSchema = z.enum([
   "no_host",
   "permission_denied",
   "accessibility_unavailable",
+  "window_unavailable",
   "screen_recording_unavailable",
   "app_not_found",
   "app_open_failed",


### PR DESCRIPTION
## Summary
- harden Desktop's local computer-use runtime so `app.open` can recover a running macOS app with no readable windows
- add native app resolution by bundle id, app name, and app path, plus a `window_unavailable` failure code for unresolved windows
- expose screen-recording permission request through native helper / Electron IPC / renderer UI and refresh persisted auth headers from Electron session cookies

Replaces #15006, which was closed because required GitHub checks never materialized on that PR.

## Validation
- `swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/api-contracts check-types`
- `git diff --check origin/main...HEAD`
- `node apps/desktop/dist/vm0-computer.js open-app --app Things` with Things running and 0 windows: returned `windowReady: true`
- `node apps/desktop/dist/vm0-computer.js get-app-state --app Things`: succeeded with window screenshot and AX tree
