### PR TITLE
refactor: rename oauth grant config getters

### DIFF
--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,5 +1,5 @@
 import {
-  getConnectorOAuthGrantConfigIfSupported,
+  getConnectorOAuthGrantConfig,
   getConnectorOAuthClient,
   isOAuthAuthCodeConnectorType,
   type ConnectorEnvReader,
@@ -49,7 +49,7 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
 export function resolveConnectorOAuthStartType(
   type: ConnectorType,
 ): ResolveConnectorOAuthStartTypeResult {
-  if (!getConnectorOAuthGrantConfigIfSupported(type)) {
+  if (!getConnectorOAuthGrantConfig(type)) {
     return { ok: false, reason: "connector_does_not_use_oauth" };
   }
   if (!isOAuthConnectorType(type)) {

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -10,7 +10,7 @@ import type {
   OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthGrantConfigIfSupported,
+  getConnectorOAuthGrantConfig,
   getConnectorOAuthClient,
   isOAuthDeviceAuthConnectorType,
   type ConnectorOAuthClient,
@@ -182,7 +182,7 @@ function resolveDeviceAuthType(
   | OAuthDeviceAuthConnectorType
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof internalServerError> {
-  if (!getConnectorOAuthGrantConfigIfSupported(type)) {
+  if (!getConnectorOAuthGrantConfig(type)) {
     return badRequestMessage(`${type} connector does not use OAuth`);
   }
   if (!isOAuthConnectorType(type)) {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -25,16 +25,16 @@ import {
   getConfiguredConnectorAuthMethods,
   deriveConnectedManualGrantMethods,
   hasRequiredScopes,
-  getConnectorAuthCodeGrantConfigIfSupported,
+  getConnectorAuthCodeGrantConfig,
   getConnectorAuthMethod,
-  getConnectorDeviceAuthGrantConfigIfSupported,
+  getConnectorDeviceAuthGrantConfig,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorEnvBindings,
   getConnectorProvidedEnvNames,
   getConnectorOAuthClientConfig,
   getConnectorOAuthClient,
-  getConnectorOAuthGrantConfigIfSupported,
+  getConnectorOAuthGrantConfig,
   getConnectorOAuthScopes,
   getConnectorManualGrantFieldNames,
   getApiTokenFieldStorageType,
@@ -367,7 +367,7 @@ describe("isOAuthConnectorType", () => {
   it("matches exactly the connector types that declare OAuth grants", () => {
     const oauthConnectorTypes = connectorTypeSchema.options
       .filter((type) => {
-        return getConnectorOAuthGrantConfigIfSupported(type) !== undefined;
+        return getConnectorOAuthGrantConfig(type) !== undefined;
       })
       .sort();
 
@@ -1453,7 +1453,7 @@ describe("getConnectorEnvBindings", () => {
     //   envBindings: values -> declared OAuth connector secrets
     //   api-token secrets:  XXX_TOKEN (if api-token auth method exists)
     for (const type of connectorTypeSchema.options) {
-      if (!getConnectorOAuthGrantConfigIfSupported(type)) continue;
+      if (!getConnectorOAuthGrantConfig(type)) continue;
 
       const oauthSecrets = getConnectorSecretNames(type, "oauth");
       const prefix = oauthSecrets
@@ -1549,7 +1549,7 @@ describe("getConnectorEnvBindings", () => {
 
   it("api-token-only connectors expose all secrets via envBindings with same name", () => {
     for (const type of connectorTypeSchema.options) {
-      if (getConnectorOAuthGrantConfigIfSupported(type)) continue;
+      if (getConnectorOAuthGrantConfig(type)) continue;
       const fields = getApiTokenManualGrantFields(type);
       if (!fields) continue;
 
@@ -1790,7 +1790,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
 
   it("includes active OAuth connectors when their runtime env is configured", () => {
     const activeOAuthTypes = connectorTypeSchema.options.filter((type) => {
-      return getConnectorOAuthGrantConfigIfSupported(type);
+      return getConnectorOAuthGrantConfig(type);
     });
 
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(() => {
@@ -1840,7 +1840,7 @@ describe("getConnectorProvidedEnvNames", () => {
 
 describe("getConnectorOAuthScopes - google-meet scopes", () => {
   it("uses meetings.space.readonly for google meet oauth scopes", () => {
-    const grant = getConnectorAuthCodeGrantConfigIfSupported("google-meet");
+    const grant = getConnectorAuthCodeGrantConfig("google-meet");
     const scopes = getConnectorOAuthScopes("google-meet");
     expect(scopes).toStrictEqual(grant?.scopes);
     expect(scopes).toContain(
@@ -1861,10 +1861,8 @@ describe("connector OAuth lifecycle grant helpers", () => {
   it("returns auth-code grant config for GitHub", () => {
     const method = getConnectorAuthMethod("github", "oauth");
 
-    expect(getConnectorOAuthGrantConfigIfSupported("github")).toStrictEqual(
-      method?.grant,
-    );
-    expect(getConnectorAuthCodeGrantConfigIfSupported("github")).toMatchObject({
+    expect(getConnectorOAuthGrantConfig("github")).toStrictEqual(method?.grant);
+    expect(getConnectorAuthCodeGrantConfig("github")).toMatchObject({
       kind: "auth-code",
       tokenUrl: "https://github.com/login/oauth/access_token",
       scopes: ["repo", "project", "workflow"],
@@ -1879,7 +1877,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
 
   it("returns device-auth grant config for device OAuth connectors", () => {
     expect(
-      getConnectorDeviceAuthGrantConfigIfSupported("test-oauth-device"),
+      getConnectorDeviceAuthGrantConfig("test-oauth-device"),
     ).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "/api/test/oauth-provider/device/code",
@@ -1891,9 +1889,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
       },
       scopes: ["read"],
     });
-    expect(
-      getConnectorDeviceAuthGrantConfigIfSupported("base44"),
-    ).toMatchObject({
+    expect(getConnectorDeviceAuthGrantConfig("base44")).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://app.base44.com/oauth/device/code",
       tokenUrl: "https://app.base44.com/oauth/token",
@@ -1904,30 +1900,24 @@ describe("connector OAuth lifecycle grant helpers", () => {
       },
       scopes: ["apps:read", "apps:write", "offline"],
     });
-    expect(getConnectorDeviceAuthGrantConfigIfSupported("slock")).toMatchObject(
-      {
-        kind: "device-auth",
-        deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
-        tokenUrl: "https://api.slock.ai/api/auth/device/token",
-        client: {
-          clientRegistration: "static",
-          clientType: "public",
-          clientId: "vm0",
-        },
-        scopes: [],
+    expect(getConnectorDeviceAuthGrantConfig("slock")).toMatchObject({
+      kind: "device-auth",
+      deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
+      tokenUrl: "https://api.slock.ai/api/auth/device/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        clientId: "vm0",
       },
-    );
+      scopes: [],
+    });
   });
 
   it("returns undefined for connectors without OAuth grants", () => {
-    expect(getConnectorOAuthGrantConfigIfSupported("axiom")).toBeUndefined();
+    expect(getConnectorOAuthGrantConfig("axiom")).toBeUndefined();
     expect(getConnectorOAuthScopes("axiom")).toStrictEqual([]);
-    expect(
-      getConnectorAuthCodeGrantConfigIfSupported("base44"),
-    ).toBeUndefined();
-    expect(
-      getConnectorDeviceAuthGrantConfigIfSupported("github"),
-    ).toBeUndefined();
+    expect(getConnectorAuthCodeGrantConfig("base44")).toBeUndefined();
+    expect(getConnectorDeviceAuthGrantConfig("github")).toBeUndefined();
   });
 });
 
@@ -1939,7 +1929,7 @@ describe("connector OAuth authorization-code config", () => {
       }
 
       expect(
-        getConnectorAuthCodeGrantConfigIfSupported(type)?.kind,
+        getConnectorAuthCodeGrantConfig(type)?.kind,
         `${type}: OAuth grant kind`,
       ).toBe("auth-code");
     }
@@ -1947,7 +1937,7 @@ describe("connector OAuth authorization-code config", () => {
 
   it("keeps provider authorization URLs out of connector OAuth grants", () => {
     for (const type of connectorTypeSchema.options) {
-      const grant = getConnectorOAuthGrantConfigIfSupported(type);
+      const grant = getConnectorOAuthGrantConfig(type);
       if (!grant) {
         continue;
       }
@@ -1968,7 +1958,7 @@ describe("connector OAuth device authorization config", () => {
   it("declares the test OAuth device connector as a device authorization flow", () => {
     expect(isOAuthDeviceAuthConnectorType("test-oauth-device")).toBe(true);
     expect(
-      getConnectorDeviceAuthGrantConfigIfSupported("test-oauth-device"),
+      getConnectorDeviceAuthGrantConfig("test-oauth-device"),
     ).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "/api/test/oauth-provider/device/code",
@@ -1984,9 +1974,7 @@ describe("connector OAuth device authorization config", () => {
 
   it("declares the Base44 connector as a device authorization flow", () => {
     expect(isOAuthDeviceAuthConnectorType("base44")).toBe(true);
-    expect(
-      getConnectorDeviceAuthGrantConfigIfSupported("base44"),
-    ).toMatchObject({
+    expect(getConnectorDeviceAuthGrantConfig("base44")).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://app.base44.com/oauth/device/code",
       tokenUrl: "https://app.base44.com/oauth/token",
@@ -2001,19 +1989,17 @@ describe("connector OAuth device authorization config", () => {
 
   it("declares the Slock connector as a device authorization flow", () => {
     expect(isOAuthDeviceAuthConnectorType("slock")).toBe(true);
-    expect(getConnectorDeviceAuthGrantConfigIfSupported("slock")).toMatchObject(
-      {
-        kind: "device-auth",
-        deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
-        tokenUrl: "https://api.slock.ai/api/auth/device/token",
-        client: {
-          clientRegistration: "static",
-          clientType: "public",
-          clientId: "vm0",
-        },
-        scopes: [],
+    expect(getConnectorDeviceAuthGrantConfig("slock")).toMatchObject({
+      kind: "device-auth",
+      deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
+      tokenUrl: "https://api.slock.ai/api/auth/device/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        clientId: "vm0",
       },
-    );
+      scopes: [],
+    });
   });
 });
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
@@ -5,14 +5,14 @@ import type {
   OAuthDeviceAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorAuthCodeGrantConfigIfSupported,
-  getConnectorDeviceAuthGrantConfigIfSupported,
+  getConnectorAuthCodeGrantConfig,
+  getConnectorDeviceAuthGrantConfig,
 } from "@vm0/connectors/connector-utils";
 
 export function getAuthCodeGrantConfig(
   type: OAuthAuthCodeConnectorType,
 ): ConnectorAuthCodeGrantConfig {
-  const grant = getConnectorAuthCodeGrantConfigIfSupported(type);
+  const grant = getConnectorAuthCodeGrantConfig(type);
   if (!grant) {
     throw new Error(`${type} auth-code grant config not found`);
   }
@@ -22,7 +22,7 @@ export function getAuthCodeGrantConfig(
 export function getDeviceAuthGrantConfig(
   type: OAuthDeviceAuthConnectorType,
 ): ConnectorDeviceAuthGrantConfig {
-  const grant = getConnectorDeviceAuthGrantConfigIfSupported(type);
+  const grant = getConnectorDeviceAuthGrantConfig(type);
   if (!grant) {
     throw new Error(`${type} device-auth grant config not found`);
   }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -282,7 +282,7 @@ function isConnectorOAuthGrantConfig(
   }
 }
 
-export function getConnectorOAuthGrantConfigIfSupported(
+export function getConnectorOAuthGrantConfig(
   type: ConnectorType,
 ): ConnectorOAuthGrantConfig | undefined {
   for (const method of connectorAuthMethodValues(type)) {
@@ -309,10 +309,10 @@ export function connectorAuthMethodHasOAuthGrant(
   }
 }
 
-export function getConnectorAuthCodeGrantConfigIfSupported(
+export function getConnectorAuthCodeGrantConfig(
   type: ConnectorType,
 ): ConnectorAuthCodeGrantConfig | undefined {
-  const grant = getConnectorOAuthGrantConfigIfSupported(type);
+  const grant = getConnectorOAuthGrantConfig(type);
   switch (grant?.kind) {
     case "auth-code":
       return grant;
@@ -322,10 +322,10 @@ export function getConnectorAuthCodeGrantConfigIfSupported(
   }
 }
 
-export function getConnectorDeviceAuthGrantConfigIfSupported(
+export function getConnectorDeviceAuthGrantConfig(
   type: ConnectorType,
 ): ConnectorDeviceAuthGrantConfig | undefined {
-  const grant = getConnectorOAuthGrantConfigIfSupported(type);
+  const grant = getConnectorOAuthGrantConfig(type);
   switch (grant?.kind) {
     case "device-auth":
       return grant;
@@ -336,7 +336,7 @@ export function getConnectorDeviceAuthGrantConfigIfSupported(
 }
 
 export function getConnectorOAuthScopes(type: ConnectorType): string[] {
-  return [...(getConnectorOAuthGrantConfigIfSupported(type)?.scopes ?? [])];
+  return [...(getConnectorOAuthGrantConfig(type)?.scopes ?? [])];
 }
 
 export function getConnectorGenerationTypes(
@@ -477,7 +477,7 @@ export function isStaticConfidentialConnectorOAuthClient(
 export function getConnectorOAuthClientConfig(
   type: ConnectorType,
 ): ConnectorOAuthClientConfig | undefined {
-  return getConnectorOAuthGrantConfigIfSupported(type)?.client;
+  return getConnectorOAuthGrantConfig(type)?.client;
 }
 
 export function resolveConnectorOAuthClient(
@@ -711,13 +711,13 @@ export function getConnectorProvidedEnvNames(
 export function isOAuthAuthCodeConnectorType(
   type: ConnectorType,
 ): type is OAuthAuthCodeConnectorType {
-  return getConnectorOAuthGrantConfigIfSupported(type)?.kind === "auth-code";
+  return getConnectorOAuthGrantConfig(type)?.kind === "auth-code";
 }
 
 export function isOAuthDeviceAuthConnectorType(
   type: ConnectorType,
 ): type is OAuthDeviceAuthConnectorType {
-  return getConnectorOAuthGrantConfigIfSupported(type)?.kind === "device-auth";
+  return getConnectorOAuthGrantConfig(type)?.kind === "device-auth";
 }
 
 /**
@@ -729,7 +729,7 @@ export function hasRequiredScopes(
   connectorType: ConnectorType,
   storedScopes: string[] | null,
 ): boolean {
-  const scopes = getConnectorOAuthGrantConfigIfSupported(connectorType)?.scopes;
+  const scopes = getConnectorOAuthGrantConfig(connectorType)?.scopes;
   if (!scopes) return true;
   if (scopes.length === 0) return true;
   if (!storedScopes) return false;
@@ -754,7 +754,7 @@ export function getScopeDiff(
   storedScopes: string[] | null,
 ): ScopeDiff {
   const currentScopes = [
-    ...(getConnectorOAuthGrantConfigIfSupported(connectorType)?.scopes ?? []),
+    ...(getConnectorOAuthGrantConfig(connectorType)?.scopes ?? []),
   ];
   const stored = storedScopes ?? [];
   const storedSet = new Set(stored);


### PR DESCRIPTION
## Summary
- rename connector OAuth grant nullable getters to drop the ambiguous IfSupported suffix
- update API and OAuth provider call sites to use the new helper names
- update connector tests for the new exported names

## Tests
- pnpm format
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/connectors test
- pre-commit: prettier, knip, pnpm check-types, commitlint