### PR TITLE
feat: register grainy-duotone styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2930,6 +2930,15 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     desc: 'Mellow-pop flat-vector editorial illustration: a recurring chill character with closed-eye smile, tiny nose hint, and short dark bobbed hair, posed inside a scene-as-metaphor composition on a single fully saturated solid color background, with a signature pop of bright leaf-green woven into every piece (hero prop, plants, motifs, or sweater). Thin uniform black outlines, flat solid fills only, no gradients or texture. Five dials per brief: palette, scene metaphor, complexity (L1/L2/L3), pose, outfit accent. Trigger when user says /mellow-pop, asks for a "mellow-pop illustration", "chill flat-vector poster", or briefs with a scene metaphor + palette + complexity.',
     source: { path: "illustration-template/mellow-pop" },
   },
+  {
+    id: "vm0:image-style:grainy-duotone",
+    kind: "image-style",
+    name: "Grainy Duotone",
+    description:
+      "Editorial spot illustration on a warm cream background — grainy charcoal-stippled hands, outline-free flat two-tone color blocks with internal patterns, and scattered ambient marks.",
+    desc: 'Grainy-duotone editorial spot illustration: warm cream off-white background, grainy charcoal-stippled hands (and occasional faces) drawn in textured black ink, paired with free-floating flat two-tone color blocks that carry NO outlines and are filled with internal patterns (grid, dots, spiral, hatching, squiggles, wavy lines), surrounded by scattered ambient marks (zigzags, triangles, x marks, circles, dashes). Square 1:1 scene-as-metaphor compositions. Five creative dials per brief: palette (two flat hues, e.g. teal+yellow / coral+sage / lavender+mustard / navy+peach / burgundy+dusty pink), elements (hand(s) + 1-3 props like flag, sprout, magnifier, balloons, ladder), scene archetype (Launch / Grow / Connect / Discover / Communicate / Reflect / Navigate / Care / Transform / Build), complexity (L1 minimal / L2 balanced / L3 rich), and mood (celebratory / calm / curious / reflective / determined / warm / quiet). Trigger when user says /grainy-duotone, asks for a "grainy two-tone editorial illustration", "charcoal-stippled hand illustration", "duotone editorial spot", or briefs with a scene metaphor + two-color palette + complexity.',
+    source: { path: "illustration-template/grainy-duotone" },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers a new Open Design image-style: **grainy-duotone**.

- Registry ID: \`vm0:image-style:grainy-duotone\`
- Source: \`vm0-ai/vm0-skills:illustration-template/grainy-duotone\`
- Paired vm0-skills PR: https://github.com/vm0-ai/vm0-skills/pull/224

## What the style produces

Editorial spot illustrations on a warm cream background — grainy charcoal-stippled hands paired with outline-free flat two-tone color blocks (each carrying an internal pattern: grid · dots · spiral · hatching · squiggles · wavy lines), surrounded by scattered ambient marks. Square 1:1. Scene-as-metaphor compositions.

Five creative dials sit on the locked frame: palette · elements · scene archetype · complexity (L1/L2/L3) · mood.

## Files

- \`turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts\` — appends one entry after \`vm0:image-style:mellow-pop\`

## Validation

- [x] Entry uses only the six allowed fields (\`id\`, \`kind\`, \`name\`, \`description\`, \`desc\`, \`source\`)
- [x] \`source\` is \`{ path: "..." }\` only — no \`repo\`, no \`commit\`, no helper calls
- [x] ID prefix is \`vm0:*\` (matching the \`vm0-skills\` source repo)
- [x] \`description\` ≤ 200 chars (one selection sentence)
- [x] Detailed style guidance + trigger phrasing kept in optional \`desc\` field
- [x] Rebased on current main before pushing

## Test plan

- [ ] Resolve \`vm0:image-style:grainy-duotone\` via \`pnpm --filter @vm0/cli exec zero built-in generate image --style vm0:image-style:grainy-duotone --prompt "hand holding a megaphone" --json\` — confirms registry resolution and source path fetch