### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"


### PR DESCRIPTION
## Summary

Weekly Rust dependency update. Only 1 crate was updated:

- **memchr**: 2.8.0 → 2.8.1 (patch bump)

## Dependencies that could NOT be updated

| Dependency | Current | Latest | Reason |
|------------|---------|--------|--------|
| `generic-array` | 0.14.7 | 0.14.9 | Transitive dep locked by `block-buffer` 0.10.4 / `crypto-common` 0.1.7 via the `digest` → `sha1` → `tungstenite` chain |

All direct workspace dependencies are already at their latest versions within their current version constraints.

## Manual version bumps

None — `cargo update` resolved all eligible updates without constraint changes.

## Test status

**PASS** — All tests pass across 20 tested crates (0 failures).

Runner integration tests could not be built due to sandbox disk/memory limits (OOM during linking of large test binaries), but this is a pre-existing environment constraint unrelated to the memchr patch bump. Runner unit tests (1,274 tests) all pass.

All other crates tested clean with zero failures:
- `ably-subscriber` (124 tests)
- `agent-diagnostics` (7)
- `api-contracts` (18)
- `guest-agent` (300+)
- `guest-common` (17)
- `guest-download` (36)
- `guest-init` (62)
- `guest-mock-claude` (33)
- `guest-mock-codex` (25)
- `guest-reseed` (8)
- `guest-write-file` (19)
- `nbd-cow` (215)
- `process-control-ipc` (15)
- `sandbox` (21)
- `sandbox-fc` (460)
- `sandbox-mock` (80)
- `vsock-guest` (227)
- `vsock-host` (54)
- `vsock-proto` (72)
- `vsock-test` (26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)