### PR TITLE
ci: add connector oauth 1password verifier

### DIFF
--- a/.github/scripts/tests/verify-1password-secrets-test.sh
+++ b/.github/scripts/tests/verify-1password-secrets-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERIFY="${SCRIPT_DIR}/verify-1password-secrets.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local output=$1 expected=$2
+  if [[ "$output" != *"$expected"* ]]; then
+    fail "expected output to contain: ${expected}"
+  fi
+}
+
+assert_not_contains() {
+  local output=$1 unexpected=$2
+  if [[ "$output" == *"$unexpected"* ]]; then
+    fail "expected output not to contain: ${unexpected}"
+  fi
+}
+
+mkdir -p "${TMPDIR}/bin"
+cat > "${TMPDIR}/bin/op" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1 $2" == "vault list" ]]; then
+  case "${OP_STUB_VAULTS:-development}" in
+    both)
+      printf '[{"name":"Development"},{"name":"Production"}]\n'
+      ;;
+    empty)
+      printf '[]\n'
+      ;;
+    *)
+      printf '[{"name":"Development"}]\n'
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "read" ]]; then
+  case "$2" in
+    op://Development/google/GOOGLE_OAUTH_CLIENT_SECRET)
+      printf 'shared-google-secret'
+      ;;
+    op://Development/slack/SLACK_CLIENT_SECRET)
+      printf 'shared-slack-secret'
+      ;;
+    op://Development/github/GH_OAUTH_CLIENT_SECRET)
+      printf 'op-github-secret'
+      ;;
+    *)
+      echo "op-error-secret" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected op invocation: $*" >&2
+exit 1
+BASH
+chmod +x "${TMPDIR}/bin/op"
+
+run_verifier() {
+  PATH="${TMPDIR}/bin:${PATH}" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Development \
+    EXPECTED_FORBIDDEN_VAULT=Production \
+    "$VERIFY"
+}
+
+success_output="$(
+  EXPECTED_KEYS=$'GOOGLE_OAUTH_CLIENT_SECRET\nSLACK_CLIENT_SECRET' \
+    GOOGLE_OAUTH_CLIENT_SECRET=shared-google-secret \
+    SLACK_CLIENT_SECRET=shared-slack-secret \
+    run_verifier
+)"
+assert_contains "$success_output" "ok: GOOGLE_OAUTH_CLIENT_SECRET"
+assert_contains "$success_output" "ok: SLACK_CLIENT_SECRET"
+assert_contains "$success_output" "Checked 2 Development secrets"
+assert_not_contains "$success_output" "shared-google-secret"
+assert_not_contains "$success_output" "shared-slack-secret"
+
+status=0
+mixed_output="$(
+  EXPECTED_KEYS=$'GOOGLE_OAUTH_CLIENT_SECRET\nSLACK_CLIENT_SECRET\nX_OAUTH_CLIENT_SECRET\nGH_OAUTH_CLIENT_SECRET' \
+    GOOGLE_OAUTH_CLIENT_SECRET=shared-google-secret \
+    SLACK_CLIENT_SECRET=shared-slack-secret \
+    GH_OAUTH_CLIENT_SECRET=github-github-secret \
+    run_verifier 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected mixed verifier case to fail"
+fi
+assert_contains "$mixed_output" "ok: GOOGLE_OAUTH_CLIENT_SECRET"
+assert_contains "$mixed_output" "ok: SLACK_CLIENT_SECRET"
+assert_contains "$mixed_output" "X_OAUTH_CLIENT_SECRET is missing from GitHub secrets"
+assert_contains "$mixed_output" "X_OAUTH_CLIENT_SECRET is missing or unreadable from 1Password"
+assert_contains "$mixed_output" "GH_OAUTH_CLIENT_SECRET differs between GitHub secrets and 1Password"
+assert_contains "$mixed_output" "3 secret comparison(s) failed"
+assert_not_contains "$mixed_output" "github-github-secret"
+assert_not_contains "$mixed_output" "op-github-secret"
+assert_not_contains "$mixed_output" "op-error-secret"
+
+status=0
+empty_output="$(
+  OP_STUB_VAULTS=empty \
+    EXPECTED_KEYS=GOOGLE_OAUTH_CLIENT_SECRET \
+    GOOGLE_OAUTH_CLIENT_SECRET=shared-google-secret \
+    run_verifier 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected empty vault case to fail"
+fi
+assert_contains "$empty_output" "visible vault count: 0"
+assert_not_contains "$empty_output" "Visible vaults"
+
+status=0
+forbidden_output="$(
+  OP_STUB_VAULTS=both \
+    EXPECTED_KEYS=GOOGLE_OAUTH_CLIENT_SECRET \
+    GOOGLE_OAUTH_CLIENT_SECRET=shared-google-secret \
+    run_verifier 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected forbidden vault case to fail"
+fi
+assert_contains "$forbidden_output" "unexpectedly has access to Production vault"
+assert_not_contains "$forbidden_output" "Visible vaults"
+
+echo "verify-1password-secrets-test: ok"

