### PR TITLE
feat: mention agent-browser in zero system prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -478,6 +478,7 @@ describe("POST /api/zero/runs", () => {
     for (const toolHint of [
       "zero web download-file -h",
       "Localhost URLs, local dev server ports, and processes started inside the agent runtime are generally only reachable inside that runtime",
+      "`agent-browser` for browser automation and inspection",
       "Local dev servers are useful for agent-side verification",
       "For static web artifacts, Zero provides `zero host <dir> --site <slug> [--spa]`",
       "For apps or services that require a long-running backend, database, worker, external service, or framework-specific runtime",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -222,6 +222,7 @@ function buildAgentToolsPrompt(
     "- Discover available commands: `zero --help`.",
     "- Search agent run logs, web chat messages, or external services via connectors: `zero search --help`.",
     "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
+    "- Browser access: the runtime environment includes `agent-browser` for browser automation and inspection.",
     ...buildIntegrationToolsPrompt(triggerSource),
     ...buildZeroMapsToolsPrompt(args.zeroMapsEnabled),
     "- Static web artifacts can be published with `zero host <dir> --site <slug> [--spa]`; run `zero host --help` for details.",


### PR DESCRIPTION
## Summary
- Add an Agent Tools prompt line that tells Zero agents the runtime includes `agent-browser` for browser automation and inspection.
- Update the zero run creation test assertion for the injected system prompt.

## Verification
- `pnpm prettier --check apps/api/src/signals/services/zero-runs-create.service.ts apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm vitest run apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts` attempted; fails in this local environment because PostgreSQL is not running on `127.0.0.1:5432` / `::1:5432`.