### PR TITLE
fix: write persistent secrets with kms only

### DIFF
--- a/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
+++ b/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
@@ -9,6 +9,7 @@ import {
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
+import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
@@ -134,7 +135,7 @@ function parsePositiveInteger(value: string | undefined): number {
 function parseArgs(argv: readonly string[]): MigrationArgs {
   let dryRun = false;
   let reportOnly = false;
-  let mode: Exclude<StoredSecretWriteMode, "legacy"> = "dual";
+  let mode: Exclude<StoredSecretWriteMode, "legacy"> = "kms";
   let batchSize = DEFAULT_BATCH_SIZE;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -608,6 +609,58 @@ async function migrateCliAuthProviderStates(
   );
 }
 
+async function countConnectorOauthDeviceProviderStates(): Promise<CiphertextCounts> {
+  const rows = await db()
+    .select({
+      encrypted:
+        connectorOauthDeviceAuthorizationSessions.encryptedProviderState,
+    })
+    .from(connectorOauthDeviceAuthorizationSessions);
+  return countCiphertexts(rows);
+}
+
+async function migrateConnectorOauthDeviceProviderStates(
+  args: MigrationArgs,
+  targetName: string,
+): Promise<number> {
+  const database = db();
+  return await migrateDirectColumn(
+    targetName,
+    args,
+    async (cursor, batchSize) => {
+      const predicates = cursor
+        ? [gt(connectorOauthDeviceAuthorizationSessions.id, cursor)]
+        : [];
+      return await database
+        .select({
+          key: connectorOauthDeviceAuthorizationSessions.id,
+          encrypted:
+            connectorOauthDeviceAuthorizationSessions.encryptedProviderState,
+        })
+        .from(connectorOauthDeviceAuthorizationSessions)
+        .where(predicates.length > 0 ? and(...predicates) : undefined)
+        .orderBy(asc(connectorOauthDeviceAuthorizationSessions.id))
+        .limit(batchSize);
+    },
+    async (row, encrypted) => {
+      const updated = await database
+        .update(connectorOauthDeviceAuthorizationSessions)
+        .set({ encryptedProviderState: encrypted })
+        .where(
+          and(
+            eq(connectorOauthDeviceAuthorizationSessions.id, row.key),
+            eq(
+              connectorOauthDeviceAuthorizationSessions.encryptedProviderState,
+              row.encrypted!,
+            ),
+          ),
+        )
+        .returning({ key: connectorOauthDeviceAuthorizationSessions.id });
+      return updated.length;
+    },
+  );
+}
+
 async function countAgentRunQueuePayloads(): Promise<CiphertextCounts> {
   const rows = await db()
     .select({ encrypted: agentRunQueue.encryptedParams })
@@ -878,6 +931,12 @@ async function run(): Promise<void> {
       "connector_cli_auth_sessions.encrypted_provider_state",
       countCliAuthProviderStates,
       migrateCliAuthProviderStates,
+      args,
+    ),
+    await report(
+      "connector_oauth_device_authorization_sessions.encrypted_provider_state",
+      countConnectorOauthDeviceProviderStates,
+      migrateConnectorOauthDeviceProviderStates,
       args,
     ),
     await report(

--- a/turbo/apps/api/src/scripts/backfill-secret-kms-encryption.ts
+++ b/turbo/apps/api/src/scripts/backfill-secret-kms-encryption.ts
@@ -129,7 +129,7 @@ function parsePositiveInteger(value: string | undefined): number {
 function parseArgs(argv: readonly string[]): MigrationArgs {
   let dryRun = false;
   let reportOnly = false;
-  let mode: Exclude<StoredSecretWriteMode, "legacy"> = "dual";
+  let mode: Exclude<StoredSecretWriteMode, "legacy"> = "kms";
   let batchSize = DEFAULT_BATCH_SIZE;
 
   for (let index = 0; index < argv.length; index += 1) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
@@ -187,8 +187,8 @@ describe("Claude Code device auth routes", () => {
     expect(
       inspectPersistentSecretCiphertext(session!.encryptedProviderState!),
     ).toStrictEqual({
-      format: "dual",
-      hasLegacy: true,
+      format: "kms",
+      hasLegacy: false,
       hasKms: true,
     });
     expect(kms.calls).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts
@@ -305,8 +305,8 @@ describe("Codex device auth routes", () => {
     expect(
       inspectPersistentSecretCiphertext(sessions[0]!.encryptedProviderState!),
     ).toStrictEqual({
-      format: "dual",
-      hasLegacy: true,
+      format: "kms",
+      hasLegacy: false,
       hasKms: true,
     });
     expect(kms.calls).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -463,8 +463,8 @@ describe("OAuth device authorization connector routes", () => {
     expect(
       inspectPersistentSecretCiphertext(session.encryptedProviderState),
     ).toStrictEqual({
-      format: "dual",
-      hasLegacy: true,
+      format: "kms",
+      hasLegacy: false,
       hasKms: true,
     });
     const decryptedProviderState = await decryptPersistentSecretValue(

--- a/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
@@ -250,14 +250,14 @@ describe("stored secret encryption", () => {
     expect(fakeKmsClient.calls).toHaveLength(0);
   });
 
-  it("dual-writes persistent secrets and reads KMS material when KMS env is set", async () => {
+  it("writes persistent secrets as KMS-only when KMS env is set", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = await encryptPersistentSecretValue("bot-token", {});
 
     expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
-      format: "dual",
-      hasLegacy: true,
+      format: "kms",
+      hasLegacy: false,
       hasKms: true,
     });
     await expect(decryptPersistentSecretValue(encrypted, {})).resolves.toBe(
@@ -286,7 +286,7 @@ describe("stored secret encryption", () => {
     ).resolves.toBe("callback-secret");
   });
 
-  it("dual-writes persistent secret maps when KMS env is set", async () => {
+  it("writes persistent secret maps as KMS-only when KMS env is set", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = await encryptPersistentSecretsMap(
@@ -299,7 +299,7 @@ describe("stored secret encryption", () => {
       throw new Error("Expected encrypted persistent secrets map");
     }
     expect(inspectStoredSecretCiphertext(encrypted)).toMatchObject({
-      format: "dual",
+      format: "kms",
     });
   });
 });

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -407,7 +407,7 @@ export async function encryptPersistentSecretValue(
     return encryptSecretValue(plaintext);
   }
 
-  return await encryptPersistentSecretValueWithMode(plaintext, "dual");
+  return await encryptPersistentSecretValueWithMode(plaintext, "kms");
 }
 
 export async function decryptPersistentSecretValue(


### PR DESCRIPTION
## Summary
- write persistent secret values and maps as KMS-only when `SECRETS_KMS_KEY_ID` is configured
- keep persistent reads on `prefer-kms` so existing legacy and dual ciphertext remains readable during cleanup
- default both stored and persistent KMS backfill scripts to `mode=kms` so a bare run does not recreate dual envelopes
- add `connector_oauth_device_authorization_sessions.encrypted_provider_state` to the persistent KMS backfill report/migration targets
- update persistent KMS assertions for Codex, Claude Code, and connector OAuth device auth flows

## Testing
- `pnpm exec prettier --write apps/api/src/signals/services/crypto.utils.ts apps/api/src/signals/services/__tests__/crypto.utils.test.ts apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts apps/api/src/scripts/backfill-secret-kms-encryption.ts apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts`
- `pnpm -F api exec vitest run src/signals/services/__tests__/crypto.utils.test.ts src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts src/signals/routes/__tests__/zero-codex-device-auth.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/scripts/__tests__/backfill-secret-kms-encryption.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Note: the full pre-commit hook currently fails on repository-wide `pnpm knip --cache` findings in unrelated non-api workspaces; the API-scoped knip check passes for this change.