### PR TITLE
refactor: align connector lifecycle checks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type {
   ConnectorOAuthClientConfig,
-  OAuthConnectorType,
+  OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
@@ -390,7 +390,7 @@ function mockSlackOAuth(options: {
 }
 
 interface ProviderMockOptions {
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthGrantConnectorType;
   readonly accessToken?: string;
   readonly refreshToken?: string | null;
   readonly expiresIn?: number;
@@ -870,7 +870,9 @@ function mockXeroProvider(options: ResolvedProviderMockOptions): void {
 }
 
 function mockProviderOAuth(options: ProviderMockOptions): void {
-  const providerMockers: Partial<Record<OAuthConnectorType, ProviderMocker>> = {
+  const providerMockers: Partial<
+    Record<OAuthGrantConnectorType, ProviderMocker>
+  > = {
     github: (resolvedOptions) => {
       mockGitHubOAuth({
         accessToken: resolvedOptions.accessToken,
@@ -1018,7 +1020,7 @@ async function findDecryptedSecret(args: {
 }
 
 interface ProviderSuccessCase {
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthGrantConnectorType;
   readonly externalId: string;
   readonly externalUsername: string;
   readonly externalEmail: string | null;
@@ -1159,7 +1161,7 @@ const providerSuccessCases = [
   },
 ] as const satisfies readonly ProviderSuccessCase[];
 
-function hasFetchableUserInfo(type: OAuthConnectorType): boolean {
+function hasFetchableUserInfo(type: OAuthGrantConnectorType): boolean {
   return type !== "notion" && type !== "sentry" && type !== "intervals-icu";
 }
 

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -9,7 +9,7 @@ import {
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
   getConnectorOAuthSecretMetadata,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
 } from "@vm0/connectors/auth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -211,7 +211,7 @@ const createTestConnector$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    if (!isOAuthConnectorType(connectorType)) {
+    if (!hasConnectorOAuthProvider(connectorType)) {
       return stringError(400, `${connectorType} connector does not use OAuth`);
     }
     const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,17 +1,17 @@
 import {
-  getConnectorOAuthGrantConfig,
   getConnectorOAuthClient,
-  isOAuthAuthCodeConnectorType,
+  hasConnectorOAuthGrant,
+  hasConnectorAuthCodeGrant,
   type ConnectorEnvReader,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorType,
-  OAuthAuthCodeConnectorType,
+  AuthCodeGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorOAuthAuthUrl,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 
@@ -32,7 +32,7 @@ type PrepareResolvedConnectorOAuthStartResult =
 type ResolveConnectorOAuthStartTypeResult =
   | {
       readonly ok: true;
-      readonly type: OAuthAuthCodeConnectorType;
+      readonly type: AuthCodeGrantConnectorType;
     }
   | {
       readonly ok: false;
@@ -49,14 +49,14 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
 export function resolveConnectorOAuthStartType(
   type: ConnectorType,
 ): ResolveConnectorOAuthStartTypeResult {
-  if (!getConnectorOAuthGrantConfig(type)) {
+  if (!hasConnectorOAuthGrant(type)) {
     return { ok: false, reason: "connector_does_not_use_oauth" };
   }
-  if (!isOAuthConnectorType(type)) {
-    return { ok: false, reason: "oauth_provider_not_configured" };
-  }
-  if (!isOAuthAuthCodeConnectorType(type)) {
+  if (!hasConnectorAuthCodeGrant(type)) {
     return { ok: false, reason: "unsupported_oauth_flow" };
+  }
+  if (!hasConnectorOAuthProvider(type)) {
+    return { ok: false, reason: "oauth_provider_not_configured" };
   }
   return { ok: true, type };
 }
@@ -65,7 +65,7 @@ export function resolveConnectorOAuthStartType(
 // ConnectorType first so non-OAuth connectors keep their route-specific errors,
 // then build the provider authorization URL at the normal async commit point.
 export function prepareResolvedConnectorOAuthStart(args: {
-  readonly type: OAuthAuthCodeConnectorType;
+  readonly type: AuthCodeGrantConnectorType;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareResolvedConnectorOAuthStartResult {
@@ -85,7 +85,7 @@ export function prepareResolvedConnectorOAuthStart(args: {
 }
 
 export async function buildResolvedConnectorOAuthAuthResult(args: {
-  readonly type: OAuthAuthCodeConnectorType;
+  readonly type: AuthCodeGrantConnectorType;
   readonly oauthClient: ConnectorOAuthClient;
   readonly redirectUri: string;
   readonly state: string;

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -52,11 +52,11 @@ export function resolveConnectorOAuthStartType(
   if (!hasConnectorOAuthGrant(type)) {
     return { ok: false, reason: "connector_does_not_use_oauth" };
   }
-  if (!hasConnectorAuthCodeGrant(type)) {
-    return { ok: false, reason: "unsupported_oauth_flow" };
-  }
   if (!hasConnectorOAuthProvider(type)) {
     return { ok: false, reason: "oauth_provider_not_configured" };
+  }
+  if (!hasConnectorAuthCodeGrant(type)) {
+    return { ok: false, reason: "unsupported_oauth_flow" };
   }
   return { ok: true, type };
 }

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -3,19 +3,20 @@ import { unescape as decodeCookieComponent } from "node:querystring";
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
-  isOAuthAuthCodeConnectorType,
+  hasConnectorAuthCodeGrant,
+  hasConnectorOAuthGrant,
   getConnectorOAuthClient,
   getConnectorOAuthScopes,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type OAuthAuthCodeConnectorType,
-  type OAuthConnectorType,
+  type AuthCodeGrantConnectorType,
+  type OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorOAuthCode,
   getConnectorOAuthSecretMetadata,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
   type OAuthTokenResult,
 } from "@vm0/connectors/auth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -59,7 +60,7 @@ type CallbackIdentity = {
 };
 
 type CompleteOAuthCallbackInput = {
-  readonly connectorType: OAuthAuthCodeConnectorType;
+  readonly connectorType: AuthCodeGrantConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -109,7 +110,7 @@ type ClaimedCallbackState =
 type ResolvedOAuthConnectorType =
   | {
       readonly ok: true;
-      readonly connectorType: OAuthAuthCodeConnectorType;
+      readonly connectorType: AuthCodeGrantConnectorType;
     }
   | {
       readonly ok: false;
@@ -171,7 +172,7 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
 }
 
 async function exchangeTokenForConnector(args: {
-  readonly connectorType: OAuthAuthCodeConnectorType;
+  readonly connectorType: AuthCodeGrantConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -195,7 +196,7 @@ async function exchangeTokenForConnector(args: {
 }
 
 function getRequestedScopes(
-  connectorType: OAuthAuthCodeConnectorType,
+  connectorType: AuthCodeGrantConnectorType,
 ): readonly string[] {
   return getConnectorOAuthScopes(connectorType);
 }
@@ -213,7 +214,7 @@ function resolveOAuthConnectorType(
   }
 
   const connectorType = typeResult.data;
-  if (!isOAuthConnectorType(connectorType)) {
+  if (!hasConnectorOAuthGrant(connectorType)) {
     return {
       ok: false,
       response: redirectWithError(
@@ -223,13 +224,23 @@ function resolveOAuthConnectorType(
       ),
     };
   }
-  if (!isOAuthAuthCodeConnectorType(connectorType)) {
+  if (!hasConnectorAuthCodeGrant(connectorType)) {
     return {
       ok: false,
       response: redirectWithError(
         origin,
         type,
         `${type} connector does not use authorization-code OAuth`,
+      ),
+    };
+  }
+  if (!hasConnectorOAuthProvider(connectorType)) {
+    return {
+      ok: false,
+      response: redirectWithError(
+        origin,
+        type,
+        `${type} OAuth provider is not configured`,
       ),
     };
   }
@@ -240,7 +251,7 @@ function resolveOAuthConnectorType(
 async function claimStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: OAuthAuthCodeConnectorType;
+  readonly connectorType: AuthCodeGrantConnectorType;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
@@ -269,7 +280,7 @@ async function claimStoredOAuthStateForCallback(args: {
 async function rejectInvalidStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: OAuthAuthCodeConnectorType;
+  readonly connectorType: AuthCodeGrantConnectorType;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
@@ -325,7 +336,7 @@ async function markConnectorSessionError(
 
 async function linkGithubIntegrationAfterConnectorConnect(args: {
   readonly db: Db;
-  readonly connectorType: OAuthConnectorType;
+  readonly connectorType: OAuthGrantConnectorType;
   readonly identity: CallbackIdentity;
   readonly token: OAuthTokenResult;
   readonly signal: AbortSignal;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -4,7 +4,6 @@ import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
   hasConnectorAuthCodeGrant,
-  hasConnectorOAuthGrant,
   getConnectorOAuthClient,
   getConnectorOAuthScopes,
 } from "@vm0/connectors/connector-utils";
@@ -214,7 +213,7 @@ function resolveOAuthConnectorType(
   }
 
   const connectorType = typeResult.data;
-  if (!hasConnectorOAuthGrant(connectorType)) {
+  if (!hasConnectorOAuthProvider(connectorType)) {
     return {
       ok: false,
       response: redirectWithError(
@@ -231,16 +230,6 @@ function resolveOAuthConnectorType(
         origin,
         type,
         `${type} connector does not use authorization-code OAuth`,
-      ),
-    };
-  }
-  if (!hasConnectorOAuthProvider(connectorType)) {
-    return {
-      ok: false,
-      response: redirectWithError(
-        origin,
-        type,
-        `${type} OAuth provider is not configured`,
       ),
     };
   }

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -3,7 +3,7 @@ import {
   githubOauthContract,
   type GithubOauthConnectQuery,
 } from "@vm0/api-contracts/contracts/github-oauth";
-import type { OAuthAuthCodeConnectorType } from "@vm0/connectors/connectors";
+import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import {
   getConnectorOAuthClient,
   getConnectorOAuthScopes,
@@ -52,7 +52,7 @@ import {
 } from "./oauth-web-origin";
 
 const REDIRECT_STATUS = 307;
-const GITHUB_CONNECTOR_TYPE = "github" satisfies OAuthAuthCodeConnectorType;
+const GITHUB_CONNECTOR_TYPE = "github" satisfies AuthCodeGrantConnectorType;
 const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
 const L = logger("GithubOAuthRoute");
 

--- a/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import type { OAuthGrantConnectorType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { createStore } from "ccstate";
 import { inArray } from "drizzle-orm";
@@ -14,7 +14,7 @@ const store = createStore();
 
 type SeedOAuthStateInput = {
   readonly state?: string;
-  readonly type?: OAuthConnectorType;
+  readonly type?: OAuthGrantConnectorType;
   readonly consumedAt?: Date | null;
   readonly expiresAt?: Date;
 };

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -5,12 +5,12 @@ import {
   getConnectorOAuthClient,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
-import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import type { OAuthGrantConnectorType } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
   getConnectorOAuthSecretMetadata,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
   refreshConnectorOAuthToken,
   type ProviderEnv,
 } from "@vm0/connectors/auth-providers";
@@ -174,7 +174,7 @@ interface RefreshTokenContext {
 type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
-      readonly connectorType: OAuthConnectorType;
+      readonly connectorType: OAuthGrantConnectorType;
       readonly oauthClient: ConnectorOAuthClient;
       readonly context: RefreshTokenContext;
     }
@@ -638,7 +638,7 @@ function prepareRefreshTokenContext(
     };
   }
 
-  if (!isOAuthConnectorType(args.connectorType)) {
+  if (!hasConnectorOAuthProvider(args.connectorType)) {
     L.debug(`${args.connectorType} is not an OAuth connector type, skipping`);
     return null;
   }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -7,17 +7,17 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
   ConnectorType,
-  OAuthDeviceAuthConnectorType,
+  DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthGrantConfig,
   getConnectorOAuthClient,
-  isOAuthDeviceAuthConnectorType,
+  hasConnectorOAuthGrant,
+  hasConnectorDeviceAuthGrant,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
   pollConnectorOAuthDeviceAuth,
   startConnectorOAuthDeviceAuth,
 } from "@vm0/connectors/auth-providers";
@@ -85,7 +85,7 @@ type PollClaimedSessionArgs = {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthConnectorType;
+  readonly type: DeviceAuthGrantConnectorType;
   readonly oauthClient: ConnectorOAuthClient;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
@@ -179,25 +179,25 @@ function isFreshPollingSession(
 function resolveDeviceAuthType(
   type: ConnectorType,
 ):
-  | OAuthDeviceAuthConnectorType
+  | DeviceAuthGrantConnectorType
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof internalServerError> {
-  if (!getConnectorOAuthGrantConfig(type)) {
+  if (!hasConnectorOAuthGrant(type)) {
     return badRequestMessage(`${type} connector does not use OAuth`);
   }
-  if (!isOAuthConnectorType(type)) {
-    return internalServerError(`${type} OAuth provider is not configured`);
-  }
-  if (!isOAuthDeviceAuthConnectorType(type)) {
+  if (!hasConnectorDeviceAuthGrant(type)) {
     return badRequestMessage(
       `${type} connector does not support OAuth device authorization`,
     );
+  }
+  if (!hasConnectorOAuthProvider(type)) {
+    return internalServerError(`${type} OAuth provider is not configured`);
   }
   return type;
 }
 
 function resolveRequiredOAuthClient(
-  type: OAuthDeviceAuthConnectorType,
+  type: DeviceAuthGrantConnectorType,
 ): ConnectorOAuthClient | ReturnType<typeof internalServerError> {
   const oauthClient = getConnectorOAuthClient(type, optionalEnv);
   if (!oauthClient) {
@@ -210,7 +210,7 @@ async function lockDeviceAuthSessionOwner(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthConnectorType;
+  readonly type: DeviceAuthGrantConnectorType;
 }): Promise<void> {
   await args.writeDb.execute(
     sql`SELECT pg_advisory_xact_lock(hashtext('oauth_device_authorization:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type}))`,
@@ -221,7 +221,7 @@ async function markActiveSessionsSuperseded(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthConnectorType;
+  readonly type: DeviceAuthGrantConnectorType;
   readonly now: Date;
 }): Promise<void> {
   await args.writeDb
@@ -278,7 +278,7 @@ async function loadOwnedSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthConnectorType;
+  readonly type: DeviceAuthGrantConnectorType;
   readonly sessionId: string;
   readonly sessionToken: string;
   readonly signal: AbortSignal;
@@ -380,7 +380,7 @@ async function claimSession(args: {
 
 async function parseEncryptedProviderState(args: {
   readonly session: DeviceAuthSessionRow;
-  readonly type: OAuthDeviceAuthConnectorType;
+  readonly type: DeviceAuthGrantConnectorType;
 }): Promise<EncryptedProviderState> {
   const decrypted = await decryptPersistentSecretValue(
     args.session.encryptedProviderState,
@@ -526,7 +526,7 @@ async function completeClaimedSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthDeviceAuthConnectorType;
+  readonly type: DeviceAuthGrantConnectorType;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly result: OAuthDeviceAuthCompleteResult;

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -185,13 +185,13 @@ function resolveDeviceAuthType(
   if (!hasConnectorOAuthGrant(type)) {
     return badRequestMessage(`${type} connector does not use OAuth`);
   }
+  if (!hasConnectorOAuthProvider(type)) {
+    return internalServerError(`${type} OAuth provider is not configured`);
+  }
   if (!hasConnectorDeviceAuthGrant(type)) {
     return badRequestMessage(
       `${type} connector does not support OAuth device authorization`,
     );
-  }
-  if (!hasConnectorOAuthProvider(type)) {
-    return internalServerError(`${type} OAuth provider is not configured`);
   }
   return type;
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,4 +1,4 @@
-import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import type { OAuthGrantConnectorType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
@@ -21,7 +21,7 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: OAuthConnectorType;
+    readonly connectorType: OAuthGrantConnectorType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
@@ -55,7 +55,7 @@ export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: OAuthConnectorType;
+    readonly connectorType: OAuthGrantConnectorType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateClaimResult> {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -23,7 +23,7 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
   revokeConnectorOAuthToken,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -32,7 +32,7 @@ import {
   connectorTypeSchema,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type OAuthConnectorType,
+  type OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getAllFeatureStates,
@@ -106,7 +106,7 @@ interface EncryptedApiTokenSecret {
 }
 
 interface PendingOAuthRevoke {
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthGrantConnectorType;
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
@@ -521,7 +521,7 @@ async function loadPendingOAuthRevoke(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingOAuthRevoke | null> {
-  if (!isOAuthConnectorType(args.type)) {
+  if (!hasConnectorOAuthProvider(args.type)) {
     return null;
   }
 
@@ -1101,7 +1101,7 @@ function connectorTokenExpiresAt(args: {
 }
 
 function allowedOAuthConnectorSecretNames(
-  type: OAuthConnectorType,
+  type: OAuthGrantConnectorType,
 ): Set<string> {
   return new Set(getConnectorSecretNames(type, "oauth"));
 }
@@ -1117,7 +1117,7 @@ function isOAuthPrimaryTokenSecret(args: {
 }
 
 function validateExtraOAuthConnectorSecrets(args: {
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthGrantConnectorType;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
   readonly accessSecretName: string;
   readonly refreshSecretName: string | undefined;
@@ -1154,7 +1154,7 @@ async function upsertExtraOAuthConnectorSecrets(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthConnectorType;
+  readonly type: OAuthGrantConnectorType;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
@@ -1182,7 +1182,7 @@ export const upsertOAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: OAuthConnectorType;
+      readonly type: OAuthGrantConnectorType;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -17,8 +17,8 @@ import {
   getConnectorTags,
   hasRequiredScopes,
   isGoogleOAuthConnector,
-  isOAuthAuthCodeConnectorType,
-  isOAuthDeviceAuthConnectorType,
+  hasConnectorAuthCodeGrant,
+  hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
 import {
   zeroLocalAgentHostsContract,
@@ -165,7 +165,7 @@ export function getConnectorConnectLaunchMode({
   if (!hasAuthCodeGrant) {
     return "modal";
   }
-  if (!isOAuthAuthCodeConnectorType(type)) {
+  if (!hasConnectorAuthCodeGrant(type)) {
     return "modal";
   }
   if (preferModalForGoogleOAuth && isGoogleOAuthConnector(type)) {
@@ -1421,7 +1421,7 @@ export const connectConnectorOAuthDeviceAuth$ = command(
     options: PostConnectOptions,
     signal: AbortSignal,
   ): Promise<boolean> => {
-    if (!isOAuthDeviceAuthConnectorType(type)) {
+    if (!hasConnectorDeviceAuthGrant(type)) {
       throw new Error(`${type} does not use device authorization OAuth`);
     }
 
@@ -1624,7 +1624,7 @@ const resetOAuthAuthCodeConnectorPopupSignal$ = resetSignal();
 // ---------------------------------------------------------------------------
 
 function assertConnectorUsesOAuthAuthCode(type: ConnectorType): void {
-  if (!isOAuthAuthCodeConnectorType(type)) {
+  if (!hasConnectorAuthCodeGrant(type)) {
     throw new Error(`${type} does not use authorization-code OAuth`);
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -27,8 +27,8 @@ import {
   connectorAuthMethodHasOAuthGrant,
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
-  isOAuthAuthCodeConnectorType,
-  isOAuthDeviceAuthConnectorType,
+  hasConnectorAuthCodeGrant,
+  hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
 import {
   allConnectorTypes$,
@@ -884,13 +884,13 @@ function getConnectMethodContentComponent(
 ): ConnectMethodContentComponent | null {
   switch (method.grant.kind) {
     case "auth-code": {
-      if (isOAuthAuthCodeConnectorType(item.type)) {
+      if (hasConnectorAuthCodeGrant(item.type)) {
         return OAuthAuthCodeConnectMethodContent;
       }
       return null;
     }
     case "device-auth": {
-      if (isOAuthDeviceAuthConnectorType(item.type)) {
+      if (hasConnectorDeviceAuthGrant(item.type)) {
         return OAuthDeviceAuthConnectMethodContent;
       }
       return null;
@@ -1078,7 +1078,7 @@ function ConnectModalContent({
 
   const progressContent =
     hasAuthCodeGrant(item.type, item.availableAuthMethods) &&
-    isOAuthAuthCodeConnectorType(item.type)
+    hasConnectorAuthCodeGrant(item.type)
       ? getOAuthAuthCodeProgressContent({
           isPolling,
           settling,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -59,7 +59,7 @@ import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
-import { isOAuthAuthCodeConnectorType } from "@vm0/connectors/connector-utils";
+import { hasConnectorAuthCodeGrant } from "@vm0/connectors/connector-utils";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
@@ -707,7 +707,7 @@ function startGoogleDriveConnectAndSync(params: {
     toast.error("Agent is still loading");
     return;
   }
-  if (!isOAuthAuthCodeConnectorType("google-drive")) {
+  if (!hasConnectorAuthCodeGrant("google-drive")) {
     toast.error("Google Drive connection is not available");
     return;
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -6,7 +6,7 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   isGoogleOAuthConnector,
-  isOAuthAuthCodeConnectorType,
+  hasConnectorAuthCodeGrant,
 } from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -134,7 +134,7 @@ function canAuthorizeConnector(
 ): boolean {
   return (
     isConnected ||
-    (isOAuthAuthCodeConnectorType(connectorType) &&
+    (hasConnectorAuthCodeGrant(connectorType) &&
       (item?.availableAuthMethods.includes("oauth") ?? false))
   );
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectorType,
-  OAuthConnectorType,
+  OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import { getConnectorOAuthScopes } from "@vm0/connectors/connector-utils";
 import { createTestOAuthConnectorRecord } from "../db-test-seeders/connectors";
@@ -56,7 +56,7 @@ async function createTestApiTokenConnector(options?: {
  * callback flow completes.
  */
 async function createTestOAuthConnector(options?: {
-  type?: OAuthConnectorType;
+  type?: OAuthGrantConnectorType;
   accessToken?: string;
   externalUsername?: string;
   externalId?: string | null;
@@ -87,7 +87,7 @@ async function createTestOAuthConnector(options?: {
  */
 type CreateTestConnectorOptions =
   | {
-      type?: OAuthConnectorType;
+      type?: OAuthGrantConnectorType;
       authMethod?: "oauth";
       accessToken?: string;
       externalUsername?: string;

--- a/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectorType,
-  OAuthConnectorType,
+  OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import { initServices } from "../../lib/init-services";
 import { connectors } from "@vm0/db/schema/connector";
@@ -75,7 +75,7 @@ export async function insertTestConnectorSecret(
 export async function createTestOAuthConnectorRecord(options: {
   orgId: string;
   userId: string;
-  type: OAuthConnectorType;
+  type: OAuthGrantConnectorType;
   accessToken: string;
   externalId: string;
   externalUsername: string;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -700,7 +700,7 @@ export {
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorType,
-  type OAuthConnectorType,
+  type OAuthGrantConnectorType,
   type ConnectorConfig,
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -14,11 +14,13 @@ import {
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
+  type ConnectorDeviceAuthGrantConfig,
   type ConnectorInvalidDefaultAuthMethodType,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type OAuthAuthCodeConnectorType,
+  type AuthCodeGrantConnectorType,
 } from "../connectors";
 import {
   getAvailableConnectorAuthMethods,
@@ -42,8 +44,9 @@ import {
   getEligibleConnectorTypes,
   getRuntimeAvailableConnectorTypes,
   getConnectorSecretNames,
-  isOAuthAuthCodeConnectorType,
-  isOAuthDeviceAuthConnectorType,
+  hasConnectorOAuthGrant,
+  hasConnectorAuthCodeGrant,
+  hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorOAuthClient,
   isStaticConnectorOAuthClient,
   isGoogleOAuthConnector,
@@ -52,7 +55,7 @@ import {
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorOAuthAuthUrl,
-  isOAuthConnectorType,
+  hasConnectorOAuthProvider,
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
   refreshConnectorOAuthToken,
@@ -153,7 +156,7 @@ const EXPECTED_PROVIDER_AUTHORIZATION_BASE_URLS = {
   x: "https://twitter.com/i/oauth2/authorize",
   xero: "https://login.xero.com/identity/connect/authorize",
   zoom: "https://zoom.us/oauth/authorize",
-} as const satisfies Record<OAuthAuthCodeConnectorType, string>;
+} as const satisfies Record<AuthCodeGrantConnectorType, string>;
 
 function authorizationBaseUrl(url: string): string {
   const parsed = new URL(url);
@@ -363,17 +366,15 @@ describe("connector auth method config", () => {
   });
 });
 
-describe("isOAuthConnectorType", () => {
+describe("hasConnectorOAuthProvider", () => {
   it("matches exactly the connector types that declare OAuth grants", () => {
-    const oauthConnectorTypes = connectorTypeSchema.options
-      .filter((type) => {
-        return getConnectorOAuthGrantConfig(type) !== undefined;
-      })
-      .sort();
+    const oauthConnectorTypes = new Set<ConnectorType>(
+      connectorTypeSchema.options.filter(hasConnectorOAuthGrant),
+    );
 
     for (const type of connectorTypeSchema.options) {
-      expect(isOAuthConnectorType(type)).toBe(
-        oauthConnectorTypes.includes(type),
+      expect(hasConnectorOAuthProvider(type)).toBe(
+        oauthConnectorTypes.has(type),
       );
     }
   });
@@ -502,15 +503,12 @@ describe("isOAuthConnectorType", () => {
 
     try {
       const providerTypes = connectorTypeSchema.options.filter(
-        isOAuthAuthCodeConnectorType,
+        hasConnectorAuthCodeGrant,
       );
 
       for (const type of providerTypes) {
         const client = getConnectorOAuthClientConfig(type);
         expect(client, `${type}: OAuth client config`).toBeDefined();
-        if (!client) {
-          throw new Error(`${type} OAuth client config not found`);
-        }
         const oauthClient = resolveConnectorOAuthClient(client, () => {
           return "test-client-credential";
         });
@@ -1861,6 +1859,9 @@ describe("connector OAuth lifecycle grant helpers", () => {
   it("returns auth-code grant config for GitHub", () => {
     const method = getConnectorAuthMethod("github", "oauth");
 
+    expectTypeOf(
+      getConnectorAuthCodeGrantConfig("github"),
+    ).toEqualTypeOf<ConnectorAuthCodeGrantConfig>();
     expect(getConnectorOAuthGrantConfig("github")).toStrictEqual(method?.grant);
     expect(getConnectorAuthCodeGrantConfig("github")).toMatchObject({
       kind: "auth-code",
@@ -1876,6 +1877,9 @@ describe("connector OAuth lifecycle grant helpers", () => {
   });
 
   it("returns device-auth grant config for device OAuth connectors", () => {
+    expectTypeOf(
+      getConnectorDeviceAuthGrantConfig("test-oauth-device"),
+    ).toEqualTypeOf<ConnectorDeviceAuthGrantConfig>();
     expect(
       getConnectorDeviceAuthGrantConfig("test-oauth-device"),
     ).toMatchObject({
@@ -1924,12 +1928,12 @@ describe("connector OAuth lifecycle grant helpers", () => {
 describe("connector OAuth authorization-code config", () => {
   it("declares the current auth-code OAuth connectors with auth-code grants", () => {
     for (const type of connectorTypeSchema.options) {
-      if (!isOAuthAuthCodeConnectorType(type)) {
+      if (!hasConnectorAuthCodeGrant(type)) {
         continue;
       }
 
       expect(
-        getConnectorAuthCodeGrantConfig(type)?.kind,
+        getConnectorAuthCodeGrantConfig(type).kind,
         `${type}: OAuth grant kind`,
       ).toBe("auth-code");
     }
@@ -1956,7 +1960,7 @@ describe("connector OAuth authorization-code config", () => {
 
 describe("connector OAuth device authorization config", () => {
   it("declares the test OAuth device connector as a device authorization flow", () => {
-    expect(isOAuthDeviceAuthConnectorType("test-oauth-device")).toBe(true);
+    expect(hasConnectorDeviceAuthGrant("test-oauth-device")).toBe(true);
     expect(
       getConnectorDeviceAuthGrantConfig("test-oauth-device"),
     ).toMatchObject({
@@ -1973,7 +1977,7 @@ describe("connector OAuth device authorization config", () => {
   });
 
   it("declares the Base44 connector as a device authorization flow", () => {
-    expect(isOAuthDeviceAuthConnectorType("base44")).toBe(true);
+    expect(hasConnectorDeviceAuthGrant("base44")).toBe(true);
     expect(getConnectorDeviceAuthGrantConfig("base44")).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://app.base44.com/oauth/device/code",
@@ -1988,7 +1992,7 @@ describe("connector OAuth device authorization config", () => {
   });
 
   it("declares the Slock connector as a device authorization flow", () => {
-    expect(isOAuthDeviceAuthConnectorType("slock")).toBe(true);
+    expect(hasConnectorDeviceAuthGrant("slock")).toBe(true);
     expect(getConnectorDeviceAuthGrantConfig("slock")).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,12 +1,12 @@
 import type {
   ConnectorType,
-  OAuthAuthCodeConnectorType,
-  OAuthConnectorType,
-  OAuthDeviceAuthConnectorType,
+  AuthCodeGrantConnectorType,
+  OAuthGrantConnectorType,
+  DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
-  isOAuthAuthCodeConnectorType,
+  hasConnectorAuthCodeGrant,
   isStaticConfidentialConnectorOAuthClient,
   isStaticConnectorOAuthClient,
   type ConnectorOAuthClient,
@@ -110,25 +110,25 @@ export type ConnectorOAuthRevokeResult =
   | { readonly status: "unsupported" };
 
 type AuthCodeConnectorOAuthProviderMap = {
-  readonly [Type in OAuthAuthCodeConnectorType]: AuthCodeConnectorAuthProvider<Type>;
+  readonly [Type in AuthCodeGrantConnectorType]: AuthCodeConnectorAuthProvider<Type>;
 };
 
 type DeviceAuthConnectorOAuthProviderMap = {
-  readonly [Type in OAuthDeviceAuthConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
+  readonly [Type in DeviceAuthGrantConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
 export type ConnectorOAuthSecretMetadata = AuthProviderSecretMetadata;
 
-function deviceAuthConnectorProviderFor<T extends OAuthDeviceAuthConnectorType>(
+function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   type: T,
 ): DeviceAuthConnectorOAuthProviderMap[T] {
   return DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type];
 }
 
-function connectorAccessProviderFor<T extends OAuthConnectorType>(
+function connectorAccessProviderFor<T extends OAuthGrantConnectorType>(
   type: T,
 ): OAuthConnectorAccessProvider<T> {
-  if (isOAuthAuthCodeConnectorType(type)) {
+  if (hasConnectorAuthCodeGrant(type)) {
     return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type]
       .access as OAuthConnectorAccessProvider<T>;
   }
@@ -137,10 +137,10 @@ function connectorAccessProviderFor<T extends OAuthConnectorType>(
     .access as OAuthConnectorAccessProvider<T>;
 }
 
-function connectorRevokeProviderFor<T extends OAuthConnectorType>(
+function connectorRevokeProviderFor<T extends OAuthGrantConnectorType>(
   type: T,
 ): OAuthConnectorRevokeProvider<T> {
-  if (isOAuthAuthCodeConnectorType(type)) {
+  if (hasConnectorAuthCodeGrant(type)) {
     return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type]
       .revoke as OAuthConnectorRevokeProvider<T>;
   }
@@ -224,12 +224,14 @@ const CONNECTOR_OAUTH_PROVIDERS = {
   ...DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS,
 };
 
-export function isOAuthConnectorType(type: string): type is OAuthConnectorType {
+export function hasConnectorOAuthProvider(
+  type: string,
+): type is OAuthGrantConnectorType {
   return Object.hasOwn(CONNECTOR_OAUTH_PROVIDERS, type);
 }
 
 export function getConnectorOAuthSecretMetadata(
-  type: OAuthConnectorType,
+  type: OAuthGrantConnectorType,
 ): ConnectorOAuthSecretMetadata;
 export function getConnectorOAuthSecretMetadata(
   type: string,
@@ -237,11 +239,11 @@ export function getConnectorOAuthSecretMetadata(
 export function getConnectorOAuthSecretMetadata(
   type: string,
 ): ConnectorOAuthSecretMetadata | undefined {
-  if (!isOAuthConnectorType(type)) {
+  if (!hasConnectorOAuthProvider(type)) {
     return undefined;
   }
 
-  if (isOAuthAuthCodeConnectorType(type)) {
+  if (hasConnectorAuthCodeGrant(type)) {
     return getAuthProviderSecretMetadata(
       AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type],
     );
@@ -253,7 +255,7 @@ export function getConnectorOAuthSecretMetadata(
 }
 
 export async function buildConnectorOAuthAuthUrl<
-  T extends OAuthAuthCodeConnectorType,
+  T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -270,7 +272,7 @@ export async function buildConnectorOAuthAuthUrl<
 }
 
 export async function exchangeConnectorOAuthCode<
-  T extends OAuthAuthCodeConnectorType,
+  T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -293,7 +295,7 @@ export async function exchangeConnectorOAuthCode<
 }
 
 export async function startConnectorOAuthDeviceAuth<
-  T extends OAuthDeviceAuthConnectorType,
+  T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -308,7 +310,7 @@ export async function startConnectorOAuthDeviceAuth<
 }
 
 export async function pollConnectorOAuthDeviceAuth<
-  T extends OAuthDeviceAuthConnectorType,
+  T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -323,7 +325,7 @@ export async function pollConnectorOAuthDeviceAuth<
 }
 
 export async function refreshConnectorOAuthToken<
-  T extends OAuthConnectorType,
+  T extends OAuthGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -344,7 +346,7 @@ export async function refreshConnectorOAuthToken<
 }
 
 export async function revokeConnectorOAuthToken<
-  T extends OAuthConnectorType,
+  T extends OAuthGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;

--- a/turbo/packages/connectors/src/auth-providers/oauth/google-connectors.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google-connectors.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectorType,
-  OAuthAuthCodeConnectorType,
+  AuthCodeGrantConnectorType,
 } from "../../connectors";
 
 export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
@@ -11,7 +11,7 @@ export const GOOGLE_OAUTH_CONNECTOR_TYPES = [
   "google-drive",
   "google-meet",
   "google-sheets",
-] as const satisfies readonly OAuthAuthCodeConnectorType[];
+] as const satisfies readonly AuthCodeGrantConnectorType[];
 
 export type GoogleOAuthConnectorType =
   (typeof GOOGLE_OAUTH_CONNECTOR_TYPES)[number];

--- a/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/grant-config.ts
@@ -1,8 +1,8 @@
 import type {
   ConnectorAuthCodeGrantConfig,
   ConnectorDeviceAuthGrantConfig,
-  OAuthAuthCodeConnectorType,
-  OAuthDeviceAuthConnectorType,
+  AuthCodeGrantConnectorType,
+  DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthCodeGrantConfig,
@@ -10,21 +10,15 @@ import {
 } from "@vm0/connectors/connector-utils";
 
 export function getAuthCodeGrantConfig(
-  type: OAuthAuthCodeConnectorType,
+  type: AuthCodeGrantConnectorType,
 ): ConnectorAuthCodeGrantConfig {
   const grant = getConnectorAuthCodeGrantConfig(type);
-  if (!grant) {
-    throw new Error(`${type} auth-code grant config not found`);
-  }
   return { ...grant, scopes: [...grant.scopes] };
 }
 
 export function getDeviceAuthGrantConfig(
-  type: OAuthDeviceAuthConnectorType,
+  type: DeviceAuthGrantConnectorType,
 ): ConnectorDeviceAuthGrantConfig {
   const grant = getConnectorDeviceAuthGrantConfig(type);
-  if (!grant) {
-    throw new Error(`${type} device-auth grant config not found`);
-  }
   return { ...grant, scopes: [...grant.scopes] };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -1,4 +1,4 @@
-import type { OAuthAuthCodeConnectorType } from "@vm0/connectors/connectors";
+import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import { z } from "zod";
 
 import { getAuthCodeGrantConfig } from "./grant-config";
@@ -10,7 +10,7 @@ const MICROSOFT_AUTHORIZATION_URL =
 const MICROSOFT_USERINFO_URL = "https://graph.microsoft.com/v1.0/me";
 
 type MicrosoftOAuthConnectorType = Extract<
-  OAuthAuthCodeConnectorType,
+  AuthCodeGrantConnectorType,
   "outlook-calendar" | "outlook-mail"
 >;
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 import { getConnectorOAuthClient } from "../../../../connector-utils";
-import { isOAuthConnectorType } from "../../../connector-auth";
+import { hasConnectorOAuthProvider } from "../../../connector-auth";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
 
@@ -11,7 +11,7 @@ const USER_INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
 describe("connector/providers/google-ads", () => {
   describe("googleAdsProvider", () => {
     it("registers google-ads as an OAuth connector type", () => {
-      expect(isOAuthConnectorType("google-ads")).toBe(true);
+      expect(hasConnectorOAuthProvider("google-ads")).toBe(true);
     });
 
     it("buildAuthUrl builds Google OAuth URL with Google Ads and userinfo scopes", () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 import { getConnectorOAuthClient } from "../../../../connector-utils";
-import { isOAuthConnectorType } from "../../../connector-auth";
+import { hasConnectorOAuthProvider } from "../../../connector-auth";
 import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
@@ -139,7 +139,7 @@ describe("connector/providers/meta-ads", () => {
 
   describe("metaAdsProvider", () => {
     it("registers meta-ads as an OAuth connector type", () => {
-      expect(isOAuthConnectorType("meta-ads")).toBe(true);
+      expect(hasConnectorOAuthProvider("meta-ads")).toBe(true);
     });
 
     it("buildAuthUrl delegates to buildMetaAdsAuthorizationUrl", () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,8 +1,8 @@
 import type {
   CONNECTOR_TYPES,
   ConnectorOAuthClientConfig,
-  OAuthConnectorType,
-  OAuthDeviceAuthConnectorType,
+  OAuthGrantConnectorType,
+  DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 
 export interface OAuthTokenResult {
@@ -128,7 +128,7 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorOAuthClientFor<T extends OAuthConnectorType> = {
+type ConnectorOAuthClientFor<T extends OAuthGrantConnectorType> = {
   [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
     readonly grant: {
       readonly kind: "auth-code" | "device-auth";
@@ -160,24 +160,24 @@ type TokenCredentialArgs<Client extends ConnectorOAuthClientConfig> =
       ? { readonly clientId: string }
       : NoClientCredentialArgs;
 
-export type ConnectorOAuthAuthorizeArgs<T extends OAuthConnectorType> =
+export type ConnectorOAuthAuthorizeArgs<T extends OAuthGrantConnectorType> =
   OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthExchangeArgs<T extends OAuthConnectorType> =
+export type ConnectorOAuthExchangeArgs<T extends OAuthGrantConnectorType> =
   OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthRefreshArgs<T extends OAuthConnectorType> =
+export type ConnectorOAuthRefreshArgs<T extends OAuthGrantConnectorType> =
   OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthRevokeArgs<T extends OAuthConnectorType> =
+export type ConnectorOAuthRevokeArgs<T extends OAuthGrantConnectorType> =
   OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
 export type ConnectorOAuthDeviceAuthStartArgs<
-  T extends OAuthDeviceAuthConnectorType,
+  T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthStartFlowArgs &
   StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
 
 export type ConnectorOAuthDeviceAuthPollArgs<
-  T extends OAuthDeviceAuthConnectorType,
+  T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthPollFlowArgs &
   TokenCredentialArgs<ConnectorOAuthClientFor<T>>;

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,7 +1,7 @@
 import type {
-  OAuthAuthCodeConnectorType,
-  OAuthConnectorType,
-  OAuthDeviceAuthConnectorType,
+  AuthCodeGrantConnectorType,
+  OAuthGrantConnectorType,
+  DeviceAuthGrantConnectorType,
 } from "../connectors";
 import type {
   AuthUrlResult,
@@ -22,7 +22,7 @@ interface NoneGrantProvider {
   readonly kind: "none";
 }
 
-export interface AuthCodeGrantProvider<T extends OAuthAuthCodeConnectorType> {
+export interface AuthCodeGrantProvider<T extends AuthCodeGrantConnectorType> {
   readonly kind: "auth-code";
   buildAuthUrl(
     args: ConnectorOAuthAuthorizeArgs<T>,
@@ -31,7 +31,7 @@ export interface AuthCodeGrantProvider<T extends OAuthAuthCodeConnectorType> {
 }
 
 export interface DeviceAuthGrantProvider<
-  T extends OAuthDeviceAuthConnectorType,
+  T extends DeviceAuthGrantConnectorType,
 > {
   readonly kind: "device-auth";
   startDeviceAuth(
@@ -47,14 +47,14 @@ export interface NoneAccessProvider {
   getAccessSecretName(): string;
 }
 
-export interface RefreshTokenAccessProvider<T extends OAuthConnectorType> {
+export interface RefreshTokenAccessProvider<T extends OAuthGrantConnectorType> {
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
   getRefreshSecretName(): string;
   refreshToken(args: ConnectorOAuthRefreshArgs<T>): Promise<OAuthRefreshResult>;
 }
 
-export type OAuthConnectorAccessProvider<T extends OAuthConnectorType> =
+export type OAuthConnectorAccessProvider<T extends OAuthGrantConnectorType> =
   | NoneAccessProvider
   | RefreshTokenAccessProvider<T>;
 
@@ -62,12 +62,12 @@ interface NoneRevokeProvider {
   readonly kind: "none";
 }
 
-interface TokenRevokeProvider<T extends OAuthConnectorType> {
+interface TokenRevokeProvider<T extends OAuthGrantConnectorType> {
   readonly kind: "token-revoke";
   revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
 }
 
-export type OAuthConnectorRevokeProvider<T extends OAuthConnectorType> =
+export type OAuthConnectorRevokeProvider<T extends OAuthGrantConnectorType> =
   | NoneRevokeProvider
   | TokenRevokeProvider<T>;
 
@@ -78,7 +78,7 @@ export interface AuthProvider<TGrant, TAccess, TRevoke> {
 }
 
 export type AuthCodeConnectorAuthProvider<
-  T extends OAuthAuthCodeConnectorType,
+  T extends AuthCodeGrantConnectorType,
 > = AuthProvider<
   AuthCodeGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,
@@ -86,7 +86,7 @@ export type AuthCodeConnectorAuthProvider<
 >;
 
 export type DeviceAuthConnectorAuthProvider<
-  T extends OAuthDeviceAuthConnectorType,
+  T extends DeviceAuthGrantConnectorType,
 > = AuthProvider<
   DeviceAuthGrantProvider<T>,
   OAuthConnectorAccessProvider<T>,

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -13,8 +13,9 @@ import {
   type ConnectorOAuthClientConfig,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type OAuthAuthCodeConnectorType,
-  type OAuthDeviceAuthConnectorType,
+  type OAuthGrantConnectorType,
+  type AuthCodeGrantConnectorType,
+  type DeviceAuthGrantConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors";
@@ -283,6 +284,12 @@ function isConnectorOAuthGrantConfig(
 }
 
 export function getConnectorOAuthGrantConfig(
+  type: OAuthGrantConnectorType,
+): ConnectorOAuthGrantConfig;
+export function getConnectorOAuthGrantConfig(
+  type: ConnectorType,
+): ConnectorOAuthGrantConfig | undefined;
+export function getConnectorOAuthGrantConfig(
   type: ConnectorType,
 ): ConnectorOAuthGrantConfig | undefined {
   for (const method of connectorAuthMethodValues(type)) {
@@ -291,6 +298,12 @@ export function getConnectorOAuthGrantConfig(
     }
   }
   return undefined;
+}
+
+export function hasConnectorOAuthGrant(
+  type: ConnectorType,
+): type is OAuthGrantConnectorType {
+  return getConnectorOAuthGrantConfig(type) !== undefined;
 }
 
 export function connectorAuthMethodHasOAuthGrant(
@@ -310,6 +323,12 @@ export function connectorAuthMethodHasOAuthGrant(
 }
 
 export function getConnectorAuthCodeGrantConfig(
+  type: AuthCodeGrantConnectorType,
+): ConnectorAuthCodeGrantConfig;
+export function getConnectorAuthCodeGrantConfig(
+  type: ConnectorType,
+): ConnectorAuthCodeGrantConfig | undefined;
+export function getConnectorAuthCodeGrantConfig(
   type: ConnectorType,
 ): ConnectorAuthCodeGrantConfig | undefined {
   const grant = getConnectorOAuthGrantConfig(type);
@@ -322,6 +341,12 @@ export function getConnectorAuthCodeGrantConfig(
   }
 }
 
+export function getConnectorDeviceAuthGrantConfig(
+  type: DeviceAuthGrantConnectorType,
+): ConnectorDeviceAuthGrantConfig;
+export function getConnectorDeviceAuthGrantConfig(
+  type: ConnectorType,
+): ConnectorDeviceAuthGrantConfig | undefined;
 export function getConnectorDeviceAuthGrantConfig(
   type: ConnectorType,
 ): ConnectorDeviceAuthGrantConfig | undefined {
@@ -474,6 +499,12 @@ export function isStaticConfidentialConnectorOAuthClient(
   );
 }
 
+export function getConnectorOAuthClientConfig(
+  type: OAuthGrantConnectorType,
+): ConnectorOAuthClientConfig;
+export function getConnectorOAuthClientConfig(
+  type: ConnectorType,
+): ConnectorOAuthClientConfig | undefined;
 export function getConnectorOAuthClientConfig(
   type: ConnectorType,
 ): ConnectorOAuthClientConfig | undefined {
@@ -708,15 +739,15 @@ export function getConnectorProvidedEnvNames(
   return provided;
 }
 
-export function isOAuthAuthCodeConnectorType(
+export function hasConnectorAuthCodeGrant(
   type: ConnectorType,
-): type is OAuthAuthCodeConnectorType {
+): type is AuthCodeGrantConnectorType {
   return getConnectorOAuthGrantConfig(type)?.kind === "auth-code";
 }
 
-export function isOAuthDeviceAuthConnectorType(
+export function hasConnectorDeviceAuthGrant(
   type: ConnectorType,
-): type is OAuthDeviceAuthConnectorType {
+): type is DeviceAuthGrantConnectorType {
   return getConnectorOAuthGrantConfig(type)?.kind === "device-auth";
 }
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -331,14 +331,17 @@ export function getConnectorAuthCodeGrantConfig(
 export function getConnectorAuthCodeGrantConfig(
   type: ConnectorType,
 ): ConnectorAuthCodeGrantConfig | undefined {
-  const grant = getConnectorOAuthGrantConfig(type);
-  switch (grant?.kind) {
-    case "auth-code":
-      return grant;
-    case "device-auth":
-    case undefined:
-      return undefined;
+  for (const method of connectorAuthMethodValues(type)) {
+    switch (method.grant.kind) {
+      case "auth-code":
+        return method.grant;
+      case "device-auth":
+      case "manual":
+      case "managed":
+        break;
+    }
   }
+  return undefined;
 }
 
 export function getConnectorDeviceAuthGrantConfig(
@@ -350,14 +353,17 @@ export function getConnectorDeviceAuthGrantConfig(
 export function getConnectorDeviceAuthGrantConfig(
   type: ConnectorType,
 ): ConnectorDeviceAuthGrantConfig | undefined {
-  const grant = getConnectorOAuthGrantConfig(type);
-  switch (grant?.kind) {
-    case "device-auth":
-      return grant;
-    case "auth-code":
-    case undefined:
-      return undefined;
+  for (const method of connectorAuthMethodValues(type)) {
+    switch (method.grant.kind) {
+      case "device-auth":
+        return method.grant;
+      case "auth-code":
+      case "manual":
+      case "managed":
+        break;
+    }
   }
+  return undefined;
 }
 
 export function getConnectorOAuthScopes(type: ConnectorType): string[] {
@@ -742,13 +748,13 @@ export function getConnectorProvidedEnvNames(
 export function hasConnectorAuthCodeGrant(
   type: ConnectorType,
 ): type is AuthCodeGrantConnectorType {
-  return getConnectorOAuthGrantConfig(type)?.kind === "auth-code";
+  return getConnectorAuthCodeGrantConfig(type) !== undefined;
 }
 
 export function hasConnectorDeviceAuthGrant(
   type: ConnectorType,
 ): type is DeviceAuthGrantConnectorType {
-  return getConnectorOAuthGrantConfig(type)?.kind === "device-auth";
+  return getConnectorDeviceAuthGrantConfig(type) !== undefined;
 }
 
 /**

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -913,11 +913,11 @@ export type ConnectorTypesByRevokeKind<Kind extends ConnectorRevokeKind> = {
   }[keyof ConnectorAuthMethodsOf<Type>];
 }[ConnectorType];
 
-export type OAuthConnectorType = ConnectorTypesByGrantKind<
+export type OAuthGrantConnectorType = ConnectorTypesByGrantKind<
   "auth-code" | "device-auth"
 >;
-export type OAuthAuthCodeConnectorType = ConnectorTypesByGrantKind<"auth-code">;
-export type OAuthDeviceAuthConnectorType =
+export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;
+export type DeviceAuthGrantConnectorType =
   ConnectorTypesByGrantKind<"device-auth">;
 
 export type ConnectorInvalidDefaultAuthMethodType<

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -573,7 +573,7 @@ export {
   type TriggerSource,
   type LogsFilters,
   type ConnectorType,
-  type OAuthConnectorType,
+  type OAuthGrantConnectorType,
   type ConnectorConfig,
   type ConnectorEnvBindings,
   type ConnectorAuthMethodConfig,


### PR DESCRIPTION
## Summary
- Rename connector OAuth-derived type guards/types around grant phases and provider-map availability
- Narrow auth-code/device-auth API boundaries before downstream OAuth protocol calls
- Update platform connector flow checks and tests to use grant-oriented helper names

Closes #15107

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- pnpm -F web check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors test
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F web lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/core lint
- pre-commit: prettier, knip --cache, turbo run check-types --concurrency=1