### PR TITLE
fix: make zero run cancellation race-safe

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -171,6 +171,9 @@ async function insertRunFixture(args?: {
 async function insertQueueEntry(
   fixture: RunFixture,
   expiresAt: Date,
+  options?: {
+    readonly encryptedParams?: string;
+  },
 ): Promise<void> {
   const db = store.set(writeDb$);
   const [run] = await db
@@ -192,6 +195,9 @@ async function insertQueueEntry(
     orgId: run.orgId,
     createdAt: run.createdAt,
     expiresAt,
+    ...(options?.encryptedParams !== undefined
+      ? { encryptedParams: options.encryptedParams }
+      : {}),
   });
 }
 
@@ -262,6 +268,18 @@ async function findRunnerJob(runId: string): Promise<{
     .select({ runId: runnerJobQueue.runId })
     .from(runnerJobQueue)
     .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function findQueueEntry(runId: string): Promise<{
+  readonly runId: string;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ runId: agentRunQueue.runId })
+    .from(agentRunQueue)
+    .where(eq(agentRunQueue.runId, runId))
     .limit(1);
   return row ?? null;
 }
@@ -542,6 +560,26 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       status: "timeout",
       error: "Queued run expired (exceeded queue TTL)",
     });
+    await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
+  });
+
+  it("deletes expired stale queue entries without changing terminal runs", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "cancelled", createdAt: minutesAgo(130) }),
+    );
+    await insertQueueEntry(fixture, minutesAgo(1));
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "cancelled",
+      error: null,
+    });
+    await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
   });
 
   it("drains queued runs when an org has no active runs", async () => {
@@ -560,6 +598,27 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       status: "pending",
       error: null,
     });
+  });
+
+  it("removes stale queue entries before decrypting queued payloads", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "cancelled", createdAt: minutesAgo(1) }),
+    );
+    await insertQueueEntry(fixture, minutesAgo(-60), {
+      encryptedParams: "invalid-encrypted-payload",
+    });
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "cancelled",
+      error: null,
+    });
+    await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
   });
 
   it("cleans expired export jobs and fails stuck export jobs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -164,6 +164,70 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     );
   });
 
