### PR TITLE
fix: harden ably endpoint url construction

### DIFF
--- a/crates/ably-subscriber/src/connection/auth.rs
+++ b/crates/ably-subscriber/src/connection/auth.rs
@@ -1,7 +1,7 @@
 use crate::TokenRequest;
 use crate::types::{Error, TokenDetails};
 
-use super::endpoint::{PROTOCOL_VERSION, is_localhost};
+use super::endpoint::{PROTOCOL_VERSION, build_token_request_url};
 
 /// Exchange a TokenRequest for a TokenDetails via Ably's REST API.
 pub(crate) async fn exchange_token(
@@ -9,13 +9,9 @@ pub(crate) async fn exchange_token(
     token_request: &TokenRequest,
     host: &str,
 ) -> Result<TokenDetails, Error> {
-    let scheme = if is_localhost(host) { "http" } else { "https" };
-    let url = format!(
-        "{scheme}://{host}/keys/{}/requestToken",
-        token_request.key_name
-    );
+    let url = build_token_request_url(host, &token_request.key_name)?;
     let resp = client
-        .post(&url)
+        .post(url)
         .header("X-Ably-Version", PROTOCOL_VERSION)
         .json(token_request)
         .send()

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -158,6 +158,18 @@ mod tests {
             url.as_str(),
             "http://127.0.0.1:9000/keys/testKey.testId/requestToken"
         );
+
+        let url = build_token_request_url("localhost:9000", "testKey.testId").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "http://localhost:9000/keys/testKey.testId/requestToken"
+        );
+
+        let url = build_token_request_url("[::1]:9000", "testKey.testId").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "http://[::1]:9000/keys/testKey.testId/requestToken"
+        );
     }
 
     #[test]
@@ -185,6 +197,23 @@ mod tests {
         let url = build_token_request_url("rest.ably.io", "%2F").unwrap();
 
         assert_eq!(url.as_str(), "https://rest.ably.io/keys/%252F/requestToken");
+    }
+
+    #[test]
+    fn build_token_request_url_encodes_backslash_as_key_name_text() {
+        let url = build_token_request_url("rest.ably.io", r"a\b").unwrap();
+
+        assert_eq!(url.as_str(), "https://rest.ably.io/keys/a%5Cb/requestToken");
+    }
+
+    #[test]
+    fn build_token_request_url_preserves_preencoded_dot_segments_as_raw_text() {
+        let url = build_token_request_url("rest.ably.io", "%2E%2E").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://rest.ably.io/keys/%252E%252E/requestToken"
+        );
     }
 
     #[test]