--- a/.github/scripts/tests/verify-1password-secrets-test.sh
+++ b/.github/scripts/tests/verify-1password-secrets-test.sh
@@ -25,6 +25,10 @@ assert_not_contains() {
   fi
 }
 
+without_mask_commands() {
+  grep -v '^::add-mask::' <<< "$1" || true
+}
+
 mkdir -p "${TMPDIR}/bin"
 cat > "${TMPDIR}/bin/op" <<'BASH'
 #!/usr/bin/env bash
@@ -86,8 +90,9 @@ success_output="$(
 assert_contains "$success_output" "ok: GOOGLE_OAUTH_CLIENT_SECRET"
 assert_contains "$success_output" "ok: SLACK_CLIENT_SECRET"
 assert_contains "$success_output" "Checked 2 Development secrets"
-assert_not_contains "$success_output" "shared-google-secret"
-assert_not_contains "$success_output" "shared-slack-secret"
+success_log_output="$(without_mask_commands "$success_output")"
+assert_not_contains "$success_log_output" "shared-google-secret"
+assert_not_contains "$success_log_output" "shared-slack-secret"
 
 status=0
 mixed_output="$(
@@ -106,9 +111,10 @@ assert_contains "$mixed_output" "X_OAUTH_CLIENT_SECRET is missing from GitHub se
 assert_contains "$mixed_output" "X_OAUTH_CLIENT_SECRET is missing or unreadable from 1Password"
 assert_contains "$mixed_output" "GH_OAUTH_CLIENT_SECRET differs between GitHub secrets and 1Password"
 assert_contains "$mixed_output" "3 secret comparison(s) failed"
-assert_not_contains "$mixed_output" "github-github-secret"
-assert_not_contains "$mixed_output" "op-github-secret"
-assert_not_contains "$mixed_output" "op-error-secret"
+mixed_log_output="$(without_mask_commands "$mixed_output")"
+assert_not_contains "$mixed_log_output" "github-github-secret"
+assert_not_contains "$mixed_log_output" "op-github-secret"
+assert_not_contains "$mixed_log_output" "op-error-secret"
 
 status=0
 empty_output="$(

--- a/.github/scripts/tests/verify-1password-secrets-test.sh
+++ b/.github/scripts/tests/verify-1password-secrets-test.sh
@@ -74,10 +74,17 @@ BASH
 chmod +x "${TMPDIR}/bin/op"
 
 run_verifier() {
-  PATH="${TMPDIR}/bin:${PATH}" \
+  env -i \
+    PATH="${TMPDIR}/bin:${PATH}" \
+    GITHUB_ACTIONS="${GITHUB_ACTIONS:-}" \
+    OP_STUB_VAULTS="${OP_STUB_VAULTS:-}" \
     OP_SERVICE_ACCOUNT_TOKEN=test-token \
     VAULT_NAME=Development \
     EXPECTED_FORBIDDEN_VAULT=Production \
+    EXPECTED_KEYS="${EXPECTED_KEYS:-}" \
+    GH_OAUTH_CLIENT_SECRET="${GH_OAUTH_CLIENT_SECRET:-}" \
+    GOOGLE_OAUTH_CLIENT_SECRET="${GOOGLE_OAUTH_CLIENT_SECRET:-}" \
+    SLACK_CLIENT_SECRET="${SLACK_CLIENT_SECRET:-}" \
     "$VERIFY"
 }
 

