### PR TITLE
refactor: model slock oauth client as dynamic

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -259,10 +259,10 @@ function mockSlockOAuthProvider(): { readonly accessToken: string } {
     }),
     http.post(SLOCK_TOKEN_URL, async ({ request }) => {
       const body = await request.json();
-      expect(body).toHaveProperty("deviceCode");
       const deviceCode = z
         .object({ deviceCode: z.string() })
         .parse(body).deviceCode;
+      expect(body).toStrictEqual({ deviceCode });
       if (deviceCode === "userinfo-error") {
         return HttpResponse.json({
           accessToken: "slock-access-userinfo-error",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -949,10 +949,10 @@ describe("hasConnectorOAuthProvider", () => {
         "https://api.slock.ai/api/auth/device/token",
         async ({ request }) => {
           const body = await request.json();
-          expect(body).toHaveProperty("deviceCode");
           const deviceCode = z
             .object({ deviceCode: z.string() })
             .parse(body).deviceCode;
+          expect(body).toStrictEqual({ deviceCode });
           if (deviceCode === "pending") {
             return HttpResponse.json(
               {
@@ -1909,9 +1909,8 @@ describe("connector OAuth lifecycle grant helpers", () => {
       deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
       tokenUrl: "https://api.slock.ai/api/auth/device/token",
       client: {
-        clientRegistration: "static",
+        clientRegistration: "dynamic",
         clientType: "public",
-        clientId: "vm0",
       },
       scopes: [],
     });
@@ -1998,9 +1997,8 @@ describe("connector OAuth device authorization config", () => {
       deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
       tokenUrl: "https://api.slock.ai/api/auth/device/token",
       client: {
-        clientRegistration: "static",
+        clientRegistration: "dynamic",
         clientType: "public",
-        clientId: "vm0",
       },
       scopes: [],
     });

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -313,6 +313,10 @@ export type DynamicPublicConnectorOAuthClientConfig = Extract<
   }
 >;
 
+export type PublicConnectorOAuthClientConfig =
+  | StaticPublicConnectorOAuthClientConfig
+  | DynamicPublicConnectorOAuthClientConfig;
+
 export type ConnectorGrantKind =
   | "manual"
   | "auth-code"
@@ -335,7 +339,7 @@ export interface ConnectorDeviceAuthGrantConfig {
   readonly kind: "device-auth";
   readonly deviceAuthUrl: string;
   readonly tokenUrl: string;
-  readonly client: StaticPublicConnectorOAuthClientConfig;
+  readonly client: PublicConnectorOAuthClientConfig;
   readonly scopes: string[];
 }
 

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -17,9 +17,8 @@ export const slock = {
           deviceAuthUrl: `${SLOCK_API_BASE_URL}/api/auth/device/authorize`,
           tokenUrl: `${SLOCK_API_BASE_URL}/api/auth/device/token`,
           client: {
-            clientRegistration: "static",
+            clientRegistration: "dynamic",
             clientType: "public",
-            clientId: "vm0",
           },
           scopes: [],
         },


### PR DESCRIPTION
## Summary
- model Slock device auth as a dynamic public OAuth client instead of a static client with an unused client id
- allow device-auth grants to use public static or dynamic OAuth client configs
- tighten Slock device token tests so the request body cannot include extra client fields

## Verification
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts --run
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts --run
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pre-commit: pnpm check-types