### PR TITLE
fix: validate claude tool list entries

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -24,6 +24,22 @@ pub(super) fn build_cli_command_for_framework(
     }
 }
 
+fn push_comma_separated_flag_values(args: &mut Vec<String>, flag: &str, values: &str) {
+    let mut has_values = false;
+
+    for value in values
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !has_values {
+            args.push(flag.to_string());
+            has_values = true;
+        }
+        args.push(value.to_string());
+    }
+}
+
 /// Build the argument list from explicit parameters (testable).
 fn build_claude_args(
     resume_id: &str,
@@ -54,25 +70,8 @@ fn build_claude_args(
         args.push(append_system_prompt.to_string());
     }
 
-    if !disallowed_tools.is_empty() {
-        args.push("--disallowed-tools".to_string());
-        for tool in disallowed_tools.split(',') {
-            let tool = tool.trim();
-            if !tool.is_empty() {
-                args.push(tool.to_string());
-            }
-        }
-    }
-
-    if !tools.is_empty() {
-        args.push("--tools".to_string());
-        for tool in tools.split(',') {
-            let tool = tool.trim();
-            if !tool.is_empty() {
-                args.push(tool.to_string());
-            }
-        }
-    }
+    push_comma_separated_flag_values(&mut args, "--disallowed-tools", disallowed_tools);
+    push_comma_separated_flag_values(&mut args, "--tools", tools);
 
     if !settings.is_empty() {
         args.push("--settings".to_string());
@@ -602,6 +601,26 @@ mod tests {
             .map(|s| s.as_str())
             .collect();
         assert_eq!(tool_args, vec!["CronCreate", "CronDelete"]);
+    }
+
+    #[test]
+    fn build_claude_args_tools_empty_items_skipped() {
+        let args = build_claude_args_for_test("", "", "", "Bash,,Read,", "", "test");
+        let t_idx = args.iter().position(|a| a == "--tools").unwrap();
+        let tool_args: Vec<&str> = args[t_idx + 1..]
+            .iter()
+            .take_while(|a| a.as_str() != "--" && !a.starts_with("--"))
+            .map(|s| s.as_str())
+            .collect();
+        assert_eq!(tool_args, vec!["Bash", "Read"]);
+    }
+
+    #[test]
+    fn build_claude_args_comma_only_tool_values_omitted() {
+        let args = build_claude_args_for_test("", "", " , ,, ", ",,,", "", "test");
+        assert!(!args.contains(&"--disallowed-tools".to_string()));
+        assert!(!args.contains(&"--tools".to_string()));
+        assert_prompt_with_separator(&args, "test");
     }
 
     #[test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2213,6 +2213,11 @@ fn validate_claude_tool_env_entries(env_name: &str, tools: &[String]) -> Result<
                 "{env_name} entry at index {index} must not contain commas"
             ));
         }
+        if tool.trim_start().starts_with('-') {
+            return Err(format!(
+                "{env_name} entry at index {index} must not start with a hyphen"
+            ));
+        }
     }
 
     Ok(())