--- a/.github/scripts/verify-1password-secrets.sh
+++ b/.github/scripts/verify-1password-secrets.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  echo "::error::OP_SERVICE_ACCOUNT_TOKEN is not available"
+  exit 1
+fi
+
+if [[ -z "${VAULT_NAME:-}" ]]; then
+  echo "::error::VAULT_NAME is required"
+  exit 1
+fi
+
+if [[ -z "${EXPECTED_KEYS:-}" ]]; then
+  echo "::error::EXPECTED_KEYS is required"
+  exit 1
+fi
+
+visible_vaults="$(op vault list --format json | jq -r '.[].name' | sort)"
+if ! grep -qx "$VAULT_NAME" <<< "$visible_vaults"; then
+  echo "::error::1Password token cannot access ${VAULT_NAME} vault"
+  echo "Visible vaults:"
+  sed 's/^/- /' <<< "$visible_vaults"
+  exit 1
+fi
+
+if [[ -n "${EXPECTED_FORBIDDEN_VAULT:-}" ]] && grep -qx "$EXPECTED_FORBIDDEN_VAULT" <<< "$visible_vaults"; then
+  echo "::error::1Password token unexpectedly has access to ${EXPECTED_FORBIDDEN_VAULT} vault"
+  exit 1
+fi
+
+op_item_for_key() {
+  local key="$1"
+  case "$key" in
+    GH_OAUTH_CLIENT_SECRET)
+      printf 'github'
+      ;;
+    SLACK_CLIENT_SECRET)
+      printf 'slack'
+      ;;
+    *_OAUTH_CLIENT_SECRET)
+      local prefix="${key%_OAUTH_CLIENT_SECRET}"
+      printf '%s' "$prefix" | tr '[:upper:]_' '[:lower:]-'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+hash_value() {
+  printf '%s' "$1" | sha256sum | cut -d' ' -f1
+}
+
+mask_value() {
+  if [[ "${GITHUB_ACTIONS:-}" != "true" || -z "$1" ]]; then
+    return
+  fi
+  local value="$1"
+  value="${value//'%'/'%25'}"
+  value="${value//$'\r'/'%0D'}"
+  value="${value//$'\n'/'%0A'}"
+  echo "::add-mask::$value"
+}
+
+failures=0
+checked=0
+
+while IFS= read -r key; do
+  [[ -n "$key" ]] || continue
+  checked=$((checked + 1))
+
+  has_github_value=true
+  github_value="${!key-}"
+  if [[ -z "$github_value" ]]; then
+    echo "::error::${key} is missing from GitHub secrets"
+    failures=$((failures + 1))
+    has_github_value=false
+  else
+    mask_value "$github_value"
+  fi
+
+  if ! item="$(op_item_for_key "$key")"; then
+    echo "::error::No 1Password item mapping for ${key}"
+    failures=$((failures + 1))
+    continue
+  fi
+  ref="op://${VAULT_NAME}/${item}/${key}"
+
+  has_op_value=true
+  err_file="$(mktemp)"
+  if ! op_value="$(op read "$ref" 2>"$err_file")"; then
+    echo "::error::${key} is missing from 1Password (${ref})"
+    sed -n '1,3p' "$err_file"
+    rm -f "$err_file"
+    failures=$((failures + 1))
+    has_op_value=false
+    op_value=
+  else
+    rm -f "$err_file"
+  fi
+
+  if [[ "$has_op_value" == "true" && -z "$op_value" ]]; then
+    echo "::error::${key} is empty in 1Password (${ref})"
+    failures=$((failures + 1))
+    has_op_value=false
+  elif [[ "$has_op_value" == "true" ]]; then
+    mask_value "$op_value"
+  fi
+
+  if [[ "$has_github_value" != "true" || "$has_op_value" != "true" ]]; then
+    continue
+  fi
+
+  if [[ "$(hash_value "$github_value")" != "$(hash_value "$op_value")" ]]; then
+    echo "::error::${key} differs between GitHub secrets and 1Password (${ref})"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "ok: ${key}"
+done <<< "$EXPECTED_KEYS"
+
+echo "Checked ${checked} ${VAULT_NAME} secrets"
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "::error::${failures} secret comparison(s) failed"
+  exit 1
+fi

