### PR TITLE
fix: use consistent manual connector snapshot for runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -592,6 +592,58 @@ describe("POST /api/agent/runs", () => {
     });
   });
 
+  it("does not load unreferenced persisted secrets into runner secrets", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    await db.insert(secretsTable).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "API_KEY",
+      encryptedValue: encryptSecretForTests("persisted-secret-value"),
+      type: "user",
+    });
+    await db.insert(secretsTable).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "UNREFERENCED_SECRET",
+      encryptedValue: encryptSecretForTests("should-not-load"),
+      type: "user",
+    });
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: {
+        environment: {
+          ANTHROPIC_API_KEY: "test-key",
+          API_KEY: vm0Template("{{ secrets.API_KEY }}"),
+        },
+      },
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use persisted secret",
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.environment.API_KEY).toBe("persisted-secret-value");
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toStrictEqual({
+      API_KEY: "persisted-secret-value",
+    });
+  });
+
   it("stores the user timezone in the runner context", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
@@ -762,6 +814,59 @@ describe("POST /api/agent/runs", () => {
       return firewall.name === "zendesk";
     });
     expect(zendesk?.apis[0]?.base).toBe("https://acme.zendesk.com");
+  });
+
+  it("does not enable a manual connector from run-provided env values alone", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: {
+        environment: {
+          ANTHROPIC_API_KEY: "test-key",
+          ZENDESK_API_TOKEN: vm0Template("{{ secrets.ZENDESK_API_TOKEN }}"),
+          ZENDESK_EMAIL: vm0Template("{{ vars.ZENDESK_EMAIL }}"),
+          ZENDESK_SUBDOMAIN: vm0Template("{{ vars.ZENDESK_SUBDOMAIN }}"),
+        },
+      },
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use provided zendesk values",
+          vars: {
+            ZENDESK_EMAIL: "run@example.com",
+            ZENDESK_SUBDOMAIN: "run-subdomain",
+          },
+          secrets: { ZENDESK_API_TOKEN: "run-zendesk-token" },
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly firewalls?: readonly { readonly name: string }[];
+    };
+    expect(executionContext.environment.ZENDESK_API_TOKEN).toBe(
+      "run-zendesk-token",
+    );
+    expect(executionContext.environment.ZENDESK_EMAIL).toBe("run@example.com");
+    expect(executionContext.environment.ZENDESK_SUBDOMAIN).toBe(
+      "run-subdomain",
+    );
+    expect(
+      executionContext.firewalls?.some((firewall) => {
+        return firewall.name === "zendesk";
+      }),
+    ).toBeFalsy();
   });
 
   it("loads an api-token connector secret used only by the firewall, not the compose environment", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -927,6 +927,60 @@ describe("POST /api/agent/runs", () => {
     });
   });
 
