### PR TITLE
fix: make guest-agent api http config explicit

### DIFF
--- a/crates/guest-agent/src/artifact/api.rs
+++ b/crates/guest-agent/src/artifact/api.rs
@@ -2,7 +2,6 @@ use super::FileEntry;
 use crate::constants;
 use crate::error::AgentError;
 use crate::http::HttpClient;
-use crate::urls;
 use api_contracts::generated::types::webhooks::agent::storages::{
     FileEntryWithHash, commit as storage_commit, prepare as storage_prepare,
 };
@@ -65,12 +64,14 @@ pub(super) async fn prepare_snapshot(
         changes: None,
     };
 
+    let url = http
+        .storage_prepare_url()
+        .map_err(|error| PrepareSnapshotError {
+            error,
+            telemetry_error: None,
+        })?;
     let response = match http
-        .post_json(
-            urls::storage_prepare_url(),
-            &payload,
-            constants::HTTP_MAX_RETRIES,
-        )
+        .post_json(url, &payload, constants::HTTP_MAX_RETRIES)
         .await
     {
         Ok(Some(value)) => value,
@@ -122,12 +123,9 @@ pub(super) async fn commit_snapshot(
         message: request.message.map(str::to_string),
     };
 
+    let url = http.storage_commit_url()?;
     let response = http
-        .post_json(
-            urls::storage_commit_url(),
-            &payload,
-            constants::HTTP_MAX_RETRIES,
-        )
+        .post_json(url, &payload, constants::HTTP_MAX_RETRIES)
         .await?;
 
     Ok(response

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -286,21 +286,22 @@ pub(crate) async fn create_snapshot(
 mod tests {
     use super::*;
     use std::sync::LazyLock;
+    use std::time::Duration;
 
-    static SNAPSHOT_MOCK_SERVER: LazyLock<httpmock::MockServer> = LazyLock::new(|| {
-        let server = httpmock::MockServer::start();
-        unsafe {
-            std::env::set_var("VM0_API_URL", server.base_url());
-        }
-        server
-    });
+    static SNAPSHOT_MOCK_SERVER: LazyLock<httpmock::MockServer> =
+        LazyLock::new(httpmock::MockServer::start);
 
     fn disable_system_log() {
         guest_common::log::clear_system_log_file();
     }
 
+    fn test_http_client(server: &httpmock::MockServer) -> Result<HttpClient, AgentError> {
+        HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+    }
+
     #[tokio::test]
-    async fn dedup_snapshot_posts_file_payloads_before_validation_failure_blocks_commit() {
+    async fn dedup_snapshot_posts_file_payloads_before_validation_failure_blocks_commit()
+    -> Result<(), AgentError> {
         disable_system_log();
         let server = &*SNAPSHOT_MOCK_SERVER;
 
@@ -357,7 +358,7 @@ mod tests {
             }));
         });
 
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server)?;
         let result = create_snapshot(
             &http,
             CreateSnapshotRequest {
@@ -401,7 +402,7 @@ mod tests {
                 .json_body(serde_json::json!({ "success": true }));
         });
 
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server)?;
         let result = create_snapshot(
             &http,
             CreateSnapshotRequest {
@@ -427,5 +428,6 @@ mod tests {
         commit.assert_calls(0);
         prepare.delete_async().await;
         commit.delete_async().await;
+        Ok(())
     }
 }

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -8,7 +8,6 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::paths;
 use crate::session_history;
-use crate::urls;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
@@ -83,9 +82,10 @@ async fn upload_session_history(
     history_bytes: Vec<u8>,
 ) -> Result<(), AgentError> {
     let prep_start = std::time::Instant::now();
+    let url = http.checkpoint_prepare_history_url()?;
     let prep_resp = match http
         .post_json(
-            urls::checkpoint_prepare_history_url(),
+            url,
             &json!({
                 "runId": env::run_id(),
                 "hash": history_hash,
@@ -402,12 +402,9 @@ async fn create_checkpoint_impl(http: &HttpClient, mode: CheckpointMode) -> Resu
 
     log_info!(LOG_TAG, "Calling checkpoint API...");
     let api_start = std::time::Instant::now();
+    let url = http.checkpoint_url()?;
     let result = match http
-        .post_json(
-            urls::checkpoint_url(),
-            &payload,
-            constants::HTTP_MAX_RETRIES,
-        )
+        .post_json(url, &payload, constants::HTTP_MAX_RETRIES)
         .await
     {
         Ok(v) => v,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -243,6 +243,7 @@ pub async fn execute_cli(
     // stdout reading loop.  Unbounded channel because events are small
     // and CLI lifetime is bounded by JOB_TIMEOUT.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
+    let should_send_events = http.has_api();
     let event_http = http.clone();
     let event_sender = tokio::spawn(async move {
         let mut acked_prefix = AckedEventPrefix::default();
@@ -352,15 +353,20 @@ pub async fn execute_cli(
 
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
-                            if let Some(payload) = events::prepare_event(&mut event, seq, masker)
-                                && event_tx
+                            if should_send_events {
+                                let payload = events::prepare_event(&mut event, seq, masker);
+                                if event_tx
                                     .send(PreparedEvent {
                                         sequence: seq,
                                         payload,
                                     })
                                     .is_err()
-                            {
-                                log_warn!(LOG_TAG, "Event channel closed, dropping event seq={seq}");
+                                {
+                                    log_warn!(
+                                        LOG_TAG,
+                                        "Event channel closed, dropping event seq={seq}"
+                                    );
+                                }
                             }
                             seq += 1;
                         }

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -20,7 +20,6 @@
 
 use crate::env;
 use crate::http::HttpClient;
-use crate::urls;
 use guest_common::{log_info, log_warn};
 use serde::Serialize;
 
@@ -63,7 +62,7 @@ pub async fn report_success(
     sandbox_reuse_result: &str,
     last_event_sequence: Option<u32>,
 ) {
-    if !env::has_api() {
+    if !http.has_api() {
         return;
     }
 
@@ -77,7 +76,14 @@ pub async fn report_success(
 
     // 1 attempt — the runner's fallback is the safety net. Retrying from the
     // guest just delays VM exit without improving the outcome.
-    match http.post_json(urls::complete_url(), &payload, 1).await {
+    let url = match http.complete_url() {
+        Ok(url) => url,
+        Err(e) => {
+            log_warn!(LOG_TAG, "Complete webhook skipped: {e}");
+            return;
+        }
+    };
+    match http.post_json(url, &payload, 1).await {
         Ok(_) => log_info!(LOG_TAG, "Complete webhook acknowledged"),
         Err(e) => log_warn!(LOG_TAG, "Complete webhook failed (runner will retry): {e}"),
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -10,7 +10,6 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
-use crate::urls;
 use agent_diagnostics::FailureReason;
 use guest_common::{log_error, log_info};
 use serde_json::{Value, json};
@@ -44,25 +43,21 @@ pub async fn send_event(
 ) -> Result<(), AgentError> {
     capture_session_metadata(event);
 
-    let Some(payload) = prepare_event(event, seq, masker) else {
+    if !http.has_api() {
         return Ok(());
-    };
+    }
+
+    let payload = prepare_event(event, seq, masker);
     post_event(http, &payload).await
 }
 
 /// Prepare an event webhook payload by adding a sequence number, masking
 /// secrets, and wrapping the event in the HTTP payload shape.
 ///
-/// Returns `None` if there is no API token (local/test mode) or the event
-/// should not be posted. This function does not perform filesystem or network
-/// I/O; session metadata capture is handled separately before payload
-/// preparation, and network delivery happens in `post_event` / `send_event`.
-pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Option<Value> {
-    // No API token → local/test mode; skip posting events.
-    if !env::has_api() {
-        return None;
-    }
-
+/// This function does not perform filesystem or network I/O; session metadata
+/// capture is handled separately before payload preparation, and network
+/// delivery happens in `post_event` / `send_event`.
+pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Value {
     // Add sequence number
     if let Some(obj) = event.as_object_mut() {
         obj.insert("sequenceNumber".to_string(), json!(seq));
@@ -72,10 +67,10 @@ pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Opti
     masker.mask_value(event);
 
     // Build payload
-    Some(json!({
+    json!({
         "runId": env::run_id(),
         "events": [event],
-    }))
+    })
 }
 
 /// Extract a secret-masked Codex failure diagnostic from stdout JSONL.
@@ -253,8 +248,9 @@ fn truncate_diagnostic_message(message: &str) -> String {
 
 /// POST a prepared event payload to the webhook endpoint.
 pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentError> {
+    let url = http.events_url()?;
     match http
-        .post_json(urls::events_url(), payload, constants::HTTP_MAX_RETRIES)
+        .post_json(url, payload, constants::HTTP_MAX_RETRIES)
         .await
     {
         Ok(_) => Ok(()),

--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -8,7 +8,6 @@ use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::http::HttpClient;
-use crate::urls;
 use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use std::time::Duration;
@@ -42,10 +41,12 @@ pub async fn heartbeat_loop_with_interval(
     interval: Duration,
 ) -> Result<(), AgentError> {
     // No API token → local/test mode; heartbeat has no server to reach.
-    if !env::has_api() {
+    if !http.has_api() {
         shutdown.cancelled().await;
         return Ok(());
     }
+
+    let heartbeat_url = http.heartbeat_url()?;
 
     let mut interval = tokio::time::interval(interval);
     let mut is_first = true;
@@ -56,7 +57,7 @@ pub async fn heartbeat_loop_with_interval(
             _ = shutdown.cancelled() => return Ok(()),
             _ = interval.tick() => {
                 let payload = json!({ "runId": env::run_id() });
-                match http.post_json(urls::heartbeat_url(), &payload, constants::HTTP_MAX_RETRIES).await {
+                match http.post_json(heartbeat_url, &payload, constants::HTTP_MAX_RETRIES).await {
                     Ok(_) => {
                         if is_first {
                             log_info!(LOG_TAG, "Heartbeat sent (initial)");
@@ -72,7 +73,7 @@ pub async fn heartbeat_loop_with_interval(
                         log_error!(LOG_TAG, "Network connectivity check failed: {e}");
                         return Err(AgentError::Execution(format!(
                             "Network connectivity check failed - cannot reach API at {}",
-                            urls::heartbeat_url()
+                            heartbeat_url
                         )));
                     }
                     Err(e) => {

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -3,6 +3,7 @@
 use crate::constants;
 use crate::env;
 use crate::error::AgentError;
+use crate::urls;
 use bytes::{Bytes, BytesMut};
 use guest_common::log_warn;
 use http_body::{Frame, SizeHint};
@@ -33,16 +34,36 @@ const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 pub struct HttpClient {
     inner: Option<Client>,
     retry_delay: Duration,
+    api: Option<ApiHttpConfig>,
+}
+
+#[derive(Clone)]
+struct ApiHttpConfig {
+    urls: ApiUrls,
+    token: String,
+    vercel_bypass: String,
+}
+
+#[derive(Clone)]
+struct ApiUrls {
+    events: String,
+    checkpoint: String,
+    complete: String,
+    heartbeat: String,
+    telemetry: String,
+    checkpoint_prepare_history: String,
+    storage_prepare: String,
+    storage_commit: String,
 }
 
 impl HttpClient {
-    /// Build an enabled HTTP client.
+    /// Build an HTTP transport client without API webhook configuration.
     ///
     /// This constructor always initializes the underlying `reqwest` client and
-    /// does not check `VM0_API_TOKEN` or [`env::has_api`]. Use this in tests or
-    /// manual callers that intentionally need HTTP requests to be active.
-    /// Production guest-agent initialization should use
-    /// [`Self::for_current_env`] so no-API runs can use a disabled client.
+    /// does not check `VM0_API_TOKEN`. It can send presigned uploads, but
+    /// webhook JSON posts require API config from [`Self::with_api_config`] or
+    /// [`Self::for_current_env`]. Production guest-agent initialization should
+    /// use [`Self::for_current_env`] so no-API runs can use a disabled client.
     pub fn new() -> Result<Self, AgentError> {
         Self::with_retry_delay(DEFAULT_RETRY_DELAY)
     }
@@ -50,11 +71,32 @@ impl HttpClient {
     /// Build an enabled client with a custom retry delay.
     ///
     /// Integration tests use this to cover real retry behavior without paying
-    /// production backoff time. Production guest-agent initialization should use
-    /// [`Self::for_current_env`] so environment-gated no-API runs get a disabled
-    /// client.
+    /// production backoff time. This constructor does not enable API webhook
+    /// auth by itself; use [`Self::with_api_config`] for explicit API tests or
+    /// [`Self::for_current_env`] for production guest-agent initialization.
     #[doc(hidden)]
     pub fn with_retry_delay(retry_delay: Duration) -> Result<Self, AgentError> {
+        Self::build(None, retry_delay)
+    }
+
+    #[doc(hidden)]
+    pub fn with_api_config(
+        base_url: impl Into<String>,
+        token: impl Into<String>,
+        vercel_bypass: impl Into<String>,
+        retry_delay: Duration,
+    ) -> Result<Self, AgentError> {
+        Self::build(
+            Some(ApiHttpConfig::new(
+                base_url.into(),
+                token.into(),
+                vercel_bypass.into(),
+            )?),
+            retry_delay,
+        )
+    }
+
+    fn build(api: Option<ApiHttpConfig>, retry_delay: Duration) -> Result<Self, AgentError> {
         let inner = Client::builder()
             .connect_timeout(Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS))
             .timeout(Duration::from_secs(constants::HTTP_TIMEOUT_SECS))
@@ -66,25 +108,30 @@ impl HttpClient {
         Ok(Self {
             inner: Some(inner),
             retry_delay,
+            api,
         })
     }
 
     /// Build the HTTP client appropriate for the current environment.
     ///
     /// Production guest-agent initialization should use this constructor. When
-    /// [`env::has_api`] is true, currently when `VM0_API_TOKEN` is non-empty,
-    /// this returns the same enabled client as [`Self::new`]. Otherwise it
-    /// returns a disabled client whose request methods fail with the
-    /// disabled-client error before building or sending HTTP requests.
+    /// `VM0_API_TOKEN` is non-empty, this captures `VM0_API_URL`, the API
+    /// token, and optional Vercel bypass header once and returns a webhook-ready
+    /// client. Otherwise it returns a disabled client whose request methods fail
+    /// with the disabled-client error before building or sending HTTP requests.
     pub fn for_current_env() -> Result<Self, AgentError> {
-        if env::has_api() {
-            Self::new()
-        } else {
-            Ok(Self {
+        let Some(api) = Self::api_config_from_current_env()? else {
+            return Ok(Self {
                 inner: None,
                 retry_delay: DEFAULT_RETRY_DELAY,
-            })
-        }
+                api: None,
+            });
+        };
+        Self::build(Some(api), DEFAULT_RETRY_DELAY)
+    }
+
+    pub fn has_api(&self) -> bool {
+        self.api.is_some()
     }
 
     fn inner(&self) -> Result<&Client, AgentError> {
@@ -93,6 +140,94 @@ impl HttpClient {
                 "guest-agent HTTP client is disabled because VM0_API_TOKEN is unset".into(),
             )
         })
+    }
+
+    fn api_config(&self) -> Result<&ApiHttpConfig, AgentError> {
+        self.api.as_ref().ok_or_else(|| {
+            AgentError::Http(
+                "guest-agent API HTTP config is disabled because VM0_API_TOKEN is unset".into(),
+            )
+        })
+    }
+
+    fn api_config_from_current_env() -> Result<Option<ApiHttpConfig>, AgentError> {
+        let token = env::api_token();
+        if token.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(ApiHttpConfig::new(
+            env::api_url().to_string(),
+            token.to_string(),
+            env::vercel_bypass().to_string(),
+        )?))
+    }
+
+    pub(crate) fn events_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.events)
+    }
+
+    pub(crate) fn checkpoint_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.checkpoint)
+    }
+
+    pub(crate) fn complete_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.complete)
+    }
+
+    pub(crate) fn heartbeat_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.heartbeat)
+    }
+
+    pub(crate) fn telemetry_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.telemetry)
+    }
+
+    pub(crate) fn checkpoint_prepare_history_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.checkpoint_prepare_history)
+    }
+
+    pub(crate) fn storage_prepare_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.storage_prepare)
+    }
+
+    pub(crate) fn storage_commit_url(&self) -> Result<&str, AgentError> {
+        Ok(&self.api_config()?.urls.storage_commit)
+    }
+}
+
+impl ApiHttpConfig {
+    fn new(base_url: String, token: String, vercel_bypass: String) -> Result<Self, AgentError> {
+        if base_url.is_empty() {
+            return Err(AgentError::Http(
+                "VM0_API_URL is required when VM0_API_TOKEN is set".into(),
+            ));
+        }
+        if token.is_empty() {
+            return Err(AgentError::Http(
+                "VM0_API_TOKEN is required for enabled API HTTP config".into(),
+            ));
+        }
+        Ok(Self {
+            urls: ApiUrls::new(&base_url),
+            token,
+            vercel_bypass,
+        })
+    }
+}
+
+impl ApiUrls {
+    fn new(base_url: &str) -> Self {
+        Self {
+            events: urls::events_url(base_url),
+            checkpoint: urls::checkpoint_url(base_url),
+            complete: urls::complete_url(base_url),
+            heartbeat: urls::heartbeat_url(base_url),
+            telemetry: urls::telemetry_url(base_url),
+            checkpoint_prepare_history: urls::checkpoint_prepare_history_url(base_url),
+            storage_prepare: urls::storage_prepare_url(base_url),
+            storage_commit: urls::storage_commit_url(base_url),
+        }
     }
 }
 
@@ -153,6 +288,7 @@ impl HttpClient {
         max_retries: u32,
     ) -> Result<Option<Value>, AgentError> {
         let client = self.inner()?;
+        let api = self.api_config()?;
         let resp = send_with_retry(
             "POST",
             max_retries,
@@ -161,12 +297,11 @@ impl HttpClient {
             || {
                 let mut req = client
                     .post(url)
-                    .header("Authorization", format!("Bearer {}", env::api_token()))
+                    .header("Authorization", format!("Bearer {}", api.token))
                     .json(body);
 
-                let bypass = env::vercel_bypass();
-                if !bypass.is_empty() {
-                    req = req.header("x-vercel-protection-bypass", bypass);
+                if !api.vercel_bypass.is_empty() {
+                    req = req.header("x-vercel-protection-bypass", &api.vercel_bypass);
                 }
 
                 std::future::ready(Ok(req))
@@ -436,6 +571,7 @@ mod tests {
         let client = HttpClient {
             inner: None,
             retry_delay: DEFAULT_RETRY_DELAY,
+            api: None,
         };
         let result = client
             .post_json("http://127.0.0.1:1/test", &serde_json::json!({}), 1)
@@ -452,6 +588,7 @@ mod tests {
         let client = HttpClient {
             inner: None,
             retry_delay: DEFAULT_RETRY_DELAY,
+            api: None,
         };
         let result = client
             .put_presigned(
@@ -472,6 +609,7 @@ mod tests {
         let client = HttpClient {
             inner: None,
             retry_delay: DEFAULT_RETRY_DELAY,
+            api: None,
         };
         let result = client
             .put_presigned_file(

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -34,10 +34,9 @@ const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 pub struct HttpClient {
     inner: Option<Client>,
     retry_delay: Duration,
-    api: Option<ApiHttpConfig>,
+    api: Option<Arc<ApiHttpConfig>>,
 }
 
-#[derive(Clone)]
 struct ApiHttpConfig {
     urls: ApiUrls,
     token: String,
@@ -108,7 +107,7 @@ impl HttpClient {
         Ok(Self {
             inner: Some(inner),
             retry_delay,
-            api,
+            api: api.map(Arc::new),
         })
     }
 
@@ -143,11 +142,14 @@ impl HttpClient {
     }
 
     fn api_config(&self) -> Result<&ApiHttpConfig, AgentError> {
-        self.api.as_ref().ok_or_else(|| {
-            AgentError::Http(
-                "guest-agent API HTTP config is disabled because VM0_API_TOKEN is unset".into(),
-            )
-        })
+        self.api
+            .as_ref()
+            .map(Arc::as_ref)
+            .ok_or_else(|| {
+                AgentError::Http(
+                    "guest-agent API HTTP config is disabled; build the client with API config to send webhooks".into(),
+                )
+            })
     }
 
     fn api_config_from_current_env() -> Result<Option<ApiHttpConfig>, AgentError> {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -228,7 +228,7 @@ async fn execute(
                     false,
                     Some(diagnostic),
                 )
-            } else if env::has_api()
+            } else if http.has_api()
                 && is_claude_zero_turn_result(env::Framework::from_env(), &cli_result)
             {
                 let history_check_start = Instant::now();
@@ -584,7 +584,7 @@ async fn complete_execution(
     // final pass. Both go through the single-writer uploader, so the two
     // flushes never race the periodic tick on the pos files.
     let agent_type = env::Framework::from_env().agent_type();
-    if should_create_success_checkpoint(cli_exit_code, exit_code) && env::has_api() {
+    if should_create_success_checkpoint(cli_exit_code, exit_code) && http.has_api() {
         log_info!(LOG_TAG, "{agent_type} completed successfully");
 
         log_info!(LOG_TAG, "▷ Checkpoint");
@@ -664,7 +664,7 @@ async fn complete_execution(
             );
         }
 
-        if env::has_api() {
+        if http.has_api() {
             if state.skip_recovery_checkpoint_for_no_history {
                 log_info!(
                     LOG_TAG,
@@ -713,6 +713,10 @@ mod tests {
         TEST_STATE_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn test_http_client(server: &MockServer) -> HttpClient {
+        HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO).unwrap()
     }
 
     struct SystemLogOverrideGuard;
@@ -1252,7 +1256,7 @@ mod tests {
             None,
         );
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http);
 
         final_telemetry(&telemetry).await;
@@ -1358,7 +1362,7 @@ mod tests {
         });
 
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let exit_code = complete_execution(
             0,
@@ -1431,7 +1435,7 @@ mod tests {
         });
 
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let exit_code = complete_execution(
             0,
@@ -1503,7 +1507,7 @@ mod tests {
         });
 
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let failure_message = "CLI failed before all events uploaded";
         let failure_diagnostic = FailureDiagnostic::new(
@@ -1586,7 +1590,7 @@ mod tests {
         });
 
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
         let failure_diagnostic = FailureDiagnostic::new(
@@ -1700,7 +1704,7 @@ mod tests {
         });
 
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let http = HttpClient::new().unwrap();
+        let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let failure_message = "You've hit your usage limit.";
         let failure_diagnostic = FailureDiagnostic::new(

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -16,7 +16,6 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
-use crate::urls;
 use guest_common::log_warn;
 use serde_json::{Value, json};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -182,7 +181,8 @@ async fn upload_telemetry(
     });
 
     // Use 1 attempt for telemetry (non-critical, best-effort)
-    match http.post_json(urls::telemetry_url(), &payload, 1).await {
+    let url = http.telemetry_url()?;
+    match http.post_json(url, &payload, 1).await {
         Ok(_) => {
             save_position(paths::telemetry_system_log_pos_file(), log_pos);
             save_position(paths::telemetry_metrics_pos_file(), metrics_pos);
@@ -271,7 +271,7 @@ impl Telemetry {
 /// tick that hasn't started yet. (A tick already in its `await` cannot
 /// be preempted; the worst-case wait for a flush is one in-flight tick.)
 async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>, http: HttpClient) {
-    if !env::has_api() {
+    if !http.has_api() {
         // Drain commands so callers don't block on `reply_rx`. Flushes
         // are a no-op (no API to upload to); Shutdown ends the loop.
         while let Some(cmd) = rx.recv().await {

--- a/crates/guest-agent/src/urls.rs
+++ b/crates/guest-agent/src/urls.rs
@@ -1,48 +1,35 @@
-//! Derived webhook URLs — built from `VM0_API_URL`.
+//! Derived webhook URLs built from the active API base URL.
 
-use crate::env;
 use api_contracts::generated::routes;
-use std::sync::LazyLock;
 
-static EVENTS_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::events::SEND.url(env::api_url()));
-static CHECKPOINT_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::checkpoints::CREATE.url(env::api_url()));
-static COMPLETE_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::complete::COMPLETE.url(env::api_url()));
-static HEARTBEAT_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::heartbeat::SEND.url(env::api_url()));
-static TELEMETRY_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::telemetry::SEND.url(env::api_url()));
-static CHECKPOINT_PREPARE_HISTORY_URL: LazyLock<String> = LazyLock::new(|| {
-    routes::webhooks::agent::checkpoints::prepare_history::PREPARE.url(env::api_url())
-});
-static STORAGE_PREPARE_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::storages::prepare::PREPARE.url(env::api_url()));
-static STORAGE_COMMIT_URL: LazyLock<String> =
-    LazyLock::new(|| routes::webhooks::agent::storages::commit::COMMIT.url(env::api_url()));
+pub(crate) fn events_url(base_url: &str) -> String {
+    routes::webhooks::agent::events::SEND.url(base_url)
+}
 
-pub fn events_url() -> &'static str {
-    &EVENTS_URL
+pub(crate) fn checkpoint_url(base_url: &str) -> String {
+    routes::webhooks::agent::checkpoints::CREATE.url(base_url)
 }
-pub fn checkpoint_url() -> &'static str {
-    &CHECKPOINT_URL
+
+pub(crate) fn complete_url(base_url: &str) -> String {
+    routes::webhooks::agent::complete::COMPLETE.url(base_url)
 }
-pub fn complete_url() -> &'static str {
-    &COMPLETE_URL
+
+pub(crate) fn heartbeat_url(base_url: &str) -> String {
+    routes::webhooks::agent::heartbeat::SEND.url(base_url)
 }
-pub fn heartbeat_url() -> &'static str {
-    &HEARTBEAT_URL
+
+pub(crate) fn telemetry_url(base_url: &str) -> String {
+    routes::webhooks::agent::telemetry::SEND.url(base_url)
 }
-pub fn telemetry_url() -> &'static str {
-    &TELEMETRY_URL
+
+pub(crate) fn checkpoint_prepare_history_url(base_url: &str) -> String {
+    routes::webhooks::agent::checkpoints::prepare_history::PREPARE.url(base_url)
 }
-pub fn checkpoint_prepare_history_url() -> &'static str {
-    &CHECKPOINT_PREPARE_HISTORY_URL
+
+pub(crate) fn storage_prepare_url(base_url: &str) -> String {
+    routes::webhooks::agent::storages::prepare::PREPARE.url(base_url)
 }
-pub fn storage_prepare_url() -> &'static str {
-    &STORAGE_PREPARE_URL
-}
-pub fn storage_commit_url() -> &'static str {
-    &STORAGE_COMMIT_URL
+
+pub(crate) fn storage_commit_url(base_url: &str) -> String {
+    routes::webhooks::agent::storages::commit::COMMIT.url(base_url)
 }

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -98,7 +98,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         guest_agent::cli::execute_cli(
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::with_retry_delay(Duration::ZERO)?,
+            HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)?,
         ),
     )
     .await

--- a/crates/guest-agent/tests/http_env_missing_api_url.rs
+++ b/crates/guest-agent/tests/http_env_missing_api_url.rs
@@ -1,0 +1,17 @@
+use guest_agent::http::HttpClient;
+
+#[test]
+fn for_current_env_requires_api_url_when_api_token_is_set() {
+    unsafe {
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var("VM0_API_URL", "");
+    }
+
+    let Err(err) = HttpClient::for_current_env() else {
+        panic!("missing API URL should fail fast");
+    };
+    assert!(
+        err.to_string().contains("VM0_API_URL"),
+        "error should identify VM0_API_URL, got: {err}"
+    );
+}

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -17,8 +17,8 @@ use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 /// Shared mock server — env vars are set once before any `LazyLock` in the
-/// library is accessed, so `env::api_url()`, `urls::*`, etc. all resolve to
-/// the mock server's address.
+/// library is accessed, so environment-backed guest-agent state resolves to
+/// test values.
 static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
     let server = MockServer::start();
     unsafe {
@@ -49,7 +49,14 @@ const MOCK_CALL_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[allow(clippy::expect_used)]
 fn test_http_client(retry_delay: Duration) -> guest_agent::http::HttpClient {
-    guest_agent::http::HttpClient::with_retry_delay(retry_delay).expect("build test http client")
+    let server = &*MOCK_SERVER;
+    guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token-abc123",
+        "test-bypass-value",
+        retry_delay,
+    )
+    .expect("build test http client")
 }
 
 fn http_status(status: u16) -> HttpMockResponse {
@@ -85,12 +92,20 @@ fn request_header_eq(req: &HttpMockRequest, name: &str, expected: &str) -> bool 
         .any(|(key, value)| key.eq_ignore_ascii_case(name) && value == expected)
 }
 
+fn request_header_absent(req: &HttpMockRequest, name: &str) -> bool {
+    !req.headers_vec()
+        .iter()
+        .any(|(key, _)| key.eq_ignore_ascii_case(name))
+}
+
 fn upload_request_matches(
     req: &HttpMockRequest,
     expected_body: &[u8],
     expected_content_length: &str,
 ) -> bool {
     request_header_eq(req, "content-length", expected_content_length)
+        && request_header_absent(req, "authorization")
+        && request_header_absent(req, "x-vercel-protection-bypass")
         && req.body_ref() == expected_body
 }
 
@@ -227,6 +242,37 @@ async fn for_current_env_uses_enabled_client_when_api_token_is_set()
 
     mock.assert_calls_async(1).await;
     assert_eq!(result.unwrap()["status"], "ok");
+    mock.delete_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn for_current_env_uses_env_api_url_for_webhook_routes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .header("Authorization", "Bearer test-token-abc123")
+            .header("x-vercel-protection-bypass", "test-bypass-value")
+            .json_body_includes(r#"{"runId": "test-run-001"}"#);
+        then.status(200);
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let mut event = json!({"type": "test", "data": "env route"});
+    guest_agent::events::send_event(
+        &guest_agent::http::HttpClient::for_current_env()?,
+        &mut event,
+        7,
+        &masker,
+    )
+    .await?;
+
+    mock.assert_calls_async(1).await;
+    assert_eq!(event["sequenceNumber"], 7);
     mock.delete_async().await;
     Ok(())
 }
@@ -377,6 +423,33 @@ async fn post_json_sends_vercel_bypass_header() {
     mock.delete_async().await;
 }
 
+#[tokio::test]
+async fn post_json_uses_explicit_api_config_without_env_api_url() {
+    let server = MockServer::start();
+    let http = guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "explicit-token",
+        "explicit-bypass",
+        Duration::ZERO,
+    )
+    .expect("build explicit API client");
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .header("Authorization", "Bearer explicit-token")
+            .header("x-vercel-protection-bypass", "explicit-bypass");
+        then.status(200).json_body(json!({}));
+    });
+
+    let url = format!("{}/api/webhooks/agent/events", server.base_url());
+    let result = http.post_json(&url, &json!({"events": []}), 1).await;
+
+    mock.assert_calls_async(1).await;
+    assert!(result.is_ok());
+    mock.delete_async().await;
+}
+
 // =========================================================================
 // Group 3: put_presigned
 // =========================================================================
@@ -394,6 +467,35 @@ async fn put_presigned_success() {
     });
 
     let url = format!("{}/test/put-success", server.base_url());
+    let data = Bytes::from_static(b"test data");
+    let result = http_client!()
+        .put_presigned(&url, data, "application/octet-stream")
+        .await;
+
+    mock.assert_calls_async(1).await;
+    assert!(result.is_ok());
+    mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn put_presigned_does_not_send_api_headers() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/put-no-api-headers");
+        then.respond_with(|req| {
+            if request_header_absent(req, "authorization")
+                && request_header_absent(req, "x-vercel-protection-bypass")
+            {
+                http_status(200)
+            } else {
+                http_status(400)
+            }
+        });
+    });
+
+    let url = format!("{}/test/put-no-api-headers", server.base_url());
     let data = Bytes::from_static(b"test data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -1024,10 +1126,7 @@ async fn prepare_event_does_not_capture_session_metadata() {
     });
     let payload = guest_agent::events::prepare_event(&mut event, 1, &masker);
 
-    assert!(
-        payload.is_some(),
-        "prepare_event should still prepare a payload when the API token is configured"
-    );
+    assert_eq!(payload["runId"], "test-run-001");
     assert!(
         !std::path::Path::new(sid_file).exists(),
         "prepare_event must not write the session ID file"

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -450,6 +450,48 @@ async fn post_json_uses_explicit_api_config_without_env_api_url() {
     mock.delete_async().await;
 }
 
+#[tokio::test]
+async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
+-> Result<(), Box<dyn std::error::Error>> {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let env_server = &*MOCK_SERVER;
+    let explicit_server = MockServer::start();
+
+    let env_mock = env_server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200);
+    });
+    let explicit_mock = explicit_server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .header("Authorization", "Bearer explicit-token");
+        then.respond_with(|req| {
+            if request_header_absent(req, "x-vercel-protection-bypass") {
+                http_status(200)
+            } else {
+                http_status(400)
+            }
+        });
+    });
+
+    let http = guest_agent::http::HttpClient::with_api_config(
+        explicit_server.base_url(),
+        "explicit-token",
+        "",
+        Duration::ZERO,
+    )?;
+    let masker = SecretMasker::from_raw("");
+    let mut event = json!({"type": "test", "data": "explicit route"});
+    guest_agent::events::send_event(&http, &mut event, 3, &masker).await?;
+
+    explicit_mock.assert_calls_async(1).await;
+    env_mock.assert_calls_async(0).await;
+    assert_eq!(event["sequenceNumber"], 3);
+    explicit_mock.delete_async().await;
+    env_mock.delete_async().await;
+    Ok(())
+}
+
 // =========================================================================
 // Group 3: put_presigned
 // =========================================================================
@@ -475,6 +517,29 @@ async fn put_presigned_success() {
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
     mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn transport_only_client_can_send_presigned_upload_without_api_config()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/put-transport-only");
+        then.respond_with(|req| upload_validation_response(req, b"transport-only upload", "21"));
+    });
+
+    let url = format!("{}/test/put-transport-only", server.base_url());
+    let http = guest_agent::http::HttpClient::new()?;
+    http.put_presigned(
+        &url,
+        Bytes::from_static(b"transport-only upload"),
+        "application/octet-stream",
+    )
+    .await?;
+
+    mock.assert_calls_async(1).await;
+    mock.delete_async().await;
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- make guest-agent HttpClient capture API base URL, token, bypass header, and derived webhook URLs at construction time
- route webhook send decisions through HttpClient instead of global env/url LazyLocks
- remove artifact snapshot test VM0_API_URL mutation and add coverage for explicit config, env URL routing, missing URL failure, and presigned upload auth isolation

## Tests
- cargo fmt -p guest-agent -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -j1 -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent -j1

Closes #15080