### PR TITLE
refactor: remove sse usage parser wrapper

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -11,7 +11,7 @@ import body_utils
 
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
-from .sse import SseUsageParser
+from .sse import SseUsageScanner
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 _SseUsageParseErrorCallback = Callable[[str, str], None]
@@ -53,7 +53,7 @@ def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, 
 
 def create_anthropic_messages_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
-) -> tuple[SseUsageParser, dict]:
+) -> tuple[SseUsageScanner, dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
     Anthropic-shaped model providers use the Anthropic Messages API streaming
@@ -67,7 +67,7 @@ def create_anthropic_messages_sse_usage_extractor(
     incrementally and *usage* is a dict that accumulates extracted fields.
     """
     usage: dict = {}
-    parser = SseUsageParser(
+    parser = SseUsageScanner(
         _AnthropicMessagesSseUsageHandler(usage, on_parse_error=on_parse_error),
         capture_data_without_event=True,
     )

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -31,7 +31,7 @@ from .model_tokens import (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
-from .sse import SseUsageParser
+from .sse import SseUsageScanner
 
 # Terminal Responses events whose Response object may carry usage. Keep this
 # narrow so high-volume delta events stay on the SSE discard path.
@@ -187,11 +187,11 @@ def _store_sse_result_values(
 
 def create_openai_responses_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
-) -> tuple[SseUsageParser, dict]:
+) -> tuple[SseUsageScanner, dict]:
     """Create an incremental SSE parser for OpenAI Responses streams."""
 
     usage: dict = {}
-    parser = SseUsageParser(
+    parser = SseUsageScanner(
         _OpenAIResponsesSseUsageHandler(usage, on_parse_error=on_parse_error),
         capture_data_without_event=True,
     )

--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -66,6 +66,9 @@ class SseUsageScanner:
         self._capturing_event = False
         self._captured_data_lines = 0
 
+    def __call__(self, chunk: bytes) -> None:
+        self.feed(chunk)
+
     def feed(self, chunk: bytes) -> None:
         i = 0
         while i < len(chunk):
@@ -251,27 +254,3 @@ def _find_next_line_ending(chunk: bytes, start: int) -> int:
     if next_cr == -1:
         return next_lf
     return min(next_lf, next_cr)
-
-
-class SseUsageParser:
-    """Callable parser wrapper with an explicit stream-end flush hook."""
-
-    def __init__(
-        self,
-        handler: SseUsageEventHandler,
-        *,
-        capture_data_without_event: bool = False,
-    ) -> None:
-        self._scanner = SseUsageScanner(
-            handler,
-            capture_data_without_event=capture_data_without_event,
-        )
-
-    def __call__(self, chunk: bytes) -> None:
-        self.feed(chunk)
-
-    def feed(self, chunk: bytes) -> None:
-        self._scanner.feed(chunk)
-
-    def finish(self) -> None:
-        self._scanner.finish()

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -63,6 +63,17 @@ def test_finish_flushes_current_event_without_blank_line() -> None:
     assert handler.events == [("target", b"ok")]
 
 
+def test_callable_scanner_feeds_chunks_and_finish_flushes() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner(b"event: target\n")
+    scanner(b"data: ok")
+    scanner.finish()
+
+    assert handler.events == [("target", b"ok")]
+
+
 def test_supports_no_optional_space_and_split_crlf() -> None:
     handler = _CaptureHandler({"target"})
     scanner = SseUsageScanner(handler)


### PR DESCRIPTION
## Summary

- make `SseUsageScanner` directly callable so it can be used by response streaming without a wrapper
- remove the pass-through `SseUsageParser` class
- update Anthropic and OpenAI SSE factories to return scanners directly
- add scanner callable coverage with `finish()` flushing

## Tests

- `python3 -m pytest tests/test_sse.py -v`
- `python3 -m pytest tests/test_anthropic_messages.py tests/test_openai_responses_sse.py -v`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m basedpyright -p .`
- `python3 -m pytest tests/ -v`

Closes #15038