### PR TITLE
fix(platform): align pricing cards with content area edges

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -320,7 +320,7 @@ function PricingPage({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 -mx-4 sm:-mx-10">
         {COMPARE_PLANS.map((plan) => {
           return (
             <PlanCard


### PR DESCRIPTION
## Summary

- The Compare Plans cards inside the settings billing tab were inset by the dialog content's `px-10` padding, so the two-card row sat narrower than the sidebar-to-edge content area.
- Add `-mx-4 sm:-mx-10` to the cards grid so it extends past that padding — the cards now run from the sidebar nav's right border on the left to the dialog content's right edge.
- Back-arrow header above keeps its original indent so the back button stays comfortably off the sidebar border.

## Test plan

- [ ] Open Settings → Billing → "Compare all plans" on a desktop viewport (≥ sm) and confirm the two cards align with the sidebar's right border and the dialog's right edge.
- [ ] On mobile (< sm) confirm the single-column layout still respects the `px-4` content padding (since `-mx-4` cancels it, cards should reach the dialog edges as expected).
- [ ] No regressions to the back-arrow + "Compare plans" header alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)