### PR TITLE
fix: clear artifact sidebar on thread switch

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -8,6 +8,7 @@ import {
 } from "../route.ts";
 import { resetSignal } from "../utils.ts";
 import { createRestoredAttachment } from "../zero-page/chat-draft.ts";
+import { clearArtifactPreview$ } from "../zero-page/zero-artifact-sidebar.ts";
 import {
   createChatThreadSignals,
   ensureDraft$,
@@ -204,6 +205,7 @@ export const loadLeftThread$ = command(
     }
 
     if (get(currentChatThreadId$) !== threadId) {
+      set(clearArtifactPreview$);
       set(pushPathSilently$, "/chats/:threadId", { threadId });
     }
 
@@ -236,6 +238,8 @@ export const loadRightThread$ = command(
     if (get(internalRightThread$)?.threadId === threadId) {
       return;
     }
+
+    set(clearArtifactPreview$);
 
     const next = new URLSearchParams(get(searchParams$));
     if (next.get(SIDEBAR_PARAM) !== threadId) {

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -102,6 +102,16 @@ export const closeArtifact$ = command(({ get, set }) => {
   set(internalArtifactFullscreen$, false);
 });
 
+export const clearArtifactPreview$ = command(({ get, set }) => {
+  const params = new URLSearchParams(get(searchParams$));
+  set(internalArtifactFullscreen$, false);
+  if (!params.has(ARTIFACT_QUERY_PARAM)) {
+    return;
+  }
+  params.delete(ARTIFACT_QUERY_PARAM);
+  set(replaceSearchParams$, params);
+});
+
 // ---------------------------------------------------------------------------
 // Fullscreen toggle — the sidebar fills the viewport on demand. Lives in
 // memory (intentionally not URL-routed) so deep links open at the default

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -23,6 +23,7 @@ import {
 } from "../zero-artifact-sidebar.tsx";
 import {
   artifactFullscreen$,
+  clearArtifactPreview$,
   currentArtifactRef$,
 } from "../../../signals/zero-page/zero-artifact-sidebar.ts";
 
@@ -176,6 +177,17 @@ describe("chatArtifactSidebar: sidebar slot rendering", () => {
     setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt");
     renderWithStore(<ArtifactSidebarSlot />);
     expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+  });
+
+  it("clears the artifact pane state", () => {
+    setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt");
+
+    expect(context.store.get(currentArtifactRef$)).not.toBeNull();
+
+    context.store.set(clearArtifactPreview$);
+
+    expect(context.store.get(currentArtifactRef$)).toBeNull();
+    expect(search()).not.toContain("artifact=");
   });
 });
 


### PR DESCRIPTION
## Summary
- Clear the artifact preview query param when switching chat thread panes in place
- Reset artifact fullscreen state through a shared artifact sidebar command
- Add regression coverage for artifact preview cleanup

## Verification
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx --pool=threads --testTimeout=10000