### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Weekly Rust dependency update. Only one transitive dependency was updated; all direct dependencies are already at their latest semver-compatible versions.

**Updated:**
- `displaydoc`: 0.2.5 → 0.2.6 (transitive, proc-macro dependency)

## Dependencies NOT Updated

- `generic-array` (0.14.7 → 0.14.9): Held back by MSRV constraint (requires Rust ≥ 1.95.0). This is a transitive dependency through `block-buffer` → `digest` → AWS SDK / HTTP stack.

## Manual Version Bumps

None required. All direct dependencies (`serde_json`, `tokio`, `reqwest`, `sentry`, `clap`, `uuid`, etc.) are already at the latest version within their current `Cargo.toml` semver ranges.

## Test Status

All library and unit tests pass (2,261 tests across 21 crates):

| Crate | Tests | Status |
|------|-------|--------|
| vsock-proto, api-contracts, agent-diagnostics, guest-reseed, guest-write-file, guest-mock-claude, process-control-ipc, guest-common, guest-mock-codex, guest-download, guest-init, sandbox, sandbox-mock | 0 | N/A |
| nbd-cow | 2 passed | ✓ |
| vsock-guest | 54 passed | ✓ |
| vsock-host | 227 passed | ✓ |
| ably-subscriber | 2 passed + 1 doctest | ✓ |
| sandbox-fc | 460 passed | ✓ |
| vsock-test | 26 passed | ✓ |
| guest-agent (lib) | 206 passed | ✓ |
| runner (bin) | 1,284 passed | ✓ |

**Integration tests not run (sandbox resource constraint):** `guest-agent` (cli_setup_failure, no_api_mode, integration) and `runner` (axiom_layer) integration tests could not be linked due to 16 GB disk / 4 GB RAM limits in the CI sandbox. These are large multi-dependency test binaries and the issue is environment resource exhaustion (linker OOM), not a code defect. The `cargo check --workspace --tests` stage passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)