### PR TITLE
refactor(web): move rankings query behind public api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-stats.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-stats.test.ts
@@ -219,3 +219,69 @@ describe("GET /api/internal/cron/aggregate-model-stats", () => {
     expect(unknownModelRow).toBeUndefined();
   });
 });
+
+describe("GET /api/public/model-rankings", () => {
+  it("returns canonicalized public rankings without auth", async () => {
+    const db = store.set(writeDb$);
+    const model = "claude-sonnet-4-6";
+    const modelAlias = "anthropic/claude-sonnet-4.6";
+    const daySeed = Number.parseInt(randomUUID().slice(0, 8), 16);
+    const windowStart = new Date(Date.UTC(2200, 0, 1 + (daySeed % 90), 0));
+    const windowEnd = new Date(windowStart.getTime() + 12 * HOUR_MS);
+    const currentHour = new Date(windowEnd.getTime() - HOUR_MS);
+    const previousHour = new Date(windowStart.getTime() - HOUR_MS);
+    mockNow(new Date(windowEnd.getTime() + 30 * 60_000));
+
+    await db.insert(modelStat).values([
+      {
+        hourStart: currentHour,
+        model: modelAlias,
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 40,
+        cacheCreationInputTokens: 10,
+        totalTokens: 200,
+      },
+      {
+        hourStart: previousHour,
+        model,
+        totalTokens: 80,
+      },
+    ]);
+
+    const response = await accept(
+      client().rankings({ query: { period: "today" } }),
+      [200],
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=600",
+    );
+    expect(response.body).toStrictEqual({
+      period: "today",
+      totalTokens: 200,
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      rows: [
+        {
+          model,
+          inputTokens: 150,
+          outputTokens: 50,
+          totalTokens: 200,
+          previousTotalTokens: 80,
+        },
+      ],
+    });
+  });
+
+  it("defaults unsupported periods to week", async () => {
+    mockNow(new Date("2300-01-08T15:30:00.000Z"));
+
+    const response = await accept(
+      client().rankings({ query: { period: "unsupported" } }),
+      [200],
+    );
+
+    expect(response.body.period).toBe("week");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/model-stats.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-stats.test.ts
@@ -225,6 +225,7 @@ describe("GET /api/public/model-rankings", () => {
     const db = store.set(writeDb$);
     const model = "claude-sonnet-4-6";
     const modelAlias = "anthropic/claude-sonnet-4.6";
+    const unsupportedModel = `unsupported-model-${randomUUID()}`;
     const daySeed = Number.parseInt(randomUUID().slice(0, 8), 16);
     const windowStart = new Date(Date.UTC(2200, 0, 1 + (daySeed % 90), 0));
     const windowEnd = new Date(windowStart.getTime() + 12 * HOUR_MS);
@@ -246,6 +247,12 @@ describe("GET /api/public/model-rankings", () => {
         hourStart: previousHour,
         model,
         totalTokens: 80,
+      },
+      {
+        hourStart: currentHour,
+        model: unsupportedModel,
+        inputTokens: 9999,
+        totalTokens: 9999,
       },
     ]);
 

--- a/turbo/apps/api/src/signals/routes/model-stats.ts
+++ b/turbo/apps/api/src/signals/routes/model-stats.ts
@@ -3,16 +3,28 @@ import { command } from "ccstate";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
-import { authorization$ } from "../context/hono";
+import { authorization$, setResHeader$ } from "../context/hono";
 import { queryOf } from "../context/request";
 import type { RouteEntry } from "../route";
 import {
   aggregateModelStats$,
   DEFAULT_MODEL_STATS_REPROCESS_HOURS,
   MAX_MODEL_STATS_REPROCESS_HOURS,
+  MODEL_RANKING_PERIODS,
+  readPublicModelRankings$,
 } from "../services/model-stats.service";
 
 const c = initContract();
+const PUBLIC_MODEL_RANKINGS_CACHE_CONTROL =
+  "public, s-maxage=300, stale-while-revalidate=600";
+
+const modelRankingRowSchema = z.object({
+  model: z.string(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  totalTokens: z.number(),
+  previousTotalTokens: z.number(),
+});
 
 const aggregateModelStatsContract = c.router({
   aggregate: {
@@ -45,9 +57,27 @@ const aggregateModelStatsContract = c.router({
     },
     summary: "Aggregate hourly model usage statistics",
   },
+  rankings: {
+    method: "GET" as const,
+    path: "/api/public/model-rankings",
+    query: z.object({
+      period: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        period: z.enum(MODEL_RANKING_PERIODS),
+        totalTokens: z.number(),
+        windowStart: z.string(),
+        windowEnd: z.string(),
+        rows: z.array(modelRankingRowSchema),
+      }),
+    },
+    summary: "Read public model usage rankings",
+  },
 });
 
 const aggregateQuery$ = queryOf(aggregateModelStatsContract.aggregate);
+const rankingsQuery$ = queryOf(aggregateModelStatsContract.rankings);
 
 function unauthorized() {
   return {
@@ -86,10 +116,34 @@ const aggregateModelStatsRoute$ = command(
   },
 );
 
+const readPublicModelRankingsRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const query = get(rankingsQuery$);
+    const result = await set(readPublicModelRankings$, query.period, signal);
+
+    set(setResHeader$, "Cache-Control", PUBLIC_MODEL_RANKINGS_CACHE_CONTROL);
+
+    return {
+      status: 200 as const,
+      body: {
+        period: result.period,
+        totalTokens: result.totalTokens,
+        windowStart: result.windowStart.toISOString(),
+        windowEnd: result.windowEnd.toISOString(),
+        rows: result.rows,
+      },
+    };
+  },
+);
+
 export const modelStatsRoutes: readonly RouteEntry[] = [
   {
     route: aggregateModelStatsContract.aggregate,
     handler: aggregateModelStatsRoute$,
+  },
+  {
+    route: aggregateModelStatsContract.rankings,
+    handler: readPublicModelRankingsRoute$,
   },
 ];
 

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -13,11 +13,38 @@ import { nowDate } from "../external/time";
 const HOUR_MS = 60 * 60_000;
 export const DEFAULT_MODEL_STATS_REPROCESS_HOURS = 24;
 export const MAX_MODEL_STATS_REPROCESS_HOURS = 24 * 32;
+export const MODEL_RANKING_PERIODS = ["today", "week", "month"] as const;
 const MODEL_USAGE_KIND = "model";
 const TOKEN_CATEGORY_INPUT = "tokens.input";
 const TOKEN_CATEGORY_OUTPUT = "tokens.output";
 const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
 const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
+
+type ModelRankingPeriod = (typeof MODEL_RANKING_PERIODS)[number];
+
+interface ModelRankingRow {
+  readonly model: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly previousTotalTokens: number;
+}
+
+interface ModelRankingResult {
+  readonly period: ModelRankingPeriod;
+  readonly totalTokens: number;
+  readonly windowStart: Date;
+  readonly windowEnd: Date;
+  readonly rows: readonly ModelRankingRow[];
+}
+
+interface RawModelRankingRow extends Record<string, unknown> {
+  readonly model: string;
+  readonly input_tokens: string | number | bigint;
+  readonly output_tokens: string | number | bigint;
+  readonly total_tokens: string | number | bigint;
+  readonly previous_total_tokens: string | number | bigint;
+}
 
 function getModelAliasEntries() {
   return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
@@ -52,6 +79,56 @@ function utcHourStart(date: Date): Date {
   );
 }
 
+function startOfUtcDay(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function startOfUtcWeek(date: Date): Date {
+  const day = startOfUtcDay(date);
+  const dayOfWeek = day.getUTCDay();
+  const daysSinceMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  return new Date(day.getTime() - daysSinceMonday * 24 * HOUR_MS);
+}
+
+function startOfUtcMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function currentWindow(
+  period: ModelRankingPeriod,
+  now: Date,
+): { start: Date; end: Date } {
+  const end = utcHourStart(now);
+  if (period === "today") {
+    return { start: startOfUtcDay(now), end };
+  }
+  if (period === "month") {
+    return { start: startOfUtcMonth(now), end };
+  }
+  return { start: startOfUtcWeek(now), end };
+}
+
+function toNumber(value: string | number | bigint): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  return Number(value);
+}
+
+function parseModelRankingPeriod(
+  value: string | undefined,
+): ModelRankingPeriod {
+  if (value === "today" || value === "week" || value === "month") {
+    return value;
+  }
+  return "week";
+}
+
 function usageEventModelExpression() {
   const providerColumn = sql.raw('"usage_event"."provider"');
   return sql<string>`CASE ${sql.join(
@@ -60,6 +137,16 @@ function usageEventModelExpression() {
     }),
     sql` `,
   )} ELSE ${providerColumn} END`;
+}
+
+function modelStatModelExpression() {
+  const modelColumn = sql.raw('"model_stat"."model"');
+  return sql<string>`CASE ${sql.join(
+    getModelAliasEntries().map(([alias, model]) => {
+      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
+    }),
+    sql` `,
+  )} ELSE ${modelColumn} END`;
 }
 
 async function replaceModelStats(
@@ -169,6 +256,71 @@ async function replaceModelStats(
   return result.rowCount ?? 0;
 }
 
+async function selectModelRankings(
+  db: Db,
+  period: ModelRankingPeriod,
+): Promise<ModelRankingResult> {
+  const window = currentWindow(period, nowDate());
+  const duration = Math.max(window.end.getTime() - window.start.getTime(), 0);
+  const previousEnd = window.start;
+  const previousStart = new Date(previousEnd.getTime() - duration);
+  const modelExpr = modelStatModelExpression();
+
+  const result = await db.execute<RawModelRankingRow>(sql`
+    WITH current_period AS (
+      SELECT
+        ${modelExpr} AS model,
+        COALESCE(SUM(${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}), 0)::bigint AS input_tokens,
+        COALESCE(SUM(${modelStat.outputTokens}), 0)::bigint AS output_tokens,
+        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS total_tokens
+      FROM ${modelStat}
+      WHERE ${modelStat.hourStart} >= ${window.start}
+        AND ${modelStat.hourStart} < ${window.end}
+      GROUP BY 1
+    ),
+    previous_period AS (
+      SELECT
+        ${modelExpr} AS model,
+        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS previous_total_tokens
+      FROM ${modelStat}
+      WHERE ${modelStat.hourStart} >= ${previousStart}
+        AND ${modelStat.hourStart} < ${previousEnd}
+      GROUP BY 1
+    )
+    SELECT
+      current_period.model,
+      current_period.input_tokens,
+      current_period.output_tokens,
+      current_period.total_tokens,
+      COALESCE(previous_period.previous_total_tokens, 0)::bigint AS previous_total_tokens
+    FROM current_period
+    LEFT JOIN previous_period ON previous_period.model = current_period.model
+    WHERE current_period.total_tokens > 0
+    ORDER BY current_period.total_tokens DESC
+    LIMIT 50
+  `);
+
+  const rows = result.rows.map((row) => {
+    return {
+      model: row.model,
+      inputTokens: toNumber(row.input_tokens),
+      outputTokens: toNumber(row.output_tokens),
+      totalTokens: toNumber(row.total_tokens),
+      previousTotalTokens: toNumber(row.previous_total_tokens),
+    };
+  });
+
+  return {
+    period,
+    totalTokens: rows.reduce((sum, row) => {
+      return sum + row.totalTokens;
+    }, 0),
+    windowStart: window.start,
+    windowEnd: window.end,
+    rows,
+  };
+}
+
 export const aggregateModelStats$ = command(
   async (
     { set },
@@ -188,5 +340,22 @@ export const aggregateModelStats$ = command(
       windowEnd,
       aggregated,
     };
+  },
+);
+
+export const readPublicModelRankings$ = command(
+  async (
+    { set },
+    periodValue: string | undefined,
+    signal: AbortSignal,
+  ): Promise<ModelRankingResult> => {
+    const db = set(writeDb$);
+    const period = parseModelRankingPeriod(periodValue);
+
+    signal.throwIfAborted();
+    const result = await selectModelRankings(db, period);
+    signal.throwIfAborted();
+
+    return result;
   },
 );

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -265,6 +265,8 @@ async function selectModelRankings(
   const previousEnd = window.start;
   const previousStart = new Date(previousEnd.getTime() - duration);
   const modelExpr = modelStatModelExpression();
+  const currentModelStatsModelIdSql = getModelStatsModelIdSql();
+  const previousModelStatsModelIdSql = getModelStatsModelIdSql();
 
   const result = await db.execute<RawModelRankingRow>(sql`
     WITH current_period AS (
@@ -276,6 +278,7 @@ async function selectModelRankings(
       FROM ${modelStat}
       WHERE ${modelStat.hourStart} >= ${window.start}
         AND ${modelStat.hourStart} < ${window.end}
+        AND ${modelStat.model} IN (${currentModelStatsModelIdSql})
       GROUP BY 1
     ),
     previous_period AS (
@@ -285,6 +288,7 @@ async function selectModelRankings(
       FROM ${modelStat}
       WHERE ${modelStat.hourStart} >= ${previousStart}
         AND ${modelStat.hourStart} < ${previousEnd}
+        AND ${modelStat.model} IN (${previousModelStatsModelIdSql})
       GROUP BY 1
     )
     SELECT

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -834,6 +834,12 @@ const STORAGES_PREPARE_NEXT_NEGATIVE_PATHS = [
 const USAGE_REWRITE_SOURCE = "/api/usage";
 const USAGE_PATH = "/api/usage";
 const USAGE_NEXT_NEGATIVE_PATHS = ["/api/usage/extra", "/api/usages"] as const;
+const PUBLIC_MODEL_RANKINGS_REWRITE_SOURCE = "/api/public/model-rankings";
+const PUBLIC_MODEL_RANKINGS_PATH = "/api/public/model-rankings";
+const PUBLIC_MODEL_RANKINGS_NEXT_NEGATIVE_PATHS = [
+  "/api/public/model-rankings/extra",
+  "/api/public/models-rankings",
+] as const;
 const TEST_SLACK_DISPATCH_PROBE_REWRITE_SOURCE =
   "/api/test/slack-dispatch-probe";
 const TEST_SLACK_DISPATCH_PROBE_PATH = "/api/test/slack-dispatch-probe";
@@ -2285,6 +2291,10 @@ describe("API backend rewrites", () => {
         {
           source: USAGE_REWRITE_SOURCE,
           destination: "https://api.example.test/api/usage",
+        },
+        {
+          source: PUBLIC_MODEL_RANKINGS_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/public/model-rankings",
         },
         {
           source: TEST_SLACK_DISPATCH_PROBE_REWRITE_SOURCE,
@@ -5351,6 +5361,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(USAGE_PATH)).toStrictEqual({});
     for (const pathname of USAGE_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact public model rankings rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === PUBLIC_MODEL_RANKINGS_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: PUBLIC_MODEL_RANKINGS_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/public/model-rankings",
+    });
+
+    const matcher = getPathMatch(PUBLIC_MODEL_RANKINGS_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(PUBLIC_MODEL_RANKINGS_PATH)).toStrictEqual({});
+    for (const pathname of PUBLIC_MODEL_RANKINGS_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -551,6 +551,7 @@ export const API_BACKEND_REWRITES = [
   ["/api/storages/list", "/api/storages/list"],
   ["/api/storages/prepare", "/api/storages/prepare"],
   ["/api/usage", "/api/usage"],
+  ["/api/public/model-rankings", "/api/public/model-rankings"],
   [
     BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE,
     "/api/webhooks/built-in-generations/fal/:generationId",

--- a/turbo/apps/web/app/[locale]/rankings/page.tsx
+++ b/turbo/apps/web/app/[locale]/rankings/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from "next";
-import { sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
-import { modelStat } from "@vm0/db/schema/model-stat";
-import {
-  VM0_MODEL_ALIAS_TO_MODEL,
-  normalizeVm0ModelId,
-} from "@vm0/api-contracts/contracts/model-providers";
+import { z } from "zod";
+import { normalizeVm0ModelId } from "@vm0/api-contracts/contracts/model-providers";
 
 import { type Locale } from "../../../i18n";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
-import { initServices } from "../../../src/lib/init-services";
+import { env } from "../../../src/env";
 import { MODELS, vendorIconPath, type ModelEntry } from "../models/data";
 
 const BASE_URL = "https://www.vm0.ai";
-const HOUR_MS = 60 * 60_000;
+const MODEL_RANKINGS_API_PATH = "/api/public/model-rankings";
 
 type PeriodKey = "today" | "week" | "month";
 
@@ -37,15 +33,25 @@ interface RankingRow {
   readonly share: number;
 }
 
-interface RawRankingRow {
-  readonly model: unknown;
-  readonly input_tokens: unknown;
-  readonly output_tokens: unknown;
-  readonly total_tokens: unknown;
-  readonly previous_total_tokens: unknown;
-}
-
 export const dynamic = "force-dynamic";
+
+const modelRankingApiRowSchema = z.object({
+  model: z.string(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  totalTokens: z.number(),
+  previousTotalTokens: z.number(),
+});
+
+const modelRankingsApiResponseSchema = z.object({
+  period: z.enum(["today", "week", "month"]),
+  totalTokens: z.number(),
+  windowStart: z.string(),
+  windowEnd: z.string(),
+  rows: z.array(modelRankingApiRowSchema),
+});
+
+type ModelRankingApiRow = z.infer<typeof modelRankingApiRowSchema>;
 
 const MODELS_BY_ID = new Map(
   MODELS.flatMap((model) => {
@@ -55,10 +61,6 @@ const MODELS_BY_ID = new Map(
     ] as const;
   }),
 );
-
-function getModelAliasEntries() {
-  return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
-}
 
 export async function generateMetadata({
   params,
@@ -100,55 +102,6 @@ function parsePeriod(value: string | string[] | undefined): PeriodKey {
   const raw = Array.isArray(value) ? value[0] : value;
   if (raw === "today" || raw === "week" || raw === "month") return raw;
   return "week";
-}
-
-function startOfUtcDay(date: Date): Date {
-  return new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-  );
-}
-
-function startOfUtcWeek(date: Date): Date {
-  const day = startOfUtcDay(date);
-  const dayOfWeek = day.getUTCDay();
-  const daysSinceMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-  return new Date(day.getTime() - daysSinceMonday * 24 * HOUR_MS);
-}
-
-function startOfUtcMonth(date: Date): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
-}
-
-function currentUtcHour(date: Date): Date {
-  return new Date(
-    Date.UTC(
-      date.getUTCFullYear(),
-      date.getUTCMonth(),
-      date.getUTCDate(),
-      date.getUTCHours(),
-    ),
-  );
-}
-
-function currentWindow(
-  period: PeriodKey,
-  now: Date,
-): { start: Date; end: Date } {
-  const end = currentUtcHour(now);
-  if (period === "today") {
-    return { start: startOfUtcDay(now), end };
-  }
-  if (period === "month") {
-    return { start: startOfUtcMonth(now), end };
-  }
-  return { start: startOfUtcWeek(now), end };
-}
-
-function toNumber(value: unknown): number {
-  if (typeof value === "number") return value;
-  if (typeof value === "bigint") return Number(value);
-  if (typeof value === "string") return Number(value);
-  return 0;
 }
 
 function formatTokens(value: number): string {
@@ -210,14 +163,30 @@ function resolveModel(modelId: string): ModelEntry | undefined {
   return MODELS_BY_ID.get(suffix.toLowerCase());
 }
 
-function modelStatModelExpression() {
-  const modelColumn = sql.raw('"model_stat"."model"');
-  return sql<string>`CASE ${sql.join(
-    getModelAliasEntries().map(([alias, model]) => {
-      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
-    }),
-    sql` `,
-  )} ELSE ${modelColumn} END`;
+function modelRankingsApiUrl(period: PeriodKey): string {
+  const { VM0_API_BACKEND_URL, VM0_API_URL } = env();
+  const baseUrl = VM0_API_BACKEND_URL ?? VM0_API_URL;
+  if (!baseUrl) {
+    throw new Error("VM0_API_BACKEND_URL or VM0_API_URL is required");
+  }
+
+  const url = new URL(MODEL_RANKINGS_API_PATH, baseUrl);
+  url.searchParams.set("period", period);
+  return url.toString();
+}
+
+async function fetchModelRankings(period: PeriodKey) {
+  const response = await fetch(modelRankingsApiUrl(period), {
+    headers: { accept: "application/json" },
+    next: { revalidate: 300 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch model rankings: ${response.status}`);
+  }
+
+  const body: unknown = await response.json();
+  return modelRankingsApiResponseSchema.parse(body);
 }
 
 async function getRankings(period: PeriodKey): Promise<{
@@ -226,65 +195,23 @@ async function getRankings(period: PeriodKey): Promise<{
   windowStart: Date;
   windowEnd: Date;
 }> {
-  initServices();
-
-  const window = currentWindow(period, new Date());
-  const duration = Math.max(window.end.getTime() - window.start.getTime(), 0);
-  const previousEnd = window.start;
-  const previousStart = new Date(previousEnd.getTime() - duration);
-  const modelExpr = modelStatModelExpression();
-
-  const result = await globalThis.services.db.execute(sql`
-    WITH current_period AS (
-      SELECT
-        ${modelExpr} AS model,
-        COALESCE(SUM(${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}), 0)::bigint AS input_tokens,
-        COALESCE(SUM(${modelStat.outputTokens}), 0)::bigint AS output_tokens,
-        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS total_tokens
-      FROM ${modelStat}
-      WHERE ${modelStat.hourStart} >= ${window.start}
-        AND ${modelStat.hourStart} < ${window.end}
-      GROUP BY 1
-    ),
-    previous_period AS (
-      SELECT
-        ${modelExpr} AS model,
-        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS previous_total_tokens
-      FROM ${modelStat}
-      WHERE ${modelStat.hourStart} >= ${previousStart}
-        AND ${modelStat.hourStart} < ${previousEnd}
-      GROUP BY 1
-    )
-    SELECT
-      current_period.model,
-      current_period.input_tokens,
-      current_period.output_tokens,
-      current_period.total_tokens,
-      COALESCE(previous_period.previous_total_tokens, 0)::bigint AS previous_total_tokens
-    FROM current_period
-    LEFT JOIN previous_period ON previous_period.model = current_period.model
-    WHERE current_period.total_tokens > 0
-    ORDER BY current_period.total_tokens DESC
-    LIMIT 50
-  `);
-
-  const rawRows = result.rows as unknown as RawRankingRow[];
+  const result = await fetchModelRankings(period);
   const knownRows: {
-    readonly row: RawRankingRow;
+    readonly row: ModelRankingApiRow;
     readonly model: string;
     readonly modelEntry: ModelEntry;
     readonly totalTokens: number;
   }[] = [];
 
-  for (const row of rawRows) {
-    const model = String(row.model);
+  for (const row of result.rows) {
+    const model = row.model;
     const modelEntry = resolveModel(model);
     if (!modelEntry) continue;
     knownRows.push({
       row,
       model,
       modelEntry,
-      totalTokens: toNumber(row.total_tokens),
+      totalTokens: row.totalTokens,
     });
   }
 
@@ -294,8 +221,8 @@ async function getRankings(period: PeriodKey): Promise<{
 
   return {
     totalTokens,
-    windowStart: window.start,
-    windowEnd: window.end,
+    windowStart: new Date(result.windowStart),
+    windowEnd: new Date(result.windowEnd),
     rows: knownRows.map((item, index) => {
       return {
         rank: index + 1,
@@ -303,10 +230,10 @@ async function getRankings(period: PeriodKey): Promise<{
         name: item.modelEntry.name,
         vendor: item.modelEntry.vendor,
         iconPath: vendorIconPath(item.modelEntry.vendor),
-        inputTokens: toNumber(item.row.input_tokens),
-        outputTokens: toNumber(item.row.output_tokens),
+        inputTokens: item.row.inputTokens,
+        outputTokens: item.row.outputTokens,
         totalTokens: item.totalTokens,
-        previousTotalTokens: toNumber(item.row.previous_total_tokens),
+        previousTotalTokens: item.row.previousTotalTokens,
         share: totalTokens > 0 ? (item.totalTokens / totalTokens) * 100 : 0,
       };
     }),


### PR DESCRIPTION
## Summary
- add unauthenticated GET /api/public/model-rankings in apps/api with public cache headers
- move model_stat ranking SQL and model alias normalization out of the web rankings page
- have the web rankings page fetch normalized public API data and keep UI-only model metadata resolution in web
- add API route coverage and web rewrite matcher coverage

Closes #15150

## Verification
- pnpm -F api exec vitest run src/signals/routes/__tests__/model-stats.test.ts
- pnpm -F web exec vitest run __tests__/security-headers.test.ts
- pnpm -F web check-types
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F web lint
- git diff --check
- rg -n '@vm0/db|drizzle-orm|initServices|globalThis\.services\.db' 'turbo/apps/web/app/[locale]/rankings/page.tsx' (no matches)
- pre-commit: full pnpm knip --cache and turbo run check-types --concurrency=1