### PR TITLE
feat: register endpaper image-style resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2930,6 +2930,15 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     desc: 'Mellow-pop flat-vector editorial illustration: a recurring chill character with closed-eye smile, tiny nose hint, and short dark bobbed hair, posed inside a scene-as-metaphor composition on a single fully saturated solid color background, with a signature pop of bright leaf-green woven into every piece (hero prop, plants, motifs, or sweater). Thin uniform black outlines, flat solid fills only, no gradients or texture. Five dials per brief: palette, scene metaphor, complexity (L1/L2/L3), pose, outfit accent. Trigger when user says /mellow-pop, asks for a "mellow-pop illustration", "chill flat-vector poster", or briefs with a scene metaphor + palette + complexity.',
     source: { path: "illustration-template/mellow-pop" },
   },
+  {
+    id: "vm0:image-style:endpaper",
+    kind: "image-style",
+    name: "Endpaper",
+    description:
+      "Riso-grain flat-vector collection of chill characters or objects scattered across a saturated solid color field, with two-tone interior shading and closed-eye sleepy faces.",
+    desc: 'Riso-grain flat-vector editorial collection illustration. Many small animals or objects scattered across a fully saturated solid color background — like the inside endpaper of a children\'s picture book. Subtle riso/screenprint grain inside every fill, two-tone interior shading on every character (darker top + lighter belly), closed crescent-eye sleepy smiles with tiny dot noses, NO outlines on character bodies, loose hand-drawn line details on props (yarn spirals, leaf veins, pot stripes), scattered curated composition where characters overlap and touch the canvas edges. Five dials: background hue, cast (cats/dogs/foxes/birds/sea-creatures/houseplants/kitchen-objects/etc.), character palette (3–5 curated fills), density (L1 sparse / L2 balanced / L3 packed), prop vocabulary matched to cast. Trigger when user says /endpaper, asks for an "endpaper illustration", a "scattered animal or object collection on saturated color", a "children\'s-book endpaper scene", or briefs with a cast + background hue + density + palette.',
+    source: { path: "illustration-template/endpaper" },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Wire the new `vm0:image-style:endpaper` resource into the Open Design registry. Source lives at `illustration-template/endpaper/` in [vm0-ai/vm0-skills#228](https://github.com/vm0-ai/vm0-skills/pull/228).

**Style:** Riso-grain flat-vector collection of chill characters or objects scattered across a fully saturated solid color field — like the inside endpaper of a children's picture book. Five dials (background hue, cast, character palette, density, prop vocabulary), strict locked frame (riso grain in every fill, two-tone interior shading, closed crescent-eye faces, no body outlines, scattered overlapping composition that touches the canvas edges).

Single nine-line addition to `open-design-registry.ts` using only the six allowed fields (`id`, `kind`, `name`, `description`, `desc`, `source.path`). No structural changes elsewhere.

## Paired PR

- vm0-skills resource: https://github.com/vm0-ai/vm0-skills/pull/228 (contains the full SKILL.md and six reference images)

## Test plan

- [x] `pnpm --filter @vm0/cli check-types` — passes locally
- [ ] `pnpm --filter @vm0/cli test -- open-design` — registry test passes
- [ ] `zero generate image --style vm0:image-style:endpaper --prompt "<test prompt>"` — resolves the registry ID and produces a usable artifact

## Validation outputs

Six worked examples already generated and committed to the paired vm0-skills PR. Two examples for reviewer reference:

- T2 (garden-birds · butter · jewel-garden · L3): https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/fd4c90df-457d-4cd4-b4b3-cc659d38b4ee/image-fd4c90df.png
- T4 (sea-creatures · cobalt · ocean-coral · L3): https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/943b6927-e007-4e18-9f58-c6ee0467b237/image-943b6927.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)