@@ -3378,6 +3383,8 @@ mod tests {
             ("", "must not be empty"),
             ("   ", "must not be empty"),
             ("CronCreate,CronDelete", "must not contain commas"),
+            ("--help", "must not start with a hyphen"),
+            (" -v", "must not start with a hyphen"),
         ] {
             let mut ctx = minimal_context();
             ctx.disallowed_tools = Some(vec![tool.into()]);
@@ -3392,6 +3399,8 @@ mod tests {
             ("", "must not be empty"),
             ("   ", "must not be empty"),
             ("Bash,Read", "must not contain commas"),
+            ("--help", "must not start with a hyphen"),
+            (" -x", "must not start with a hyphen"),
         ] {
             let mut ctx = minimal_context();
             ctx.tools = Some(vec![tool.into()]);

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -5386,6 +5386,37 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn execute_job_codex_ignores_claude_tool_validation() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = "codex".into();
+        ctx.disallowed_tools = Some(vec!["".into()]);
+        ctx.tools = Some(vec!["Bash,Read".into()]);
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::NoSessionId,
+            },
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 0);
+        assert!(outcome.error().is_none());
+        assert!(outcome.sandbox.is_some());
+        assert_eq!(overrides.create_configs().len(), 1);
+    }
+
     // -----------------------------------------------------------------------
     // Keep-alive VM reuse integration tests
     // -----------------------------------------------------------------------

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -263,7 +263,7 @@ pub async fn execute_job(
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
-    let outcome = if let Err(error) = validate_model_provider_env_placeholders(&context) {
+    let outcome = if let Err(error) = validate_execution_context_before_sandbox(&context) {
         ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(error)),
             sandbox: None,
@@ -324,7 +324,7 @@ pub async fn execute_job_reuse(
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
-    let outcome = if let Err(error) = validate_model_provider_env_placeholders(&context) {
+    let outcome = if let Err(error) = validate_execution_context_before_sandbox(&context) {
         ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(error)),
             sandbox: Some(sandbox),
@@ -483,6 +483,27 @@ fn validate_model_provider_env_placeholders(context: &ExecutionContext) -> Resul
         "model provider environment contains non-placeholder values for: {}",
         invalid_keys.join(", ")
     ))
+}
+
+fn validate_execution_context_before_sandbox(context: &ExecutionContext) -> Result<(), String> {
+    validate_model_provider_env_placeholders(context)?;
+    validate_claude_tool_lists(context)?;
+    Ok(())
+}
+
+fn validate_claude_tool_lists(context: &ExecutionContext) -> Result<(), String> {
+    if effective_cli_framework(&context.cli_agent_type) != EffectiveCliFramework::ClaudeCode {
+        return Ok(());
+    }
+
+    if let Some(tools) = &context.disallowed_tools {
+        validate_claude_tool_env_entries("VM0_DISALLOWED_TOOLS", tools)?;
+    }
+    if let Some(tools) = &context.tools {
+        validate_claude_tool_env_entries("VM0_TOOLS", tools)?;
+    }
+
+    Ok(())
 }
 
 /// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM
@@ -2175,20 +2196,26 @@ fn serialize_claude_tool_env(env_name: &str, tools: &[String]) -> RunnerResult<O
         return Ok(None);
     }
 
+    validate_claude_tool_env_entries(env_name, tools).map_err(RunnerError::Internal)?;
+
+    Ok(Some(tools.join(",")))
+}
+
+fn validate_claude_tool_env_entries(env_name: &str, tools: &[String]) -> Result<(), String> {
     for (index, tool) in tools.iter().enumerate() {
         if tool.trim().is_empty() {
-            return Err(RunnerError::Internal(format!(
+            return Err(format!(
                 "{env_name} entry at index {index} must not be empty"
-            )));
+            ));
         }
         if tool.contains(',') {
-            return Err(RunnerError::Internal(format!(
+            return Err(format!(
                 "{env_name} entry at index {index} must not contain commas"
-            )));
+            ));
         }
     }
 
-    Ok(Some(tools.join(",")))
+    Ok(())
 }
 
 fn insert_codex_env(
@@ -5325,6 +5352,40 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn execute_job_claude_tool_validation_failure_skips_sandbox_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut ctx = minimal_context();
+        ctx.tools = Some(vec!["Bash,Read".into()]);
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::NoSessionId,
+            },
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(error.contains("VM0_TOOLS"));
+        assert!(error.contains("must not contain commas"));
+        assert!(outcome.sandbox.is_none());
+        assert!(
+            overrides.create_configs().is_empty(),
+            "fresh sandbox must not be created after tool validation failure"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Keep-alive VM reuse integration tests
     // -----------------------------------------------------------------------
@@ -5389,6 +5450,34 @@ mod tests {
         assert!(
             overrides.start_process_calls().is_empty(),
             "reused sandbox must not start a process after env validation failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_claude_tool_validation_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let source_ip = sandbox.source_ip().to_string();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+        let mut ctx = minimal_context();
+        ctx.disallowed_tools = Some(vec!["   ".into()]);
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, cancel).await;
+
+        assert_eq!(reuse_outcome.exit_code(), 1);
+        let error = reuse_outcome.error().unwrap();
+        assert!(error.contains("VM0_DISALLOWED_TOOLS"));
+        assert!(error.contains("must not be empty"));
+        assert!(reuse_outcome.sandbox.is_some());
+        assert!(reuse_outcome.network_log_session.is_none());
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "reused sandbox must not start a process after tool validation failure"
         );
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -865,7 +865,7 @@ async fn run_in_sandbox_with_process_cancel_timeouts(
     }
 
     // 5. Build env vars (passed directly via vsock protocol)
-    let env_map = build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result);
+    let env_map = build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result)?;
     let env_pairs: Vec<(String, String)> = env_map.into_iter().collect();
     let env_refs: Vec<(&str, &str)> = env_pairs
         .iter()
@@ -1920,7 +1920,7 @@ fn build_env_json(
     api_url: &str,
     sandbox_id: &str,
     reuse_result: SandboxReuseResult,
-) -> HashMap<String, String> {
+) -> RunnerResult<HashMap<String, String>> {
     let host_env = HostEnv::from_process();
     build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, &host_env)
 }
