### PR TITLE
feat: add presentation design gallery

### DIFF
--- a/turbo/apps/web/app/[locale]/presentation-design/PresentationDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation-design/PresentationDesignClient.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Image from "next/image";
+import { IconArrowUpRight } from "@tabler/icons-react";
+import { Footer } from "../../components/Footer";
+import { Particles } from "../../components/Particles";
+import {
+  PRESENTATION_GALLERY_ITEMS,
+  buildPresentationPromptHref,
+  type PresentationGalleryItem,
+} from "./data";
+
+const MAX_WIDTH = 1200;
+const PAGE_PADDING = 24;
+
+function PresentationCard({
+  item,
+  locale,
+}: {
+  item: PresentationGalleryItem;
+  locale: string;
+}) {
+  const href = buildPresentationPromptHref(item, locale);
+
+  return (
+    <article
+      id={item.slug}
+      className="group overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
+    >
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Open ${item.title}`}
+        className="block"
+        style={{ textDecoration: "none" }}
+      >
+        <div className="relative aspect-[16/10] overflow-hidden bg-[hsl(var(--gray-1))]">
+          <div className="absolute inset-y-0 left-0 w-[calc(100%+18px)] transition-transform duration-300 group-hover:scale-[1.03]">
+            <Image
+              src={item.previewImage}
+              alt={item.title}
+              fill
+              sizes="(min-width: 1024px) 378px, (min-width: 768px) calc(50vw + 18px), calc(100vw + 18px)"
+              className="object-cover object-top"
+            />
+          </div>
+          <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-2 text-[13px] font-medium text-[hsl(var(--foreground))] shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
+              <IconArrowUpRight size={16} stroke={2} />
+              View & remix
+            </div>
+          </div>
+        </div>
+      </a>
+    </article>
+  );
+}
+
+export function PresentationDesignClient({ locale }: { locale: string }) {
+  return (
+    <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+      <Particles />
+
+      <section className="hero-section" style={{ paddingBottom: 32 }}>
+        <div
+          style={{
+            maxWidth: MAX_WIDTH,
+            margin: "0 auto",
+            padding: `0 ${PAGE_PADDING}px`,
+          }}
+        >
+          <h1 className="hero-title">Presentation Design</h1>
+          <p className="hero-description">
+            Presentation examples you can open, inspect, and remix into your own
+            Zero deck.
+          </p>
+        </div>
+      </section>
+
+      <section style={{ paddingBottom: 120 }}>
+        <div
+          style={{
+            maxWidth: MAX_WIDTH,
+            margin: "0 auto",
+            padding: `0 ${PAGE_PADDING}px`,
+          }}
+          className="grid grid-cols-1 items-start gap-5 md:grid-cols-2 lg:grid-cols-3"
+        >
+          {PRESENTATION_GALLERY_ITEMS.map((item) => {
+            return (
+              <PresentationCard key={item.slug} item={item} locale={locale} />
+            );
+          })}
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/turbo/apps/web/app/[locale]/presentation-design/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation-design/data.ts
@@ -33,9 +33,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `ink`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5046fc31-02e7-4ec2-8c1d-be5600d196b9/editorial-ink-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c6c75152-d6f5-4949-9fb1-aa209a01139f/editorial-ink-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-ink-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-ink-product-launch-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "ink",
     slides: 10,
@@ -51,9 +51,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `ink`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/11b85ae4-e8d0-45c1-a97a-97a2e6c26d0e/editorial-ink-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b9c771c6-8549-423a-b15b-0158e74e970c/editorial-ink-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-ink-fundraising-pitch-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-ink-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "ink",
     slides: 12,
@@ -69,9 +69,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `ink`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3a1bc202-83a3-4443-84af-264de5ccf8a9/editorial-ink-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0f083e9f-559a-410a-99e3-9136e8bf4036/editorial-ink-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-ink-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-ink-strategy-memo-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "ink",
     slides: 9,
@@ -87,9 +87,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `ink`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/90d3b97b-0da6-4004-8412-42b3339deb2c/editorial-ink-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/927d1b40-e601-44eb-a60e-36479b096745/editorial-ink-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-ink-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-ink-research-report-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "ink",
     slides: 11,
@@ -105,9 +105,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `ink`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/cb81bfe1-1eb3-4d7b-9112-3d714ebaf9a1/editorial-ink-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a466db3c-1f09-4583-ac4e-393deca54919/editorial-ink-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-ink-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-ink-sales-enablement-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "ink",
     slides: 8,
@@ -123,9 +123,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `ink`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0d16add4-33c4-4673-859e-e258569ecbd0/editorial-ink-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/af7fca9a-bb17-49c5-bb90-e53f7bffd468/editorial-ink-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-ink-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-ink-roadmap-planning-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "ink",
     slides: 10,
@@ -141,9 +141,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `coral`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/45df176d-1a71-4097-8948-3c7c5d6f126f/editorial-coral-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ac619f30-585f-4890-ad52-aab38c42ead5/editorial-coral-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-coral-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-coral-product-launch-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "coral",
     slides: 10,
@@ -159,9 +159,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `coral`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c417ce39-4279-41d7-bdd8-5d78b253b7b9/editorial-coral-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8e64fad0-405d-44c8-8399-916a50cc7cec/editorial-coral-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-coral-fundraising-pitch-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-coral-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "coral",
     slides: 12,
@@ -177,9 +177,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `coral`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/db08b7c2-cd59-492c-8324-a095b7a1f690/editorial-coral-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/652756c0-da99-48d3-b453-08073e35dc0d/editorial-coral-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-coral-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-coral-strategy-memo-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "coral",
     slides: 9,
@@ -195,9 +195,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `coral`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/7ab44459-d1a1-4fc4-804b-ac52f2103568/editorial-coral-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8c6134e4-2195-4082-aa21-101944026c13/editorial-coral-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-coral-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-coral-research-report-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "coral",
     slides: 11,
@@ -213,9 +213,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `coral`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8c316b67-a8b8-4217-a03a-c9b127851381/editorial-coral-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a5b340f9-b3ff-4f2e-984b-2510827e54fc/editorial-coral-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-coral-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-coral-sales-enablement-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "coral",
     slides: 8,
@@ -231,9 +231,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `coral`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5538033d-c17b-4d7b-ad76-ef4b32ed854a/editorial-coral-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/00012544-3d7b-42b0-9b69-2301af6d27a9/editorial-coral-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-coral-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-coral-roadmap-planning-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "coral",
     slides: 10,
@@ -249,9 +249,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `forest`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/f9598db5-7784-4422-80b7-c60c3883507b/editorial-forest-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c4489a4f-18de-4aeb-9886-a4e77e04dac9/editorial-forest-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-forest-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-forest-product-launch-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "forest",
     slides: 10,
@@ -267,9 +267,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `forest`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d1aff75a-f2bb-4e09-8d1c-65e986919e9f/editorial-forest-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c1bd7250-8816-40cf-967e-27906cfdd2a7/editorial-forest-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-forest-fundraising-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-forest-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "forest",
     slides: 12,
@@ -285,9 +285,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `forest`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ddf01411-50ed-4d2c-acc4-c5ee9e39a975/editorial-forest-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3ca2ea6b-694d-4ec3-989b-05360cf67a1a/editorial-forest-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-forest-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-forest-strategy-memo-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "forest",
     slides: 9,
@@ -303,9 +303,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `forest`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5f0551f5-d568-4ede-9073-d7fa5dc9bb15/editorial-forest-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/9acf6e48-7a92-49ab-9d79-0787ecbe2e07/editorial-forest-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-forest-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-forest-research-report-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "forest",
     slides: 11,
@@ -321,9 +321,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `forest`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/9d7d144c-8faf-4cdf-8c16-f9d507bb4a4b/editorial-forest-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/fa5c50fa-dc8b-471d-bd97-5c56093dab59/editorial-forest-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-forest-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-forest-sales-enablement-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "forest",
     slides: 8,
@@ -339,9 +339,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `editorial`, theme `forest`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6a27156f-cb77-4326-8873-1ba4b3e7212c/editorial-forest-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e7aa9c1a-919d-4a43-ac47-c82fa1b93a1c/editorial-forest-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-editorial-forest-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-editorial-forest-roadmap-planning-715f6d07.sites.vm0.io",
     style: "editorial",
     theme: "forest",
     slides: 10,
@@ -357,9 +357,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `ikb`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c10e7911-ca79-4cb9-bcf4-fae6c75076e1/swiss-ikb-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8e479d0a-2945-4f64-bb60-9258f14cac72/swiss-ikb-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-ikb-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-ikb-product-launch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "ikb",
     slides: 10,
@@ -375,9 +375,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `ikb`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/55c91bb8-cab4-46e7-ba0a-1f9109d88261/swiss-ikb-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3955b9b1-f75b-4cfb-8040-483606901796/swiss-ikb-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-ikb-fundraising-pitch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-ikb-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "ikb",
     slides: 12,
@@ -393,9 +393,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `ikb`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5eb59b2e-a72c-4506-bb6d-55bbc8a5ea1c/swiss-ikb-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ad72fab9-e4df-4b09-ba9f-a58338c0d0c7/swiss-ikb-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-ikb-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-ikb-strategy-memo-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "ikb",
     slides: 9,
@@ -411,9 +411,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `ikb`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a4e2b68b-a46c-4d7d-b015-e7231d60bde0/swiss-ikb-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/176d0b44-f45d-4110-a4b3-90367ad50cee/swiss-ikb-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-ikb-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-ikb-research-report-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "ikb",
     slides: 11,
@@ -429,9 +429,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `ikb`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8ac6b3a2-706f-4e5d-bcfa-b0ad5a731693/swiss-ikb-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/49394e7c-1b56-468a-bbd0-71b9a74f7777/swiss-ikb-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-ikb-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-ikb-sales-enablement-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "ikb",
     slides: 8,
@@ -447,9 +447,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `ikb`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/fb88a4c9-4d7c-4f11-b415-4be3efb7828c/swiss-ikb-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2884be61-b2d2-4431-b540-91fc3380d175/swiss-ikb-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-ikb-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-ikb-roadmap-planning-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "ikb",
     slides: 10,
@@ -465,9 +465,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lemon`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/eec8d2ac-d131-442e-b13c-0f2a3f7dd3e1/swiss-lemon-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5c731686-218c-438d-8bb6-ead0fef654f7/swiss-lemon-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lemon-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lemon-product-launch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lemon",
     slides: 10,
@@ -483,9 +483,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lemon`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4e91bcf8-becd-4f86-95ee-088fb516163f/swiss-lemon-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8771328d-914c-475d-8ffc-97acf03e894e/swiss-lemon-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lemon-fundraising-pitch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lemon-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lemon",
     slides: 12,
@@ -501,9 +501,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lemon`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4d94220e-2725-4e60-8556-d5414df1ebf8/swiss-lemon-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6ac7f64e-8775-4cb1-bf1c-4d053fbc45af/swiss-lemon-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lemon-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lemon-strategy-memo-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lemon",
     slides: 9,
@@ -519,9 +519,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lemon`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/17284a00-dc0f-4beb-9759-76e1532d8993/swiss-lemon-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/f63fdb15-dfd6-4f16-a8ae-c0e5f13ef2e7/swiss-lemon-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lemon-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lemon-research-report-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lemon",
     slides: 11,
@@ -537,9 +537,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lemon`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/09c35873-7961-4484-bad9-fe2cc03e3be9/swiss-lemon-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/1112b1e3-4ea4-4581-af06-5c8e224aa46a/swiss-lemon-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lemon-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lemon-sales-enablement-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lemon",
     slides: 8,
@@ -555,9 +555,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lemon`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/dbbd9b62-dd0f-4944-bbe7-e7a66cbe649b/swiss-lemon-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/f6f1d015-8891-4fc9-93b0-c9ca6f20d201/swiss-lemon-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lemon-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lemon-roadmap-planning-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lemon",
     slides: 10,
@@ -573,9 +573,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lime`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8d6bac1e-f0d1-4407-ba3b-8f7fc6ce07ad/swiss-lime-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6a137d40-746b-4dd8-a446-1fb51d9e764f/swiss-lime-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lime-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lime-product-launch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lime",
     slides: 10,
@@ -591,9 +591,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lime`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/bf74b313-5e74-4206-964e-0788efc1c775/swiss-lime-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c5df08a7-25bd-4a48-8105-6ac13b6e846e/swiss-lime-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lime-fundraising-pitch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lime-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lime",
     slides: 12,
@@ -609,9 +609,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lime`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2542469e-1eb6-4497-ae34-1407ae21d905/swiss-lime-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/1adebb40-33bb-4f91-bb34-bc5b4581b91a/swiss-lime-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lime-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lime-strategy-memo-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lime",
     slides: 9,
@@ -627,9 +627,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lime`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2dd2e097-5db9-453a-9710-c6a0e5d2f909/swiss-lime-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5f26a75f-8171-447d-8501-4f0a8e0e3770/swiss-lime-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lime-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lime-research-report-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lime",
     slides: 11,
@@ -645,9 +645,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lime`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5d116b77-d602-4f21-b74c-82a5be2c370e/swiss-lime-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/63a77d56-0a51-4959-aea5-ad5a6ea7548e/swiss-lime-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lime-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lime-sales-enablement-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lime",
     slides: 8,
@@ -663,9 +663,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `lime`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d30e45bd-867e-4f35-b91d-6f379dceff74/swiss-lime-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8362eb0f-69d0-4742-9ea8-f7786958f234/swiss-lime-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-lime-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-lime-roadmap-planning-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "lime",
     slides: 10,
@@ -681,9 +681,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `mono`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e8f20e73-7b8b-47f1-9152-5102ae2b78b4/swiss-mono-product-launch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e40503ff-dd17-44bb-a4e8-d221320dd40d/swiss-mono-product-launch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-mono-product-launch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-mono-product-launch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "mono",
     slides: 10,
@@ -699,9 +699,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `mono`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a3911aab-4979-4dc3-9607-389510680ef1/swiss-mono-fundraising-pitch.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/1aaf3b28-b496-4dec-9fb9-ac5d98388fe0/swiss-mono-fundraising-pitch.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-mono-fundraising-pitch-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-mono-fundraising-pitch-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "mono",
     slides: 12,
@@ -717,9 +717,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `mono`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a2fb8252-a9ff-41d3-a045-0566cc145912/swiss-mono-strategy-memo.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/96fb7a52-6f2d-468e-9001-7f6028950d0d/swiss-mono-strategy-memo.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-mono-strategy-memo-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-mono-strategy-memo-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "mono",
     slides: 9,
@@ -735,9 +735,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `mono`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/598b605c-62ac-41f0-8fae-f182b8cb0d9e/swiss-mono-research-report.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/9d6e794e-71b0-4593-843e-36d4771644c1/swiss-mono-research-report.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-mono-research-report-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-mono-research-report-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "mono",
     slides: 11,
@@ -753,9 +753,9 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `mono`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6b4f2057-3ac3-49b7-bc9e-4e0913e854fc/swiss-mono-sales-enablement.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/456f0b18-240f-4c57-89c8-58e16bfd3ad3/swiss-mono-sales-enablement.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-mono-sales-enablement-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-mono-sales-enablement-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "mono",
     slides: 8,
@@ -771,16 +771,16 @@ export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
     prompt:
       "Using `zero generate presentation` with style `swiss`, theme `mono`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b04cb6fb-ed4b-4b59-9969-08c92fc62aa3/swiss-mono-roadmap-planning.png",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/66af7d8c-ffda-43d1-aeb6-a9a8b8485b15/swiss-mono-roadmap-planning.png",
     artifactUrl:
-      "https://presentation-gallery-swiss-mono-roadmap-planning-715f6d07.sites.vm0.io",
+      "https://presentation-real-swiss-mono-roadmap-planning-715f6d07.sites.vm0.io",
     style: "swiss",
     theme: "mono",
     slides: 10,
     images: 2,
     imageModel: "gpt-image-1",
     audience: "product and engineering leadership",
-  },
+  }
 ];
 
 export function buildPresentationPromptHref(

--- a/turbo/apps/web/app/[locale]/presentation-design/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation-design/data.ts
@@ -1,0 +1,794 @@
+export type PresentationStyle = "editorial" | "swiss";
+
+export type PresentationTheme =
+  | "ink"
+  | "coral"
+  | "forest"
+  | "ikb"
+  | "lemon"
+  | "lime"
+  | "mono";
+
+export interface PresentationGalleryItem {
+  readonly slug: string;
+  readonly title: string;
+  readonly description: string;
+  readonly prompt: string;
+  readonly previewImage: string;
+  readonly artifactUrl: string;
+  readonly style: PresentationStyle;
+  readonly theme: PresentationTheme;
+  readonly slides: number;
+  readonly images: number;
+  readonly imageModel: string;
+  readonly audience: string;
+}
+
+export const PRESENTATION_GALLERY_ITEMS: readonly PresentationGalleryItem[] = [
+  {
+    slug: "editorial-ink-product-launch",
+    title: "Ink Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `ink`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5046fc31-02e7-4ec2-8c1d-be5600d196b9/editorial-ink-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-ink-product-launch-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "ink",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "editorial-ink-fundraising-pitch",
+    title: "Ink Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `ink`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/11b85ae4-e8d0-45c1-a97a-97a2e6c26d0e/editorial-ink-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-ink-fundraising-pitch-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "ink",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "editorial-ink-strategy-memo",
+    title: "Ink Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `ink`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3a1bc202-83a3-4443-84af-264de5ccf8a9/editorial-ink-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-ink-strategy-memo-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "ink",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "editorial-ink-research-report",
+    title: "Ink Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `ink`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/90d3b97b-0da6-4004-8412-42b3339deb2c/editorial-ink-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-ink-research-report-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "ink",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "editorial-ink-sales-enablement",
+    title: "Ink Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `ink`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/cb81bfe1-1eb3-4d7b-9112-3d714ebaf9a1/editorial-ink-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-ink-sales-enablement-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "ink",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "editorial-ink-roadmap-planning",
+    title: "Ink Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `ink`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0d16add4-33c4-4673-859e-e258569ecbd0/editorial-ink-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-ink-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "ink",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+  {
+    slug: "editorial-coral-product-launch",
+    title: "Coral Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `coral`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/45df176d-1a71-4097-8948-3c7c5d6f126f/editorial-coral-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-coral-product-launch-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "coral",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "editorial-coral-fundraising-pitch",
+    title: "Coral Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `coral`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c417ce39-4279-41d7-bdd8-5d78b253b7b9/editorial-coral-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-coral-fundraising-pitch-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "coral",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "editorial-coral-strategy-memo",
+    title: "Coral Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `coral`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/db08b7c2-cd59-492c-8324-a095b7a1f690/editorial-coral-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-coral-strategy-memo-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "coral",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "editorial-coral-research-report",
+    title: "Coral Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `coral`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/7ab44459-d1a1-4fc4-804b-ac52f2103568/editorial-coral-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-coral-research-report-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "coral",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "editorial-coral-sales-enablement",
+    title: "Coral Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `coral`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8c316b67-a8b8-4217-a03a-c9b127851381/editorial-coral-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-coral-sales-enablement-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "coral",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "editorial-coral-roadmap-planning",
+    title: "Coral Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `coral`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5538033d-c17b-4d7b-ad76-ef4b32ed854a/editorial-coral-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-coral-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "coral",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+  {
+    slug: "editorial-forest-product-launch",
+    title: "Forest Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `forest`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/f9598db5-7784-4422-80b7-c60c3883507b/editorial-forest-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-forest-product-launch-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "forest",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "editorial-forest-fundraising-pitch",
+    title: "Forest Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `forest`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d1aff75a-f2bb-4e09-8d1c-65e986919e9f/editorial-forest-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-forest-fundraising-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "forest",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "editorial-forest-strategy-memo",
+    title: "Forest Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `forest`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ddf01411-50ed-4d2c-acc4-c5ee9e39a975/editorial-forest-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-forest-strategy-memo-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "forest",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "editorial-forest-research-report",
+    title: "Forest Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `forest`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5f0551f5-d568-4ede-9073-d7fa5dc9bb15/editorial-forest-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-forest-research-report-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "forest",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "editorial-forest-sales-enablement",
+    title: "Forest Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `forest`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/9d7d144c-8faf-4cdf-8c16-f9d507bb4a4b/editorial-forest-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-forest-sales-enablement-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "forest",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "editorial-forest-roadmap-planning",
+    title: "Forest Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `editorial`, theme `forest`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6a27156f-cb77-4326-8873-1ba4b3e7212c/editorial-forest-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-editorial-forest-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "editorial",
+    theme: "forest",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+  {
+    slug: "swiss-ikb-product-launch",
+    title: "Ikb Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `ikb`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c10e7911-ca79-4cb9-bcf4-fae6c75076e1/swiss-ikb-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-ikb-product-launch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "ikb",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "swiss-ikb-fundraising-pitch",
+    title: "Ikb Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `ikb`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/55c91bb8-cab4-46e7-ba0a-1f9109d88261/swiss-ikb-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-ikb-fundraising-pitch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "ikb",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "swiss-ikb-strategy-memo",
+    title: "Ikb Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `ikb`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5eb59b2e-a72c-4506-bb6d-55bbc8a5ea1c/swiss-ikb-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-ikb-strategy-memo-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "ikb",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "swiss-ikb-research-report",
+    title: "Ikb Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `ikb`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a4e2b68b-a46c-4d7d-b015-e7231d60bde0/swiss-ikb-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-ikb-research-report-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "ikb",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "swiss-ikb-sales-enablement",
+    title: "Ikb Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `ikb`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8ac6b3a2-706f-4e5d-bcfa-b0ad5a731693/swiss-ikb-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-ikb-sales-enablement-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "ikb",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "swiss-ikb-roadmap-planning",
+    title: "Ikb Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `ikb`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/fb88a4c9-4d7c-4f11-b415-4be3efb7828c/swiss-ikb-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-ikb-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "ikb",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+  {
+    slug: "swiss-lemon-product-launch",
+    title: "Lemon Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lemon`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/eec8d2ac-d131-442e-b13c-0f2a3f7dd3e1/swiss-lemon-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lemon-product-launch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lemon",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "swiss-lemon-fundraising-pitch",
+    title: "Lemon Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lemon`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4e91bcf8-becd-4f86-95ee-088fb516163f/swiss-lemon-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lemon-fundraising-pitch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lemon",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "swiss-lemon-strategy-memo",
+    title: "Lemon Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lemon`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4d94220e-2725-4e60-8556-d5414df1ebf8/swiss-lemon-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lemon-strategy-memo-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lemon",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "swiss-lemon-research-report",
+    title: "Lemon Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lemon`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/17284a00-dc0f-4beb-9759-76e1532d8993/swiss-lemon-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lemon-research-report-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lemon",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "swiss-lemon-sales-enablement",
+    title: "Lemon Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lemon`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/09c35873-7961-4484-bad9-fe2cc03e3be9/swiss-lemon-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lemon-sales-enablement-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lemon",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "swiss-lemon-roadmap-planning",
+    title: "Lemon Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lemon`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/dbbd9b62-dd0f-4944-bbe7-e7a66cbe649b/swiss-lemon-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lemon-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lemon",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+  {
+    slug: "swiss-lime-product-launch",
+    title: "Lime Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lime`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8d6bac1e-f0d1-4407-ba3b-8f7fc6ce07ad/swiss-lime-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lime-product-launch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lime",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "swiss-lime-fundraising-pitch",
+    title: "Lime Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lime`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/bf74b313-5e74-4206-964e-0788efc1c775/swiss-lime-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lime-fundraising-pitch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lime",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "swiss-lime-strategy-memo",
+    title: "Lime Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lime`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2542469e-1eb6-4497-ae34-1407ae21d905/swiss-lime-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lime-strategy-memo-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lime",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "swiss-lime-research-report",
+    title: "Lime Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lime`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2dd2e097-5db9-453a-9710-c6a0e5d2f909/swiss-lime-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lime-research-report-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lime",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "swiss-lime-sales-enablement",
+    title: "Lime Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lime`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5d116b77-d602-4f21-b74c-82a5be2c370e/swiss-lime-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lime-sales-enablement-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lime",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "swiss-lime-roadmap-planning",
+    title: "Lime Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `lime`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d30e45bd-867e-4f35-b91d-6f379dceff74/swiss-lime-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-lime-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "lime",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+  {
+    slug: "swiss-mono-product-launch",
+    title: "Mono Product Launch Narrative",
+    description:
+      "A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `mono`, 10 slides, and 4 generated images, create A launch deck explaining the market shift, product promise, proof, rollout plan, and launch metrics. Audience: product and growth leaders. Cover Market shift, product promise, customer proof, launch plan, metrics, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e8f20e73-7b8b-47f1-9152-5102ae2b78b4/swiss-mono-product-launch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-mono-product-launch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "mono",
+    slides: 10,
+    images: 4,
+    imageModel: "gpt-image-1",
+    audience: "product and growth leaders",
+  },
+  {
+    slug: "swiss-mono-fundraising-pitch",
+    title: "Mono Fundraising Pitch",
+    description:
+      "A fundraising deck with problem, market, product, traction, business model, team, and ask.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `mono`, 12 slides, and 3 generated images, create A fundraising deck with problem, market, product, traction, business model, team, and ask. Audience: seed and Series A investors. Cover Problem, market size, product wedge, traction, business model, team, ask, and use of funds.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a3911aab-4979-4dc3-9607-389510680ef1/swiss-mono-fundraising-pitch.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-mono-fundraising-pitch-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "mono",
+    slides: 12,
+    images: 3,
+    imageModel: "gpt-image-1",
+    audience: "seed and Series A investors",
+  },
+  {
+    slug: "swiss-mono-strategy-memo",
+    title: "Mono Strategy Memo",
+    description:
+      "A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `mono`, 9 slides, and 1 generated images, create A strategic planning deck with context, options, tradeoffs, recommendation, risks, and operating cadence. Audience: executive team. Cover Context, strategic options, tradeoffs, recommendation, risks, decision points, and operating cadence.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a2fb8252-a9ff-41d3-a045-0566cc145912/swiss-mono-strategy-memo.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-mono-strategy-memo-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "mono",
+    slides: 9,
+    images: 1,
+    imageModel: "gpt-image-1",
+    audience: "executive team",
+  },
+  {
+    slug: "swiss-mono-research-report",
+    title: "Mono Research Report",
+    description:
+      "A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `mono`, 11 slides, and 5 generated images, create A research findings deck with methodology, user segments, insights, evidence, opportunities, and next steps. Audience: product, design, and research teams. Cover Methodology, user segments, key insights, evidence snapshots, opportunity areas, and next steps.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/598b605c-62ac-41f0-8fae-f182b8cb0d9e/swiss-mono-research-report.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-mono-research-report-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "mono",
+    slides: 11,
+    images: 5,
+    imageModel: "gpt-image-1",
+    audience: "product, design, and research teams",
+  },
+  {
+    slug: "swiss-mono-sales-enablement",
+    title: "Mono Sales Enablement",
+    description:
+      "A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `mono`, 8 slides, and 2 generated images, create A sales enablement deck with buyer pain, qualification cues, demo flow, objection handling, and ROI proof. Audience: account executives and solutions engineers. Cover Buyer pain, qualification cues, demo flow, proof points, objection handling, ROI story, and close plan.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6b4f2057-3ac3-49b7-bc9e-4e0913e854fc/swiss-mono-sales-enablement.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-mono-sales-enablement-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "mono",
+    slides: 8,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "account executives and solutions engineers",
+  },
+  {
+    slug: "swiss-mono-roadmap-planning",
+    title: "Mono Roadmap Planning",
+    description:
+      "A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones.",
+    prompt:
+      "Using `zero generate presentation` with style `swiss`, theme `mono`, 10 slides, and 2 generated images, create A roadmap planning deck with bets, sequencing, dependencies, resourcing, risks, and milestones. Audience: product and engineering leadership. Cover Strategic bets, sequencing, dependencies, resourcing, risks, milestones, and review rhythm.",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b04cb6fb-ed4b-4b59-9969-08c92fc62aa3/swiss-mono-roadmap-planning.png",
+    artifactUrl:
+      "https://presentation-gallery-swiss-mono-roadmap-planning-715f6d07.sites.vm0.io",
+    style: "swiss",
+    theme: "mono",
+    slides: 10,
+    images: 2,
+    imageModel: "gpt-image-1",
+    audience: "product and engineering leadership",
+  },
+];
+
+export function buildPresentationPromptHref(
+  item: PresentationGalleryItem,
+  locale: string,
+): string {
+  const url = new URL(`/${locale}/showcase`, "https://www.vm0.ai");
+  url.searchParams.set("prompt", item.prompt);
+  url.searchParams.set("website", item.artifactUrl);
+  return `${url.pathname}${url.search}`;
+}

--- a/turbo/apps/web/app/[locale]/presentation-design/page.tsx
+++ b/turbo/apps/web/app/[locale]/presentation-design/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import type { Locale } from "../../../i18n";
+import { buildLocaleAlternates } from "../../lib/seo/alternates";
+import { PresentationDesignClient } from "./PresentationDesignClient";
+import { PRESENTATION_GALLERY_ITEMS } from "./data";
+
+const BASE_URL = "https://www.vm0.ai";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const url = `${BASE_URL}/${locale}/presentation-design`;
+
+  return {
+    title: "Presentation Design Gallery - Remix Zero Prompts",
+    description:
+      "Hidden gallery of presentation design examples for remixing Zero presentation generation.",
+    alternates: buildLocaleAlternates("/presentation-design", locale as Locale),
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title: "VM0 Presentation Design Gallery",
+      description: "Presentation design examples for remixing Zero generation.",
+      url,
+      type: "website",
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "VM0 Presentation Design Gallery",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "VM0 Presentation Design Gallery",
+      description: "Presentation design examples for remixing Zero generation.",
+      images: ["/og-image.png"],
+      creator: "@vm0_ai",
+      site: "@vm0_ai",
+    },
+  };
+}
+
+export default async function PresentationGalleryPage({ params }: PageProps) {
+  const { locale } = await params;
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "VM0 Presentation Design Gallery",
+    description: "Presentation design examples for remixing Zero generation.",
+    itemListElement: PRESENTATION_GALLERY_ITEMS.map((item, i) => {
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${BASE_URL}/${locale}/presentation-design#${item.slug}`,
+        name: item.title,
+        description: item.description,
+      };
+    }),
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(itemListJsonLd)}
+      </script>
+      <PresentationDesignClient locale={locale} />
+    </>
+  );
+}

