### PR TITLE
test: cover reconnect spacing saturation

### DIFF
--- a/crates/ably-subscriber/src/connection/state.rs
+++ b/crates/ably-subscriber/src/connection/state.rs
@@ -427,6 +427,16 @@ mod tests {
     }
 
     #[test]
+    fn reconnect_spacing_delay_elapsed_exceeds_min_interval_returns_zero() {
+        let long_ago = Instant::now() - Duration::from_secs(60);
+
+        assert_eq!(
+            reconnect_spacing_delay(Some(long_ago), Duration::from_secs(5)),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
     fn conn_state_uses_default_idle_interval_without_connection_details() {
         let timing = TimingConfig::default();
         let token = TokenDetails {


### PR DESCRIPTION
## Summary
- add a focused inline test for `reconnect_spacing_delay` when elapsed time already exceeds `min_interval`
- keep reconnect behavior coverage in the existing integration test without adding sleeps, fake timers, or new websocket scenarios

Fixes #15159

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber reconnect_spacing_delay`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber repeated_clean_close_reconnect_is_rate_limited`
- `cargo fmt --manifest-path crates/ably-subscriber/Cargo.toml --check`
- `cd crates && cargo clippy --all-targets --all-features`
