### PR TITLE
fix: harden runner claim lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -96,7 +96,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         warn!(
             run_id = %run_id,
             context_run_id = %claimed.context().run_id,
-            "claimed job run_id mismatch, skipping"
+            "provider returned claimed job with mismatched run_id"
         );
         ctx.cancel_tokens.lock().await.remove(&run_id);
         drop(job_lease);

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -157,16 +157,19 @@ impl JobProvider for ApiProvider {
         let run_id = candidate.run_id();
         match self.api.claim(run_id).await {
             Ok(ctx) => {
-                if ctx.run_id != run_id {
-                    error!(
-                        run_id = %run_id,
-                        context_run_id = %ctx.run_id,
-                        "claim response run_id mismatch"
-                    );
-                    return None;
-                }
+                let claimed = match ClaimedJob::api(run_id, ctx) {
+                    Ok(claimed) => claimed,
+                    Err(err) => {
+                        error!(
+                            run_id = %err.expected_run_id,
+                            context_run_id = %err.context_run_id,
+                            "claim response run_id mismatch"
+                        );
+                        return None;
+                    }
+                };
                 info!(run_id = %run_id, "job claimed");
-                Some(ClaimedJob::api(ctx))
+                Some(claimed)
             }
             Err(RunnerError::AlreadyClaimed) => {
                 info!(run_id = %run_id, "already claimed, skipping");

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -671,9 +671,7 @@ impl JobProvider for LocalProvider {
             return None;
         }
 
-        self.cancel_scanner.mark_owned_claim(run_id).await;
-        info!(run_id = %run_id, "local: job claimed");
-        Some(ClaimedJob::local(ExecutionContext {
+        let context = ExecutionContext {
             run_id,
             prompt: req.prompt,
             append_system_prompt: None,
@@ -707,7 +705,24 @@ impl JobProvider for LocalProvider {
             feature_flags: req.feature_flags,
             billable_firewalls: vec![],
             model_usage_provider: None,
-        }))
+        };
+        match ClaimedJob::local(run_id, context) {
+            Ok(claimed) => {
+                self.cancel_scanner.mark_owned_claim(run_id).await;
+                info!(run_id = %run_id, "local: job claimed");
+                Some(claimed)
+            }
+            Err(err) => {
+                let error = format!(
+                    "claimed job run_id mismatch: expected={}, context={}",
+                    err.expected_run_id, err.context_run_id
+                );
+                warn!(run_id = %run_id, error = %error, "local: claimed job invariant violation");
+                self.fail_claimed_job(run_id, &claim_file, &job_file, error)
+                    .await;
+                None
+            }
+        }
     }
 
     async fn complete(

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use tokio::sync::{Mutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
 use crate::ids::RunId;
@@ -270,12 +271,23 @@ impl JobProvider for MockJobProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        self.claim_results
+        let context = self
+            .claim_results
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(&run_id)
-            .flatten()
-            .map(ClaimedJob::local)
+            .flatten()?;
+        match ClaimedJob::local(run_id, context) {
+            Ok(claimed) => Some(claimed),
+            Err(err) => {
+                warn!(
+                    run_id = %err.expected_run_id,
+                    context_run_id = %err.context_run_id,
+                    "mock: claimed job run_id mismatch"
+                );
+                None
+            }
+        }
     }
 
     async fn complete(
@@ -316,5 +328,79 @@ impl JobProvider for MockJobProvider {
     /// The main loop must `drop(discover_fut)` before calling this.
     async fn shutdown(&self) {
         let _lock = self.discovery.lock().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_context(run_id: RunId) -> ExecutionContext {
+        ExecutionContext {
+            run_id,
+            prompt: "test".into(),
+            append_system_prompt: None,
+            _agent_compose_version_id: None,
+            vars: None,
+            checkpoint_id: None,
+            sandbox_token: "tok".into(),
+            working_dir: "/workspace".into(),
+            storage_manifest: None,
+            environment: None,
+            resume_session: None,
+            secret_values: None,
+            encrypted_secrets: None,
+            secret_connector_map: None,
+            secret_connector_metadata_map: None,
+            cli_agent_type: String::new(),
+            debug_no_mock_claude: None,
+            debug_no_mock_codex: None,
+            api_start_time: None,
+            user_timezone: None,
+            capture_network_bodies: None,
+            firewalls: None,
+            network_policies: None,
+            disallowed_tools: None,
+            tools: None,
+            settings: None,
+            experimental_profile: None,
+            feature_flags: None,
+            billable_firewalls: vec![],
+            model_usage_provider: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_mismatched_context() {
+        let candidate_run_id = RunId::nil();
+        let context_run_id = RunId::new_v4();
+        let (provider, _handle) = MockJobProvider::new(CancellationToken::new());
+        provider.set_claim_result(candidate_run_id, Some(minimal_context(context_run_id)));
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                candidate_run_id,
+                crate::profile::DEFAULT_PROFILE.to_owned(),
+            ))
+            .await;
+
+        assert!(claimed.is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_accepts_matching_context() {
+        let run_id = RunId::nil();
+        let (provider, _handle) = MockJobProvider::new(CancellationToken::new());
+        provider.set_claim_result(run_id, Some(minimal_context(run_id)));
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_owned(),
+            ))
+            .await
+            .expect("matching context should be claimed");
+
+        assert_eq!(claimed.context().run_id, run_id);
     }
 }

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -65,22 +65,49 @@ pub struct ClaimedJob {
     completion_auth: CompletionAuth,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ClaimedJobRunIdMismatch {
+    pub(crate) expected_run_id: RunId,
+    pub(crate) context_run_id: RunId,
+}
+
 impl ClaimedJob {
-    fn new(context: ExecutionContext, completion_auth: CompletionAuth) -> Self {
-        Self {
-            context,
-            completion_auth,
+    fn validate_run_id(
+        expected_run_id: RunId,
+        context: &ExecutionContext,
+    ) -> Result<(), ClaimedJobRunIdMismatch> {
+        if context.run_id == expected_run_id {
+            Ok(())
+        } else {
+            Err(ClaimedJobRunIdMismatch {
+                expected_run_id,
+                context_run_id: context.run_id,
+            })
         }
     }
 
-    pub(crate) fn api(context: ExecutionContext) -> Self {
+    pub(crate) fn api(
+        expected_run_id: RunId,
+        context: ExecutionContext,
+    ) -> Result<Self, ClaimedJobRunIdMismatch> {
+        Self::validate_run_id(expected_run_id, &context)?;
         let completion_auth =
             CompletionAuth::sandbox_token(context.run_id, context.sandbox_token.clone());
-        Self::new(context, completion_auth)
+        Ok(Self {
+            context,
+            completion_auth,
+        })
     }
 
-    pub(crate) fn local(context: ExecutionContext) -> Self {
-        Self::new(context, CompletionAuth::local())
+    pub(crate) fn local(
+        expected_run_id: RunId,
+        context: ExecutionContext,
+    ) -> Result<Self, ClaimedJobRunIdMismatch> {
+        Self::validate_run_id(expected_run_id, &context)?;
+        Ok(Self {
+            context,
+            completion_auth: CompletionAuth::local(),
+        })
     }
 
     pub(crate) fn into_parts(self) -> (ExecutionContext, CompletionAuth) {
@@ -211,4 +238,74 @@ pub trait JobProvider: Send + Sync {
     /// Called once after `discover()` returns `None` and before draining
     /// in-flight jobs. `complete()` calls may still arrive after this.
     async fn shutdown(&self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_context(run_id: RunId) -> ExecutionContext {
+        ExecutionContext {
+            run_id,
+            prompt: "test".into(),
+            append_system_prompt: None,
+            _agent_compose_version_id: None,
+            vars: None,
+            checkpoint_id: None,
+            sandbox_token: "sandbox-token".into(),
+            working_dir: "/workspace".into(),
+            storage_manifest: None,
+            environment: None,
+            resume_session: None,
+            secret_values: None,
+            encrypted_secrets: None,
+            secret_connector_map: None,
+            secret_connector_metadata_map: None,
+            cli_agent_type: String::new(),
+            debug_no_mock_claude: None,
+            debug_no_mock_codex: None,
+            api_start_time: None,
+            user_timezone: None,
+            capture_network_bodies: None,
+            firewalls: None,
+            network_policies: None,
+            disallowed_tools: None,
+            tools: None,
+            settings: None,
+            experimental_profile: None,
+            feature_flags: None,
+            billable_firewalls: vec![],
+            model_usage_provider: None,
+        }
+    }
+
+    #[test]
+    fn claimed_job_rejects_mismatched_api_context() {
+        let expected_run_id = RunId::nil();
+        let context_run_id = RunId::new_v4();
+
+        let Err(err) = ClaimedJob::api(expected_run_id, minimal_context(context_run_id)) else {
+            panic!("mismatched context must be rejected");
+        };
+
+        assert_eq!(
+            err,
+            ClaimedJobRunIdMismatch {
+                expected_run_id,
+                context_run_id,
+            }
+        );
+    }
+
+    #[test]
+    fn claimed_job_accepts_matching_api_context() {
+        let run_id = RunId::nil();
+
+        let claimed =
+            ClaimedJob::api(run_id, minimal_context(run_id)).expect("matching context is valid");
+        let (context, completion_auth) = claimed.into_parts();
+
+        assert_eq!(context.run_id, run_id);
+        assert!(completion_auth.matches_sandbox_token_for_test(run_id, "sandbox-token"));
+    }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -645,6 +645,114 @@ describe("POST /api/runners/*", () => {
     );
   });
 
+  it("returns not found after a successful claim dequeues the job", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+
+    const firstResponse = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 200,
+    });
+    expect(firstResponse.body).toMatchObject({ runId: queued.runId });
+
+    const secondResponse = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 404,
+    });
+
+    expect(secondResponse.body).toStrictEqual({
+      error: { message: "Job not found in queue", code: "NOT_FOUND" },
+    });
+  });
+
+  it("removes a stale queued job when the run is no longer pending", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({
+        status: "failed",
+        completedAt: new Date(now()),
+        error: "already failed",
+      })
+      .where(eq(agentRuns.id, queued.runId));
+
+    const response = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 404,
+    });
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Run not found", code: "NOT_FOUND" },
+    });
+    const remainingJobs = await db
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    expect(remainingJobs).toHaveLength(0);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      `run:changed:${queued.runId}`,
+      { status: "running" },
+    );
+  });
+
+  it("fails and dequeues a job with invalid stored execution context", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+    const db = store.set(writeDb$);
+    await db
+      .update(runnerJobQueue)
+      .set({ executionContext: { workingDir: "/workspace" } })
+      .where(eq(runnerJobQueue.runId, queued.runId));
+
+    const response = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 400,
+    });
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Job missing execution context", code: "BAD_REQUEST" },
+    });
+    const [run] = await db
+      .select({
+        status: agentRuns.status,
+        error: agentRuns.error,
+        completedAt: agentRuns.completedAt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run).toMatchObject({
+      status: "failed",
+      error: "Runner job missing valid execution context",
+    });
+    expect(run?.completedAt).toBeInstanceOf(Date);
+
+    const remainingJobs = await db
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    expect(remainingJobs).toHaveLength(0);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${queued.runId}`,
+      { status: "failed" },
+    );
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      `run:changed:${queued.runId}`,
+      { status: "running" },
+    );
+  });
+
   it("returns appendSystemPrompt in claim responses", async () => {
     const fixture = await trackUsageFixture(
       store.set(seedUsageInsightFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -17,6 +17,7 @@ import { and, eq, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
 import { runnerAuth$, type RunnerAuthContext } from "../auth/runner-auth";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
 import {
   createRunnerGroupRealtimeToken,
@@ -28,12 +29,16 @@ import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
+import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route";
+import { tapError } from "../utils";
 
 const L = logger("Runners");
 
 const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
+const INVALID_EXECUTION_CONTEXT_ERROR =
+  "Runner job missing valid execution context";
 
 const unauthorizedNotAuthenticated = Object.freeze({
   status: 401 as const,
@@ -229,7 +234,7 @@ const claimBody$ = bodyResultOf(runnersJobClaimContract.claim);
 
 interface ClaimableJob {
   readonly job: typeof runnerJobQueue.$inferSelect;
-  readonly runUserId: string;
+  readonly run: ClaimedRun;
 }
 
 interface ClaimedRun {
@@ -260,7 +265,16 @@ async function getClaimableJob(
   const [jobWithRun] = await db
     .select({
       job: runnerJobQueue,
-      runUserId: agentRuns.userId,
+      run: {
+        id: agentRuns.id,
+        userId: agentRuns.userId,
+        orgId: agentRuns.orgId,
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+        agentComposeVersionId: agentRuns.agentComposeVersionId,
+        vars: agentRuns.vars,
+        resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
+      },
     })
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
@@ -296,7 +310,7 @@ function claimAuthorizationError(
       : forbidden("Official runners can only claim jobs from vm0/* groups");
   }
 
-  if (jobWithRun.runUserId !== auth.userId) {
+  if (jobWithRun.run.userId !== auth.userId) {
     return forbidden("Job does not belong to user");
   }
   return isOfficialRunnerGroup(jobWithRun.job.runnerGroup)
@@ -304,49 +318,99 @@ function claimAuthorizationError(
     : forbidden("Only vm0/* runner groups are supported");
 }
 
-async function markJobClaimed(
+type ClaimTransitionResult =
+  | { readonly status: "claimed" }
+  | { readonly status: "conflict" }
+  | { readonly status: "not-found" };
+
+async function transitionClaimedJobToRunning(
   db: Db,
   runId: string,
   claimedAt: Date,
   signal: AbortSignal,
-) {
-  const [claimedJob] = await db
-    .update(runnerJobQueue)
-    .set({ claimedAt })
-    .where(
-      and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
-    )
-    .returning();
-  signal.throwIfAborted();
-  return claimedJob ?? null;
+): Promise<ClaimTransitionResult> {
+  return await db.transaction(async (tx) => {
+    const [claimedJob] = await tx
+      .update(runnerJobQueue)
+      .set({ claimedAt })
+      .where(
+        and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+      )
+      .returning({ runId: runnerJobQueue.runId });
+    signal.throwIfAborted();
+    if (!claimedJob) {
+      return { status: "conflict" as const };
+    }
+
+    const [run] = await tx
+      .update(agentRuns)
+      .set({
+        status: "running",
+        startedAt: claimedAt,
+        lastHeartbeatAt: claimedAt,
+      })
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (!run) {
+      await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+      signal.throwIfAborted();
+      return { status: "not-found" };
+    }
+
+    await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+    signal.throwIfAborted();
+
+    return { status: "claimed" as const };
+  });
 }
 
-async function markRunRunning(
+type PoisonJobResult =
+  | { readonly status: "failed" }
+  | { readonly status: "conflict" }
+  | { readonly status: "not-found" };
+
+async function failPoisonQueuedJob(
   db: Db,
   runId: string,
   claimedAt: Date,
+  errorMessage: string,
   signal: AbortSignal,
-): Promise<ClaimedRun | null> {
-  const [run] = await db
-    .update(agentRuns)
-    .set({
-      status: "running",
-      startedAt: claimedAt,
-      lastHeartbeatAt: claimedAt,
-    })
-    .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
-    .returning({
-      id: agentRuns.id,
-      userId: agentRuns.userId,
-      orgId: agentRuns.orgId,
-      prompt: agentRuns.prompt,
-      appendSystemPrompt: agentRuns.appendSystemPrompt,
-      agentComposeVersionId: agentRuns.agentComposeVersionId,
-      vars: agentRuns.vars,
-      resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
-    });
-  signal.throwIfAborted();
-  return run ?? null;
+): Promise<PoisonJobResult> {
+  return await db.transaction(async (tx) => {
+    const [claimedJob] = await tx
+      .update(runnerJobQueue)
+      .set({ claimedAt })
+      .where(
+        and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+      )
+      .returning({ runId: runnerJobQueue.runId });
+    signal.throwIfAborted();
+    if (!claimedJob) {
+      return { status: "conflict" as const };
+    }
+
+    const [run] = await tx
+      .update(agentRuns)
+      .set({
+        status: "failed",
+        completedAt: nowDate(),
+        error: errorMessage,
+      })
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (!run) {
+      await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+      signal.throwIfAborted();
+      return { status: "not-found" };
+    }
+
+    await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+    signal.throwIfAborted();
+
+    return { status: "failed" as const };
+  });
 }
 
 async function secretValuesForRunner(
@@ -397,13 +461,78 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const currentTime = now();
   const claimedAt = new Date(currentTime);
-  const claimedJob = await markJobClaimed(db, runId, claimedAt, signal);
-  if (!claimedJob) {
+  const run = jobWithRun.run;
+
+  const storedContextResult = storedExecutionContextSchema.safeParse(
+    jobWithRun.job.executionContext,
+  );
+  if (!storedContextResult.success) {
+    L.warn(INVALID_EXECUTION_CONTEXT_ERROR, { runId });
+    const poisonResult = await failPoisonQueuedJob(
+      db,
+      runId,
+      claimedAt,
+      INVALID_EXECUTION_CONTEXT_ERROR,
+      signal,
+    );
+    if (poisonResult.status === "conflict") {
+      return conflict("Job was claimed by another runner");
+    }
+    if (poisonResult.status === "not-found") {
+      return notFound("Run not found");
+    }
+
+    await publishRunChangedForUserSafely(run.userId, runId, {
+      status: "failed",
+    });
+    signal.throwIfAborted();
+    waitUntil(
+      tapError(
+        set(
+          dispatchCompleteSideEffects$,
+          {
+            runId,
+            orgId: run.orgId,
+            status: "failed",
+            error: INVALID_EXECUTION_CONTEXT_ERROR,
+          },
+          signal,
+        ),
+        (error) => {
+          L.error("dispatchCompleteSideEffects failed", {
+            runId,
+            error,
+          });
+        },
+      ),
+    );
+    return badRequestMessage("Job missing execution context");
+  }
+  const storedContext = storedContextResult.data;
+
+  const featureSwitchContext = await loadUserFeatureSwitchContext(
+    db,
+    run.orgId,
+    run.userId,
+  );
+  signal.throwIfAborted();
+  const secretValues = await secretValuesForRunner(
+    storedContext,
+    featureSwitchContext,
+  );
+  signal.throwIfAborted();
+  const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
+
+  const claimResult = await transitionClaimedJobToRunning(
+    db,
+    runId,
+    claimedAt,
+    signal,
+  );
+  if (claimResult.status === "conflict") {
     return conflict("Job was claimed by another runner");
   }
-
-  const run = await markRunRunning(db, runId, claimedAt, signal);
-  if (!run) {
+  if (claimResult.status === "not-found") {
     return notFound("Run not found");
   }
 
@@ -411,17 +540,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     status: "running",
   });
   signal.throwIfAborted();
-
-  const storedContextResult = storedExecutionContextSchema.safeParse(
-    claimedJob.executionContext,
-  );
-  if (!storedContextResult.success) {
-    L.warn("Runner job missing valid execution context", { runId });
-    return badRequestMessage("Job missing execution context");
-  }
-  const storedContext = storedContextResult.data;
-
-  const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
 
   const apiToClaimMs = elapsedSinceApiStartMs(
     storedContext.apiStartTime,
@@ -437,9 +555,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     });
   }
 
-  await db.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
-  signal.throwIfAborted();
-
   return {
     status: 200 as const,
     body: {
@@ -451,10 +566,7 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       vars: (run.vars as Record<string, string>) ?? null,
       checkpointId: run.resumedFromCheckpointId ?? null,
       sandboxToken,
-      secretValues: await secretValuesForRunner(
-        storedContext,
-        await loadUserFeatureSwitchContext(db, run.orgId, run.userId),
-      ),
+      secretValues,
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -433,6 +433,48 @@ async function secretValuesForRunner(
   });
 }
 
+function scheduleClaimSucceededSideEffects(args: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly apiToClaimMs: number | undefined;
+}): void {
+  waitUntil(
+    publishRunChangedForUserSafely(args.userId, args.runId, {
+      status: "running",
+    }),
+  );
+  const apiToClaimMs = args.apiToClaimMs;
+  if (apiToClaimMs === undefined) {
+    return;
+  }
+
+  waitUntil(
+    tapError(
+      recordClaimApiToClaimMetric({
+        runId: args.runId,
+        durationMs: apiToClaimMs,
+      }),
+      (error) => {
+        L.warn("recordSandboxOperation failed", { runId: args.runId, error });
+      },
+    ),
+  );
+}
+
+async function recordClaimApiToClaimMetric(args: {
+  readonly runId: string;
+  readonly durationMs: number;
+}): Promise<void> {
+  await Promise.resolve();
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "api_to_claim",
+    durationMs: args.durationMs,
+    success: true,
+    runId: args.runId,
+  });
+}
+
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = await set(runnerAuth$, get(authorization$), signal);
   signal.throwIfAborted();
@@ -522,6 +564,21 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
   signal.throwIfAborted();
   const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
+  const apiToClaimMs = elapsedSinceApiStartMs(
+    storedContext.apiStartTime,
+    currentTime,
+  );
+  const responseBody = {
+    ...storedContext,
+    runId: run.id,
+    prompt: run.prompt,
+    appendSystemPrompt: run.appendSystemPrompt,
+    agentComposeVersionId: run.agentComposeVersionId,
+    vars: (run.vars as Record<string, string>) ?? null,
+    checkpointId: run.resumedFromCheckpointId ?? null,
+    sandboxToken,
+    secretValues,
+  };
 
   const claimResult = await transitionClaimedJobToRunning(
     db,
@@ -536,38 +593,15 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Run not found");
   }
 
-  await publishRunChangedForUserSafely(run.userId, runId, {
-    status: "running",
+  scheduleClaimSucceededSideEffects({
+    runId,
+    userId: run.userId,
+    apiToClaimMs,
   });
-  signal.throwIfAborted();
-
-  const apiToClaimMs = elapsedSinceApiStartMs(
-    storedContext.apiStartTime,
-    currentTime,
-  );
-  if (apiToClaimMs !== undefined) {
-    recordSandboxOperation({
-      sandboxType: "runner",
-      actionType: "api_to_claim",
-      durationMs: apiToClaimMs,
-      success: true,
-      runId,
-    });
-  }
 
   return {
     status: 200 as const,
-    body: {
-      ...storedContext,
-      runId: run.id,
-      prompt: run.prompt,
-      appendSystemPrompt: run.appendSystemPrompt,
-      agentComposeVersionId: run.agentComposeVersionId,
-      vars: (run.vars as Record<string, string>) ?? null,
-      checkpointId: run.resumedFromCheckpointId ?? null,
-      sandboxToken,
-      secretValues,
-    },
+    body: responseBody,
   };
 });
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, type Setter } from "ccstate";
 import {
   elapsedSinceApiStartMs,
   runnersHeartbeatContract,
@@ -475,6 +475,41 @@ async function recordClaimApiToClaimMetric(args: {
   });
 }
 
+function scheduleClaimFailedSideEffects(args: {
+  readonly set: Setter;
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly error: string;
+}): void {
+  const backgroundSignal = new AbortController().signal;
+  waitUntil(
+    publishRunChangedForUserSafely(args.userId, args.runId, {
+      status: "failed",
+    }),
+  );
+  waitUntil(
+    tapError(
+      args.set(
+        dispatchCompleteSideEffects$,
+        {
+          runId: args.runId,
+          orgId: args.orgId,
+          status: "failed",
+          error: args.error,
+        },
+        backgroundSignal,
+      ),
+      (error) => {
+        L.error("dispatchCompleteSideEffects failed", {
+          runId: args.runId,
+          error,
+        });
+      },
+    ),
+  );
+}
+
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = await set(runnerAuth$, get(authorization$), signal);
   signal.throwIfAborted();
@@ -524,30 +559,13 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       return notFound("Run not found");
     }
 
-    await publishRunChangedForUserSafely(run.userId, runId, {
-      status: "failed",
+    scheduleClaimFailedSideEffects({
+      set,
+      runId,
+      userId: run.userId,
+      orgId: run.orgId,
+      error: INVALID_EXECUTION_CONTEXT_ERROR,
     });
-    signal.throwIfAborted();
-    waitUntil(
-      tapError(
-        set(
-          dispatchCompleteSideEffects$,
-          {
-            runId,
-            orgId: run.orgId,
-            status: "failed",
-            error: INVALID_EXECUTION_CONTEXT_ERROR,
-          },
-          signal,
-        ),
-        (error) => {
-          L.error("dispatchCompleteSideEffects failed", {
-            runId,
-            error,
-          });
-        },
-      ),
-    );
     return badRequestMessage("Job missing execution context");
   }
   const storedContext = storedContextResult.data;


### PR DESCRIPTION
## Summary
- enforce the ClaimedJob run-id invariant at provider construction boundaries
- make runner API claims validate/prepare response data before the durable claim transition
- fail and dequeue poison runner jobs with invalid stored execution context
- add Rust and API regression coverage for mismatched/invalid claim paths

Fixes #15086

## Testing
- cargo test --manifest-path crates/Cargo.toml -p runner provider::
- cargo test --manifest-path crates/Cargo.toml -p runner
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pre-commit hook passed: cargo-fmt, prettier, knip, cargo-clippy, cargo-doc, turbo check-types