### PR TITLE
fix: rename docs channels section

### DIFF
--- a/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
@@ -123,6 +123,40 @@ describe("docs/strapi", () => {
     });
   });
 
+  it("renames the legacy Channels docs section to Integrations", async () => {
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 4,
+              documentId: "doc-slack",
+              title: "Slack",
+              description: "Connect Slack.",
+              slug: "slack",
+              path: "integrations/slack",
+              order: 1,
+              createdAt: "2026-05-01T00:00:00.000Z",
+              updatedAt: "2026-05-01T00:00:00.000Z",
+              publishedAt: "2026-05-01T00:00:00.000Z",
+              section: { title: "Channels", slug: "channels" },
+              body: "# Slack",
+            },
+          ],
+          meta: {},
+        });
+      }),
+    );
+
+    const pages = await getDocsPagesFromStrapi("en");
+
+    expect(pages[0]?.section).toEqual({
+      title: "Integrations",
+      slug: "integrations",
+      order: 50,
+    });
+  });
+
   it("fetches a single docs page by path", async () => {
     let capturedLocale: string | null = null;
     let capturedPath: string | null = null;

--- a/turbo/apps/web/app/lib/docs/strapi.ts
+++ b/turbo/apps/web/app/lib/docs/strapi.ts
@@ -125,29 +125,42 @@ const SECTION_ORDER: Record<string, number> = {
   "Core concepts": 30,
   "Core Concepts": 30,
   "What Zero delivers": 40,
-  Channels: 50,
+  Integrations: 50,
   Connectors: 60,
   "Who it's for": 70,
 };
 
 const UNKNOWN_SECTION_ORDER = 1000;
 
+function normalizeSectionTitle(title: string): string {
+  return title === "Channels" ? "Integrations" : title;
+}
+
+function normalizeSectionSlug(slug: string | undefined, title: string): string {
+  if (!slug || slug === "channels") {
+    return slugify(title);
+  }
+  return slug;
+}
+
 function resolveSection(
   section: string | StrapiDocsSection | undefined,
 ): DocsSection {
   if (typeof section === "string") {
-    const title = section.trim();
-    if (!title) {
+    const rawTitle = section.trim();
+    if (!rawTitle) {
       return { title: "Docs", slug: "docs", order: 0 };
     }
+    const title = normalizeSectionTitle(rawTitle);
     return {
       title,
       slug: slugify(title),
       order: SECTION_ORDER[title] ?? UNKNOWN_SECTION_ORDER,
     };
   }
-  const sectionTitle = section?.title || section?.name || "Docs";
-  const sectionSlug = section?.slug || slugify(sectionTitle);
+  const rawSectionTitle = section?.title || section?.name || "Docs";
+  const sectionTitle = normalizeSectionTitle(rawSectionTitle);
+  const sectionSlug = normalizeSectionSlug(section?.slug, sectionTitle);
   const explicitOrder = section?.order;
   return {
     title: sectionTitle,


### PR DESCRIPTION
## Summary
- Normalize the legacy Strapi docs section label `Channels` to `Integrations`
- Normalize the legacy `channels` section slug to `integrations`
- Add coverage for the Strapi docs section rename

## Tests
- `pnpm -F web exec oxlint app/lib/docs/strapi.ts app/lib/docs/__tests__/strapi.test.ts`
- `pnpm exec prettier --check apps/web/app/lib/docs/strapi.ts apps/web/app/lib/docs/__tests__/strapi.test.ts`

Note: `pnpm -F web test app/lib/docs/__tests__/strapi.test.ts` could not run in this environment because the web Vitest global setup requires a local Postgres instance on port 5432.