--- a/.github/scripts/verify-1password-secrets.sh
+++ b/.github/scripts/verify-1password-secrets.sh
@@ -27,7 +27,7 @@ if [[ -n "${EXPECTED_FORBIDDEN_VAULT:-}" ]] && grep -qx "$EXPECTED_FORBIDDEN_VAU
 fi
 
 if ! grep -qx "$VAULT_NAME" <<< "$visible_vaults"; then
-  visible_vault_count="$(grep -c . <<< "$visible_vaults")"
+  visible_vault_count="$(awk 'NF { count++ } END { print count + 0 }' <<< "$visible_vaults")"
   echo "::error::1Password token cannot access ${VAULT_NAME} vault; visible vault count: ${visible_vault_count}"
   exit 1
 fi

--- a/.github/scripts/verify-1password-secrets.sh
+++ b/.github/scripts/verify-1password-secrets.sh
@@ -16,16 +16,19 @@ if [[ -z "${EXPECTED_KEYS:-}" ]]; then
   exit 1
 fi
 
-visible_vaults="$(op vault list --format json | jq -r '.[].name' | sort)"
-if ! grep -qx "$VAULT_NAME" <<< "$visible_vaults"; then
-  echo "::error::1Password token cannot access ${VAULT_NAME} vault"
-  echo "Visible vaults:"
-  sed 's/^/- /' <<< "$visible_vaults"
+if ! visible_vaults="$(op vault list --format json | jq -r '.[].name' | sort)"; then
+  echo "::error::failed to list 1Password vaults"
   exit 1
 fi
 
 if [[ -n "${EXPECTED_FORBIDDEN_VAULT:-}" ]] && grep -qx "$EXPECTED_FORBIDDEN_VAULT" <<< "$visible_vaults"; then
   echo "::error::1Password token unexpectedly has access to ${EXPECTED_FORBIDDEN_VAULT} vault"
+  exit 1
+fi
+
+if ! grep -qx "$VAULT_NAME" <<< "$visible_vaults"; then
+  visible_vault_count="$(grep -c . <<< "$visible_vaults")"
+  echo "::error::1Password token cannot access ${VAULT_NAME} vault; visible vault count: ${visible_vault_count}"
   exit 1
 fi
 
@@ -88,16 +91,11 @@ while IFS= read -r key; do
   ref="op://${VAULT_NAME}/${item}/${key}"
 
   has_op_value=true
-  err_file="$(mktemp)"
-  if ! op_value="$(op read "$ref" 2>"$err_file")"; then
-    echo "::error::${key} is missing from 1Password (${ref})"
-    sed -n '1,3p' "$err_file"
-    rm -f "$err_file"
+  if ! op_value="$(op read "$ref" 2>/dev/null)"; then
+    echo "::error::${key} is missing or unreadable from 1Password (${ref})"
     failures=$((failures + 1))
     has_op_value=false
     op_value=
-  else
-    rm -f "$err_file"
   fi
 
   if [[ "$has_op_value" == "true" && -z "$op_value" ]]; then

--- a/.github/workflows/verify-1password-secrets.yml
+++ b/.github/workflows/verify-1password-secrets.yml
@@ -13,8 +13,23 @@ on:
         default: development
 
 jobs:
+  validate-ref:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      contents: read
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Run this workflow from the main branch"
+            exit 1
+          fi
+
   verify-development:
-    if: inputs.scope == 'development'
+    needs: validate-ref
+    if: github.ref == 'refs/heads/main' && inputs.scope == 'development'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
@@ -87,7 +102,8 @@ jobs:
         run: .github/scripts/verify-1password-secrets.sh
 
   verify-production:
