### PR TITLE
feat: register vm0:image-style:loose-contour

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -3000,6 +3000,19 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
       path: "illustration-template/mellow-pop",
     },
   },
+  {
+    id: "vm0:image-style:loose-contour",
+    kind: "image-style",
+    name: "Loose Contour",
+    description:
+      "Flat editorial spot illustration — open teal contour lines, offset color blobs (printing-misregistration look), one ribbon line on warm cream paper.",
+    desc: 'Loose-contour flat editorial spot illustration: confident open-contour ink drawings in dark teal-green (#1e4d4a) over flat offset color blobs (printing-misregistration look) on warm cream paper (#f0ebdc), with exactly one continuous looping ribbon line of the same teal weaving through the scene. Tight 5-color palette: cream + teal + mustard + soft blue + coral. Lines are deliberately broken at joints and edges. Five dials per brief: scene metaphor, cast, complexity (L1/L2/L3), accent lead, ribbon path. Trigger when user says /loose-contour, asks for a "loose-contour illustration", "offset-blob editorial illustration", or "cream paper ribbon-line scene".',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/loose-contour",
+    },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers a new Open Design `image-style` resource — **Loose Contour**.

A flat editorial spot illustration style:
- Confident open-contour ink drawings in dark teal-green (`#1e4d4a`) — outlines deliberately broken at edges and joints
- Flat color blobs **without outlines**, sitting beneath the line art and offset like printing misregistration
- Exactly one continuous looping ribbon line of the same teal-green weaving through the composition
- Warm cream paper background (`#f0ebdc`), strict 5-color palette (cream + teal + mustard + soft blue + coral)

### Registry entry
- ID: `vm0:image-style:loose-contour`
- Source: `vm0-ai/vm0-skills` → `illustration-template/loose-contour`
- Paired PR (resource): vm0-ai/vm0-skills#231

### Validation
- `pnpm --filter @vm0/cli exec vitest run open-design-artifacts` → **9/9 pass**
- `pnpm --filter @vm0/cli exec tsc --noEmit` → **clean**

## Test plan
- [ ] `zero generate image --style vm0:image-style:loose-contour --prompt "<scene brief>"` resolves and produces an artifact
- [ ] Output follows the locked frame (open teal contour, offset blobs, single ribbon line, cream background)
- [ ] At least one piece across L1, L2, L3 complexity reads correctly