### PR TITLE
refactor: centralize mitm flow metadata keys

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 
 from mitmproxy import ctx, http
 
+import flow_metadata_keys as metadata_keys
 import matching
 from auth_base_forwarder import (
     forward_request,
@@ -101,14 +102,14 @@ def _prepare_firewall_metadata(
     # field entirely for non-vm0 / no-billable-connector runs.
     firewall_billable = is_billable_firewall(allow.name, vm_info)
 
-    flow.metadata["firewall_base"] = firewall_base
-    flow.metadata["firewall_api_id"] = api_id
-    flow.metadata["firewall_name"] = allow.name
-    flow.metadata["firewall_permission"] = allow.permission or ""
-    flow.metadata["firewall_rule_match"] = allow.rule or ""
-    flow.metadata["firewall_params"] = allow.params
-    flow.metadata["firewall_billable"] = firewall_billable
-    flow.metadata["model_usage_provider"] = vm_info.get("modelUsageProvider")
+    flow.metadata[metadata_keys.FIREWALL_BASE] = firewall_base
+    flow.metadata[metadata_keys.FIREWALL_API_ID] = api_id
+    flow.metadata[metadata_keys.FIREWALL_NAME] = allow.name
+    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = allow.permission or ""
+    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = allow.rule or ""
+    flow.metadata[metadata_keys.FIREWALL_PARAMS] = allow.params
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = vm_info.get("modelUsageProvider")
 
 
 def _set_matched_firewall_failure_response(
@@ -127,9 +128,9 @@ def _set_matched_firewall_failure_response(
     # failures. They are orthogonal: for example, action=ALLOW can pair with
     # an auth or forwarding error when the firewall granted the request but
     # the addon could not fulfill it. See #10493.
-    firewall_base = flow.metadata["firewall_base"]
-    flow.metadata["firewall_action"] = action
-    flow.metadata["firewall_error"] = error_code
+    firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = action
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = error_code
     body: dict[str, object] = {
         "error": error_code,
         "message": message,
@@ -476,11 +477,13 @@ async def get_firewall_headers(
 
 
 def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:
-    flow.metadata["firewall_action"] = "ALLOW"
-    flow.metadata["auth_resolved_secrets"] = token_meta.get("resolved_secrets", [])
-    flow.metadata["auth_refreshed_connectors"] = token_meta.get("refreshed_connectors", [])
-    flow.metadata["auth_refreshed_secrets"] = token_meta.get("refreshed_secrets", [])
-    flow.metadata["auth_cache_hit"] = token_meta.get("cache_hit", False)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] = token_meta.get("resolved_secrets", [])
+    flow.metadata[metadata_keys.AUTH_REFRESHED_CONNECTORS] = token_meta.get(
+        "refreshed_connectors", []
+    )
+    flow.metadata[metadata_keys.AUTH_REFRESHED_SECRETS] = token_meta.get("refreshed_secrets", [])
+    flow.metadata[metadata_keys.AUTH_CACHE_HIT] = token_meta.get("cache_hit", False)
 
 
 def _apply_header_query_injection(
@@ -546,7 +549,7 @@ async def _apply_url_rewrite(
         )
         return False
 
-    flow.metadata["auth_url_rewrite"] = True
+    flow.metadata[metadata_keys.AUTH_URL_REWRITE] = True
     log_proxy_entry(
         proxy_log_path,
         "info",
@@ -600,10 +603,10 @@ async def handle_firewall_request(
     """Handle a firewall-matched request: fetch resolved headers, inject into request."""
     _prepare_firewall_metadata(flow, allow, vm_info)
     api_entry = allow.api_entry
-    firewall_base = flow.metadata["firewall_base"]
-    api_id = flow.metadata["firewall_api_id"]
-    run_id = flow.metadata.get("vm_run_id", "")
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+    api_id = flow.metadata[metadata_keys.FIREWALL_API_ID]
+    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     sandbox_token = vm_info.get("sandboxToken", "")
     encrypted_secrets = vm_info.get("encryptedSecrets")
     auth_headers = api_entry.get("auth", {}).get("headers", {})
@@ -613,7 +616,7 @@ async def handle_firewall_request(
     secret_connector_metadata_map = vm_info.get("secretConnectorMetadataMap")
     vars_map = vm_info.get("vars")
 
-    firewall_billable = bool(flow.metadata["firewall_billable"])
+    firewall_billable = bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE])
 
     if not encrypted_secrets:
         log_proxy_entry(
@@ -729,7 +732,9 @@ async def handle_firewall_request(
 
     _record_firewall_auth_success_metadata(flow, token_meta)
 
-    trusted_host = flow.metadata.get("trusted_authority_host") or flow.request.pretty_host
+    trusted_host = (
+        flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST) or flow.request.pretty_host
+    )
     log_proxy_entry(
         proxy_log_path,
         "info",

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -20,6 +20,8 @@ import brotli  # type: ignore[import-untyped]
 import zstandard
 from mitmproxy import ctx, http
 
+import flow_metadata_keys as metadata_keys
+
 # Cap for non-model-provider response body buffering and decompression output.
 STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
 
@@ -423,8 +425,8 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     # Response body — read from stream_buffer (available for all responses).
     # The buffer contains raw wire bytes (possibly gzip/br/zstd compressed).
     if flow.response:
-        stream_buf = flow.metadata.get("stream_buffer")
-        stream_state = flow.metadata.get("stream_buffer_state")
+        stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
+        stream_state = flow.metadata.get(metadata_keys.STREAM_BUFFER_STATE)
         stream_truncated = False
         if stream_buf is not None:
             # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -1,0 +1,38 @@
+"""Shared ``flow.metadata`` keys used across mitm addon modules."""
+
+from typing import Final
+
+# Run and request context
+VM_RUN_ID: Final = "vm_run_id"
+VM_NETWORK_LOG_PATH: Final = "vm_network_log_path"
+VM_PROXY_LOG_PATH: Final = "vm_proxy_log_path"
+VM_SANDBOX_AUTH_KEY: Final = "vm_sandbox_token"
+ORIGINAL_URL: Final = "original_url"
+CAPTURE_BODY: Final = "capture_body"
+CLI_AGENT_TYPE: Final = "cli_agent_type"
+
+# Firewall and auth metadata
+FIREWALL_BASE: Final = "firewall_base"
+FIREWALL_API_ID: Final = "firewall_api_id"
+FIREWALL_NAME: Final = "firewall_name"
+FIREWALL_PERMISSION: Final = "firewall_permission"
+FIREWALL_RULE_MATCH: Final = "firewall_rule_match"
+FIREWALL_PARAMS: Final = "firewall_params"
+FIREWALL_BILLABLE: Final = "firewall_billable"
+FIREWALL_ACTION: Final = "firewall_action"
+FIREWALL_ERROR: Final = "firewall_error"
+AUTH_RESOLVED_SECRETS: Final = "auth_resolved_secrets"
+AUTH_REFRESHED_CONNECTORS: Final = "auth_refreshed_connectors"
+AUTH_REFRESHED_SECRETS: Final = "auth_refreshed_secrets"
+AUTH_CACHE_HIT: Final = "auth_cache_hit"
+AUTH_URL_REWRITE: Final = "auth_url_rewrite"
+TRUSTED_AUTHORITY_HOST: Final = "trusted_authority_host"
+
+# Usage and streaming metadata
+MODEL_PROVIDER_USAGE: Final = "model_provider_usage"
+MODEL_USAGE_PROVIDER: Final = "model_usage_provider"
+MODEL_JSON_USAGE_FINALIZED: Final = "_model_json_usage_finalized"
+STREAM_BUFFER: Final = "stream_buffer"
+STREAM_BUFFER_STATE: Final = "stream_buffer_state"
+X_NDJSON_STATE: Final = "x_ndjson_state"
+X_JSON_STATE: Final = "x_json_state"

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 
 from mitmproxy import ctx, http
 
+import flow_metadata_keys as metadata_keys
+
 _PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
 
 
@@ -63,22 +65,22 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     """Copy firewall and auth metadata from flow into a log entry."""
     # [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     meta = flow.metadata
-    log_entry["firewall_base"] = meta.get("firewall_base", "")
-    log_entry["firewall_name"] = meta.get("firewall_name", "")
-    log_entry["firewall_permission"] = meta.get("firewall_permission", "")
-    log_entry["firewall_rule_match"] = meta.get("firewall_rule_match", "")
-    log_entry["firewall_billable"] = meta.get("firewall_billable", False)
+    log_entry["firewall_base"] = meta.get(metadata_keys.FIREWALL_BASE, "")
+    log_entry["firewall_name"] = meta.get(metadata_keys.FIREWALL_NAME, "")
+    log_entry["firewall_permission"] = meta.get(metadata_keys.FIREWALL_PERMISSION, "")
+    log_entry["firewall_rule_match"] = meta.get(metadata_keys.FIREWALL_RULE_MATCH, "")
+    log_entry["firewall_billable"] = meta.get(metadata_keys.FIREWALL_BILLABLE, False)
 
     # Optional fields — only include when present
-    for key in (
-        "firewall_params",
-        "firewall_error",
-        "auth_resolved_secrets",
-        "auth_refreshed_connectors",
-        "auth_refreshed_secrets",
-        "auth_cache_hit",
-        "auth_url_rewrite",
+    for metadata_key, log_key in (
+        (metadata_keys.FIREWALL_PARAMS, "firewall_params"),
+        (metadata_keys.FIREWALL_ERROR, "firewall_error"),
+        (metadata_keys.AUTH_RESOLVED_SECRETS, "auth_resolved_secrets"),
+        (metadata_keys.AUTH_REFRESHED_CONNECTORS, "auth_refreshed_connectors"),
+        (metadata_keys.AUTH_REFRESHED_SECRETS, "auth_refreshed_secrets"),
+        (metadata_keys.AUTH_CACHE_HIT, "auth_cache_hit"),
+        (metadata_keys.AUTH_URL_REWRITE, "auth_url_rewrite"),
     ):
-        value = meta.get(key)
+        value = meta.get(metadata_key)
         if value is not None:
-            log_entry[key] = value
+            log_entry[log_key] = value

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -32,6 +32,7 @@ from mitmproxy.addonmanager import Loader
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import body_utils
+import flow_metadata_keys as metadata_keys
 import matching
 import registry
 import response_streaming
@@ -49,6 +50,7 @@ from url_utils import AuthorityValidationError, get_trusted_authority
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
+_USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 _RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
 _usage_flush_requested = threading.Event()
 _usage_flush_signal_lock = threading.Lock()
@@ -168,10 +170,10 @@ _request_start_times: dict = {}
 
 
 def _block_authority_validation_error(flow: http.HTTPFlow, error: AuthorityValidationError) -> None:
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
-    flow.metadata["original_url"] = error.fallback_url
-    flow.metadata["firewall_action"] = "DENY"
-    flow.metadata["firewall_error"] = error.reason
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    flow.metadata[metadata_keys.ORIGINAL_URL] = error.fallback_url
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = error.reason
 
     log_proxy_entry(
         proxy_log_path,
@@ -261,13 +263,13 @@ async def request(flow: http.HTTPFlow) -> None:
 
     try:
         # Store info for response handler
-        flow.metadata["vm_run_id"] = run_id
+        flow.metadata[metadata_keys.VM_RUN_ID] = run_id
         flow.metadata["vm_client_ip"] = client_ip
-        flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
-        flow.metadata["vm_proxy_log_path"] = vm_info.get("proxyLogPath", "")
-        flow.metadata["capture_body"] = vm_info.get("captureNetworkBodies", False)
-        flow.metadata["vm_sandbox_token"] = vm_info.get("sandboxToken", "")
-        flow.metadata["cli_agent_type"] = vm_info.get("cliAgentType") or "claude-code"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
+        flow.metadata[metadata_keys.CAPTURE_BODY] = vm_info.get("captureNetworkBodies", False)
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = vm_info.get("sandboxToken", "")
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = vm_info.get("cliAgentType") or "claude-code"
 
         try:
             trusted_authority = get_trusted_authority(flow)
@@ -276,8 +278,8 @@ async def request(flow: http.HTTPFlow) -> None:
             return
 
         original_url = trusted_authority.url
-        flow.metadata["original_url"] = original_url
-        flow.metadata["trusted_authority_host"] = trusted_authority.host
+        flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+        flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
         flow.metadata["trusted_authority_port"] = trusted_authority.port
 
         hostname = trusted_authority.host.lower()
@@ -298,7 +300,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
                 and not flow.request.path.startswith("/api/test/")
             ):
-                flow.metadata["firewall_action"] = "ALLOW"
+                flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
                 return
 
         # --- Step 2: Firewall match with permission check ---
@@ -311,7 +313,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 compiled_network_policies,
             )
             if isinstance(result, matching.FirewallBlock):
-                proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+                proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
                 block_message = (
                     "malformed network policy"
                     if result.reason == "malformed_network_policy"
@@ -330,9 +332,9 @@ async def request(flow: http.HTTPFlow) -> None:
                     name=result.name,
                     reason=result.reason,
                 )
-                flow.metadata["firewall_action"] = "DENY"
-                flow.metadata["firewall_base"] = result.base
-                flow.metadata["firewall_name"] = result.name
+                flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
+                flow.metadata[metadata_keys.FIREWALL_BASE] = result.base
+                flow.metadata[metadata_keys.FIREWALL_NAME] = result.name
                 error_body = json.dumps(
                     {
                         "error": "permission_denied",
@@ -357,7 +359,9 @@ async def request(flow: http.HTTPFlow) -> None:
                     is_billable_firewall(result.name, vm_info),
                 )
                 await handle_firewall_request(flow, result, vm_info)
-                if flow.response is not None and not flow.metadata.get("auth_url_rewrite"):
+                if flow.response is not None and not flow.metadata.get(
+                    metadata_keys.AUTH_URL_REWRITE
+                ):
                     # Local firewall/auth errors never reach a provider. They only
                     # need pre-tracking to keep shutdown from racing while auth is
                     # resolving, so release as soon as the local response exists.
@@ -365,7 +369,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 return
 
         # No firewall match — pass through directly
-        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except Exception:
         _request_start_times.pop(flow.id, None)
         _release_tracked_usage_flow(flow)
@@ -380,15 +384,15 @@ def _maybe_track_usage_flow(flow: http.HTTPFlow, firewall_billable: bool) -> Non
     The response/error decorator pops the metadata flag so decrement runs
     exactly once.
     """
-    if flow.metadata.get("_usage_flow_tracked"):
+    if flow.metadata.get(_USAGE_FLOW_TRACKED):
         return
     if firewall_billable:
         usage.increment_in_flight_flows()
-        flow.metadata["_usage_flow_tracked"] = True
+        flow.metadata[_USAGE_FLOW_TRACKED] = True
 
 
 def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
-    if flow.metadata.pop("_usage_flow_tracked", False):
+    if flow.metadata.pop(_USAGE_FLOW_TRACKED, False):
         usage.decrement_in_flight_flows()
 
 
@@ -414,7 +418,7 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     """Feed server-side WebSocket frames into model-provider usage parsers."""
     if not flow.websocket or not flow.websocket.messages:
         return
-    if not flow.metadata.get("vm_run_id", ""):
+    if not flow.metadata.get(metadata_keys.VM_RUN_ID, ""):
         return
 
     message = flow.websocket.messages[-1]
@@ -456,7 +460,7 @@ def _track_usage_flow(fn):
 @_track_usage_flow
 def websocket_end(flow: http.HTTPFlow) -> None:
     """Report model-provider usage extracted from a WebSocket-upgraded response."""
-    run_id = flow.metadata.get("vm_run_id", "")
+    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
     if run_id:
         _report_model_provider_usage_once(flow, run_id)
 
@@ -472,19 +476,19 @@ def response(flow: http.HTTPFlow) -> None:
     # not leak into ``_request_start_times``. Mirrors ``error()``.
     start_time = _request_start_times.pop(flow.id, None)
 
-    run_id = flow.metadata.get("vm_run_id", "")
+    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
     if not run_id:
         # Unregistered VM: the request handler returned before populating
         # metadata, so none of this handler's work applies.
         return
 
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
-    original_url = flow.metadata["original_url"]
-    firewall_action = flow.metadata.get("firewall_action", "ALLOW")
+    original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
+    firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
 
     request_size = len(flow.request.raw_content or b"")
     response_size = _response_size(flow)
-    stream_buf = flow.metadata.get("stream_buffer")
+    stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
     status_code = flow.response.status_code if flow.response else 0
 
     # Parse URL for host
@@ -499,8 +503,8 @@ def response(flow: http.HTTPFlow) -> None:
     # Log HTTP network entry for this run. DNS/kmsg rows are produced by the
     # Rust runner; api-contracts is the shared network-log schema boundary.
     # [NETWORK_LOG_FIELDS]
-    network_log_path = flow.metadata.get("vm_network_log_path", "")
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if network_log_path:
         log_entry = {
             "type": "http",
@@ -516,12 +520,12 @@ def response(flow: http.HTTPFlow) -> None:
         }
 
         # Add firewall match info if this was a firewall request
-        firewall_base = flow.metadata.get("firewall_base")
+        firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
         if firewall_base:
             add_firewall_metadata(flow, log_entry)
 
         # Add request headers, request body, and response body when capture is enabled
-        if flow.metadata.get("capture_body"):
+        if flow.metadata.get(metadata_keys.CAPTURE_BODY):
             body_utils.add_capture_fields(flow, log_entry)
 
         log_network_entry(network_log_path, log_entry)
@@ -534,13 +538,13 @@ def response(flow: http.HTTPFlow) -> None:
     # buffered JSON body only for legacy/test flows that did not pass through
     # responseheaders() and therefore have no incremental extractor.
     if (
-        not flow.metadata.get("_model_json_usage_finalized")
-        and not flow.metadata.get("model_provider_usage")
+        not flow.metadata.get(metadata_keys.MODEL_JSON_USAGE_FINALIZED)
+        and not flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
         and stream_buf
     ):
-        firewall_name = flow.metadata.get("firewall_name", "")
+        firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
         if firewall_name.startswith("model-provider:") and flow.metadata.get(
-            "firewall_billable", False
+            metadata_keys.FIREWALL_BILLABLE, False
         ):
             if response_streaming.uses_openai_responses_usage_protocol(flow):
                 json_usage, json_error = usage.extract_openai_responses_usage_with_error_from_json(
@@ -555,7 +559,7 @@ def response(flow: http.HTTPFlow) -> None:
                     )
                 )
             if json_usage:
-                flow.metadata["model_provider_usage"] = json_usage
+                flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = json_usage
             elif json_error is not None:
                 log_proxy_entry(
                     proxy_log_path,
@@ -579,9 +583,9 @@ def response(flow: http.HTTPFlow) -> None:
     if (
         flow.response
         and flow.response.status_code == _HTTP_STATUS_UNAUTHORIZED
-        and flow.metadata.get("firewall_base")
+        and flow.metadata.get(metadata_keys.FIREWALL_BASE)
     ):
-        api_id = flow.metadata.get("firewall_api_id", "")
+        api_id = flow.metadata.get(metadata_keys.FIREWALL_API_ID, "")
         if api_id:
             cache_key = (run_id, api_id)
             clear_cached_firewall_headers(cache_key)
@@ -606,16 +610,16 @@ def error(flow: http.HTTPFlow) -> None:
     """
     start_time = _request_start_times.pop(flow.id, None)
 
-    run_id = flow.metadata.get("vm_run_id", "")
-    network_log_path = flow.metadata.get("vm_network_log_path", "")
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
 
     if not run_id or not network_log_path:
         return
 
     latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
-    original_url = flow.metadata["original_url"]
-    firewall_action = flow.metadata.get("firewall_action", "ALLOW")
+    original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
+    firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
 
     try:
         parsed_url = urllib.parse.urlparse(original_url)
@@ -644,7 +648,7 @@ def error(flow: http.HTTPFlow) -> None:
     }
 
     # Add firewall context if available
-    firewall_base = flow.metadata.get("firewall_base")
+    firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
     if firewall_base:
         add_firewall_metadata(flow, log_entry)
 
@@ -662,7 +666,7 @@ def error(flow: http.HTTPFlow) -> None:
     # dropped from billing.  Do not run the generic connector fallback for
     # non-streaming JSON errors: partial bodies could otherwise be treated
     # as unparseable successes and billed from request-side hints.
-    if flow.metadata.get("x_ndjson_state") is not None:
+    if flow.metadata.get(metadata_keys.X_NDJSON_STATE) is not None:
         usage.report_connector_usage(flow, run_id)
 
     log_proxy_entry(
@@ -710,9 +714,9 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
     if not vm_info:
         return
 
-    flow.metadata["vm_run_id"] = vm_info.get("runId", "")
-    flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
-    flow.metadata["vm_proxy_log_path"] = vm_info.get("proxyLogPath", "")
+    flow.metadata[metadata_keys.VM_RUN_ID] = vm_info.get("runId", "")
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
     flow.metadata["tcp_start_time"] = time.time()
 
 
@@ -727,8 +731,8 @@ def tcp_error(flow: tcp.TCPFlow) -> None:
 
 
 def _log_tcp(flow: tcp.TCPFlow) -> None:
-    run_id = flow.metadata.get("vm_run_id", "")
-    network_log_path = flow.metadata.get("vm_network_log_path", "")
+    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
     if not run_id or not network_log_path:
         return
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from mitmproxy import http
 
 import body_utils
+import flow_metadata_keys as metadata_keys
 import usage
 from logging_utils import log_proxy_entry
 
@@ -16,7 +17,6 @@ _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_REDIRECT_MIN = 300
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
-_MODEL_JSON_USAGE_FINALIZED = "_model_json_usage_finalized"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
@@ -27,7 +27,7 @@ _SseUsageParseErrorLogger = Callable[[str, str], None]
 
 
 def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
-    return flow.metadata.get("cli_agent_type") == "codex"
+    return flow.metadata.get(metadata_keys.CLI_AGENT_TYPE) == "codex"
 
 
 def _make_response_chunk_parser(
@@ -49,7 +49,7 @@ def _make_model_sse_parse_error_logger(
     *,
     usage_protocol: str,
 ) -> _SseUsageParseErrorLogger:
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
 
     def log_parse_error(event: str, error: str) -> None:
         log_proxy_entry(
@@ -72,12 +72,12 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     if not flow.response:
         return None
 
-    firewall_name = flow.metadata.get("firewall_name", "")
+    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
     is_model_provider = firewall_name.startswith("model-provider:")
     # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
     # and the incremental response parsers used for billing payload extraction.
-    is_billable_flow = flow.metadata.get("firewall_billable", False)
+    is_billable_flow = flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False)
     is_billable_model_provider = is_model_provider and is_billable_flow
     # X-specific NDJSON stream classification — tied to the x firewall itself,
     # not to billing.  Kept separate so a future non-x billable connector
@@ -101,7 +101,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     # populated ``original_url`` before ``responseheaders`` fires.
     is_x_stream = False
     if is_x_flow and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN:
-        stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
+        stream_path = urllib.parse.urlparse(flow.metadata.get(metadata_keys.ORIGINAL_URL, "")).path
         is_x_stream = usage.x.is_stream_path(stream_path)
 
     if (
@@ -109,7 +109,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         and flow.response.status_code == _HTTP_STATUS_SWITCHING_PROTOCOLS
         and uses_openai_responses_usage_protocol(flow)
     ):
-        flow.metadata["model_provider_usage"] = {}
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {}
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return None
     if is_billable_model_provider:
@@ -129,7 +129,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
                         usage_protocol="anthropic_messages_sse",
                     )
                 )
-            flow.metadata["model_provider_usage"] = usage_dict
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = parser_fn.finish
             return _make_response_chunk_parser(parser_fn, flow.response.headers)
 
@@ -144,7 +144,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         # Deliberately NOT "model_provider_usage" — that key would route through
         # report_model_provider_usage and trigger the model-provider webhook.
         # x_ndjson_state is only consumed by report_connector_usage.
-        flow.metadata["x_ndjson_state"] = ndjson_state
+        flow.metadata[metadata_keys.X_NDJSON_STATE] = ndjson_state
         return _make_response_chunk_parser(parser_fn, flow.response.headers)
     if (
         is_x_flow
@@ -166,7 +166,7 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
     while accumulating a copy in memory (up to ``STREAM_BUFFER_LIMIT``).
     Once the limit is exceeded, buffering stops but streaming continues
     uninterrupted.  The buffered body is available in the ``response()``
-    hook via ``flow.metadata["stream_buffer"]``.
+    hook via ``flow.metadata[metadata_keys.STREAM_BUFFER]``.
     """
     if not flow.response:
         return
@@ -195,13 +195,13 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
         return chunk
 
     flow.response.stream = stream_and_buffer
-    flow.metadata["stream_buffer"] = buf
-    flow.metadata["stream_buffer_state"] = state
+    flow.metadata[metadata_keys.STREAM_BUFFER] = buf
+    flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = state
     flow.metadata[_RESPONSE_STREAM_CALLBACK] = stream_and_buffer
 
 
 def streamed_response_size(flow: http.HTTPFlow) -> int | None:
-    state = flow.metadata.get("stream_buffer_state")
+    state = flow.metadata.get(metadata_keys.STREAM_BUFFER_STATE)
     if state is None:
         return None
     return int(state["total_bytes"])
@@ -211,10 +211,10 @@ def finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
     finish = flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
     if finish is None:
         return
-    flow.metadata[_MODEL_JSON_USAGE_FINALIZED] = True
+    flow.metadata[metadata_keys.MODEL_JSON_USAGE_FINALIZED] = True
     usage_result, error = finish()
     if usage_result:
-        flow.metadata["model_provider_usage"] = usage_result
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_result
         return
     if error:
         log_proxy_entry(
@@ -239,10 +239,10 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     usage_result = usage.extract_openai_responses_usage_from_event_json(body)
     if not usage_result:
         return
-    usage_target = flow.metadata.get("model_provider_usage")
+    usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
     if not isinstance(usage_target, dict):
         usage_target = {}
-        flow.metadata["model_provider_usage"] = usage_target
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_target
     usage.merge_openai_responses_usage_result(usage_target, usage_result)
 
 
@@ -253,13 +253,13 @@ def finalize_x_json_state(flow: http.HTTPFlow) -> None:
     state, error = finish()
     if error:
         state["parse_error"] = error
-    flow.metadata["x_json_state"] = state
+    flow.metadata[metadata_keys.X_JSON_STATE] = state
 
 
 def release_response_stream_state(flow: http.HTTPFlow) -> None:
     stream_callback = flow.metadata.pop(_RESPONSE_STREAM_CALLBACK, None)
-    flow.metadata.pop("stream_buffer", None)
-    flow.metadata.pop("stream_buffer_state", None)
+    flow.metadata.pop(metadata_keys.STREAM_BUFFER, None)
+    flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
     flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
     flow.metadata.pop(_MODEL_SSE_USAGE_FINISH, None)
     flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -16,12 +16,13 @@ from collections.abc import Callable
 
 from mitmproxy import http
 
+import flow_metadata_keys as metadata_keys
 from logging_utils import log_proxy_entry
 
 from . import x
 
 # Map firewall_name → per-connector report_usage handler.  A handler is only
-# invoked when ``flow.metadata["firewall_billable"]`` is True, so the
+# invoked when ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True, so the
 # BILLABLE_CONNECTORS whitelist in ``@vm0/core`` and this table must stay
 # in sync.  (The web layer controls who shows up as ``billable``; this
 # table controls who we know how to parse.  Desync manifests as a
@@ -45,9 +46,9 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     connector module):
 
     - ``run_id`` is empty (no billing attribution).
-    - ``flow.metadata["firewall_billable"]`` is False (web layer decided
+    - ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is False (web layer decided
       this firewall is not platform-billable for this run).
-    - ``flow.metadata["firewall_name"]`` has no registered handler (covers
+    - ``flow.metadata[metadata_keys.FIREWALL_NAME]`` has no registered handler (covers
       both the model-provider path — routed through
       :func:`report_model_provider_usage` instead — and any firewall that
       ``@vm0/core``'s ``BILLABLE_CONNECTORS`` flags as billable but which
@@ -55,9 +56,9 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     """
     if not run_id:
         return
-    if not flow.metadata.get("firewall_billable", False):
+    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
         return
-    firewall_name = flow.metadata.get("firewall_name", "")
+    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
     if firewall_name.startswith("model-provider:"):
         return
     handler = _HANDLERS.get(firewall_name)
@@ -65,7 +66,7 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
         if firewall_name and firewall_name not in _unregistered_handler_warned:
             _unregistered_handler_warned.add(firewall_name)
             log_proxy_entry(
-                flow.metadata.get("vm_proxy_log_path", ""),
+                flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
                 "warn",
                 f"Billable firewall {firewall_name!r} has no registered handler — "
                 "billing records for this firewall will be dropped.  Check that "

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -14,6 +14,7 @@ from typing import TypedDict
 from mitmproxy import http
 
 import body_utils
+import flow_metadata_keys as metadata_keys
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
@@ -260,11 +261,11 @@ def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
       - ``is_stream``: bool — True when the request path is one of the X v2
         NDJSON streaming endpoints (see :data:`_STREAM_ENDPOINTS`).
 
-    Reads from ``flow.metadata["original_url"]`` (set by the request handler
+    Reads from ``flow.metadata[metadata_keys.ORIGINAL_URL]`` (set by the request handler
     via ``url_utils.get_original_url``) rather than ``pretty_url`` to stay
     consistent with the rest of the addon.
     """
-    parsed = urllib.parse.urlparse(flow.metadata.get("original_url", ""))
+    parsed = urllib.parse.urlparse(flow.metadata.get(metadata_keys.ORIGINAL_URL, ""))
     qs = urllib.parse.parse_qs(parsed.query)
     id_like_values = qs.get("ids", []) + qs.get("usernames", [])
     ids_count = _count_non_empty_comma_segments(id_like_values)
@@ -300,7 +301,7 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
         billing dimension, so we collapse them into one log key.
 
     For X NDJSON streaming endpoints, the responseheaders hook registers an
-    incremental parser that populates ``flow.metadata["x_ndjson_state"]``
+    incremental parser that populates ``flow.metadata[metadata_keys.X_NDJSON_STATE]``
     as response bytes arrive.  When that state is present we return its
     accumulated counters directly (``body_format: "ndjson"``) and skip
     the legacy buffered ``json.loads`` fallback, since stream buffers are
@@ -314,7 +315,7 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     Incremental parser failures may also include ``parse_error`` for proxy
     audit logs.
     """
-    state = flow.metadata.get("stream_buffer_state") or {}
+    state = flow.metadata.get(metadata_keys.STREAM_BUFFER_STATE) or {}
     truncated = bool(state.get("truncated", False))
     result: dict = {"body_parsed": False, "body_truncated": truncated}
 
@@ -327,7 +328,7 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     # every chunk regardless of that cap, so billing counts are complete.
     # Reporting body_truncated=True here would misleadingly suggest the
     # counts are unreliable when they are not.
-    ndjson_state = flow.metadata.get("x_ndjson_state")
+    ndjson_state = flow.metadata.get(metadata_keys.X_NDJSON_STATE)
     if ndjson_state is not None:
         result["body_parsed"] = True
         result["body_truncated"] = False
@@ -339,11 +340,11 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
         result["ndjson_lines_failed"] = ndjson_state["lines_failed"]
         return result
 
-    json_state = flow.metadata.get("x_json_state")
+    json_state = flow.metadata.get(metadata_keys.X_JSON_STATE)
     if isinstance(json_state, dict):
         return {**result, **json_state}
 
-    buf = flow.metadata.get("stream_buffer")
+    buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
     if not buf:
         return result
     if not flow.response:
@@ -480,8 +481,8 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
 
     **Caller contract**: the dispatcher in
     :mod:`usage.providers.connectors` guarantees ``run_id`` is non-empty,
-    ``flow.metadata["firewall_billable"]`` is True, and
-    ``flow.metadata["firewall_name"] == "x"`` before calling this.  Those
+    ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True, and
+    ``flow.metadata[metadata_keys.FIREWALL_NAME] == "x"`` before calling this.  Those
     gates are not re-checked here.
 
     Additional X-specific skip conditions:
@@ -492,12 +493,12 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     - ``firewall_permission`` is not mapped to an X billing bucket
       (e.g. the ``"app-only"`` scope for BearerToken-only endpoints)
     """
-    firewall_name = flow.metadata.get("firewall_name", "")
+    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
     if not flow.response or not (
         _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
     ):
         return
-    permission = flow.metadata.get("firewall_permission", "")
+    permission = flow.metadata.get(metadata_keys.FIREWALL_PERMISSION, "")
     if not permission:
         return
     # mitmproxy's ``flow.request.path`` is the raw request-target — it
@@ -524,7 +525,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
 
     req_meta = _parse_request_metadata(flow)
     resp_meta = _parse_response_metadata(flow)
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
 
     # Structured context common to every billing-side proxy log entry
     # for this flow — threaded into the helper so the log firing at the
@@ -575,7 +576,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         )
 
     # Buffer usage events for aggregate platform upload.
-    sandbox_token = flow.metadata.get("vm_sandbox_token", "")
+    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
     api_url = get_api_url()
     if not sandbox_token or not api_url:
         log_proxy_entry(

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -1,11 +1,11 @@
 """Model-provider billing entry point.
 
 Buffers token counts already normalized by an addon-side provider extractor
-(stored in ``flow.metadata["model_provider_usage"]``) for aggregate upload to
+(stored in ``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]``) for aggregate upload to
 the platform ``/api/webhooks/agent/usage-event`` endpoint.
 
 Model-provider usage is intentionally reported only for platform-billable
-flows. ``flow.metadata["firewall_billable"]`` comes from the web layer's
+flows. ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` comes from the web layer's
 ``billableFirewalls`` list; when it is false, the run is using BYO provider
 credentials or another non-platform-billable path and must not charge platform
 credits. The same flag gates incremental usage extraction before this reporter
@@ -17,6 +17,7 @@ from typing import TypeGuard
 
 from mitmproxy import http
 
+import flow_metadata_keys as metadata_keys
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
@@ -46,26 +47,26 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     writes a proxy warning because that indicates an environment/reporting setup
     problem.
     """
-    firewall_name = flow.metadata.get("firewall_name", "")
+    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
     if not (firewall_name.startswith("model-provider:") and run_id):
         return False
-    if not flow.metadata.get("firewall_billable", False):
+    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
         return False
-    usage = flow.metadata.get("model_provider_usage")
+    usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
     if not usage or not isinstance(usage, dict):
         return False
     message_id = _string_or_none(usage.get("message_id")) or flow.id
     provider = (
-        _string_or_none(flow.metadata.get("model_usage_provider"))
+        _string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER))
         or _string_or_none(usage.get("model"))
         or "unknown"
     )
     events = _build_usage_events(run_id, message_id, provider, usage)
     if not events:
         return False
-    sandbox_token = flow.metadata.get("vm_sandbox_token", "")
+    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
     api_url = get_api_url()
-    proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if not sandbox_token or not api_url:
         log_proxy_entry(
             proxy_log_path,

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1151,6 +1151,7 @@ exit 0
             "mitm_addon.py",
             "auth.py",
             "body_utils.py",
+            "flow_metadata_keys.py",
             "matching.py",
             "registry.py",
             "response_streaming.py",

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -150,6 +150,14 @@ assert flow.metadata["firewall_action"] == "ALLOW"
 assert flow.metadata["service_base"] == "https://api.github.com"
 ```
 
+### Shared Flow Metadata Keys
+
+Shared `flow.metadata` contract keys used across addon modules live in
+`src/flow_metadata_keys.py`. Tests may import those constants when seeding
+internal metadata for later hook phases. Keep externally visible log or schema
+field assertions as string literals so tests still catch accidental output key
+changes.
+
 ## What to Test
 
 - **URL matching**: `match_service()` with various URLs, path boundaries


### PR DESCRIPTION
## Summary

- add a dependency-free `flow_metadata_keys.py` module for shared mitm `flow.metadata` contract keys
- update cross-module metadata reads/writes to use named constants while keeping private hook sentinels local
- document the test boundary for metadata constants versus external log/schema literal assertions
- cover the new runtime module in the runner addon embedding check

Closes #15163

## Tests

- `ruff format .`
- `ruff check .`
- `pytest tests/test_firewall_auth.py tests/test_firewall_rewrite.py tests/test_response_handler.py tests/test_response_headers_handler.py tests/test_response_streaming.py tests/test_model_provider_usage.py tests/test_connector_usage.py tests/test_usage_reporting.py tests/test_webhook.py tests/test_counters.py tests/test_error_handler.py tests/test_connection_hooks.py`
- `pytest tests/`
- `cargo test -p runner addon_scripts_are_embedded`
- `cargo fmt -p runner`

Pre-commit also ran runner `cargo-clippy` and `cargo-doc` for the staged Rust change.

`basedpyright` is not installed in this local environment (`command not found` / no Python module).
