### PR TITLE
fix: disable single-dollar inline math to keep currency literal

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -386,7 +386,12 @@ export function Markdown({
       wrapperElement={{ "data-color-mode": theme }}
       rehypeRewrite={rehypeRewriteHandler}
       remarkPlugins={
-        mathEnabled ? [remarkMath, ...(remarkPlugins ?? [])] : remarkPlugins
+        mathEnabled
+          ? [
+              [remarkMath, { singleDollarTextMath: false }],
+              ...(remarkPlugins ?? []),
+            ]
+          : remarkPlugins
       }
       rehypePlugins={
         mathEnabled ? [rehypeKatex, ...(rehypePlugins ?? [])] : rehypePlugins


### PR DESCRIPTION
## Problem

`remark-math@6` defaults to `singleDollarTextMath: true`, which treats any `$…$` pair on the same line as inline math. In assistant messages, currency strings like `$20 to $40`, `total is $5`, or `$100/month` get parsed into KaTeX spans and rendered as garbled math instead of plain text. This is annoying in any chat that mentions prices.

## Change

Pass `{ singleDollarTextMath: false }` to `remark-math` in `markdown.tsx`. Display math (`$$ … $$`) and the explicit inline form (`\( … \)`) still work — only the ambiguous single-dollar inline math is turned off, which is the same fix GitHub Flavored Math applied for the same reason.

Touched file: `turbo/apps/platform/src/views/components/markdown.tsx`

## Test plan

- [ ] In a chat thread, send a message containing `$20 to $40` and confirm it renders verbatim
- [ ] Send a message with `$$E = mc^2$$` and confirm KaTeX still renders it
- [ ] Send a message with `\(a^2 + b^2 = c^2\)` and confirm inline math still renders