### PR TITLE
fix: ignore unbound GitHub app webhooks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -1845,7 +1845,7 @@ describe("POST /api/webhooks/github", () => {
     expect(runs).toHaveLength(0);
   });
 
-  it("acknowledges dispatch failures such as missing installations", async () => {
+  it("ignores label triggers for unbound GitHub installations", async () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
@@ -1856,6 +1856,28 @@ describe("POST /api/webhooks/github", () => {
       payload: buildGitHubIssuesPayload(fixture, {
         action: "opened",
         installationId: remoteGitHubId(),
+      }),
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+
+    const runs = await selectGitHubRuns(fixture);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("ignores bot mentions for unbound GitHub installations", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockGitHubWebhookEnv();
+
+    const response = await postGitHubWebhook({
+      event: "issue_comment",
+      payload: buildGitHubIssueCommentPayload(fixture, {
+        installationId: remoteGitHubId(),
+        commentBody: `@${GITHUB_APP_SLUG}[bot] please help`,
       }),
     });
     await clearAllDetached();

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -825,6 +825,22 @@ async function loadActiveInstallation(args: {
   readonly ghInstallationId: string;
   readonly signal: AbortSignal;
 }): Promise<GitHubInstallationRecord> {
+  const installation = await findActiveInstallation(args);
+
+  if (!installation) {
+    throw new Error(
+      `GitHub installation not found: installationId=${args.ghInstallationId}`,
+    );
+  }
+
+  return installation;
+}
+
+async function findActiveInstallation(args: {
+  readonly db: Db;
+  readonly ghInstallationId: string;
+  readonly signal: AbortSignal;
+}): Promise<GitHubInstallationRecord | null> {
   const [installation] = await args.db
     .select()
     .from(githubInstallations)
@@ -837,13 +853,7 @@ async function loadActiveInstallation(args: {
     .limit(1);
   args.signal.throwIfAborted();
 
-  if (!installation) {
-    throw new Error(
-      `GitHub installation not found: installationId=${args.ghInstallationId}`,
-    );
-  }
-
-  return installation;
+  return installation ?? null;
 }
 
 async function maybeAddCommentReaction(args: {
@@ -1195,11 +1205,19 @@ const dispatchMatchingLabelListener$ = command(
 
     const labelNames = labelsForAction({ action, labels: issue.labels, label });
     const db = set(writeDb$);
-    const installationRecord = await loadActiveInstallation({
+    const installationRecord = await findActiveInstallation({
       db,
       ghInstallationId: String(installation.id),
       signal,
     });
+    if (!installationRecord) {
+      L.debug("Ignoring GitHub label trigger for unbound installation", {
+        action,
+        installationId: String(installation.id),
+        repo: repository.full_name,
+      });
+      return;
+    }
     const listener = await loadMatchingLabelListener({
       db,
       installationId: installationRecord.id,
@@ -1337,11 +1355,20 @@ export const handleGithubIssueCommentEvent$ = command(
     }
 
     const db = set(writeDb$);
-    const installation = await loadActiveInstallation({
+    const installation = await findActiveInstallation({
       db,
       ghInstallationId: String(payload.installation.id),
       signal,
     });
+    if (!installation) {
+      L.debug("Ignoring GitHub issue_comment for unbound installation", {
+        action: payload.action,
+        installationId: String(payload.installation.id),
+        repo: payload.repository.full_name,
+        commentId: payload.comment.id,
+      });
+      return;
+    }
     const token = await getGitHubTokenForInstallation({ installation, signal });
     signal.throwIfAborted();
 


### PR DESCRIPTION
## Summary
- Treat GitHub App webhooks for installations that are not bound in vm0 as ignored events instead of background errors
- Keep the existing strict `loadActiveInstallation` path for accepted internal dispatches
- Add webhook tests for unbound label triggers and bot mentions

## Test plan
- [x] `pnpm exec prettier --write apps/api/src/signals/services/webhooks-github.service.ts apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts`
- [x] `NODE_OPTIONS=--max-old-space-size=6144 pnpm -F api check-types`
- [x] `pnpm -F api lint`
- [ ] `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-third-party.test.ts` — blocked locally: no Postgres listening on `127.0.0.1:5432` / `::1:5432`; tests fail before assertions with `ECONNREFUSED`

## Notes
This addresses the production Axiom noise where GitHub keeps sending `issues` / `pull_request` events for an installation id that exists on GitHub but has no active `github_installations` row in vm0.