### PR TITLE
fix(mitm-addon): bound auth base forwarded responses

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -26,6 +26,15 @@ HOP_BY_HOP: frozenset[str] = frozenset(
 )
 DEFAULT_HTTP_PORT = 80
 DEFAULT_HTTPS_PORT = 443
+MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
+MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
+
+_forward_request_semaphore: asyncio.Semaphore | None = None
+_forward_request_semaphore_loop: asyncio.AbstractEventLoop | None = None
+
+
+class ForwardedResponseTooLargeError(Exception):
+    """Raised when an auth.base upstream response exceeds the local body cap."""
 
 
 def header_pairs(headers) -> list[tuple[str, str]]:
@@ -149,6 +158,13 @@ def _outbound_request_headers(
     return outbound
 
 
+def _read_response_body(resp) -> bytes:
+    body = resp.read(MAX_AUTH_BASE_RESPONSE_BODY_BYTES + 1)
+    if len(body) > MAX_AUTH_BASE_RESPONSE_BODY_BYTES:
+        raise ForwardedResponseTooLargeError("Forwarded auth.base response body too large")
+    return body
+
+
 def _forward_request_sync(
     url: str,
     method: str,
@@ -183,12 +199,23 @@ def _forward_request_sync(
             conn.putheader(header_name, header_value)
         conn.endheaders(body)
         resp = conn.getresponse()
-        resp_body = resp.read()
+        resp_body = _read_response_body(resp)
         return resp.status, resp_body, _filter_response_headers(resp.getheaders())
     finally:
         if resp is not None:
             resp.close()
         conn.close()
+
+
+def _get_forward_request_semaphore() -> asyncio.Semaphore:
+    global _forward_request_semaphore
+    global _forward_request_semaphore_loop
+
+    loop = asyncio.get_running_loop()
+    if _forward_request_semaphore is None or _forward_request_semaphore_loop is not loop:
+        _forward_request_semaphore = asyncio.Semaphore(MAX_CONCURRENT_AUTH_BASE_FORWARDS)
+        _forward_request_semaphore_loop = loop
+    return _forward_request_semaphore
 
 
 async def forward_request(
@@ -198,4 +225,5 @@ async def forward_request(
     body: bytes | None,
 ) -> tuple[int, bytes, http.Headers]:
     """Async wrapper for _forward_request_sync."""
-    return await asyncio.to_thread(_forward_request_sync, url, method, headers, body)
+    async with _get_forward_request_semaphore():
+        return await asyncio.to_thread(_forward_request_sync, url, method, headers, body)

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -29,8 +29,7 @@ DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 
-_forward_request_semaphore: asyncio.Semaphore | None = None
-_forward_request_semaphore_loop: asyncio.AbstractEventLoop | None = None
+_forward_request_semaphore_state: tuple[asyncio.AbstractEventLoop, asyncio.Semaphore] | None = None
 
 
 class ForwardedResponseTooLargeError(Exception):
@@ -208,14 +207,15 @@ def _forward_request_sync(
 
 
 def _get_forward_request_semaphore() -> asyncio.Semaphore:
-    global _forward_request_semaphore
-    global _forward_request_semaphore_loop
+    global _forward_request_semaphore_state
 
     loop = asyncio.get_running_loop()
-    if _forward_request_semaphore is None or _forward_request_semaphore_loop is not loop:
-        _forward_request_semaphore = asyncio.Semaphore(MAX_CONCURRENT_AUTH_BASE_FORWARDS)
-        _forward_request_semaphore_loop = loop
-    return _forward_request_semaphore
+    if _forward_request_semaphore_state is None or _forward_request_semaphore_state[0] is not loop:
+        _forward_request_semaphore_state = (
+            loop,
+            asyncio.Semaphore(MAX_CONCURRENT_AUTH_BASE_FORWARDS),
+        )
+    return _forward_request_semaphore_state[1]
 
 
 async def forward_request(

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -514,8 +514,7 @@ class TestForwardRequestAsyncWrapper:
     async def test_releases_forward_slot_when_forwarding_raises(self):
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
-            patch.object(forwarder, "_forward_request_semaphore", None),
-            patch.object(forwarder, "_forward_request_semaphore_loop", None),
+            patch.object(forwarder, "_forward_request_semaphore_state", None),
             patch.object(
                 forwarder,
                 "_forward_request_sync",

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1,5 +1,6 @@
 """Tests for auth.base low-level HTTP forwarding."""
 
+import asyncio
 import contextlib
 import threading
 from collections.abc import Iterator
@@ -398,6 +399,52 @@ class TestAuthBaseForwarderSecurity:
         assert ("X-Keep", "ok") in pairs
 
 
+class TestAuthBaseForwarderResponseBodyLimit:
+    def test_reads_response_with_bounded_size(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            _patched_forwarder_connection(body=b"ok") as upstream,
+        ):
+            status, body, _headers = forwarder._forward_request_sync(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert status == 200
+        assert body == b"ok"
+        upstream.resp.read.assert_called_once_with(5)
+
+    def test_accepts_body_at_limit(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            _patched_forwarder_connection(body=b"1234") as upstream,
+        ):
+            status, body, _headers = forwarder._forward_request_sync(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert status == 200
+        assert body == b"1234"
+        upstream.resp.read.assert_called_once_with(5)
+
+    def test_rejects_body_over_limit_and_closes_resources(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            _patched_forwarder_connection(body=b"12345") as upstream,
+            pytest.raises(forwarder.ForwardedResponseTooLargeError),
+        ):
+            forwarder._forward_request_sync("https://example.com", "GET", [], None)
+
+        upstream.resp.read.assert_called_once_with(5)
+        upstream.resp.close.assert_called_once()
+        upstream.conn.close.assert_called_once()
+
+
 class TestAuthBaseForwarderResourceCleanup:
     def test_closes_response_on_success(self):
         with _patched_forwarder_connection(
@@ -464,6 +511,56 @@ class TestAuthBaseForwarderResourceCleanup:
 
 
 class TestForwardRequestAsyncWrapper:
+    async def test_limits_concurrent_forwarding_work(self):
+        active = 0
+        max_active = 0
+        started = 0
+        lock = threading.Lock()
+        cap_reached = threading.Event()
+        release = threading.Event()
+
+        def blocking_forward(*_args):
+            nonlocal active
+            nonlocal max_active
+            nonlocal started
+
+            with lock:
+                active += 1
+                started += 1
+                max_active = max(max_active, active)
+                if started == forwarder.MAX_CONCURRENT_AUTH_BASE_FORWARDS:
+                    cap_reached.set()
+            try:
+                if not release.wait(timeout=5):
+                    raise TimeoutError("test did not release blocked forwards")
+                return 200, b"ok", {}
+            finally:
+                with lock:
+                    active -= 1
+
+        task_count = forwarder.MAX_CONCURRENT_AUTH_BASE_FORWARDS + 2
+        with patch.object(forwarder, "_forward_request_sync", side_effect=blocking_forward):
+            tasks = [
+                asyncio.create_task(
+                    forwarder.forward_request("https://example.com", "GET", [], None)
+                )
+                for _ in range(task_count)
+            ]
+            try:
+                cap_was_reached = await asyncio.to_thread(cap_reached.wait, 2)
+                assert cap_was_reached
+                await asyncio.sleep(0)
+                with lock:
+                    assert started == forwarder.MAX_CONCURRENT_AUTH_BASE_FORWARDS
+                    assert max_active == forwarder.MAX_CONCURRENT_AUTH_BASE_FORWARDS
+                release.set()
+                results = await asyncio.gather(*tasks)
+            finally:
+                release.set()
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert results == [(200, b"ok", {})] * task_count
+
     async def test_offloads_request_work_from_event_loop_thread(self):
         event_loop_thread_id = threading.get_ident()
         forwarding_thread_ids = []
@@ -474,7 +571,7 @@ class TestForwardRequestAsyncWrapper:
         class FakeResponse:
             status = 200
 
-            def read(self):
+            def read(self, size):
                 record_forwarding_thread()
                 return b"ok"
 

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -511,6 +511,30 @@ class TestAuthBaseForwarderResourceCleanup:
 
 
 class TestForwardRequestAsyncWrapper:
+    async def test_releases_forward_slot_when_forwarding_raises(self):
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            patch.object(forwarder, "_forward_request_semaphore", None),
+            patch.object(forwarder, "_forward_request_semaphore_loop", None),
+            patch.object(
+                forwarder,
+                "_forward_request_sync",
+                side_effect=[
+                    ConnectionError("upstream unavailable"),
+                    (200, b"ok", {}),
+                ],
+            ),
+        ):
+            with pytest.raises(ConnectionError, match="upstream unavailable"):
+                await forwarder.forward_request("https://example.com", "GET", [], None)
+
+            result = await asyncio.wait_for(
+                forwarder.forward_request("https://example.com", "GET", [], None),
+                timeout=1,
+            )
+
+        assert result == (200, b"ok", {})
+
     async def test_limits_concurrent_forwarding_work(self):
         active = 0
         max_active = 0


### PR DESCRIPTION
## Summary
- Bound auth.base forwarded upstream response reads to 32 MiB plus one sentinel byte
- Limit concurrent auth.base forwarding work to four in-flight sync forwards
- Add focused tests for response size boundaries, cleanup, and concurrency capping

Closes #15065

## Validation
- python3 -m pytest tests/test_auth_base_forwarder.py
- python3 -m pytest
- PATH="$HOME/.local/bin:$PATH" ruff check src/auth_base_forwarder.py tests/test_auth_base_forwarder.py
- PATH="$HOME/.local/bin:$PATH" ruff format --check src/auth_base_forwarder.py tests/test_auth_base_forwarder.py
- python3 -m py_compile src/auth_base_forwarder.py tests/test_auth_base_forwarder.py
- git diff --check