### PR TITLE
fix: classify hosted-site URLs as html in artifact sidebar

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -393,7 +393,7 @@ function isPreviewableChatUrl(url: string): boolean {
   return isPlatformFileUrl(url) || isHostedSiteUrl(url);
 }
 
-function previewAttachmentFromUrl(
+export function previewAttachmentFromUrl(
   url: string,
   title?: string,
 ): ChatAttachmentDescriptor {

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -6,7 +6,10 @@ import {
   searchParams$,
   updateSearchParams$,
 } from "../route.ts";
-import { classifyChatAttachment } from "../chat-page/parse-body-blocks.ts";
+import {
+  classifyChatAttachment,
+  previewAttachmentFromUrl,
+} from "../chat-page/parse-body-blocks.ts";
 import {
   openDocumentLightbox$ as openDocumentLightboxModal$,
   openImageLightbox$ as openImageLightboxModal$,
@@ -64,8 +67,11 @@ export const chatArtifactSidebarEnabled$ = computed((get) => {
 });
 
 // The URL alone is the source of truth: kind + filename are derived from
-// the URL itself via classifyChatAttachment, so deep-linking or refreshing
+// the URL itself via previewAttachmentFromUrl, so deep-linking or refreshing
 // the page re-renders the right body without any in-memory metadata cache.
+// Reusing previewAttachmentFromUrl keeps hosted-site URLs (e.g.
+// *.sites.vm0.io) classified as html, matching how the chat body renders
+// them.
 export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
   const params = get(searchParams$);
   const raw = params.get(ARTIFACT_QUERY_PARAM);
@@ -75,16 +81,10 @@ export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
   if (raw.startsWith(IMAGE_ID_PREFIX)) {
     return decodeArtifactParam(raw);
   }
-  const filename = filenameFromUrl(raw);
-  const kind = classifyChatAttachment({ filename, url: raw });
-  return { source: "url", url: raw, kind, filename };
+  const attachment = previewAttachmentFromUrl(raw);
+  const kind = classifyChatAttachment(attachment);
+  return { source: "url", url: raw, kind, filename: attachment.filename };
 });
-
-function filenameFromUrl(url: string): string {
-  const cleaned = url.split("?")[0].split("#")[0];
-  const last = cleaned.split("/").pop();
-  return last && last.length > 0 ? last : "file";
-}
 
 const openArtifact$ = command(({ get, set }, url: string) => {
   const params = new URLSearchParams(get(searchParams$));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -134,6 +134,26 @@ describe("chatArtifactSidebar: inline anchor chip behavior", () => {
   });
 });
 
+describe("chatArtifactSidebar: hosted-site URL classification", () => {
+  it("classifies hosted-site URLs without a path as html", () => {
+    // Regression: previously the sidebar built its own
+    // filenameFromUrl + classifyChatAttachment pair without contentType,
+    // so *.sites.<host>.io URLs (no path, no extension) fell through to
+    // "file" and rendered the generic "No inline preview" placeholder
+    // instead of the iframe HTML body.
+    const url = "https://demo-site-a1b2c3d4.sites.vm7.io";
+    setup(`/chats/thread-1?artifact=${encodeURIComponent(url)}`);
+
+    const ref = context.store.get(currentArtifactRef$);
+    expect(ref).toStrictEqual({
+      source: "url",
+      url,
+      kind: "html",
+      filename: url,
+    });
+  });
+});
+
 describe("chatArtifactSidebar: sidebar slot rendering", () => {
   it("does not render the sidebar when the switch is off", () => {
     detachedSetupPage({


### PR DESCRIPTION
## Summary

- The artifact sidebar's `currentArtifactRef$` built its own `filenameFromUrl + classifyChatAttachment` pair without supplying a `contentType`. Hosted-site URLs like `*.sites.vm0.io` / `*.sites.vm7.io` have no path segment and no file extension, so `kind` collapsed to `"file"` and `ArtifactGenericBody` rendered the *"No inline preview available for this file."* placeholder.
- Chat-body parsing already had a `previewAttachmentFromUrl` helper that detects hosted-site hostnames and tags them as `text/html`. This PR exports that helper and reuses it from the sidebar so both code paths agree, and the iframe HTML body renders for hosted-site artifacts.
- Drops the duplicate `filenameFromUrl` from `zero-artifact-sidebar.ts`.

Repro before the fix: open `?artifact=https%3A%2F%2F<slug>.sites.vm0.io` → generic "No inline preview" body. After: iframe HTML preview.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx` (9 passed, including the new hosted-site regression test)
- [x] `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/parse-body-blocks.test.ts` (13 passed)
- [x] `pnpm -F @vm0/app run lint`
- [x] `pnpm -F @vm0/app exec tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)