### PR TITLE
fix: classify invalid billable auth expiry

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -35,8 +35,8 @@ class InsufficientCreditsError(Exception):
     """Raised when the auth endpoint denies billable firewall auth for credits."""
 
 
-class MissingAuthExpiryError(Exception):
-    """Raised when billable firewall auth succeeds without a valid cache expiry."""
+class InvalidBillableAuthExpiryError(Exception):
+    """Raised when billable firewall auth succeeds with an invalid cache expiry."""
 
 
 # Vercel bypass secret (still from environment as it's a secret)
@@ -439,7 +439,7 @@ async def get_firewall_headers(
             force_refresh=force_refresh,
         )
         if firewall_billable and not _has_valid_expiry(result.get("expiresAt")):
-            raise MissingAuthExpiryError(
+            raise InvalidBillableAuthExpiryError(
                 "Billable firewall auth response did not include a valid cache expiry"
             )
         headers = result["headers"]
@@ -678,6 +678,23 @@ async def handle_firewall_request(
             status=402,
             action="BLOCK",
             error_code="insufficient_credits",
+            message=str(e),
+            permission=allow.name,
+        )
+        return
+    except InvalidBillableAuthExpiryError as e:
+        log_proxy_entry(
+            proxy_log_path,
+            "error",
+            f"Billable firewall auth response returned invalid expiresAt for {firewall_base}: {e}",
+            type="firewall",
+            firewall_base=firewall_base,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=502,
+            action="ALLOW",
+            error_code="invalid_auth_expiry",
             message=str(e),
             permission=allow.name,
         )

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -741,6 +741,8 @@ class TestHandleFirewallRequest:
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["firewall_error"] == "invalid_auth_expiry"
+        assert "Authorization" not in flow.request.headers
+        assert cached_headers(("test-run", "https://api.github.com")) is None
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_auth_expiry"
         assert "valid cache expiry" in body["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -182,9 +182,20 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
 
-    @pytest.mark.parametrize("expiry", [None, True, "123", float("inf"), float("nan")])
-    def test_expiry_validation_rejects_invalid_values(self, expiry):
-        assert auth._has_valid_expiry(expiry, now=time.time()) is False
+    @pytest.mark.parametrize(
+        ("expiry", "now"),
+        [
+            pytest.param(None, 100.0, id="none"),
+            pytest.param(True, 0.0, id="bool-true"),
+            pytest.param(False, -1.0, id="bool-false"),
+            pytest.param("123", 100.0, id="string"),
+            pytest.param(float("inf"), 100.0, id="infinity"),
+            pytest.param(float("nan"), 100.0, id="nan"),
+            pytest.param(100.0, 100.0, id="exact-now"),
+        ],
+    )
+    def test_expiry_validation_rejects_invalid_values(self, expiry, now):
+        assert auth._has_valid_expiry(expiry, now=now) is False
 
     @pytest.mark.parametrize("expiry", [True, "123", float("inf"), float("nan")])
     async def test_cache_with_invalid_expiry_refetches(self, headers, expiry):

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -225,7 +225,7 @@ class TestGetFirewallHeaders:
             expires_at=None,
         )
         fresh_headers = {"Authorization": "Bearer fresh-token"}
-        expires_at = time.time() + 30
+        expires_at = int(time.time()) + 30
         mock_fetch = AsyncMock(
             return_value={
                 "headers": fresh_headers,

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -277,7 +277,7 @@ class TestGetFirewallHeaders:
 
         with (
             patch.object(auth, "fetch_firewall_headers", mock_fetch),
-            pytest.raises(auth.MissingAuthExpiryError),
+            pytest.raises(auth.InvalidBillableAuthExpiryError),
         ):
             await auth.get_firewall_headers(
                 "run-1",
@@ -679,6 +679,51 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
+
+    async def test_invalid_billable_auth_expiry_returns_502(self, real_flow, mitm_ctx, tmp_path):
+        flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+        flow.metadata["vm_run_id"] = "test-run"
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "billableFirewalls": ["github"],
+        }
+        allow = _allow(api_entry)
+
+        with (
+            patch.object(
+                auth,
+                "fetch_firewall_headers",
+                AsyncMock(
+                    return_value={
+                        "headers": {"Authorization": "Bearer token"},
+                        "expiresAt": None,
+                    }
+                ),
+            ),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "invalid_auth_expiry"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "invalid_auth_expiry"
+        assert "valid cache expiry" in body["message"]
+        assert body["permission"] == "github"
+        assert body["base"] == "https://api.github.com"
+        assert "connectors" not in body
+        log_text = await asyncio.to_thread(
+            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
+        )
+        assert "invalid expiresAt" in log_text
 
     async def test_no_response_set_on_success(self, real_flow, headers, mitm_ctx):
         """On success, flow.response should remain None (request continues to origin)."""

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -729,6 +729,8 @@ class TestHandleFirewallRequest:
                 AsyncMock(
                     return_value={
                         "headers": {"Authorization": "Bearer token"},
+                        "base": "https://forward.example/secret",
+                        "query": {"api_key": "secret"},
                         "expiresAt": None,
                     }
                 ),
@@ -742,6 +744,8 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["firewall_error"] == "invalid_auth_expiry"
         assert "Authorization" not in flow.request.headers
+        assert "auth_url_rewrite" not in flow.metadata
+        assert "api_key" not in flow.request.query
         assert cached_headers(("test-run", "https://api.github.com")) is None
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_auth_expiry"

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -267,13 +267,39 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is False
         mock_fetch.assert_called_once()
 
-    async def test_billable_fetch_without_expiry_fails_closed(self, headers):
-        mock_fetch = AsyncMock(
-            return_value={
-                "headers": {"Authorization": "Bearer token"},
-                "expiresAt": None,
-            }
-        )
+    @pytest.mark.parametrize(
+        "fetch_result",
+        [
+            pytest.param({"headers": {"Authorization": "Bearer token"}}, id="missing"),
+            pytest.param(
+                {"headers": {"Authorization": "Bearer token"}, "expiresAt": None},
+                id="none",
+            ),
+            pytest.param(
+                {"headers": {"Authorization": "Bearer token"}, "expiresAt": True},
+                id="bool",
+            ),
+            pytest.param(
+                {"headers": {"Authorization": "Bearer token"}, "expiresAt": "123"},
+                id="string",
+            ),
+            pytest.param(
+                {"headers": {"Authorization": "Bearer token"}, "expiresAt": float("inf")},
+                id="infinity",
+            ),
+            pytest.param(
+                {"headers": {"Authorization": "Bearer token"}, "expiresAt": float("nan")},
+                id="nan",
+            ),
+            pytest.param(
+                {"headers": {"Authorization": "Bearer token"}, "expiresAt": 0},
+                id="expired",
+            ),
+        ],
+    )
+    async def test_billable_fetch_with_invalid_expiry_fails_closed(self, fetch_result):
+        cache_key = ("run-1", "api-1")
+        mock_fetch = AsyncMock(return_value=fetch_result)
 
         with (
             patch.object(auth, "fetch_firewall_headers", mock_fetch),
@@ -287,6 +313,7 @@ class TestGetFirewallHeaders:
                 "tok-xyz",
                 firewall_billable=True,
             )
+        assert cached_headers(cache_key) is None
 
     async def test_cache_hit_includes_base_when_present(self, headers):
         """Cached entry with 'base' returns it on cache hit."""


### PR DESCRIPTION
## Summary
- rename the billable auth expiry exception to reflect invalid expiry values
- classify invalid billable firewall auth expiry as invalid_auth_expiry instead of generic auth_failed
- add regression coverage through handle_firewall_request -> get_firewall_headers by patching fetch_firewall_headers
- cover invalid billable expiresAt values including missing, null, bool, string, non-finite, exact-now, and expired responses
- cover a valid integer expiresAt response because API Unix-second values may be integers
- assert invalid billable auth responses do not inject returned auth headers, rewrite URLs, inject query params, or populate the auth cache

## Tests
- python3 -m pytest tests/test_firewall_auth.py::TestGetFirewallHeaders::test_billable_cache_without_expiry_refetches tests/test_firewall_auth.py::TestGetFirewallHeaders::test_billable_cache_with_expired_expiry_refetches tests/test_firewall_auth.py::TestGetFirewallHeaders::test_billable_cache_hit_requires_valid_expiry -v
- python3 -m pytest tests/test_firewall_auth.py::TestGetFirewallHeaders::test_expiry_validation_rejects_invalid_values tests/test_firewall_auth.py::TestGetFirewallHeaders::test_billable_fetch_with_invalid_expiry_fails_closed tests/test_firewall_auth.py::TestHandleFirewallRequest::test_invalid_billable_auth_expiry_returns_502 -v
- python3 -m pytest tests/test_firewall_auth.py::TestGetFirewallHeaders::test_billable_fetch_with_invalid_expiry_fails_closed -v
- python3 -m pytest tests/test_firewall_auth.py -v
- python3 -m pytest tests/ -v
- python3 -m ruff format --check .
- python3 -m ruff check .
- python3 -m basedpyright -p .

Closes #15061
