### PR TITLE
fix: add compare plans links for integration credit errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-email-inbound.ts
+++ b/turbo/apps/api/src/signals/routes/zero-email-inbound.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { command } from "ccstate";
+import { command, type Setter } from "ccstate";
 import { zeroEmailInboundContract } from "@vm0/api-contracts/contracts/zero-email";
 import { emailSuppressions } from "@vm0/db/schema/email-suppression";
 import { emailThreadSessions } from "@vm0/db/schema/email-thread-session";
@@ -14,6 +14,7 @@ import { clerk$ } from "../external/clerk";
 import { writeDb$ } from "../external/db";
 import { now } from "../external/time";
 import type { RouteEntry } from "../route";
+import { formatIntegrationRunError } from "../services/integration-run-errors.service";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import {
   apiUrl,
@@ -116,6 +117,12 @@ function expiredThreadResult(): HandlerResult {
   };
 }
 
+function findReplyToAddress(addresses: readonly string[]): string | undefined {
+  return addresses.find((address) => {
+    return address.includes("reply+");
+  });
+}
+
 function verifiedReplyToken(replyToAddress: string): string | null {
   const token = replyToAddress.match(/reply\+([^@]+)@/)?.[1];
   if (!token || !verifyReplyToken(token)) {
@@ -198,7 +205,16 @@ function triggerCallbacks(args: {
   ];
 }
 
-function runErrorMessage(result: unknown): string {
+function runError(args: {
+  readonly set: Setter;
+  readonly result: unknown;
+  readonly context: {
+    readonly orgId: string;
+    readonly userId: string;
+  };
+  readonly signal: AbortSignal;
+}): string | Promise<string> {
+  const { result } = args;
   if (
     result &&
     typeof result === "object" &&
@@ -211,9 +227,38 @@ function runErrorMessage(result: unknown): string {
     "message" in result.body.error &&
     typeof result.body.error.message === "string"
   ) {
-    return result.body.error.message;
+    const code =
+      "code" in result.body.error && typeof result.body.error.code === "string"
+        ? result.body.error.code
+        : "INTERNAL_SERVER_ERROR";
+    return formatIntegrationRunError({
+      set: args.set,
+      orgId: args.context.orgId,
+      userId: args.context.userId,
+      code,
+      message: result.body.error.message,
+      signal: args.signal,
+    });
   }
   return "Failed to create the agent run.";
+}
+
+async function failedRunResult(args: {
+  readonly set: Setter;
+  readonly result: unknown;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<HandlerResult> {
+  return {
+    ok: false,
+    errorMessage: await runError({
+      set: args.set,
+      result: args.result,
+      context: { orgId: args.orgId, userId: args.userId },
+      signal: args.signal,
+    }),
+  };
 }
 
 const sendInboundErrorReply$ = command(
@@ -316,9 +361,7 @@ const handleInboundEmailReply$ = command(
     args: { readonly event: InboundEmailEvent; readonly apiStartTime: number },
     signal: AbortSignal,
   ): Promise<HandlerResult> => {
-    const replyToAddress = args.event.data.to.find((address) => {
-      return address.includes("reply+");
-    });
+    const replyToAddress = findReplyToAddress(args.event.data.to);
     if (!replyToAddress) {
       return {
         ok: false,
@@ -407,13 +450,14 @@ const handleInboundEmailReply$ = command(
       prompt = `${prompt}\n\n${attachmentText}`;
     }
 
+    const runtimeOrgId = session.orgId ?? agent.orgId;
     const result = await set(
       createZeroRun$,
       {
         auth: {
           tokenType: "session",
           userId: session.userId,
-          orgId: session.orgId ?? agent.orgId,
+          orgId: runtimeOrgId,
           orgRole: "member",
         },
         body: {
@@ -437,7 +481,13 @@ const handleInboundEmailReply$ = command(
     signal.throwIfAborted();
     return result.status === 201
       ? { ok: true }
-      : { ok: false, errorMessage: runErrorMessage(result) };
+      : await failedRunResult({
+          set,
+          result,
+          orgId: runtimeOrgId,
+          userId: session.userId,
+          signal,
+        });
   },
 );
 
@@ -567,7 +617,7 @@ const handleInboundEmailTrigger$ = command(
     signal.throwIfAborted();
     return result.status === 201
       ? { ok: true }
-      : { ok: false, errorMessage: runErrorMessage(result) };
+      : await failedRunResult({ set, result, orgId, userId, signal });
   },
 );
 

--- a/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
@@ -1,0 +1,43 @@
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
+import type { Setter } from "ccstate";
+
+import { env } from "../../lib/env";
+import { getMemberRoleAndUpdateCache$ } from "./auth.service";
+
+function comparePlansUrl(): string {
+  const appUrl = env("APP_URL").replace(/\/$/, "");
+  return `${appUrl}/?settings=billing&billingView=plans`;
+}
+
+export async function formatIntegrationRunError(args: {
+  readonly set: Setter;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly code: string;
+  readonly message: string;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  if (args.code !== "INSUFFICIENT_CREDITS") {
+    return formatRunErrorForExternalSurface({
+      code: args.code,
+      message: args.message,
+    });
+  }
+
+  const membership = await args.set(
+    getMemberRoleAndUpdateCache$,
+    args.orgId,
+    args.userId,
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  return formatRunErrorForExternalSurface({
+    code: args.code,
+    message: args.message,
+    insufficientCredits: {
+      canManageBilling: membership?.role === "admin",
+      comparePlansUrl: comparePlansUrl(),
+    },
+  });
+}

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
 
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   githubIssuesCallbackPayloadSchema,
   type GitHubIssuesCallbackPayload,
@@ -32,6 +31,7 @@ import {
 import { getGithubInstallationAccessToken } from "./github-app.service";
 import { signGithubConnectParams } from "./github-oauth.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import { formatIntegrationRunError } from "./integration-run-errors.service";
 import {
   resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
@@ -752,7 +752,14 @@ async function resolveExistingSession(args: {
   };
 }
 
-function routeErrorMessage(body: unknown): string | undefined {
+function routeErrorMessage(args: {
+  readonly body: unknown;
+  readonly set: Setter;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): string | Promise<string> | undefined {
+  const { body } = args;
   if (typeof body !== "object" || body === null || !("error" in body)) {
     return undefined;
   }
@@ -768,7 +775,14 @@ function routeErrorMessage(body: unknown): string | undefined {
     "code" in error && typeof error.code === "string"
       ? error.code
       : "INTERNAL_SERVER_ERROR";
-  return formatRunErrorForExternalSurface({ code, message });
+  return formatIntegrationRunError({
+    set: args.set,
+    orgId: args.orgId,
+    userId: args.userId,
+    code,
+    message,
+    signal: args.signal,
+  });
 }
 
 function stringField(body: unknown, key: string): string | undefined {
@@ -1062,7 +1076,14 @@ async function runAgentForGitHub(args: {
   if (result.status !== 201) {
     return {
       status: "failed",
-      response: routeErrorMessage(result.body) ?? RUN_START_FALLBACK_MESSAGE,
+      response:
+        (await routeErrorMessage({
+          body: result.body,
+          set: args.set,
+          orgId: args.orgId,
+          userId: args.userId,
+          signal: args.signal,
+        })) ?? RUN_START_FALLBACK_MESSAGE,
     };
   }
 

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -7,7 +7,6 @@ import {
 import { gzipSync } from "node:zlib";
 
 import { command, type Getter, type Setter } from "ccstate";
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   getCanonicalModelDisplayName,
   getVm0VisibleModels,
@@ -41,6 +40,7 @@ import {
 } from "../external/agentphone-client";
 import { safeUrlParse, settle } from "../utils";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import { formatIntegrationRunError } from "./integration-run-errors.service";
 import {
   resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
@@ -1915,9 +1915,13 @@ async function runAgentForAgentPhone(
 
   return {
     status: "failed",
-    response: formatRunErrorForExternalSurface({
+    response: await formatIntegrationRunError({
+      set,
+      orgId: args.auth.orgId,
+      userId: args.auth.userId,
       code: result.body.error.code,
       message: result.body.error.message,
+      signal,
     }),
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -13,7 +13,6 @@ import {
   type ModelProviderCredentialScope,
   type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { slackOrgCallbackPayloadSchema } from "@vm0/api-contracts/contracts/internal-callbacks-slack-org";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -74,6 +73,7 @@ import {
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import { formatIntegrationRunError } from "./integration-run-errors.service";
 import { zeroComposeList } from "./zero-compose-data.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import {
@@ -1082,9 +1082,13 @@ async function runAgentForSlackOrg(
 
   return {
     status: "failed",
-    response: formatRunErrorForExternalSurface({
+    response: await formatIntegrationRunError({
+      set,
+      orgId: params.orgId,
+      userId: params.userId,
       code: result.body.error.code,
       message: result.body.error.message,
+      signal,
     }),
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -1,7 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 import { command, type Getter, type Setter } from "ccstate";
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   getCanonicalModelDisplayName,
   getVm0VisibleModels,
@@ -64,6 +63,7 @@ import {
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import { formatIntegrationRunError } from "./integration-run-errors.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { telegramIntegrationBotStatus } from "./zero-telegram-data.service";
@@ -1754,9 +1754,13 @@ async function runAgentForTelegram(
 
   return {
     status: "failed",
-    response: formatRunErrorForExternalSurface({
+    response: await formatIntegrationRunError({
+      set,
+      orgId: args.auth.orgId,
+      userId: args.auth.userId,
       code: result.body.error.code,
       message: result.body.error.message,
+      signal,
     }),
   };
 }

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { mockLocation } from "../../../location.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { createPushStateMock } from "../../../../__tests__/page-helper.ts";
@@ -10,10 +10,18 @@ import {
   settingsActiveSection$,
   settingsDialogOpen$,
 } from "../settings-dialog.ts";
+import { billingSubPage$ } from "../org-manage-tabs-state.ts";
 import { searchParams$ } from "../../../route.ts";
-import { setMockOrg } from "../../../../mocks/handlers/api-org.ts";
+import {
+  resetMockOrg,
+  setMockOrg,
+} from "../../../../mocks/handlers/api-org.ts";
 
 const context = testContext();
+
+afterEach(() => {
+  resetMockOrg();
+});
 
 function setupAuth(signal: AbortSignal) {
   mockUser(
@@ -37,6 +45,42 @@ describe("checkUnifiedSettingsParam$", () => {
     expect(store.get(settingsDialogOpen$)).toBeTruthy();
     expect(store.get(settingsActiveSection$)).toBe("billing");
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
+  });
+
+  it("opens billing on Compare plans when ?settings=billing&billingView=plans", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    createPushStateMock(signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=billing&billingView=plans" },
+      signal,
+    );
+
+    await store.set(checkUnifiedSettingsParam$, signal);
+
+    expect(store.get(settingsDialogOpen$)).toBeTruthy();
+    expect(store.get(settingsActiveSection$)).toBe("billing");
+    expect(store.get(billingSubPage$)).toBeTruthy();
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
+  });
+
+  it("keeps non-admins on the home page when opening Compare plans link", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    setMockOrg({ role: "member" });
+    createPushStateMock(signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=billing&billingView=plans" },
+      signal,
+    );
+
+    await store.set(checkUnifiedSettingsParam$, signal);
+
+    expect(store.get(settingsDialogOpen$)).toBeFalsy();
+    expect(store.get(billingSubPage$)).toBeFalsy();
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
   });
 
   it("falls back to preference for non-admin on admin-only section", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -2,7 +2,10 @@ import { command, computed, state } from "ccstate";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
-import { initProfileName$ } from "./org-manage-tabs-state.ts";
+import {
+  initProfileName$,
+  setBillingSubPage$,
+} from "./org-manage-tabs-state.ts";
 
 export const SETTINGS_SECTIONS = [
   "preference",
@@ -114,24 +117,33 @@ export const checkUnifiedSettingsParam$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const params = get(searchParams$);
     const value = params.get("settings");
+    const billingView = params.get("billingView");
     if (!value) {
       return;
     }
     if (isSettingsSection(value)) {
       const section = value;
+      const opensBillingPlans =
+        section === "billing" && billingView === "plans";
       const isAdmin = await get(isOrgAdmin$);
       signal.throwIfAborted();
-      const resolved =
-        !isAdmin && isAdminOnlySettingsSection(section)
-          ? "preference"
-          : section;
-      set(internalActiveSection$, resolved);
-      await set(setSettingsDialogOpen$, true, signal);
+      if (!isAdmin && opensBillingPlans) {
+        set(setBillingSubPage$, false);
+      } else {
+        const resolved =
+          !isAdmin && isAdminOnlySettingsSection(section)
+            ? "preference"
+            : section;
+        set(internalActiveSection$, resolved);
+        set(setBillingSubPage$, opensBillingPlans && resolved === "billing");
+        await set(setSettingsDialogOpen$, true, signal);
+      }
     }
 
     // Strip the param so a reload doesn't re-pin the dialog on this section
     const next = new URLSearchParams(get(searchParams$));
     next.delete("settings");
+    next.delete("billingView");
     set(updateSearchParams$, next);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -109,6 +109,22 @@ describe("org billing tab - plan display", () => {
 });
 
 describe("org billing tab - pricing sub-page navigation", () => {
+  it("opens pricing sub-page directly from URL", async () => {
+    setMockBillingStatus({ tier: "free", credits: 0 });
+
+    detachedSetupPage({
+      context,
+      path: "/?settings=billing&billingView=plans",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Free")).not.toBeInTheDocument();
+    expect(screen.getByText("Pro")).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeInTheDocument();
+  });
+
   it("should navigate to pricing page when clicking Compare all plans", async () => {
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { formatRunErrorForExternalSurface } from "../errors";
+import {
+  formatRunErrorForExternalSurface,
+  INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE,
+} from "../errors";
 
 describe("formatRunErrorForExternalSurface", () => {
   it("preserves allowlisted run errors like Web chat", () => {
@@ -19,6 +22,36 @@ describe("formatRunErrorForExternalSurface", () => {
         message: "Cannot continue session with this provider",
       }),
     ).toBe("Cannot continue session with this provider");
+  });
+
+  it("appends Compare plans link for admins on insufficient credits", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "INSUFFICIENT_CREDITS",
+        message: "Insufficient credits. Please add credits to continue.",
+        insufficientCredits: {
+          canManageBilling: true,
+          comparePlansUrl:
+            "https://app.example.test/?settings=billing&billingView=plans",
+        },
+      }),
+    ).toBe(
+      "Insufficient credits. Please add credits to continue.\n\nCompare plans: https://app.example.test/?settings=billing&billingView=plans",
+    );
+  });
+
+  it("asks non-admins to contact an admin on insufficient credits", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "INSUFFICIENT_CREDITS",
+        message: "Insufficient credits. Please add credits to continue.",
+        insufficientCredits: {
+          canManageBilling: false,
+          comparePlansUrl:
+            "https://app.example.test/?settings=billing&billingView=plans",
+        },
+      }),
+    ).toBe(INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE);
   });
 
   it("preserves ChatGPT Codex usage limit guidance", () => {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -119,6 +119,9 @@ export const RUN_ERROR_GUIDANCE: Record<
 export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 
+export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =
+  "Ask a workspace admin to add credits or upgrade the workspace plan.";
+
 export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
     return [guidance.title, guidance.guidance];
@@ -155,12 +158,26 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
 export function formatRunErrorForExternalSurface(params: {
   readonly code: string;
   readonly message: string;
+  readonly insufficientCredits?: {
+    readonly canManageBilling: boolean;
+    readonly comparePlansUrl: string;
+  };
 }): string {
   const errorMessage = params.message.trim() || "Run failed";
   const chatgptCodexUsageLimitMessage =
     formatChatgptCodexUsageLimitError(errorMessage);
   if (chatgptCodexUsageLimitMessage) {
     return chatgptCodexUsageLimitMessage;
+  }
+
+  if (
+    params.code === "INSUFFICIENT_CREDITS" &&
+    params.insufficientCredits !== undefined
+  ) {
+    if (!params.insufficientCredits.canManageBilling) {
+      return INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE;
+    }
+    return `${errorMessage}\n\nCompare plans: ${params.insufficientCredits.comparePlansUrl}`;
   }
 
   return isGenericRunErrorForDisplay(errorMessage)


### PR DESCRIPTION
## Summary
- add integration-specific insufficient-credit formatting: admins get a Compare plans URL, non-admins get an Ask admin message without a link
- support `/?settings=billing&billingView=plans` for admins so the Compare plans link opens the billing plans view
- keep non-admins on the home page when they open that billing plans link
- keep the Web chat insufficient-credit prompt card and Compare plans UI unchanged

## Tests
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts src/signals/routes/__tests__/zero-slack-events.test.ts
- pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/errors.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/settings-dialog.test.ts src/views/zero-page/__tests__/org-billing-tab.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pre-commit: prettier, knip, check-types