### PR TITLE
Simplify computer-use command output

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -433,7 +433,7 @@ describe("desktop computer-use runtime", () => {
         body: {
           status: "succeeded",
           result: {
-            text: "snapshot_id=snap_1\n1 button Open",
+            appState: "snapshot_id=snap_1\n1 button Open",
             snapshotId: "snap_1",
           },
         },
@@ -523,7 +523,7 @@ describe("desktop computer-use runtime", () => {
         body: {
           status: "succeeded",
           result: {
-            text: "clicked",
+            summary: "Clicked elementIndex=7",
             elementIndex: 7,
             dispatchMode: "accessibility_action",
             dispatchTarget: "element",
@@ -552,7 +552,7 @@ describe("desktop computer-use runtime", () => {
       dispatchTarget: "element",
       elementIndex: 7,
       inputRisk: "targeted_app_action",
-      textLength: 7,
+      summary: "Clicked elementIndex=7",
     });
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -251,6 +251,7 @@ function redactedResultForAudit(
     "key",
     "pages",
     "role",
+    "summary",
     "x",
     "y",
   ]) {
@@ -263,11 +264,27 @@ function redactedResultForAudit(
       redacted[key] = value;
     }
   }
-  if (typeof result.text === "string") {
-    redacted.textLength = result.text.length;
+  if (typeof result.appState === "string") {
+    redacted.appStateLength = result.appState.length;
   }
   if (typeof result.screenshot === "string") {
     redacted.screenshot = "[redacted]";
+  }
+  const action = result.action;
+  if (action && typeof action === "object" && !Array.isArray(action)) {
+    const redactedAction: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(action)) {
+      if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ) {
+        redactedAction[key] = value;
+      }
+    }
+    if (Object.keys(redactedAction).length > 0) {
+      redacted.action = redactedAction;
+    }
   }
   if (Object.keys(redacted).length > 0) {
     return redacted;

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -178,15 +178,18 @@ describe("computer-use command visibility", () => {
     const text = await formatComputerUseResultForConsole({
       app: "Slack/Test App",
       snapshotId: "desktop_test_snapshot",
-      text: "snapshot_id=snap_1\nw0 AXWindow",
+      appState: "snapshot_id=snap_1\nw0 AXWindow",
       screenshot: `data:image/png;base64,${screenshotBase64}`,
       screenshotSource: "window",
     });
 
     const parsed = JSON.parse(text) as Record<string, unknown>;
+    expect(parsed.status).toBe("succeeded");
+    expect(parsed.snapshotId).toBe("desktop_test_snapshot");
     expect(parsed.screenshot).toBe(TEST_SCREENSHOT_PATH);
+    expect(parsed.appState).toBe("snapshot_id=snap_1\nw0 AXWindow");
     expect(text).toContain("snapshot_id=snap_1");
-    expect(text).toContain("screenshotSource");
+    expect(text).not.toContain("screenshotSource");
     expect(text).not.toContain(screenshotBase64);
     await expect(readFile(TEST_SCREENSHOT_PATH)).resolves.toEqual(
       screenshotBytes,
@@ -225,7 +228,7 @@ describe("computer-use command visibility", () => {
             result: {
               app: "Slack/Test App",
               snapshotId: "desktop_test_snapshot",
-              text: "snapshot_id=desktop_test_snapshot\nw0 AXWindow",
+              appState: "snapshot_id=desktop_test_snapshot\nw0 AXWindow",
               screenshot: `data:image/png;base64,${screenshotBase64}`,
               screenshotMimeType: "image/png",
               screenshotWidth: 1363,
@@ -252,10 +255,14 @@ describe("computer-use command visibility", () => {
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed.status).toBe("succeeded");
+    expect(parsed.snapshotId).toBe("desktop_test_snapshot");
     expect(parsed.screenshot).toBe(TEST_SCREENSHOT_PATH);
-    expect(parsed.text).toBe("snapshot_id=desktop_test_snapshot\nw0 AXWindow");
-    expect(parsed.screenshotWidth).toBe(1363);
-    expect(parsed.screenshotHeight).toBe(1200);
+    expect(parsed.appState).toBe(
+      "snapshot_id=desktop_test_snapshot\nw0 AXWindow",
+    );
+    expect(parsed.screenshotWidth).toBeUndefined();
+    expect(parsed.screenshotHeight).toBeUndefined();
     expect(output).not.toContain(screenshotBase64);
     await expect(readFile(TEST_SCREENSHOT_PATH)).resolves.toEqual(
       screenshotBytes,
@@ -304,7 +311,7 @@ describe("computer-use command visibility", () => {
               button: "right",
               clickCount: 2,
             },
-            result: { text: "clicked" },
+            result: { action: { summary: "Clicked 680,600" } },
             timeoutMs: 10_000,
             createdAt: "2026-05-21T10:00:00.000Z",
             claimedAt: "2026-05-21T10:00:01.000Z",
@@ -335,7 +342,8 @@ describe("computer-use command visibility", () => {
     ]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain('"text": "clicked"');
+    expect(output).toContain('"status": "succeeded"');
+    expect(output).toContain('"summary": "Clicked 680,600"');
   });
 
   it("should send click element indexes", async () => {
@@ -378,7 +386,7 @@ describe("computer-use command visibility", () => {
               button: "left",
               clickCount: 1,
             },
-            result: { text: "clicked" },
+            result: { action: { summary: "Clicked elementIndex=7" } },
             timeoutMs: 30_000,
             createdAt: "2026-05-21T10:00:00.000Z",
             claimedAt: "2026-05-21T10:00:01.000Z",
@@ -401,6 +409,7 @@ describe("computer-use command visibility", () => {
     ]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain('"text": "clicked"');
+    expect(output).toContain('"status": "succeeded"');
+    expect(output).toContain('"summary": "Clicked elementIndex=7"');
   });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -207,6 +207,18 @@ function extensionForMimeType(mimeType: string): string {
   return sanitizeFilenamePart(suffix, "bin").toLowerCase();
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const field = value[key];
+  return typeof field === "string" ? field : undefined;
+}
+
 async function writeScreenshotDataUrl(
   result: Record<string, unknown>,
   dataUrl: string,
@@ -234,23 +246,51 @@ async function writeScreenshotDataUrl(
   return outputPath;
 }
 
+function compactActionResult(
+  action: Record<string, unknown>,
+): Record<string, unknown> {
+  const compact: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(action)) {
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      compact[key] = value;
+    }
+  }
+  return compact;
+}
+
 export async function formatComputerUseResultForConsole(
   result: Record<string, unknown>,
 ): Promise<string> {
-  const printable: Record<string, unknown> = { ...result };
-  if (typeof printable.screenshot === "string") {
-    const screenshotPath = await writeScreenshotDataUrl(
-      printable,
-      printable.screenshot,
-    );
-    if (screenshotPath) {
-      printable.screenshot = screenshotPath;
-    }
+  const printable: Record<string, unknown> = { status: "succeeded" };
+  const apps = result.apps;
+  if (Array.isArray(apps)) {
+    printable.apps = apps;
+  }
+  const snapshotId = stringField(result, "snapshotId");
+  if (snapshotId) {
+    printable.snapshotId = snapshotId;
+  }
+  const appState = stringField(result, "appState");
+  if (appState) {
+    printable.appState = appState;
+  }
+  const screenshot = stringField(result, "screenshot");
+  if (screenshot) {
+    const screenshotPath = await writeScreenshotDataUrl(result, screenshot);
+    printable.screenshot = screenshotPath ?? screenshot;
+  }
+  const action = result.action;
+  if (isRecord(action)) {
+    printable.action = compactActionResult(action);
   }
   return JSON.stringify(printable, null, 2);
 }
 
-async function resultText(
+async function commandOutputText(
   command: ComputerUseCommandResponse,
 ): Promise<string> {
   if (!command.result) {
@@ -290,7 +330,7 @@ async function waitForCommand(
       );
     }
 
-    const text = await resultText(command);
+    const text = await commandOutputText(command);
     if (text) {
       console.log(text);
     }

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1169,7 +1169,7 @@ function buildComputerUseAppStateResult(
   );
   return {
     ...publicAppStateSnapshot(snapshot),
-    text: renderAccessibilityTree(snapshot),
+    appState: renderAccessibilityTree(snapshot),
     visibleTextSource: "accessibility",
     visibleText: renderAccessibilityVisibleText(visibleElements),
     visibleElements,
@@ -1243,7 +1243,7 @@ async function listApps(
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
   const apps = [...(await nativeBackend.listApps())].sort();
-  return { status: "succeeded", result: { apps, text: apps.join("\n") } };
+  return { status: "succeeded", result: { apps } };
 }
 
 async function getAppState(
@@ -1344,7 +1344,7 @@ async function openApp(
     result: {
       app,
       ...nativeResult,
-      text: `Opened ${app}`,
+      summary: `Opened ${app}`,
     },
   };
 }
@@ -1467,7 +1467,7 @@ async function clickElement(args: {
         button: args.button,
         clickCount: args.clickCount,
         ...nativeResult,
-        text: `Clicked ${elementTargetText(target)}`,
+        summary: `Clicked ${elementTargetText(target)}`,
       },
     };
   }
@@ -1505,7 +1505,7 @@ async function clickElement(args: {
         button: args.button,
         clickCount: args.clickCount,
         ...nativeResult,
-        text: `Clicked ${args.x},${args.y}`,
+        summary: `Clicked ${args.x},${args.y}`,
       },
     };
   }
@@ -1535,7 +1535,7 @@ async function setElementValue(
       app,
       ...elementTargetResult(target),
       ...nativeResult,
-      text: `Set ${elementTargetText(target)}`,
+      summary: `Set ${elementTargetText(target)}`,
     },
   };
 }
@@ -1562,7 +1562,7 @@ async function performElementAction(
       ...elementTargetResult(target),
       action,
       ...nativeResult,
-      text: `Performed ${action}`,
+      summary: `Performed ${action}`,
     },
   };
 }
@@ -1578,7 +1578,7 @@ async function typeText(
     result: {
       app,
       ...result,
-      text: "Typed text",
+      summary: "Typed text",
     },
   };
 }
@@ -1596,7 +1596,7 @@ async function pressKey(
       app,
       key: normalizedKey,
       ...nativeResult,
-      text: `Pressed ${normalizedKey}`,
+      summary: `Pressed ${normalizedKey}`,
     },
   };
 }
@@ -1626,7 +1626,7 @@ async function scrollElement(
       direction,
       pages,
       ...nativeResult,
-      text: `Scrolled ${elementTargetText(target)}`,
+      summary: `Scrolled ${elementTargetText(target)}`,
     },
   };
 }

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -177,7 +177,7 @@ describe("ComputerUseHostRuntime", () => {
       return {
         status: "succeeded",
         result: {
-          text: "0 standard window Inbox",
+          appState: "0 standard window Inbox",
           screenshot: "data:image/png;base64,abc123",
           screenshotWidth: 800,
           screenshotHeight: 600,
@@ -198,7 +198,7 @@ describe("ComputerUseHostRuntime", () => {
       status: "succeeded",
       payload: { app: "Things" },
       result: {
-        text: "0 standard window Inbox",
+        appState: "0 standard window Inbox",
         screenshot: "data:image/png;base64,abc123",
         screenshotWidth: 800,
         screenshotHeight: 600,
@@ -226,7 +226,7 @@ describe("ComputerUseHostRuntime", () => {
     expect(JSON.parse(String(completionCall[1]?.body))).toMatchObject({
       status: "succeeded",
       result: {
-        text: "0 standard window Inbox",
+        appState: "0 standard window Inbox",
         screenshot: "data:image/png;base64,abc123",
       },
     });

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -465,7 +465,7 @@ describe("computer use native backend", () => {
           app: "Safari",
           elementIdsByIndex: ["w0", "w0.e0"],
           screenshot: "data:image/png;base64,abc123",
-          text: expect.stringContaining("<app_state>"),
+          appState: expect.stringContaining("<app_state>"),
         },
       });
       expect(responses[1]).toMatchObject({
@@ -473,7 +473,7 @@ describe("computer use native backend", () => {
         result: {
           app: "Safari",
           screenshot: "data:image/png;base64,abc123",
-          text: expect.stringContaining("<app_state>"),
+          appState: expect.stringContaining("<app_state>"),
           action: {
             app: "Safari",
             elementIndex: 1,
@@ -514,7 +514,7 @@ describe("computer use native backend", () => {
           app: "Safari",
           elementIdsByIndex: ["w0", "w0.e0"],
           screenshot: "data:image/png;base64,abc123",
-          text: expect.stringContaining("<app_state>"),
+          appState: expect.stringContaining("<app_state>"),
         },
       });
     } finally {

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -65,12 +65,12 @@ const COMMAND_STATUS_LABELS = {
 } as const satisfies Record<CommandLogEntry["status"], string>;
 
 const RESULT_SUMMARY_KEYS_TO_SKIP = new Set([
+  "appState",
   "elements",
   "screenshot",
-  "text",
   "visibleElements",
 ]);
-const RESULT_TEXT_PREVIEW_LABEL = "[shown in App State]";
+const RESULT_APP_STATE_PREVIEW_LABEL = "[shown in App State]";
 
 function BridgeSubscription() {
   const setupBridge = useSet(setupComputerUseBridge$);
@@ -265,8 +265,8 @@ function resultSummaryRecord(
       summary[key] = jsonDisplayValue(value);
     }
   }
-  if (recordStringValue(result, "text")) {
-    summary.text = RESULT_TEXT_PREVIEW_LABEL;
+  if (recordStringValue(result, "appState")) {
+    summary.appState = RESULT_APP_STATE_PREVIEW_LABEL;
   }
   if (recordStringValue(result, "screenshot")) {
     summary.screenshot = "[shown as image]";
@@ -647,7 +647,7 @@ function CommandLogRow({
   readonly onPreviewScreenshot: (preview: ScreenshotPreview) => void;
   readonly onToggle: () => void;
 }) {
-  const resultText = recordStringValue(entry.result, "text");
+  const resultAppState = recordStringValue(entry.result, "appState");
   const screenshot = recordStringValue(entry.result, "screenshot");
   const visibleElements = visibleElementRecords(entry.result);
   const completedAt = entry.completedAt ?? entry.startedAt;
@@ -703,9 +703,9 @@ function CommandLogRow({
               />
             </CommandLogSection>
           )}
-          {resultText && (
+          {resultAppState && (
             <CommandLogSection title="App State" icon={<IconCode size={15} />}>
-              <pre className="agent-state-block">{resultText}</pre>
+              <pre className="agent-state-block">{resultAppState}</pre>
             </CommandLogSection>
           )}
           {screenshot && (

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1058,7 +1058,7 @@ describe("computer use desktop runtime", () => {
         screenshotSourceBounds: { x: 100, y: 200, width: 800, height: 600 },
       },
     });
-    expect(result.result.text).toContain("0 standard window Example");
+    expect(result.result.appState).toContain("0 standard window Example");
     expect(result.result.elements).toStrictEqual([
       {
         index: 0,
@@ -1145,9 +1145,11 @@ describe("computer use desktop runtime", () => {
       app: "Slack",
       snapshotId: expect.stringMatching(/^desktop_/),
     });
-    expect(result.result.text).toContain("Release notes posted");
-    expect(result.result.text).toContain("text entry area Message composer");
-    expect(result.result.text).toContain("Secondary Actions: Confirm");
+    expect(result.result.appState).toContain("Release notes posted");
+    expect(result.result.appState).toContain(
+      "text entry area Message composer",
+    );
+    expect(result.result.appState).toContain("Secondary Actions: Confirm");
     expect(result.result.visibleText).toContain(
       "AXStaticText [AXValue] Release notes posted",
     );
@@ -1279,10 +1281,10 @@ describe("computer use desktop runtime", () => {
         app: "Things",
         elementId: "sidebar.inbox",
         dispatchMode: "accessibility_action",
-        text: "Clicked sidebar.inbox",
+        summary: "Clicked sidebar.inbox",
       },
     });
-    expect(result.result.text).toContain("Can you see this?");
+    expect(result.result.appState).toContain("Can you see this?");
     expect(result.result.visibleText).toContain("Can you see this?");
   });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -42,6 +42,7 @@ export const computerUseCommandErrorCodeSchema = z.enum([
   "screen_recording_unavailable",
   "app_not_found",
   "app_open_failed",
+  "element_action_unsupported",
   "unsupported_command",
   "timeout",
 ]);


### PR DESCRIPTION
## Summary
- rename Computer Use app-state payloads from `text` to `appState` at the desktop/native result layer
- return `apps` directly for `list-apps` instead of newline text
- make CLI stdout agent-facing: `status`, `apps`, `snapshotId`, `appState`, `screenshot`, and compact scalar `action` only
- update desktop renderer, API audit redaction, contracts, and tests for the final non-compatible output shape

## Validation
- `pnpm format`
- `pnpm check-types`
- `pnpm lint`
- `pnpm knip`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/cli test`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts`
- `pnpm -F @vm0/desktop build`
- `pnpm -F @vm0/cli build`
- `pnpm -F api build`

## Local environment note
- `pnpm -F api test` currently fails locally because the local test database schema is stale and missing `org_metadata.onboarding_payment_pending`; the focused zero-computer-use API test passes.