### PR TITLE
feat: enable public docs site

### DIFF
--- a/turbo/apps/web/app/lib/docs/__tests__/access.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/access.test.ts
@@ -22,23 +22,23 @@ describe("docs access", () => {
     loadFeatureSwitchOverridesMock.mockReset();
   });
 
-  it("does not query feature switch overrides for signed-out users", async () => {
+  it("allows signed-out users without querying feature switch overrides", async () => {
     const canViewDocsForUser = createCanViewDocsForUser(
       loadFeatureSwitchOverridesMock,
     );
 
-    await expect(canViewDocsForUser(null, null)).resolves.toBe(false);
+    await expect(canViewDocsForUser(null, null)).resolves.toBe(true);
 
     expect(loadFeatureSwitchOverridesMock).not.toHaveBeenCalled();
   });
 
-  it("does not query feature switch overrides for users without an org", async () => {
+  it("allows users without an org without querying feature switch overrides", async () => {
     const canViewDocsForUser = createCanViewDocsForUser(
       loadFeatureSwitchOverridesMock,
     );
 
     await expect(canViewDocsForUser("user-without-org", null)).resolves.toBe(
-      false,
+      true,
     );
 
     expect(loadFeatureSwitchOverridesMock).not.toHaveBeenCalled();
@@ -70,7 +70,7 @@ describe("docs access", () => {
 
     await expect(
       canViewDocsForUser("user-docs-fallback", "org-docs-fallback"),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
   });
 
   it("evaluates the current Clerk session", async () => {
@@ -79,7 +79,7 @@ describe("docs access", () => {
       orgId: null,
     });
 
-    await expect(canViewDocs()).resolves.toBe(false);
+    await expect(canViewDocs()).resolves.toBe(true);
 
     expect(authMock).toHaveBeenCalledTimes(1);
   });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -58,10 +58,12 @@ describe("isFeatureEnabled", () => {
     ).toBe(true);
   });
 
-  it("should enable docs site for staff orgs", () => {
+  it("should enable docs site globally", () => {
+    expect(isFeatureEnabled(FeatureSwitchKey.DocsSite, {})).toBe(true);
+
     expect(
       isFeatureEnabled(FeatureSwitchKey.DocsSite, {
-        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+        orgId: "org_nonexistent",
       }),
     ).toBe(true);
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -266,9 +266,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.DocsSite]: {
     maintainer: "linghan@vm0.ai",
     description:
-      "Enable the authenticated Strapi-backed docs site routes, navigation entry, and docs pages. Staff-only during rollout; per-user toggle via Lab.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+      "Enable the Strapi-backed public docs site routes, navigation entry, and docs pages.",
+    enabled: true,
   },
   [FeatureSwitchKey.FreshdeskConnector]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable the DocsSite feature switch globally for the public Strapi-backed docs site
- update docs access and feature switch tests for signed-out and non-staff access

## Tests
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F web exec vitest run app/lib/docs/__tests__/access.test.ts
- pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/web/app/lib/docs/__tests__/access.test.ts
- pnpm -F @vm0/core lint
- pnpm -F web lint
- pnpm -F @vm0/core check-types
- pnpm -F web check-types
- pre-commit: pnpm knip
- pre-commit: pnpm check-types