@@ -260,7 +289,10 @@ mod tests {
     #[test]
     fn endpoint_builders_reject_base_url_inputs() {
         let cases = [
+            "",
+            "https://example.com",
             "example.com/path",
+            "example.com/",
             "example.com?x=1",
             "example.com#frag",
             "user@example.com",

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -4,17 +4,46 @@ pub(crate) const DEFAULT_REALTIME_HOST: &str = "realtime.ably.io";
 pub(super) const PROTOCOL_VERSION: &str = "5";
 const AGENT_STRING: &str = concat!("ably-subscriber-rs/", env!("CARGO_PKG_VERSION"));
 
-pub(super) fn is_localhost(host: &str) -> bool {
-    let Ok(url) = url::Url::parse(&format!("http://{host}/")) else {
-        return false;
-    };
-
+fn is_localhost_url(url: &url::Url) -> bool {
     match url.host() {
         Some(url::Host::Domain(host)) if host.eq_ignore_ascii_case("localhost") => true,
         Some(url::Host::Ipv4(addr)) if addr == std::net::Ipv4Addr::LOCALHOST => true,
         Some(url::Host::Ipv6(addr)) if addr == std::net::Ipv6Addr::LOCALHOST => true,
         _ => false,
     }
+}
+
+fn parse_endpoint_host(host: &str) -> Result<url::Url, Error> {
+    let url =
+        url::Url::parse(&format!("http://{host}/")).map_err(|_| Error::InvalidEndpointHost)?;
+
+    if url.host().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(Error::InvalidEndpointHost);
+    }
+
+    Ok(url)
+}
+
+fn build_endpoint_base_url(
+    host: &str,
+    localhost_scheme: &str,
+    remote_scheme: &str,
+) -> Result<url::Url, Error> {
+    let mut url = parse_endpoint_host(host)?;
+    let scheme = if is_localhost_url(&url) {
+        localhost_scheme
+    } else {
+        remote_scheme
+    };
+    url.set_scheme(scheme)
+        .map_err(|_| Error::InvalidEndpointHost)?;
+    Ok(url)
 }
 
 /// Derive REST host from realtime host.
@@ -27,8 +56,7 @@ pub(crate) fn rest_host(realtime_host: &str) -> String {
 }
 
 pub(super) fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Result<String, Error> {
-    let scheme = if is_localhost(host) { "ws" } else { "wss" };
-    let mut u = url::Url::parse(&format!("{scheme}://{host}/"))?;
+    let mut u = build_endpoint_base_url(host, "ws", "wss")?;
     {
         let mut q = u.query_pairs_mut();
         q.append_pair("access_token", token);
@@ -42,6 +70,16 @@ pub(super) fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Res
         }
     }
     Ok(u.to_string())
+}
+
+pub(super) fn build_token_request_url(host: &str, key_name: &str) -> Result<url::Url, Error> {
+    let mut url = build_endpoint_base_url(host, "http", "https")?;
+    url.path_segments_mut()
+        .map_err(|_| Error::InvalidEndpointHost)?
+        .push("keys")
+        .push(key_name)
+        .push("requestToken");
+    Ok(url)
 }
 
 #[cfg(test)]
@@ -86,6 +124,43 @@ mod tests {
     #[test]
     fn rest_host_custom() {
         assert_eq!(rest_host("custom.example.com"), "custom.example.com");
+    }
+
+    #[test]
+    fn build_token_request_url_basic() {
+        let url = build_token_request_url("rest.ably.io", "testKey.testId").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://rest.ably.io/keys/testKey.testId/requestToken"
+        );
+    }
+
+    #[test]
+    fn build_token_request_url_localhost_uses_http() {
+        let url = build_token_request_url("127.0.0.1:9000", "testKey.testId").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "http://127.0.0.1:9000/keys/testKey.testId/requestToken"
+        );
+    }
+
+    #[test]
+    fn build_token_request_url_encodes_key_name_as_single_segment() {
+        let url = build_token_request_url("rest.ably.io", "a/b?c#d% e").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://rest.ably.io/keys/a%2Fb%3Fc%23d%25%20e/requestToken"
+        );
+    }
+
+    #[test]
+    fn build_token_request_url_preserves_preencoded_key_name_as_raw_text() {
+        let url = build_token_request_url("rest.ably.io", "%2F").unwrap();
+
+        assert_eq!(url.as_str(), "https://rest.ably.io/keys/%252F/requestToken");
     }
 
     fn assert_websocket_endpoint(
@@ -146,5 +221,38 @@ mod tests {
             let url = build_ws_url(host, "tok", None).unwrap();
             assert_websocket_endpoint(&url, "wss", expected_host, None);
         }
+    }
+
+    #[test]
+    fn endpoint_builders_reject_base_url_inputs() {
+        let cases = [
+            "example.com/path",
+            "example.com?x=1",
+            "example.com#frag",
+            "user@example.com",
+            "user:pass@example.com",
+        ];
+
+        for host in cases {
+            assert!(matches!(
+                build_ws_url(host, "tok", None),
+                Err(Error::InvalidEndpointHost)
+            ));
+            assert!(matches!(
+                build_token_request_url(host, "testKey.testId"),
+                Err(Error::InvalidEndpointHost)
+            ));
+        }
+    }
+
+    #[test]
+    fn invalid_endpoint_host_error_does_not_include_raw_host() {
+        let err = build_ws_url("user:secret@example.com", "tok", None).unwrap_err();
+        let message = err.to_string();
+
+        assert_eq!(message, "Invalid Ably endpoint host");
+        assert!(!message.contains("user"));
+        assert!(!message.contains("secret"));
+        assert!(!message.contains("example.com"));
     }
 }

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -13,9 +13,9 @@ fn is_localhost_url(url: &url::Url) -> bool {
     }
 }
 
