### PR TITLE
refactor: simplify vsock guest test helper setter

### DIFF
--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -215,11 +215,10 @@ fn guest_write_file_path() -> PathBuf {
 }
 
 #[cfg(any(debug_assertions, feature = "test-support"))]
-pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) -> Result<(), PathBuf> {
+pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) {
     *DEBUG_GUEST_WRITE_FILE_PATH
         .lock()
         .unwrap_or_else(|e| e.into_inner()) = Some(path);
-    Ok(())
 }
 
 pub(crate) fn decode_write_file_message(

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -27,8 +27,6 @@ pub use log::log;
 
 #[cfg(any(debug_assertions, feature = "test-support"))]
 #[doc(hidden)]
-pub fn set_debug_guest_write_file_path_for_tests(
-    path: std::path::PathBuf,
-) -> Result<(), std::path::PathBuf> {
-    handlers::set_debug_guest_write_file_path(path)
+pub fn set_debug_guest_write_file_path_for_tests(path: std::path::PathBuf) {
+    handlers::set_debug_guest_write_file_path(path);
 }

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -17,8 +17,7 @@ const WRITE_FILE_HELPER_BIN: &str = env!("CARGO_BIN_EXE_guest-write-file-test-he
 
 fn install_write_file_helper() {
     WRITE_FILE_HELPER.call_once(|| {
-        vsock_guest::set_debug_guest_write_file_path_for_tests(WRITE_FILE_HELPER_BIN.into())
-            .expect("set guest-write-file test helper path");
+        vsock_guest::set_debug_guest_write_file_path_for_tests(WRITE_FILE_HELPER_BIN.into());
     });
 }
 


### PR DESCRIPTION
Closes #15041.

## Summary
- change the debug/test-support write-file helper setter to return `()`
- update the public test-support wrapper to match
- remove dead `.expect()` handling from the vsock integration test setup

## Verification
- `cargo check --manifest-path crates/Cargo.toml -p vsock-guest --features test-support`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-test --tests`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test --test integration`
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc