### PR TITLE
ci: split neon branch and web build steps

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -799,12 +799,59 @@ jobs:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
 
-      # Step 2: Create Neon branch + Build web in parallel
-      - name: Create Neon Branch and Build Web
+      # Step 2: Create Neon branch
+      - name: Create Neon Branch
         id: neon
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          WEB_API_ENV_FILE: ${{ steps.web-build-env.outputs.file }}
+          DEV_MODEL_ANTHROPIC_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY || 'fake-key' }}
+          DEV_MODEL_DEEPSEEK_KEY: fake-key
+        run: |
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              key="${line%%=*}"
+              value="${line#*=}"
+              export "$key=$value"
+            fi
+          done < "$WEB_API_ENV_FILE"
+
+          npm install -g neonctl@2.15.0
+
+          BRANCH_NAME="preview/${{ needs.prepare.outputs.job-ref }}"
+
+          if neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
+            neonctl branches reset "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --parent
+
+            for i in {1..30}; do
+              CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg name "$BRANCH_NAME" '.[] | select(.name == $name) | .current_state')
+              [ "$CURRENT_STATE" = "ready" ] && break
+              sleep 2
+            done
+          else
+            neonctl branches create --name "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
+          fi
+
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+          if [ -z "$DATABASE_URL" ]; then
+            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
+          fi
+
+          API_SEED_WEB_URL="${VM0_WEB_URL:-${{ needs.prepare.outputs.web-preview-url }}}"
+          if [ -z "$API_SEED_WEB_URL" ]; then
+            API_SEED_WEB_URL="https://www.vm0.ai"
+          fi
+
+          cd turbo
+          DATABASE_URL="$DATABASE_URL" pnpm -F @vm0/db db:migrate
+          ENV=preview VM0_WEB_URL="$API_SEED_WEB_URL" DATABASE_URL="$DATABASE_URL" pnpm -F api db:dev-seed
+
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+
+      # Step 3: Build web
+      - name: Build Web
+        env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           WEB_API_ENV_FILE: ${{ steps.web-build-env.outputs.file }}
           DEV_MODEL_ANTHROPIC_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY || 'fake-key' }}
@@ -818,109 +865,7 @@ jobs:
             fi
           done < "$WEB_API_ENV_FILE"
 
-          # --- Start Neon branch creation in background ---
-          (
-            set -e
-            NEON_STARTED_AT=$(date +%s)
-
-            log_neon() {
-              local now
-              now=$(date +%s)
-              printf '[neon %s +%ss] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$((now - NEON_STARTED_AT))" "$*"
-            }
-
-            run_timed() {
-              local label="$1"
-              shift
-              local started_at finished_at status
-              started_at=$(date +%s)
-              log_neon "$label started"
-              set +e
-              "$@"
-              status=$?
-              set -e
-              finished_at=$(date +%s)
-              if [ "$status" -eq 0 ]; then
-                log_neon "$label completed in $((finished_at - started_at))s"
-              else
-                log_neon "$label failed after $((finished_at - started_at))s with exit code $status"
-              fi
-              return "$status"
-            }
-
-            if ! command -v neonctl &> /dev/null; then
-              run_timed "install neonctl" npm install -g neonctl@2.15.0
-            else
-              log_neon "neonctl already installed"
-            fi
-
-            BRANCH_NAME="preview/${{ needs.prepare.outputs.job-ref }}"
-
-            log_neon "checking branch $BRANCH_NAME"
-            BRANCH_LOOKUP_STARTED_AT=$(date +%s)
-            if neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -e ".[] | select(.name == \"$BRANCH_NAME\")" > /dev/null 2>&1; then
-              log_neon "branch lookup completed in $(($(date +%s) - BRANCH_LOOKUP_STARTED_AT))s; branch exists"
-              run_timed "reset branch $BRANCH_NAME" neonctl branches reset "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --parent
-
-              BRANCH_READY_STARTED_AT=$(date +%s)
-              log_neon "waiting for branch $BRANCH_NAME to become ready"
-              for i in {1..30}; do
-                CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r ".[] | select(.name == \"$BRANCH_NAME\") | .current_state")
-                if [ "$CURRENT_STATE" = "ready" ]; then
-                  log_neon "branch ready after $(( $(date +%s) - BRANCH_READY_STARTED_AT ))s"
-                  break
-                fi
-                log_neon "branch state: $CURRENT_STATE (attempt $i/30)"
-                sleep 2
-              done
-              if [ "${CURRENT_STATE:-}" != "ready" ]; then
-                log_neon "branch wait ended after $(( $(date +%s) - BRANCH_READY_STARTED_AT ))s with state ${CURRENT_STATE:-unknown}"
-              fi
-            else
-              log_neon "branch lookup completed in $(($(date +%s) - BRANCH_LOOKUP_STARTED_AT))s; branch missing"
-              run_timed "create branch $BRANCH_NAME" neonctl branches create --name "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
-            fi
-
-            CONNECTION_STRING_STARTED_AT=$(date +%s)
-            log_neon "fetching pooled connection string"
-            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
-            log_neon "pooled connection string fetched in $(($(date +%s) - CONNECTION_STRING_STARTED_AT))s"
-            if [ -z "$DATABASE_URL" ]; then
-              CONNECTION_STRING_STARTED_AT=$(date +%s)
-              log_neon "pooled connection string empty; fetching direct connection string"
-              DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
-              log_neon "direct connection string fetched in $(($(date +%s) - CONNECTION_STRING_STARTED_AT))s"
-            fi
-            echo "$DATABASE_URL" > /tmp/neon-database-url
-
-            API_SEED_WEB_URL="${VM0_WEB_URL:-${{ needs.prepare.outputs.web-preview-url }}}"
-            if [ -z "$API_SEED_WEB_URL" ]; then
-              API_SEED_WEB_URL="https://www.vm0.ai"
-            fi
-
-            cd turbo
-            run_timed "run database migrations" env DATABASE_URL="$DATABASE_URL" pnpm -F @vm0/db db:migrate
-            run_timed "run API dev seed" env ENV=preview VM0_WEB_URL="$API_SEED_WEB_URL" DATABASE_URL="$DATABASE_URL" pnpm -F api db:dev-seed
-            log_neon "Neon branch ready"
-          ) > /tmp/neon-log 2>&1 &
-          NEON_PID=$!
-
-          # --- Build web in foreground ---
-          echo "::group::Vercel Build"
           vercel build --token="$VERCEL_TOKEN"
-          echo "::endgroup::"
-
-          # --- Wait for Neon (child process, so wait works) ---
-          echo "::group::Neon Branch"
-          if ! wait $NEON_PID; then
-            cat /tmp/neon-log
-            echo "::error::Neon branch creation failed"
-            exit 1
-          fi
-          cat /tmp/neon-log
-          echo "::endgroup::"
-
-          echo "database-url=$(cat /tmp/neon-database-url)" >> "$GITHUB_OUTPUT"
 
       - name: Resolve Web deploy environment
         id: web-deploy-env

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -824,9 +824,10 @@ jobs:
           if neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
             neonctl branches reset "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --parent
 
-            for i in {1..30}; do
+            for attempt in {1..30}; do
               CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg name "$BRANCH_NAME" '.[] | select(.name == $name) | .current_state')
               [ "$CURRENT_STATE" = "ready" ] && break
+              echo "Branch state: $CURRENT_STATE (attempt $attempt/30)"
               sleep 2
             done
           else


### PR DESCRIPTION
## Summary
- split the combined Neon branch creation and Vercel web build step into separate GitHub Actions steps
- remove the background process and custom timing/log wrapper around the combined step
- keep the existing Neon database URL output for downstream deploy environment resolution

## Validation
- ./actionlint .github/workflows/turbo.yml
- git diff --check