### PR TITLE
fix: make artifact sidebar state url-driven

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -205,6 +205,10 @@ export const loadLeftThread$ = command(
     }
 
     if (get(currentChatThreadId$) !== threadId) {
+      // Drop the artifact sidebar before switching threads — the open
+      // artifact is anchored to the previous thread's messages, so
+      // preserving `?artifact=` (which `pushPathSilently$` does by design)
+      // would carry over a stale preview.
       set(clearArtifactPreview$);
       set(pushPathSilently$, "/chats/:threadId", { threadId });
     }

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
@@ -21,9 +21,17 @@ import {
 // attachment next to the chat thread area. Gated behind
 // FeatureSwitchKey.ChatArtifactSidebar; the OFF path keeps the old modal
 // lightbox in place.
+//
+// Every piece of sidebar state lives in `?artifact=` (plus the optional
+// `?artifact-fullscreen=1` flag). There is no in-memory state — opening
+// is a search-param write, closing is a search-param delete, and the
+// fullscreen toggle is just another search-param flip. Components read
+// the state through `currentArtifactRef$` / `artifactFullscreen$`, which
+// are pure computeds over `searchParams$`.
 // ---------------------------------------------------------------------------
 
 const ARTIFACT_QUERY_PARAM = "artifact";
+const ARTIFACT_FULLSCREEN_PARAM = "artifact-fullscreen";
 const IMAGE_ID_PREFIX = "image:";
 
 export type ArtifactPreviewKind =
@@ -89,43 +97,41 @@ export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
 const openArtifact$ = command(({ get, set }, url: string) => {
   const params = new URLSearchParams(get(searchParams$));
   params.set(ARTIFACT_QUERY_PARAM, url);
+  // Don't carry a previous artifact's fullscreen flag onto a fresh open;
+  // a new artifact starts at the default 50/50 size.
+  params.delete(ARTIFACT_FULLSCREEN_PARAM);
   set(updateSearchParams$, params);
 });
 
 export const closeArtifact$ = command(({ get, set }) => {
   const params = new URLSearchParams(get(searchParams$));
-  if (!params.has(ARTIFACT_QUERY_PARAM)) {
+  if (
+    !params.has(ARTIFACT_QUERY_PARAM) &&
+    !params.has(ARTIFACT_FULLSCREEN_PARAM)
+  ) {
     return;
   }
   params.delete(ARTIFACT_QUERY_PARAM);
-  set(replaceSearchParams$, params);
-  set(internalArtifactFullscreen$, false);
-});
-
-export const clearArtifactPreview$ = command(({ get, set }) => {
-  const params = new URLSearchParams(get(searchParams$));
-  set(internalArtifactFullscreen$, false);
-  if (!params.has(ARTIFACT_QUERY_PARAM)) {
-    return;
-  }
-  params.delete(ARTIFACT_QUERY_PARAM);
+  params.delete(ARTIFACT_FULLSCREEN_PARAM);
   set(replaceSearchParams$, params);
 });
 
-// ---------------------------------------------------------------------------
-// Fullscreen toggle — the sidebar fills the viewport on demand. Lives in
-// memory (intentionally not URL-routed) so deep links open at the default
-// 50/50 size.
-// ---------------------------------------------------------------------------
-
-const internalArtifactFullscreen$ = state<boolean>(false);
+export const clearArtifactPreview$ = command(({ set }) => {
+  set(closeArtifact$);
+});
 
 export const artifactFullscreen$ = computed((get) => {
-  return get(internalArtifactFullscreen$);
+  return get(searchParams$).get(ARTIFACT_FULLSCREEN_PARAM) === "1";
 });
 
 export const toggleArtifactFullscreen$ = command(({ get, set }) => {
-  set(internalArtifactFullscreen$, !get(internalArtifactFullscreen$));
+  const params = new URLSearchParams(get(searchParams$));
+  if (params.get(ARTIFACT_FULLSCREEN_PARAM) === "1") {
+    params.delete(ARTIFACT_FULLSCREEN_PARAM);
+  } else {
+    params.set(ARTIFACT_FULLSCREEN_PARAM, "1");
+  }
+  set(updateSearchParams$, params);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -180,20 +180,25 @@ describe("chatArtifactSidebar: sidebar slot rendering", () => {
   });
 
   it("clears the artifact pane state", () => {
-    setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt");
+    setup(
+      "/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt&artifact-fullscreen=1",
+    );
 
     expect(context.store.get(currentArtifactRef$)).not.toBeNull();
+    expect(context.store.get(artifactFullscreen$)).toBeTruthy();
 
     context.store.set(clearArtifactPreview$);
 
     expect(context.store.get(currentArtifactRef$)).toBeNull();
+    expect(context.store.get(artifactFullscreen$)).toBeFalsy();
     expect(search()).not.toContain("artifact=");
+    expect(search()).not.toContain("artifact-fullscreen=");
   });
 });
 
 describe("chatArtifactSidebar: fullscreen toggle", () => {
   it("toggles fullscreen state when the fullscreen button is clicked", () => {
-    setup();
+    setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt");
     renderWithStore(
       <ArtifactSidebar
         artifactRef={{
@@ -209,8 +214,10 @@ describe("chatArtifactSidebar: fullscreen toggle", () => {
 
     fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
     expect(context.store.get(artifactFullscreen$)).toBeTruthy();
+    expect(search()).toContain("artifact-fullscreen=1");
 
     fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
     expect(context.store.get(artifactFullscreen$)).toBeFalsy();
+    expect(search()).not.toContain("artifact-fullscreen=");
   });
 });


### PR DESCRIPTION
## Summary

- Make the artifact sidebar fullscreen state URL-backed instead of keeping a separate in-memory ccstate state.
- Clear stale `artifact` and `artifact-fullscreen` search params when closing the sidebar or switching the primary thread.
- Keep the existing `clearArtifactPreview$` call sites while routing them through the same close behavior.
- Add regression coverage for URL-backed fullscreen toggling and cleanup.

## Why

`pushPathSilently$` preserves search params when switching threads. If the artifact preview stays open, the new thread can inherit an artifact ref from the previous thread. Fullscreen also had split state during the stash-pop conflict: the artifact itself lived in the URL, while fullscreen could still live in memory. This makes the URL the sole source of truth for artifact sidebar state.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm -F @vm0/app exec eslint src/signals/chat-page/chat-thread-panes.ts src/signals/zero-page/zero-artifact-sidebar.ts src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx --max-warnings 0`
- [x] `pnpm knip --cache`
- [x] pre-commit hook: prettier, knip, full `pnpm check-types`