+  it("loads a firewall-only api-token connector secret without compose secret refs", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    await db.insert(secretsTable).values([
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "WEREAD_TOKEN",
+        encryptedValue: encryptSecretForTests("weread-real-token"),
+        type: "user",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "UNREFERENCED_SECRET",
+        encryptedValue: encryptSecretForTests("should-not-load"),
+        type: "user",
+      },
+    ]);
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Read my books",
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+      readonly firewalls: readonly { readonly name: string }[];
+    };
+    expect(executionContext.environment.WEREAD_TOKEN).toBe(
+      "wrk-CoffeeSafeLocalCoffeeSafeLocalCoffee",
+    );
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toStrictEqual({
+      WEREAD_TOKEN: "weread-real-token",
+    });
+    expect(
+      executionContext.firewalls.some((firewall) => {
+        return firewall.name === "weread";
+      }),
+    ).toBeTruthy();
+  });
+
   it("accepts OAuth connector-provided env secrets during compose validation", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1316,17 +1316,13 @@ async function loadPersistedRunEnvironmentSnapshot(
     const secretNameRows = await tx
       .select({
         name: secretsTable.name,
-        userId: secretsTable.userId,
       })
       .from(secretsTable)
       .where(
         and(
           eq(secretsTable.orgId, args.orgId),
           eq(secretsTable.type, "user"),
-          or(
-            eq(secretsTable.userId, ORG_SENTINEL_USER_ID),
-            eq(secretsTable.userId, args.userId),
-          ),
+          eq(secretsTable.userId, args.userId),
         ),
       );
     const variableRows = await tx
@@ -1347,8 +1343,8 @@ async function loadPersistedRunEnvironmentSnapshot(
       );
 
     const userSecretNames = new Set(
-      secretNameRows.flatMap((row) => {
-        return row.userId === args.userId ? [row.name] : [];
+      secretNameRows.map((row) => {
+        return row.name;
       }),
     );
     const userVariableNames = new Set(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -337,6 +337,24 @@ interface ConnectorRuntimeContext {
   readonly connectorTypes: readonly ConnectorType[];
 }
 
+interface PersistedRunEnvironmentSecret {
+  readonly name: string;
+  readonly encryptedValue: string;
+  readonly userId: string;
+}
+
+interface PersistedRunEnvironmentVariable {
+  readonly name: string;
+  readonly value: string;
+  readonly userId: string;
+}
+
+interface PersistedRunEnvironmentSnapshot {
+  readonly secrets: readonly PersistedRunEnvironmentSecret[];
+  readonly variables: readonly PersistedRunEnvironmentVariable[];
+  readonly manualGrantConnectorTypes: readonly ConnectorType[];
+}
+
 interface CreditCheckRow extends Record<string, unknown> {
   readonly tier: string | null;
   readonly credits: string | null;
@@ -1282,34 +1300,120 @@ async function resolveModelProviderEnvironment(
   return null;
 }
 
-async function loadMergedVariables(
+async function loadPersistedRunEnvironmentSnapshot(
   db: Db,
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly runVars: Record<string, string> | undefined;
+    readonly content: AgentComposeContent;
+    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
   },
-): Promise<Record<string, string> | undefined> {
-  const rows = await db
-    .select({
-      name: variables.name,
-      value: variables.value,
-      userId: variables.userId,
-    })
-    .from(variables)
-    .where(
-      and(
-        eq(variables.orgId, args.orgId),
-        or(
-          eq(variables.userId, ORG_SENTINEL_USER_ID),
-          eq(variables.userId, args.userId),
+): Promise<PersistedRunEnvironmentSnapshot> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+    );
+    const secretNameRows = await tx
+      .select({
+        name: secretsTable.name,
+        userId: secretsTable.userId,
+      })
+      .from(secretsTable)
+      .where(
+        and(
+          eq(secretsTable.orgId, args.orgId),
+          eq(secretsTable.type, "user"),
+          or(
+            eq(secretsTable.userId, ORG_SENTINEL_USER_ID),
+            eq(secretsTable.userId, args.userId),
+          ),
         ),
-      ),
+      );
+    const variableRows = await tx
+      .select({
+        name: variables.name,
+        value: variables.value,
+        userId: variables.userId,
+      })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, args.orgId),
+          or(
+            eq(variables.userId, ORG_SENTINEL_USER_ID),
+            eq(variables.userId, args.userId),
+          ),
+        ),
+      );
+
+    const userSecretNames = new Set(
+      secretNameRows.flatMap((row) => {
+        return row.userId === args.userId ? [row.name] : [];
+      }),
+    );
+    const userVariableNames = new Set(
+      variableRows.flatMap((row) => {
+        return row.userId === args.userId ? [row.name] : [];
+      }),
     );
 
+    const snapshotWithoutSecrets = {
+      variables: variableRows,
+      manualGrantConnectorTypes: deriveConnectedManualGrantMethods(
+        userSecretNames,
+        userVariableNames,
+      ).map((method) => {
+        return method.type;
+      }),
+    };
+    const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
+      allowedManualGrantConnectorTypes({
+        manualGrantTypes: snapshotWithoutSecrets.manualGrantConnectorTypes,
+        allowedConnectorTypes: args.allowedConnectorTypes,
+      }),
+    );
+    const environment = firstAgent(args.content)?.environment;
+    const referencedSecretNames = environment
+      ? extractAndGroupVariables(environment).secrets.map((ref) => {
+          return ref.name;
+        })
+      : [];
+    const secretNamesToLoad = [
+      ...new Set([...referencedSecretNames, ...dynamicConnectorSecretNames]),
+    ];
+    const secretRows =
+      secretNamesToLoad.length > 0
+        ? await tx
+            .select({
+              name: secretsTable.name,
+              encryptedValue: secretsTable.encryptedValue,
+              userId: secretsTable.userId,
+            })
+            .from(secretsTable)
+            .where(
+              and(
+                eq(secretsTable.orgId, args.orgId),
+                eq(secretsTable.type, "user"),
+                or(
+                  eq(secretsTable.userId, ORG_SENTINEL_USER_ID),
+                  eq(secretsTable.userId, args.userId),
+                ),
+                inArray(secretsTable.name, secretNamesToLoad),
+              ),
+            )
+        : [];
+
+    return { ...snapshotWithoutSecrets, secrets: secretRows };
+  });
+}
+
+function buildMergedVariables(args: {
+  readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
+  readonly runVars: Record<string, string> | undefined;
+}): Record<string, string> | undefined {
   const orgVars: Record<string, string> = {};
   const userVars: Record<string, string> = {};
-  for (const row of rows) {
+  for (const row of args.persistedEnvironment.variables) {
     if (row.userId === ORG_SENTINEL_USER_ID) {
       orgVars[row.name] = row.value;
     } else {
@@ -1321,27 +1425,20 @@ async function loadMergedVariables(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-async function loadReferencedSecrets(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly content: AgentComposeContent;
-    readonly runSecrets: Record<string, string> | undefined;
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
-    readonly featureSwitchContext: FeatureSwitchContext;
-  },
-): Promise<Record<string, string> | undefined> {
+async function buildReferencedSecrets(args: {
+  readonly content: AgentComposeContent;
+  readonly runSecrets: Record<string, string> | undefined;
+  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+  readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<Record<string, string> | undefined> {
   const environment = firstAgent(args.content)?.environment;
   const referencedNames = environment
     ? extractAndGroupVariables(environment).secrets.map((ref) => {
         return ref.name;
       })
     : [];
-  const manualGrantTypes = await loadManualGrantConnectorTypes(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-  });
+  const manualGrantTypes = args.persistedEnvironment.manualGrantConnectorTypes;
   const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
     allowedManualGrantConnectorTypes({
       manualGrantTypes,
@@ -1352,31 +1449,12 @@ async function loadReferencedSecrets(
     return args.runSecrets;
   }
 
-  // Load all user secrets, not only those named in the compose environment:
-  // Manual grant secrets are consumed by firewall auth templates,
-  // which the compose environment never references. Connector-owned secrets
-  // are still scoped by filterDbSecretsByConnectorPermissions below.
-  const rows = await db
-    .select({
-      name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
-      userId: secretsTable.userId,
-    })
-    .from(secretsTable)
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.type, "user"),
-        or(
-          eq(secretsTable.userId, ORG_SENTINEL_USER_ID),
-          eq(secretsTable.userId, args.userId),
-        ),
-      ),
-    );
-
+  // Manual grant secrets can be consumed by firewall auth templates even when
+  // the compose environment never references them. Connector-owned secrets are
+  // still scoped by filterDbSecretsByConnectorPermissions below.
   const orgSecrets: Record<string, string> = {};
   const userSecrets: Record<string, string> = {};
-  for (const row of rows) {
+  for (const row of args.persistedEnvironment.secrets) {
     const target =
       row.userId === ORG_SENTINEL_USER_ID ? orgSecrets : userSecrets;
     target[row.name] = await decryptStoredSecretValue(
@@ -1396,48 +1474,6 @@ async function loadReferencedSecrets(
       : filteredSecrets;
   const merged = { ...connectorSecrets, ...args.runSecrets };
   return Object.keys(merged).length > 0 ? merged : undefined;
-}
-
-async function loadManualGrantConnectorTypes(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-  },
-): Promise<readonly ConnectorType[]> {
-  const [secretRows, variableRows] = await Promise.all([
-    db
-      .select({ name: secretsTable.name })
-      .from(secretsTable)
-      .where(
-        and(
-          eq(secretsTable.orgId, args.orgId),
-          eq(secretsTable.userId, args.userId),
-          eq(secretsTable.type, "user"),
-        ),
-      ),
-    db
-      .select({ name: variables.name })
-      .from(variables)
-      .where(
-        and(eq(variables.orgId, args.orgId), eq(variables.userId, args.userId)),
-      ),
-  ]);
-
-  return deriveConnectedManualGrantMethods(
-    new Set(
-      secretRows.map((row) => {
-        return row.name;
-      }),
-    ),
-    new Set(
-      variableRows.map((row) => {
-        return row.name;
-      }),
-    ),
-  ).map((method) => {
-    return method.type;
-  });
 }
 
 function filterDbSecretsByConnectorPermissions(args: {
@@ -3194,6 +3230,7 @@ async function loadRunConnectorContexts(
   args: {
     readonly orgId: string;
     readonly userId: string;
+    readonly manualGrantConnectorTypes: readonly ConnectorType[];
     readonly allowedConnectorTypes?: readonly ConnectorType[];
     readonly allowedCustomConnectorIds?: readonly string[];
   },
@@ -3202,20 +3239,12 @@ async function loadRunConnectorContexts(
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
 }> {
-  const [
-    oauthConnectorContext,
-    manualGrantConnectorTypes,
-    customConnectorContext,
-  ] = await Promise.all([
+  const [oauthConnectorContext, customConnectorContext] = await Promise.all([
     loadOauthConnectorContext(db, {
       orgId: args.orgId,
       userId: args.userId,
       allowedConnectorTypes: args.allowedConnectorTypes,
       featureSwitchContext,
-    }),
-    loadManualGrantConnectorTypes(db, {
-      orgId: args.orgId,
-      userId: args.userId,
     }),
     loadCustomConnectorContext(db, {
       orgId: args.orgId,
@@ -3225,10 +3254,10 @@ async function loadRunConnectorContexts(
     }),
   ]);
   const allowedManualGrantTypes = args.allowedConnectorTypes
-    ? manualGrantConnectorTypes.filter((type) => {
+    ? args.manualGrantConnectorTypes.filter((type) => {
         return args.allowedConnectorTypes?.includes(type);
       })
-    : manualGrantConnectorTypes;
+    : args.manualGrantConnectorTypes;
   return {
     connectorContext: {
       ...oauthConnectorContext,
@@ -3244,10 +3273,10 @@ async function loadRunConnectorContexts(
 }
 
 async function buildResolvedRunBody(args: {
-  readonly db: Db;
   readonly runArgs: CreateAgentRunArgs;
   readonly initialBody: CreateRunBody;
   readonly resolved: ResolvedCompose;
+  readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<CreateRunBody> {
@@ -3255,9 +3284,8 @@ async function buildResolvedRunBody(args: {
     args.initialBody.vars !== undefined
       ? args.initialBody.vars
       : args.resolved.vars;
-  const mergedVars = await loadMergedVariables(args.db, {
-    orgId: args.runArgs.orgId,
-    userId: args.runArgs.userId,
+  const mergedVars = buildMergedVariables({
+    persistedEnvironment: args.persistedEnvironment,
     runVars,
   });
   args.signal.throwIfAborted();
@@ -3270,12 +3298,11 @@ async function buildResolvedRunBody(args: {
         ? args.initialBody.volumeVersions
         : args.resolved.volumeVersions,
   };
-  const mergedSecrets = await loadReferencedSecrets(args.db, {
-    orgId: args.runArgs.orgId,
-    userId: args.runArgs.userId,
+  const mergedSecrets = await buildReferencedSecrets({
     content: args.resolved.content,
     runSecrets: body.secrets,
     allowedConnectorTypes: args.runArgs.allowedConnectorTypes,
+    persistedEnvironment: args.persistedEnvironment,
     featureSwitchContext: args.featureSwitchContext,
   });
   args.signal.throwIfAborted();
@@ -3364,11 +3391,19 @@ async function prepareRunContext(
     return notFound("Resource not found");
   }
 
+  const persistedEnvironment = await loadPersistedRunEnvironmentSnapshot(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    content: resolved.content,
+    allowedConnectorTypes: args.allowedConnectorTypes,
+  });
+  signal.throwIfAborted();
+
   const body = await buildResolvedRunBody({
-    db,
     runArgs: args,
     initialBody,
     resolved,
+    persistedEnvironment,
     featureSwitchContext,
     signal,
   });
@@ -3404,7 +3439,15 @@ async function prepareRunContext(
     : requestedFramework;
 
   const { connectorContext, customConnectorContext } =
-    await loadRunConnectorContexts(db, args, featureSwitchContext);
+    await loadRunConnectorContexts(
+      db,
+      {
+        ...args,
+        manualGrantConnectorTypes:
+          persistedEnvironment.manualGrantConnectorTypes,
+      },
+      featureSwitchContext,
+    );
   signal.throwIfAborted();
 
   const validation = validateRunEnvironmentReferences({


### PR DESCRIPTION
## Summary

- Load persisted user/org vars, user secret names, and required persisted secret values from one short repeatable-read run-creation snapshot.
- Reuse that snapshot for vars/secrets merging and manual connector context so run-provided env values do not grant manual connector connectivity.
- Avoid loading encrypted persisted secret values unless the run needs compose-referenced secrets or allowed connector firewall-only secrets.

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- pre-commit hook: `prettier`, `knip`, `check-types`, `commitlint`

Closes #15093