### PR TITLE
feat: support xdotool press-key names

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -174,6 +174,8 @@ describe("computer-use command visibility", () => {
     expect(helpOutput).toContain("--snapshot-id desktop_abc --element-index 7");
     expect(helpOutput).toContain("/tmp/vm0/computer-use");
     expect(helpOutput).toContain("overwrites the same files");
+    expect(helpOutput).toContain("shift+semicolon");
+    expect(helpOutput).toContain("Control_L+J");
   });
 
   it("should write screenshot and app state data to local files in command result console output", async () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -83,6 +83,8 @@ Notes:
   get-app-state; pass the matching --snapshot-id when acting on a prior snapshot.
   type-text sends literal keyboard input to the target app's current focus. Use
   set-value when you need deterministic accessibility value assignment.
+  press-key accepts xdotool-style names such as shift+semicolon, Control_L+J,
+  ctrl+alt+n, and BackSpace, plus existing macOS-style forms such as Command+L.
 
 Examples:
   List available apps:
@@ -101,7 +103,7 @@ Examples:
     zero computer-use type-text --app Safari --text "Hello"
 
   Press a keyboard shortcut:
-    zero computer-use press-key --app Safari --key Command+L
+    zero computer-use press-key --app Safari --key shift+semicolon
 
   Open an app without activating the current foreground app:
     zero computer-use open-app --app Things`;
@@ -547,7 +549,7 @@ const pressKeyCommand = appOption(
       .description("Send a background key or key combination to the target app")
       .requiredOption(
         "--key <key>",
-        "Key or key combination to press, for example Command+K or Control+K",
+        "Key or xdotool-style combination, for example Command+K, shift+semicolon, or Control_L+J",
       )
       .action(
         withErrorHandler(async (options: ComputerUsePressKeyOptions) => {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -214,14 +214,58 @@ let keyModifierDefinitions = [
 
 let keyModifierAliases = [
     "alt": "option",
+    "altl": "option",
+    "altr": "option",
     "cmd": "command",
+    "cmdl": "command",
+    "cmdr": "command",
     "command": "command",
+    "commandl": "command",
+    "commandr": "command",
     "control": "control",
+    "controll": "control",
+    "controlr": "control",
     "ctrl": "control",
+    "ctrll": "control",
+    "ctrlr": "control",
+    "hyper": "command",
+    "hyperl": "command",
+    "hyperr": "command",
     "meta": "command",
+    "metal": "command",
+    "metar": "command",
     "option": "option",
+    "optionl": "option",
+    "optionr": "option",
     "shift": "shift",
+    "shiftl": "shift",
+    "shiftr": "shift",
     "super": "command",
+    "superl": "command",
+    "superr": "command",
+]
+
+let keyAliases = [
+    "apostrophe": "'",
+    "backquote": "`",
+    "backslash": "\\",
+    "bracketleft": "[",
+    "bracketright": "]",
+    "comma": ",",
+    "equal": "=",
+    "equals": "=",
+    "grave": "`",
+    "leftbracket": "[",
+    "minus": "-",
+    "next": "pagedown",
+    "period": ".",
+    "pgdn": "pagedown",
+    "pgup": "pageup",
+    "prior": "pageup",
+    "quote": "'",
+    "rightbracket": "]",
+    "semicolon": ";",
+    "slash": "/",
 ]
 
 let keyCodes = [
@@ -309,6 +353,17 @@ let keyCodes = [
 ]
 
 let keyDisplayNames = [
+    "'": "Apostrophe",
+    ",": "Comma",
+    "-": "Minus",
+    ".": "Period",
+    "/": "Slash",
+    ";": "Semicolon",
+    "=": "Equal",
+    "[": "BracketLeft",
+    "\\": "Backslash",
+    "]": "BracketRight",
+    "`": "Grave",
     "backspace": "Backspace",
     "delete": "Backspace",
     "down": "Down",
@@ -330,6 +385,9 @@ let keyDisplayNames = [
     "up": "Up",
     "uparrow": "Up",
 ]
+
+let keySyntaxHint =
+    "Use xdotool-style names such as shift+semicolon, Control_L+J, ctrl+alt+n, or BackSpace."
 
 struct WindowTarget {
     let pid: pid_t
@@ -3071,12 +3129,19 @@ func performElementAccessibilityClick(
 }
 
 func normalizeKeyToken(_ value: String) -> String {
-    return value
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.count == 1 {
+        return trimmed.lowercased()
+    }
+    return trimmed
         .lowercased()
         .filter { character in
             !character.isWhitespace && character != "_" && character != "-"
         }
+}
+
+func canonicalKeyToken(_ token: String) -> String {
+    return keyAliases[token] ?? token
 }
 
 func displayKeyToken(_ token: String) -> String {
@@ -3116,10 +3181,11 @@ func parseKeyPress(_ key: String) throws -> ParsedKeyPress {
             modifierNames.insert(modifierName)
             continue
         }
-        guard let code = keyCodes[token] else {
+        let keyToken = canonicalKeyToken(token)
+        guard let code = keyCodes[keyToken] else {
             throw HelperFailure(
                 code: "unsupported_command",
-                message: "Unsupported key specification: \(rawPart)"
+                message: "Unsupported key specification: \(rawPart). \(keySyntaxHint)"
             )
         }
         if keyCode != nil {
@@ -3129,7 +3195,7 @@ func parseKeyPress(_ key: String) throws -> ParsedKeyPress {
             )
         }
         keyCode = code
-        displayKey = displayKeyToken(token)
+        displayKey = displayKeyToken(keyToken)
     }
 
     guard let keyCode, let displayKey else {

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -599,7 +599,7 @@ describe("computer use native backend", () => {
         "AXShowMenu",
       ],
       ["type-text", "--app", "Safari", "--text", "hello"],
-      ["press-key", "--app", "Safari", "--key", "Escape"],
+      ["press-key", "--app", "Safari", "--key", "shift+semicolon"],
     ];
 
     try {
@@ -658,7 +658,7 @@ describe("computer use native backend", () => {
         text: "hello",
       });
       expect(publicCommandRequests[7]?.payload).toMatchObject({
-        key: "Escape",
+        key: "shift+semicolon",
       });
     } finally {
       await stopDaemon(daemonDir);

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1740,6 +1740,22 @@ describe("computer use desktop runtime", () => {
         key: "Command+Shift+S",
         normalizedKey: "Command+Shift+S",
       },
+      {
+        key: "shift+semicolon",
+        normalizedKey: "Shift+Semicolon",
+      },
+      {
+        key: "Control_L+J",
+        normalizedKey: "Control+J",
+      },
+      {
+        key: "ctrl+alt+n",
+        normalizedKey: "Control+Option+N",
+      },
+      {
+        key: "Shift+;",
+        normalizedKey: "Shift+Semicolon",
+      },
     ];
 
     for (const testCase of cases) {
@@ -1838,7 +1854,7 @@ describe("computer use desktop runtime", () => {
     pressKey.mockRejectedValue(
       new ComputerUseNativeHelperError(
         "unsupported_command",
-        "Unsupported key specification: Launchpad",
+        "Unsupported key specification: Launchpad. Use xdotool-style names such as shift+semicolon, Control_L+J, ctrl+alt+n, or BackSpace.",
       ),
     );
     const result = await executeComputerUseCommand(
@@ -1858,7 +1874,8 @@ describe("computer use desktop runtime", () => {
       status: "failed",
       error: {
         code: "unsupported_command",
-        message: "Unsupported key specification: Launchpad",
+        message:
+          "Unsupported key specification: Launchpad. Use xdotool-style names such as shift+semicolon, Control_L+J, ctrl+alt+n, or BackSpace.",
       },
     });
     expect(pressKey).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- accept xdotool-style modifier aliases such as Control_L and ctrl+alt+n
- add named punctuation keys such as semicolon, comma, slash, brackets, backslash, grave, quote, minus, and equal
- document xdotool-style press-key syntax and surface unsupported-key examples

Closes #15213.

## Validation
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm prettier --write --ignore-unknown apps/cli/src/commands/zero/computer-use/index.ts apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts apps/desktop/src/window-policy.test.ts apps/desktop/src/computer-use-native.test.ts
- pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/computer-use-native.test.ts
- pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/cli check-types
- pnpm knip --workspace @vm0/desktop
- pnpm knip --workspace @vm0/cli
- pnpm -F @vm0/desktop build:cli
- Manual: TextEdit press-key shift+semicolon returned Shift+Semicolon
- Manual: TextEdit press-key Shift+; returned Shift+Semicolon
- Manual: TextEdit press-key Control_L+J returned Control+J