-fn parse_endpoint_host(host: &str) -> Result<url::Url, Error> {
+fn parse_endpoint_host(host: &str, scheme: &str) -> Result<url::Url, Error> {
     let url =
-        url::Url::parse(&format!("http://{host}/")).map_err(|_| Error::InvalidEndpointHost)?;
+        url::Url::parse(&format!("{scheme}://{host}/")).map_err(|_| Error::InvalidEndpointHost)?;
 
     if url.host().is_none()
         || !url.username().is_empty()
@@ -35,15 +35,13 @@ fn build_endpoint_base_url(
     localhost_scheme: &str,
     remote_scheme: &str,
 ) -> Result<url::Url, Error> {
-    let mut url = parse_endpoint_host(host)?;
-    let scheme = if is_localhost_url(&url) {
+    let host_url = parse_endpoint_host(host, "http")?;
+    let scheme = if is_localhost_url(&host_url) {
         localhost_scheme
     } else {
         remote_scheme
     };
-    url.set_scheme(scheme)
-        .map_err(|_| Error::InvalidEndpointHost)?;
-    Ok(url)
+    parse_endpoint_host(host, scheme)
 }
 
 /// Derive REST host from realtime host.
@@ -117,6 +115,18 @@ mod tests {
     }
 
     #[test]
+    fn build_ws_url_preserves_explicit_remote_port() {
+        let url = build_ws_url("sandbox-realtime.ably.io:80", "tok", None).unwrap();
+
+        assert_websocket_endpoint(
+            &url,
+            "wss",
+            url::Host::Domain("sandbox-realtime.ably.io"),
+            Some(80),
+        );
+    }
+
+    #[test]
     fn rest_host_default() {
         assert_eq!(rest_host("realtime.ably.io"), "rest.ably.io");
     }
@@ -143,6 +153,16 @@ mod tests {
         assert_eq!(
             url.as_str(),
             "http://127.0.0.1:9000/keys/testKey.testId/requestToken"
+        );
+    }
+
+    #[test]
+    fn build_token_request_url_preserves_explicit_remote_port() {
+        let url = build_token_request_url("rest.ably.io:80", "testKey.testId").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://rest.ably.io:80/keys/testKey.testId/requestToken"
         );
     }
 

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -17,12 +17,16 @@ fn contains_url_ignored_ascii_whitespace(value: &str) -> bool {
     value.bytes().any(|b| matches!(b, b'\t' | b'\n' | b'\r'))
 }
 
+fn contains_endpoint_path_separator(value: &str) -> bool {
+    value.bytes().any(|b| matches!(b, b'/' | b'\\'))
+}
+
 fn invalid_url_component() -> Error {
     Error::Url(url::ParseError::InvalidDomainCharacter)
 }
 
 fn parse_endpoint_host(host: &str, scheme: &str) -> Result<url::Url, Error> {
-    if contains_url_ignored_ascii_whitespace(host) {
+    if contains_url_ignored_ascii_whitespace(host) || contains_endpoint_path_separator(host) {
         return Err(invalid_url_component());
     }
 
@@ -314,6 +318,11 @@ mod tests {
             "https://example.com",
             "example.com/path",
             "example.com/",
+            "example.com/.",
+            "example.com/..",
+            "example.com/%2e%2e",
+            r"example.com\path",
+            r"example.com\..",
             "example.com?x=1",
             "example.com#frag",
             "rest\t.ably.io",

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -17,13 +17,16 @@ fn contains_url_ignored_ascii_whitespace(value: &str) -> bool {
     value.bytes().any(|b| matches!(b, b'\t' | b'\n' | b'\r'))
 }
 
+fn invalid_url_component() -> Error {
+    Error::Url(url::ParseError::InvalidDomainCharacter)
+}
+
 fn parse_endpoint_host(host: &str, scheme: &str) -> Result<url::Url, Error> {
     if contains_url_ignored_ascii_whitespace(host) {
-        return Err(Error::InvalidEndpointHost);
+        return Err(invalid_url_component());
     }
 
-    let url =
-        url::Url::parse(&format!("{scheme}://{host}/")).map_err(|_| Error::InvalidEndpointHost)?;
+    let url = url::Url::parse(&format!("{scheme}://{host}/"))?;
 
     if url.host().is_none()
         || !url.username().is_empty()
@@ -32,7 +35,7 @@ fn parse_endpoint_host(host: &str, scheme: &str) -> Result<url::Url, Error> {
         || url.query().is_some()
         || url.fragment().is_some()
     {
-        return Err(Error::InvalidEndpointHost);
+        return Err(invalid_url_component());
     }
 
     Ok(url)
@@ -80,12 +83,12 @@ pub(super) fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Res
 
 pub(super) fn build_token_request_url(host: &str, key_name: &str) -> Result<url::Url, Error> {
     if matches!(key_name, "." | "..") || contains_url_ignored_ascii_whitespace(key_name) {
-        return Err(Error::InvalidTokenRequestKeyName);
+        return Err(invalid_url_component());
     }
 
     let mut url = build_endpoint_base_url(host, "http", "https")?;
     url.path_segments_mut()
-        .map_err(|_| Error::InvalidEndpointHost)?
+        .map_err(|_| invalid_url_component())?
         .push("keys")
         .push(key_name)
         .push("requestToken");
@@ -229,7 +232,7 @@ mod tests {
         for key_name in [".", ".."] {
             assert!(matches!(
                 build_token_request_url("rest.ably.io", key_name),
-                Err(Error::InvalidTokenRequestKeyName)
+                Err(Error::Url(url::ParseError::InvalidDomainCharacter))
             ));
         }
     }
@@ -239,7 +242,7 @@ mod tests {
         for key_name in ["a\tb", "a\nb", "a\rb", ".\n", "..\r"] {
             assert!(matches!(
                 build_token_request_url("rest.ably.io", key_name),
-                Err(Error::InvalidTokenRequestKeyName)
+                Err(Error::Url(url::ParseError::InvalidDomainCharacter))
             ));
         }
     }
@@ -323,21 +326,21 @@ mod tests {
         for host in cases {
             assert!(matches!(
                 build_ws_url(host, "tok", None),
-                Err(Error::InvalidEndpointHost)
+                Err(Error::Url(_))
             ));
             assert!(matches!(
                 build_token_request_url(host, "testKey.testId"),
-                Err(Error::InvalidEndpointHost)
+                Err(Error::Url(_))
             ));
         }
     }
 
     #[test]
-    fn invalid_endpoint_host_error_does_not_include_raw_host() {
+    fn invalid_endpoint_host_url_error_does_not_include_raw_host() {
         let err = build_ws_url("user:secret@example.com", "tok", None).unwrap_err();
         let message = err.to_string();
 
-        assert_eq!(message, "Invalid Ably endpoint host");
+        assert_eq!(message, "URL parse error: invalid domain character");
         assert!(!message.contains("user"));
         assert!(!message.contains("secret"));
         assert!(!message.contains("example.com"));

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -13,7 +13,15 @@ fn is_localhost_url(url: &url::Url) -> bool {
     }
 }
 
+fn contains_url_ignored_ascii_whitespace(value: &str) -> bool {
+    value.bytes().any(|b| matches!(b, b'\t' | b'\n' | b'\r'))
+}
+
 fn parse_endpoint_host(host: &str, scheme: &str) -> Result<url::Url, Error> {
+    if contains_url_ignored_ascii_whitespace(host) {
+        return Err(Error::InvalidEndpointHost);
+    }
+
     let url =
         url::Url::parse(&format!("{scheme}://{host}/")).map_err(|_| Error::InvalidEndpointHost)?;
 
@@ -71,7 +79,7 @@ pub(super) fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Res
 }
 
 pub(super) fn build_token_request_url(host: &str, key_name: &str) -> Result<url::Url, Error> {
-    if matches!(key_name, "." | "..") {
+    if matches!(key_name, "." | "..") || contains_url_ignored_ascii_whitespace(key_name) {
         return Err(Error::InvalidTokenRequestKeyName);
     }
 
@@ -226,6 +234,16 @@ mod tests {
         }
     }
 
+    #[test]
+    fn build_token_request_url_rejects_key_names_with_url_ignored_whitespace() {
+        for key_name in ["a\tb", "a\nb", "a\rb", ".\n", "..\r"] {
+            assert!(matches!(
+                build_token_request_url("rest.ably.io", key_name),
+                Err(Error::InvalidTokenRequestKeyName)
+            ));
+        }
+    }
+
     fn assert_websocket_endpoint(
         url: &str,
         scheme: &str,
@@ -295,6 +313,9 @@ mod tests {
             "example.com/",
             "example.com?x=1",
             "example.com#frag",
+            "rest\t.ably.io",
+            "rest.\nably.io",
+            "rest.ably.io\r",
             "user@example.com",
             "user:pass@example.com",
         ];

--- a/crates/ably-subscriber/src/connection/endpoint.rs
+++ b/crates/ably-subscriber/src/connection/endpoint.rs
@@ -71,6 +71,10 @@ pub(super) fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Res
 }
 
 pub(super) fn build_token_request_url(host: &str, key_name: &str) -> Result<url::Url, Error> {
+    if matches!(key_name, "." | "..") {
+        return Err(Error::InvalidTokenRequestKeyName);
+    }
+
     let mut url = build_endpoint_base_url(host, "http", "https")?;
     url.path_segments_mut()
         .map_err(|_| Error::InvalidEndpointHost)?
@@ -181,6 +185,16 @@ mod tests {
         let url = build_token_request_url("rest.ably.io", "%2F").unwrap();
 
         assert_eq!(url.as_str(), "https://rest.ably.io/keys/%252F/requestToken");
+    }
+
+    #[test]
+    fn build_token_request_url_rejects_dot_segments() {
+        for key_name in [".", ".."] {
+            assert!(matches!(
+                build_token_request_url("rest.ably.io", key_name),
+                Err(Error::InvalidTokenRequestKeyName)
+            ));
+        }
     }
 
     fn assert_websocket_endpoint(

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -316,8 +316,15 @@ pub enum Error {
     #[error("Token fetch failed: {}", redact_access_token(&.0.to_string()))]
     TokenFetch(BoxError),
 
-    /// Failure while parsing a realtime WebSocket URL built from the
-    /// subscription configuration.
+    /// Invalid realtime or REST endpoint host in the subscription configuration.
+    ///
+    /// The message deliberately omits the raw host input because callers may
+    /// accidentally include credentials in a host-like value.
+    #[error("Invalid Ably endpoint host")]
+    InvalidEndpointHost,
+
+    /// Failure while parsing an endpoint URL built from the subscription
+    /// configuration.
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
 }

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -232,10 +232,13 @@ pub struct SubscribeConfig {
     pub channel: String,
     /// Optional channel parameters (e.g. `{"rewind": "2m"}`).
     pub channel_params: Option<HashMap<String, String>>,
-    /// Ably realtime host. Defaults to `"realtime.ably.io"`.
+    /// Ably realtime host/authority, without a URL scheme, path, query, or
+    /// fragment. Defaults to `"realtime.ably.io"`.
     pub host: Option<String>,
     /// Ably REST host for token exchange. Defaults to `"rest.ably.io"` when
     /// `host` is the default, otherwise falls back to the realtime host value.
+    /// Like [`host`](Self::host), this must be a host/authority rather than a
+    /// base URL.
     pub rest_host: Option<String>,
     /// Override timing parameters. `None` uses [`TimingConfig::default()`].
     pub timing: Option<TimingConfig>,

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -319,23 +319,9 @@ pub enum Error {
     #[error("Token fetch failed: {}", redact_access_token(&.0.to_string()))]
     TokenFetch(BoxError),
 
-    /// Invalid realtime or REST endpoint host in the subscription configuration.
-    ///
-    /// The message deliberately omits the raw host input because callers may
-    /// accidentally include credentials in a host-like value.
-    #[error("Invalid Ably endpoint host")]
-    InvalidEndpointHost,
-
-    /// Token request key name cannot be represented safely as an endpoint path
-    /// segment.
-    ///
-    /// The message deliberately omits the raw key name because token request
-    /// fields are authentication material.
-    #[error("Invalid Ably token request key name")]
-    InvalidTokenRequestKeyName,
-
     /// Failure while parsing an endpoint URL built from the subscription
-    /// configuration.
+    /// configuration. The message deliberately omits the raw URL input because
+    /// callers may accidentally include credentials in host-like values.
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
 }

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -326,6 +326,14 @@ pub enum Error {
     #[error("Invalid Ably endpoint host")]
     InvalidEndpointHost,
 
+    /// Token request key name cannot be represented safely as an endpoint path
+    /// segment.
+    ///
+    /// The message deliberately omits the raw key name because token request
+    /// fields are authentication material.
+    #[error("Invalid Ably token request key name")]
+    InvalidTokenRequestKeyName,
+
     /// Failure while parsing an endpoint URL built from the subscription
     /// configuration.
     #[error("URL parse error: {0}")]

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -319,9 +319,14 @@ pub enum Error {
     #[error("Token fetch failed: {}", redact_access_token(&.0.to_string()))]
     TokenFetch(BoxError),
 
-    /// Failure while parsing an endpoint URL built from the subscription
-    /// configuration. The message deliberately omits the raw URL input because
-    /// callers may accidentally include credentials in host-like values.
+    /// Invalid endpoint URL or URL component built from the subscription
+    /// configuration or token request.
+    ///
+    /// This also covers local validation failures for endpoint host and
+    /// [`TokenRequest`] key-name values that would otherwise be silently
+    /// normalized by URL parsing. The message deliberately omits the raw input
+    /// because callers may accidentally include credentials in host-like values
+    /// or authentication material in token request fields.
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
 }

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -750,6 +750,29 @@ async fn token_exchange_invalid_rest_host_fails_before_request() {
     assert_eq!(token_mock.calls(), 0);
 }
 
+#[tokio::test]
+async fn token_exchange_dot_segment_key_name_fails_before_request() {
+    let http = MockServer::start();
+    let token_mock = http.mock(|when, then| {
+        when.method(POST).path("/keys/requestToken");
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "token": "mock-token-abc",
+                "expires": now_ms() + 3_600_000,
+                "issued": now_ms(),
+            }));
+    });
+
+    let result = subscribe(test_config_with_key_name(19999, http.port(), "ch", ".")).await;
+    match result {
+        Err(ably_subscriber::Error::InvalidTokenRequestKeyName) => {}
+        Err(other) => panic!("expected InvalidTokenRequestKeyName error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+    assert_eq!(token_mock.calls(), 0);
+}
+
 // ---------------------------------------------------------------------------
 // Test 8: token renewal — server receives AUTH after short-TTL token
 // ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -222,14 +222,25 @@ fn mock_token_endpoint(server: &MockServer, key_name: &str) {
 }
 
 fn test_config(ws_port: u16, http_port: u16, channel: &str) -> SubscribeConfig {
+    test_config_with_key_name(ws_port, http_port, channel, "testKey.testId")
+}
+
+fn test_config_with_key_name(
+    ws_port: u16,
+    http_port: u16,
+    channel: &str,
+    key_name: &str,
+) -> SubscribeConfig {
     let host = format!("127.0.0.1:{ws_port}");
     let rest_host = format!("127.0.0.1:{http_port}");
     let channel = channel.to_string();
+    let key_name = key_name.to_string();
     let mut config = SubscribeConfig::new(
         Box::new(move || {
+            let key_name = key_name.clone();
             Box::pin(async {
                 Ok(ably_subscriber::TokenRequest {
-                    key_name: "testKey.testId".into(),
+                    key_name,
                     timestamp: now_ms(),
                     nonce: "nonce-1".into(),
                     mac: "fake-mac".into(),
@@ -655,6 +666,88 @@ async fn http_token_exchange_error() {
         Err(other) => panic!("expected Http error, got {other:?}"),
         Ok(_) => panic!("expected error, got Ok"),
     }
+}
+
+#[tokio::test]
+async fn token_exchange_encodes_key_name_as_path_segment() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+
+    let now = now_ms();
+    let token_mock = http.mock(|when, then| {
+        when.method(POST)
+            .path("/keys/a%2Fb%3Fc%23d%25%20e/requestToken");
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "token": "mock-token-abc",
+                "expires": now + 3_600_000,
+                "issued": now,
+            }));
+    });
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let _conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+    });
+
+    let mut sub = subscribe(test_config_with_key_name(
+        ws_port,
+        http.port(),
+        "ch",
+        "a/b?c#d% e",
+    ))
+    .await
+    .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    assert_eq!(token_mock.calls(), 1);
+    sub.close();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn token_exchange_invalid_json_response_is_http_error() {
+    let http = MockServer::start();
+    http.mock(|when, then| {
+        when.method(POST).path("/keys/testKey.testId/requestToken");
+        then.status(201)
+            .header("content-type", "application/json")
+            .body("{not-json");
+    });
+
+    let result = subscribe(test_config(19999, http.port(), "ch")).await;
+    match result {
+        Err(ably_subscriber::Error::Http(_)) => {}
+        Err(other) => panic!("expected Http error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+#[tokio::test]
+async fn token_exchange_invalid_rest_host_fails_before_request() {
+    let http = MockServer::start();
+    let token_mock = http.mock(|when, then| {
+        when.method(POST).path("/keys/testKey.testId/requestToken");
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "token": "mock-token-abc",
+                "expires": now_ms() + 3_600_000,
+                "issued": now_ms(),
+            }));
+    });
+
+    let mut config = test_config(19999, http.port(), "ch");
+    config.rest_host = Some(format!("127.0.0.1:{}/path", http.port()));
+
+    let result = subscribe(config).await;
+    match result {
+        Err(ably_subscriber::Error::InvalidEndpointHost) => {}
+        Err(other) => panic!("expected InvalidEndpointHost error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+    assert_eq!(token_mock.calls(), 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -743,8 +743,8 @@ async fn token_exchange_invalid_rest_host_fails_before_request() {
 
     let result = subscribe(config).await;
     match result {
-        Err(ably_subscriber::Error::InvalidEndpointHost) => {}
-        Err(other) => panic!("expected InvalidEndpointHost error, got {other:?}"),
+        Err(ably_subscriber::Error::Url(_)) => {}
+        Err(other) => panic!("expected Url error, got {other:?}"),
         Ok(_) => panic!("expected error, got Ok"),
     }
     assert_eq!(token_mock.calls(), 0);
@@ -766,8 +766,8 @@ async fn token_exchange_dot_segment_key_name_fails_before_request() {
 
     let result = subscribe(test_config_with_key_name(19999, http.port(), "ch", ".")).await;
     match result {
-        Err(ably_subscriber::Error::InvalidTokenRequestKeyName) => {}
-        Err(other) => panic!("expected InvalidTokenRequestKeyName error, got {other:?}"),
+        Err(ably_subscriber::Error::Url(_)) => {}
+        Err(other) => panic!("expected Url error, got {other:?}"),
         Ok(_) => panic!("expected error, got Ok"),
     }
     assert_eq!(token_mock.calls(), 0);


### PR DESCRIPTION
## Summary
- centralize Ably endpoint URL construction for realtime and REST hosts
- encode token request key names as a single REST path segment
- reject base-URL-style endpoint host inputs without logging raw host values

## Tests
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- pre-commit cargo-clippy / cargo-doc

Closes #15081