### PR TITLE
feat: register editorial-flatfolk image-style resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -3000,6 +3000,19 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
       path: "illustration-template/mellow-pop",
     },
   },
+  {
+    id: "vm0:image-style:editorial-flatfolk",
+    kind: "image-style",
+    name: "Editorial Flatfolk",
+    description:
+      "Editorial hand-drawn naive book-illustration style — flat saturated color blocks, loose ink line overlay, paper grain, and a strong sense of place.",
+    desc: 'Editorial hand-drawn naive book-illustration style. Flat saturated color blocks with loose hand-drawn ink line work sitting ON TOP of the color, subtle paper grain across the canvas, simple ink hatching for sky / sun rays / rain / snow, and a strong sense of place built from tall narrow architecture and a one-point depth axis. Five dials per brief: palette (warm-primary, coastal-peach, jewel-night, winter-cool, autumn-rust, monsoon-twilight), scene metaphor (street, harbor, market, transit, park, square, interior, alpine-village), perspective (one-point street, frontal facade, low-angle hero, isometric, top-down), cast (solo wanderer, paired, small crowd, none), and light/weather (midday sun, golden hour, rain, snow, blue hour). Trigger when user says /editorial-flatfolk, asks for an "editorial flat-folk illustration", a "saturated naive book-illustration scene", a "tall narrow row-house illustration", or briefs a palette + scene metaphor + season.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/editorial-flatfolk",
+    },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers `vm0:image-style:editorial-flatfolk` in the Open Design registry. The resource template lives in `vm0-ai/vm0-skills@main:illustration-template/editorial-flatfolk/`.

## Style

Editorial hand-drawn naive book-illustration style — flat saturated color blocks, loose ink line overlay sitting **on top of** the color, subtle paper grain, simple ink hatching, and a strong sense of place built from tall narrow architecture and a one-point depth axis. Five creative dials sit over the locked core: palette, scene metaphor, perspective, cast, and light/weather.

The companion vm0-skills PR adds the SKILL.md and four reference anchors (one canonical + three exemplars from the validation batch).

## Registry entry shape

Matches the established `vm0:image-style:*` neighbors and the post-#15113 `OpenDesignSourceRef` shape (path + repo + ref):

```typescript
{
  id: "vm0:image-style:editorial-flatfolk",
  kind: "image-style",
  name: "Editorial Flatfolk",
  description: "Editorial hand-drawn naive book-illustration style — flat saturated color blocks, loose ink line overlay, paper grain, and a strong sense of place.",
  desc: "<longer trigger-bearing description>",
  source: {
    repo: VM0_SKILLS_REPO,
    ref: VM0_SKILLS_REF,
    path: "illustration-template/editorial-flatfolk",
  },
},
```

`description` is 147 chars — under the ~150-char selection budget.

## Linked PR

Resource template: https://github.com/vm0-ai/vm0-skills/pull/229

## Validation

Locally green:
- `pnpm --filter @vm0/cli exec tsc --noEmit` — no errors
- `pnpm --filter @vm0/cli exec vitest run open-design` — 9/9
- `pnpm --filter @vm0/cli exec vitest run presentation` — 3/3
- `pnpm --filter @vm0/cli exec vitest run image.test` — 14/14

## Test plan

- [ ] CI green
- [ ] `zero generate image --style vm0:image-style:editorial-flatfolk --prompt "..."` resolves the new ID end-to-end
- [ ] Visual smoke render matches the locked style axes documented in the SKILL.md