### PR TITLE
feat: register soft-vector styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -2988,6 +2988,19 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     },
   },
   {
+    id: "vm0:image-style:soft-vector",
+    kind: "image-style",
+    name: "Soft Vector",
+    description:
+      "Airy flat-vector spot illustration — square pale-blue canvas, thin ~1.5-2px dark-navy linework with intentionally open / unclosed outlines, flat fills, one muted accent hue, centered subject with breathing room.",
+    desc: 'Soft Vector — an airy flat-vector spot illustration style for in-app onboarding art, empty states, billing cards, and friendly UI moments. Square 1:1 canvas on a single flat pale-blue field #EEF1F5; thin uniform dark-navy outlines (~1.5-2px, rounded caps, NOT chunky); the signature lift comes from several intentionally OPEN / unclosed outlines per piece (mug rim gap, handle that doesn\'t close, ground line ending in mid-air, cloud silhouette break, lamp arm fade, pot rim gap); strictly flat colour fills with no gradients or shading; one muted lead accent (mustard / lime-sage / warm-orange / violet) plus neutrals; subject centered at ~60-75% of canvas with generous breathing room; scattered thin-navy micro-marks (dots, plus signs, sparkles, or motion ticks). Six dials per brief: palette accent, scene metaphor, complexity (L1/L2/L3), cast, accent marks, action/mood. Trigger when user says /soft-vector, asks for a "soft-vector illustration", a "friendly UI onboarding illustration", a "thin-line flat spot illustration", or briefs a scene metaphor + palette + complexity in this house style.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/soft-vector",
+    },
+  },
+  {
     id: "vm0:image-style:mellow-pop",
     kind: "image-style",
     name: "Mellow Pop",


### PR DESCRIPTION
## Summary

Adds `vm0:image-style:soft-vector` to the Open Design registry. Resource lives at `vm0-ai/vm0-skills:illustration-template/soft-vector/`.

Soft Vector is an airy flat-vector spot illustration style:
- Square 1:1 pale-blue canvas (`#EEF1F5`)
- Thin ~1.5–2px dark-navy linework with intentionally **open / unclosed outlines** (rim gaps, handles that don't close, ground lines that end in mid-air)
- Strictly flat colour fills, no gradients
- One muted lead accent: mustard / lime-sage / warm-orange / violet
- Scattered thin-navy micro-marks (dots / plus signs / sparkles / motion ticks)
- Centered subject at ~60–75% of canvas with generous breathing room

For in-app onboarding art, empty states, billing cards, and friendly UI moments.

## Paired resource PR

vm0-ai/vm0-skills#230

## Test plan

- [ ] `lint-types` green on rebased commit
- [ ] `build-cli` green on rebased commit
- [ ] `pnpm --filter @vm0/cli test -- open-design` passes locally
- [ ] Styled generate smoke test resolves `vm0:image-style:soft-vector` and produces an artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)