### PR TITLE
fix(desktop): align vm0-computer app state output

### DIFF
--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -482,7 +482,9 @@ describe("computer use native backend", () => {
       expect(output).toMatchObject({
         status: "succeeded",
         snapshotId: expect.stringMatching(/^desktop_/),
-        appState: expect.stringContaining("<app_state>"),
+        appState: expect.stringMatching(
+          /^\/tmp\/vm0\/computer-use\/Safari-desktop_[a-z0-9]+\.appState\.txt$/,
+        ),
         screenshot: expect.stringMatching(
           /^\/tmp\/vm0\/computer-use\/Safari-desktop_[a-z0-9]+\.png$/,
         ),
@@ -490,7 +492,11 @@ describe("computer use native backend", () => {
       expect(output.result).toBeUndefined();
       expect(output.elements).toBeUndefined();
       expect(output.elementIdsByIndex).toBeUndefined();
+      expect(stdout).not.toContain("<app_state>");
       expect(output.screenshot).not.toBe("data:image/png;base64,abc123");
+      await expect(
+        readFile(String(output.appState), "utf8"),
+      ).resolves.toContain("<app_state>");
       expect(await readFile(String(output.screenshot))).toStrictEqual(
         screenshotBytes,
       );
@@ -530,7 +536,9 @@ describe("computer use native backend", () => {
       expect(output).toMatchObject({
         status: "succeeded",
         snapshotId: expect.stringMatching(/^desktop_/),
-        appState: expect.stringContaining("<app_state>"),
+        appState: expect.stringMatching(
+          /^\/tmp\/vm0\/computer-use\/Safari-desktop_[a-z0-9]+\.appState\.txt$/,
+        ),
         screenshot: expect.stringMatching(
           /^\/tmp\/vm0\/computer-use\/Safari-desktop_[a-z0-9]+\.png$/,
         ),
@@ -543,6 +551,10 @@ describe("computer use native backend", () => {
         },
       });
       expect(output.result).toBeUndefined();
+      expect(stdout).not.toContain("<app_state>");
+      await expect(
+        readFile(String(output.appState), "utf8"),
+      ).resolves.toContain("<app_state>");
       expect(output.screenshot).not.toBe("data:image/png;base64,abc123");
     } finally {
       await stopDaemon(daemonDir);

--- a/turbo/apps/desktop/src/vm0-computer.ts
+++ b/turbo/apps/desktop/src/vm0-computer.ts
@@ -101,7 +101,7 @@ const zeroCommands = new Map<string, string>([
   ["press-key", "keyboard.press_key"],
 ]);
 
-const COMPUTER_USE_SCREENSHOT_DIR = "/tmp/vm0/computer-use";
+const COMPUTER_USE_OUTPUT_DIR = "/tmp/vm0/computer-use";
 const DATA_URL_PATTERN = /^data:([^;,]+);base64,(.*)$/s;
 
 function usage(): string {
@@ -392,12 +392,28 @@ async function writeScreenshotDataUrl(
   const appName = sanitizeFilenamePart(result.app, "app");
   const snapshotId = sanitizeFilenamePart(result.snapshotId, "snapshot");
   const outputPath = path.join(
-    COMPUTER_USE_SCREENSHOT_DIR,
+    COMPUTER_USE_OUTPUT_DIR,
     `${appName}-${snapshotId}.${extensionForMimeType(mimeType)}`,
   );
 
-  await mkdir(COMPUTER_USE_SCREENSHOT_DIR, { recursive: true });
+  await mkdir(COMPUTER_USE_OUTPUT_DIR, { recursive: true });
   await writeFile(outputPath, Buffer.from(base64Data, "base64"));
+  return outputPath;
+}
+
+async function writeAppStateText(
+  result: Record<string, unknown>,
+  appState: string,
+): Promise<string> {
+  const appName = sanitizeFilenamePart(result.app, "app");
+  const snapshotId = sanitizeFilenamePart(result.snapshotId, "snapshot");
+  const outputPath = path.join(
+    COMPUTER_USE_OUTPUT_DIR,
+    `${appName}-${snapshotId}.appState.txt`,
+  );
+
+  await mkdir(COMPUTER_USE_OUTPUT_DIR, { recursive: true });
+  await writeFile(outputPath, appState, "utf8");
   return outputPath;
 }
 
@@ -431,7 +447,7 @@ async function formatComputerUseResultForConsole(
   }
   const appState = stringField(result, "appState");
   if (appState) {
-    printable.appState = appState;
+    printable.appState = await writeAppStateText(result, appState);
   }
   const screenshot = stringField(result, "screenshot");
   if (screenshot) {


### PR DESCRIPTION
## Summary

- Save vm0-computer AppState output to `/tmp/vm0/computer-use/*.appState.txt` like `zero computer-use`
- Keep screenshot output as a local file path and avoid printing full AppState text to stdout
- Update vm0-computer CLI tests for both `get-app-state` and post-action `click` output

## Validation

- `pnpm format`
- `pnpm -F @vm0/desktop exec vitest run src/computer-use-native.test.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build:cli`
- `pnpm -F @vm0/desktop exec vitest run src/computer-use-native.test.ts`
- `pnpm turbo run lint`
- `pnpm knip`

## Notes

- `pnpm check-types` currently fails outside this change in `@vm0/connectors`: `src/firewalls/index.ts` imports missing `./slock.generated`.
- `pnpm vitest` currently fails during web global setup before tests run because local Postgres auth is not configured: `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string`.
