### PR TITLE
feat: add capability-driven desktop element clicks

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1095,6 +1095,133 @@ func actionNames(_ element: AXUIElement) -> [String] {
     }
 }
 
+let axPressActionName = "AXPress"
+let axPickActionName = "AXPick"
+let selectableRoles: Set<String> = ["AXCell", "AXColumn", "AXRow", "AXTab"]
+let selectableSubroles: Set<String> = ["AXOutlineRow"]
+
+enum ElementClickStrategy: String {
+    case mouse
+    case pick
+    case press
+}
+
+struct ElementClickCapabilities {
+    let role: String?
+    let subrole: String?
+    let frame: CGRect?
+    let pressable: Bool
+    let pickable: Bool
+    let selectable: Bool
+    let mouseClickable: Bool
+    let webAreaMouseClick: Bool
+
+    var clickableKind: String? {
+        if webAreaMouseClick, frame != nil {
+            return "mouse"
+        }
+        if pressable {
+            return "press"
+        }
+        if pickable {
+            return "pick"
+        }
+        if selectable, frame != nil {
+            return "select"
+        }
+        if mouseClickable {
+            return "mouse"
+        }
+        return nil
+    }
+}
+
+struct ElementClickTarget {
+    let element: AXUIElement
+    let capabilities: ElementClickCapabilities
+    let promotedDepth: Int
+    let strategy: ElementClickStrategy
+}
+
+func clickableFrame(_ element: AXUIElement) -> CGRect? {
+    guard let frame = elementFrame(element),
+          frame.width > 0,
+          frame.height > 0
+    else {
+        return nil
+    }
+    return frame
+}
+
+func isSelectableElement(role roleName: String?, subrole: String?, selected: Bool?) -> Bool {
+    if let roleName, selectableRoles.contains(roleName), selected != nil {
+        return true
+    }
+    if let subrole, selectableSubroles.contains(subrole), selected != nil {
+        return true
+    }
+    return false
+}
+
+func clickCapabilities(
+    _ element: AXUIElement,
+    actions actionList: [String]? = nil,
+    selected selectedValue: Bool? = nil
+) -> ElementClickCapabilities {
+    let elementRole = role(element)
+    let elementSubrole = stringValue(attribute(element, kAXSubroleAttribute as CFString))
+    let elementActions = Set(actionList ?? actionNames(element))
+    let elementSelected = selectedValue ?? boolValue(attribute(element, kAXSelectedAttribute as CFString))
+    let frame = clickableFrame(element)
+    let selectable = isSelectableElement(role: elementRole, subrole: elementSubrole, selected: elementSelected)
+    let webAreaMouseClick = shouldUseMouseClickForElement(element)
+    let mouseClickable = frame != nil && (webAreaMouseClick || selectable)
+    return ElementClickCapabilities(
+        role: elementRole,
+        subrole: elementSubrole,
+        frame: frame,
+        pressable: elementActions.contains(axPressActionName),
+        pickable: elementActions.contains(axPickActionName),
+        selectable: selectable,
+        mouseClickable: mouseClickable,
+        webAreaMouseClick: webAreaMouseClick
+    )
+}
+
+func preferredClickStrategy(_ capabilities: ElementClickCapabilities) -> ElementClickStrategy? {
+    if capabilities.webAreaMouseClick, capabilities.frame != nil {
+        return .mouse
+    }
+    if capabilities.pressable {
+        return .press
+    }
+    if capabilities.pickable {
+        return .pick
+    }
+    if capabilities.mouseClickable {
+        return .mouse
+    }
+    return nil
+}
+
+func setClickCapabilityFields(_ node: inout [String: Any], capabilities: ElementClickCapabilities) {
+    if capabilities.pressable {
+        node["pressable"] = true
+    }
+    if capabilities.pickable {
+        node["pickable"] = true
+    }
+    if capabilities.selectable {
+        node["selectable"] = true
+    }
+    if capabilities.mouseClickable {
+        node["mouseClickable"] = true
+    }
+    if let clickableKind = capabilities.clickableKind {
+        node["clickableKind"] = clickableKind
+    }
+}
+
 func attributeIsSettable(_ element: AXUIElement, _ name: CFString) -> Bool? {
     var settable = DarwinBoolean(false)
     let error = AXUIElementIsAttributeSettable(element, name, &settable)
@@ -1842,7 +1969,8 @@ func describe(
     if let enabled = boolValue(attribute(element, kAXEnabledAttribute as CFString)) {
         node["enabled"] = enabled
     }
-    if let selected = boolValue(attribute(element, kAXSelectedAttribute as CFString)) {
+    let selected = boolValue(attribute(element, kAXSelectedAttribute as CFString))
+    if let selected {
         node["selected"] = selected
     }
     if let expanded = boolValue(attribute(element, kAXExpandedAttribute as CFString)) {
@@ -1858,6 +1986,7 @@ func describe(
     if let bounds = bounds(element) {
         node["bounds"] = bounds
     }
+    setClickCapabilityFields(&node, capabilities: clickCapabilities(element, actions: actions, selected: selected))
 
     if depth >= limits.maxDepth {
         markTruncated(&truncationReasons, "max_depth")
@@ -2214,53 +2343,63 @@ func handleElementClick(_ request: [String: Any], session: ComputerUseRuntimeSes
     let elementId = try resolveElementId(request, session: session, commandName: "element.click")
     let clickCount = max(1, min(optionalInt(request, "clickCount", default: 1), 3))
     let button = optionalString(request, "button") ?? "left"
-    let config = try mouseEventConfig(button: button)
     let app = try resolveRunningApp(named: appName)
     let element = try resolveElement(appName: appName, elementId: elementId)
-    if shouldUseMouseClickForElement(element), let frame = elementFrame(element) {
-        let point = CGPoint(x: frame.midX, y: frame.midY)
-        return try withFrontmostPreservation(
-            dispatchMode: "background_mouse_event",
-            dispatchTarget: "element_point",
-            inputRisk: "background_app_pointer"
-        ) {
-            guard let target = resolveWindowTarget(app: app, preferredScreenPoint: point) else {
-                throw windowTargetUnavailableFailure(appName: appName)
-            }
-            var result = try performBackgroundMouseClick(
-                target: target,
-                point: point,
-                config: config,
-                clickCount: clickCount
-            )
-            result["elementClickMode"] = "web_area_mouse_fallback"
-            return (targetPID: target.pid, result: result)
-        }
+    guard let clickTarget = resolveElementClickTarget(element) else {
+        throw HelperFailure(
+            code: "element_action_unsupported",
+            message: "Element is visible but does not support a primary click action: \(elementId)"
+        )
     }
-    if button != "left" {
+    if clickTarget.strategy != .mouse && button != "left" {
         throw HelperFailure(
             code: "unsupported_command",
             message: "element.click with element target only supports the left button"
         )
     }
-    return try withFrontmostPreservation(
-        dispatchMode: "accessibility_action",
-        dispatchTarget: "element",
-        inputRisk: "targeted_app_action"
-    ) {
-        for index in 0..<clickCount {
-            let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
-            if error != .success {
-                throw HelperFailure(
-                    code: "accessibility_unavailable",
-                    message: "Unable to press \(elementId): \(error.rawValue)"
-                )
-            }
-            if index + 1 < clickCount {
-                usleep(50_000)
-            }
+
+    if clickTarget.strategy == .mouse {
+        let config = try mouseEventConfig(button: button)
+        let mode = clickTarget.capabilities.webAreaMouseClick
+            ? "web_area_mouse_fallback"
+            : "capability_mouse_fallback"
+        return try performElementMouseClick(
+            app: app,
+            appName: appName,
+            clickTarget: clickTarget,
+            config: config,
+            clickCount: clickCount,
+            mode: mode
+        )
+    }
+
+    do {
+        return try performElementAccessibilityClick(
+            app: app,
+            elementId: elementId,
+            clickTarget: clickTarget,
+            clickCount: clickCount
+        )
+    } catch let unsupported as UnsupportedClickAction {
+        guard clickTarget.capabilities.frame != nil else {
+            throw HelperFailure(
+                code: "element_action_unsupported",
+                message: "Primary click action \(unsupported.actionName) is unsupported for \(elementId): \(unsupported.error.rawValue)"
+            )
         }
-        return (targetPID: app.processIdentifier, result: [:])
+        let config = try mouseEventConfig(button: button)
+        return try performElementMouseClick(
+            app: app,
+            appName: appName,
+            clickTarget: clickTarget,
+            config: config,
+            clickCount: clickCount,
+            mode: "unsupported_action_mouse_fallback",
+            extra: [
+                "unsupportedAction": unsupported.actionName,
+                "unsupportedActionError": unsupported.error.rawValue,
+            ]
+        )
     }
 }
 
@@ -2349,6 +2488,130 @@ func shouldUseMouseClickForElement(_ element: AXUIElement) -> Bool {
         return false
     }
     return hasRoleInElementAncestry(element, roleName: "AXWebArea")
+}
+
+struct UnsupportedClickAction: Error {
+    let actionName: String
+    let error: AXError
+}
+
+func isUnsupportedActionError(_ error: AXError) -> Bool {
+    return error == .actionUnsupported || error == .attributeUnsupported
+}
+
+func resolveElementClickTarget(_ element: AXUIElement) -> ElementClickTarget? {
+    var current: AXUIElement? = element
+    var depth = 0
+    while let node = current, depth <= limits.maxDepth {
+        let capabilities = clickCapabilities(node)
+        if !(depth > 0 && capabilities.role == "AXWebArea"),
+           let strategy = preferredClickStrategy(capabilities)
+        {
+            return ElementClickTarget(
+                element: node,
+                capabilities: capabilities,
+                promotedDepth: depth,
+                strategy: strategy
+            )
+        }
+        current = axElementValue(attribute(node, kAXParentAttribute as CFString))
+        depth += 1
+    }
+    return nil
+}
+
+func elementClickResultMetadata(clickTarget: ElementClickTarget) -> [String: Any] {
+    var result: [String: Any] = [
+        "clickStrategy": clickTarget.strategy.rawValue,
+    ]
+    if clickTarget.promotedDepth > 0 {
+        result["clickTargetPromoted"] = true
+        result["clickTargetPromotedDepth"] = clickTarget.promotedDepth
+    }
+    if let role = clickTarget.capabilities.role {
+        result["clickTargetRole"] = role
+    }
+    if let subrole = clickTarget.capabilities.subrole {
+        result["clickTargetSubrole"] = subrole
+    }
+    if let clickableKind = clickTarget.capabilities.clickableKind {
+        result["clickableKind"] = clickableKind
+    }
+    return result
+}
+
+func performElementMouseClick(
+    app: NSRunningApplication,
+    appName: String,
+    clickTarget: ElementClickTarget,
+    config: (down: CGEventType, up: CGEventType, button: CGMouseButton),
+    clickCount: Int,
+    mode: String,
+    extra: [String: Any] = [:]
+) throws -> [String: Any] {
+    guard let frame = clickTarget.capabilities.frame else {
+        throw HelperFailure(
+            code: "element_action_unsupported",
+            message: "Element does not have a usable frame for a mouse click"
+        )
+    }
+    let point = CGPoint(x: frame.midX, y: frame.midY)
+    return try withFrontmostPreservation(
+        dispatchMode: "background_mouse_event",
+        dispatchTarget: "element_point",
+        inputRisk: "background_app_pointer"
+    ) {
+        guard let target = resolveWindowTarget(app: app, preferredScreenPoint: point) else {
+            throw windowTargetUnavailableFailure(appName: appName)
+        }
+        var result = try performBackgroundMouseClick(
+            target: target,
+            point: point,
+            config: config,
+            clickCount: clickCount
+        )
+        result["elementClickMode"] = mode
+        for (key, value) in elementClickResultMetadata(clickTarget: clickTarget) {
+            result[key] = value
+        }
+        for (key, value) in extra {
+            result[key] = value
+        }
+        return (targetPID: target.pid, result: result)
+    }
+}
+
+func performElementAccessibilityClick(
+    app: NSRunningApplication,
+    elementId: String,
+    clickTarget: ElementClickTarget,
+    clickCount: Int
+) throws -> [String: Any] {
+    let actionName = clickTarget.strategy == .pick ? axPickActionName : axPressActionName
+    return try withFrontmostPreservation(
+        dispatchMode: "accessibility_action",
+        dispatchTarget: "element",
+        inputRisk: "targeted_app_action"
+    ) {
+        for index in 0..<clickCount {
+            let error = AXUIElementPerformAction(clickTarget.element, actionName as CFString)
+            if error != .success {
+                if index == 0, isUnsupportedActionError(error) {
+                    throw UnsupportedClickAction(actionName: actionName, error: error)
+                }
+                throw HelperFailure(
+                    code: "accessibility_unavailable",
+                    message: "Unable to perform \(actionName) on \(elementId): \(error.rawValue)"
+                )
+            }
+            if index + 1 < clickCount {
+                usleep(50_000)
+            }
+        }
+        var result = elementClickResultMetadata(clickTarget: clickTarget)
+        result["clickAction"] = actionName
+        return (targetPID: app.processIdentifier, result: result)
+    }
 }
 
 func normalizeKeyToken(_ value: String) -> String {

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -20,11 +20,7 @@ export const SUPPORTED_COMPUTER_USE_CAPABILITIES = [
 export type ComputerUseCommandKind =
   (typeof SUPPORTED_COMPUTER_USE_CAPABILITIES)[number];
 
-export type AccessibilityElementClickableKind =
-  | "mouse"
-  | "pick"
-  | "press"
-  | "select";
+type AccessibilityElementClickableKind = "mouse" | "pick" | "press" | "select";
 
 export interface ComputerUseCommand {
   readonly id: string;

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -20,6 +20,12 @@ export const SUPPORTED_COMPUTER_USE_CAPABILITIES = [
 export type ComputerUseCommandKind =
   (typeof SUPPORTED_COMPUTER_USE_CAPABILITIES)[number];
 
+export type AccessibilityElementClickableKind =
+  | "mouse"
+  | "pick"
+  | "press"
+  | "select";
+
 export interface ComputerUseCommand {
   readonly id: string;
   readonly kind: ComputerUseCommandKind;
@@ -51,6 +57,11 @@ export interface AccessibilityElementSnapshot {
   readonly expanded?: boolean;
   readonly hidden?: boolean;
   readonly actions?: readonly string[];
+  readonly pressable?: boolean;
+  readonly pickable?: boolean;
+  readonly selectable?: boolean;
+  readonly mouseClickable?: boolean;
+  readonly clickableKind?: AccessibilityElementClickableKind;
   readonly bounds?: ComputerUseCoordinateBounds;
   readonly children?: readonly AccessibilityElementSnapshot[];
 }
@@ -81,6 +92,11 @@ interface AccessibilityVisibleElement {
   readonly selected?: boolean;
   readonly expanded?: boolean;
   readonly actions?: readonly string[];
+  readonly pressable?: boolean;
+  readonly pickable?: boolean;
+  readonly selectable?: boolean;
+  readonly mouseClickable?: boolean;
+  readonly clickableKind?: AccessibilityElementClickableKind;
 }
 
 export interface AccessibilityAppStateSnapshot {
@@ -144,6 +160,7 @@ export interface ComputerUseCommandFailure {
     readonly code:
       | "permission_denied"
       | "accessibility_unavailable"
+      | "element_action_unsupported"
       | "window_unavailable"
       | "screen_recording_unavailable"
       | "app_not_found"
@@ -391,6 +408,11 @@ function elementHasMeaningfulContent(
     element.enabled === false ||
     element.selected === true ||
     element.expanded !== undefined ||
+    element.pressable === true ||
+    element.pickable === true ||
+    element.selectable === true ||
+    element.mouseClickable === true ||
+    element.clickableKind !== undefined ||
     (element.actions !== undefined && element.actions.length > 0)
   );
 }
@@ -642,6 +664,11 @@ function visibleElementForSnapshotElement(
     ...(element.actions && element.actions.length > 0
       ? { actions: element.actions }
       : {}),
+    ...(element.pressable === true ? { pressable: true } : {}),
+    ...(element.pickable === true ? { pickable: true } : {}),
+    ...(element.selectable === true ? { selectable: true } : {}),
+    ...(element.mouseClickable === true ? { mouseClickable: true } : {}),
+    ...(element.clickableKind ? { clickableKind: element.clickableKind } : {}),
   };
 }
 
@@ -806,6 +833,15 @@ const ROLE_LABELS: Readonly<Record<string, string>> = Object.freeze({
 });
 
 const DEFAULT_ACTION_NAMES = new Set(["AXPress"]);
+const PRIMARY_CLICK_ROLE_NAMES = new Set([
+  "AXButton",
+  "AXCheckBox",
+  "AXDisclosureTriangle",
+  "AXMenuBarItem",
+  "AXMenuItem",
+  "AXPopUpButton",
+  "AXRadioButton",
+]);
 
 const ACTION_LABELS: Readonly<Record<string, string>> = Object.freeze({
   AXCancel: "Cancel",
@@ -879,9 +915,29 @@ function elementAnnotations(element: AccessibilityElementSnapshot): string[] {
   }
   if (element.selected === true) {
     annotations.push("selected");
+  } else if (element.selectable === true) {
+    annotations.push("selectable");
   }
   if (element.expanded === true) {
     annotations.push("expanded");
+  }
+  if (
+    element.pressable === true &&
+    element.clickableKind === "press" &&
+    (element.role === undefined || !PRIMARY_CLICK_ROLE_NAMES.has(element.role))
+  ) {
+    annotations.push("pressable");
+  }
+  if (element.pickable === true && element.clickableKind === "pick") {
+    annotations.push("pickable");
+  }
+  if (
+    element.mouseClickable === true &&
+    element.clickableKind === "mouse" &&
+    element.selectable !== true &&
+    (element.role === undefined || !PRIMARY_CLICK_ROLE_NAMES.has(element.role))
+  ) {
+    annotations.push("clickable");
   }
   return annotations;
 }
@@ -909,6 +965,9 @@ function actionLabel(action: string): string {
 function secondaryActions(element: AccessibilityElementSnapshot): string[] {
   return (element.actions ?? [])
     .filter((action) => {
+      if (action === "AXPick" && element.clickableKind === "pick") {
+        return false;
+      }
       return !DEFAULT_ACTION_NAMES.has(action);
     })
     .map((action) => {

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -319,6 +319,7 @@ describe("computer use native backend", () => {
   it.each([
     ["app_not_found", "Unable to open Things: Unable to find application"],
     ["app_open_failed", "Unable to open Things"],
+    ["element_action_unsupported", "Element does not support a primary click"],
     ["window_unavailable", "Unable to resolve a background window target"],
   ])("preserves %s helper failures", async (code, message) => {
     const helper = await createHelper({

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -148,6 +148,7 @@ function responseErrorCode(value: unknown): ComputerUseNativeErrorCode {
   if (
     value === "permission_denied" ||
     value === "accessibility_unavailable" ||
+    value === "element_action_unsupported" ||
     value === "window_unavailable" ||
     value === "screen_recording_unavailable" ||
     value === "app_not_found" ||

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -758,6 +758,64 @@ describe("computer use desktop runtime", () => {
     );
   });
 
+  it("renders click capability annotations for model target selection", () => {
+    const snapshot = {
+      app: "Things",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "Things",
+          children: [
+            {
+              id: "w0.r0",
+              role: "AXRow",
+              description: "Inbox",
+              selected: false,
+              selectable: true,
+              mouseClickable: true,
+              clickableKind: "select",
+            },
+            {
+              id: "w0.r1",
+              role: "AXRow",
+              description: "Today",
+              selected: true,
+              selectable: true,
+              mouseClickable: true,
+              clickableKind: "select",
+            },
+            {
+              id: "w0.g0",
+              role: "AXGroup",
+              name: "Reveal details",
+              actions: ["AXPress"],
+              pressable: true,
+              clickableKind: "press",
+            },
+            {
+              id: "w0.m0",
+              role: "AXMenuItem",
+              name: "Choose workspace",
+              actions: ["AXPick"],
+              pickable: true,
+              clickableKind: "pick",
+            },
+          ],
+        },
+      ],
+    } as const;
+
+    const text = renderAccessibilityTree(snapshot);
+
+    expect(text).toContain("\t1 row (selectable) Inbox");
+    expect(text).toContain("\t2 row (selected) Today");
+    expect(text).toContain("\t3 container (pressable) Reveal details");
+    expect(text).toContain("\t4 menu item (pickable) Choose workspace");
+    expect(text).not.toContain("Secondary Actions: Pick");
+  });
+
   it("builds an AX-derived visible element summary", () => {
     const snapshot = normalizeAccessibilitySnapshot({
       app: "Things",
@@ -774,12 +832,18 @@ describe("computer use desktop runtime", () => {
               role: "AXRow",
               description: "Hello Computer Use",
               selected: true,
+              selectable: true,
+              mouseClickable: true,
+              clickableKind: "select",
               bounds: { x: 24, y: 120, width: 360, height: 24 },
             },
             {
               id: "w0.a1",
               role: "AXRow",
               help: "Can you see this?",
+              selectable: true,
+              mouseClickable: true,
+              clickableKind: "select",
               bounds: { x: 24, y: 152, width: 360, height: 24 },
             },
             {
@@ -824,6 +888,9 @@ describe("computer use desktop runtime", () => {
         sourceAttributes: ["AXDescription"],
         bounds: { x: 24, y: 120, width: 360, height: 24 },
         selected: true,
+        selectable: true,
+        mouseClickable: true,
+        clickableKind: "select",
       },
       {
         elementId: "w0.a1",
@@ -832,6 +899,9 @@ describe("computer use desktop runtime", () => {
         source: "accessibility",
         sourceAttributes: ["AXHelp"],
         bounds: { x: 24, y: 152, width: 360, height: 24 },
+        selectable: true,
+        mouseClickable: true,
+        clickableKind: "select",
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- expose desktop accessibility click capability metadata such as pressable, pickable, selectable, mouseClickable, and clickableKind
- let the native helper resolve element.click strategy internally from AX capabilities, including target promotion, WebArea/background mouse clicks, AXPress/AXPick, and unsupported-action mouse fallback
- render selectable/pressable/pickable hints in model-facing app state and preserve element_action_unsupported as a distinct native error code

## Validation
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- vm0-computer smoke: Things AXRow exposes selectable/mouseClickable/clickableKind=select
- vm0-computer smoke: clicking a selectable Things row returns capability_mouse_fallback with clickStrategy=mouse
- vm0-computer smoke: clicking a child image promotes to a pressable parent with clickTargetPromoted=true

Closes #15120
Refs #15116