### PR TITLE
docs(mitm-addon): explain usage zero-clobber guard

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -45,6 +45,12 @@ def _is_usage_quantity(value: object) -> TypeGuard[int]:
 
 
 def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, ...]) -> None:
+    """Store usage quantities using positive-wins, zero-does-not-clobber semantics.
+
+    Some provider update payloads echo fields from earlier events as ``0``.
+    Preserve an already-recorded quantity in that case, while still recording
+    initial zero values when a category has not appeared yet.
+    """
     for raw_field, category in ANTHROPIC_USAGE_FIELD_CATEGORIES.items():
         value = values.get((*prefix, raw_field))
         if _is_usage_quantity(value) and (value > 0 or category not in target):
@@ -153,10 +159,7 @@ class AnthropicMessagesJsonUsageExtractor:
         model = result.values.get(("model",))
         if isinstance(model, str) and model:
             usage["model"] = model
-        for raw_field, category in ANTHROPIC_USAGE_FIELD_CATEGORIES.items():
-            value = result.values.get(("usage", raw_field))
-            if _is_usage_quantity(value) and (value > 0 or category not in usage):
-                usage[category] = value
+        _store_selected_usage_values(result.values, usage, ("usage",))
         if not usage:
             return None, None
         message_id = result.values.get(("id",))

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -65,11 +65,15 @@ def _is_usage_quantity(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
-def _store_quantity(target: dict, category: str, value: object) -> bool:
+def _store_quantity(target: dict, category: str, value: object) -> None:
+    """Store usage quantities using positive-wins, zero-does-not-clobber semantics.
+
+    Later provider update payloads may report ``0`` for a category that an
+    earlier payload reported as non-zero. Preserve the recorded quantity in
+    that case, while still recording initial zero values for missing categories.
+    """
     if _is_usage_quantity(value) and (value > 0 or category not in target):
         target[category] = value
-        return True
-    return False
 
 
 def _has_positive_usage_quantity(values: dict) -> bool:


### PR DESCRIPTION
## Summary

- document the positive-wins, zero-does-not-clobber usage storage invariant
- reuse the Anthropic usage storage helper from the JSON extraction path
- remove the unused boolean return from the OpenAI Responses storage helper

Closes #15037

## Tests

- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m pytest tests/test_anthropic_messages.py tests/test_openai_responses_event_json.py tests/test_openai_responses_sse.py -v`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m ruff check .`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m ruff format --check .`
- `PATH=/tmp/vm0-mitm-addon-deps/bin:$PATH PYTHONPATH=/tmp/vm0-mitm-addon-deps basedpyright -p .`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m pytest tests/ -v`
