### PR TITLE
refactor: rename connector oauth client resolution

### DIFF
--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,9 +1,9 @@
 import {
   getConnectorOAuthGrantConfigIfSupported,
-  getConnectorOAuthCredentials,
+  getConnectorOAuthClient,
   isOAuthAuthCodeConnectorType,
   type ConnectorEnvReader,
-  type ConnectorOAuthCredentials,
+  type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorType,
@@ -17,17 +17,12 @@ import {
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
 
-type ConfiguredConnectorOAuthCredentials = Extract<
-  ConnectorOAuthCredentials,
-  { readonly configured: true }
->;
-
 type PrepareResolvedConnectorOAuthStartResult =
   | {
       readonly ok: true;
       readonly state: string;
       readonly redirectUri: string;
-      readonly credentials: ConfiguredConnectorOAuthCredentials;
+      readonly oauthClient: ConnectorOAuthClient;
     }
   | {
       readonly ok: false;
@@ -76,8 +71,8 @@ export function prepareResolvedConnectorOAuthStart(args: {
 }): PrepareResolvedConnectorOAuthStartResult {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
-  const credentials = getConnectorOAuthCredentials(args.type, args.readEnv);
-  if (!credentials?.configured) {
+  const oauthClient = getConnectorOAuthClient(args.type, args.readEnv);
+  if (!oauthClient) {
     return { ok: false, reason: "oauth_not_configured" };
   }
 
@@ -85,20 +80,20 @@ export function prepareResolvedConnectorOAuthStart(args: {
     ok: true,
     state,
     redirectUri,
-    credentials,
+    oauthClient,
   };
 }
 
 export async function buildResolvedConnectorOAuthAuthResult(args: {
   readonly type: OAuthAuthCodeConnectorType;
-  readonly credentials: ConfiguredConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<AuthUrlResult> {
   return normalizeAuthUrlResult(
     await buildConnectorOAuthAuthUrl({
       type: args.type,
-      credentials: args.credentials,
+      oauthClient: args.oauthClient,
       redirectUri: args.redirectUri,
       state: args.state,
     }),

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -4,7 +4,7 @@ import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
   isOAuthAuthCodeConnectorType,
-  getConnectorOAuthCredentials,
+  getConnectorOAuthClient,
   getConnectorOAuthScopes,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -178,17 +178,14 @@ async function exchangeTokenForConnector(args: {
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  const credentials = getConnectorOAuthCredentials(
-    args.connectorType,
-    optionalEnv,
-  );
-  if (!credentials?.configured) {
+  const oauthClient = getConnectorOAuthClient(args.connectorType, optionalEnv);
+  if (!oauthClient) {
     throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
   return await exchangeConnectorOAuthCode({
     type: args.connectorType,
-    credentials,
+    oauthClient,
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -5,10 +5,10 @@ import {
 } from "@vm0/api-contracts/contracts/github-oauth";
 import type { OAuthAuthCodeConnectorType } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthCredentials,
+  getConnectorOAuthClient,
   getConnectorOAuthScopes,
-  isStaticConfidentialConnectorOAuthCredentials,
-  type StaticConfidentialConnectorOAuthCredentials,
+  isStaticConfidentialConnectorOAuthClient,
+  type StaticConfidentialConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import { exchangeConnectorOAuthCode } from "@vm0/connectors/auth-providers";
 import {
@@ -85,17 +85,17 @@ function githubAppSetupCallbackRedirectUri(origin: string): string {
   return `${origin}${GITHUB_APP_SETUP_CALLBACK_PATH}`;
 }
 
-function githubUserOauthCredentials():
-  | StaticConfidentialConnectorOAuthCredentials
+function githubUserOauthClient():
+  | StaticConfidentialConnectorOAuthClient
   | undefined {
-  const credentials = getConnectorOAuthCredentials("github", optionalEnv);
-  if (!credentials?.configured) {
+  const oauthClient = getConnectorOAuthClient("github", optionalEnv);
+  if (!oauthClient) {
     return undefined;
   }
-  if (!isStaticConfidentialConnectorOAuthCredentials(credentials)) {
+  if (!isStaticConfidentialConnectorOAuthClient(oauthClient)) {
     return undefined;
   }
-  return credentials;
+  return oauthClient;
 }
 
 function githubAppUserOauthCredentials():
@@ -726,8 +726,8 @@ const callbackGithubUserOauth$ = command(
       );
     }
 
-    const credentials = githubUserOauthCredentials();
-    if (!credentials) {
+    const oauthClient = githubUserOauthClient();
+    if (!oauthClient) {
       return worksErrorRedirect("GitHub OAuth is not configured");
     }
 
@@ -735,7 +735,7 @@ const callbackGithubUserOauth$ = command(
     const redirectUri = githubUserConnectCallbackRedirectUri(origin);
     const token = await exchangeConnectorOAuthCode({
       type: "github",
-      credentials,
+      oauthClient,
       code: query.code,
       redirectUri,
       state: query.state,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -427,7 +427,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     }
     const authResult = await buildResolvedConnectorOAuthAuthResult({
       type: startType.type,
-      credentials: prepared.credentials,
+      oauthClient: prepared.oauthClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
     });
@@ -497,7 +497,7 @@ const startConnectorOauthInner$ = command(
     }
     const authResult = await buildResolvedConnectorOAuthAuthResult({
       type: startType.type,
-      credentials: prepared.credentials,
+      oauthClient: prepared.oauthClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
     });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2,8 +2,8 @@ import { Buffer } from "node:buffer";
 
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
-  getConnectorOAuthCredentials,
-  type ConnectorOAuthCredentials,
+  getConnectorOAuthClient,
+  type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import type { OAuthConnectorType } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
@@ -169,7 +169,7 @@ type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
       readonly connectorType: OAuthConnectorType;
-      readonly credentials: ConnectorOAuthCredentials;
+      readonly oauthClient: ConnectorOAuthClient;
       readonly context: RefreshTokenContext;
     }
   | {
@@ -640,15 +640,12 @@ function prepareRefreshTokenContext(
   if (!secretMetadata.isRefreshable) {
     return null;
   }
-  const credentials = getConnectorOAuthCredentials(
-    args.connectorType,
-    (name) => {
-      return optionalEnv(name);
-    },
-  );
-  if (!credentials?.configured) {
+  const oauthClient = getConnectorOAuthClient(args.connectorType, (name) => {
+    return optionalEnv(name);
+  });
+  if (!oauthClient) {
     L.debug(
-      `${args.connectorType} OAuth credentials not configured, skipping token refresh`,
+      `${args.connectorType} OAuth client not configured, skipping token refresh`,
     );
     return null;
   }
@@ -674,7 +671,7 @@ function prepareRefreshTokenContext(
   return {
     sourceType: "connector",
     connectorType: args.connectorType,
-    credentials,
+    oauthClient,
     context,
   };
 }
@@ -795,7 +792,7 @@ async function refreshConnectorAccessToken(
     prepared.sourceType === "connector"
       ? refreshConnectorOAuthToken({
           type: prepared.connectorType,
-          credentials: prepared.credentials,
+          oauthClient: prepared.oauthClient,
           refreshToken: prepared.context.currentRefreshToken,
         })
       : refreshModelProviderOAuthToken({

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -11,8 +11,9 @@ import type {
 } from "@vm0/connectors/connectors";
 import {
   getConnectorOAuthGrantConfigIfSupported,
-  getConnectorOAuthCredentials,
+  getConnectorOAuthClient,
   isOAuthDeviceAuthConnectorType,
+  type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
@@ -55,11 +56,6 @@ const SUPERSEDED_SESSION_ERROR_CODE = "session_superseded";
 const SUPERSEDED_SESSION_ERROR_MESSAGE =
   "OAuth device authorization session was superseded";
 
-type ConfiguredConnectorOAuthCredentials = Extract<
-  NonNullable<ReturnType<typeof getConnectorOAuthCredentials>>,
-  { readonly configured: true }
->;
-
 type DeviceAuthSessionRow =
   typeof connectorOauthDeviceAuthorizationSessions.$inferSelect;
 
@@ -90,7 +86,7 @@ type PollClaimedSessionArgs = {
   readonly orgId: string;
   readonly userId: string;
   readonly type: OAuthDeviceAuthConnectorType;
-  readonly credentials: ConfiguredConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly signal: AbortSignal;
@@ -200,16 +196,14 @@ function resolveDeviceAuthType(
   return type;
 }
 
-function resolveConfiguredCredentials(
+function resolveRequiredOAuthClient(
   type: OAuthDeviceAuthConnectorType,
-):
-  | ConfiguredConnectorOAuthCredentials
-  | ReturnType<typeof internalServerError> {
-  const credentials = getConnectorOAuthCredentials(type, optionalEnv);
-  if (!credentials?.configured) {
+): ConnectorOAuthClient | ReturnType<typeof internalServerError> {
+  const oauthClient = getConnectorOAuthClient(type, optionalEnv);
+  if (!oauthClient) {
     return internalServerError(`${type} OAuth is not configured`);
   }
-  return credentials;
+  return oauthClient;
 }
 
 async function lockDeviceAuthSessionOwner(args: {
@@ -597,7 +591,7 @@ async function runClaimedSession(
   });
   const pollResult = await pollConnectorOAuthDeviceAuth({
     type: args.type,
-    credentials: args.credentials,
+    oauthClient: args.oauthClient,
     deviceCode: providerState.deviceCode,
   });
   args.signal.throwIfAborted();
@@ -699,14 +693,14 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const credentials = resolveConfiguredCredentials(resolvedType);
-    if ("status" in credentials) {
-      return credentials;
+    const oauthClient = resolveRequiredOAuthClient(resolvedType);
+    if ("status" in oauthClient) {
+      return oauthClient;
     }
 
     const startResult = await startConnectorOAuthDeviceAuth({
       type: resolvedType,
-      credentials,
+      oauthClient,
     });
     signal.throwIfAborted();
 
@@ -809,9 +803,9 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const credentials = resolveConfiguredCredentials(resolvedType);
-    if ("status" in credentials) {
-      return credentials;
+    const oauthClient = resolveRequiredOAuthClient(resolvedType);
+    if ("status" in oauthClient) {
+      return oauthClient;
     }
 
     const writeDb = set(writeDb$);
@@ -881,7 +875,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       orgId: args.orgId,
       userId: args.userId,
       type: resolvedType,
-      credentials,
+      oauthClient,
       session: claimedSession,
       claimStartedAt,
       signal,

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -12,8 +12,8 @@ import {
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 import {
-  getConnectorOAuthCredentials,
-  isStaticConfidentialConnectorOAuthCredentials,
+  getConnectorOAuthClient,
+  isStaticConfidentialConnectorOAuthClient,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
@@ -370,11 +370,8 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   readonly readEnv: ConnectorEnvReader;
   readonly signal: AbortSignal;
 }): Promise<string | null> {
-  const credentials = getConnectorOAuthCredentials("github", args.readEnv);
-  if (
-    !credentials?.configured ||
-    !isStaticConfidentialConnectorOAuthCredentials(credentials)
-  ) {
+  const oauthClient = getConnectorOAuthClient("github", args.readEnv);
+  if (!oauthClient || !isStaticConfidentialConnectorOAuthClient(oauthClient)) {
     return null;
   }
 
@@ -383,7 +380,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   const authResult = normalizeAuthUrlResult(
     await buildConnectorOAuthAuthUrl({
       type: "github",
-      credentials,
+      oauthClient,
       redirectUri,
       state,
     }),

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -11,7 +11,7 @@ import {
   deriveConnectedManualGrantMethods,
   getAvailableConnectorAuthMethods,
   getConnectorManualGrantFieldNames,
-  getConnectorOAuthCredentials,
+  getConnectorOAuthClient,
   getConnectorProvidedSecretNames,
   getConnectorSecretNames,
   getRuntimeAvailableConnectorTypes,
@@ -403,8 +403,8 @@ async function revokeExistingConnectorToken(args: {
     return;
   }
 
-  const credentials = getConnectorOAuthCredentials(connectorType, optionalEnv);
-  if (!credentials) {
+  const oauthClient = getConnectorOAuthClient(connectorType, optionalEnv);
+  if (!oauthClient) {
     return;
   }
 
@@ -412,7 +412,7 @@ async function revokeExistingConnectorToken(args: {
   await bestEffort(
     revokeConnectorOAuthToken({
       type: connectorType,
-      credentials,
+      oauthClient,
       loadAccessToken: () => {
         return decryptStoredSecretValue(
           accessTokenSecret.encryptedValue,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1644,7 +1644,8 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     });
 
     expect(oauthClient).toStrictEqual({
-      client: getConnectorOAuthClientConfig("github"),
+      clientRegistration: "static",
+      clientType: "confidential",
       clientId: "github-client-id",
       clientSecret: "github-client-secret",
     });
@@ -1662,7 +1663,8 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     const oauthClient = getConnectorOAuthClient("test-oauth", emptyEnv);
 
     expect(oauthClient).toStrictEqual({
-      client: getConnectorOAuthClientConfig("test-oauth"),
+      clientRegistration: "static",
+      clientType: "confidential",
       clientId: "test-oauth-client",
       clientSecret: "test-oauth-secret",
     });
@@ -1683,11 +1685,8 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     );
 
     expect(oauthClient).toStrictEqual({
-      client: {
-        clientRegistration: "static",
-        clientType: "public",
-        clientIdEnv: "PUBLIC_OAUTH_CLIENT_ID",
-      },
+      clientRegistration: "static",
+      clientType: "public",
       clientId: "public-client-id",
     });
   });
@@ -1699,7 +1698,8 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     } as const;
 
     expect(resolveConnectorOAuthClient(client, emptyEnv)).toStrictEqual({
-      client,
+      clientRegistration: "dynamic",
+      clientType: "public",
     });
   });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -33,7 +33,7 @@ import {
   getConnectorEnvironmentMapping,
   getConnectorProvidedSecretNames,
   getConnectorOAuthClientConfig,
-  getConnectorOAuthCredentials,
+  getConnectorOAuthClient,
   getConnectorOAuthGrantConfigIfSupported,
   getConnectorOAuthScopes,
   getConnectorManualGrantFieldNames,
@@ -44,10 +44,10 @@ import {
   getConnectorSecretNames,
   isOAuthAuthCodeConnectorType,
   isOAuthDeviceAuthConnectorType,
-  isStaticConfidentialConnectorOAuthCredentials,
-  isStaticConnectorOAuthCredentials,
+  isStaticConfidentialConnectorOAuthClient,
+  isStaticConnectorOAuthClient,
   isGoogleOAuthConnector,
-  resolveConnectorOAuthClientCredentials,
+  resolveConnectorOAuthClient,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
@@ -392,28 +392,28 @@ describe("isOAuthConnectorType", () => {
   });
 
   it("rejects refresh for OAuth connectors without refresh-token access", async () => {
-    const credentials = getConnectorOAuthCredentials("github", (name) => {
+    const oauthClient = getConnectorOAuthClient("github", (name) => {
       return name === "GITHUB_CLIENT_ID"
         ? "test-github-client"
         : "test-github-secret";
     });
-    expect(credentials?.configured).toBe(true);
+    expect(oauthClient).toBeDefined();
 
-    if (!credentials?.configured) {
-      throw new Error("Expected github OAuth credentials");
+    if (!oauthClient) {
+      throw new Error("Expected github OAuth client");
     }
 
     await expect(
       refreshConnectorOAuthToken({
         type: "github",
-        credentials,
+        oauthClient,
         refreshToken: "refresh-token",
       }),
     ).rejects.toThrow("github OAuth provider does not support refresh");
   });
 
   it("revokes OAuth tokens through the provider registry", async () => {
-    const credentials = getConnectorOAuthCredentials("github", (name) => {
+    const oauthClient = getConnectorOAuthClient("github", (name) => {
       if (name === "GH_OAUTH_CLIENT_ID") {
         return "test-github-client";
       }
@@ -422,10 +422,10 @@ describe("isOAuthConnectorType", () => {
       }
       return undefined;
     });
-    expect(credentials?.configured).toBe(true);
+    expect(oauthClient).toBeDefined();
 
-    if (!credentials?.configured) {
-      throw new Error("Expected github OAuth credentials");
+    if (!oauthClient) {
+      throw new Error("Expected github OAuth client");
     }
 
     let authorization: string | null = null;
@@ -444,7 +444,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       revokeConnectorOAuthToken({
         type: "github",
-        credentials,
+        oauthClient,
         loadAccessToken: () => {
           return "gh-access-token";
         },
@@ -457,7 +457,7 @@ describe("isOAuthConnectorType", () => {
   });
 
   it("returns unsupported for OAuth connectors without revoke support", async () => {
-    const credentials = getConnectorOAuthCredentials("notion", (name) => {
+    const oauthClient = getConnectorOAuthClient("notion", (name) => {
       if (name === "NOTION_OAUTH_CLIENT_ID") {
         return "test-notion-client";
       }
@@ -466,10 +466,10 @@ describe("isOAuthConnectorType", () => {
       }
       return undefined;
     });
-    expect(credentials?.configured).toBe(true);
+    expect(oauthClient).toBeDefined();
 
-    if (!credentials?.configured) {
-      throw new Error("Expected notion OAuth credentials");
+    if (!oauthClient) {
+      throw new Error("Expected notion OAuth client");
     }
 
     let loadedAccessToken = false;
@@ -477,38 +477,13 @@ describe("isOAuthConnectorType", () => {
     await expect(
       revokeConnectorOAuthToken({
         type: "notion",
-        credentials,
+        oauthClient,
         loadAccessToken: () => {
           loadedAccessToken = true;
           return "notion-access-token";
         },
       }),
     ).resolves.toStrictEqual({ status: "unsupported" });
-    expect(loadedAccessToken).toBe(false);
-  });
-
-  it("returns unconfigured when OAuth credentials are unavailable for revoke", async () => {
-    const credentials = getConnectorOAuthCredentials("github", () => {
-      return undefined;
-    });
-    expect(credentials?.configured).toBe(false);
-
-    if (!credentials) {
-      throw new Error("Expected github OAuth credentials shape");
-    }
-
-    let loadedAccessToken = false;
-
-    await expect(
-      revokeConnectorOAuthToken({
-        type: "github",
-        credentials,
-        loadAccessToken: () => {
-          loadedAccessToken = true;
-          return "gh-access-token";
-        },
-      }),
-    ).resolves.toStrictEqual({ status: "unconfigured" });
     expect(loadedAccessToken).toBe(false);
   });
 
@@ -532,15 +507,16 @@ describe("isOAuthConnectorType", () => {
         if (!client) {
           throw new Error(`${type} OAuth client config not found`);
         }
-        const credentials = resolveConnectorOAuthClientCredentials(
-          client,
-          () => {
-            return "test-client-credential";
-          },
-        );
+        const oauthClient = resolveConnectorOAuthClient(client, () => {
+          return "test-client-credential";
+        });
+        expect(oauthClient, `${type}: OAuth client`).toBeDefined();
+        if (!oauthClient) {
+          throw new Error(`${type} OAuth client not found`);
+        }
         const authResult = await buildConnectorOAuthAuthUrl({
           type,
-          credentials,
+          oauthClient,
           redirectUri: "https://app.test/callback",
           state: "state-123",
         });
@@ -631,21 +607,18 @@ describe("isOAuthConnectorType", () => {
       }),
     );
 
-    const credentials = getConnectorOAuthCredentials(
-      "test-oauth-device",
-      () => {
-        return undefined;
-      },
-    );
-    expect(credentials?.configured).toBe(true);
+    const oauthClient = getConnectorOAuthClient("test-oauth-device", () => {
+      return undefined;
+    });
+    expect(oauthClient).toBeDefined();
 
-    if (!credentials?.configured) {
-      throw new Error("Expected test-oauth-device OAuth credentials");
+    if (!oauthClient) {
+      throw new Error("Expected test-oauth-device OAuth client");
     }
 
     const startResult = await startConnectorOAuthDeviceAuth({
       type: "test-oauth-device",
-      credentials,
+      oauthClient,
     });
     expect(startResult).toStrictEqual({
       deviceCode: "test-device:test-oauth-device-client:read",
@@ -660,21 +633,21 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: "slow-down",
       }),
     ).resolves.toStrictEqual({ status: "slow_down" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: "denied",
       }),
     ).resolves.toStrictEqual({
@@ -685,7 +658,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: "expired",
       }),
     ).resolves.toStrictEqual({
@@ -696,7 +669,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: "error",
       }),
     ).resolves.toStrictEqual({
@@ -707,7 +680,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: "invalid-grant",
       }),
     ).resolves.toStrictEqual({
@@ -718,7 +691,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        credentials,
+        oauthClient,
         deviceCode: startResult.deviceCode,
       }),
     ).resolves.toStrictEqual({
@@ -837,19 +810,19 @@ describe("isOAuthConnectorType", () => {
       }),
     );
 
-    const credentials = getConnectorOAuthCredentials("base44", () => {
+    const oauthClient = getConnectorOAuthClient("base44", () => {
       return undefined;
     });
-    expect(credentials?.configured).toBe(true);
+    expect(oauthClient).toBeDefined();
 
-    if (!credentials?.configured) {
-      throw new Error("Expected base44 OAuth credentials");
+    if (!oauthClient) {
+      throw new Error("Expected base44 OAuth client");
     }
 
     await expect(
       startConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
       }),
     ).resolves.toStrictEqual({
       deviceCode: "base44-device-code",
@@ -864,21 +837,21 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
         deviceCode: "slow-down",
       }),
     ).resolves.toStrictEqual({ status: "slow_down" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
         deviceCode: "denied",
       }),
     ).resolves.toStrictEqual({
@@ -889,7 +862,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
         deviceCode: "expired",
       }),
     ).resolves.toStrictEqual({
@@ -900,7 +873,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
         deviceCode: "temporarily-unavailable",
       }),
     ).resolves.toStrictEqual({
@@ -911,7 +884,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        credentials,
+        oauthClient,
         deviceCode: "base44-device-code",
       }),
     ).resolves.toStrictEqual({
@@ -932,7 +905,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       refreshConnectorOAuthToken({
         type: "base44",
-        credentials,
+        oauthClient,
         refreshToken: "base44-refresh-rotation",
       }),
     ).resolves.toStrictEqual({
@@ -943,7 +916,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       refreshConnectorOAuthToken({
         type: "base44",
-        credentials,
+        oauthClient,
         refreshToken: "base44-refresh-without-rotation",
       }),
     ).resolves.toStrictEqual({
@@ -1117,19 +1090,19 @@ describe("isOAuthConnectorType", () => {
       ),
     );
 
-    const credentials = getConnectorOAuthCredentials("slock", () => {
+    const oauthClient = getConnectorOAuthClient("slock", () => {
       return undefined;
     });
-    expect(credentials?.configured).toBe(true);
+    expect(oauthClient).toBeDefined();
 
-    if (!credentials?.configured) {
-      throw new Error("Expected slock OAuth credentials");
+    if (!oauthClient) {
+      throw new Error("Expected slock OAuth client");
     }
 
     await expect(
       startConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
       }),
     ).resolves.toStrictEqual({
       deviceCode: "slock-device-code",
@@ -1143,14 +1116,14 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "denied",
       }),
     ).resolves.toStrictEqual({
@@ -1161,7 +1134,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "expired",
       }),
     ).resolves.toStrictEqual({
@@ -1172,7 +1145,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "no-servers",
       }),
     ).resolves.toStrictEqual({
@@ -1183,7 +1156,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "missing-refresh",
       }),
     ).resolves.toMatchObject({
@@ -1193,7 +1166,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "server-error",
       }),
     ).resolves.toStrictEqual({
@@ -1205,7 +1178,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        credentials,
+        oauthClient,
         deviceCode: "userinfo-error",
       }),
     ).resolves.toStrictEqual({
@@ -1216,7 +1189,7 @@ describe("isOAuthConnectorType", () => {
     });
     const completeResult = await pollConnectorOAuthDeviceAuth({
       type: "slock",
-      credentials,
+      oauthClient,
       deviceCode: "slock-device-code",
     });
     expect(completeResult).toMatchObject({
@@ -1250,7 +1223,7 @@ describe("isOAuthConnectorType", () => {
 
     const malformedCompleteResult = await pollConnectorOAuthDeviceAuth({
       type: "slock",
-      credentials,
+      oauthClient,
       deviceCode: "malformed-token",
     });
     expect(malformedCompleteResult).toMatchObject({
@@ -1264,7 +1237,7 @@ describe("isOAuthConnectorType", () => {
 
     const refreshResult = await refreshConnectorOAuthToken({
       type: "slock",
-      credentials,
+      oauthClient,
       refreshToken: "slock-refresh-token",
     });
     expect(refreshResult).toStrictEqual({
@@ -1283,7 +1256,7 @@ describe("isOAuthConnectorType", () => {
     await expect(
       refreshConnectorOAuthToken({
         type: "slock",
-        credentials,
+        oauthClient,
         refreshToken: "slock-refresh-malformed",
       }),
     ).resolves.toStrictEqual({
@@ -1614,7 +1587,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     return undefined;
   };
 
-  it("includes manual-grant connectors without environment credentials or feature switches", () => {
+  it("includes manual-grant connectors without runtime OAuth client env or feature switches", () => {
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(runtimeAvailableTypes).toContain("amplitude");
@@ -1622,7 +1595,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(runtimeAvailableTypes).toContain("openai");
   });
 
-  it("includes static OAuth test connectors without runtime environment credentials", () => {
+  it("includes static OAuth test connectors without runtime OAuth client env", () => {
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(runtimeAvailableTypes).toContain("test-oauth");
@@ -1660,8 +1633,8 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(runtimeAvailableTypes).not.toContain("sentry");
   });
 
-  it("derives static confidential OAuth credentials from connector config", () => {
-    const credentials = getConnectorOAuthCredentials("github", (name) => {
+  it("derives static confidential OAuth client from connector config", () => {
+    const oauthClient = getConnectorOAuthClient("github", (name) => {
       return (
         {
           GH_OAUTH_CLIENT_ID: "github-client-id",
@@ -1670,8 +1643,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       )[name];
     });
 
-    expect(credentials).toStrictEqual({
-      configured: true,
+    expect(oauthClient).toStrictEqual({
       client: getConnectorOAuthClientConfig("github"),
       clientId: "github-client-id",
       clientSecret: "github-client-secret",
@@ -1679,21 +1651,17 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("does not configure static confidential OAuth when the secret is missing", () => {
-    const credentials = getConnectorOAuthCredentials("github", (name) => {
+    const oauthClient = getConnectorOAuthClient("github", (name) => {
       return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
     });
 
-    expect(credentials).toStrictEqual({
-      configured: false,
-      client: getConnectorOAuthClientConfig("github"),
-    });
+    expect(oauthClient).toBeUndefined();
   });
 
-  it("supports literal static OAuth clients without environment credentials", () => {
-    const credentials = getConnectorOAuthCredentials("test-oauth", emptyEnv);
+  it("supports literal static OAuth clients without runtime OAuth client env", () => {
+    const oauthClient = getConnectorOAuthClient("test-oauth", emptyEnv);
 
-    expect(credentials).toStrictEqual({
-      configured: true,
+    expect(oauthClient).toStrictEqual({
       client: getConnectorOAuthClientConfig("test-oauth"),
       clientId: "test-oauth-client",
       clientSecret: "test-oauth-secret",
@@ -1701,7 +1669,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("supports static public OAuth clients with only a client id", () => {
-    const credentials = resolveConnectorOAuthClientCredentials(
+    const oauthClient = resolveConnectorOAuthClient(
       {
         clientRegistration: "static",
         clientType: "public",
@@ -1714,8 +1682,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       },
     );
 
-    expect(credentials).toStrictEqual({
-      configured: true,
+    expect(oauthClient).toStrictEqual({
       client: {
         clientRegistration: "static",
         clientType: "public",
@@ -1725,22 +1692,19 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     });
   });
 
-  it("supports dynamic public OAuth clients without environment credentials", () => {
+  it("supports dynamic public OAuth clients without runtime OAuth client env", () => {
     const client = {
       clientRegistration: "dynamic",
       clientType: "public",
     } as const;
 
-    expect(
-      resolveConnectorOAuthClientCredentials(client, emptyEnv),
-    ).toStrictEqual({
-      configured: true,
+    expect(resolveConnectorOAuthClient(client, emptyEnv)).toStrictEqual({
       client,
     });
   });
 
-  it("identifies static OAuth credential variants", () => {
-    const staticCredentials = getConnectorOAuthCredentials("github", (name) => {
+  it("identifies static OAuth client variants", () => {
+    const staticOAuthClient = getConnectorOAuthClient("github", (name) => {
       return (
         {
           GH_OAUTH_CLIENT_ID: "github-client-id",
@@ -1748,19 +1712,19 @@ describe("getRuntimeAvailableConnectorTypes", () => {
         } as Record<string, string>
       )[name];
     });
-    if (!staticCredentials) {
-      throw new Error("Expected GitHub OAuth credentials");
+    if (!staticOAuthClient) {
+      throw new Error("Expected GitHub OAuth client");
     }
-    expect(isStaticConnectorOAuthCredentials(staticCredentials)).toBeTruthy();
+    expect(isStaticConnectorOAuthClient(staticOAuthClient)).toBeTruthy();
     expect(
-      isStaticConfidentialConnectorOAuthCredentials(staticCredentials),
+      isStaticConfidentialConnectorOAuthClient(staticOAuthClient),
     ).toBeTruthy();
-    if (isStaticConfidentialConnectorOAuthCredentials(staticCredentials)) {
-      const clientSecret: string = staticCredentials.clientSecret;
+    if (isStaticConfidentialConnectorOAuthClient(staticOAuthClient)) {
+      const clientSecret: string = staticOAuthClient.clientSecret;
       expect(clientSecret).toBe("github-client-secret");
     }
 
-    const publicCredentials = resolveConnectorOAuthClientCredentials(
+    const publicOAuthClient = resolveConnectorOAuthClient(
       {
         clientRegistration: "static",
         clientType: "public",
@@ -1768,12 +1732,15 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       },
       emptyEnv,
     );
-    expect(isStaticConnectorOAuthCredentials(publicCredentials)).toBeTruthy();
+    if (!publicOAuthClient) {
+      throw new Error("Expected public OAuth client");
+    }
+    expect(isStaticConnectorOAuthClient(publicOAuthClient)).toBeTruthy();
     expect(
-      isStaticConfidentialConnectorOAuthCredentials(publicCredentials),
+      isStaticConfidentialConnectorOAuthClient(publicOAuthClient),
     ).toBeFalsy();
-    if (isStaticConnectorOAuthCredentials(publicCredentials)) {
-      const clientId: string = publicCredentials.clientId;
+    if (isStaticConnectorOAuthClient(publicOAuthClient)) {
+      const clientId: string = publicOAuthClient.clientId;
       expect(clientId).toBe("public-client-id");
     }
 
@@ -1781,13 +1748,16 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       clientRegistration: "dynamic",
       clientType: "public",
     } as const;
-    const dynamicCredentials = resolveConnectorOAuthClientCredentials(
+    const dynamicOAuthClient = resolveConnectorOAuthClient(
       dynamicClient,
       emptyEnv,
     );
-    expect(isStaticConnectorOAuthCredentials(dynamicCredentials)).toBeFalsy();
+    if (!dynamicOAuthClient) {
+      throw new Error("Expected dynamic OAuth client");
+    }
+    expect(isStaticConnectorOAuthClient(dynamicOAuthClient)).toBeFalsy();
     expect(
-      isStaticConfidentialConnectorOAuthCredentials(dynamicCredentials),
+      isStaticConfidentialConnectorOAuthClient(dynamicOAuthClient),
     ).toBeFalsy();
   });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -393,9 +393,13 @@ describe("isOAuthConnectorType", () => {
 
   it("rejects refresh for OAuth connectors without refresh-token access", async () => {
     const oauthClient = getConnectorOAuthClient("github", (name) => {
-      return name === "GITHUB_CLIENT_ID"
-        ? "test-github-client"
-        : "test-github-secret";
+      if (name === "GH_OAUTH_CLIENT_ID") {
+        return "test-github-client";
+      }
+      if (name === "GH_OAUTH_CLIENT_SECRET") {
+        return "test-github-secret";
+      }
+      return undefined;
     });
     expect(oauthClient).toBeDefined();
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -7,9 +7,9 @@ import type {
 import {
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isOAuthAuthCodeConnectorType,
-  isStaticConfidentialConnectorOAuthCredentials,
-  isStaticConnectorOAuthCredentials,
-  type ConnectorOAuthCredentials,
+  isStaticConfidentialConnectorOAuthClient,
+  isStaticConnectorOAuthClient,
+  type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   getAuthProviderSecretMetadata,
@@ -107,8 +107,7 @@ export { providerEnvFromObject };
 
 export type ConnectorOAuthRevokeResult =
   | { readonly status: "revoked" }
-  | { readonly status: "unsupported" }
-  | { readonly status: "unconfigured" };
+  | { readonly status: "unsupported" };
 
 type AuthCodeConnectorOAuthProviderMap = {
   readonly [Type in OAuthAuthCodeConnectorType]: AuthCodeConnectorAuthProvider<Type>;
@@ -150,28 +149,19 @@ function connectorRevokeProviderFor<T extends OAuthConnectorType>(
     .revoke as OAuthConnectorRevokeProvider<T>;
 }
 
-function connectorCredentialArgs(
-  credentials: ConnectorOAuthCredentials,
+function connectorOAuthClientArgs(
+  oauthClient: ConnectorOAuthClient,
 ): Pick<OAuthExchangeArgs, "clientId" | "clientSecret"> {
-  if (!isStaticConnectorOAuthCredentials(credentials)) {
+  if (!isStaticConnectorOAuthClient(oauthClient)) {
     return {};
   }
-  if (isStaticConfidentialConnectorOAuthCredentials(credentials)) {
+  if (isStaticConfidentialConnectorOAuthClient(oauthClient)) {
     return {
-      clientId: credentials.clientId,
-      clientSecret: credentials.clientSecret,
+      clientId: oauthClient.clientId,
+      clientSecret: oauthClient.clientSecret,
     };
   }
-  return { clientId: credentials.clientId };
-}
-
-function assertConfiguredConnectorOAuthCredentials(
-  type: OAuthConnectorType,
-  credentials: ConnectorOAuthCredentials,
-): void {
-  if (!credentials.configured) {
-    throw new Error(`${type} OAuth not configured`);
-  }
+  return { clientId: oauthClient.clientId };
 }
 
 const AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS: AuthCodeConnectorOAuthProviderMap = {
@@ -266,15 +256,14 @@ export async function buildConnectorOAuthAuthUrl<
   T extends OAuthAuthCodeConnectorType,
 >(args: {
   readonly type: T;
-  readonly credentials: ConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
-  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.buildAuthUrl({
-    ...connectorCredentialArgs(args.credentials),
+    ...connectorOAuthClientArgs(args.oauthClient),
     redirectUri: args.redirectUri,
     state: args.state,
   } as ConnectorOAuthAuthorizeArgs<T>);
@@ -284,18 +273,17 @@ export async function exchangeConnectorOAuthCode<
   T extends OAuthAuthCodeConnectorType,
 >(args: {
   readonly type: T;
-  readonly credentials: ConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.exchangeCode({
-    ...connectorCredentialArgs(args.credentials),
+    ...connectorOAuthClientArgs(args.oauthClient),
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,
@@ -308,14 +296,13 @@ export async function startConnectorOAuthDeviceAuth<
   T extends OAuthDeviceAuthConnectorType,
 >(args: {
   readonly type: T;
-  readonly credentials: ConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
 }): Promise<OAuthDeviceAuthStartResult> {
-  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const grant = getDeviceAuthGrantConfig(args.type);
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.startDeviceAuth({
-    ...connectorCredentialArgs(args.credentials),
+    ...connectorOAuthClientArgs(args.oauthClient),
     scopes: grant.scopes,
   } as ConnectorOAuthDeviceAuthStartArgs<T>);
 }
@@ -324,14 +311,13 @@ export async function pollConnectorOAuthDeviceAuth<
   T extends OAuthDeviceAuthConnectorType,
 >(args: {
   readonly type: T;
-  readonly credentials: ConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.pollDeviceAuth({
-    ...connectorCredentialArgs(args.credentials),
+    ...connectorOAuthClientArgs(args.oauthClient),
     deviceCode: args.deviceCode,
   } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
@@ -340,10 +326,9 @@ export async function refreshConnectorOAuthToken<
   T extends OAuthConnectorType,
 >(args: {
   readonly type: T;
-  readonly credentials: ConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  assertConfiguredConnectorOAuthCredentials(args.type, args.credentials);
   const access = connectorAccessProviderFor(args.type);
 
   switch (access.kind) {
@@ -352,7 +337,7 @@ export async function refreshConnectorOAuthToken<
 
     case "refresh-token":
       return await access.refreshToken({
-        ...connectorCredentialArgs(args.credentials),
+        ...connectorOAuthClientArgs(args.oauthClient),
         refreshToken: args.refreshToken,
       } as ConnectorOAuthRefreshArgs<T>);
   }
@@ -362,13 +347,9 @@ export async function revokeConnectorOAuthToken<
   T extends OAuthConnectorType,
 >(args: {
   readonly type: T;
-  readonly credentials: ConnectorOAuthCredentials;
+  readonly oauthClient: ConnectorOAuthClient;
   readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorOAuthRevokeResult> {
-  if (!args.credentials.configured) {
-    return { status: "unconfigured" };
-  }
-
   const revoke = connectorRevokeProviderFor(args.type);
 
   switch (revoke.kind) {
@@ -377,7 +358,7 @@ export async function revokeConnectorOAuthToken<
 
     case "token-revoke":
       await revoke.revokeToken({
-        ...connectorCredentialArgs(args.credentials),
+        ...connectorOAuthClientArgs(args.oauthClient),
         accessToken: await args.loadAccessToken(),
       } as ConnectorOAuthRevokeArgs<T>);
       return { status: "revoked" };

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getConnectorOAuthCredentials } from "../../../../connector-utils";
+import { getConnectorOAuthClient } from "../../../../connector-utils";
 import { isOAuthConnectorType } from "../../../connector-auth";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
@@ -41,18 +41,17 @@ describe("connector/providers/google-ads", () => {
       );
     });
 
-    it("resolves OAuth client credentials from Google env keys", () => {
+    it("resolves the OAuth client from Google env keys", () => {
       const env: Record<string, string> = {
         GOOGLE_OAUTH_CLIENT_ID: "test-client-id",
         GOOGLE_OAUTH_CLIENT_SECRET: "test-client-secret",
       };
 
       expect(
-        getConnectorOAuthCredentials("google-ads", (name) => {
+        getConnectorOAuthClient("google-ads", (name) => {
           return env[name];
         }),
       ).toMatchObject({
-        configured: true,
         clientId: "test-client-id",
         clientSecret: "test-client-secret",
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getConnectorOAuthCredentials } from "../../../../connector-utils";
+import { getConnectorOAuthClient } from "../../../../connector-utils";
 import { isOAuthConnectorType } from "../../../connector-auth";
 import {
   buildMetaAdsAuthorizationUrl,
@@ -153,18 +153,17 @@ describe("connector/providers/meta-ads", () => {
       expect(url).toContain("facebook.com/v22.0/dialog/oauth");
     });
 
-    it("resolves OAuth client credentials from Meta Ads env keys", () => {
+    it("resolves the OAuth client from Meta Ads env keys", () => {
       const env: Record<string, string> = {
         META_ADS_OAUTH_CLIENT_ID: "test-client-id",
         META_ADS_OAUTH_CLIENT_SECRET: "test-client-secret",
       };
 
       expect(
-        getConnectorOAuthCredentials("meta-ads", (name) => {
+        getConnectorOAuthClient("meta-ads", (name) => {
           return env[name];
         }),
       ).toMatchObject({
-        configured: true,
         clientId: "test-client-id",
         clientSecret: "test-client-secret",
       });

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -435,11 +435,6 @@ export function getAvailableConnectorAuthMethods(
 
 export type ConnectorEnvReader = (name: string) => string | undefined;
 
-export interface ConnectorOAuthEnvKeys {
-  readonly clientId: string;
-  readonly clientSecret?: string;
-}
-
 export type StaticConfidentialConnectorOAuthClient = {
   readonly clientRegistration: "static";
   readonly clientType: "confidential";
@@ -549,24 +544,6 @@ function hasConfiguredOAuth(
   type: ConnectorType,
 ): boolean {
   return getConnectorOAuthClient(type, readEnv) !== undefined;
-}
-
-export function getConnectorOAuthEnvKeys(
-  type: ConnectorType,
-): ConnectorOAuthEnvKeys | undefined {
-  const client = getConnectorOAuthClientConfig(type);
-  if (
-    !client ||
-    client.clientRegistration !== "static" ||
-    !("clientIdEnv" in client)
-  ) {
-    return undefined;
-  }
-  return {
-    clientId: client.clientIdEnv,
-    clientSecret:
-      client.clientType === "confidential" ? client.clientSecretEnv : undefined,
-  };
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -9,11 +9,8 @@ import {
   type ConnectorConfig,
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorGenerationType,
-  type DynamicPublicConnectorOAuthClientConfig,
   type ConnectorOAuthClientConfig,
   type ConnectorManualGrantFieldConfig,
-  type StaticConfidentialConnectorOAuthClientConfig,
-  type StaticPublicConnectorOAuthClientConfig,
   type ConnectorType,
   type OAuthAuthCodeConnectorType,
   type OAuthDeviceAuthConnectorType,
@@ -444,18 +441,21 @@ export interface ConnectorOAuthEnvKeys {
 }
 
 export type StaticConfidentialConnectorOAuthClient = {
-  readonly client: StaticConfidentialConnectorOAuthClientConfig;
+  readonly clientRegistration: "static";
+  readonly clientType: "confidential";
   readonly clientId: string;
   readonly clientSecret: string;
 };
 
 export type StaticPublicConnectorOAuthClient = {
-  readonly client: StaticPublicConnectorOAuthClientConfig;
+  readonly clientRegistration: "static";
+  readonly clientType: "public";
   readonly clientId: string;
 };
 
 export type DynamicPublicConnectorOAuthClient = {
-  readonly client: DynamicPublicConnectorOAuthClientConfig;
+  readonly clientRegistration: "dynamic";
+  readonly clientType: "public";
 };
 
 export type StaticConnectorOAuthClient =
@@ -469,7 +469,7 @@ export type ConnectorOAuthClient =
 export function isStaticConnectorOAuthClient(
   oauthClient: ConnectorOAuthClient,
 ): oauthClient is StaticConnectorOAuthClient {
-  return oauthClient.client.clientRegistration === "static";
+  return oauthClient.clientRegistration === "static";
 }
 
 export function isStaticConfidentialConnectorOAuthClient(
@@ -477,7 +477,7 @@ export function isStaticConfidentialConnectorOAuthClient(
 ): oauthClient is StaticConfidentialConnectorOAuthClient {
   return (
     isStaticConnectorOAuthClient(oauthClient) &&
-    oauthClient.client.clientType === "confidential"
+    oauthClient.clientType === "confidential"
   );
 }
 
@@ -492,18 +492,23 @@ export function resolveConnectorOAuthClient(
   readEnv: ConnectorEnvReader,
 ): ConnectorOAuthClient | undefined {
   if (client.clientRegistration === "dynamic") {
-    return { client };
+    return { clientRegistration: "dynamic", clientType: "public" };
   }
 
   if ("clientId" in client) {
     if (client.clientType === "confidential") {
       return {
-        client,
+        clientRegistration: "static",
+        clientType: "confidential",
         clientId: client.clientId,
         clientSecret: client.clientSecret,
       };
     }
-    return { client, clientId: client.clientId };
+    return {
+      clientRegistration: "static",
+      clientType: "public",
+      clientId: client.clientId,
+    };
   }
 
   const clientId = readEnv(client.clientIdEnv);
@@ -512,7 +517,7 @@ export function resolveConnectorOAuthClient(
   }
 
   if (client.clientType === "public") {
-    return { client, clientId };
+    return { clientRegistration: "static", clientType: "public", clientId };
   }
 
   const clientSecret = readEnv(client.clientSecretEnv);
@@ -520,7 +525,12 @@ export function resolveConnectorOAuthClient(
     return undefined;
   }
 
-  return { client, clientId, clientSecret };
+  return {
+    clientRegistration: "static",
+    clientType: "confidential",
+    clientId,
+    clientSecret,
+  };
 }
 
 export function getConnectorOAuthClient(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -443,52 +443,41 @@ export interface ConnectorOAuthEnvKeys {
   readonly clientSecret?: string;
 }
 
-export type UnconfiguredConnectorOAuthCredentials = {
-  readonly configured: false;
-  readonly client: ConnectorOAuthClientConfig;
-};
-
-export type StaticConfidentialConnectorOAuthCredentials = {
-  readonly configured: true;
+export type StaticConfidentialConnectorOAuthClient = {
   readonly client: StaticConfidentialConnectorOAuthClientConfig;
   readonly clientId: string;
   readonly clientSecret: string;
 };
 
-export type StaticPublicConnectorOAuthCredentials = {
-  readonly configured: true;
+export type StaticPublicConnectorOAuthClient = {
   readonly client: StaticPublicConnectorOAuthClientConfig;
   readonly clientId: string;
 };
 
-export type DynamicPublicConnectorOAuthCredentials = {
-  readonly configured: true;
+export type DynamicPublicConnectorOAuthClient = {
   readonly client: DynamicPublicConnectorOAuthClientConfig;
 };
 
-export type StaticConnectorOAuthCredentials =
-  | StaticConfidentialConnectorOAuthCredentials
-  | StaticPublicConnectorOAuthCredentials;
+export type StaticConnectorOAuthClient =
+  | StaticConfidentialConnectorOAuthClient
+  | StaticPublicConnectorOAuthClient;
 
-export type ConnectorOAuthCredentials =
-  | UnconfiguredConnectorOAuthCredentials
-  | StaticConnectorOAuthCredentials
-  | DynamicPublicConnectorOAuthCredentials;
+export type ConnectorOAuthClient =
+  | StaticConnectorOAuthClient
+  | DynamicPublicConnectorOAuthClient;
 
-export function isStaticConnectorOAuthCredentials(
-  credentials: ConnectorOAuthCredentials,
-): credentials is StaticConnectorOAuthCredentials {
-  return (
-    credentials.configured && credentials.client.clientRegistration === "static"
-  );
+export function isStaticConnectorOAuthClient(
+  oauthClient: ConnectorOAuthClient,
+): oauthClient is StaticConnectorOAuthClient {
+  return oauthClient.client.clientRegistration === "static";
 }
 
-export function isStaticConfidentialConnectorOAuthCredentials(
-  credentials: ConnectorOAuthCredentials,
-): credentials is StaticConfidentialConnectorOAuthCredentials {
+export function isStaticConfidentialConnectorOAuthClient(
+  oauthClient: ConnectorOAuthClient,
+): oauthClient is StaticConfidentialConnectorOAuthClient {
   return (
-    isStaticConnectorOAuthCredentials(credentials) &&
-    credentials.client.clientType === "confidential"
+    isStaticConnectorOAuthClient(oauthClient) &&
+    oauthClient.client.clientType === "confidential"
   );
 }
 
@@ -498,59 +487,58 @@ export function getConnectorOAuthClientConfig(
   return getConnectorOAuthGrantConfigIfSupported(type)?.client;
 }
 
-export function resolveConnectorOAuthClientCredentials(
+export function resolveConnectorOAuthClient(
   client: ConnectorOAuthClientConfig,
   readEnv: ConnectorEnvReader,
-): ConnectorOAuthCredentials {
+): ConnectorOAuthClient | undefined {
   if (client.clientRegistration === "dynamic") {
-    return { configured: true, client };
+    return { client };
   }
 
   if ("clientId" in client) {
     if (client.clientType === "confidential") {
       return {
-        configured: true,
         client,
         clientId: client.clientId,
         clientSecret: client.clientSecret,
       };
     }
-    return { configured: true, client, clientId: client.clientId };
+    return { client, clientId: client.clientId };
   }
 
   const clientId = readEnv(client.clientIdEnv);
   if (!clientId) {
-    return { configured: false, client };
+    return undefined;
   }
 
   if (client.clientType === "public") {
-    return { configured: true, client, clientId };
+    return { client, clientId };
   }
 
   const clientSecret = readEnv(client.clientSecretEnv);
   if (!clientSecret) {
-    return { configured: false, client };
+    return undefined;
   }
 
-  return { configured: true, client, clientId, clientSecret };
+  return { client, clientId, clientSecret };
 }
 
-export function getConnectorOAuthCredentials(
+export function getConnectorOAuthClient(
   type: ConnectorType,
   readEnv: ConnectorEnvReader,
-): ConnectorOAuthCredentials | undefined {
+): ConnectorOAuthClient | undefined {
   const client = getConnectorOAuthClientConfig(type);
   if (!client) {
     return undefined;
   }
-  return resolveConnectorOAuthClientCredentials(client, readEnv);
+  return resolveConnectorOAuthClient(client, readEnv);
 }
 
 function hasConfiguredOAuth(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
-  return getConnectorOAuthCredentials(type, readEnv)?.configured ?? false;
+  return getConnectorOAuthClient(type, readEnv) !== undefined;
 }
 
 export function getConnectorOAuthEnvKeys(
@@ -576,8 +564,8 @@ export function getConnectorOAuthEnvKeys(
  *
  * This is not user connected state and it does not evaluate feature switches.
  * It includes connectors with user-entered manual grant methods because they
- * do not require server credentials, while OAuth connectors require their
- * runtime OAuth env to exist unless their client config is static inline.
+ * do not require a server OAuth client, while OAuth connectors require their
+ * runtime OAuth client env to exist unless their client config is static inline.
  */
 export function getRuntimeAvailableConnectorTypes(
   readEnv: ConnectorEnvReader,


### PR DESCRIPTION
## Summary\n- rename connector OAuth credential resolution APIs and call sites to OAuth client terminology\n- remove the redundant configured flag and model missing runtime OAuth client env as undefined\n- update connector OAuth tests for the simplified client shape\n\n## Tests\n- pnpm -F @vm0/connectors check-types\n- pnpm -F api check-types\n- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/auth-providers/oauth/providers/__tests__/google-ads.test.ts src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts\n- git diff --check\n- pre-commit: prettier, knip, full pnpm check-types