### PR TITLE
fix: correct computer use cursor shadow direction

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -471,7 +471,7 @@ final class ComputerUseVisualPointerView: NSView {
         let bottomShadow = NSShadow()
         bottomShadow.shadowColor = NSColor(calibratedWhite: 0.02, alpha: 0.48)
         bottomShadow.shadowBlurRadius = 3.4
-        bottomShadow.shadowOffset = NSSize(width: 0.9, height: 2.1)
+        bottomShadow.shadowOffset = NSSize(width: 0.9, height: -2.1)
         bottomShadow.set()
 
         NSColor(calibratedRed: 0.34, green: 0.37, blue: 0.40, alpha: 1).setFill()


### PR DESCRIPTION
## Summary
- Flip the native Computer Use visual cursor shadow y offset so the shadow falls down-right instead of up-right.

## Testing
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm desktop:make