### PR TITLE
test: cover SSE parse error callbacks

### DIFF
--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -61,10 +61,30 @@ class TestAnthropicSseUsageExtractor:
         )
         assert usage == {}
 
-    def test_resilient_to_malformed_json(self):
-        parse, usage = create_anthropic_messages_sse_usage_extractor()
+    def test_malformed_usage_event_reports_error_and_recovers(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_anthropic_messages_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
         parse(b"event: message_start\ndata: {invalid json}\n\n")
-        assert usage == {}  # no crash, no data
+        assert len(parse_errors) == 1
+        event, error = parse_errors[0]
+        assert event == "message_start"
+        assert error
+        assert usage == {}
+
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":21,"output_tokens":1}}}\n\n'
+        )
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 21
+        assert usage["tokens.output"] == 1
 
     def test_finish_flushes_message_start_without_blank_line(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -83,6 +83,7 @@ class TestAnthropicSseUsageExtractor:
             b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":21,"output_tokens":1}}}\n\n'
         )
+        assert len(parse_errors) == 1
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 21
         assert usage["tokens.output"] == 1

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -1,5 +1,7 @@
 """Tests for Anthropic Messages usage extraction."""
 
+import pytest
+
 from usage import (
     create_anthropic_messages_sse_usage_extractor,
 )
@@ -61,21 +63,30 @@ class TestAnthropicSseUsageExtractor:
         )
         assert usage == {}
 
-    def test_malformed_usage_event_reports_error_and_recovers(self):
+    @pytest.mark.parametrize("with_parse_error_callback", [False, True])
+    def test_malformed_usage_event_recovers_with_optional_parse_error_callback(
+        self, with_parse_error_callback
+    ):
         parse_errors: list[tuple[str, str]] = []
 
         def record_parse_error(event: str, error: str) -> None:
             parse_errors.append((event, error))
 
-        parse, usage = create_anthropic_messages_sse_usage_extractor(
-            on_parse_error=record_parse_error
-        )
+        if with_parse_error_callback:
+            parse, usage = create_anthropic_messages_sse_usage_extractor(
+                on_parse_error=record_parse_error
+            )
+        else:
+            parse, usage = create_anthropic_messages_sse_usage_extractor()
         parse(b"event: message_start\ndata: {invalid json}\n\n")
-        assert len(parse_errors) == 1
-        event, error = parse_errors[0]
-        assert event == "message_start"
-        assert isinstance(error, str)
-        assert error
+        if with_parse_error_callback:
+            assert len(parse_errors) == 1
+            event, error = parse_errors[0]
+            assert event == "message_start"
+            assert isinstance(error, str)
+            assert error
+        else:
+            assert parse_errors == []
         assert usage == {}
 
         parse(
@@ -83,7 +94,10 @@ class TestAnthropicSseUsageExtractor:
             b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":21,"output_tokens":1}}}\n\n'
         )
-        assert len(parse_errors) == 1
+        if with_parse_error_callback:
+            assert len(parse_errors) == 1
+        else:
+            assert parse_errors == []
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 21
         assert usage["tokens.output"] == 1

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -74,6 +74,7 @@ class TestAnthropicSseUsageExtractor:
         assert len(parse_errors) == 1
         event, error = parse_errors[0]
         assert event == "message_start"
+        assert isinstance(error, str)
         assert error
         assert usage == {}
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -214,7 +214,14 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["tokens.output"] == 11
 
     def test_malformed_usage_event_recovers_for_next_event(self):
-        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
         parse(
             b"event: response.completed\n"
             b"data: {invalid json}\n\n"
@@ -222,6 +229,10 @@ class TestOpenAIResponsesSseUsageExtractor:
             b'data: {"response":{"model":"gpt-5.4",'
             b'"usage":{"input_tokens":13,"output_tokens":8}}}\n\n'
         )
+        assert len(parse_errors) == 1
+        event, error = parse_errors[0]
+        assert event == "response.completed"
+        assert error
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.input"] == 13
         assert usage["tokens.output"] == 8

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -232,6 +232,7 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert len(parse_errors) == 1
         event, error = parse_errors[0]
         assert event == "response.completed"
+        assert isinstance(error, str)
         assert error
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.input"] == 13

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -1,5 +1,7 @@
 """Tests for OpenAI Responses SSE usage extraction."""
 
+import pytest
+
 from usage import (
     create_openai_responses_sse_usage_extractor,
 )
@@ -213,15 +215,19 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.2"
         assert usage["tokens.output"] == 11
 
-    def test_malformed_usage_event_recovers_for_next_event(self):
+    @pytest.mark.parametrize("with_parse_error_callback", [False, True])
+    def test_malformed_usage_event_recovers_for_next_event(self, with_parse_error_callback):
         parse_errors: list[tuple[str, str]] = []
 
         def record_parse_error(event: str, error: str) -> None:
             parse_errors.append((event, error))
 
-        parse, usage = create_openai_responses_sse_usage_extractor(
-            on_parse_error=record_parse_error
-        )
+        if with_parse_error_callback:
+            parse, usage = create_openai_responses_sse_usage_extractor(
+                on_parse_error=record_parse_error
+            )
+        else:
+            parse, usage = create_openai_responses_sse_usage_extractor()
         parse(
             b"event: response.completed\n"
             b"data: {invalid json}\n\n"
@@ -229,11 +235,14 @@ class TestOpenAIResponsesSseUsageExtractor:
             b'data: {"response":{"model":"gpt-5.4",'
             b'"usage":{"input_tokens":13,"output_tokens":8}}}\n\n'
         )
-        assert len(parse_errors) == 1
-        event, error = parse_errors[0]
-        assert event == "response.completed"
-        assert isinstance(error, str)
-        assert error
+        if with_parse_error_callback:
+            assert len(parse_errors) == 1
+            event, error = parse_errors[0]
+            assert event == "response.completed"
+            assert isinstance(error, str)
+            assert error
+        else:
+            assert parse_errors == []
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.input"] == 13
         assert usage["tokens.output"] == 8


### PR DESCRIPTION
## Summary

- extend OpenAI Responses SSE malformed recovery test to assert `on_parse_error` receives the terminal event and a non-empty error
- extend Anthropic Messages malformed usage test to assert callback dispatch and recovery for a following valid usage event

Closes #15138

## Tests

- `python3 -m pytest tests/test_openai_responses_sse.py tests/test_anthropic_messages.py -v`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