-    if: inputs.scope == 'production'
+    needs: validate-ref
+    if: github.ref == 'refs/heads/main' && inputs.scope == 'production'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525

--- a/.github/workflows/verify-1password-secrets.yml
+++ b/.github/workflows/verify-1password-secrets.yml
@@ -1,0 +1,167 @@
+name: Verify Connector OAuth 1Password Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Secret scope to verify"
+        required: true
+        type: choice
+        options:
+          - development
+          - production
+        default: development
+
+jobs:
+  verify-development:
+    if: inputs.scope == 'development'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    # Connector OAuth client secrets declared by `clientSecretEnv` and currently
+    # configured as repository-level GitHub secrets.
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      AIRTABLE_OAUTH_CLIENT_SECRET: ${{ secrets.AIRTABLE_OAUTH_CLIENT_SECRET }}
+      ASANA_OAUTH_CLIENT_SECRET: ${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
+      CANVA_OAUTH_CLIENT_SECRET: ${{ secrets.CANVA_OAUTH_CLIENT_SECRET }}
+      CLOSE_OAUTH_CLIENT_SECRET: ${{ secrets.CLOSE_OAUTH_CLIENT_SECRET }}
+      DEEL_OAUTH_CLIENT_SECRET: ${{ secrets.DEEL_OAUTH_CLIENT_SECRET }}
+      DOCUSIGN_OAUTH_CLIENT_SECRET: ${{ secrets.DOCUSIGN_OAUTH_CLIENT_SECRET }}
+      DROPBOX_OAUTH_CLIENT_SECRET: ${{ secrets.DROPBOX_OAUTH_CLIENT_SECRET }}
+      FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
+      GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+      GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+      HUBSPOT_OAUTH_CLIENT_SECRET: ${{ secrets.HUBSPOT_OAUTH_CLIENT_SECRET }}
+      LINEAR_OAUTH_CLIENT_SECRET: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
+      META_ADS_OAUTH_CLIENT_SECRET: ${{ secrets.META_ADS_OAUTH_CLIENT_SECRET }}
+      MICROSOFT_OAUTH_CLIENT_SECRET: ${{ secrets.MICROSOFT_OAUTH_CLIENT_SECRET }}
+      MONDAY_OAUTH_CLIENT_SECRET: ${{ secrets.MONDAY_OAUTH_CLIENT_SECRET }}
+      NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
+      SENTRY_OAUTH_CLIENT_SECRET: ${{ secrets.SENTRY_OAUTH_CLIENT_SECRET }}
+      SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
+      SPOTIFY_OAUTH_CLIENT_SECRET: ${{ secrets.SPOTIFY_OAUTH_CLIENT_SECRET }}
+      STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+      TODOIST_OAUTH_CLIENT_SECRET: ${{ secrets.TODOIST_OAUTH_CLIENT_SECRET }}
+      VERCEL_OAUTH_CLIENT_SECRET: ${{ secrets.VERCEL_OAUTH_CLIENT_SECRET }}
+      WEBFLOW_OAUTH_CLIENT_SECRET: ${{ secrets.WEBFLOW_OAUTH_CLIENT_SECRET }}
+      XERO_OAUTH_CLIENT_SECRET: ${{ secrets.XERO_OAUTH_CLIENT_SECRET }}
+      X_OAUTH_CLIENT_SECRET: ${{ secrets.X_OAUTH_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify development secrets
+        shell: bash
+        env:
+          VAULT_NAME: Development
+          EXPECTED_FORBIDDEN_VAULT: Production
+          EXPECTED_KEYS: |
+            AIRTABLE_OAUTH_CLIENT_SECRET
+            ASANA_OAUTH_CLIENT_SECRET
+            CANVA_OAUTH_CLIENT_SECRET
+            CLOSE_OAUTH_CLIENT_SECRET
+            DEEL_OAUTH_CLIENT_SECRET
+            DOCUSIGN_OAUTH_CLIENT_SECRET
+            DROPBOX_OAUTH_CLIENT_SECRET
+            FIGMA_OAUTH_CLIENT_SECRET
+            GH_OAUTH_CLIENT_SECRET
+            GOOGLE_OAUTH_CLIENT_SECRET
+            HUBSPOT_OAUTH_CLIENT_SECRET
+            LINEAR_OAUTH_CLIENT_SECRET
+            META_ADS_OAUTH_CLIENT_SECRET
+            MICROSOFT_OAUTH_CLIENT_SECRET
+            MONDAY_OAUTH_CLIENT_SECRET
+            NOTION_OAUTH_CLIENT_SECRET
+            SENTRY_OAUTH_CLIENT_SECRET
+            SLACK_CLIENT_SECRET
+            SPOTIFY_OAUTH_CLIENT_SECRET
+            STRIPE_OAUTH_CLIENT_SECRET
+            TODOIST_OAUTH_CLIENT_SECRET
+            VERCEL_OAUTH_CLIENT_SECRET
+            WEBFLOW_OAUTH_CLIENT_SECRET
+            XERO_OAUTH_CLIENT_SECRET
+            X_OAUTH_CLIENT_SECRET
+        run: .github/scripts/verify-1password-secrets.sh
+
+  verify-production:
+    if: inputs.scope == 'production'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    environment: production
+    # Connector OAuth client secrets declared by `clientSecretEnv` and currently
+    # configured in the production GitHub environment.
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      AIRTABLE_OAUTH_CLIENT_SECRET: ${{ secrets.AIRTABLE_OAUTH_CLIENT_SECRET }}
+      ASANA_OAUTH_CLIENT_SECRET: ${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
+      CANVA_OAUTH_CLIENT_SECRET: ${{ secrets.CANVA_OAUTH_CLIENT_SECRET }}
+      CLOSE_OAUTH_CLIENT_SECRET: ${{ secrets.CLOSE_OAUTH_CLIENT_SECRET }}
+      DEEL_OAUTH_CLIENT_SECRET: ${{ secrets.DEEL_OAUTH_CLIENT_SECRET }}
+      DOCUSIGN_OAUTH_CLIENT_SECRET: ${{ secrets.DOCUSIGN_OAUTH_CLIENT_SECRET }}
+      DROPBOX_OAUTH_CLIENT_SECRET: ${{ secrets.DROPBOX_OAUTH_CLIENT_SECRET }}
+      FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
+      GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+      GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+      GUMROAD_OAUTH_CLIENT_SECRET: ${{ secrets.GUMROAD_OAUTH_CLIENT_SECRET }}
+      HUBSPOT_OAUTH_CLIENT_SECRET: ${{ secrets.HUBSPOT_OAUTH_CLIENT_SECRET }}
+      INTERVALS_ICU_OAUTH_CLIENT_SECRET: ${{ secrets.INTERVALS_ICU_OAUTH_CLIENT_SECRET }}
+      LINEAR_OAUTH_CLIENT_SECRET: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
+      META_ADS_OAUTH_CLIENT_SECRET: ${{ secrets.META_ADS_OAUTH_CLIENT_SECRET }}
+      MICROSOFT_OAUTH_CLIENT_SECRET: ${{ secrets.MICROSOFT_OAUTH_CLIENT_SECRET }}
+      MONDAY_OAUTH_CLIENT_SECRET: ${{ secrets.MONDAY_OAUTH_CLIENT_SECRET }}
+      NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
+      SENTRY_OAUTH_CLIENT_SECRET: ${{ secrets.SENTRY_OAUTH_CLIENT_SECRET }}
+      SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
+      SPOTIFY_OAUTH_CLIENT_SECRET: ${{ secrets.SPOTIFY_OAUTH_CLIENT_SECRET }}
+      STRAVA_OAUTH_CLIENT_SECRET: ${{ secrets.STRAVA_OAUTH_CLIENT_SECRET }}
+      STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+      TODOIST_OAUTH_CLIENT_SECRET: ${{ secrets.TODOIST_OAUTH_CLIENT_SECRET }}
+      VERCEL_OAUTH_CLIENT_SECRET: ${{ secrets.VERCEL_OAUTH_CLIENT_SECRET }}
+      WEBFLOW_OAUTH_CLIENT_SECRET: ${{ secrets.WEBFLOW_OAUTH_CLIENT_SECRET }}
+      XERO_OAUTH_CLIENT_SECRET: ${{ secrets.XERO_OAUTH_CLIENT_SECRET }}
+      X_OAUTH_CLIENT_SECRET: ${{ secrets.X_OAUTH_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify production secrets
+        shell: bash
+        env:
+          VAULT_NAME: Production
+          EXPECTED_FORBIDDEN_VAULT: Development
+          EXPECTED_KEYS: |
+            AIRTABLE_OAUTH_CLIENT_SECRET
+            ASANA_OAUTH_CLIENT_SECRET
+            CANVA_OAUTH_CLIENT_SECRET
+            CLOSE_OAUTH_CLIENT_SECRET
+            DEEL_OAUTH_CLIENT_SECRET
+            DOCUSIGN_OAUTH_CLIENT_SECRET
+            DROPBOX_OAUTH_CLIENT_SECRET
+            FIGMA_OAUTH_CLIENT_SECRET
+            GH_OAUTH_CLIENT_SECRET
+            GOOGLE_OAUTH_CLIENT_SECRET
+            GUMROAD_OAUTH_CLIENT_SECRET
+            HUBSPOT_OAUTH_CLIENT_SECRET
+            INTERVALS_ICU_OAUTH_CLIENT_SECRET
+            LINEAR_OAUTH_CLIENT_SECRET
+            META_ADS_OAUTH_CLIENT_SECRET
+            MICROSOFT_OAUTH_CLIENT_SECRET
+            MONDAY_OAUTH_CLIENT_SECRET
+            NOTION_OAUTH_CLIENT_SECRET
+            SENTRY_OAUTH_CLIENT_SECRET
+            SLACK_CLIENT_SECRET
+            SPOTIFY_OAUTH_CLIENT_SECRET
+            STRAVA_OAUTH_CLIENT_SECRET
+            STRIPE_OAUTH_CLIENT_SECRET
+            TODOIST_OAUTH_CLIENT_SECRET
+            VERCEL_OAUTH_CLIENT_SECRET
+            WEBFLOW_OAUTH_CLIENT_SECRET
+            XERO_OAUTH_CLIENT_SECRET
+            X_OAUTH_CLIENT_SECRET
+        run: .github/scripts/verify-1password-secrets.sh


### PR DESCRIPTION
## Summary

- add a manual workflow to verify connector OAuth client secrets that already exist in GitHub against 1Password
- split development and production checks so the same OP_SERVICE_ACCOUNT_TOKEN name resolves through repo-level or production environment secrets
- restrict the manual verifier to the main branch before any secret-reading verification job can run
- add a read-only verifier that masks secret values, compares hashes, and reports all per-key failures without printing values
- cover the verifier with workflow script tests for success, missing GitHub secret, missing 1Password secret, value mismatch, empty vault access, forbidden vault access, GitHub Actions mask output, and ambient env isolation

This is a validation step for #15114 and does not move deployment env rendering to 1Password yet.

## Scope

- development: repository-level GitHub secrets intersected with connector clientSecretEnv keys
- production: production environment GitHub secrets intersected with connector clientSecretEnv keys
- excludes non-connector OAuth secrets such as WIX, DISCORD, and VM0_GITHUB_APP

## Testing

- git diff --check
- bash -n .github/scripts/*.sh .github/scripts/tests/*.sh
- bash .github/scripts/tests/verify-1password-secrets-test.sh
- GITHUB_ACTIONS=true X_OAUTH_CLIENT_SECRET=ambient-value GH_OAUTH_CLIENT_SECRET=ambient-gh bash .github/scripts/tests/verify-1password-secrets-test.sh
- for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done
- Python YAML parse for .github/workflows/verify-1password-secrets.yml
- workflow key consistency check against current GitHub secret names and connector clientSecretEnv declarations
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/verify-1password-secrets.yml

## Notes

The new workflow uses workflow_dispatch and explicitly fails unless it is run from the main branch. Since this is a new workflow file, it should be run after it exists on the default branch.