### PR TITLE
refactor: unify mitm network log target handling

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -8,6 +8,7 @@ VM_NETWORK_LOG_PATH: Final = "vm_network_log_path"
 VM_PROXY_LOG_PATH: Final = "vm_proxy_log_path"
 VM_SANDBOX_AUTH_KEY: Final = "vm_sandbox_token"
 ORIGINAL_URL: Final = "original_url"
+NETWORK_LOG_TARGET: Final = "network_log_target"
 CAPTURE_BODY: Final = "capture_body"
 CLI_AGENT_TYPE: Final = "cli_agent_type"
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -49,6 +49,8 @@ from url_utils import AuthorityValidationError, get_trusted_authority
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
+_HTTP_DEFAULT_PORT = 80
+_HTTPS_DEFAULT_PORT = 443
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 _RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
@@ -169,9 +171,70 @@ def get_registry_path() -> str:
 _request_start_times: dict = {}
 
 
+def _set_network_log_target(flow: http.HTTPFlow, *, url: str, host: str, port: int) -> None:
+    flow.metadata[metadata_keys.NETWORK_LOG_TARGET] = {
+        "url": url,
+        "host": host,
+        "port": port,
+    }
+
+
+def _fallback_network_log_host_port(flow: http.HTTPFlow, original_url: str) -> tuple[str, int]:
+    try:
+        parsed_url = urllib.parse.urlparse(original_url)
+        host = parsed_url.hostname or flow.request.pretty_host
+        port = parsed_url.port or (
+            _HTTPS_DEFAULT_PORT if parsed_url.scheme == "https" else _HTTP_DEFAULT_PORT
+        )
+    except ValueError:
+        host = flow.request.pretty_host
+        port = flow.request.port
+    return host, port
+
+
+def _set_network_log_target_from_url(flow: http.HTTPFlow, url: str) -> None:
+    host, port = _fallback_network_log_host_port(flow, url)
+    _set_network_log_target(flow, url=url, host=host, port=port)
+
+
+def _network_log_target(flow: http.HTTPFlow, original_url: str) -> tuple[str, str, int]:
+    target = flow.metadata.get(metadata_keys.NETWORK_LOG_TARGET)
+    if target is not None:
+        return target["url"], target["host"], target["port"]
+
+    host, port = _fallback_network_log_host_port(flow, original_url)
+    return original_url, host, port
+
+
+def _http_network_log_entry(
+    flow: http.HTTPFlow,
+    *,
+    action: str,
+    original_url: str,
+    status_code: int,
+    latency_ms: int,
+    request_size: int,
+    response_size: int,
+) -> dict:
+    url, host, port = _network_log_target(flow, original_url)
+    return {
+        "type": "http",
+        "action": action,
+        "host": host,
+        "port": port,
+        "method": flow.request.method,
+        "url": url,
+        "status": status_code,
+        "latency_ms": latency_ms,
+        "request_size": request_size,
+        "response_size": response_size,
+    }
+
+
 def _block_authority_validation_error(flow: http.HTTPFlow, error: AuthorityValidationError) -> None:
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     flow.metadata[metadata_keys.ORIGINAL_URL] = error.fallback_url
+    _set_network_log_target_from_url(flow, error.fallback_url)
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
     flow.metadata[metadata_keys.FIREWALL_ERROR] = error.reason
 
@@ -281,6 +344,12 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
         flow.metadata["trusted_authority_port"] = trusted_authority.port
+        _set_network_log_target(
+            flow,
+            url=original_url,
+            host=trusted_authority.host,
+            port=trusted_authority.port,
+        )
 
         hostname = trusted_authority.host.lower()
 
@@ -491,33 +560,21 @@ def response(flow: http.HTTPFlow) -> None:
     stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
     status_code = flow.response.status_code if flow.response else 0
 
-    # Parse URL for host
-    try:
-        parsed_url = urllib.parse.urlparse(original_url)
-        host = parsed_url.hostname or flow.request.pretty_host
-        port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
-    except ValueError:
-        host = flow.request.pretty_host
-        port = flow.request.port
-
     # Log HTTP network entry for this run. DNS/kmsg rows are produced by the
     # Rust runner; api-contracts is the shared network-log schema boundary.
     # [NETWORK_LOG_FIELDS]
     network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if network_log_path:
-        log_entry = {
-            "type": "http",
-            "action": firewall_action,
-            "host": host,
-            "port": port,
-            "method": flow.request.method,
-            "url": original_url,
-            "status": status_code,
-            "latency_ms": latency_ms,
-            "request_size": request_size,
-            "response_size": response_size,
-        }
+        log_entry = _http_network_log_entry(
+            flow,
+            action=firewall_action,
+            original_url=original_url,
+            status_code=status_code,
+            latency_ms=latency_ms,
+            request_size=request_size,
+            response_size=response_size,
+        )
 
         # Add firewall match info if this was a firewall request
         firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
@@ -621,31 +678,20 @@ def error(flow: http.HTTPFlow) -> None:
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
 
-    try:
-        parsed_url = urllib.parse.urlparse(original_url)
-        host = parsed_url.hostname or flow.request.pretty_host
-        port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
-    except ValueError:
-        host = flow.request.pretty_host
-        port = flow.request.port
-
     request_size = len(flow.request.raw_content or b"")
     error_msg = flow.error.msg if flow.error else "unknown error"
 
     # [NETWORK_LOG_FIELDS] — HTTP error fields; api-contracts is the shared schema boundary.
