### PR TITLE
fix(zero): gate local-agent skill and token access

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -133,4 +133,32 @@ describe("auth tokens", () => {
     );
     expect(verifyZeroToken(enabledToken)?.capabilities).toContain("maps:read");
   });
+
+  it("gates local-agent capabilities on the Local Agent connector feature switch", () => {
+    const disabledToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      "org_zero",
+      { [FeatureSwitchKey.LocalAgentConnector]: false },
+    );
+    const enabledToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      "org_zero",
+      { [FeatureSwitchKey.LocalAgentConnector]: true },
+    );
+
+    expect(verifyZeroToken(disabledToken)?.capabilities).not.toContain(
+      "local-agent:read",
+    );
+    expect(verifyZeroToken(disabledToken)?.capabilities).not.toContain(
+      "local-agent:write",
+    );
+    expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
+      "local-agent:read",
+    );
+    expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
+      "local-agent:write",
+    );
+  });
 });

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -26,6 +26,8 @@ const CONDITIONAL_CAPABILITIES = [
   ["computer-use:write", FeatureSwitchKey.ComputerUse],
   ["host:read", FeatureSwitchKey.HostedSites],
   ["host:write", FeatureSwitchKey.HostedSites],
+  ["local-agent:read", FeatureSwitchKey.LocalAgentConnector],
+  ["local-agent:write", FeatureSwitchKey.LocalAgentConnector],
   ["maps:read", FeatureSwitchKey.ZeroMaps],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -699,6 +699,7 @@ describe("POST /api/zero/chat/messages", () => {
         switches: {
           [FeatureSwitchKey.ComputerUse]: true,
           [FeatureSwitchKey.HostedSites]: true,
+          [FeatureSwitchKey.LocalAgentConnector]: true,
         },
         updatedAt: nowDate(),
       });
@@ -714,6 +715,8 @@ describe("POST /api/zero/chat/messages", () => {
     expect(zeroAuth?.capabilities).toContain("computer-use:write");
     expect(zeroAuth?.capabilities).toContain("host:read");
     expect(zeroAuth?.capabilities).toContain("host:write");
+    expect(zeroAuth?.capabilities).toContain("local-agent:read");
+    expect(zeroAuth?.capabilities).toContain("local-agent:write");
   });
 
   it("persists attachments on the user message and injects them into the run prompt", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1893,6 +1893,11 @@ describe("POST /api/zero/runs", () => {
       }),
     ).toBeFalsy();
     expect(
+      volumes.some((volume) => {
+        return volume.mountPath === "/home/user/.claude/skills/local-agent";
+      }),
+    ).toBeFalsy();
+    expect(
       volumes.every((volume) => {
         return volume.system === true;
       }),
@@ -1906,12 +1911,25 @@ describe("POST /api/zero/runs", () => {
       customSkills: ["research-kit"],
     });
     const db = store.set(writeDb$);
-    await db.insert(userConnectors).values({
+    await db.insert(userFeatureSwitches).values({
       orgId: fx.orgId,
       userId: fx.userId,
-      agentId: agent.agentId,
-      connectorType: "slack",
+      switches: { [FeatureSwitchKey.LocalAgentConnector]: true },
     });
+    await db.insert(userConnectors).values([
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        agentId: agent.agentId,
+        connectorType: "slack",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        agentId: agent.agentId,
+        connectorType: "local-agent",
+      },
+    ]);
 
     const response = await accept(
       zeroRunsClient().create({
@@ -1929,12 +1947,17 @@ describe("POST /api/zero/runs", () => {
     const slackIndex = volumes.findIndex((volume) => {
       return volume.mountPath === "/home/user/.claude/skills/slack";
     });
+    const localAgentIndex = volumes.findIndex((volume) => {
+      return volume.mountPath === "/home/user/.claude/skills/local-agent";
+    });
     const customIndex = volumes.findIndex((volume) => {
       return volume.mountPath === "/home/user/.claude/skills/research-kit";
     });
     expect(slackIndex).toBeGreaterThanOrEqual(0);
+    expect(localAgentIndex).toBeGreaterThanOrEqual(0);
     expect(customIndex).toBeGreaterThan(slackIndex);
     expect(volumes[slackIndex]?.system).toBeTruthy();
+    expect(volumes[localAgentIndex]?.system).toBeTruthy();
     expect(volumes[customIndex]).toMatchObject({
       name: "custom-skill@research-kit",
     });

--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -30,7 +30,6 @@ export const SEED_SKILLS: readonly string[] = [
   "kb-authoring",
   "legal-briefing",
   "legal-risk-scoring",
-  "local-agent",
   "marketing-analytics",
   "nda-screening",
   "period-close",


### PR DESCRIPTION
## Summary
- remove `local-agent` from Zero seed skills so it is not mounted by default
- gate `local-agent:read` and `local-agent:write` ZERO_TOKEN capabilities behind `LocalAgentConnector`
- update API tests for token capability gating and connector-skill mounting

## Validation
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/auth/__tests__/tokens.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts -t "mounts seed skills|mounts authorized connector skills"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts -t "passes user feature switch overrides into generated ZERO_TOKEN capabilities"`
- `pnpm -F api lint`
- `git diff --check`
- `pnpm -F api check-types` fails locally on clean `origin/main` too; first error: `src/signals/context/__tests__/route.test.ts(141,21): error TS2339: Property 'body' does not exist on type 'never'.`
