### PR TITLE
feat: type computer-use text with keyboard events

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -81,6 +81,8 @@ Notes:
   Write commands are sent to the connected Desktop host and may wait for local
   approval before they run. Coordinate fallbacks use screenshot coordinates from
   get-app-state; pass the matching --snapshot-id when acting on a prior snapshot.
+  type-text sends literal keyboard input to the target app's current focus. Use
+  set-value when you need deterministic accessibility value assignment.
 
 Examples:
   List available apps:
@@ -525,7 +527,7 @@ const typeTextCommand = appOption(
   addTargetOptions(
     new Command()
       .name("type-text")
-      .description("Type literal text into the target app")
+      .description("Type literal keyboard input into the target app")
       .requiredOption("--text <text>", "Text to type")
       .action(
         withErrorHandler(async (options: ComputerUseTypeTextOptions) => {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1006,6 +1006,45 @@ struct AddressedEventDispatcher {
         event.setWindowAddressingFields(windowNumber: target.windowNumber)
         event.postToPid(target.pid)
     }
+
+    func postText(_ text: String) throws {
+        for character in text {
+            try postTextCharacter(character)
+            usleep(5_000)
+        }
+    }
+
+    private func postTextCharacter(_ character: Character) throws {
+        let utf16 = Array(String(character).utf16)
+        guard !utf16.isEmpty else {
+            return
+        }
+
+        let keyDown = try textKeyboardEvent(keyDown: true, utf16: utf16)
+        keyDown.postToPid(target.pid)
+
+        let keyUp = try textKeyboardEvent(keyDown: false, utf16: utf16)
+        keyUp.postToPid(target.pid)
+    }
+
+    private func textKeyboardEvent(keyDown: Bool, utf16: [UInt16]) throws -> CGEvent {
+        guard let event = CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: 0,
+            keyDown: keyDown
+        ) else {
+            throw HelperFailure(code: "accessibility_unavailable", message: "Unable to create text keyboard event")
+        }
+        utf16.withUnsafeBufferPointer { buffer in
+            event.keyboardSetUnicodeString(
+                stringLength: utf16.count,
+                unicodeString: buffer.baseAddress
+            )
+        }
+        event.setIntegerValueField(.eventTargetUnixProcessID, value: Int64(target.pid))
+        event.setWindowAddressingFields(windowNumber: target.windowNumber)
+        return event
+    }
 }
 
 final class BackgroundActivationSession: @unchecked Sendable {
@@ -3222,41 +3261,17 @@ func handleElementPerformAction(_ request: [String: Any], session: ComputerUseRu
 func handleTypeText(_ request: [String: Any]) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let inputText = try requiredString(request, "text")
-    let app = try resolveRunningApp(named: appName)
     return try withFrontmostPreservation(
-        dispatchMode: "accessibility_value",
-        dispatchTarget: "focused_editable_element",
-        inputRisk: "targeted_app_text"
+        dispatchMode: "background_keyboard_text",
+        dispatchTarget: "app_process",
+        inputRisk: "background_app_text"
     ) {
-        let root = AXUIElementCreateApplication(app.processIdentifier)
-        guard let element = axElementValue(attribute(root, kAXFocusedUIElementAttribute as CFString)) else {
-            throw HelperFailure(
-                code: "unsupported_command",
-                message: "keyboard.type_text requires a focused editable text element in \(appName)"
-            )
+        let targetPID = try performWithRequiredBackgroundTarget(appName: appName) { target in
+            let dispatcher = AddressedEventDispatcher(target: target)
+            try dispatcher.postText(inputText)
+            return target.pid
         }
-        let role = role(element)
-        let editableRoles = Set([
-            "AXComboBox",
-            "AXSearchField",
-            "AXTextArea",
-            "AXTextField",
-            "AXTextView",
-        ])
-        guard let role, editableRoles.contains(role) else {
-            throw HelperFailure(
-                code: "unsupported_command",
-                message: "keyboard.type_text requires a focused editable text element in \(appName)"
-            )
-        }
-
-        let currentValue = stringValue(attribute(element, kAXValueAttribute as CFString)) ?? ""
-        try setAttribute(element, kAXValueAttribute as CFString, (currentValue + inputText) as CFString)
-        var result: [String: Any] = ["role": role]
-        if let description = stringValue(attribute(element, kAXDescriptionAttribute as CFString)) {
-            result["description"] = description
-        }
-        return (targetPID: app.processIdentifier, result: result)
+        return (targetPID: targetPID, result: ["characterCount": inputText.count])
     }
 }
 

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1867,7 +1867,15 @@ describe("computer use desktop runtime", () => {
     });
   });
 
-  it("rejects type-text when the target app has no focused editable element", async () => {
+  it("types text through native keyboard input without requiring an editable AX focus", async () => {
+    const typeText = vi.fn<ComputerUseNativeBackend["typeText"]>();
+    typeText.mockResolvedValue(
+      nativeDispatchResult(
+        "background_keyboard_text",
+        "app_process",
+        "background_app_text",
+      ),
+    );
     const result = await executeComputerUseCommand(
       {
         id: "cmd_1",
@@ -1878,23 +1886,26 @@ describe("computer use desktop runtime", () => {
       {
         platform: "darwin",
         nativeBackend: createNativeBackend({
-          typeText: async () => {
-            throw new ComputerUseNativeHelperError(
-              "unsupported_command",
-              "keyboard.type_text requires a focused editable text element in Safari",
-            );
+          typeText,
+          getAppState: async (app, snapshotId) => {
+            return nativeAppStateWithScreenshot(app, snapshotId);
           },
         }),
       },
     );
 
-    expect(result).toStrictEqual({
-      status: "failed",
-      error: {
-        code: "unsupported_command",
-        message:
-          "keyboard.type_text requires a focused editable text element in Safari",
+    expect(result).toMatchObject({
+      status: "succeeded",
+      result: {
+        screenshot: "data:image/png;base64,abc123",
+        action: {
+          app: "Safari",
+          dispatchMode: "background_keyboard_text",
+          dispatchTarget: "app_process",
+          inputRisk: "background_app_text",
+        },
       },
     });
+    expect(typeText).toHaveBeenCalledWith({ app: "Safari", text: "hello" });
   });
 });


### PR DESCRIPTION
## Summary

- changes `keyboard.type_text` to dispatch Unicode keyboard events to the target app process instead of mutating the focused AX value
- keeps `element.set_value` as the precise AX value mutation path
- updates Desktop runtime coverage to expect keyboard-input dispatch metadata
- documents that `type-text` sends literal keyboard input and `set-value` is the deterministic accessibility value assignment path

Fixes #15211.

## Validation

- `swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release`
- `pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/computer-use-native.test.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test`
- `pnpm prettier --write --ignore-unknown apps/desktop/src/window-policy.test.ts`
- `pnpm prettier --write --ignore-unknown apps/cli/src/commands/zero/computer-use/index.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm knip --workspace @vm0/desktop`

## Manual validation

- Rebuilt the desktop CLI with `pnpm -F @vm0/desktop build:cli`
- Started `vm0-computer` daemon with the freshly built native helper
- Ran `node dist/vm0-computer.js type-text --app TextEdit --text ' t15211' --timeout 10`
- Verified the action returned `dispatchMode=background_keyboard_text`, `dispatchTarget=app_process`, and post-action app-state contained `t15211`