--- a/turbo/apps/web/src/__tests__/presentation-gallery-data.test.ts
+++ b/turbo/apps/web/src/__tests__/presentation-gallery-data.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRESENTATION_GALLERY_ITEMS,
+  buildPresentationPromptHref,
+} from "../../app/[locale]/presentation-design/data";
+
+describe("presentation design gallery data", () => {
+  it("uses unique slugs and covers presentation style/theme combinations", () => {
+    const slugs = PRESENTATION_GALLERY_ITEMS.map((item) => {
+      return item.slug;
+    });
+    expect(new Set(slugs).size).toBe(slugs.length);
+    expect(PRESENTATION_GALLERY_ITEMS.length).toBe(42);
+
+    const styleThemes = new Set(
+      PRESENTATION_GALLERY_ITEMS.map((item) => {
+        return `${item.style}:${item.theme}`;
+      }),
+    );
+    expect([...styleThemes].sort()).toEqual([
+      "editorial:coral",
+      "editorial:forest",
+      "editorial:ink",
+      "swiss:ikb",
+      "swiss:lemon",
+      "swiss:lime",
+      "swiss:mono",
+    ]);
+  });
+
+  it("has hosted previews and artifacts for every item", () => {
+    expect(
+      PRESENTATION_GALLERY_ITEMS.every((item) => {
+        return (
+          item.previewImage.startsWith("https://cdn.vm0.io/") &&
+          item.artifactUrl.startsWith("https://") &&
+          item.prompt.includes("zero generate presentation")
+        );
+      }),
+    ).toBe(true);
+  });
+
+  it("builds showcase URLs for hosted presentation items", () => {
+    const item = PRESENTATION_GALLERY_ITEMS[0];
+    if (!item) {
+      throw new Error("Expected at least one presentation gallery item");
+    }
+
+    const href = buildPresentationPromptHref(item, "en");
+    const url = new URL(href, "https://www.vm0.ai");
+
+    expect(href.startsWith("/en/showcase?")).toBe(true);
+    expect(url.pathname).toBe("/en/showcase");
+    expect(url.searchParams.get("prompt")).toContain(item.prompt);
+    expect(url.searchParams.get("website")).toBe(item.artifactUrl);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a hidden presentation design gallery at `/[locale]/presentation-design`, following the same lightweight gallery pattern as `/web-design`.

- Adds 42 hosted presentation examples covering the meaningful `zero generate presentation` surface:
  - 7 style/theme combinations: editorial ink/coral/forest and swiss ikb/lemon/lime/mono
  - 6 deck archetypes per theme: product launch, fundraising pitch, strategy memo, research report, sales enablement, roadmap planning
- Each card has a hosted HTML deck artifact, CDN screenshot preview, and remix prompt using `zero generate presentation`.
- Reuses `/showcase` iframe preview by passing the hosted deck as the `website` param.
- Adds a focused data test for count, unique slugs, style/theme coverage, hosted previews/artifacts, and showcase URL construction.

## Validation

- 42/42 hosted deck URLs return HTTP 200
- 42/42 screenshots generated and uploaded to CDN
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run src/__tests__/presentation-gallery-data.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`

Note: I also tried a local Next dev route check by bypassing the tunnel wrapper, but this runtime lacks required app env vars such as Clerk/R2/OpenAI secrets, so the page request returns the existing env validation 500 before rendering.