@@ -1931,7 +1931,7 @@ fn build_env_json_with_host_env(
     sandbox_id: &str,
     reuse_result: SandboxReuseResult,
     host_env: &HostEnv,
-) -> HashMap<String, String> {
+) -> RunnerResult<HashMap<String, String>> {
     let mut env = HashMap::new();
 
     // --- User-provided environment ---
@@ -2051,7 +2051,7 @@ fn build_env_json_with_host_env(
     }
 
     match effective_cli_framework(&context.cli_agent_type) {
-        EffectiveCliFramework::ClaudeCode => insert_claude_code_env(&mut env, context, host_env),
+        EffectiveCliFramework::ClaudeCode => insert_claude_code_env(&mut env, context, host_env)?,
         EffectiveCliFramework::Codex => insert_codex_env(&mut env, context, host_env),
     }
 
@@ -2063,7 +2063,7 @@ fn build_env_json_with_host_env(
         env.insert("VM0_FEATURE_FLAGS".into(), json);
     }
 
-    env
+    Ok(env)
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -2139,7 +2139,7 @@ fn insert_claude_code_env(
     env: &mut HashMap<String, String>,
     context: &ExecutionContext,
     host_env: &HostEnv,
-) {
+) -> RunnerResult<()> {
     // Pass USE_MOCK_CLAUDE from host environment for testing
     // (skip if debugNoMockClaude is set in execution context)
     if let Some(val) = &host_env.use_mock_claude
@@ -2148,18 +2148,16 @@ fn insert_claude_code_env(
         env.insert("USE_MOCK_CLAUDE".into(), val.clone());
     }
 
-    // Disallowed tools (comma-separated for guest-agent)
     if let Some(tools) = &context.disallowed_tools
-        && !tools.is_empty()
+        && let Some(serialized) = serialize_claude_tool_env("VM0_DISALLOWED_TOOLS", tools)?
     {
-        env.insert("VM0_DISALLOWED_TOOLS".into(), tools.join(","));
+        env.insert("VM0_DISALLOWED_TOOLS".into(), serialized);
     }
 
-    // Tools to make available (comma-separated for guest-agent)
     if let Some(tools) = &context.tools
-        && !tools.is_empty()
+        && let Some(serialized) = serialize_claude_tool_env("VM0_TOOLS", tools)?
     {
-        env.insert("VM0_TOOLS".into(), tools.join(","));
+        env.insert("VM0_TOOLS".into(), serialized);
     }
 
     // Settings JSON (passed directly as single string)
@@ -2168,6 +2166,29 @@ fn insert_claude_code_env(
     {
         env.insert("VM0_SETTINGS".into(), settings.clone());
     }
+
+    Ok(())
+}
+
+fn serialize_claude_tool_env(env_name: &str, tools: &[String]) -> RunnerResult<Option<String>> {
+    if tools.is_empty() {
+        return Ok(None);
+    }
+
+    for (index, tool) in tools.iter().enumerate() {
+        if tool.trim().is_empty() {
+            return Err(RunnerError::Internal(format!(
+                "{env_name} entry at index {index} must not be empty"
+            )));
+        }
+        if tool.contains(',') {
+            return Err(RunnerError::Internal(format!(
+                "{env_name} entry at index {index} must not contain commas"
+            )));
+        }
+    }
+
+    Ok(Some(tools.join(",")))
 }
 
 fn insert_codex_env(
@@ -2329,7 +2350,14 @@ mod tests {
     }
 
     fn build_env_for_test(ctx: &ExecutionContext, api_url: &str) -> HashMap<String, String> {
-        build_env_for_test_with_host_env(ctx, api_url, &HostEnv::default())
+        build_env_for_test_result(ctx, api_url).expect("test env should build")
+    }
+
+    fn build_env_for_test_result(
+        ctx: &ExecutionContext,
+        api_url: &str,
+    ) -> RunnerResult<HashMap<String, String>> {
+        build_env_for_test_with_host_env_result(ctx, api_url, &HostEnv::default())
     }
 
     fn build_env_for_test_with_host_env(
@@ -2337,6 +2365,15 @@ mod tests {
         api_url: &str,
         host_env: &HostEnv,
     ) -> HashMap<String, String> {
+        build_env_for_test_with_host_env_result(ctx, api_url, host_env)
+            .expect("test env should build")
+    }
+
+    fn build_env_for_test_with_host_env_result(
+        ctx: &ExecutionContext,
+        api_url: &str,
+        host_env: &HostEnv,
+    ) -> RunnerResult<HashMap<String, String>> {
         let sid = SandboxId::new_v4().to_string();
         build_env_json_with_host_env(ctx, api_url, &sid, SandboxReuseResult::Reused, host_env)
     }
@@ -2569,7 +2606,8 @@ mod tests {
                 &sid,
                 variant,
                 &HostEnv::default(),
-            );
+            )
+            .expect("test env should build");
             assert_eq!(env.get("VM0_SANDBOX_REUSE_RESULT").unwrap(), expected);
         }
     }
@@ -3291,6 +3329,58 @@ mod tests {
     fn build_env_json_no_tools() {
         let ctx = minimal_context();
         let env = build_env_for_test(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_TOOLS"));
+    }
+
+    fn assert_tool_env_error(
+        result: RunnerResult<HashMap<String, String>>,
+        env_name: &str,
+        expected: &str,
+    ) {
+        let message = match result {
+            Err(RunnerError::Internal(message)) => message,
+            other => panic!("expected internal error, got {other:?}"),
+        };
+        assert!(message.contains(env_name), "message: {message}");
+        assert!(message.contains(expected), "message: {message}");
+    }
+
+    #[test]
+    fn build_env_json_rejects_invalid_disallowed_tools_entries() {
+        for (tool, expected) in [
+            ("", "must not be empty"),
+            ("   ", "must not be empty"),
+            ("CronCreate,CronDelete", "must not contain commas"),
+        ] {
+            let mut ctx = minimal_context();
+            ctx.disallowed_tools = Some(vec![tool.into()]);
+            let result = build_env_for_test_result(&ctx, "http://localhost");
+            assert_tool_env_error(result, "VM0_DISALLOWED_TOOLS", expected);
+        }
+    }
+
+    #[test]
+    fn build_env_json_rejects_invalid_tools_entries() {
+        for (tool, expected) in [
+            ("", "must not be empty"),
+            ("   ", "must not be empty"),
+            ("Bash,Read", "must not contain commas"),
+        ] {
+            let mut ctx = minimal_context();
+            ctx.tools = Some(vec![tool.into()]);
+            let result = build_env_for_test_result(&ctx, "http://localhost");
+            assert_tool_env_error(result, "VM0_TOOLS", expected);
+        }
+    }
+
+    #[test]
+    fn build_env_json_codex_ignores_claude_tool_lists() {
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = "codex".into();
+        ctx.disallowed_tools = Some(vec!["".into()]);
+        ctx.tools = Some(vec!["Bash,Read".into()]);
+        let env = build_env_for_test(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
         assert!(!env.contains_key("VM0_TOOLS"));
     }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -360,6 +360,7 @@ describe("POST /api/agent/runs", () => {
       };
       readonly field: string;
     }> = [
+      { body: { tools: [""] }, field: "tools" },
       { body: { tools: ["   "] }, field: "tools" },
       { body: { tools: ["Bash,Read"] }, field: "tools" },
       { body: { disallowedTools: [""] }, field: "disallowedTools" },

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -363,6 +363,7 @@ describe("POST /api/agent/runs", () => {
       { body: { tools: ["   "] }, field: "tools" },
       { body: { tools: ["Bash,Read"] }, field: "tools" },
       { body: { disallowedTools: [""] }, field: "disallowedTools" },
+      { body: { disallowedTools: ["   "] }, field: "disallowedTools" },
       {
         body: { disallowedTools: ["CronCreate,CronDelete"] },
         field: "disallowedTools",

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -363,12 +363,16 @@ describe("POST /api/agent/runs", () => {
       { body: { tools: [""] }, field: "tools" },
       { body: { tools: ["   "] }, field: "tools" },
       { body: { tools: ["Bash,Read"] }, field: "tools" },
+      { body: { tools: ["--help"] }, field: "tools" },
+      { body: { tools: [" -x"] }, field: "tools" },
       { body: { disallowedTools: [""] }, field: "disallowedTools" },
       { body: { disallowedTools: ["   "] }, field: "disallowedTools" },
       {
         body: { disallowedTools: ["CronCreate,CronDelete"] },
         field: "disallowedTools",
       },
+      { body: { disallowedTools: ["--settings"] }, field: "disallowedTools" },
+      { body: { disallowedTools: [" -v"] }, field: "disallowedTools" },
     ];
 
     for (const testCase of cases) {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -353,13 +353,13 @@ describe("POST /api/agent/runs", () => {
 
   it("rejects ambiguous Claude tool list entries", async () => {
     await fixture();
-    const cases: Array<{
+    const cases: {
       readonly body: {
         readonly disallowedTools?: string[];
         readonly tools?: string[];
       };
       readonly field: string;
-    }> = [
+    }[] = [
       { body: { tools: [""] }, field: "tools" },
       { body: { tools: ["   "] }, field: "tools" },
       { body: { tools: ["Bash,Read"] }, field: "tools" },

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -351,6 +351,43 @@ describe("POST /api/agent/runs", () => {
     expect(response.body.error.message).toContain("prompt");
   });
 
+  it("rejects ambiguous Claude tool list entries", async () => {
+    await fixture();
+    const cases: Array<{
+      readonly body: {
+        readonly disallowedTools?: string[];
+        readonly tools?: string[];
+      };
+      readonly field: string;
+    }> = [
+      { body: { tools: ["   "] }, field: "tools" },
+      { body: { tools: ["Bash,Read"] }, field: "tools" },
+      { body: { disallowedTools: [""] }, field: "disallowedTools" },
+      {
+        body: { disallowedTools: ["CronCreate,CronDelete"] },
+        field: "disallowedTools",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await accept(
+        runsClient().create({
+          headers: { authorization: "Bearer clerk-session" },
+          body: {
+            agentComposeId: randomUUID(),
+            prompt: "test",
+            ...testCase.body,
+          },
+        }),
+        [400],
+      );
+
+      expect(response.body.error.code).toBe("BAD_REQUEST");
+      expect(response.body.error.message).toContain(testCase.field);
+      expect(response.body.error.message).toContain("Claude tool name");
+    }
+  });
+
   it("rejects vm0 provider pinning on direct runs", async () => {
     await fixture();
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -553,7 +553,7 @@ describe("POST /api/runners/*", () => {
     });
   });
 
-  it("rejects invalid stored execution context without claiming the job", async () => {
+  it("fails invalid stored execution context and dequeues the job", async () => {
     const fixture = await trackUsageFixture(
       store.set(seedUsageInsightFixture$, undefined, context.signal),
     );
@@ -576,21 +576,35 @@ describe("POST /api/runners/*", () => {
     });
 
     const db = store.set(writeDb$);
-    const [job] = await db
-      .select({ claimedAt: runnerJobQueue.claimedAt })
+    const remainingJobs = await db
+      .select({ runId: runnerJobQueue.runId })
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, queued.runId));
-    expect(job?.claimedAt).toBeNull();
+    expect(remainingJobs).toHaveLength(0);
 
     const [run] = await db
       .select({
         status: agentRuns.status,
+        error: agentRuns.error,
+        completedAt: agentRuns.completedAt,
         startedAt: agentRuns.startedAt,
       })
       .from(agentRuns)
       .where(eq(agentRuns.id, queued.runId));
-    expect(run?.status).toBe("pending");
+    expect(run).toMatchObject({
+      status: "failed",
+      error: "Runner job missing valid execution context",
+    });
+    expect(run?.completedAt).toBeInstanceOf(Date);
     expect(run?.startedAt).toBeNull();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${queued.runId}`,
+      { status: "failed" },
+    );
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      `run:changed:${queued.runId}`,
+      { status: "running" },
+    );
   });
 
   it("removes a claimable job when the run is no longer pending", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -553,6 +553,46 @@ describe("POST /api/runners/*", () => {
     });
   });
 
+  it("rejects invalid stored execution context without claiming the job", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({
+      fixture,
+      contextOverrides: { tools: ["Bash,Read"] },
+    });
+
+    const response = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 400,
+    });
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Job missing execution context",
+        code: "BAD_REQUEST",
+      },
+    });
+
+    const db = store.set(writeDb$);
+    const [job] = await db
+      .select({ claimedAt: runnerJobQueue.claimedAt })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    expect(job?.claimedAt).toBeNull();
+
+    const [run] = await db
+      .select({
+        status: agentRuns.status,
+        startedAt: agentRuns.startedAt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run?.status).toBe("pending");
+    expect(run?.startedAt).toBeNull();
+  });
+
   it("prevents official runners from claiming non-vm0 runner groups", async () => {
     const fixture = await trackUsageFixture(
       store.set(seedUsageInsightFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -559,7 +559,7 @@ describe("POST /api/runners/*", () => {
     );
     const queued = await seedQueuedRun({
       fixture,
-      contextOverrides: { tools: ["Bash,Read"] },
+      contextOverrides: { apiStartTime: 1 },
     });
 
     const response = await claimRunnerJob({

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -593,6 +593,44 @@ describe("POST /api/runners/*", () => {
     expect(run?.startedAt).toBeNull();
   });
 
+  it("removes a claimable job when the run is no longer pending", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "cancelled", completedAt: new Date(now()) })
+      .where(eq(agentRuns.id, queued.runId));
+
+    const response = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 404,
+    });
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Run not found", code: "NOT_FOUND" },
+    });
+
+    const remainingJobs = await db
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    expect(remainingJobs).toHaveLength(0);
+
+    const [run] = await db
+      .select({
+        status: agentRuns.status,
+        startedAt: agentRuns.startedAt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run?.status).toBe("cancelled");
+    expect(run?.startedAt).toBeNull();
+  });
+
   it("prevents official runners from claiming non-vm0 runner groups", async () => {
     const fixture = await trackUsageFixture(
       store.set(seedUsageInsightFixture$, undefined, context.signal),
@@ -791,6 +829,46 @@ describe("POST /api/runners/*", () => {
       `run:changed:${queued.runId}`,
       { status: "running" },
     );
+  });
+
+  it("allows only one concurrent runner claim for a queued job", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+    const client = setupApp({ context })(runnersJobClaimContract);
+
+    const responses = await Promise.all(
+      [0, 1].map(() => {
+        return accept(
+          client.claim({
+            params: { id: queued.runId },
+            body: {},
+            headers: { authorization: OFFICIAL_RUNNER_TOKEN },
+          }),
+          [200, 404, 409],
+        );
+      }),
+    );
+
+    expect(
+      responses.filter((response) => {
+        return response.status === 200;
+      }),
+    ).toHaveLength(1);
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run?.status).toBe("running");
+
+    const remainingJobs = await db
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    expect(remainingJobs).toHaveLength(0);
   });
 
   it("returns appendSystemPrompt in claim responses", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -4,6 +4,7 @@ import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { createStore } from "ccstate";
@@ -194,6 +195,59 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     );
     expect(response.body.error.code).toBe("RUN_NOT_CANCELLABLE");
     expect(response.body.error.message).toContain("cannot be cancelled");
+  });
+
+  it("deletes a pending runner job when cancelling before claim", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "pending",
+      },
+      context.signal,
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(runnerJobQueue).values({
+      runId,
+      runnerGroup: "vm0/test",
+      profile: "vm0/default",
+      sessionId: null,
+      executionContext: {
+        workingDir: "/workspace",
+        storageManifest: null,
+        environment: null,
+        resumeSession: null,
+        encryptedSecrets: null,
+        cliAgentType: "claude-code",
+      },
+      expiresAt: new Date(now() + 60_000),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const remainingJobs = await writeDb
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, runId));
+    expect(remainingJobs).toHaveLength(0);
   });
 
   it("returns 200 when run is already cancelled (idempotent; no side effects)", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -391,6 +391,31 @@ describe("POST /api/zero/runs", () => {
     expect(response.body.error.message).toBe("agentId is required");
   });
 
+  it("rejects ambiguous Claude tool list entries", async () => {
+    await fixture();
+    const cases: Array<{
+      readonly tools: string[];
+    }> = [{ tools: ["   "] }, { tools: ["Bash,Read"] }];
+
+    for (const testCase of cases) {
+      const response = await accept(
+        zeroRunsClient().create({
+          headers: { authorization: "Bearer clerk-session" },
+          body: {
+            prompt: "hello",
+            agentId: randomUUID(),
+            tools: testCase.tools,
+          },
+        }),
+        [400],
+      );
+
+      expect(response.body.error.code).toBe("BAD_REQUEST");
+      expect(response.body.error.message).toContain("tools");
+      expect(response.body.error.message).toContain("Claude tool name");
+    }
+  });
+
   it("returns 404 when session inference cannot find a session", async () => {
     await fixture();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -395,7 +395,13 @@ describe("POST /api/zero/runs", () => {
     await fixture();
     const cases: {
       readonly tools: string[];
-    }[] = [{ tools: [""] }, { tools: ["   "] }, { tools: ["Bash,Read"] }];
+    }[] = [
+      { tools: [""] },
+      { tools: ["   "] },
+      { tools: ["Bash,Read"] },
+      { tools: ["--help"] },
+      { tools: [" -x"] },
+    ];
 
     for (const testCase of cases) {
       const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -395,7 +395,7 @@ describe("POST /api/zero/runs", () => {
     await fixture();
     const cases: Array<{
       readonly tools: string[];
-    }> = [{ tools: ["   "] }, { tools: ["Bash,Read"] }];
+    }> = [{ tools: [""] }, { tools: ["   "] }, { tools: ["Bash,Read"] }];
 
     for (const testCase of cases) {
       const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -393,9 +393,9 @@ describe("POST /api/zero/runs", () => {
 
   it("rejects ambiguous Claude tool list entries", async () => {
     await fixture();
-    const cases: Array<{
+    const cases: {
       readonly tools: string[];
-    }> = [{ tools: [""] }, { tools: ["   "] }, { tools: ["Bash,Read"] }];
+    }[] = [{ tools: [""] }, { tools: ["   "] }, { tools: ["Bash,Read"] }];
 
     for (const testCase of cases) {
       const response = await accept(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -162,6 +162,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const whereConditions: SQL<unknown>[] = [
     eq(runnerJobQueue.runnerGroup, group),
     isNull(runnerJobQueue.claimedAt),
+    eq(agentRuns.status, "pending"),
   ];
 
   if (auth.type === "official-runner") {

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
@@ -96,6 +97,9 @@ export const cancelRun$ = command(
 
     const cancelled = await writeDb.transaction(async (tx) => {
       await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, args.runId));
+      await tx
+        .delete(runnerJobQueue)
+        .where(eq(runnerJobQueue.runId, args.runId));
       const [updated] = await tx
         .update(agentRuns)
         .set({ status: "cancelled", completedAt: nowDate() })

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -174,15 +174,12 @@ describe("runner apiStartTime contract", () => {
 });
 
 describe("runner Claude tool list contracts", () => {
-  it("keeps stored execution contexts tolerant of legacy tool list values", () => {
+  it("keeps runner context schemas tolerant of legacy tool list values", () => {
     expect(
       storedExecutionContextSchema.shape.tools.safeParse(["Bash,Read"]).success,
     ).toBe(true);
-  });
-
-  it("rejects ambiguous tool list values in claimed execution contexts", () => {
     expect(
       executionContextSchema.shape.tools.safeParse(["Bash,Read"]).success,
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -172,3 +172,17 @@ describe("runner apiStartTime contract", () => {
     );
   });
 });
+
+describe("runner Claude tool list contracts", () => {
+  it("keeps stored execution contexts tolerant of legacy tool list values", () => {
+    expect(
+      storedExecutionContextSchema.shape.tools.safeParse(["Bash,Read"]).success,
+    ).toBe(true);
+  });
+
+  it("rejects ambiguous tool list values in claimed execution contexts", () => {
+    expect(
+      executionContextSchema.shape.tools.safeParse(["Bash,Read"]).success,
+    ).toBe(false);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { claudeToolEntrySchema } from "../runs";
+
+describe("Claude tool entry contract", () => {
+  it("accepts single Claude tool names", () => {
+    expect(claudeToolEntrySchema.safeParse("Bash").success).toBe(true);
+    expect(claudeToolEntrySchema.safeParse("mcp__github__search").success).toBe(
+      true,
+    );
+  });
+
+  it("rejects ambiguous Claude tool entries", () => {
+    for (const tool of ["", "   ", "Bash,Read", "--help", " -x"]) {
+      expect(claudeToolEntrySchema.safeParse(tool).success).toBe(false);
+    }
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -5,7 +5,6 @@ import {
   networkPoliciesSchema,
 } from "@vm0/connectors/firewall-types";
 import { apiErrorSchema } from "./errors";
-import { claudeToolEntrySchema } from "./runs";
 
 const c = initContract();
 
@@ -225,9 +224,9 @@ export const executionContextSchema = z.object({
   // Per-firewall network policies: which permissions are granted + unknownPolicy
   networkPolicies: networkPoliciesSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
-  disallowedTools: z.array(claudeToolEntrySchema).optional(),
+  disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
-  tools: z.array(claudeToolEntrySchema).optional(),
+  tools: z.array(z.string()).optional(),
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings: z.string().optional(),
   // VM profile for resource allocation (e.g., "vm0/default")

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -169,9 +169,9 @@ export const storedExecutionContextSchema = z.object({
   // Per-firewall network policies: which permissions are granted + unknownPolicy
   networkPolicies: networkPoliciesSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
-  disallowedTools: z.array(claudeToolEntrySchema).optional(),
+  disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
-  tools: z.array(claudeToolEntrySchema).optional(),
+  tools: z.array(z.string()).optional(),
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings: z.string().optional(),
   // VM profile for resource allocation (e.g., "vm0/default")

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -5,6 +5,7 @@ import {
   networkPoliciesSchema,
 } from "@vm0/connectors/firewall-types";
 import { apiErrorSchema } from "./errors";
+import { claudeToolEntrySchema } from "./runs";
 
 const c = initContract();
 
@@ -168,9 +169,9 @@ export const storedExecutionContextSchema = z.object({
   // Per-firewall network policies: which permissions are granted + unknownPolicy
   networkPolicies: networkPoliciesSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
-  disallowedTools: z.array(z.string()).optional(),
+  disallowedTools: z.array(claudeToolEntrySchema).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
-  tools: z.array(z.string()).optional(),
+  tools: z.array(claudeToolEntrySchema).optional(),
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings: z.string().optional(),
   // VM profile for resource allocation (e.g., "vm0/default")
@@ -224,9 +225,9 @@ export const executionContextSchema = z.object({
   // Per-firewall network policies: which permissions are granted + unknownPolicy
   networkPolicies: networkPoliciesSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
-  disallowedTools: z.array(z.string()).optional(),
+  disallowedTools: z.array(claudeToolEntrySchema).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
-  tools: z.array(z.string()).optional(),
+  tools: z.array(claudeToolEntrySchema).optional(),
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings: z.string().optional(),
   // VM profile for resource allocation (e.g., "vm0/default")

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -36,6 +36,14 @@ export const claudeToolEntrySchema = z
     {
       message: "Claude tool name must not contain commas",
     },
+  )
+  .refine(
+    (tool) => {
+      return !tool.trimStart().startsWith("-");
+    },
+    {
+      message: "Claude tool name must not start with a hyphen",
+    },
   );
 
 // Stored in Postgres `integer` columns. Keep request validation aligned with

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -19,6 +19,15 @@ const directRunModelProviderTypeSchema = modelProviderTypeSchema.refine(
   { message: "vm0 model provider is only supported by zero runs" },
 );
 
+export const claudeToolEntrySchema = z
+  .string()
+  .refine((tool) => tool.trim().length > 0, {
+    message: "Claude tool name must not be empty",
+  })
+  .refine((tool) => !tool.includes(","), {
+    message: "Claude tool name must not contain commas",
+  });
+
 // Stored in Postgres `integer` columns. Keep request validation aligned with
 // the DB range so malformed sandbox payloads fail as 400s instead of DB errors.
 export const MAX_EVENT_SEQUENCE_NUMBER = 2_147_483_647;
@@ -110,10 +119,10 @@ const unifiedRunRequestSchema = z
     appendSystemPrompt: z.string().optional(),
 
     // Optional list of tools to disable in Claude CLI (passed as --disallowed-tools)
-    disallowedTools: z.array(z.string()).optional(),
+    disallowedTools: z.array(claudeToolEntrySchema).optional(),
 
     // Optional list of tools to make available in Claude CLI (passed as --tools)
-    tools: z.array(z.string()).optional(),
+    tools: z.array(claudeToolEntrySchema).optional(),
 
     // Settings JSON to pass to Claude CLI (passed as --settings)
     settings: z.string().optional(),

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -21,12 +21,22 @@ const directRunModelProviderTypeSchema = modelProviderTypeSchema.refine(
 
 export const claudeToolEntrySchema = z
   .string()
-  .refine((tool) => tool.trim().length > 0, {
-    message: "Claude tool name must not be empty",
-  })
-  .refine((tool) => !tool.includes(","), {
-    message: "Claude tool name must not contain commas",
-  });
+  .refine(
+    (tool) => {
+      return tool.trim().length > 0;
+    },
+    {
+      message: "Claude tool name must not be empty",
+    },
+  )
+  .refine(
+    (tool) => {
+      return !tool.includes(",");
+    },
+    {
+      message: "Claude tool name must not contain commas",
+    },
+  );
 
 // Stored in Postgres `integer` columns. Keep request validation aligned with
 // the DB range so malformed sandbox payloads fail as 400s instead of DB errors.


### PR DESCRIPTION
## Summary
- validate Claude `tools` and `disallowedTools` entries in API contracts before runner context creation
- fail runner context validation before sandbox startup when Claude tool entries are empty, whitespace-only, or comma-containing, while keeping the env serialization guard
- deduplicate guest-agent comma-separated argv parsing and avoid bare variadic flags for empty token lists

Closes #15083

## Tests
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm --filter api check-types`
- `pnpm --filter @vm0/api-contracts check-types`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/runs.ts packages/api-contracts/src/contracts/runners.ts apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib cli::command`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit hook: prettier, knip, check-types, cargo-doc, cargo-fmt, cargo-clippy, commitlint