### PR TITLE
fix: harden runner job expiry claims

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -10,6 +10,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { exportJobs } from "@vm0/db/schema/export-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -65,9 +66,16 @@ function minutesAgo(minutes: number): Date {
   return new Date(FIXED_NOW_MS - minutes * 60 * 1000);
 }
 
+function farFuture(): Date {
+  return new Date("2999-01-01T00:00:00.000Z");
+}
+
 async function cleanupRunFixture(fixture: RunFixture): Promise<void> {
   const db = store.set(writeDb$);
   await db.delete(agentRunQueue).where(eq(agentRunQueue.runId, fixture.runId));
+  await db
+    .delete(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, fixture.runId));
   await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
   await db.delete(agentRuns).where(eq(agentRuns.id, fixture.runId));
   await db.delete(agentSessions).where(eq(agentSessions.id, fixture.sessionId));
@@ -187,6 +195,28 @@ async function insertQueueEntry(
   });
 }
 
+async function insertRunnerJobEntry(
+  fixture: RunFixture,
+  expiresAt: Date,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(runnerJobQueue).values({
+    runId: fixture.runId,
+    runnerGroup: "vm0/test",
+    profile: "vm0/default",
+    executionContext: {
+      workingDir: "/workspace",
+      storageManifest: null,
+      environment: null,
+      resumeSession: null,
+      encryptedSecrets: null,
+      cliAgentType: "claude-code",
+      apiStartTime: FIXED_NOW_MS,
+    },
+    expiresAt,
+  });
+}
+
 async function insertExportJob(args: {
   readonly status: string;
   readonly createdAt?: Date;
@@ -220,6 +250,18 @@ async function findRun(runId: string): Promise<{
     .select({ status: agentRuns.status, error: agentRuns.error })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function findRunnerJob(runId: string): Promise<{
+  readonly runId: string;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ runId: runnerJobQueue.runId })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
     .limit(1);
   return row ?? null;
 }
@@ -295,6 +337,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     const fixture = await trackRun(
       insertRunFixture({ status: "pending", createdAt: minutesAgo(1) }),
     );
+    await insertRunnerJobEntry(fixture, farFuture());
 
     const response = await accept(
       apiClient().cleanup({ headers: cronHeaders() }),
@@ -305,6 +348,9 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     await expect(findRun(fixture.runId)).resolves.toMatchObject({
       status: "pending",
       error: null,
+    });
+    await expect(findRunnerJob(fixture.runId)).resolves.toStrictEqual({
+      runId: fixture.runId,
     });
   });
 
@@ -333,6 +379,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     const fixture = await trackRun(
       insertRunFixture({ status: "pending", createdAt: minutesAgo(6) }),
     );