+  it("emits cancel side effects once for concurrent cancels", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(agentRuns)
+      .set({ runnerGroup: "vm0/test" })
+      .where(eq(agentRuns.id, runId));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const responses = await Promise.all(
+      [0, 1].map(() => {
+        return accept(
+          client.cancel({
+            params: { id: runId },
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200],
+        );
+      }),
+    );
+    expect(responses).toHaveLength(2);
+
+    await clearAllDetached();
+    const cancelPublishes = context.mocks.ably.publish.mock.calls.filter(
+      ([topic, payload]) => {
+        const runIdValue =
+          payload && typeof payload === "object" && "runId" in payload
+            ? (payload as { readonly runId?: unknown }).runId
+            : undefined;
+        return topic === "cancel" && runIdValue === runId;
+      },
+    );
+    expect(cancelPublishes).toHaveLength(1);
+
+    const runChangedPublishes = context.mocks.ably.publish.mock.calls.filter(
+      ([topic, payload]) => {
+        const status =
+          payload && typeof payload === "object" && "status" in payload
+            ? (payload as { readonly status?: unknown }).status
+            : undefined;
+        return topic === `runChanged:${runId}` && status === "cancelled";
+      },
+    );
+    expect(runChangedPublishes).toHaveLength(1);
+  });
+
   it("returns 400 RUN_NOT_CANCELLABLE when run already completed", async () => {
     const fixture = await track(
       store.set(seedUsageInsightFixture$, undefined, context.signal),
@@ -248,6 +312,57 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, runId));
     expect(remainingJobs).toHaveLength(0);
+  });
+
+  it("deletes a queued run queue entry when cancelling before drain", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "queued",
+      },
+      context.signal,
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(agentRunQueue).values({
+      runId,
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      createdAt: nowDate(),
+      expiresAt: new Date(now() + 60_000),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const [run] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+
+    const queueRows = await writeDb
+      .select({ runId: agentRunQueue.runId })
+      .from(agentRunQueue)
+      .where(eq(agentRunQueue.runId, runId));
+    expect(queueRows).toHaveLength(0);
   });
 
   it("returns 200 when run is already cancelled (idempotent; no side effects)", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -334,29 +334,46 @@ type ClaimTransitionResult =
   | { readonly status: "job-not-found" }
   | { readonly status: "run-not-found" };
 
-type ClaimMissResult =
-  | { readonly status: "conflict" }
-  | { readonly status: "job-not-found" };
+interface LockedClaimRunRow extends Record<string, unknown> {
+  readonly id: string;
+  readonly status: string;
+}
 
-async function classifyClaimMiss(
-  db: Pick<Db, "select">,
+interface LockedRunnerJobRow extends Record<string, unknown> {
+  readonly runId: string;
+  readonly claimedAt: Date | null;
+  readonly isExpired: boolean;
+}
+
+async function lockClaimRun(
+  db: Pick<Db, "execute">,
   runId: string,
-  signal: AbortSignal,
-): Promise<ClaimMissResult> {
-  const [existingJob] = await db
-    .select({
-      runId: runnerJobQueue.runId,
-      isExpired: sql<boolean>`${runnerJobQueue.expiresAt} <= now()`,
-    })
-    .from(runnerJobQueue)
-    .where(eq(runnerJobQueue.runId, runId))
-    .limit(1);
-  signal.throwIfAborted();
+): Promise<LockedClaimRunRow | undefined> {
+  const rows = await db.execute<LockedClaimRunRow>(sql`
+    SELECT
+      ${agentRuns.id} AS "id",
+      ${agentRuns.status} AS "status"
+    FROM ${agentRuns}
+    WHERE ${agentRuns.id} = ${runId}
+    FOR UPDATE
+  `);
+  return rows.rows[0];
+}
 
-  if (!existingJob || existingJob.isExpired) {
-    return { status: "job-not-found" };
-  }
-  return { status: "conflict" };
+async function lockRunnerJob(
+  db: Pick<Db, "execute">,
+  runId: string,
+): Promise<LockedRunnerJobRow | undefined> {
+  const rows = await db.execute<LockedRunnerJobRow>(sql`
+    SELECT
+      ${runnerJobQueue.runId} AS "runId",
+      ${runnerJobQueue.claimedAt} AS "claimedAt",
+      ${runnerJobQueue.expiresAt} <= now() AS "isExpired"
+    FROM ${runnerJobQueue}
+    WHERE ${runnerJobQueue.runId} = ${runId}
+    FOR UPDATE
+  `);
+  return rows.rows[0];
 }
 
 async function transitionClaimedJobToRunning(
@@ -365,48 +382,45 @@ async function transitionClaimedJobToRunning(
   signal: AbortSignal,
 ): Promise<ClaimTransitionResult> {
   return await db.transaction(async (tx) => {
-    const [claimedJob] = await tx
-      .update(runnerJobQueue)
-      .set({ claimedAt: sql`now()` })
-      .where(
-        and(
-          eq(runnerJobQueue.runId, runId),
-          isNull(runnerJobQueue.claimedAt),
-          gt(runnerJobQueue.expiresAt, sql`now()`),
-        ),
-      )
-      .returning({
-        runId: runnerJobQueue.runId,
-        claimedAt: runnerJobQueue.claimedAt,
-      });
-    signal.throwIfAborted();
-    if (!claimedJob) {
-      return await classifyClaimMiss(tx, runId, signal);
-    }
-    if (!claimedJob.claimedAt) {
-      throw new Error("Runner job claim timestamp missing");
-    }
-
-    const [run] = await tx
-      .update(agentRuns)
-      .set({
-        status: "running",
-        startedAt: claimedJob.claimedAt,
-        lastHeartbeatAt: claimedJob.claimedAt,
-      })
-      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
-      .returning({ id: agentRuns.id });
+    const run = await lockClaimRun(tx, runId);
     signal.throwIfAborted();
     if (!run) {
+      return { status: "run-not-found" };
+    }
+    if (run.status !== "pending") {
       await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
       signal.throwIfAborted();
       return { status: "run-not-found" };
     }
 
+    const job = await lockRunnerJob(tx, runId);
+    signal.throwIfAborted();
+    if (!job || job.isExpired) {
+      return { status: "job-not-found" };
+    }
+    if (job.claimedAt) {
+      return { status: "conflict" };
+    }
+
+    const claimedAt = nowDate();
+    const [updatedRun] = await tx
+      .update(agentRuns)
+      .set({
+        status: "running",
+        startedAt: claimedAt,
+        lastHeartbeatAt: claimedAt,
+      })
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (!updatedRun) {
+      throw new Error("Locked pending run was not claimed");
+    }
+
     await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
     signal.throwIfAborted();
 
-    return { status: "claimed" as const, claimedAt: claimedJob.claimedAt };
+    return { status: "claimed" as const, claimedAt };
   });
 }
 
@@ -423,42 +437,39 @@ async function failPoisonQueuedJob(
   signal: AbortSignal,
 ): Promise<PoisonJobResult> {
   return await db.transaction(async (tx) => {
-    const [claimedJob] = await tx
-      .update(runnerJobQueue)
-      .set({ claimedAt: sql`now()` })
-      .where(
-        and(
-          eq(runnerJobQueue.runId, runId),
-          isNull(runnerJobQueue.claimedAt),
-          gt(runnerJobQueue.expiresAt, sql`now()`),
-        ),
-      )
-      .returning({
-        runId: runnerJobQueue.runId,
-        claimedAt: runnerJobQueue.claimedAt,
-      });
+    const run = await lockClaimRun(tx, runId);
     signal.throwIfAborted();
-    if (!claimedJob) {
-      return await classifyClaimMiss(tx, runId, signal);
+    if (!run) {
+      return { status: "run-not-found" };
     }
-    if (!claimedJob.claimedAt) {
-      throw new Error("Runner job claim timestamp missing");
+    if (run.status !== "pending") {
+      await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+      signal.throwIfAborted();
+      return { status: "run-not-found" };
     }
 
-    const [run] = await tx
+    const job = await lockRunnerJob(tx, runId);
+    signal.throwIfAborted();
+    if (!job || job.isExpired) {
+      return { status: "job-not-found" };
+    }
+    if (job.claimedAt) {
+      return { status: "conflict" };
+    }
+
+    const failedAt = nowDate();
+    const [updatedRun] = await tx
       .update(agentRuns)
       .set({
         status: "failed",
-        completedAt: claimedJob.claimedAt,
+        completedAt: failedAt,
         error: errorMessage,
       })
       .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
       .returning({ id: agentRuns.id });
     signal.throwIfAborted();
-    if (!run) {
-      await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
-      signal.throwIfAborted();
-      return { status: "run-not-found" };
+    if (!updatedRun) {
+      throw new Error("Locked pending run was not failed");
     }
 
     await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -52,6 +52,7 @@ import {
 import {
   type CreateRunResponse,
   type RunStatus,
+  runStatusSchema,
   unifiedRunRequestSchema,
 } from "@vm0/api-contracts/contracts/runs";
 import {
@@ -163,6 +164,7 @@ const CONNECTOR_VAR_REF_PREFIX = "$vars.";
 
 type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
 type ComputedGetter = Getter;
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 function withZeroTokenSecret(
   body: CreateRunBody,
@@ -240,6 +242,16 @@ interface RunRecord {
   readonly createdAt: Date;
   readonly sessionId: string;
   readonly status: "pending" | "queued";
+}
+
+interface LockedRunPersistenceRow extends Record<string, unknown> {
+  readonly status: string;
+  readonly sandboxId: string | null;
+}
+
+interface DerivedPersistenceResult {
+  readonly status: RunStatus;
+  readonly sandboxId?: string;
 }
 
 interface RunCallback {
@@ -3280,6 +3292,26 @@ async function buildRunnerJobPayload(
   });
 }
 
+async function lockRunForDerivedPersistence(
+  tx: DbTransaction,
+  runId: string,
+): Promise<DerivedPersistenceResult | null> {
+  const rows = await tx.execute<LockedRunPersistenceRow>(sql`
+    SELECT
+      ${agentRuns.status} AS "status",
+      ${agentRuns.sandboxId} AS "sandboxId"
+    FROM ${agentRuns}
+    WHERE ${agentRuns.id} = ${runId}
+    FOR UPDATE
+  `);
+  const row = rows.rows[0];
+  if (!row) {
+    return null;
+  }
+  const status = runStatusSchema.parse(row.status);
+  return row.sandboxId ? { status, sandboxId: row.sandboxId } : { status };
+}
+
 async function dispatchRun(
   get: ComputedGetter,
   db: Db,
@@ -3301,7 +3333,7 @@ async function dispatchRun(
     readonly userTimezone: string | undefined;
     readonly featureSwitchContext: FeatureSwitchContext;
   },
-): Promise<{ readonly status: RunStatus; readonly sandboxId?: string }> {
+): Promise<DerivedPersistenceResult> {
   await db
     .update(agentRuns)
     .set({ lastHeartbeatAt: nowDate() })
@@ -3309,28 +3341,44 @@ async function dispatchRun(
 
   const payload = await buildRunnerJobPayload(get, db, args);
 
-  await db.insert(runnerJobQueue).values({
-    runId: args.run.id,
-    runnerGroup: payload.runnerGroup,
-    profile: payload.profile,
-    sessionId: payload.sessionId,
-    executionContext: payload.executionContext,
-    expiresAt: new Date(now() + 2 * 60 * 60 * 1000),
+  const persisted = await db.transaction(async (tx) => {
+    const currentRun = await lockRunForDerivedPersistence(tx, args.run.id);
+    if (!currentRun) {
+      throw new Error("Run disappeared before runner job persistence");
+    }
+    if (currentRun.status !== "pending") {
+      return currentRun;
+    }
+
+    await tx.insert(runnerJobQueue).values({
+      runId: args.run.id,
+      runnerGroup: payload.runnerGroup,
+      profile: payload.profile,
+      sessionId: payload.sessionId,
+      executionContext: payload.executionContext,
+      expiresAt: new Date(now() + 2 * 60 * 60 * 1000),
+    });
+
+    await tx
+      .update(agentRuns)
+      .set({ runnerGroup: payload.runnerGroup })
+      .where(
+        and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "pending")),
+      );
+
+    return { status: "pending" as const };
   });
 
-  await db
-    .update(agentRuns)
-    .set({ runnerGroup: payload.runnerGroup })
-    .where(eq(agentRuns.id, args.run.id));
+  if (persisted.status === "pending") {
+    await notifyRunnerJob(db, {
+      runnerGroup: payload.runnerGroup,
+      runId: args.run.id,
+      profile: payload.profile,
+      sessionId: payload.sessionId,
+    });
+  }
 
-  await notifyRunnerJob(db, {
-    runnerGroup: payload.runnerGroup,
-    runId: args.run.id,
-    profile: payload.profile,
-    sessionId: payload.sessionId,
-  });
-
-  return { status: "pending" };
+  return persisted;
 }
 
 async function enqueueRunForConcurrency(
@@ -3354,38 +3402,59 @@ async function enqueueRunForConcurrency(
     readonly userTimezone: string | undefined;
     readonly featureSwitchContext: FeatureSwitchContext;
   },
-): Promise<void> {
+): Promise<DerivedPersistenceResult> {
   const payload = await buildRunnerJobPayload(get, db, args);
-  await db.insert(agentRunQueue).values({
-    runId: args.run.id,
-    userId: args.userId,
-    orgId: args.orgId,
-    encryptedParams: await encryptQueuedRunnerJobPayload(
-      payload,
-      args.featureSwitchContext,
-    ),
-    createdAt: args.run.createdAt,
-    expiresAt: new Date(now() + QUEUED_RUN_TTL_MS),
+  const encryptedParams = await encryptQueuedRunnerJobPayload(
+    payload,
+    args.featureSwitchContext,
+  );
+
+  const persisted = await db.transaction(async (tx) => {
+    const currentRun = await lockRunForDerivedPersistence(tx, args.run.id);
+    if (!currentRun) {
+      throw new Error("Run disappeared before queue persistence");
+    }
+    if (currentRun.status !== "queued") {
+      return currentRun;
+    }
+
+    await tx.insert(agentRunQueue).values({
+      runId: args.run.id,
+      userId: args.userId,
+      orgId: args.orgId,
+      encryptedParams,
+      createdAt: args.run.createdAt,
+      expiresAt: new Date(now() + QUEUED_RUN_TTL_MS),
+    });
+    const [depthRow] = await tx
+      .select({ depth: count() })
+      .from(agentRunQueue)
+      .where(eq(agentRunQueue.orgId, args.orgId));
+    recordSandboxOperation({
+      sandboxType: "runner",
+      actionType: "enqueue_zero_run",
+      durationMs: 0,
+      success: true,
+      runId: args.run.id,
+      dimensions: {
+        queue_depth: Number(depthRow?.depth ?? 0),
+      },
+    });
+    await tx
+      .update(agentRuns)
+      .set({ runnerGroup: payload.runnerGroup })
+      .where(
+        and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "queued")),
+      );
+
+    return { status: "queued" as const };
   });
-  const [depthRow] = await db
-    .select({ depth: count() })
-    .from(agentRunQueue)
-    .where(eq(agentRunQueue.orgId, args.orgId));
-  recordSandboxOperation({
-    sandboxType: "runner",
-    actionType: "enqueue_zero_run",
-    durationMs: 0,
-    success: true,
-    runId: args.run.id,
-    dimensions: {
-      queue_depth: Number(depthRow?.depth ?? 0),
-    },
-  });
-  await db
-    .update(agentRuns)
-    .set({ runnerGroup: payload.runnerGroup })
-    .where(eq(agentRuns.id, args.run.id));
-  await publishOrgSignal(args.orgId, "queue:changed");
+
+  if (persisted.status === "queued") {
+    await publishOrgSignal(args.orgId, "queue:changed");
+  }
+
+  return persisted;
 }
 
 function createdRunResponse(
@@ -3862,7 +3931,7 @@ async function completeQueuedRun(input: {
     input.signal.throwIfAborted();
     return failedRunResponse(input.run, enqueueResult.error);
   }
-  return createdRunResponse(input.run, { status: "queued" });
+  return createdRunResponse(input.run, enqueueResult.value);
 }
 
 async function completePendingRun(input: {

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -182,14 +182,6 @@ async function cleanupSingleRun(
   const cutoff = staleRunCutoff(run, cutoffs);
 
   const updated = await db.transaction(async (tx) => {
-    await tx
-      .select({ runId: runnerJobQueue.runId })
-      .from(runnerJobQueue)
-      .where(eq(runnerJobQueue.runId, run.id))
-      .for("update")
-      .limit(1);
-    signal.throwIfAborted();
-
     const [updatedRun] = await tx
       .update(agentRuns)
       .set({

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
@@ -34,6 +34,20 @@ type NotFoundResponse = ReturnType<typeof notFound>;
 type RunNotCancellableResponse = ReturnType<typeof runNotCancellable>;
 
 const ACTIVE_STATUSES = ["queued", "pending", "running"] as const;
+type ActiveStatus = (typeof ACTIVE_STATUSES)[number];
+
+interface LockedCancelRunRow extends Record<string, unknown> {
+  readonly id: string;
+  readonly status: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly sandboxId: string | null;
+  readonly runnerGroup: string | null;
+}
+
+function isActiveStatus(status: string): status is ActiveStatus {
+  return (ACTIVE_STATUSES as readonly string[]).includes(status);
+}
 
 /**
  * Cancel a run. Idempotent for already-cancelled runs (returns success
@@ -41,10 +55,9 @@ const ACTIVE_STATUSES = ["queued", "pending", "running"] as const;
  * exist or is owned by another (org, user) tuple. Returns
  * runNotCancellable for non-cancellable terminal statuses.
  *
- * The transactional shape (DELETE queue + UPDATE status guarded by
- * allowed-from list, with a re-read on lost-race) mirrors web's
- * `cancelRun` and is the correctness anchor for concurrent cancel
- * attempts.
+ * The transactional shape locks the run row first, classifies the
+ * current status under that lock, then updates status and removes
+ * derived queue/job rows. Side effects use the committed transition.
  */
 export const cancelRun$ = command(
   async (
@@ -60,61 +73,60 @@ export const cancelRun$ = command(
   > => {
     const writeDb = set(writeDb$);
 
-    const [run] = await writeDb
-      .select()
-      .from(agentRuns)
-      .where(
-        and(
-          eq(agentRuns.id, args.runId),
-          eq(agentRuns.userId, args.userId),
-          eq(agentRuns.orgId, args.orgId),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
+    const result = await writeDb.transaction(async (tx) => {
+      const lockedRows = await tx.execute<LockedCancelRunRow>(sql`
+        SELECT
+          ${agentRuns.id} AS "id",
+          ${agentRuns.status} AS "status",
+          ${agentRuns.userId} AS "userId",
+          ${agentRuns.orgId} AS "orgId",
+          ${agentRuns.sandboxId} AS "sandboxId",
+          ${agentRuns.runnerGroup} AS "runnerGroup"
+        FROM ${agentRuns}
+        WHERE ${agentRuns.id} = ${args.runId}
+          AND ${agentRuns.userId} = ${args.userId}
+          AND ${agentRuns.orgId} = ${args.orgId}
+        FOR UPDATE
+      `);
+      const run = lockedRows.rows[0];
+      if (!run) {
+        return notFound(`No such run: '${args.runId}'`);
+      }
 
-    if (!run) {
-      return notFound(`No such run: '${args.runId}'`);
-    }
+      if (run.status === "cancelled") {
+        return {
+          runId: args.runId,
+          previousStatus: run.status,
+          userId: run.userId,
+          orgId: run.orgId,
+          sandboxId: run.sandboxId,
+          runnerGroup: run.runnerGroup,
+          alreadyCancelled: true,
+        };
+      }
 
-    if (run.status === "cancelled") {
-      return {
-        runId: args.runId,
-        previousStatus: run.status,
-        userId: run.userId,
-        orgId: run.orgId,
-        sandboxId: run.sandboxId,
-        runnerGroup: run.runnerGroup,
-        alreadyCancelled: true,
-      };
-    }
+      if (!isActiveStatus(run.status)) {
+        return runNotCancellable(
+          `Run cannot be cancelled: current status is '${run.status}'`,
+        );
+      }
 
-    if (!(ACTIVE_STATUSES as readonly string[]).includes(run.status)) {
-      return runNotCancellable(
-        `Run cannot be cancelled: current status is '${run.status}'`,
-      );
-    }
-
-    const cancelled = await writeDb.transaction(async (tx) => {
-      await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, args.runId));
-      await tx
-        .delete(runnerJobQueue)
-        .where(eq(runnerJobQueue.runId, args.runId));
       const [updated] = await tx
         .update(agentRuns)
         .set({ status: "cancelled", completedAt: nowDate() })
         .where(
-          and(
-            eq(agentRuns.id, args.runId),
-            inArray(agentRuns.status, [...ACTIVE_STATUSES]),
-          ),
+          and(eq(agentRuns.id, args.runId), eq(agentRuns.status, run.status)),
         )
         .returning({ id: agentRuns.id });
-      return Boolean(updated);
-    });
-    signal.throwIfAborted();
+      if (!updated) {
+        throw new Error("Locked cancellable run was not updated");
+      }
 
-    if (cancelled) {
+      await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, args.runId));
+      await tx
+        .delete(runnerJobQueue)
+        .where(eq(runnerJobQueue.runId, args.runId));
+
       return {
         runId: args.runId,
         previousStatus: run.status,
@@ -124,34 +136,10 @@ export const cancelRun$ = command(
         runnerGroup: run.runnerGroup,
         alreadyCancelled: false,
       };
-    }
-
-    // Lost the race: another writer transitioned the row first. Re-read
-    // and classify — if the winner moved it to cancelled the user's intent
-    // is satisfied and we respond idempotently; any other terminal state
-    // is a genuine error.
-    const [current] = await writeDb
-      .select({ status: agentRuns.status })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, args.runId))
-      .limit(1);
+    });
     signal.throwIfAborted();
 
-    if (current?.status === "cancelled") {
-      return {
-        runId: args.runId,
-        previousStatus: "cancelled",
-        userId: run.userId,
-        orgId: run.orgId,
-        sandboxId: run.sandboxId,
-        runnerGroup: run.runnerGroup,
-        alreadyCancelled: true,
-      };
-    }
-
-    return runNotCancellable(
-      `Run cannot be cancelled: status has already changed`,
-    );
+    return result;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -4,7 +4,18 @@ import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { and, count, eq, gt, inArray, lt, or, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  lt,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
@@ -39,7 +50,35 @@ type QueuedRunnerJobPayload = NonNullable<
   Awaited<ReturnType<typeof decryptQueuedRunnerJobPayload>>
 >;
 
-async function promoteApiQueuedRunnerJob(
+interface QueueCandidate {
+  readonly runId: string;
+  readonly userId: string;
+  readonly createdAt: Date;
+  readonly encryptedParams: string | null;
+  readonly runStatus: string | null;
+}
+
+interface RunnerNotification {
+  readonly runId: string;
+  readonly runnerGroup: string;
+  readonly profile: string;
+  readonly sessionId: string | null;
+}
+
+type PromoteQueuedCandidateResult =
+  | {
+      readonly status: "promoted";
+      readonly runnerNotification: RunnerNotification | null;
+    }
+  | { readonly status: "full" }
+  | { readonly status: "removed-stale" }
+  | { readonly status: "lost" };
+
+interface LockedQueueRunRow extends Record<string, unknown> {
+  readonly status: string;
+}
+
+async function insertPromotedRunnerJob(
   tx: DbTransaction,
   args: {
     readonly orgId: string;
@@ -76,10 +115,204 @@ async function promoteApiQueuedRunnerJob(
     },
     expiresAt: new Date(promotedAt + 2 * 60 * 60 * 1000),
   });
-  await tx
-    .update(agentRuns)
-    .set({ runnerGroup: args.payload.runnerGroup })
-    .where(eq(agentRuns.id, args.runId));
+}
+
+async function loadDrainCandidates(
+  db: Db,
+  orgId: string,
+): Promise<readonly QueueCandidate[]> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
+
+    const [orgRow] = await tx
+      .select({ tier: orgMetadata.tier })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+    const limit = tierLimit(orgRow?.tier as OrgTier | null | undefined);
+
+    const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
+    const [activeRow] = await tx
+      .select({ count: count() })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, orgId),
+          or(
+            eq(agentRuns.status, "running"),
+            and(
+              eq(agentRuns.status, "pending"),
+              gt(agentRuns.createdAt, staleThreshold),
+            ),
+          ),
+        ),
+      );
+    const activeCount = Number(activeRow?.count ?? 0);
+    if (activeCount >= limit) {
+      return [];
+    }
+
+    return await tx
+      .select({
+        runId: agentRunQueue.runId,
+        userId: agentRunQueue.userId,
+        createdAt: agentRunQueue.createdAt,
+        encryptedParams: agentRunQueue.encryptedParams,
+        runStatus: agentRuns.status,
+      })
+      .from(agentRunQueue)
+      .leftJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
+      .where(eq(agentRunQueue.orgId, orgId))
+      .orderBy(agentRunQueue.createdAt);
+  });
+}
+
+async function promoteQueuedCandidate(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly row: QueueCandidate;
+    readonly payload: QueuedRunnerJobPayload | null;
+  },
+): Promise<PromoteQueuedCandidateResult> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
+    );
+
+    const [orgRow] = await tx
+      .select({ tier: orgMetadata.tier })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    const limit = tierLimit(orgRow?.tier as OrgTier | null | undefined);
+
+    const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
+    const [activeRow] = await tx
+      .select({ count: count() })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, args.orgId),
+          or(
+            eq(agentRuns.status, "running"),
+            and(
+              eq(agentRuns.status, "pending"),
+              gt(agentRuns.createdAt, staleThreshold),
+            ),
+          ),
+        ),
+      );
+    const activeCount = Number(activeRow?.count ?? 0);
+    if (activeCount >= limit) {
+      return { status: "full" };
+    }
+
+    const lockedRunRows = await tx.execute<LockedQueueRunRow>(sql`
+      SELECT ${agentRuns.status} AS "status"
+      FROM ${agentRuns}
+      WHERE ${agentRuns.id} = ${args.row.runId}
+      FOR UPDATE
+    `);
+    const lockedRun = lockedRunRows.rows[0];
+    if (!lockedRun) {
+      await tx
+        .delete(agentRunQueue)
+        .where(eq(agentRunQueue.runId, args.row.runId));
+      return { status: "removed-stale" };
+    }
+    if (lockedRun.status !== "queued") {
+      await tx
+        .delete(agentRunQueue)
+        .where(eq(agentRunQueue.runId, args.row.runId));
+      return { status: "removed-stale" };
+    }
+    if (args.row.runStatus !== "queued") {
+      return { status: "lost" };
+    }
+
+    const [queueRow] = await tx
+      .select({ runId: agentRunQueue.runId })
+      .from(agentRunQueue)
+      .where(
+        and(
+          eq(agentRunQueue.runId, args.row.runId),
+          eq(agentRunQueue.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    if (!queueRow) {
+      return { status: "lost" };
+    }
+
+    const runValues = args.payload
+      ? {
+          status: "pending",
+          lastHeartbeatAt: nowDate(),
+          runnerGroup: args.payload.runnerGroup,
+        }
+      : {
+          status: "pending",
+          lastHeartbeatAt: nowDate(),
+        };
+    const [updated] = await tx
+      .update(agentRuns)
+      .set(runValues)
+      .where(
+        and(eq(agentRuns.id, args.row.runId), eq(agentRuns.status, "queued")),
+      )
+      .returning({ id: agentRuns.id });
+    if (!updated) {
+      return { status: "lost" };
+    }
+
+    await tx
+      .delete(agentRunQueue)
+      .where(eq(agentRunQueue.runId, args.row.runId));
+
+    if (!args.payload) {
+      return { status: "promoted", runnerNotification: null };
+    }
+
+    await insertPromotedRunnerJob(tx, {
+      orgId: args.orgId,
+      runId: args.row.runId,
+      queuedAt: args.row.createdAt,
+      payload: args.payload,
+    });
+    return {
+      status: "promoted",
+      runnerNotification: {
+        runId: args.row.runId,
+        runnerGroup: args.payload.runnerGroup,
+        profile: args.payload.profile,
+        sessionId: args.payload.sessionId,
+      },
+    };
+  });
+}
+
+async function loadQueuedRunnerJobPayload(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly encryptedParams: string | null;
+  },
+  signal: AbortSignal,
+): Promise<QueuedRunnerJobPayload | null> {
+  const featureSwitchContext = await loadUserFeatureSwitchContext(
+    db,
+    args.orgId,
+    args.userId,
+  );
+  signal.throwIfAborted();
+  const payload = await decryptQueuedRunnerJobPayload(
+    args.encryptedParams,
+    featureSwitchContext,
+  );
+  signal.throwIfAborted();
+  return payload;
 }
 
 /**
@@ -106,113 +339,56 @@ export const drainOrgQueue$ = command(
   ): Promise<number> => {
     const writeDb = set(writeDb$);
 
-    const transitioned = await writeDb.transaction(async (tx) => {
-      // Serialize all queue operations for this org; same hash as web.
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
-      );
+    const queueRows = await loadDrainCandidates(writeDb, args.orgId);
+    signal.throwIfAborted();
 
-      const [orgRow] = await tx
-        .select({ tier: orgMetadata.tier })
-        .from(orgMetadata)
-        .where(eq(orgMetadata.orgId, args.orgId))
-        .limit(1);
-      const limit = tierLimit(orgRow?.tier as OrgTier | null | undefined);
-
-      const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
-      const [activeRow] = await tx
-        .select({ count: count() })
-        .from(agentRuns)
-        .where(
-          and(
-            eq(agentRuns.orgId, args.orgId),
-            or(
-              eq(agentRuns.status, "running"),
-              and(
-                eq(agentRuns.status, "pending"),
-                gt(agentRuns.createdAt, staleThreshold),
-              ),
-            ),
-          ),
-        );
-      const activeCount = Number(activeRow?.count ?? 0);
-      if (activeCount >= limit) {
-        return { promoted: 0, runnerNotification: null };
-      }
-
-      const queueRows = await tx
-        .select({
-          runId: agentRunQueue.runId,
-          userId: agentRunQueue.userId,
-          createdAt: agentRunQueue.createdAt,
-          encryptedParams: agentRunQueue.encryptedParams,
-        })
-        .from(agentRunQueue)
-        .where(eq(agentRunQueue.orgId, args.orgId))
-        .orderBy(agentRunQueue.createdAt);
-
-      let promoted = 0;
-      for (const row of queueRows) {
-        await tx
-          .delete(agentRunQueue)
-          .where(eq(agentRunQueue.runId, row.runId));
-        const [updated] = await tx
-          .update(agentRuns)
-          .set({ status: "pending", lastHeartbeatAt: nowDate() })
-          .where(
-            and(eq(agentRuns.id, row.runId), eq(agentRuns.status, "queued")),
-          )
-          .returning({ id: agentRuns.id });
-        if (!updated) {
-          L.debug("drainOrgQueue: queued run already transitioned, skipping", {
-            runId: row.runId,
-          });
-          continue;
-        }
-        const featureSwitchContext = await loadUserFeatureSwitchContext(
-          tx,
-          args.orgId,
-          row.userId,
-        );
-        const payload = await decryptQueuedRunnerJobPayload(
-          row.encryptedParams,
-          featureSwitchContext,
-        );
-        if (payload) {
-          await promoteApiQueuedRunnerJob(tx, {
-            orgId: args.orgId,
-            runId: row.runId,
-            queuedAt: row.createdAt,
-            payload,
-          });
-        }
-        promoted = 1;
-        return payload
-          ? {
-              promoted,
-              runnerNotification: {
-                runId: row.runId,
-                runnerGroup: payload.runnerGroup,
-                profile: payload.profile,
-                sessionId: payload.sessionId,
+    for (const row of queueRows) {
+      const payload =
+        row.runStatus === "queued"
+          ? await loadQueuedRunnerJobPayload(
+              writeDb,
+              {
+                orgId: args.orgId,
+                userId: row.userId,
+                encryptedParams: row.encryptedParams,
               },
-            }
-          : { promoted, runnerNotification: null };
+              signal,
+            )
+          : null;
+
+      const result = await promoteQueuedCandidate(writeDb, {
+        orgId: args.orgId,
+        row,
+        payload,
+      });
+      signal.throwIfAborted();
+      if (result.status === "removed-stale") {
+        await publishOrgSignal(args.orgId, "queue:changed");
+        signal.throwIfAborted();
+        continue;
+      }
+      if (result.status === "full") {
+        return 0;
+      }
+      if (result.status === "lost") {
+        L.debug("drainOrgQueue: queued run already transitioned, skipping", {
+          runId: row.runId,
+        });
+        continue;
       }
 
-      return { promoted, runnerNotification: null };
-    });
-    signal.throwIfAborted();
-
-    await publishOrgSignal(args.orgId, "queue:changed");
-    signal.throwIfAborted();
-
-    if (transitioned.runnerNotification) {
-      await notifyRunnerJob(writeDb, transitioned.runnerNotification);
+      await publishOrgSignal(args.orgId, "queue:changed");
       signal.throwIfAborted();
+
+      if (result.runnerNotification) {
+        await notifyRunnerJob(writeDb, result.runnerNotification);
+        signal.throwIfAborted();
+      }
+
+      return 1;
     }
 
-    return transitioned.promoted;
+    return 0;
   },
 );
 
@@ -221,38 +397,70 @@ export const cleanupExpiredQueueEntries$ = command(
     const writeDb = set(writeDb$);
     const currentTime = nowDate();
 
-    const deleted = await writeDb
-      .delete(agentRunQueue)
-      .where(lt(agentRunQueue.expiresAt, currentTime))
-      .returning({ runId: agentRunQueue.runId });
-    signal.throwIfAborted();
+    const result = await writeDb.transaction(async (tx) => {
+      const expiredRunIds = tx
+        .select({ runId: agentRunQueue.runId })
+        .from(agentRunQueue)
+        .where(lt(agentRunQueue.expiresAt, currentTime));
 
-    if (deleted.length === 0) {
-      return 0;
-    }
+      const timedOut = await tx
+        .update(agentRuns)
+        .set({
+          status: "timeout",
+          completedAt: currentTime,
+          error: "Queued run expired (exceeded queue TTL)",
+        })
+        .where(
+          and(
+            inArray(agentRuns.id, expiredRunIds),
+            eq(agentRuns.status, "queued"),
+          ),
+        )
+        .returning({ runId: agentRuns.id });
 
-    await writeDb
-      .update(agentRuns)
-      .set({
-        status: "timeout",
-        completedAt: currentTime,
-        error: "Queued run expired (exceeded queue TTL)",
-      })
-      .where(
-        and(
+      const deletableRows = await tx
+        .select({ runId: agentRunQueue.runId })
+        .from(agentRunQueue)
+        .leftJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
+        .where(
+          and(
+            lt(agentRunQueue.expiresAt, currentTime),
+            or(isNull(agentRuns.id), ne(agentRuns.status, "queued")),
+          ),
+        );
+
+      if (deletableRows.length === 0) {
+        return { deletedCount: 0, timedOutCount: timedOut.length };
+      }
+
+      const deleted = await tx
+        .delete(agentRunQueue)
+        .where(
           inArray(
-            agentRuns.id,
-            deleted.map((entry) => {
+            agentRunQueue.runId,
+            deletableRows.map((entry) => {
               return entry.runId;
             }),
           ),
-          eq(agentRuns.status, "queued"),
-        ),
-      );
+        )
+        .returning({ runId: agentRunQueue.runId });
+
+      return {
+        deletedCount: deleted.length,
+        timedOutCount: timedOut.length,
+      };
+    });
     signal.throwIfAborted();
 
-    L.debug("Cleaned up expired queue entries", { count: deleted.length });
-    return deleted.length;
+    if (result.deletedCount === 0) {
+      return 0;
+    }
+
+    L.debug("Cleaned up expired queue entries", {
+      count: result.deletedCount,
+      timedOut: result.timedOutCount,
+    });
+    return result.deletedCount;
   },
 );
 


### PR DESCRIPTION
Closes #15177.

## Summary
- Lock zero run rows before cancellation, runner claim/poison, queued promotion, and derived queue/job persistence.
- Treat `agent_runs.status` as the source of truth, then clean up derived `agent_run_queue` / `runner_job_queue` rows after classification.
- Rework queued-run drain to decrypt outside row-lock-sensitive sections, revalidate under the org advisory lock, and remove stale queue entries safely.
- Add integration coverage for concurrent cancels, queued cancel cleanup, expired queue cleanup, and stale queue rows.

## Verification
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts src/signals/routes/__tests__/zero-runs-cancel.test.ts src/signals/routes/__tests__/agent-runs-cancel.test.ts src/signals/routes/__tests__/runners.test.ts src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm format`
- `git diff --check`
- `pnpm knip` (exit 0; existing configuration hints only)
- `pnpm turbo run lint`
- `pnpm check-types`

## Notes
- Full `pnpm test` was run and failed in unrelated suites: `@vm0/app` network-insights date interaction tests and `@vm0/desktop` computer-use-native CLI tests. The focused API tests for this change passed.