-    log_entry: dict = {
-        "type": "http",
-        "action": firewall_action,
-        "host": host,
-        "port": port,
-        "method": flow.request.method,
-        "url": original_url,
-        "status": 0,
-        "latency_ms": latency_ms,
-        "request_size": request_size,
-        "response_size": 0,
-        "error": error_msg,
-    }
+    log_entry = _http_network_log_entry(
+        flow,
+        action=firewall_action,
+        original_url=original_url,
+        status_code=0,
+        latency_ms=latency_ms,
+        request_size=request_size,
+        response_size=0,
+    )
+    log_entry["error"] = error_msg
 
     # Add firewall context if available
     firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -157,6 +157,34 @@ class TestErrorHandler:
         assert entry["latency_ms"] > 0
         assert_utc_millisecond_timestamp(entry["timestamp"])
 
+    async def test_request_classified_error_logs_network_target(
+        self, registry_file, real_flow, mitm_ctx, headers
+    ):
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.1",
+            host="203.0.113.10",
+            port=8443,
+            sni="api.anthropic.com",
+            path="/v1/messages",
+            request_headers=headers(("Host", "api.anthropic.com")),
+        )
+
+        with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+            await mitm_addon.request(flow)
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        entry = json.loads((registry_file.parent / "network.jsonl").read_text().strip())
+        assert entry["type"] == "http"
+        assert entry["action"] == "ALLOW"
+        assert entry["host"] == "api.anthropic.com"
+        assert entry["port"] == 8443
+        assert entry["url"] == "https://api.anthropic.com:8443/v1/messages"
+        assert entry["status"] == 0
+        assert entry["error"] == "connection reset by peer"
+        assert flow.id not in mitm_addon._request_start_times
+
     def test_error_logs_legacy_target_when_original_url_port_is_invalid(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -157,6 +157,26 @@ class TestErrorHandler:
         assert entry["latency_ms"] > 0
         assert_utc_millisecond_timestamp(entry["timestamp"])
 
+    def test_error_logs_legacy_target_when_original_url_port_is_invalid(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["original_url"] = "https://invalid.example.com:bad/path"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.error = Error("connection reset by peer")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["host"] == "fallback.example.com"
+        assert entry["port"] == 9443
+        assert entry["url"] == "https://invalid.example.com:bad/path"
+        assert entry["error"] == "connection reset by peer"
+
     def test_error_includes_firewall_context(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="slack.com")
         log_path = str(tmp_path / "network.jsonl")

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.request_handler_helpers import _write_github_firewall_registry
 
@@ -48,6 +49,11 @@ async def test_rejects_spoofed_host_before_firewall_auth(
     assert flow.metadata["firewall_action"] == "DENY"
     assert flow.metadata["firewall_error"] == "authority_mismatch"
     assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET] == {
+        "url": expected_original_url,
+        "host": "attacker.example.com",
+        "port": request_port,
+    }
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -77,6 +83,11 @@ async def test_matching_sni_and_host_allows_firewall_auth(
     assert flow.metadata["firewall_permission"] == "full-access"
     assert flow.request.headers["Authorization"] == "Bearer x"
     assert flow.metadata["original_url"] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET] == {
+        "url": "https://api.github.com/repos",
+        "host": "api.github.com",
+        "port": 443,
+    }
 
 
 @pytest.mark.parametrize("http_version", ["HTTP/2.0", "HTTP/3"])

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -58,6 +58,43 @@ async def test_rejects_spoofed_host_before_firewall_auth(
     assert "Authorization" not in flow.request.headers
 
 
+async def test_authority_validation_deny_response_logs_network_target(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        port=8443,
+        sni="attacker.example.com",
+        path="/repos",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    auth_fetch.assert_not_called()
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+    assert entry["type"] == "http"
+    assert entry["action"] == "DENY"
+    assert entry["host"] == "attacker.example.com"
+    assert entry["port"] == 8443
+    assert entry["url"] == "https://attacker.example.com:8443/repos"
+    assert entry["status"] == 403
+    assert flow.id not in mitm_addon._request_start_times
+
+
 async def test_matching_sni_and_host_allows_firewall_auth(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -9,6 +9,7 @@ from mitmproxy.test import tutils
 
 import auth
 import body_utils
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.auth_state_helpers import (
     cached_headers,
@@ -67,6 +68,49 @@ class TestResponseHandler:
         assert entry["latency_ms"] > 0
         assert entry["response_size"] == 256
         assert_utc_millisecond_timestamp(entry["timestamp"])
+
+    def test_logs_request_time_network_log_target(self, tmp_path, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="request.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://original.example.com/"
+        flow.metadata[metadata_keys.NETWORK_LOG_TARGET] = {
+            "url": "https://target.example.com:9443/path",
+            "host": "target.example.com",
+            "port": 9443,
+        }
+        flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["host"] == "target.example.com"
+        assert entry["port"] == 9443
+        assert entry["url"] == "https://target.example.com:9443/path"
+
+    def test_logs_legacy_target_when_original_url_port_is_invalid(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://invalid.example.com:bad/path"
+        flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["host"] == "fallback.example.com"
+        assert entry["port"] == 9443
+        assert entry["url"] == "https://invalid.example.com:bad/path"
 
     def test_response_size_tracks_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
         """response_size should use cumulative streamed bytes."""


### PR DESCRIPTION
## Summary

- store a request-time network-log target for trusted and authority-denied mitm flows
- share HTTP network-log base entry construction between response() and error()
- keep legacy original_url fallback behavior for direct hook paths with invalid URL ports

Closes #15162

## Tests

- /tmp/vm0-mitm-addon-venv/bin/pytest tests/test_request_handler_authority_validation.py tests/test_response_handler.py tests/test_error_handler.py
- /tmp/vm0-mitm-addon-venv/bin/pytest tests
- /tmp/vm0-mitm-addon-venv/bin/ruff check .
- /tmp/vm0-mitm-addon-venv/bin/basedpyright --pythonpath /tmp/vm0-mitm-addon-venv/bin/python