### PR TITLE
test: cover decode_error malformed payloads

### DIFF
--- a/crates/vsock-proto/src/payloads/error.rs
+++ b/crates/vsock-proto/src/payloads/error.rs
@@ -42,6 +42,14 @@ mod tests {
     }
 
     #[test]
+    fn error_payload_roundtrip_empty_message() {
+        let payload = encode_error("");
+
+        assert_eq!(payload.as_slice(), &[0, 0]);
+        assert!(decode_error(&payload).unwrap().is_empty());
+    }
+
+    #[test]
     fn error_payload_truncates_oversized_ascii_to_u16_max() {
         let message = "A".repeat(u16::MAX as usize + 1);
         let payload = encode_error(&message);

--- a/crates/vsock-proto/src/payloads/error.rs
+++ b/crates/vsock-proto/src/payloads/error.rs
@@ -30,6 +30,10 @@ pub fn decode_error(payload: &[u8]) -> Result<&str, ProtocolError> {
 mod tests {
     use super::*;
 
+    fn assert_invalid_payload(err: ProtocolError, expected: &'static str) {
+        assert!(matches!(err, ProtocolError::InvalidPayload(msg) if msg == expected));
+    }
+
     #[test]
     fn error_payload_roundtrip() {
         let payload = encode_error("something went wrong");
@@ -85,9 +89,22 @@ mod tests {
         let payload = [0, 1, 0xC3];
         let err = decode_error(&payload).unwrap_err();
 
-        assert!(matches!(
-            err,
-            ProtocolError::InvalidPayload("invalid UTF-8 in error")
-        ));
+        assert_invalid_payload(err, "invalid UTF-8 in error");
+    }
+
+    #[test]
+    fn decode_error_rejects_too_short_payload() {
+        for payload in [b"".as_slice(), &[0]] {
+            let err = decode_error(payload).unwrap_err();
+            assert_invalid_payload(err, "error payload too short");
+        }
+    }
+
+    #[test]
+    fn decode_error_rejects_truncated_message() {
+        let payload = [0, 2, b'a'];
+        let err = decode_error(&payload).unwrap_err();
+
+        assert_invalid_payload(err, "error message truncated");
     }
 }


### PR DESCRIPTION
## Summary
- add malformed payload coverage for decode_error too-short inputs
- add declared-length truncation coverage for decode_error
- add valid empty error-message roundtrip coverage for the minimum payload boundary
- keep production decoder behavior unchanged

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto decode_error
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto error_payload_roundtrip_empty_message
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets --all-features -- -D warnings
- cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --all-features --no-deps

Closes #15134