### PR TITLE
feat: register 8 image-style templates (bundle)

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -3000,6 +3000,90 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
       path: "illustration-template/mellow-pop",
     },
   },
+  {
+    id: "vm0:image-style:grainy-duotone",
+    kind: "image-style",
+    name: "Grainy Duotone",
+    description:
+      "Editorial spot illustration on a warm cream background — grainy charcoal-stippled hands, outline-free flat two-tone color blocks with internal patterns, and scattered ambient marks.",
+    desc: 'Grainy-duotone editorial spot illustration: warm cream off-white background, grainy charcoal-stippled hands (and occasional faces) drawn in textured black ink, paired with free-floating flat two-tone color blocks that carry NO outlines and are filled with internal patterns (grid, dots, spiral, hatching, squiggles, wavy lines), surrounded by scattered ambient marks (zigzags, triangles, x marks, circles, dashes). Square 1:1 scene-as-metaphor compositions. Five creative dials per brief: palette (two flat hues, e.g. teal+yellow / coral+sage / lavender+mustard / navy+peach / burgundy+dusty pink), elements (hand(s) + 1-3 props like flag, sprout, magnifier, balloons, ladder), scene archetype (Launch / Grow / Connect / Discover / Communicate / Reflect / Navigate / Care / Transform / Build), complexity (L1 minimal / L2 balanced / L3 rich), and mood (celebratory / calm / curious / reflective / determined / warm / quiet). Trigger when user says /grainy-duotone, asks for a "grainy two-tone editorial illustration", "charcoal-stippled hand illustration", "duotone editorial spot", or briefs with a scene metaphor + two-color palette + complexity.',
+    source: { path: "illustration-template/grainy-duotone" },
+  },
+  {
+    id: "vm0:image-style:op-ed-cover",
+    kind: "image-style",
+    name: "Op-Ed Cover",
+    description:
+      "Editorial magazine op-ed cover — flat-vector scene with paper grain, elongated ink-line characters, muted retro palette, and a serif headline block in the lower-right.",
+    desc: 'Editorial magazine op-ed cover illustration. Flat-vector + paper-grain scene with expressive elongated ink-line characters, gentle painterly shading, 1950s-60s editorial mood, and a serif headline overlay block in the lower-right corner carrying a witty contrarian or declarative title with two short lines of italic body copy. 5-axis framework: palette (background + accent + ink), complexity (L1 single hero / L2 small ensemble / L3 busy crowd), scene metaphor (specific cultural microcosm), headline voice (declarative / pun / appreciative / contrarian), and headline block style (solid vs. translucent). Trigger when user says /op-ed-cover, asks for an "editorial magazine illustration", an "op-ed cover", a "magazine essay illustration", or a scene with a headline overlay in this style.',
+    source: { path: "illustration-template/op-ed-cover" },
+  },
+  {
+    id: "vm0:image-style:grain-poster",
+    kind: "image-style",
+    name: "Grain Poster",
+    description:
+      "Flat-vector editorial poster of a serene full-body figure with one hero prop — riso grain on a single textile, closed-eye smile + red cheek blush, muted limited palette.",
+    desc: 'Grain Poster — flat-vector editorial illustration of a serene full-body figure interacting with one hero prop (bicycle, bouquet, cat, book, skateboard, sun hat, guitar, dog leash). Closed-eye smile + single round red cheek blush + dark nose mark + solid black hair, silhouette-first (no inked outlines). Riso/halftone grain confined to exactly ONE textile element (skirt or trousers); every other surface is flat color. Muted single-hue background, generous negative space, no headlines or wordmarks. Six tunable dials: palette (cool-dawn · sunset-coral · twilight · forest-green · custom), mood, scene, cast, complexity (L1/L2/L3), framing. Strongest at L1 + side-profile + solo. Trigger when user says /grain-poster, asks for a "flat-vector editorial poster", "riso-grain figure poster", "grainy editorial illustration", or briefs with a scene + palette + cast in this house style.',
+    source: { path: "illustration-template/grain-poster" },
+  },
+  {
+    id: "vm0:image-style:light-pop-portrait",
+    kind: "image-style",
+    name: "Light Pop Portrait",
+    description:
+      "Light hand-drawn flat-vector single-character portrait on a fully saturated color block — chunky black hair, big shiny eyes, tiny red nose, pink five-point-star sparkle blush.",
+    desc: 'Light Pop Portrait — a hand-drawn flat-vector single-character portrait style for playful avatars, mood pieces, and editorial character cards. Square 1:1 canvas filled with one fully saturated background hue; a single child–tween character with chunky glossy-black hair (with one or two flyaway strands), big round shiny eyes (single white glint each, thin lashes above), tiny round red nose, expressive small mouth, and pink FIVE-POINT STAR sparkle blush on the cheeks (never solid dots). Thin delicate slightly-wavy hand-drawn contour lines, flat solid fills only, no gradients or texture, ~5-color palette per piece. Eight creative dials: expression, hairstyle, gender register, pose, palette, headwear, prop, outfit. Trigger when user says /light-pop-portrait, asks for a "light pop portrait", "flat-vector character portrait", "saturated color-block character", or briefs with expression + hairstyle + palette + prop.',
+    source: { path: "illustration-template/light-pop-portrait" },
+  },
+  {
+    id: "vm0:image-style:endpaper",
+    kind: "image-style",
+    name: "Endpaper",
+    description:
+      "Riso-grain flat-vector collection of chill characters or objects scattered across a saturated solid color field, with two-tone interior shading and closed-eye sleepy faces.",
+    desc: 'Riso-grain flat-vector editorial collection illustration. Many small animals or objects scattered across a fully saturated solid color background — like the inside endpaper of a children\'s picture book. Subtle riso/screenprint grain inside every fill, two-tone interior shading on every character (darker top + lighter belly), closed crescent-eye sleepy smiles with tiny dot noses, NO outlines on character bodies, loose hand-drawn line details on props (yarn spirals, leaf veins, pot stripes), scattered curated composition where characters overlap and touch the canvas edges. Five dials: background hue, cast (cats/dogs/foxes/birds/sea-creatures/houseplants/kitchen-objects/etc.), character palette (3–5 curated fills), density (L1 sparse / L2 balanced / L3 packed), prop vocabulary matched to cast. Trigger when user says /endpaper, asks for an "endpaper illustration", a "scattered animal or object collection on saturated color", a "children\'s-book endpaper scene", or briefs with a cast + background hue + density + palette.',
+    source: { path: "illustration-template/endpaper" },
+  },
+  {
+    id: "vm0:image-style:editorial-flatfolk",
+    kind: "image-style",
+    name: "Editorial Flatfolk",
+    description:
+      "Editorial hand-drawn naive book-illustration style — flat saturated color blocks, loose ink line overlay, paper grain, and a strong sense of place.",
+    desc: 'Editorial hand-drawn naive book-illustration style. Flat saturated color blocks with loose hand-drawn ink line work sitting ON TOP of the color, subtle paper grain across the canvas, simple ink hatching for sky / sun rays / rain / snow, and a strong sense of place built from tall narrow architecture and a one-point depth axis. Five dials per brief: palette (warm-primary, coastal-peach, jewel-night, winter-cool, autumn-rust, monsoon-twilight), scene metaphor (street, harbor, market, transit, park, square, interior, alpine-village), perspective (one-point street, frontal facade, low-angle hero, isometric, top-down), cast (solo wanderer, paired, small crowd, none), and light/weather (midday sun, golden hour, rain, snow, blue hour). Trigger when user says /editorial-flatfolk, asks for an "editorial flat-folk illustration", a "saturated naive book-illustration scene", a "tall narrow row-house illustration", or briefs a palette + scene metaphor + season.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/editorial-flatfolk",
+    },
+  },
+  {
+    id: "vm0:image-style:soft-vector",
+    kind: "image-style",
+    name: "Soft Vector",
+    description:
+      "Airy flat-vector spot illustration — square pale-blue canvas, thin ~1.5-2px dark-navy linework with intentionally open / unclosed outlines, flat fills, one muted accent hue, centered subject with breathing room.",
+    desc: 'Soft Vector — an airy flat-vector spot illustration style for in-app onboarding art, empty states, billing cards, and friendly UI moments. Square 1:1 canvas on a single flat pale-blue field #EEF1F5; thin uniform dark-navy outlines (~1.5-2px, rounded caps, NOT chunky); the signature lift comes from several intentionally OPEN / unclosed outlines per piece (mug rim gap, handle that doesn\'t close, ground line ending in mid-air, cloud silhouette break, lamp arm fade, pot rim gap); strictly flat colour fills with no gradients or shading; one muted lead accent (mustard / lime-sage / warm-orange / violet) plus neutrals; subject centered at ~60-75% of canvas with generous breathing room; scattered thin-navy micro-marks (dots, plus signs, sparkles, or motion ticks). Six dials per brief: palette accent, scene metaphor, complexity (L1/L2/L3), cast, accent marks, action/mood. Trigger when user says /soft-vector, asks for a "soft-vector illustration", a "friendly UI onboarding illustration", a "thin-line flat spot illustration", or briefs a scene metaphor + palette + complexity in this house style.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/soft-vector",
+    },
+  },
+  {
+    id: "vm0:image-style:loose-contour",
+    kind: "image-style",
+    name: "Loose Contour",
+    description:
+      "Flat editorial spot illustration — open teal contour lines, offset color blobs (printing-misregistration look), one ribbon line on warm cream paper.",
+    desc: 'Loose-contour flat editorial spot illustration: confident open-contour ink drawings in dark teal-green (#1e4d4a) over flat offset color blobs (printing-misregistration look) on warm cream paper (#f0ebdc), with exactly one continuous looping ribbon line of the same teal weaving through the scene. Tight 5-color palette: cream + teal + mustard + soft blue + coral. Lines are deliberately broken at joints and edges. Five dials per brief: scene metaphor, cast, complexity (L1/L2/L3), accent lead, ribbon path. Trigger when user says /loose-contour, asks for a "loose-contour illustration", "offset-blob editorial illustration", or "cream paper ribbon-line scene".',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/loose-contour",
+    },
+  },
 ];
 
 function filterByKind(

--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -3007,7 +3007,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Editorial spot illustration on a warm cream background — grainy charcoal-stippled hands, outline-free flat two-tone color blocks with internal patterns, and scattered ambient marks.",
     desc: 'Grainy-duotone editorial spot illustration: warm cream off-white background, grainy charcoal-stippled hands (and occasional faces) drawn in textured black ink, paired with free-floating flat two-tone color blocks that carry NO outlines and are filled with internal patterns (grid, dots, spiral, hatching, squiggles, wavy lines), surrounded by scattered ambient marks (zigzags, triangles, x marks, circles, dashes). Square 1:1 scene-as-metaphor compositions. Five creative dials per brief: palette (two flat hues, e.g. teal+yellow / coral+sage / lavender+mustard / navy+peach / burgundy+dusty pink), elements (hand(s) + 1-3 props like flag, sprout, magnifier, balloons, ladder), scene archetype (Launch / Grow / Connect / Discover / Communicate / Reflect / Navigate / Care / Transform / Build), complexity (L1 minimal / L2 balanced / L3 rich), and mood (celebratory / calm / curious / reflective / determined / warm / quiet). Trigger when user says /grainy-duotone, asks for a "grainy two-tone editorial illustration", "charcoal-stippled hand illustration", "duotone editorial spot", or briefs with a scene metaphor + two-color palette + complexity.',
-    source: { path: "illustration-template/grainy-duotone" },
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/grainy-duotone",
+    },
   },
   {
     id: "vm0:image-style:op-ed-cover",
@@ -3016,7 +3020,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Editorial magazine op-ed cover — flat-vector scene with paper grain, elongated ink-line characters, muted retro palette, and a serif headline block in the lower-right.",
     desc: 'Editorial magazine op-ed cover illustration. Flat-vector + paper-grain scene with expressive elongated ink-line characters, gentle painterly shading, 1950s-60s editorial mood, and a serif headline overlay block in the lower-right corner carrying a witty contrarian or declarative title with two short lines of italic body copy. 5-axis framework: palette (background + accent + ink), complexity (L1 single hero / L2 small ensemble / L3 busy crowd), scene metaphor (specific cultural microcosm), headline voice (declarative / pun / appreciative / contrarian), and headline block style (solid vs. translucent). Trigger when user says /op-ed-cover, asks for an "editorial magazine illustration", an "op-ed cover", a "magazine essay illustration", or a scene with a headline overlay in this style.',
-    source: { path: "illustration-template/op-ed-cover" },
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/op-ed-cover",
+    },
   },
   {
     id: "vm0:image-style:grain-poster",
@@ -3025,7 +3033,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Flat-vector editorial poster of a serene full-body figure with one hero prop — riso grain on a single textile, closed-eye smile + red cheek blush, muted limited palette.",
     desc: 'Grain Poster — flat-vector editorial illustration of a serene full-body figure interacting with one hero prop (bicycle, bouquet, cat, book, skateboard, sun hat, guitar, dog leash). Closed-eye smile + single round red cheek blush + dark nose mark + solid black hair, silhouette-first (no inked outlines). Riso/halftone grain confined to exactly ONE textile element (skirt or trousers); every other surface is flat color. Muted single-hue background, generous negative space, no headlines or wordmarks. Six tunable dials: palette (cool-dawn · sunset-coral · twilight · forest-green · custom), mood, scene, cast, complexity (L1/L2/L3), framing. Strongest at L1 + side-profile + solo. Trigger when user says /grain-poster, asks for a "flat-vector editorial poster", "riso-grain figure poster", "grainy editorial illustration", or briefs with a scene + palette + cast in this house style.',
-    source: { path: "illustration-template/grain-poster" },
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/grain-poster",
+    },
   },
   {
     id: "vm0:image-style:light-pop-portrait",
@@ -3034,7 +3046,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Light hand-drawn flat-vector single-character portrait on a fully saturated color block — chunky black hair, big shiny eyes, tiny red nose, pink five-point-star sparkle blush.",
     desc: 'Light Pop Portrait — a hand-drawn flat-vector single-character portrait style for playful avatars, mood pieces, and editorial character cards. Square 1:1 canvas filled with one fully saturated background hue; a single child–tween character with chunky glossy-black hair (with one or two flyaway strands), big round shiny eyes (single white glint each, thin lashes above), tiny round red nose, expressive small mouth, and pink FIVE-POINT STAR sparkle blush on the cheeks (never solid dots). Thin delicate slightly-wavy hand-drawn contour lines, flat solid fills only, no gradients or texture, ~5-color palette per piece. Eight creative dials: expression, hairstyle, gender register, pose, palette, headwear, prop, outfit. Trigger when user says /light-pop-portrait, asks for a "light pop portrait", "flat-vector character portrait", "saturated color-block character", or briefs with expression + hairstyle + palette + prop.',
-    source: { path: "illustration-template/light-pop-portrait" },
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/light-pop-portrait",
+    },
   },
   {
     id: "vm0:image-style:endpaper",
@@ -3043,7 +3059,11 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
     description:
       "Riso-grain flat-vector collection of chill characters or objects scattered across a saturated solid color field, with two-tone interior shading and closed-eye sleepy faces.",
     desc: 'Riso-grain flat-vector editorial collection illustration. Many small animals or objects scattered across a fully saturated solid color background — like the inside endpaper of a children\'s picture book. Subtle riso/screenprint grain inside every fill, two-tone interior shading on every character (darker top + lighter belly), closed crescent-eye sleepy smiles with tiny dot noses, NO outlines on character bodies, loose hand-drawn line details on props (yarn spirals, leaf veins, pot stripes), scattered curated composition where characters overlap and touch the canvas edges. Five dials: background hue, cast (cats/dogs/foxes/birds/sea-creatures/houseplants/kitchen-objects/etc.), character palette (3–5 curated fills), density (L1 sparse / L2 balanced / L3 packed), prop vocabulary matched to cast. Trigger when user says /endpaper, asks for an "endpaper illustration", a "scattered animal or object collection on saturated color", a "children\'s-book endpaper scene", or briefs with a cast + background hue + density + palette.',
-    source: { path: "illustration-template/endpaper" },
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/endpaper",
+    },
   },
   {
     id: "vm0:image-style:editorial-flatfolk",


### PR DESCRIPTION
## Summary

Bundles 8 open-design-registry entries from previously separate PRs into one.

| Style ID | Original PR |
|---|---|
| vm0:image-style:grainy-duotone | #15119 |
| vm0:image-style:op-ed-cover | #15124 |
| vm0:image-style:grain-poster | #15126 |
| vm0:image-style:light-pop-portrait | #15131 |
| vm0:image-style:endpaper | #15148 |
| vm0:image-style:editorial-flatfolk | #15153 |
| vm0:image-style:soft-vector | #15221 |
| vm0:image-style:loose-contour | #15222 |

All entries are appended to OPEN_DESIGN_REGISTRY in
turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts.
The corresponding skill resources for the first 6 already live in
vm0-ai/vm0-skills (#224-#229, merged). soft-vector / loose-contour
skills remain in vm0-ai/vm0-skills #230 and #231.

## Test plan
- [ ] CI green on turbo/apps/cli
- [ ] zero generate image --style vm0:image-style:editorial-flatfolk resolves