### PR TITLE
refactor: remove unused connector access configs

### DIFF
--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -245,10 +245,7 @@ function connectorAccessOutputs(
   switch (access.kind) {
     case "static":
     case "refresh-token":
-    case "credential-exchange":
       return access.outputs;
-    case "managed":
-      return access.outputs ?? {};
     case "none":
       return {};
   }

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -349,12 +349,7 @@ export type ConnectorGrantConfig =
   | ConnectorDeviceAuthGrantConfig
   | ConnectorManagedGrantConfig;
 
-export type ConnectorAccessKind =
-  | "static"
-  | "refresh-token"
-  | "credential-exchange"
-  | "managed"
-  | "none";
+export type ConnectorAccessKind = "static" | "refresh-token" | "none";
 
 export interface ConnectorStaticAccessConfig {
   readonly kind: "static";
@@ -368,18 +363,6 @@ export interface ConnectorRefreshTokenAccessConfig {
   readonly outputs: Record<string, string>;
 }
 
-export interface ConnectorCredentialExchangeAccessConfig {
-  readonly kind: "credential-exchange";
-  readonly provider: string;
-  readonly inputs: Record<string, string>;
-  readonly outputs: Record<string, string>;
-}
-
-export interface ConnectorManagedAccessConfig {
-  readonly kind: "managed";
-  readonly outputs?: Record<string, string>;
-}
-
 export interface ConnectorNoAccessConfig {
   readonly kind: "none";
 }
@@ -387,8 +370,6 @@ export interface ConnectorNoAccessConfig {
 export type ConnectorAccessConfig =
   | ConnectorStaticAccessConfig
   | ConnectorRefreshTokenAccessConfig
-  | ConnectorCredentialExchangeAccessConfig
-  | ConnectorManagedAccessConfig
   | ConnectorNoAccessConfig;
 
 export type ConnectorRevokeKind = "none" | "token-revoke";


### PR DESCRIPTION
## Summary
- remove unused managed and credential-exchange connector access config variants
- keep managed as a grant kind only and simplify access output derivation

## Tests
- pnpm format
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/__tests__/firewall-secret-consistency.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- git diff --check
- pre-commit: prettier, knip, pnpm check-types