### PR TITLE
refactor: centralize exec output chunk validation

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -210,6 +210,15 @@ pub struct DecodedExecResult<'a> {
     pub diagnostic: &'a str,
 }
 
+fn validate_exec_output_chunk_limit(chunk_limit_bytes: u32) -> Result<(), ProtocolError> {
+    if chunk_limit_bytes == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "exec output chunk limit must be non-zero",
+        ));
+    }
+    Ok(())
+}
+
 fn exec_output_policy_encoded_len(policy: ExecOutputPolicy) -> Result<usize, ProtocolError> {
     match policy {
         ExecOutputPolicy::Discard => Ok(1),
@@ -217,21 +226,13 @@ fn exec_output_policy_encoded_len(policy: ExecOutputPolicy) -> Result<usize, Pro
         ExecOutputPolicy::Stream {
             chunk_limit_bytes, ..
         } => {
-            if chunk_limit_bytes == 0 {
-                return Err(ProtocolError::InvalidPayload(
-                    "exec output chunk limit must be non-zero",
-                ));
-            }
+            validate_exec_output_chunk_limit(chunk_limit_bytes)?;
             Ok(9)
         }
         ExecOutputPolicy::CaptureAndStream {
             chunk_limit_bytes, ..
         } => {
-            if chunk_limit_bytes == 0 {
-                return Err(ProtocolError::InvalidPayload(
-                    "exec output chunk limit must be non-zero",
-                ));
-            }
+            validate_exec_output_chunk_limit(chunk_limit_bytes)?;
             Ok(13)
         }
     }
@@ -635,11 +636,7 @@ fn decode_exec_output_policy(
             let limit_bytes = read_u32(payload, offset, "exec stream policy limit truncated")?;
             let chunk_limit_bytes =
                 read_u32(payload, offset, "exec stream policy chunk limit truncated")?;
-            if chunk_limit_bytes == 0 {
-                return Err(ProtocolError::InvalidPayload(
-                    "exec output chunk limit must be non-zero",
-                ));
-            }
+            validate_exec_output_chunk_limit(chunk_limit_bytes)?;
             Ok(ExecOutputPolicy::Stream {
                 limit_bytes,
                 chunk_limit_bytes,
@@ -661,11 +658,7 @@ fn decode_exec_output_policy(
                 offset,
                 "exec capture-and-stream chunk limit truncated",
             )?;
-            if chunk_limit_bytes == 0 {
-                return Err(ProtocolError::InvalidPayload(
-                    "exec output chunk limit must be non-zero",
-                ));
-            }
+            validate_exec_output_chunk_limit(chunk_limit_bytes)?;
             Ok(ExecOutputPolicy::CaptureAndStream {
                 capture_limit_bytes,
                 stream_limit_bytes,

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -831,6 +831,46 @@ fn exec_start_rejects_zero_stream_chunk_limit() {
 }
 
 #[test]
+fn exec_start_rejects_zero_capture_and_stream_chunk_limit() {
+    let err = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 1,
+            stream_limit_bytes: 1,
+            chunk_limit_bytes: 0,
+        },
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap_err();
+    assert_invalid_payload(err, "exec output chunk limit must be non-zero");
+
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 1,
+            stream_limit_bytes: 1,
+            chunk_limit_bytes: 1,
+        },
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    let chunk_limit_offset =
+        ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 2 + 1 + 4 + 4;
+    payload[chunk_limit_offset..chunk_limit_offset + 4].copy_from_slice(&0u32.to_be_bytes());
+
+    let err = decode_exec_start(&payload).unwrap_err();
+    assert_invalid_payload(err, "exec output chunk limit must be non-zero");
+}
+
+#[test]
 fn exec_start_rejects_expected_exit_count_above_limit() {
     let expected_exit_codes = vec![0; MAX_EXEC_EXPECTED_EXIT_CODES + 1];
     let err = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {


### PR DESCRIPTION
## Summary

- Add a private helper for exec output chunk-limit validation in vsock-proto
- Reuse the helper from encode length calculation and decode paths
- Preserve the existing public ExecOutputPolicy shape, wire format, and error message

Closes #15043

## Tests

- cargo test -p vsock-proto exec_start_rejects_zero_stream_chunk_limit
- cargo test -p vsock-host exec_start_encode_error_does_not_register_or_send_frame
- cargo test -p vsock-host supervised_exec_rejects_invalid_output_policy_without_sending_frame
- cargo fmt --check
- git diff --check
- cargo test -p vsock-proto
- cargo test -p vsock-host
- cargo clippy --all-targets --all-features
- lefthook pre-commit via git commit: cargo-fmt, cargo-clippy, cargo-doc
