### PR TITLE
ci: install 1Password CLI for secret verification

### DIFF
--- a/.github/scripts/tests/verify-1password-secrets-test.sh
+++ b/.github/scripts/tests/verify-1password-secrets-test.sh
@@ -73,6 +73,9 @@ exit 1
 BASH
 chmod +x "${TMPDIR}/bin/op"
 
+mkdir -p "${TMPDIR}/no-op-bin"
+ln -s "$(command -v bash)" "${TMPDIR}/no-op-bin/bash"
+
 run_verifier() {
   env -i \
     PATH="${TMPDIR}/bin:${PATH}" \
@@ -87,6 +90,34 @@ run_verifier() {
     SLACK_CLIENT_SECRET="${SLACK_CLIENT_SECRET:-}" \
     "$VERIFY"
 }
+
+status=0
+missing_op_output="$(
+  env -i \
+    PATH="${TMPDIR}/no-op-bin" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Development \
+    EXPECTED_KEYS=GOOGLE_OAUTH_CLIENT_SECRET \
+    "$VERIFY" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing op case to fail"
+fi
+assert_contains "$missing_op_output" "1Password CLI (op) is not installed"
+
+status=0
+missing_jq_output="$(
+  env -i \
+    PATH="${TMPDIR}/bin:${TMPDIR}/no-op-bin" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Development \
+    EXPECTED_KEYS=GOOGLE_OAUTH_CLIENT_SECRET \
+    "$VERIFY" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing jq case to fail"
+fi
+assert_contains "$missing_jq_output" "jq is not installed"
 
 success_output="$(
   EXPECTED_KEYS=$'GOOGLE_OAUTH_CLIENT_SECRET\nSLACK_CLIENT_SECRET' \

--- a/.github/scripts/verify-1password-secrets.sh
+++ b/.github/scripts/verify-1password-secrets.sh
@@ -16,6 +16,16 @@ if [[ -z "${EXPECTED_KEYS:-}" ]]; then
   exit 1
 fi
 
+if ! command -v op >/dev/null 2>&1; then
+  echo "::error::1Password CLI (op) is not installed"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is not installed"
+  exit 1
+fi
+
 if ! visible_vaults="$(op vault list --format json | jq -r '.[].name' | sort)"; then
   echo "::error::failed to list 1Password vaults"
   exit 1

--- a/.github/workflows/verify-1password-secrets.yml
+++ b/.github/workflows/verify-1password-secrets.yml
@@ -31,46 +31,61 @@ jobs:
     needs: validate-ref
     if: github.ref == 'refs/heads/main' && inputs.scope == 'development'
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     timeout-minutes: 10
     permissions:
       contents: read
-    # Connector OAuth client secrets declared by `clientSecretEnv` and currently
-    # configured as repository-level GitHub secrets.
-    env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      AIRTABLE_OAUTH_CLIENT_SECRET: ${{ secrets.AIRTABLE_OAUTH_CLIENT_SECRET }}
-      ASANA_OAUTH_CLIENT_SECRET: ${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
-      CANVA_OAUTH_CLIENT_SECRET: ${{ secrets.CANVA_OAUTH_CLIENT_SECRET }}
-      CLOSE_OAUTH_CLIENT_SECRET: ${{ secrets.CLOSE_OAUTH_CLIENT_SECRET }}
-      DEEL_OAUTH_CLIENT_SECRET: ${{ secrets.DEEL_OAUTH_CLIENT_SECRET }}
-      DOCUSIGN_OAUTH_CLIENT_SECRET: ${{ secrets.DOCUSIGN_OAUTH_CLIENT_SECRET }}
-      DROPBOX_OAUTH_CLIENT_SECRET: ${{ secrets.DROPBOX_OAUTH_CLIENT_SECRET }}
-      FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
-      GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
-      GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-      HUBSPOT_OAUTH_CLIENT_SECRET: ${{ secrets.HUBSPOT_OAUTH_CLIENT_SECRET }}
-      LINEAR_OAUTH_CLIENT_SECRET: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
-      META_ADS_OAUTH_CLIENT_SECRET: ${{ secrets.META_ADS_OAUTH_CLIENT_SECRET }}
-      MICROSOFT_OAUTH_CLIENT_SECRET: ${{ secrets.MICROSOFT_OAUTH_CLIENT_SECRET }}
-      MONDAY_OAUTH_CLIENT_SECRET: ${{ secrets.MONDAY_OAUTH_CLIENT_SECRET }}
-      NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
-      SENTRY_OAUTH_CLIENT_SECRET: ${{ secrets.SENTRY_OAUTH_CLIENT_SECRET }}
-      SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
-      SPOTIFY_OAUTH_CLIENT_SECRET: ${{ secrets.SPOTIFY_OAUTH_CLIENT_SECRET }}
-      STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
-      TODOIST_OAUTH_CLIENT_SECRET: ${{ secrets.TODOIST_OAUTH_CLIENT_SECRET }}
-      VERCEL_OAUTH_CLIENT_SECRET: ${{ secrets.VERCEL_OAUTH_CLIENT_SECRET }}
-      WEBFLOW_OAUTH_CLIENT_SECRET: ${{ secrets.WEBFLOW_OAUTH_CLIENT_SECRET }}
-      XERO_OAUTH_CLIENT_SECRET: ${{ secrets.XERO_OAUTH_CLIENT_SECRET }}
-      X_OAUTH_CLIENT_SECRET: ${{ secrets.X_OAUTH_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install 1Password CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+            | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+          sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/debian/debsig/1password.pol \
+            | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol >/dev/null
+          sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends 1password-cli jq
+          op --version
 
       - name: Verify development secrets
         shell: bash
         env:
+          # Connector OAuth client secrets declared by `clientSecretEnv` and
+          # currently configured as repository-level GitHub secrets.
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AIRTABLE_OAUTH_CLIENT_SECRET: ${{ secrets.AIRTABLE_OAUTH_CLIENT_SECRET }}
+          ASANA_OAUTH_CLIENT_SECRET: ${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
+          CANVA_OAUTH_CLIENT_SECRET: ${{ secrets.CANVA_OAUTH_CLIENT_SECRET }}
+          CLOSE_OAUTH_CLIENT_SECRET: ${{ secrets.CLOSE_OAUTH_CLIENT_SECRET }}
+          DEEL_OAUTH_CLIENT_SECRET: ${{ secrets.DEEL_OAUTH_CLIENT_SECRET }}
+          DOCUSIGN_OAUTH_CLIENT_SECRET: ${{ secrets.DOCUSIGN_OAUTH_CLIENT_SECRET }}
+          DROPBOX_OAUTH_CLIENT_SECRET: ${{ secrets.DROPBOX_OAUTH_CLIENT_SECRET }}
+          FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
+          GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          HUBSPOT_OAUTH_CLIENT_SECRET: ${{ secrets.HUBSPOT_OAUTH_CLIENT_SECRET }}
+          LINEAR_OAUTH_CLIENT_SECRET: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
+          META_ADS_OAUTH_CLIENT_SECRET: ${{ secrets.META_ADS_OAUTH_CLIENT_SECRET }}
+          MICROSOFT_OAUTH_CLIENT_SECRET: ${{ secrets.MICROSOFT_OAUTH_CLIENT_SECRET }}
+          MONDAY_OAUTH_CLIENT_SECRET: ${{ secrets.MONDAY_OAUTH_CLIENT_SECRET }}
+          NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
+          SENTRY_OAUTH_CLIENT_SECRET: ${{ secrets.SENTRY_OAUTH_CLIENT_SECRET }}
+          SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
+          SPOTIFY_OAUTH_CLIENT_SECRET: ${{ secrets.SPOTIFY_OAUTH_CLIENT_SECRET }}
+          STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+          TODOIST_OAUTH_CLIENT_SECRET: ${{ secrets.TODOIST_OAUTH_CLIENT_SECRET }}
+          VERCEL_OAUTH_CLIENT_SECRET: ${{ secrets.VERCEL_OAUTH_CLIENT_SECRET }}
+          WEBFLOW_OAUTH_CLIENT_SECRET: ${{ secrets.WEBFLOW_OAUTH_CLIENT_SECRET }}
+          XERO_OAUTH_CLIENT_SECRET: ${{ secrets.XERO_OAUTH_CLIENT_SECRET }}
+          X_OAUTH_CLIENT_SECRET: ${{ secrets.X_OAUTH_CLIENT_SECRET }}
           VAULT_NAME: Development
           EXPECTED_FORBIDDEN_VAULT: Production
           EXPECTED_KEYS: |
@@ -105,50 +120,65 @@ jobs:
     needs: validate-ref
     if: github.ref == 'refs/heads/main' && inputs.scope == 'production'
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     timeout-minutes: 10
     permissions:
       contents: read
     environment: production
-    # Connector OAuth client secrets declared by `clientSecretEnv` and currently
-    # configured in the production GitHub environment.
-    env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      AIRTABLE_OAUTH_CLIENT_SECRET: ${{ secrets.AIRTABLE_OAUTH_CLIENT_SECRET }}
-      ASANA_OAUTH_CLIENT_SECRET: ${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
-      CANVA_OAUTH_CLIENT_SECRET: ${{ secrets.CANVA_OAUTH_CLIENT_SECRET }}
-      CLOSE_OAUTH_CLIENT_SECRET: ${{ secrets.CLOSE_OAUTH_CLIENT_SECRET }}
-      DEEL_OAUTH_CLIENT_SECRET: ${{ secrets.DEEL_OAUTH_CLIENT_SECRET }}
-      DOCUSIGN_OAUTH_CLIENT_SECRET: ${{ secrets.DOCUSIGN_OAUTH_CLIENT_SECRET }}
-      DROPBOX_OAUTH_CLIENT_SECRET: ${{ secrets.DROPBOX_OAUTH_CLIENT_SECRET }}
-      FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
-      GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
-      GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-      GUMROAD_OAUTH_CLIENT_SECRET: ${{ secrets.GUMROAD_OAUTH_CLIENT_SECRET }}
-      HUBSPOT_OAUTH_CLIENT_SECRET: ${{ secrets.HUBSPOT_OAUTH_CLIENT_SECRET }}
-      INTERVALS_ICU_OAUTH_CLIENT_SECRET: ${{ secrets.INTERVALS_ICU_OAUTH_CLIENT_SECRET }}
-      LINEAR_OAUTH_CLIENT_SECRET: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
-      META_ADS_OAUTH_CLIENT_SECRET: ${{ secrets.META_ADS_OAUTH_CLIENT_SECRET }}
-      MICROSOFT_OAUTH_CLIENT_SECRET: ${{ secrets.MICROSOFT_OAUTH_CLIENT_SECRET }}
-      MONDAY_OAUTH_CLIENT_SECRET: ${{ secrets.MONDAY_OAUTH_CLIENT_SECRET }}
-      NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
-      SENTRY_OAUTH_CLIENT_SECRET: ${{ secrets.SENTRY_OAUTH_CLIENT_SECRET }}
-      SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
-      SPOTIFY_OAUTH_CLIENT_SECRET: ${{ secrets.SPOTIFY_OAUTH_CLIENT_SECRET }}
-      STRAVA_OAUTH_CLIENT_SECRET: ${{ secrets.STRAVA_OAUTH_CLIENT_SECRET }}
-      STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
-      TODOIST_OAUTH_CLIENT_SECRET: ${{ secrets.TODOIST_OAUTH_CLIENT_SECRET }}
-      VERCEL_OAUTH_CLIENT_SECRET: ${{ secrets.VERCEL_OAUTH_CLIENT_SECRET }}
-      WEBFLOW_OAUTH_CLIENT_SECRET: ${{ secrets.WEBFLOW_OAUTH_CLIENT_SECRET }}
-      XERO_OAUTH_CLIENT_SECRET: ${{ secrets.XERO_OAUTH_CLIENT_SECRET }}
-      X_OAUTH_CLIENT_SECRET: ${{ secrets.X_OAUTH_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install 1Password CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+            | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+          sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/debian/debsig/1password.pol \
+            | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol >/dev/null
+          sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends 1password-cli jq
+          op --version
 
       - name: Verify production secrets
         shell: bash
         env:
+          # Connector OAuth client secrets declared by `clientSecretEnv` and
+          # currently configured in the production GitHub environment.
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AIRTABLE_OAUTH_CLIENT_SECRET: ${{ secrets.AIRTABLE_OAUTH_CLIENT_SECRET }}
+          ASANA_OAUTH_CLIENT_SECRET: ${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
+          CANVA_OAUTH_CLIENT_SECRET: ${{ secrets.CANVA_OAUTH_CLIENT_SECRET }}
+          CLOSE_OAUTH_CLIENT_SECRET: ${{ secrets.CLOSE_OAUTH_CLIENT_SECRET }}
+          DEEL_OAUTH_CLIENT_SECRET: ${{ secrets.DEEL_OAUTH_CLIENT_SECRET }}
+          DOCUSIGN_OAUTH_CLIENT_SECRET: ${{ secrets.DOCUSIGN_OAUTH_CLIENT_SECRET }}
+          DROPBOX_OAUTH_CLIENT_SECRET: ${{ secrets.DROPBOX_OAUTH_CLIENT_SECRET }}
+          FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
+          GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          GUMROAD_OAUTH_CLIENT_SECRET: ${{ secrets.GUMROAD_OAUTH_CLIENT_SECRET }}
+          HUBSPOT_OAUTH_CLIENT_SECRET: ${{ secrets.HUBSPOT_OAUTH_CLIENT_SECRET }}
+          INTERVALS_ICU_OAUTH_CLIENT_SECRET: ${{ secrets.INTERVALS_ICU_OAUTH_CLIENT_SECRET }}
+          LINEAR_OAUTH_CLIENT_SECRET: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
+          META_ADS_OAUTH_CLIENT_SECRET: ${{ secrets.META_ADS_OAUTH_CLIENT_SECRET }}
+          MICROSOFT_OAUTH_CLIENT_SECRET: ${{ secrets.MICROSOFT_OAUTH_CLIENT_SECRET }}
+          MONDAY_OAUTH_CLIENT_SECRET: ${{ secrets.MONDAY_OAUTH_CLIENT_SECRET }}
+          NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
+          SENTRY_OAUTH_CLIENT_SECRET: ${{ secrets.SENTRY_OAUTH_CLIENT_SECRET }}
+          SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
+          SPOTIFY_OAUTH_CLIENT_SECRET: ${{ secrets.SPOTIFY_OAUTH_CLIENT_SECRET }}
+          STRAVA_OAUTH_CLIENT_SECRET: ${{ secrets.STRAVA_OAUTH_CLIENT_SECRET }}
+          STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+          TODOIST_OAUTH_CLIENT_SECRET: ${{ secrets.TODOIST_OAUTH_CLIENT_SECRET }}
+          VERCEL_OAUTH_CLIENT_SECRET: ${{ secrets.VERCEL_OAUTH_CLIENT_SECRET }}
+          WEBFLOW_OAUTH_CLIENT_SECRET: ${{ secrets.WEBFLOW_OAUTH_CLIENT_SECRET }}
+          XERO_OAUTH_CLIENT_SECRET: ${{ secrets.XERO_OAUTH_CLIENT_SECRET }}
+          X_OAUTH_CLIENT_SECRET: ${{ secrets.X_OAUTH_CLIENT_SECRET }}
           VAULT_NAME: Production
           EXPECTED_FORBIDDEN_VAULT: Development
           EXPECTED_KEYS: |


### PR DESCRIPTION
## Summary
- remove the project toolchain container from the 1Password secret verification workflow
- install 1Password CLI and jq explicitly on the GitHub-hosted runner
- keep GitHub secrets scoped to the verification step and add clearer missing-tool errors

## Testing
- bash .github/scripts/tests/verify-1password-secrets-test.sh
- bash -n .github/scripts/verify-1password-secrets.sh .github/scripts/tests/verify-1password-secrets-test.sh
- python3 YAML parse for .github/workflows/verify-1password-secrets.yml
- git diff --check