### PR TITLE
feat: align vm0-computer client contract

### DIFF
--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -60,6 +60,13 @@ function responseFor(request) {
       result: { accessibility: true, screenRecording: true }
     };
   }
+  if (request.kind === "apps.list") {
+    return {
+      id: request.id,
+      status: "succeeded",
+      result: { apps: ["Safari"] }
+    };
+  }
   if (request.kind === "app.state") {
     return {
       id: request.id,
@@ -419,15 +426,14 @@ describe("computer use native backend", () => {
     }
   });
 
-  it("uses the same runtime contract from the vm0-computer CLI", async () => {
+  it("returns post-action app state from the vm0-computer CLI", async () => {
     const helper = await createSessionHelper();
     const commandInput = [
-      { kind: "app.state", payload: { app: "Safari", snapshotId: "snap_1" } },
+      { kind: "app.state", payload: { app: "Safari" } },
       {
         kind: "element.click",
         payload: {
           app: "Safari",
-          snapshotId: "snap_1",
           elementIndex: 1,
           button: "left",
           clickCount: 1,
@@ -456,16 +462,23 @@ describe("computer use native backend", () => {
         status: "succeeded",
         result: {
           app: "Safari",
-          snapshotId: "snap_1",
           elementIdsByIndex: ["w0", "w0.e0"],
+          screenshot: "data:image/png;base64,abc123",
+          text: expect.stringContaining("<app_state>"),
         },
       });
       expect(responses[1]).toMatchObject({
         status: "succeeded",
         result: {
-          snapshotId: "snap_1",
-          elementIndex: 1,
-          button: "left",
+          app: "Safari",
+          screenshot: "data:image/png;base64,abc123",
+          text: expect.stringContaining("<app_state>"),
+          action: {
+            app: "Safari",
+            elementIndex: 1,
+            button: "left",
+            clickCount: 1,
+          },
         },
       });
     } finally {
@@ -475,9 +488,7 @@ describe("computer use native backend", () => {
 
   it("preserves vm0-computer run array output for single-command arrays", async () => {
     const helper = await createSessionHelper();
-    const commandInput = [
-      { kind: "app.state", payload: { app: "Safari", snapshotId: "snap_1" } },
-    ];
+    const commandInput = [{ kind: "app.state", payload: { app: "Safari" } }];
 
     try {
       const { stdout } = await execFileAsync(
@@ -500,8 +511,9 @@ describe("computer use native backend", () => {
         status: "succeeded",
         result: {
           app: "Safari",
-          snapshotId: "snap_1",
           elementIdsByIndex: ["w0", "w0.e0"],
+          screenshot: "data:image/png;base64,abc123",
+          text: expect.stringContaining("<app_state>"),
         },
       });
     } finally {
@@ -515,27 +527,13 @@ describe("computer use native backend", () => {
       ["list-apps"],
       ["get-app-state", "--app", "Safari"],
       ["open-app", "--app", "Safari"],
-      [
-        "click",
-        "--app",
-        "Safari",
-        "--snapshot-id",
-        "snap_1",
-        "--element",
-        "w0.e0",
-        "--button",
-        "right",
-        "--click-count",
-        "2",
-      ],
+      ["click", "--app", "Safari", "--element", "w0.e0", "--click-count", "2"],
       [
         "scroll",
         "--app",
         "Safari",
-        "--snapshot-id",
-        "snap_1",
-        "--element-index",
-        "1",
+        "--element",
+        "w0.e0",
         "--direction",
         "down",
         "--pages",
@@ -545,10 +543,8 @@ describe("computer use native backend", () => {
         "set-value",
         "--app",
         "Safari",
-        "--snapshot-id",
-        "snap_1",
-        "--element-index",
-        "1",
+        "--element",
+        "w0.e0",
         "--value",
         "hello",
       ],
@@ -556,10 +552,8 @@ describe("computer use native backend", () => {
         "perform-action",
         "--app",
         "Safari",
-        "--snapshot-id",
-        "snap_1",
-        "--element-index",
-        "1",
+        "--element",
+        "w0.e0",
         "--action",
         "AXShowMenu",
       ],
@@ -585,9 +579,15 @@ describe("computer use native backend", () => {
             readonly payload?: Record<string, unknown>;
           };
         });
-      expect(requests.map((request) => request.kind)).toStrictEqual([
+      const publicCommandRequests = requests.filter((request) => {
+        return (
+          request.kind !== "permissions.state" && request.kind !== "app.state"
+        );
+      });
+      expect(
+        publicCommandRequests.map((request) => request.kind),
+      ).toStrictEqual([
         "apps.list",
-        "app.state",
         "app.open",
         "element.click",
         "element.scroll",
@@ -596,22 +596,29 @@ describe("computer use native backend", () => {
         "keyboard.type_text",
         "keyboard.press_key",
       ]);
-      expect(requests[3]?.payload).toMatchObject({
+      expect(publicCommandRequests[2]?.payload).toMatchObject({
         app: "Safari",
-        snapshotId: "snap_1",
         elementId: "w0.e0",
-        button: "right",
+        button: "left",
         clickCount: 2,
       });
-      expect(requests[4]?.payload).toMatchObject({
-        elementIndex: 1,
+      expect(publicCommandRequests[3]?.payload).toMatchObject({
+        elementId: "w0.e0",
         direction: "down",
         pages: 2,
       });
-      expect(requests[5]?.payload).toMatchObject({ value: "hello" });
-      expect(requests[6]?.payload).toMatchObject({ action: "AXShowMenu" });
-      expect(requests[7]?.payload).toMatchObject({ text: "hello" });
-      expect(requests[8]?.payload).toMatchObject({ key: "Escape" });
+      expect(publicCommandRequests[4]?.payload).toMatchObject({
+        value: "hello",
+      });
+      expect(publicCommandRequests[5]?.payload).toMatchObject({
+        action: "AXShowMenu",
+      });
+      expect(publicCommandRequests[6]?.payload).toMatchObject({
+        text: "hello",
+      });
+      expect(publicCommandRequests[7]?.payload).toMatchObject({
+        key: "Escape",
+      });
     } finally {
       await rm(helper.dir, { recursive: true, force: true });
     }

--- a/turbo/apps/desktop/src/vm0-computer.ts
+++ b/turbo/apps/desktop/src/vm0-computer.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import {
+  ComputerUseSnapshotStore,
+  SUPPORTED_COMPUTER_USE_CAPABILITIES,
+  executeComputerUseCommand,
+  type ComputerUseCommandKind,
+} from "./computer-use-accessibility";
+import { createComputerUseNativeBackend } from "./computer-use-native";
 
 type JsonObject = Record<string, unknown>;
 
@@ -25,11 +31,6 @@ interface ParsedArgs {
 interface ParsedRuntimeCommands {
   readonly commands: readonly RuntimeCommand[];
   readonly outputArray: boolean;
-}
-
-interface PendingResponse {
-  readonly resolve: (response: RuntimeResponse) => void;
-  readonly reject: (error: Error) => void;
 }
 
 const appRoot = path.resolve(__dirname, "..");
@@ -67,7 +68,6 @@ const zeroCommands = new Map<string, string>([
 
 function usage(): string {
   return `Usage:
-  vm0-computer serve [--helper-path PATH]
   vm0-computer run JSON [--helper-path PATH]
   vm0-computer list-apps [--helper-path PATH]
   vm0-computer get-app-state --app APP [--helper-path PATH]
@@ -215,91 +215,26 @@ function commandFromArgs(
   return { kind, payload };
 }
 
-class RuntimeClient {
-  private readonly child: ChildProcessWithoutNullStreams;
-  private buffer = "";
-  private counter = 0;
-  private readonly pending = new Map<string, PendingResponse>();
-  private stderr = "";
-
-  constructor(helperPath: string) {
-    this.child = spawn(helperPath, ["serve"], {
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    this.child.stdout.setEncoding("utf8");
-    this.child.stdout.on("data", (chunk: string) => {
-      this.handleStdout(chunk);
-    });
-    this.child.stderr.setEncoding("utf8");
-    this.child.stderr.on("data", (chunk: string) => {
-      this.stderr += chunk;
-    });
-    this.child.on("close", (code) => {
-      for (const pending of this.pending.values()) {
-        pending.reject(
-          new Error(
-            this.stderr.trim() ||
-              `computer-use-helper exited with status ${code ?? "null"}`,
-          ),
-        );
-      }
-      this.pending.clear();
-    });
-  }
-
-  send(command: RuntimeCommand): Promise<RuntimeResponse> {
-    const id = `cli_${(this.counter += 1).toString()}`;
-    return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.child.stdin.write(
-        `${JSON.stringify({ id, ...command })}\n`,
-        (error: Error | null | undefined) => {
-          if (error) {
-            this.pending.delete(id);
-            reject(error);
-          }
-        },
-      );
-    });
-  }
-
-  close(): void {
-    this.child.stdin.end();
-  }
-
-  private handleStdout(chunk: string): void {
-    this.buffer += chunk;
-    while (this.buffer.includes("\n")) {
-      const index = this.buffer.indexOf("\n");
-      const line = this.buffer.slice(0, index).trim();
-      this.buffer = this.buffer.slice(index + 1);
-      if (line.length > 0) {
-        this.handleLine(line);
-      }
-    }
-  }
-
-  private handleLine(line: string): void {
-    const response: unknown = JSON.parse(line);
-    if (!isJsonObject(response) || typeof response.id !== "string") {
-      return;
-    }
-    const pending = this.pending.get(response.id);
-    if (!pending) {
-      return;
-    }
-    this.pending.delete(response.id);
-    pending.resolve(response);
-  }
+function isComputerUseCommandKind(
+  kind: string,
+): kind is ComputerUseCommandKind {
+  return SUPPORTED_COMPUTER_USE_CAPABILITIES.includes(
+    kind as ComputerUseCommandKind,
+  );
 }
 
-async function runServe(helperPath: string): Promise<void> {
-  const child = spawn(helperPath, ["serve"], { stdio: "inherit" });
-  const code = await new Promise<number | null>((resolve) => {
-    child.on("close", resolve);
-  });
-  process.exit(typeof code === "number" ? code : 1);
+function assertComputerUseCommandKind(kind: string): ComputerUseCommandKind {
+  if (isComputerUseCommandKind(kind)) {
+    return kind;
+  }
+  fail(`Unsupported vm0-computer command kind: ${kind}\n\n${usage()}`);
+}
+
+function runtimeResponse(
+  id: string,
+  result: Awaited<ReturnType<typeof executeComputerUseCommand>>,
+): RuntimeResponse {
+  return { id, ...result };
 }
 
 async function runCommands(
@@ -307,17 +242,31 @@ async function runCommands(
   commands: readonly RuntimeCommand[],
   outputArray: boolean,
 ): Promise<void> {
-  const client = new RuntimeClient(helperPath);
+  const nativeBackend = createComputerUseNativeBackend({ helperPath });
+  const snapshotStore = new ComputerUseSnapshotStore();
   try {
+    const permissions = await nativeBackend.getPermissions();
     const responses: RuntimeResponse[] = [];
+    let counter = 0;
     for (const command of commands) {
-      responses.push(await client.send(command));
+      const id = `cli_${(counter += 1).toString()}`;
+      const kind = assertComputerUseCommandKind(command.kind);
+      const result = await executeComputerUseCommand(
+        { id, kind, payload: command.payload ?? {} },
+        permissions,
+        {
+          nativeBackend,
+          platform: process.platform,
+          snapshotStore,
+        },
+      );
+      responses.push(runtimeResponse(id, result));
     }
     process.stdout.write(
       `${JSON.stringify(outputArray ? responses : responses[0], null, 2)}\n`,
     );
   } finally {
-    client.close();
+    nativeBackend.dispose();
   }
 }
 
@@ -330,10 +279,6 @@ async function main(): Promise<void> {
   }
 
   const helperPath = helperPathFrom(values);
-  if (command === "serve") {
-    await runServe(helperPath);
-    return;
-  }
   if (command === "run") {
     const raw = positional[1];
     if (!raw) {


### PR DESCRIPTION
## Summary
- route vm0-computer through executeComputerUseCommand so action commands return the same post-action app state payload used by the Desktop computer-use client
- keep one ComputerUseSnapshotStore per `run` invocation so multi-command workflows can reuse the latest state
- remove raw native helper passthrough commands from the public vm0-computer CLI

## Tests
- pnpm -F @vm0/desktop build:cli
- pnpm -F @vm0/desktop exec vitest run src/computer-use-native.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint

Closes #15090