### PR TITLE
fix: prefer specific firewall path matches

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -42,6 +42,7 @@ class SegmentError(NamedTuple):
 
 
 ParsedSegment = SegmentLiteral | SegmentParam | SegmentError
+_PathSpecificity = tuple[int, int, int, int, int, int, int]
 
 
 class CompiledPathPattern(NamedTuple):
@@ -60,6 +61,7 @@ class _CompiledRule(NamedTuple):
     method: str
     raw: str
     path: CompiledPathPattern
+    specificity: _PathSpecificity
 
 
 class _CompiledPermission(NamedTuple):
@@ -97,6 +99,12 @@ class _CompiledNetworkPolicy(NamedTuple):
 class CompiledNetworkPolicies(NamedTuple):
     policies: Mapping[str, _CompiledNetworkPolicy]
     top_level_malformed: bool
+
+
+class _CompiledRuleCandidate(NamedTuple):
+    permission: str
+    rule: str
+    params: dict[str, str]
 
 
 def _split_base_match_url(
@@ -469,6 +477,45 @@ def compile_path_pattern(pattern: str) -> CompiledPathPattern | None:
     return CompiledPathPattern(segments)
 
 
+def _path_specificity(
+    pattern: CompiledPathPattern,
+) -> _PathSpecificity:
+    literal_segments = 0
+    mixed_param_segments = 0
+    plain_param_segments = 0
+    plus_greedy_segments = 0
+    star_greedy_segments = 0
+    literal_chars = 0
+
+    for segment in pattern.segments:
+        if isinstance(segment, SegmentLiteral):
+            literal_segments += 1
+            literal_chars += len(segment.value)
+            continue
+        if isinstance(segment, SegmentError):
+            continue
+
+        literal_chars += len(segment.prefix) + len(segment.suffix)
+        if segment.prefix or segment.suffix:
+            mixed_param_segments += 1
+        elif segment.greedy == "+":
+            plus_greedy_segments += 1
+        elif segment.greedy == "*":
+            star_greedy_segments += 1
+        else:
+            plain_param_segments += 1
+
+    return (
+        literal_segments,
+        mixed_param_segments,
+        plain_param_segments,
+        plus_greedy_segments,
+        -star_greedy_segments,
+        literal_chars,
+        len(pattern.segments),
+    )
+
+
 def _match_compiled_path_segments(
     path_segs: list[str],
     pattern_segs: tuple[ParsedSegment, ...],
@@ -676,7 +723,7 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
     pattern = compile_path_pattern(parts[1])
     if pattern is None:
         return None
-    return _CompiledRule(parts[0].upper(), rule_str, pattern)
+    return _CompiledRule(parts[0].upper(), rule_str, pattern, _path_specificity(pattern))
 
 
 def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
@@ -848,6 +895,41 @@ def _unknown_allow(
     return FirewallAllow(api_entry, name, None, params, None, rel_path)
 
 
+def _best_compiled_rule_candidates(
+    api_entry: _CompiledApi,
+    *,
+    upper_method: str,
+    rel_path: str,
+    base_params: dict[str, str],
+) -> list[_CompiledRuleCandidate]:
+    rel_path_segs = [s for s in rel_path.split("/") if s]
+    best_specificity: _PathSpecificity | None = None
+    best_candidates: list[_CompiledRuleCandidate] = []
+
+    for perm in api_entry.permissions:
+        for rule in perm.rules:
+            if rule.method not in ("ANY", upper_method):
+                continue
+
+            params = _match_compiled_path_segments(rel_path_segs, rule.path.segments)
+            if params is None:
+                continue
+
+            if best_specificity is None or rule.specificity > best_specificity:
+                best_specificity = rule.specificity
+                best_candidates = []
+            if rule.specificity == best_specificity:
+                best_candidates.append(
+                    _CompiledRuleCandidate(
+                        perm.name,
+                        rule.raw,
+                        {**base_params, **params},
+                    )
+                )
+
+    return best_candidates
+
+
 FirewallBlockReason = Literal[
     "permission_denied",
     "unknown_endpoint",
@@ -936,34 +1018,39 @@ def match_compiled_firewall_request(
             if not api_entry.permissions:
                 continue
 
-            rel_path_segs = [s for s in rel_path.split("/") if s]
-            for perm in api_entry.permissions:
-                for rule in perm.rules:
-                    if rule.method not in ("ANY", upper_method):
-                        continue
+            candidates = _best_compiled_rule_candidates(
+                api_entry,
+                upper_method=upper_method,
+                rel_path=rel_path,
+                base_params=base_params,
+            )
+            if not candidates:
+                continue
 
-                    params = _match_compiled_path_segments(rel_path_segs, rule.path.segments)
-                    if params is not None:
-                        all_params = {**base_params, **params}
+            api_denied_perm_names: list[str] = []
+            for candidate in candidates:
+                if policy is None or candidate.permission not in policy.blocked_permissions:
+                    return _permission_allow(
+                        api_entry.raw_api_entry,
+                        name=fw_entry.name,
+                        permission=candidate.permission,
+                        params=candidate.params,
+                        rule=candidate.rule,
+                        rel_path=rel_path,
+                    )
+                if candidate.permission not in api_denied_perm_names:
+                    api_denied_perm_names.append(candidate.permission)
 
-                        if policy is None or perm.name not in policy.blocked_permissions:
-                            return _permission_allow(
-                                api_entry.raw_api_entry,
-                                name=fw_entry.name,
-                                permission=perm.name,
-                                params=all_params,
-                                rule=rule.raw,
-                                rel_path=rel_path,
-                            )
-                        if perm.name not in denied_perm_names:
-                            denied_perm_names.append(perm.name)
-                        if denied_match is None:
-                            denied_match = (
-                                api_entry.base.raw,
-                                fw_entry.name,
-                                upper_method,
-                                rel_path,
-                            )
+            for perm_name in api_denied_perm_names:
+                if perm_name not in denied_perm_names:
+                    denied_perm_names.append(perm_name)
+            if api_denied_perm_names and denied_match is None:
+                denied_match = (
+                    api_entry.base.raw,
+                    fw_entry.name,
+                    upper_method,
+                    rel_path,
+                )
 
     if blocked_match is not None:
         blocked_base, blocked_name, blocked_rel_path, first_matched_api_entry, base_params = (

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -387,6 +387,126 @@ class TestCompiledFirewallMatching:
         assert result.api_entry is api_entry
         assert result.rule == "ANY /repos/{owner}/{repo}"
 
+    def test_literal_rule_wins_over_earlier_parameter_rule(self):
+        api_entry = {
+            "base": "https://api.x.com",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [
+                {"name": "community-by-id", "rules": ["GET /2/communities/{id}"]},
+                {"name": "community-search", "rules": ["GET /2/communities/search"]},
+            ],
+        }
+        fws = wrap_firewalls([api_entry], name="x")
+        policies = {"x": {"allow": [], "deny": [], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.x.com/2/communities/search",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "community-search"
+        assert result.rule == "GET /2/communities/search"
+        assert result.params == {}
+
+    def test_denied_parameter_rule_does_not_block_more_specific_literal_allow(self):
+        api_entry = {
+            "base": "https://api.x.com",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [
+                {"name": "community-by-id", "rules": ["GET /2/communities/{id}"]},
+                {"name": "community-search", "rules": ["GET /2/communities/search"]},
+            ],
+        }
+        fws = wrap_firewalls([api_entry], name="x")
+        policies = {"x": {"allow": [], "deny": ["community-by-id"], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.x.com/2/communities/search",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "community-search"
+        assert result.rule == "GET /2/communities/search"
+
+    @pytest.mark.parametrize(
+        ("earlier_rule", "later_rule", "url", "expected_rule", "expected_params"),
+        [
+            (
+                "GET /files/{id}",
+                "GET /files/file-{slug}",
+                "https://api.example.com/files/file-readme",
+                "GET /files/file-{slug}",
+                {"slug": "readme"},
+            ),
+            (
+                "GET /files/{path+}",
+                "GET /files/{id}",
+                "https://api.example.com/files/readme",
+                "GET /files/{id}",
+                {"id": "readme"},
+            ),
+        ],
+    )
+    def test_more_specific_parameter_shape_wins(
+        self,
+        earlier_rule,
+        later_rule,
+        url,
+        expected_rule,
+        expected_params,
+    ):
+        api_entry = {
+            "base": "https://api.example.com",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [
+                {"name": "earlier", "rules": [earlier_rule]},
+                {"name": "later", "rules": [later_rule]},
+            ],
+        }
+        fws = wrap_firewalls([api_entry], name="example")
+        policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "later"
+        assert result.rule == expected_rule
+        assert result.params == expected_params
+
+    def test_allowed_parameter_rule_does_not_bypass_more_specific_literal_deny(self):
+        api_entry = {
+            "base": "https://api.x.com",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [
+                {"name": "community-by-id", "rules": ["GET /2/communities/{id}"]},
+                {"name": "community-search", "rules": ["GET /2/communities/search"]},
+            ],
+        }
+        fws = wrap_firewalls([api_entry], name="x")
+        policies = {"x": {"allow": [], "deny": ["community-search"], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.x.com/2/communities/search",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ("community-search",)
+        assert result.reason == "permission_denied"
+
     def test_later_allowed_permission_still_wins_after_earlier_denied_match(self):
         fws = wrap_firewalls(
             [

--- a/crates/runner/mitm-addon/tests/test_x_billing.py
+++ b/crates/runner/mitm-addon/tests/test_x_billing.py
@@ -625,15 +625,11 @@ class TestFirewallConsistency:
             "runtime first-match permission changed, or the override has a typo."
         )
 
-    def test_runtime_firewall_shadowing_is_limited_to_acknowledged_paths(self):
+    def test_runtime_firewall_rules_match_their_generated_permission(self):
         """Static drift checks read generated rule ownership, but runtime
-        firewall matching is first-match-wins.  A broader earlier generated
-        rule can capture a later literal path under a different permission.
-
-        Keep the known overlap explicit while the matcher/generator
-        specificity fix is tracked separately in #15117.  New shadowing
-        would affect authorization metadata, network policies, and billing
-        attribution, so it should not appear silently.
+        firewall matching decides authorization metadata, network policy, and
+        billing attribution.  A broader generated rule must not capture a
+        later, more specific generated rule under another permission.
         """
         compiled_firewall = _compile_generated_x_firewall()
         shadows: list[tuple[str, str, str, str, str]] = []
@@ -655,19 +651,10 @@ class TestFirewallConsistency:
                         (permission.name, runtime_permission, method, pattern, sample_path)
                     )
 
-        assert shadows == [
-            (
-                "users.read",
-                "list.read",
-                "GET",
-                "/2/communities/search",
-                "/2/communities/search",
-            )
-        ], (
-            "Generated X firewall rules have unexpected runtime first-match "
-            f"shadowing: {shadows}.  Literal-vs-parameter overlap is a known "
-            "problem only for `/2/communities/search`; see #15117 before "
-            "expanding this acknowledgement."
+        assert not shadows, (
+            "Generated X firewall rules are shadowed by another runtime "
+            f"permission: {shadows}.  Check path specificity handling before "
+            "expanding X firewall output."
         )
 
     # Firewall paths that deliberately take their scope's default bucket.


### PR DESCRIPTION
## Summary

- Add compiled path specificity scoring and resolve matches within each API entry using the highest-specificity candidate group.
- Preserve existing outer firewall/API traversal, equal-specificity rule order, and ANY-vs-exact method behavior.
- Add regression coverage for literal-vs-parameter policy handling and remove the acknowledged X firewall shadow.

Closes #15117

## Tests

- `ruff check src/matching.py tests/test_compiled_firewall_matching.py tests/test_x_billing.py`
- `ruff format --check src/matching.py tests/test_compiled_firewall_matching.py tests/test_x_billing.py`
- `PYTHONPATH=src pytest tests/test_matching_patterns.py tests/test_firewall_matching.py tests/test_compiled_firewall_matching.py tests/test_x_billing.py`
- `git diff --check origin/main...HEAD`

Note: `basedpyright` was not run locally because the command is unavailable in this environment.