### PR TITLE
refactor(vsock-test): replace harness deref with host accessor

### DIFF
--- a/crates/vsock-test/tests/integration/exec.rs
+++ b/crates/vsock-test/tests/integration/exec.rs
@@ -11,6 +11,7 @@ async fn test_exec() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("echo hello", 5000, &[], false)
         .await
         .expect("exec failed");
@@ -26,6 +27,7 @@ async fn test_exec_stderr() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("echo error >&2 && exit 1", 5000, &[], false)
         .await
         .expect("exec failed");
@@ -40,6 +42,7 @@ async fn test_exec_multiline() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("printf 'line1\\nline2\\nline3\\n'", 5000, &[], false)
         .await
         .expect("exec failed");
@@ -54,6 +57,7 @@ async fn test_exec_pipe_chain() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("echo 'hello world' | tr 'a-z' 'A-Z'", 5000, &[], false)
         .await
         .expect("exec failed");
@@ -68,6 +72,7 @@ async fn test_exec_env_vars() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("export TEST_VAR=hello; echo $TEST_VAR", 5000, &[], false)
         .await
         .expect("exec failed");
@@ -82,6 +87,7 @@ async fn test_exec_timeout() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("sleep 10", 100, &[], false)
         .await
         .expect("exec failed");
@@ -97,6 +103,7 @@ async fn test_exec_sequential() {
 
     for i in 0..5 {
         let result = h
+            .host()
             .exec(&format!("echo {i}"), 5000, &[], false)
             .await
             .expect("exec failed");
@@ -116,6 +123,7 @@ async fn test_exec_sudo() {
     // a result). In release/production the process runs as root so sudo=true
     // just uses `sh -c` directly.
     let result = h
+        .host()
         .exec("whoami", 5000, &[], true)
         .await
         .expect("exec sudo failed");
@@ -136,6 +144,7 @@ async fn test_exec_while_waiting_for_exit() {
     // Start a long-running supervised process. Use `exec` to replace the shell
     // so the PID we get is the actual sleep process.
     let handle = h
+        .host()
         .start_supervised_exec(SupervisedExecRequest {
             timeout: ExecTimeoutPolicy::None,
             command: "exec sleep 60",
@@ -161,7 +170,7 @@ async fn test_exec_while_waiting_for_exit() {
         // This exec must NOT block on the pending supervised wait.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            h.exec("echo alive", 5000, &[], false),
+            h.host().exec("echo alive", 5000, &[], false),
         )
         .await
         .expect("exec timed out — supervised wait is blocking")
@@ -170,14 +179,15 @@ async fn test_exec_while_waiting_for_exit() {
         assert_eq!(result.stdout, b"alive\n");
 
         // Kill the process group so supervised wait resolves.
-        h.exec(
-            &format!("kill -15 -{pid} 2>/dev/null || kill -15 {pid}"),
-            5000,
-            &[],
-            false,
-        )
-        .await
-        .expect("kill failed");
+        h.host()
+            .exec(
+                &format!("kill -15 -{pid} 2>/dev/null || kill -15 {pid}"),
+                5000,
+                &[],
+                false,
+            )
+            .await
+            .expect("kill failed");
     });
 
     let event = wait_result.expect("supervised wait failed");
@@ -201,15 +211,17 @@ async fn test_concurrent_exec_not_blocked() {
 
     // Launch a slow exec and wait until its guest-side shell has started
     // before submitting the fast exec.
-    let slow = h.exec(&slow_command, 10000, &[], false);
+    let slow = h.host().exec(&slow_command, 10000, &[], false);
     let (fast_done_tx, fast_done_rx) = tokio::sync::oneshot::channel();
     let fast = async {
         wait_for_path(&ready_marker, Duration::from_secs(3)).await;
-        let result =
-            tokio::time::timeout(Duration::from_secs(3), h.exec("echo ok", 5000, &[], false))
-                .await
-                .expect("fast exec timed out — slow exec is blocking the event loop")
-                .expect("fast exec failed");
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            h.host().exec("echo ok", 5000, &[], false),
+        )
+        .await
+        .expect("fast exec timed out — slow exec is blocking the event loop")
+        .expect("fast exec failed");
         let _ = fast_done_tx.send(());
         result
     };
@@ -239,6 +251,7 @@ async fn test_exec_with_env() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("echo $MY_VAR", 5000, &[("MY_VAR", "hello_env")], false)
         .await
         .expect("exec failed");
@@ -253,6 +266,7 @@ async fn test_exec_with_multiple_env() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec(
             "echo $A $B",
             5000,
@@ -272,6 +286,7 @@ async fn test_exec_with_env_special_chars() {
     let h = Harness::new().await;
 
     let result = h
+        .host()
         .exec("echo $VAL", 5000, &[("VAL", "it's a \"test\"")], false)
         .await
         .expect("exec failed");

--- a/crates/vsock-test/tests/integration/shutdown.rs
+++ b/crates/vsock-test/tests/integration/shutdown.rs
@@ -8,7 +8,7 @@ use crate::support::Harness;
 async fn test_shutdown() {
     let h = Harness::new().await;
 
-    let acked = h.shutdown(Duration::from_secs(5)).await;
+    let acked = h.host().shutdown(Duration::from_secs(5)).await;
     assert!(acked);
 
     h.finish_ignore_guest();
@@ -20,12 +20,13 @@ async fn test_shutdown_after_exec() {
 
     // Run a command first, then shutdown
     let result = h
+        .host()
         .exec("echo before", 5000, &[], false)
         .await
         .expect("exec failed");
     assert_eq!(result.exit_code, 0);
 
-    let acked = h.shutdown(Duration::from_secs(5)).await;
+    let acked = h.host().shutdown(Duration::from_secs(5)).await;
     assert!(acked);
 
     h.finish_ignore_guest();

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::ops::Deref;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::Path;
 use std::sync::Arc;
@@ -109,6 +108,12 @@ impl Harness {
         }
     }
 
+    pub(crate) fn host(&self) -> &VsockHost {
+        self.host
+            .as_ref()
+            .expect("Harness host should be available before finish/drop")
+    }
+
     pub(crate) fn finish(mut self) {
         drop(self.host.take());
         if let Some(g) = self.guest.take() {
@@ -180,13 +185,6 @@ fn drain_inotify_fd(fd: std::os::fd::BorrowedFd<'_>) {
         if result <= 0 {
             break;
         }
-    }
-}
-
-impl Deref for Harness {
-    type Target = VsockHost;
-    fn deref(&self) -> &VsockHost {
-        self.host.as_ref().unwrap()
     }
 }
 

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -14,12 +14,14 @@ async fn test_write_file() {
     let file_path_str = file_path.to_string_lossy().to_string();
     let content = b"hello from vsock-test";
 
-    h.write_file(&file_path_str, content, false)
+    h.host()
+        .write_file(&file_path_str, content, false)
         .await
         .expect("write_file failed");
 
     // Verify by reading the file back via exec
     let result = h
+        .host()
         .exec(&format!("cat '{file_path_str}'"), 5000, &[], false)
         .await
         .expect("exec cat failed");
@@ -37,7 +39,8 @@ async fn test_write_file_special_characters() {
     let file_path_str = file_path.to_string_lossy().to_string();
     let content = b"Line1\nLine2\tTabbed\n\"Quoted\"";
 
-    h.write_file(&file_path_str, content, false)
+    h.host()
+        .write_file(&file_path_str, content, false)
         .await
         .expect("write_file failed");
 
@@ -54,7 +57,8 @@ async fn test_write_file_path_with_shell_metacharacters() {
     let file_path_str = file_path.to_string_lossy().to_string();
     let content = b"path should be passed as an argv value";
 
-    h.write_file(&file_path_str, content, false)
+    h.host()
+        .write_file(&file_path_str, content, false)
         .await
         .expect("write_file failed");
 
@@ -71,7 +75,8 @@ async fn test_write_file_creates_parent_dirs() {
     let file_path_str = file_path.to_string_lossy().to_string();
     let content = b"nested content";
 
-    h.write_file(&file_path_str, content, false)
+    h.host()
+        .write_file(&file_path_str, content, false)
         .await
         .expect("write_file failed");
 
@@ -87,7 +92,8 @@ async fn test_write_file_sudo_create_does_not_create_parent_dirs() {
     let file_path = h.dir.join("sudo/missing/parent.txt");
     let file_path_str = file_path.to_string_lossy().to_string();
 
-    h.write_file(&file_path_str, b"content", true)
+    h.host()
+        .write_file(&file_path_str, b"content", true)
         .await
         .expect_err("sudo write_file should fail when parent is missing");
 
@@ -100,7 +106,8 @@ async fn test_write_file_unwritable_path_fails() {
     let h = Harness::new().await;
 
     let path = format!("/proc/vm0-write-file-denied-{}", std::process::id());
-    h.write_file(&path, b"content", false)
+    h.host()
+        .write_file(&path, b"content", false)
         .await
         .expect_err("write_file should fail under /proc");
 
@@ -117,7 +124,8 @@ async fn test_write_file_large() {
     // 100KB content
     let content = vec![b'x'; 100_000];
 
-    h.write_file(&file_path_str, &content, false)
+    h.host()
+        .write_file(&file_path_str, &content, false)
         .await
         .expect("write_file failed");
 
@@ -139,7 +147,8 @@ async fn test_write_file_chunked() {
     // shell rename path. The quote in the file name covers shell escaping.
     let content = vec![0xABu8; 16 * 1024 * 1024];
 
-    h.write_file(&file_path_str, &content, false)
+    h.host()
+        .write_file(&file_path_str, &content, false)
         .await
         .expect("chunked write_file failed");
 
@@ -166,7 +175,8 @@ async fn bench_write_file_many_small_files() {
     for i in 0..100 {
         let file_path = h.dir.join(format!("bench/{i}.txt"));
         let file_path_str = file_path.to_string_lossy().to_string();
-        h.write_file(&file_path_str, b"small content", false)
+        h.host()
+            .write_file(&file_path_str, b"small content", false)
             .await
             .expect("write_file failed");
     }


### PR DESCRIPTION
## Summary

- remove the `Deref<Target = VsockHost>` implementation from the vsock integration test `Harness`
- add an explicit `host()` accessor while preserving host-before-guest cleanup ordering
- update integration tests to call `VsockHost` methods through `h.host()`

Closes #15057

## Tests

- `cargo fmt --check -p vsock-test`
- `cargo test -p vsock-test --test integration`
- pre-commit hook: crates cargo-fmt, cargo-clippy, cargo-doc
- `git diff --check`