### PR TITLE
feat: hide activity logs from sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -101,21 +101,7 @@ describe("zero sidebar", () => {
     expect(features[FeatureSwitchKey.DataExport]).toBeFalsy();
   });
 
-  it("should hide Activity logs when ZeroDebug switch is off", async () => {
-    mockAPIs();
-    detachedSetupPage({
-      context,
-      path: "/",
-      featureSwitches: { [FeatureSwitchKey.ZeroDebug]: false },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Agents")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Activity logs")).not.toBeInTheDocument();
-  });
-
-  it("should show Activity logs when ZeroDebug switch is on", async () => {
+  it("should never show Activity logs in the sidebar regardless of ZeroDebug switch", async () => {
     mockAPIs();
     detachedSetupPage({
       context,
@@ -126,6 +112,6 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-    expect(screen.getByText("Activity logs")).toBeInTheDocument();
+    expect(screen.queryByText("Activity logs")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -8,7 +8,6 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
-  IconChartLine,
   IconLayoutGrid,
   IconCalendar,
   IconUsers,
@@ -97,13 +96,6 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     label: "Scheduled",
     icon: IconCalendar as NavIcon,
   },
-  {
-    id: "activities",
-    activeKeys: ["activities", "activityDetail"],
-    pathname: "/activities",
-    label: "Activity logs",
-    icon: IconChartLine as NavIcon,
-  },
 ];
 
 interface FooterNavItem {
@@ -171,9 +163,6 @@ function useResolvedNavItems() {
   const features = useLastResolved(featureSwitch$);
   const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Zero";
   const manageNav = MANAGE_NAV.filter((item) => {
-    if (item.id === "activities") {
-      return features?.[FeatureSwitchKey.ZeroDebug];
-    }
     if (item.featureGate && !features?.[item.featureGate]) {
       return false;
     }


### PR DESCRIPTION
## Summary

- Remove the **Activity logs** entry from the sidebar's Manage section entirely
- It no longer renders regardless of the `ZeroDebug` feature switch
- The `/activities` route and detail pages remain intact — only the sidebar nav item is gone

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx` — passes
- [x] Lint + format clean
- [ ] Verify sidebar does not show Activity logs with ZeroDebug toggled on or off