+    await insertRunnerJobEntry(fixture, farFuture());
 
     const response = await accept(
       apiClient().cleanup({ headers: cronHeaders() }),
@@ -350,6 +397,29 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     await expect(findRun(fixture.runId)).resolves.toMatchObject({
       status: "timeout",
       error: "Run timed out while pending (never started)",
+    });
+    await expect(findRunnerJob(fixture.runId)).resolves.toBeNull();
+  });
+
+  it("deletes expired runner job queue entries", async () => {
+    const expired = await trackRun(
+      insertRunFixture({ status: "completed", createdAt: minutesAgo(1) }),
+    );
+    const unexpired = await trackRun(
+      insertRunFixture({ status: "completed", createdAt: minutesAgo(1) }),
+    );
+    await insertRunnerJobEntry(expired, minutesAgo(1));
+    await insertRunnerJobEntry(unexpired, farFuture());
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(0);
+    await expect(findRunnerJob(expired.runId)).resolves.toBeNull();
+    await expect(findRunnerJob(unexpired.runId)).resolves.toStrictEqual({
+      runId: unexpired.runId,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -163,6 +163,7 @@ async function seedQueuedRun(args: {
   readonly runnerGroup?: string;
   readonly profile?: string;
   readonly sessionId?: string | null;
+  readonly expiresAt?: Date;
   readonly secretValue?: string;
   readonly appendSystemPrompt?: string;
   readonly contextOverrides?: Partial<StoredExecutionContext>;
@@ -204,7 +205,7 @@ async function seedQueuedRun(args: {
       secretValue: args.secretValue,
       overrides: args.contextOverrides,
     }),
-    expiresAt: new Date(now() + 60_000),
+    expiresAt: args.expiresAt ?? new Date(now() + 60_000),
   });
 
   return { runId, composeVersionId: run?.agentComposeVersionId ?? "" };
@@ -475,6 +476,29 @@ describe("POST /api/runners/*", () => {
     expect(response.body).toStrictEqual({ job: null });
   });
 
+  it("does not return expired jobs to runner polls", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const runnerGroup = `vm0/poll-${randomUUID()}`;
+    await seedQueuedRun({
+      fixture,
+      runnerGroup,
+      expiresAt: new Date(now() - 60_000),
+    });
+
+    const client = setupApp({ context })(runnersPollContract);
+    const response = await accept(
+      client.poll({
+        body: { group: runnerGroup },
+        headers: { authorization: OFFICIAL_RUNNER_TOKEN },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ job: null });
+  });
+
   it.each([
     ["missing authorization", undefined],
     ["non-Bearer authorization", "Basic sometoken"],
@@ -551,6 +575,33 @@ describe("POST /api/runners/*", () => {
     expect(response.body).toStrictEqual({
       error: { message: "Job already claimed", code: "CONFLICT" },
     });
+  });
+
+  it("returns not found when claiming an expired job", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({
+      fixture,
+      expiresAt: new Date(now() - 60_000),
+    });
+
+    const response = await claimRunnerJob({
+      runId: queued.runId,
+      authorization: OFFICIAL_RUNNER_TOKEN,
+      status: 404,
+    });
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Job not found in queue", code: "NOT_FOUND" },
+    });
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run?.status).toBe("pending");
   });
 
   it("fails invalid stored execution context and dequeues the job", async () => {
@@ -883,6 +934,56 @@ describe("POST /api/runners/*", () => {
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, queued.runId));
     expect(remainingJobs).toHaveLength(0);
+  });
+
+  it("fails invalid stored execution context once under concurrent claims", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+    const db = store.set(writeDb$);
+    await db
+      .update(runnerJobQueue)
+      .set({ executionContext: { workingDir: "/workspace" } })
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    const client = setupApp({ context })(runnersJobClaimContract);
+
+    const responses = await Promise.all(
+      [0, 1].map(() => {
+        return accept(
+          client.claim({
+            params: { id: queued.runId },
+            body: {},
+            headers: { authorization: OFFICIAL_RUNNER_TOKEN },
+          }),
+          [400, 404, 409],
+        );
+      }),
+    );
+
+    expect(
+      responses.filter((response) => {
+        return response.status === 400;
+      }),
+    ).toHaveLength(1);
+    const [run] = await db
+      .select({ status: agentRuns.status, error: agentRuns.error })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run).toMatchObject({
+      status: "failed",
+      error: "Runner job missing valid execution context",
+    });
+    const failedEvents = context.mocks.ably.publish.mock.calls.filter(
+      ([channel, payload]) => {
+        const status =
+          payload && typeof payload === "object" && "status" in payload
+            ? payload.status
+            : undefined;
+        return channel === `run:changed:${queued.runId}` && status === "failed";
+      },
+    );
+    expect(failedEvents).toHaveLength(1);
   });
 
   it("returns appendSystemPrompt in claim responses", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -12,7 +12,7 @@ import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
-import { and, eq, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
 
 import { runnerAuth$, type RunnerAuthContext } from "../auth/runner-auth";
 import { authorization$ } from "../context/hono";
@@ -24,7 +24,7 @@ import {
   publishRunChangedForUserSafely,
 } from "../external/realtime";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
-import { now, nowDate } from "../external/time";
+import { nowDate } from "../external/time";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { generateSandboxToken } from "../auth/tokens";
@@ -162,6 +162,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const whereConditions: SQL<unknown>[] = [
     eq(runnerJobQueue.runnerGroup, group),
     isNull(runnerJobQueue.claimedAt),
+    gt(runnerJobQueue.expiresAt, sql`now()`),
     eq(agentRuns.status, "pending"),
   ];
 
@@ -280,7 +281,11 @@ async function getClaimableJob(
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
     .where(
-      and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+      and(
+        eq(runnerJobQueue.runId, runId),
+        isNull(runnerJobQueue.claimedAt),
+        gt(runnerJobQueue.expiresAt, sql`now()`),
+      ),
     )
     .limit(1);
   signal.throwIfAborted();
@@ -290,15 +295,19 @@ async function getClaimableJob(
   }
 
   const [existingJob] = await db
-    .select({ runId: runnerJobQueue.runId })
+    .select({
+      runId: runnerJobQueue.runId,
+      isExpired: sql<boolean>`${runnerJobQueue.expiresAt} <= now()`,
+    })
     .from(runnerJobQueue)
     .where(eq(runnerJobQueue.runId, runId))
     .limit(1);
   signal.throwIfAborted();
 
-  return existingJob
-    ? conflict("Job already claimed")
-    : notFound("Job not found in queue");
+  if (!existingJob || existingJob.isExpired) {
+    return notFound("Job not found in queue");
+  }
+  return conflict("Job already claimed");
 }
 
 function claimAuthorizationError(
@@ -320,35 +329,70 @@ function claimAuthorizationError(
 }
 
 type ClaimTransitionResult =
-  | { readonly status: "claimed" }
+  | { readonly status: "claimed"; readonly claimedAt: Date }
   | { readonly status: "conflict" }
-  | { readonly status: "not-found" };
+  | { readonly status: "job-not-found" }
+  | { readonly status: "run-not-found" };
+
+type ClaimMissResult =
+  | { readonly status: "conflict" }
+  | { readonly status: "job-not-found" };
+
+async function classifyClaimMiss(
+  db: Pick<Db, "select">,
+  runId: string,
+  signal: AbortSignal,
+): Promise<ClaimMissResult> {
+  const [existingJob] = await db
+    .select({
+      runId: runnerJobQueue.runId,
+      isExpired: sql<boolean>`${runnerJobQueue.expiresAt} <= now()`,
+    })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!existingJob || existingJob.isExpired) {
+    return { status: "job-not-found" };
+  }
+  return { status: "conflict" };
+}
 
 async function transitionClaimedJobToRunning(
   db: Db,
   runId: string,
-  claimedAt: Date,
   signal: AbortSignal,
 ): Promise<ClaimTransitionResult> {
   return await db.transaction(async (tx) => {
     const [claimedJob] = await tx
       .update(runnerJobQueue)
-      .set({ claimedAt })
+      .set({ claimedAt: sql`now()` })
       .where(
-        and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+        and(
+          eq(runnerJobQueue.runId, runId),
+          isNull(runnerJobQueue.claimedAt),
+          gt(runnerJobQueue.expiresAt, sql`now()`),
+        ),
       )
-      .returning({ runId: runnerJobQueue.runId });
+      .returning({
+        runId: runnerJobQueue.runId,
+        claimedAt: runnerJobQueue.claimedAt,
+      });
     signal.throwIfAborted();
     if (!claimedJob) {
-      return { status: "conflict" as const };
+      return await classifyClaimMiss(tx, runId, signal);
+    }
+    if (!claimedJob.claimedAt) {
+      throw new Error("Runner job claim timestamp missing");
     }
 
     const [run] = await tx
       .update(agentRuns)
       .set({
         status: "running",
-        startedAt: claimedAt,
-        lastHeartbeatAt: claimedAt,
+        startedAt: claimedJob.claimedAt,
+        lastHeartbeatAt: claimedJob.claimedAt,
       })
       .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
       .returning({ id: agentRuns.id });
@@ -356,46 +400,56 @@ async function transitionClaimedJobToRunning(
     if (!run) {
       await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
       signal.throwIfAborted();
-      return { status: "not-found" };
+      return { status: "run-not-found" };
     }
 
     await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
     signal.throwIfAborted();
 
-    return { status: "claimed" as const };
+    return { status: "claimed" as const, claimedAt: claimedJob.claimedAt };
   });
 }
 
 type PoisonJobResult =
   | { readonly status: "failed" }
   | { readonly status: "conflict" }
-  | { readonly status: "not-found" };
+  | { readonly status: "job-not-found" }
+  | { readonly status: "run-not-found" };
 
 async function failPoisonQueuedJob(
   db: Db,
   runId: string,
-  claimedAt: Date,
   errorMessage: string,
   signal: AbortSignal,
 ): Promise<PoisonJobResult> {
   return await db.transaction(async (tx) => {
     const [claimedJob] = await tx
       .update(runnerJobQueue)
-      .set({ claimedAt })
+      .set({ claimedAt: sql`now()` })
       .where(
-        and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+        and(
+          eq(runnerJobQueue.runId, runId),
+          isNull(runnerJobQueue.claimedAt),
+          gt(runnerJobQueue.expiresAt, sql`now()`),
+        ),
       )
-      .returning({ runId: runnerJobQueue.runId });
+      .returning({
+        runId: runnerJobQueue.runId,
+        claimedAt: runnerJobQueue.claimedAt,
+      });
     signal.throwIfAborted();
     if (!claimedJob) {
-      return { status: "conflict" as const };
+      return await classifyClaimMiss(tx, runId, signal);
+    }
+    if (!claimedJob.claimedAt) {
+      throw new Error("Runner job claim timestamp missing");
     }
 
     const [run] = await tx
       .update(agentRuns)
       .set({
         status: "failed",
-        completedAt: nowDate(),
+        completedAt: claimedJob.claimedAt,
         error: errorMessage,
       })
       .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
@@ -404,7 +458,7 @@ async function failPoisonQueuedJob(
     if (!run) {
       await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
       signal.throwIfAborted();
-      return { status: "not-found" };
+      return { status: "run-not-found" };
     }
 
     await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
@@ -537,8 +591,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return authError;
   }
 
-  const currentTime = now();
-  const claimedAt = new Date(currentTime);
   const run = jobWithRun.run;
 
   const storedContextResult = storedExecutionContextSchema.safeParse(
@@ -549,14 +601,16 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     const poisonResult = await failPoisonQueuedJob(
       db,
       runId,
-      claimedAt,
       INVALID_EXECUTION_CONTEXT_ERROR,
       signal,
     );
     if (poisonResult.status === "conflict") {
       return conflict("Job was claimed by another runner");
     }
-    if (poisonResult.status === "not-found") {
+    if (poisonResult.status === "job-not-found") {
+      return notFound("Job not found in queue");
+    }
+    if (poisonResult.status === "run-not-found") {
       return notFound("Run not found");
     }
 
@@ -583,10 +637,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
   signal.throwIfAborted();
   const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
-  const apiToClaimMs = elapsedSinceApiStartMs(
-    storedContext.apiStartTime,
-    currentTime,
-  );
   const responseBody = {
     ...storedContext,
     runId: run.id,
@@ -599,23 +649,24 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     secretValues,
   };
 
-  const claimResult = await transitionClaimedJobToRunning(
-    db,
-    runId,
-    claimedAt,
-    signal,
-  );
+  const claimResult = await transitionClaimedJobToRunning(db, runId, signal);
   if (claimResult.status === "conflict") {
     return conflict("Job was claimed by another runner");
   }
-  if (claimResult.status === "not-found") {
+  if (claimResult.status === "job-not-found") {
+    return notFound("Job not found in queue");
+  }
+  if (claimResult.status === "run-not-found") {
     return notFound("Run not found");
   }
 
   scheduleClaimSucceededSideEffects({
     runId,
     userId: run.userId,
-    apiToClaimMs,
+    apiToClaimMs: elapsedSinceApiStartMs(
+      storedContext.apiStartTime,
+      claimResult.claimedAt.getTime(),
+    ),
   });
 
   return {

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -5,7 +5,8 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { exportJobs } from "@vm0/db/schema/export-job";
-import { and, eq, inArray, isNotNull, lt } from "drizzle-orm";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { and, eq, inArray, isNotNull, lt, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -53,27 +54,30 @@ interface StaleRun {
   readonly composeName: string | null;
 }
 
+interface CleanupCutoffs {
+  readonly running: Date;
+  readonly debug: Date;
+  readonly pending: Date;
+}
+
 type ComputedGetter = <T>(source: Computed<T>) => T;
 type CommandSetter = <T, TArgs extends unknown[]>(
   command: Command<T, TArgs>,
   ...args: TArgs
 ) => T;
 
-function isExpiredRun(
-  run: StaleRun,
-  cutoffs: {
-    readonly running: Date;
-    readonly debug: Date;
-    readonly pending: Date;
-  },
-): boolean {
-  const referenceTime = run.lastHeartbeatAt ?? run.createdAt;
+function staleRunCutoff(run: StaleRun, cutoffs: CleanupCutoffs): Date {
   if (run.status === "pending") {
-    return referenceTime < cutoffs.pending;
+    return cutoffs.pending;
   }
 
   const isDebug = run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;
-  return referenceTime < (isDebug ? cutoffs.debug : cutoffs.running);
+  return isDebug ? cutoffs.debug : cutoffs.running;
+}
+
+function isExpiredRun(run: StaleRun, cutoffs: CleanupCutoffs): boolean {
+  const referenceTime = run.lastHeartbeatAt ?? run.createdAt;
+  return referenceTime < staleRunCutoff(run, cutoffs);
 }
 
 async function cleanupExportJobs(
@@ -168,27 +172,53 @@ async function cleanupSingleRun(
   set: CommandSetter,
   db: Db,
   run: StaleRun,
+  cutoffs: CleanupCutoffs,
   signal: AbortSignal,
 ): Promise<CleanupResult | undefined> {
   const timeoutReason =
     run.status === "pending"
       ? "Run timed out while pending (never started)"
       : "Run timed out (no heartbeat)";
+  const cutoff = staleRunCutoff(run, cutoffs);
 
-  const [updated] = await db
-    .update(agentRuns)
-    .set({
-      status: "timeout",
-      completedAt: nowDate(),
-      error: timeoutReason,
-    })
-    .where(
-      and(
-        eq(agentRuns.id, run.id),
-        inArray(agentRuns.status, ["pending", "running"]),
-      ),
-    )
-    .returning({ id: agentRuns.id });
+  const updated = await db.transaction(async (tx) => {
+    await tx
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, run.id))
+      .for("update")
+      .limit(1);
+    signal.throwIfAborted();
+
+    const [updatedRun] = await tx
+      .update(agentRuns)
+      .set({
+        status: "timeout",
+        completedAt: nowDate(),
+        error: timeoutReason,
+      })
+      .where(
+        and(
+          eq(agentRuns.id, run.id),
+          eq(agentRuns.status, run.status),
+          sql`COALESCE(${agentRuns.lastHeartbeatAt}, ${agentRuns.createdAt}) < ${sql.param(
+            cutoff,
+            agentRuns.createdAt,
+          )}`,
+        ),
+      )
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+
+    if (!updatedRun) {
+      return undefined;
+    }
+
+    await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, run.id));
+    signal.throwIfAborted();
+
+    return updatedRun;
+  });
   signal.throwIfAborted();
 
   if (!updated) {
@@ -225,6 +255,25 @@ async function cleanupSingleRun(
     status: "cleaned",
     reason: timeoutReason,
   };
+}
+
+async function cleanupExpiredRunnerJobs(
+  db: Db,
+  signal: AbortSignal,
+): Promise<number> {
+  const result = await db.execute(sql`
+    DELETE FROM ${runnerJobQueue}
+    WHERE ${runnerJobQueue.expiresAt} <= now()
+  `);
+  signal.throwIfAborted();
+
+  const deletedCount = Number(result.rowCount ?? 0);
+  if (deletedCount > 0) {
+    L.debug("Cleaned up expired runner job queue entries", {
+      count: deletedCount,
+    });
+  }
+  return deletedCount;
 }
 
 export const cleanupSandboxes$ = command(
@@ -274,11 +323,18 @@ export const cleanupSandboxes$ = command(
 
     const expiredQueueCount = await set(cleanupExpiredQueueEntries$, signal);
     signal.throwIfAborted();
+    const expiredRunnerJobCount = await cleanupExpiredRunnerJobs(db, signal);
+    signal.throwIfAborted();
     const drainedCount = await set(drainStaleQueues$, signal);
     signal.throwIfAborted();
-    if (expiredQueueCount > 0 || drainedCount > 0) {
+    if (
+      expiredQueueCount > 0 ||
+      expiredRunnerJobCount > 0 ||
+      drainedCount > 0
+    ) {
       L.debug("Queue maintenance completed", {
         expired: expiredQueueCount,
+        expiredRunnerJobs: expiredRunnerJobCount,
         drained: drainedCount,
       });
     }
@@ -294,7 +350,7 @@ export const cleanupSandboxes$ = command(
 
     for (const run of expiredRuns) {
       const cleanupResult = await settle(
-        cleanupSingleRun(set, db, run, signal),
+        cleanupSingleRun(set, db, run, cutoffs, signal),
       );
       signal.throwIfAborted();
 


### PR DESCRIPTION
## Summary

- Filter runner poll and claim paths so expired `runner_job_queue` rows are not returned or claimed.
- Re-check claim eligibility inside the claim/fail transaction using DB `now()` before setting `claimed_at`.
- Delete runner job rows during pending timeout cleanup and add expired runner job queue cleanup.
- Keep cleanup and claim transitions on a runner-job-first order to avoid introducing opposite lock ordering with cancellation/claim flows.

## Tests

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`

Closes #15176
