### PR TITLE
chore(web): remove $100 bonus credit copy from landing

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -942,9 +942,6 @@ export function LandingPage({ initialIsSignedIn = false }: LandingPageProps) {
               />
               <AddToSlackButton />
             </div>
-            <p className="text-sm text-[hsl(var(--muted-foreground))]">
-              {t("hero.ctaSubtext")}
-            </p>
           </div>
         </section>
 

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -3697,7 +3697,6 @@
       "subtitle": "Zero connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web.",
       "ctaGetStarted": "Get started",
       "ctaOpenApp": "Open app",
-      "ctaSubtext": "Free to start. Redeem up to $100 in bonus credits.",
       "seedBanner": "Check out our $14M seed round fundraising blog."
     },
     "worksForYou": {
@@ -3806,7 +3805,7 @@
     },
     "cta": {
       "title": "You decide what matters. Zero handles the rest.",
-      "subtitle": "Start free with credits. Redeem up to $100 more. No credit card required."
+      "subtitle": "Start free with credits. No credit card required."
     }
   },
   "securityPage": {


### PR DESCRIPTION
## Summary
- Drop the hero `ctaSubtext` ("Free to start. Redeem up to $100 in bonus credits.") under the hero CTA buttons
- Trim the bottom CTA `subtitle` from "Start free with credits. Redeem up to $100 more. No credit card required." to "Start free with credits. No credit card required."
- Other locales (de/es/ja) already had no $100 reference, so en.json only

## Test plan
- [ ] Run the marketing site locally and confirm hero no longer shows the $100 subtext
- [ ] Confirm bottom CTA subtitle reads "Start free with credits. No credit card required."
- [ ] Spot-check de/es/ja landing pages render unchanged