### PR TITLE
feat: include bundle ids in computer-use apps

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -202,6 +202,33 @@ describe("computer-use command visibility", () => {
     await expect(readFile(TEST_APP_STATE_PATH, "utf8")).resolves.toBe(appState);
   });
 
+  it("should print app bundle identifiers in list-apps output", async () => {
+    const text = await formatComputerUseResultForConsole({
+      apps: [
+        {
+          name: "TextEdit",
+          bundleId: "com.apple.TextEdit",
+          appPath: "/System/Applications/TextEdit.app",
+          running: true,
+          pid: 42,
+        },
+      ],
+    });
+
+    expect(JSON.parse(text)).toStrictEqual({
+      status: "succeeded",
+      apps: [
+        {
+          name: "TextEdit",
+          bundleId: "com.apple.TextEdit",
+          appPath: "/System/Applications/TextEdit.app",
+          running: true,
+          pid: 42,
+        },
+      ],
+    });
+  });
+
   it("should print screenshot and app state file paths for get-app-state", async () => {
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1347,16 +1347,27 @@ func findRunningApp(named appName: String) -> NSRunningApplication? {
         !app.isTerminated
     }
 
-    if let exact = apps.first(where: { app in
-        app.localizedName == appName || app.bundleIdentifier == appName
+    if let exactBundle = apps.first(where: { app in
+        app.bundleIdentifier == appName
     }) {
-        return exact
+        return exactBundle
     }
 
     let normalized = appName.lowercased()
+    if let bundleMatch = apps.first(where: { app in
+        app.bundleIdentifier?.lowercased() == normalized
+    }) {
+        return bundleMatch
+    }
+
+    if let exactName = apps.first(where: { app in
+        app.localizedName == appName
+    }) {
+        return exactName
+    }
+
     return apps.first { app in
-        app.localizedName?.lowercased() == normalized ||
-            app.bundleIdentifier?.lowercased() == normalized
+        app.localizedName?.lowercased() == normalized
     }
 }
 
@@ -2613,16 +2624,128 @@ func resolveElementId(
 }
 
 func handleAppsList() -> [String: Any] {
-    var names = Set<String>()
+    func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
+    }
+
+    func appRecordKey(
+        name: String,
+        bundleId: String?,
+        appPath: String?,
+        pid: pid_t?
+    ) -> String {
+        if let bundleId = nonEmpty(bundleId) {
+            return "bundle:\(bundleId.lowercased())"
+        }
+        if let appPath = nonEmpty(appPath) {
+            return "path:\(appPath.lowercased())"
+        }
+        if let pid {
+            return "pid:\(pid)"
+        }
+        return "name:\(name.lowercased())"
+    }
+
+    func mergeAppRecord(
+        _ record: [String: Any],
+        into recordsByKey: inout [String: [String: Any]],
+        key: String
+    ) {
+        guard var existing = recordsByKey[key] else {
+            recordsByKey[key] = record
+            return
+        }
+
+        if existing["bundleId"] == nil, let bundleId = record["bundleId"] {
+            existing["bundleId"] = bundleId
+        }
+        if existing["appPath"] == nil, let appPath = record["appPath"] {
+            existing["appPath"] = appPath
+        }
+        if record["running"] as? Bool == true {
+            existing["running"] = true
+            if let pid = record["pid"] {
+                existing["pid"] = pid
+            }
+            if let name = record["name"] {
+                existing["name"] = name
+            }
+        }
+        recordsByKey[key] = existing
+    }
+
+    var recordsByKey: [String: [String: Any]] = [:]
+
+    for url in discoveredApplicationURLs() {
+        guard let name = applicationNames(for: url).first else {
+            continue
+        }
+        let bundleId = nonEmpty(Bundle(url: url)?.bundleIdentifier)
+        let appPath = nonEmpty(url.standardizedFileURL.path)
+        var record: [String: Any] = [
+            "name": name,
+            "running": false,
+        ]
+        if let bundleId {
+            record["bundleId"] = bundleId
+        }
+        if let appPath {
+            record["appPath"] = appPath
+        }
+        mergeAppRecord(
+            record,
+            into: &recordsByKey,
+            key: appRecordKey(name: name, bundleId: bundleId, appPath: appPath, pid: nil)
+        )
+    }
+
     for app in NSWorkspace.shared.runningApplications {
         if app.activationPolicy == .regular,
-           let name = app.localizedName,
-           !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+           let name = nonEmpty(app.localizedName)
         {
-            names.insert(name)
+            let bundleId = nonEmpty(app.bundleIdentifier)
+            let appPath = nonEmpty(app.bundleURL?.standardizedFileURL.path)
+            var record: [String: Any] = [
+                "name": name,
+                "running": true,
+                "pid": Int(app.processIdentifier),
+            ]
+            if let bundleId {
+                record["bundleId"] = bundleId
+            }
+            if let appPath {
+                record["appPath"] = appPath
+            }
+            mergeAppRecord(
+                record,
+                into: &recordsByKey,
+                key: appRecordKey(
+                    name: name,
+                    bundleId: bundleId,
+                    appPath: appPath,
+                    pid: app.processIdentifier
+                )
+            )
         }
     }
-    return ["apps": Array(names).sorted()]
+
+    let records = recordsByKey.values.sorted { lhs, rhs in
+        let leftName = (lhs["name"] as? String ?? "").localizedCaseInsensitiveCompare(
+            rhs["name"] as? String ?? ""
+        )
+        if leftName != .orderedSame {
+            return leftName == .orderedAscending
+        }
+        return (lhs["bundleId"] as? String ?? "").localizedCaseInsensitiveCompare(
+            rhs["bundleId"] as? String ?? ""
+        ) == .orderedAscending
+    }
+    return ["apps": records]
 }
 
 func computerUsePermissionState() -> [String: Any] {

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1242,7 +1242,21 @@ function nativeAppStateScreenshot(
 async function listApps(
   nativeBackend: ComputerUseNativeBackend,
 ): Promise<ComputerUseCommandSuccess> {
-  const apps = [...(await nativeBackend.listApps())].sort();
+  const apps = [...(await nativeBackend.listApps())].sort((left, right) => {
+    const nameOrder = left.name.localeCompare(right.name, undefined, {
+      sensitivity: "base",
+    });
+    if (nameOrder !== 0) {
+      return nameOrder;
+    }
+    return (left.bundleId ?? "").localeCompare(
+      right.bundleId ?? "",
+      undefined,
+      {
+        sensitivity: "base",
+      },
+    );
+  });
   return { status: "succeeded", result: { apps } };
 }
 

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -328,6 +328,46 @@ describe("computer use native backend", () => {
     }
   });
 
+  it("reads structured app records from the native helper", async () => {
+    const helper = await createHelper({
+      status: "succeeded",
+      result: {
+        apps: [
+          {
+            name: "TextEdit",
+            bundleId: "com.apple.TextEdit",
+            appPath: "/System/Applications/TextEdit.app",
+            running: true,
+            pid: 42,
+          },
+          "Safari",
+        ],
+      },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+        mode: "oneshot",
+      });
+
+      await expect(backend.listApps()).resolves.toEqual([
+        {
+          name: "TextEdit",
+          bundleId: "com.apple.TextEdit",
+          appPath: "/System/Applications/TextEdit.app",
+          running: true,
+          pid: 42,
+        },
+        {
+          name: "Safari",
+        },
+      ]);
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
   it("reads normalized key names from the native helper", async () => {
     const helper = await createHelper({
       status: "succeeded",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -44,12 +44,20 @@ export type ComputerUseNativeTypeTextResult = ComputerUseNativeActionResult & {
   readonly description?: string;
 };
 
+export interface ComputerUseNativeAppRecord {
+  readonly name: string;
+  readonly bundleId?: string;
+  readonly appPath?: string;
+  readonly running?: boolean;
+  readonly pid?: number;
+}
+
 export interface ComputerUseNativeBackend {
   readonly dispose: () => void;
   readonly getPermissions: () => Promise<ComputerUsePermissionState>;
   readonly requestAccessibilityPermission: () => Promise<ComputerUsePermissionState>;
   readonly requestScreenRecordingPermission: () => Promise<ComputerUsePermissionState>;
-  readonly listApps: () => Promise<readonly string[]>;
+  readonly listApps: () => Promise<readonly ComputerUseNativeAppRecord[]>;
   readonly getAppState: (
     app: string,
     snapshotId: string,
@@ -201,23 +209,51 @@ function resultRecord(result: unknown, kind: string): Record<string, unknown> {
   );
 }
 
-function resultStringArray(
+function resultOptionalNumber(
   result: Record<string, unknown>,
   key: string,
-): readonly string[] {
+): number | undefined {
   const value = result[key];
-  if (
-    Array.isArray(value) &&
-    value.every((entry): entry is string => {
-      return typeof entry === "string";
-    })
-  ) {
-    return value;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function resultAppRecords(
+  result: Record<string, unknown>,
+): readonly ComputerUseNativeAppRecord[] {
+  const value = result.apps;
+  if (!Array.isArray(value)) {
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "Native Computer Use helper returned invalid apps",
+    );
   }
-  throw new ComputerUseNativeHelperError(
-    "accessibility_unavailable",
-    `Native Computer Use helper returned invalid ${key}`,
-  );
+
+  return value.map((entry) => {
+    if (typeof entry === "string" && entry.trim().length > 0) {
+      return { name: entry };
+    }
+    if (!isRecord(entry)) {
+      throw new ComputerUseNativeHelperError(
+        "accessibility_unavailable",
+        "Native Computer Use helper returned invalid app entry",
+      );
+    }
+
+    const name = resultRequiredString(entry, "name");
+    const bundleId = resultOptionalString(entry, "bundleId");
+    const appPath = resultOptionalString(entry, "appPath");
+    const pid = resultOptionalNumber(entry, "pid");
+    const running = entry.running;
+    return {
+      name,
+      ...(bundleId ? { bundleId } : {}),
+      ...(appPath ? { appPath } : {}),
+      ...(typeof running === "boolean" ? { running } : {}),
+      ...(pid !== undefined ? { pid } : {}),
+    };
+  });
 }
 
 function resultOptionalString(
@@ -574,7 +610,7 @@ export function createComputerUseNativeBackend(
     },
     listApps: async () => {
       const result = await run({ kind: "apps.list" });
-      return resultStringArray(result, "apps");
+      return resultAppRecords(result);
     },
     getAppState: async (app, snapshotId) => {
       const result = await run({ kind: "app.state", app, snapshotId });

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -609,6 +609,54 @@ describe("computer use desktop runtime", () => {
     });
   });
 
+  it("lists app records with bundle identifiers", async () => {
+    const result = await executeComputerUseCommand(
+      { id: "cmd_1", kind: "apps.list", payload: {} },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        nativeBackend: createNativeBackend({
+          listApps: async () => [
+            {
+              name: "TextEdit",
+              bundleId: "com.apple.TextEdit",
+              appPath: "/System/Applications/TextEdit.app",
+              running: true,
+              pid: 42,
+            },
+            {
+              name: "Safari",
+              bundleId: "com.apple.Safari",
+              appPath: "/Applications/Safari.app",
+              running: false,
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(result).toStrictEqual({
+      status: "succeeded",
+      result: {
+        apps: [
+          {
+            name: "Safari",
+            bundleId: "com.apple.Safari",
+            appPath: "/Applications/Safari.app",
+            running: false,
+          },
+          {
+            name: "TextEdit",
+            bundleId: "com.apple.TextEdit",
+            appPath: "/System/Applications/TextEdit.app",
+            running: true,
+            pid: 42,
+          },
+        ],
+      },
+    });
+  });
+
   it("reports app open as a background launch without target preparation", async () => {
     const openApp = vi.fn<ComputerUseNativeBackend["openApp"]>();
     openApp.mockResolvedValue({


### PR DESCRIPTION
## Summary
- return structured computer-use app records with name, bundleId, appPath, running state, and pid when available
- prefer bundle-id matches before display-name matches when resolving running apps
- keep legacy string app-list helper responses parseable while exposing bundle ids in CLI output

Closes #15214.

## Validation
- swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release
- pnpm prettier --write --ignore-unknown apps/desktop/src/computer-use-native.ts apps/desktop/src/computer-use-accessibility.ts apps/desktop/src/window-policy.test.ts apps/desktop/src/computer-use-native.test.ts apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/computer-use-native.test.ts
- pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/cli check-types
- pnpm knip --workspace @vm0/desktop
- pnpm knip --workspace @vm0/cli
- pnpm -F @vm0/desktop build:cli
- Manual: vm0-computer list-apps returned TextEdit with bundleId com.apple.TextEdit
- Manual: vm0-computer get-app-state --app com.apple.TextEdit succeeded and appState contained bundleID com.apple.TextEdit