### PR TITLE
refactor: cut over api-token connectors to connector state

### DIFF
--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -24,9 +24,14 @@ setup_file() {
     setup_test_connector "github" "$CI_GITHUB_TOKEN"
     setup_test_connector "slack" "xoxb-multi-test-token"
 
-    # discord-webhook uses api-token auth (not OAuth), so store as user secret
-    # — same path as the frontend's "Add Connection" dialog.
-    set_user_secret "DISCORD_WEBHOOK_URL" "https://discord.com/api/webhooks/1234567890/fake-token-for-e2e"
+    # discord-webhook uses api-token auth, so set it up through the same
+    # connector-aware path as the frontend's "Add Connection" dialog.
+    $ZERO_CLI connector connect discord-webhook \
+        --value DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/1234567890/fake-token-for-e2e
+}
+
+teardown_file() {
+    zero_curl "/api/zero/connectors/discord-webhook" -X DELETE >/dev/null 2>&1 || true
 }
 
 setup() {
@@ -88,44 +93,6 @@ setup_test_connector() {
 
     if [[ "$http_code" != "200" ]]; then
         echo "Failed to set up test connector: HTTP $http_code"
-        echo "Response: $body"
-        return 1
-    fi
-}
-
-# Helper to set a user secret via the zero secrets API.
-# Uses the CLI auth token from ~/.vm0/config.json.
-# This mirrors the frontend's api-token connector flow.
-set_user_secret() {
-    local name="$1"
-    local value="$2"
-
-    # Read auth token from CLI config
-    local token
-    token=$(python3 -c "import json; print(json.load(open('$HOME/.vm0/config.json'))['token'])" 2>/dev/null)
-    if [[ -z "$token" ]]; then
-        echo "No authToken in ~/.vm0/config.json" >&2
-        return 1
-    fi
-
-    local curl_args=(-s -w "\n%{http_code}" -X POST)
-    curl_args+=(-H "Content-Type: application/json")
-    curl_args+=(-H "Authorization: Bearer $token")
-    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
-        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
-    fi
-    curl_args+=(-d "{\"name\":\"${name}\",\"value\":\"${value}\"}")
-
-    local response
-    response=$(curl "${curl_args[@]}" "${VM0_API_URL}/api/zero/secrets")
-
-    local http_code
-    http_code=$(echo "$response" | tail -n1)
-    local body
-    body=$(echo "$response" | head -n-1)
-
-    if [[ "$http_code" != "200" ]]; then
-        echo "Failed to set user secret ${name}: HTTP $http_code"
         echo "Response: $body"
         return 1
     fi

--- a/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
+++ b/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
@@ -4,7 +4,7 @@
 #
 # Verifies the full flow for zendesk (api-token connector with ${{ vars.X }} base URL):
 # 1. Set up connector via one connector-aware CLI call
-# 2. Compose agent with zendesk skill + environment referencing connector secrets/vars
+# 2. Compose agent that relies on stored connector environment injection
 # 3. System auto-detects zendesk as connected, adds firewall with resolved base URL
 # 4. Placeholder env var injected in sandbox
 # 5. Proxy matches requests to resolved base URL and injects auth header
@@ -39,10 +39,7 @@ setup_file() {
 }
 
 teardown_file() {
-    # Clean up secrets and variables
-    $ZERO_CLI secret delete -y ZENDESK_API_TOKEN 2>/dev/null || true
-    $ZERO_CLI variable delete -y ZENDESK_SUBDOMAIN 2>/dev/null || true
-    $ZERO_CLI variable delete -y ZENDESK_EMAIL 2>/dev/null || true
+    zero_curl "/api/zero/connectors/zendesk" -X DELETE >/dev/null 2>&1 || true
 
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
@@ -58,10 +55,6 @@ agents:
     description: "Zendesk dynamic base URL placeholder test"
     framework: claude-code
     working_dir: /home/user/workspace
-    environment:
-      ZENDESK_API_TOKEN: \${{ secrets.ZENDESK_API_TOKEN }}
-      ZENDESK_SUBDOMAIN: \${{ vars.ZENDESK_SUBDOMAIN }}
-      ZENDESK_EMAIL: \${{ vars.ZENDESK_EMAIL }}
 EOF
 
     run $VM0_CLI compose --yes "$TEST_DIR/vm0-placeholder.yaml"
@@ -91,10 +84,6 @@ agents:
     description: "Zendesk dynamic base URL proxy test"
     framework: claude-code
     working_dir: /home/user/workspace
-    environment:
-      ZENDESK_API_TOKEN: \${{ secrets.ZENDESK_API_TOKEN }}
-      ZENDESK_SUBDOMAIN: \${{ vars.ZENDESK_SUBDOMAIN }}
-      ZENDESK_EMAIL: \${{ vars.ZENDESK_EMAIL }}
 EOF
 
     run $VM0_CLI compose --yes "$TEST_DIR/vm0-proxy.yaml"

--- a/e2e/tests/03-runner/t51-firewall-auth-query.bats
+++ b/e2e/tests/03-runner/t51-firewall-auth-query.bats
@@ -4,9 +4,9 @@
 #
 # Verifies the full flow for connectors that authenticate via URL query params
 # (e.g., SerpApi uses ?api_key=XXX instead of an Authorization header):
-# 1. Set up connector via user secret
+# 1. Set up connector via API-token connector flow
 # 2. Compose agent with environment referencing connector secret
-# 3. System auto-detects serpapi as connected, adds firewall with auth.query
+# 3. System detects serpapi as connected, adds firewall with auth.query
 # 4. Placeholder env var injected in sandbox
 # 5. Proxy matches requests and injects api_key query parameter
 
@@ -24,8 +24,8 @@ setup_file() {
     export ARTIFACT_NAME="e2e-auth-query-artifact-${UNIQUE_ID}"
 
     # Set up serpapi connector — api-token auth, single secret.
-    # Uses $ZERO_CLI (same pattern as t43-firewall-dynamic-base-url).
-    $ZERO_CLI secret set SERPAPI_TOKEN --body "fake-serpapi-token-for-e2e"
+    $ZERO_CLI connector connect serpapi \
+        --value SERPAPI_TOKEN=fake-serpapi-token-for-e2e
 
     # Create artifact
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
@@ -37,7 +37,7 @@ setup_file() {
 }
 
 teardown_file() {
-    $ZERO_CLI secret delete -y SERPAPI_TOKEN 2>/dev/null || true
+    zero_curl "/api/zero/connectors/serpapi" -X DELETE >/dev/null 2>&1 || true
 
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -735,31 +735,47 @@ describe("POST /api/agent/runs", () => {
   it("expands api-token connector firewall vars and masks connector env secrets with placeholders", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
+    await db.insert(connectors).values([
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        type: "zendesk",
+        authMethod: "api-token",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        type: "mercury",
+        authMethod: "api-token",
+      },
+    ]);
     await db.insert(variables).values({
       orgId: fx.orgId,
       userId: fx.userId,
       name: "ZENDESK_SUBDOMAIN",
       value: "acme",
+      type: "connector",
     });
     await db.insert(variables).values({
       orgId: fx.orgId,
       userId: fx.userId,
       name: "ZENDESK_EMAIL",
       value: "agent@example.com",
+      type: "connector",
     });
     await db.insert(secretsTable).values({
       orgId: fx.orgId,
       userId: fx.userId,
       name: "ZENDESK_API_TOKEN",
       encryptedValue: encryptSecretForTests("zendesk-real-token"),
-      type: "user",
+      type: "connector",
     });
     await db.insert(secretsTable).values({
       orgId: fx.orgId,
       userId: fx.userId,
       name: "MERCURY_TOKEN",
       encryptedValue: encryptSecretForTests("mercury-real-token"),
-      type: "user",
+      type: "connector",
     });
     const compose = await createCompose({
       fixture: fx,
@@ -1056,14 +1072,20 @@ describe("POST /api/agent/runs", () => {
     // WeRead's credential is consumed by the firewall auth header template
     // (Authorization: Bearer ${{ secrets.WEREAD_TOKEN }}), so the compose
     // environment never references it. Regression: loadReferencedSecrets used
-    // to drop any user secret not named in the compose environment, leaving
+    // to drop any connector secret not named in the compose environment, leaving
     // the weread firewall to fail with 424 CONNECTOR_NOT_CONFIGURED.
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "weread",
+      authMethod: "api-token",
+    });
     await db.insert(secretsTable).values({
       orgId: fx.orgId,
       userId: fx.userId,
       name: "WEREAD_TOKEN",
       encryptedValue: encryptSecretForTests("weread-real-token"),
-      type: "user",
+      type: "connector",
     });
     // A second secret IS referenced in the compose environment, so the
     // referenced-name set is non-empty (matching real agents).
@@ -1111,13 +1133,19 @@ describe("POST /api/agent/runs", () => {
   it("loads a firewall-only api-token connector secret without compose secret refs", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "weread",
+      authMethod: "api-token",
+    });
     await db.insert(secretsTable).values([
       {
         orgId: fx.orgId,
         userId: fx.userId,
         name: "WEREAD_TOKEN",
         encryptedValue: encryptSecretForTests("weread-real-token"),
-        type: "user",
+        type: "connector",
       },
       {
         orgId: fx.orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
@@ -320,6 +320,13 @@ async function seedGithubConnector(args: {
     externalEmail: "octocat@example.test",
     oauthScopes: JSON.stringify(["repo"]),
   });
+  await writeDb.insert(secrets).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    name: "GITHUB_ACCESS_TOKEN",
+    encryptedValue: "encrypted-github-access-token",
+    type: "connector",
+  });
 }
 
 describe("GET /api/integrations/github", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
@@ -154,7 +154,7 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("connects a first-time API-token connector without creating a connector row", async () => {
+  it("connects a first-time API-token connector with connector-owned state", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context })(zeroConnectorApiTokenContract);
 
@@ -168,19 +168,22 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
     );
 
     expect(response.body).toMatchObject({
-      id: null,
       type: "openai",
       authMethod: "api-token",
-      createdAt: "1970-01-01T00:00:00.000Z",
-      updatedAt: "1970-01-01T00:00:00.000Z",
     });
-    await expect(connectorRows(fixture, "openai")).resolves.toHaveLength(0);
+    expect(typeof response.body.id).toBe("string");
+    expect(response.body.createdAt).not.toBe("1970-01-01T00:00:00.000Z");
+    expect(response.body.updatedAt).not.toBe("1970-01-01T00:00:00.000Z");
+    await expect(connectorRows(fixture, "openai")).resolves.toHaveLength(1);
+    await expect(
+      secretRows(fixture, "OPENAI_TOKEN", "connector"),
+    ).resolves.toHaveLength(1);
     await expect(
       secretRows(fixture, "OPENAI_TOKEN", "user"),
-    ).resolves.toHaveLength(1);
+    ).resolves.toHaveLength(0);
   });
 
-  it("stores Zendesk API-token fields as one user secret and two variables", async () => {
+  it("stores Zendesk API-token fields as one connector secret and two connector variables", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context })(zeroConnectorApiTokenContract);
 
@@ -200,17 +203,17 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
     );
 
     await expect(
-      secretRows(fixture, "ZENDESK_API_TOKEN", "user"),
+      secretRows(fixture, "ZENDESK_API_TOKEN", "connector"),
     ).resolves.toHaveLength(1);
     await expect(variableRows(fixture, "ZENDESK_EMAIL")).resolves.toMatchObject(
-      [{ value: "support@example.com", type: "user" }],
+      [{ value: "support@example.com", type: "connector" }],
     );
     await expect(
       variableRows(fixture, "ZENDESK_SUBDOMAIN"),
-    ).resolves.toMatchObject([{ value: "example", type: "user" }]);
+    ).resolves.toMatchObject([{ value: "example", type: "connector" }]);
   });
 
-  it("replaces stored OAuth state with derived API-token state", async () => {
+  it("replaces stored OAuth state with stored API-token state", async () => {
     const fixture = await seedFixture();
     const db = store.set(writeDb$);
     await db.insert(connectors).values({
@@ -246,7 +249,9 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
       [200],
     );
 
-    await expect(connectorRows(fixture, "stripe")).resolves.toHaveLength(0);
+    await expect(connectorRows(fixture, "stripe")).resolves.toMatchObject([
+      { authMethod: "api-token" },
+    ]);
     await expect(
       secretRows(fixture, "STRIPE_ACCESS_TOKEN", "connector"),
     ).resolves.toHaveLength(0);
@@ -254,8 +259,11 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
       secretRows(fixture, "STRIPE_REFRESH_TOKEN", "connector"),
     ).resolves.toHaveLength(0);
     await expect(
-      secretRows(fixture, "STRIPE_TOKEN", "user"),
+      secretRows(fixture, "STRIPE_TOKEN", "connector"),
     ).resolves.toHaveLength(1);
+    await expect(
+      secretRows(fixture, "STRIPE_TOKEN", "user"),
+    ).resolves.toHaveLength(0);
 
     const getClient = setupApp({ context })(zeroConnectorsByTypeContract);
     const getResponse = await accept(
@@ -315,7 +323,9 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
     );
 
     expect(response.body.authMethod).toBe("api-token");
-    await expect(connectorRows(fixture, "stripe")).resolves.toHaveLength(0);
+    await expect(connectorRows(fixture, "stripe")).resolves.toMatchObject([
+      { authMethod: "api-token" },
+    ]);
     await expect(
       secretRows(fixture, "STRIPE_ACCESS_TOKEN", "connector"),
     ).resolves.toHaveLength(0);
@@ -323,25 +333,32 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
       secretRows(fixture, "STRIPE_REFRESH_TOKEN", "connector"),
     ).resolves.toHaveLength(0);
     await expect(
-      secretRows(fixture, "STRIPE_TOKEN", "user"),
+      secretRows(fixture, "STRIPE_TOKEN", "connector"),
     ).resolves.toHaveLength(1);
   });
 
   it("deletes omitted optional API-token fields on replacement", async () => {
     const fixture = await seedFixture();
     const db = store.set(writeDb$);
+    await db.insert(connectors).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      type: "gitlab",
+      authMethod: "api-token",
+    });
     await db.insert(secrets).values({
       orgId: fixture.orgId,
       userId: fixture.userId,
       name: "GITLAB_TOKEN",
       encryptedValue: "encrypted_gitlab_token",
-      type: "user",
+      type: "connector",
     });
     await db.insert(variables).values({
       orgId: fixture.orgId,
       userId: fixture.userId,
       name: "GITLAB_HOST",
       value: "gitlab.example.com",
+      type: "connector",
     });
 
     const client = setupApp({ context })(zeroConnectorApiTokenContract);
@@ -355,7 +372,7 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
     );
 
     await expect(
-      secretRows(fixture, "GITLAB_TOKEN", "user"),
+      secretRows(fixture, "GITLAB_TOKEN", "connector"),
     ).resolves.toHaveLength(1);
     await expect(variableRows(fixture, "GITLAB_HOST")).resolves.toHaveLength(0);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
@@ -88,6 +88,67 @@ async function seedAtlassianApiTokenState(
   fixture: OrgMembershipFixture,
 ): Promise<void> {
   const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "atlassian",
+    authMethod: "api-token",
+  });
+  await writeDb.insert(secrets).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "ATLASSIAN_TOKEN",
+    encryptedValue: "encrypted_atlassian_token",
+    type: "connector",
+  });
+  await writeDb.insert(variables).values([
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "ATLASSIAN_EMAIL",
+      value: "test@example.com",
+      type: "connector",
+    },
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "ATLASSIAN_DOMAIN",
+      value: "example",
+      type: "connector",
+    },
+  ]);
+}
+
+async function seedGitlabApiTokenState(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "gitlab",
+    authMethod: "api-token",
+  });
+  await writeDb.insert(secrets).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "GITLAB_TOKEN",
+    encryptedValue: "encrypted_gitlab_token",
+    type: "connector",
+  });
+  await writeDb.insert(variables).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "GITLAB_HOST",
+    value: "gitlab.example.com",
+    type: "connector",
+  });
+}
+
+async function seedLegacyAtlassianUserCredentialState(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
   await writeDb.insert(secrets).values({
     orgId: fixture.orgId,
     userId: fixture.userId,
@@ -101,33 +162,16 @@ async function seedAtlassianApiTokenState(
       userId: fixture.userId,
       name: "ATLASSIAN_EMAIL",
       value: "test@example.com",
+      type: "user",
     },
     {
       orgId: fixture.orgId,
       userId: fixture.userId,
       name: "ATLASSIAN_DOMAIN",
       value: "example",
+      type: "user",
     },
   ]);
-}
-
-async function seedGitlabApiTokenState(
-  fixture: OrgMembershipFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(secrets).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    name: "GITLAB_TOKEN",
-    encryptedValue: "encrypted_gitlab_token",
-    type: "user",
-  });
-  await writeDb.insert(variables).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    name: "GITLAB_HOST",
-    value: "gitlab.example.com",
-  });
 }
 
 async function remainingConnectorCount(
@@ -354,51 +398,32 @@ describe("DELETE /api/zero/connectors/:type", () => {
     });
   });
 
-  it("does not delete connector-owned variables while deleting legacy API-token state", async () => {
+  it("returns 404 and preserves legacy user-owned credential state without a connector row", async () => {
     const fixture = await track(seedFixture());
-    await seedAtlassianApiTokenState(fixture);
-    const writeDb = store.set(writeDb$);
-    await writeDb.insert(variables).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      name: "ATLASSIAN_DOMAIN",
-      value: "connector.example",
-      type: "connector",
-    });
+    await seedLegacyAtlassianUserCredentialState(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroConnectorsByTypeContract);
-    await accept(
+    const response = await accept(
       client.delete({
         params: { type: "atlassian" },
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [204],
+      [404],
     );
 
-    const remainingVariables = await writeDb
-      .select({
-        name: variables.name,
-        value: variables.value,
-        type: variables.type,
-      })
-      .from(variables)
-      .where(
-        and(
-          eq(variables.orgId, fixture.orgId),
-          eq(variables.userId, fixture.userId),
-        ),
-      );
-    expect(remainingVariables).toStrictEqual([
-      {
-        name: "ATLASSIAN_DOMAIN",
-        value: "connector.example",
-        type: "connector",
-      },
-    ]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Connector not found", code: "NOT_FOUND" },
+    });
+    await expect(
+      remainingSecretAndVariableState(fixture),
+    ).resolves.toStrictEqual({
+      secrets: 1,
+      variables: 2,
+    });
   });
 
-  it("deletes optional manual grant variables", async () => {
+  it("deletes optional API-token connector variables", async () => {
     const fixture = await track(seedFixture());
     await seedGitlabApiTokenState(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
@@ -128,7 +128,7 @@ describe("GET /api/zero/connectors/:type", () => {
     expect(response.body.type).toBe("github");
   });
 
-  it("returns a connector inferred from manual credential secrets", async () => {
+  it("returns 404 for legacy user-owned credential secrets without a connector row", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     seededFixtures.push(
@@ -150,15 +150,11 @@ describe("GET /api/zero/connectors/:type", () => {
         params: { type: "openai" },
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [200],
+      [404],
     );
 
-    expect(response.body).toMatchObject({
-      id: null,
-      type: "openai",
-      authMethod: "api-token",
-      createdAt: "1970-01-01T00:00:00.000Z",
-      updatedAt: "1970-01-01T00:00:00.000Z",
+    expect(response.body).toStrictEqual({
+      error: { message: "Connector not found", code: "NOT_FOUND" },
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -100,7 +100,7 @@ describe("GET /api/zero/connectors", () => {
     ).toBeTruthy();
   });
 
-  it("returns connectors inferred from manual credential secrets", async () => {
+  it("does not infer connectors from legacy user-owned credential secrets", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     seededFixtures.push(
@@ -125,13 +125,7 @@ describe("GET /api/zero/connectors", () => {
     const openai = response.body.connectors.find((connector) => {
       return connector.type === "openai";
     });
-    expect(openai).toMatchObject({
-      id: null,
-      type: "openai",
-      authMethod: "api-token",
-      createdAt: "1970-01-01T00:00:00.000Z",
-      updatedAt: "1970-01-01T00:00:00.000Z",
-    });
+    expect(openai).toBeUndefined();
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1207,7 +1207,7 @@ describe("POST /api/zero/runs", () => {
     });
   });
 
-  it("does not forward unapproved API-token connector secrets", async () => {
+  it("treats connector-named user secrets as ordinary explicit secrets", async () => {
     const fx = await fixture();
     const agent = await seedRunnableZeroAgent({
       fixture: fx,
@@ -1221,7 +1221,7 @@ describe("POST /api/zero/runs", () => {
       orgId: fx.orgId,
       userId: fx.userId,
       name: "AXIOM_TOKEN",
-      encryptedValue: encryptSecretForTests("xaat-unapproved"),
+      encryptedValue: encryptSecretForTests("xaat-user-secret"),
       type: "user",
     });
 
@@ -1229,7 +1229,7 @@ describe("POST /api/zero/runs", () => {
       zeroRunsClient().create({
         headers: { authorization: "Bearer clerk-session" },
         body: {
-          prompt: "do not leak connector token",
+          prompt: "use explicit user secret",
           agentId: agent.agentId,
         },
       }),
@@ -1243,13 +1243,64 @@ describe("POST /api/zero/runs", () => {
     const executionContext = job?.executionContext as {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
+      readonly firewalls?: readonly { readonly name: string }[];
     };
-    expect(executionContext.environment.AXIOM_TOKEN).toBe(
-      ["${{", " secrets.AXIOM_TOKEN }}"].join(""),
+    expect(executionContext.environment.AXIOM_TOKEN).toBe("xaat-user-secret");
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      AXIOM_TOKEN: "xaat-user-secret",
+    });
+    expect(
+      executionContext.firewalls?.some((firewall) => {
+        return firewall.name === "axiom";
+      }),
+    ).toBeFalsy();
+  });
+
+  it("does not infer API-token connector runtime from legacy user secrets", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    const db = store.set(writeDb$);
+    await db.insert(userConnectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      connectorType: "axiom",
+    });
+    await db.insert(secrets).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "AXIOM_TOKEN",
+      encryptedValue: encryptSecretForTests("xaat-legacy"),
+      type: "user",
+    });
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "ignore legacy connector secret",
+          agentId: agent.agentId,
+        },
+      }),
+      [201],
     );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly encryptedSecrets: string | null;
+      readonly firewalls?: readonly { readonly name: string }[];
+    };
     expect(
       decryptSecretsMap(executionContext.encryptedSecrets)?.AXIOM_TOKEN,
     ).toBeUndefined();
+    expect(
+      executionContext.firewalls?.some((firewall) => {
+        return firewall.name === "axiom";
+      }),
+    ).toBeFalsy();
   });
 
   it("masks approved API-token connector env secrets with placeholders", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -85,6 +85,17 @@ function modelProviderSecretPlaceholder(
   return placeholder;
 }
 
+function connectorSecretPlaceholder(
+  type: Parameters<typeof getConnectorFirewall>[0],
+  secretName: string,
+): string {
+  const placeholder = getConnectorFirewall(type)?.placeholders?.[secretName];
+  if (!placeholder) {
+    throw new Error(`Missing connector placeholder for ${secretName}`);
+  }
+  return placeholder;
+}
+
 interface ZeroAgentSeed {
   readonly fixture: UsageInsightFixture;
   readonly owner?: string;
@@ -1360,6 +1371,58 @@ describe("POST /api/zero/runs", () => {
     });
   });
 
+  it("omits missing optional API-token connector env fields", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    const db = store.set(writeDb$);
+    await db.insert(userConnectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      connectorType: "gitlab",
+    });
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "gitlab",
+      authMethod: "api-token",
+    });
+    await db.insert(secrets).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "GITLAB_TOKEN",
+      encryptedValue: encryptSecretForTests("glpat-token"),
+      type: "connector",
+    });
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "use gitlab without optional host",
+          agentId: agent.agentId,
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.environment.GITLAB_TOKEN).toBe(
+      connectorSecretPlaceholder("gitlab", "GITLAB_TOKEN"),
+    );
+    expect(executionContext.environment.GITLAB_HOST).toBeUndefined();
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      GITLAB_TOKEN: "glpat-token",
+    });
+  });
+
   it("injects authorized OAuth connector secrets and refresh metadata", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
@@ -1413,12 +1476,16 @@ describe("POST /api/zero/runs", () => {
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, response.body.runId));
     const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
       readonly secretConnectorMap: Record<string, string> | null;
       readonly firewalls: readonly { readonly name: string }[];
       readonly billableFirewalls: readonly string[];
     };
     const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    expect(executionContext.environment.X_TOKEN).toBe(
+      connectorSecretPlaceholder("x", "X_TOKEN"),
+    );
     expect(decrypted).toMatchObject({ X_TOKEN: "x-access" });
     expect(decrypted).not.toHaveProperty("X_REFRESH_TOKEN");
     expect(executionContext.secretConnectorMap).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1268,12 +1268,18 @@ describe("POST /api/zero/runs", () => {
       agentId: agent.agentId,
       connectorType: "axiom",
     });
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "axiom",
+      authMethod: "api-token",
+    });
     await db.insert(secrets).values({
       orgId: fx.orgId,
       userId: fx.userId,
       name: "AXIOM_TOKEN",
       encryptedValue: encryptSecretForTests("xaat-approved"),
-      type: "user",
+      type: "connector",
     });
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -9,7 +9,6 @@ import {
 import { authHeadersSchema } from "@vm0/api-contracts/contracts/base";
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
-import { getConnectorProvidedEnvNames } from "@vm0/connectors/connector-utils";
 import {
   agentComposes,
   agentComposeVersions,
@@ -133,16 +132,11 @@ const getSlackEnvironment$ = computed(
       get(zeroConnectorList({ orgId: auth.orgId, userId: auth.userId })),
     ]);
 
-    const connectorProvidedEnvNames = getConnectorProvidedEnvNames(
-      userConnectors.connectors.map((c) => {
-        return c.type;
-      }),
-    );
     const existingSecretNames = new Set([
       ...userSecretList.secrets.map((s) => {
         return s.name;
       }),
-      ...connectorProvidedEnvNames,
+      ...userConnectors.connectorProvidedEnvNames,
     ]);
     const existingVarNames = new Set(
       userVarList.variables.map((v) => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -4,6 +4,7 @@ import { createStore } from "ccstate";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { variables } from "@vm0/db/schema/variable";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
@@ -35,6 +36,70 @@ describe("zeroConnectorList", () => {
     });
 
     expect(openai).toBeUndefined();
+  });
+
+  it("returns connector-provided env names only for stored connector credentials", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values([
+      {
+        orgId,
+        userId,
+        type: "gitlab",
+        authMethod: "api-token",
+      },
+      {
+        orgId,
+        userId,
+        type: "openai",
+        authMethod: "api-token",
+      },
+    ]);
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId,
+      name: "GITLAB_TOKEN",
+      encryptedValue: "encrypted_gitlab_token",
+      type: "connector",
+    });
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+
+    expect(list.connectorProvidedEnvNames).toContain("GITLAB_TOKEN");
+    expect(list.connectorProvidedEnvNames).not.toContain("GITLAB_HOST");
+    expect(list.connectorProvidedEnvNames).not.toContain("OPENAI_TOKEN");
+  });
+
+  it("includes optional connector-provided env names when stored", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values({
+      orgId,
+      userId,
+      type: "gitlab",
+      authMethod: "api-token",
+    });
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId,
+      name: "GITLAB_TOKEN",
+      encryptedValue: "encrypted_gitlab_token",
+      type: "connector",
+    });
+    await writeDb.insert(variables).values({
+      orgId,
+      userId,
+      name: "GITLAB_HOST",
+      value: "gitlab.example.com",
+      type: "connector",
+    });
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+
+    expect(list.connectorProvidedEnvNames).toContain("GITLAB_TOKEN");
+    expect(list.connectorProvidedEnvNames).toContain("GITLAB_HOST");
   });
 
   it("returns configuredTypes in sorted order", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -71,7 +71,7 @@ describe("zeroConnectorList", () => {
     expect(list.connectorProvidedEnvNames).not.toContain("OPENAI_TOKEN");
   });
 
-  it("includes optional connector-provided env names when stored", async () => {
+  it("does not report variable-backed connector env names as provided secrets", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
@@ -99,7 +99,7 @@ describe("zeroConnectorList", () => {
     const list = await store.get(zeroConnectorList({ orgId, userId }));
 
     expect(list.connectorProvidedEnvNames).toContain("GITLAB_TOKEN");
-    expect(list.connectorProvidedEnvNames).toContain("GITLAB_HOST");
+    expect(list.connectorProvidedEnvNames).not.toContain("GITLAB_HOST");
   });
 
   it("returns configuredTypes in sorted order", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -71,6 +71,49 @@ describe("zeroConnectorList", () => {
     expect(list.connectorProvidedEnvNames).not.toContain("OPENAI_TOKEN");
   });
 
+  it("returns OAuth connector env names only when the access secret exists", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userWithoutSecret = `user_${randomUUID()}`;
+    const userWithSecret = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values([
+      {
+        orgId,
+        userId: userWithoutSecret,
+        type: "github",
+        authMethod: "oauth",
+      },
+      {
+        orgId,
+        userId: userWithSecret,
+        type: "github",
+        authMethod: "oauth",
+      },
+    ]);
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId: userWithSecret,
+      name: "GITHUB_ACCESS_TOKEN",
+      encryptedValue: "encrypted_github_access_token",
+      type: "connector",
+    });
+
+    const withoutSecret = await store.get(
+      zeroConnectorList({ orgId, userId: userWithoutSecret }),
+    );
+    const withSecret = await store.get(
+      zeroConnectorList({ orgId, userId: userWithSecret }),
+    );
+
+    expect(withoutSecret.connectorProvidedEnvNames).not.toContain("GH_TOKEN");
+    expect(withoutSecret.connectorProvidedEnvNames).not.toContain(
+      "GITHUB_TOKEN",
+    );
+    expect(withSecret.connectorProvidedEnvNames).toEqual(
+      expect.arrayContaining(["GH_TOKEN", "GITHUB_TOKEN"]),
+    );
+  });
+
   it("does not report variable-backed connector env names as provided secrets", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -17,11 +17,10 @@ const store = createStore();
 const writeDb = store.set(writeDb$);
 
 describe("zeroConnectorList", () => {
-  it("assigns fixed sentinel timestamps to derived api-token connectors", async () => {
+  it("does not derive api-token connectors from user-owned secrets", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
-    // Seed OPENAI_TOKEN so openai is derived as a connected api-token connector
     await writeDb.insert(secrets).values({
       orgId,
       userId,
@@ -35,11 +34,7 @@ describe("zeroConnectorList", () => {
       return c.type === "openai";
     });
 
-    expect(openai).toBeDefined();
-    if (openai) {
-      expect(openai.createdAt).toBe("1970-01-01T00:00:00.000Z");
-      expect(openai.updatedAt).toBe("1970-01-01T00:00:00.000Z");
-    }
+    expect(openai).toBeUndefined();
   });
 
   it("returns configuredTypes in sorted order", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -109,7 +109,7 @@ describe("zeroConnectorList", () => {
     expect(withoutSecret.connectorProvidedEnvNames).not.toContain(
       "GITHUB_TOKEN",
     );
-    expect(withSecret.connectorProvidedEnvNames).toEqual(
+    expect(withSecret.connectorProvidedEnvNames).toStrictEqual(
       expect.arrayContaining(["GH_TOKEN", "GITHUB_TOKEN"]),
     );
   });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -666,22 +666,28 @@ function isOfficialRunnerGroup(group: string): boolean {
   return group.split("/")[0] === "vm0";
 }
 
-function addConnectorEnvironmentTemplates(
-  environment: Record<string, string>,
-  envBindings: Record<string, string>,
-): void {
-  for (const [envName, valueRef] of Object.entries(envBindings)) {
-    if (envName in environment) {
-      continue;
-    }
-    if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-      environment[envName] = `\${{ secrets.${envName} }}`;
-    } else if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
-      environment[envName] = `\${{ vars.${envName} }}`;
-    } else {
-      environment[envName] = valueRef;
-    }
+function connectorEnvironmentTemplate(
+  envName: string,
+  valueRef: string,
+): string {
+  if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+    return `\${{ secrets.${envName} }}`;
   }
+  if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
+    return `\${{ vars.${envName} }}`;
+  }
+  return valueRef;
+}
+
+function addConnectorEnvironmentTemplate(
+  environment: Record<string, string>,
+  envName: string,
+  valueRef: string,
+): void {
+  if (envName in environment) {
+    return;
+  }
+  environment[envName] = connectorEnvironmentTemplate(envName, valueRef);
 }
 
 function environmentTemplates(args: {
@@ -1554,10 +1560,11 @@ interface StoredConnectorRuntimeRow {
 interface ConnectorEnvBindingSet {
   readonly connectorType: ConnectorType;
   readonly envBindings: Record<string, string>;
+  readonly optionalSecretNames: ReadonlySet<string>;
+  readonly optionalVariableNames: ReadonlySet<string>;
 }
 
 interface StoredConnectorRequirements {
-  readonly environment: Record<string, string>;
   readonly secretNames: Set<string>;
   readonly variableNames: Set<string>;
 }
@@ -1566,6 +1573,7 @@ interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
+  readonly environment: Record<string, string>;
 }
 
 function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
@@ -1606,12 +1614,28 @@ function connectorEnvBindingSets(
         `Invalid auth method "${row.authMethod}" for stored connector "${row.connectorType}"`,
       );
     }
+    const optionalSecretNames = new Set<string>();
+    const optionalVariableNames = new Set<string>();
+    if (method.grant.kind === "manual") {
+      for (const [name, field] of Object.entries(method.grant.fields)) {
+        if (field.required !== false) {
+          continue;
+        }
+        if (field.storage === "variable") {
+          optionalVariableNames.add(name);
+        } else {
+          optionalSecretNames.add(name);
+        }
+      }
+    }
     return {
       connectorType: row.connectorType,
       envBindings: getConnectorAuthMethodEnvBindings(
         row.connectorType,
         row.authMethod,
       ),
+      optionalSecretNames,
+      optionalVariableNames,
     };
   });
 }
@@ -1619,12 +1643,10 @@ function connectorEnvBindingSets(
 function collectStoredConnectorRequirements(
   bindingSets: readonly ConnectorEnvBindingSet[],
 ): StoredConnectorRequirements {
-  const environment: Record<string, string> = {};
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
 
   for (const { envBindings } of bindingSets) {
-    addConnectorEnvironmentTemplates(environment, envBindings);
     for (const valueRef of Object.values(envBindings)) {
       if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
         secretNames.add(valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length));
@@ -1634,7 +1656,7 @@ function collectStoredConnectorRequirements(
     }
   }
 
-  return { environment, secretNames, variableNames };
+  return { secretNames, variableNames };
 }
 
 async function loadStoredConnectorSecrets(
@@ -1715,21 +1737,35 @@ function resolveStoredConnectorState(
   const secrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
+  const environment: Record<string, string> = {};
 
-  for (const { connectorType, envBindings } of bindingSets) {
+  for (const {
+    connectorType,
+    envBindings,
+    optionalSecretNames,
+    optionalVariableNames,
+  } of bindingSets) {
     for (const [envName, valueRef] of Object.entries(envBindings)) {
       if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
         const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
         const secretValue = connectorSecrets[secretName];
         if (secretValue !== undefined) {
           secrets[envName] = secretValue;
+          addConnectorEnvironmentTemplate(environment, envName, valueRef);
+        } else if (!optionalSecretNames.has(secretName)) {
+          addConnectorEnvironmentTemplate(environment, envName, valueRef);
         }
       } else if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
         const variableName = valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length);
         const variableValue = connectorVariables[variableName];
         if (variableValue !== undefined) {
           vars[envName] = variableValue;
+          addConnectorEnvironmentTemplate(environment, envName, valueRef);
+        } else if (!optionalVariableNames.has(variableName)) {
+          addConnectorEnvironmentTemplate(environment, envName, valueRef);
         }
+      } else {
+        addConnectorEnvironmentTemplate(environment, envName, valueRef);
       }
     }
 
@@ -1746,7 +1782,7 @@ function resolveStoredConnectorState(
     }
   }
 
-  return { secrets, vars, secretConnectorMap };
+  return { secrets, vars, secretConnectorMap, environment };
 }
 
 async function loadStoredConnectorContext(
@@ -1804,7 +1840,7 @@ async function loadStoredConnectorContext(
     connectorTypes: allowedConnectorRows.map((row) => {
       return row.connectorType;
     }),
-    storedEnvironment: compactRecord(requirements.environment),
+    storedEnvironment: compactRecord(resolved.environment),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1794,54 +1794,60 @@ async function loadStoredConnectorContext(
     readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<ConnectorRuntimeContext> {
-  const connectorRows = await db
-    .select({ type: connectors.type, authMethod: connectors.authMethod })
-    .from(connectors)
-    .where(
-      and(eq(connectors.orgId, args.orgId), eq(connectors.userId, args.userId)),
+  return await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
     );
-  if (connectorRows.length === 0) {
-    return emptyConnectorRuntimeContext();
-  }
+    const connectorRows = await tx
+      .select({ type: connectors.type, authMethod: connectors.authMethod })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+        ),
+      );
+    if (connectorRows.length === 0) {
+      return emptyConnectorRuntimeContext();
+    }
 
-  const allowedConnectorRows = allowedStoredConnectorRows(
-    connectorRows,
-    args.allowedConnectorTypes,
-  );
-  if (allowedConnectorRows.length === 0) {
-    return emptyConnectorRuntimeContext();
-  }
+    const allowedConnectorRows = allowedStoredConnectorRows(
+      connectorRows,
+      args.allowedConnectorTypes,
+    );
+    if (allowedConnectorRows.length === 0) {
+      return emptyConnectorRuntimeContext();
+    }
 
-  const bindingSets = connectorEnvBindingSets(allowedConnectorRows);
-  const requirements = collectStoredConnectorRequirements(bindingSets);
-  const [connectorSecrets, connectorVariables] = await Promise.all([
-    loadStoredConnectorSecrets(db, {
+    const bindingSets = connectorEnvBindingSets(allowedConnectorRows);
+    const requirements = collectStoredConnectorRequirements(bindingSets);
+    const connectorSecrets = await loadStoredConnectorSecrets(tx, {
       orgId: args.orgId,
       userId: args.userId,
       names: requirements.secretNames,
       featureSwitchContext: args.featureSwitchContext,
-    }),
-    loadStoredConnectorVariables(db, {
+    });
+    const connectorVariables = await loadStoredConnectorVariables(tx, {
       orgId: args.orgId,
       userId: args.userId,
       names: requirements.variableNames,
-    }),
-  ]);
-  const resolved = resolveStoredConnectorState(
-    bindingSets,
-    connectorSecrets,
-    connectorVariables,
-  );
+    });
+    const resolved = resolveStoredConnectorState(
+      bindingSets,
+      connectorSecrets,
+      connectorVariables,
+    );
 
-  return {
-    secrets: compactRecord(resolved.secrets),
-    vars: compactRecord(resolved.vars),
-    secretConnectorMap: compactRecord(resolved.secretConnectorMap),
-    connectorTypes: allowedConnectorRows.map((row) => {
-      return row.connectorType;
-    }),
-    storedEnvironment: compactRecord(resolved.environment),
-  };
+    return {
+      secrets: compactRecord(resolved.secrets),
+      vars: compactRecord(resolved.vars),
+      secretConnectorMap: compactRecord(resolved.secretConnectorMap),
+      connectorTypes: allowedConnectorRows.map((row) => {
+        return row.connectorType;
+      }),
+      storedEnvironment: compactRecord(resolved.environment),
+    };
+  });
 }
 
 function injectPlatformEnvSecrets(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -23,13 +23,12 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
-  deriveConnectedManualGrantMethods,
   getConnectorAuthMethod,
   getConnectorAuthMethodEnvBindings,
-  getConnectorEnvBindings,
-  getConnectorProvidedEnvNames,
+  getConnectorManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
+  CONNECTOR_TYPE_KEYS,
   connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -352,7 +351,6 @@ interface ConnectorRuntimeContext {
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly connectorTypes: readonly ConnectorType[];
   readonly storedEnvironment: Record<string, string> | undefined;
-  readonly manualEnvironment: Record<string, string> | undefined;
 }
 
 interface PersistedRunEnvironmentSecret {
@@ -370,7 +368,6 @@ interface PersistedRunEnvironmentVariable {
 interface PersistedRunEnvironmentSnapshot {
   readonly secrets: readonly PersistedRunEnvironmentSecret[];
   readonly variables: readonly PersistedRunEnvironmentVariable[];
-  readonly manualGrantConnectorTypes: readonly ConnectorType[];
 }
 
 interface CreditCheckRow extends Record<string, unknown> {
@@ -671,17 +668,6 @@ function isOfficialRunnerGroup(group: string): boolean {
   return group.split("/")[0] === "vm0";
 }
 
-function connectorEnvironmentTemplates(
-  connectorTypes: readonly ConnectorType[],
-): Record<string, string> | undefined {
-  const environment: Record<string, string> = {};
-  for (const connectorType of connectorTypes) {
-    const envBindings = getConnectorEnvBindings(connectorType);
-    addConnectorEnvironmentTemplates(environment, envBindings);
-  }
-  return compactRecord(environment);
-}
-
 function addConnectorEnvironmentTemplates(
   environment: Record<string, string>,
   envBindings: Record<string, string>,
@@ -700,32 +686,12 @@ function addConnectorEnvironmentTemplates(
   }
 }
 
-function connectorEnvironmentSecretTemplateNames(
-  connectorTypes: readonly ConnectorType[],
-): Set<string> {
-  const names = new Set<string>();
-  for (const connectorType of connectorTypes) {
-    const envBindings = getConnectorEnvBindings(connectorType);
-    for (const [envName, valueRef] of Object.entries(envBindings)) {
-      if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-        names.add(envName);
-      }
-    }
-  }
-  return names;
-}
-
 function environmentTemplates(args: {
   readonly content: AgentComposeContent;
   readonly additionalEnvironment: Record<string, string> | undefined;
-  readonly connectorEnvironment: Record<string, string> | undefined;
 }): Record<string, string> | undefined {
   const environment = firstAgent(args.content)?.environment;
-  return mergeRecords(
-    args.connectorEnvironment,
-    args.additionalEnvironment,
-    environment,
-  );
+  return mergeRecords(args.additionalEnvironment, environment);
 }
 
 function expandEnvironment(args: {
@@ -736,7 +702,6 @@ function expandEnvironment(args: {
   readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
   readonly storedConnectorEnvironment: Record<string, string> | undefined;
   readonly connectorVars: Record<string, string> | undefined;
-  readonly manualConnectorEnvironment: Record<string, string> | undefined;
 }): Record<string, string> | null {
   const storedConnectorEnvironment = expandStoredConnectorEnvironment({
     environment: effectiveStoredConnectorEnvironment({
@@ -751,7 +716,6 @@ function expandEnvironment(args: {
   const mergedEnvironment = environmentTemplates({
     content: args.content,
     additionalEnvironment: args.additionalEnvironment,
-    connectorEnvironment: args.manualConnectorEnvironment,
   });
   if (!mergedEnvironment) {
     return storedConnectorEnvironment ?? null;
@@ -864,7 +828,6 @@ function missingEnvironmentReferences(args: {
   readonly additionalEnvironment: Record<string, string> | undefined;
   readonly storedConnectorEnvironment: Record<string, string> | undefined;
   readonly connectorVars: Record<string, string> | undefined;
-  readonly manualConnectorEnvironment: Record<string, string> | undefined;
 }): string[] {
   assertStoredConnectorEnvironmentReferences({
     environment: effectiveStoredConnectorEnvironment({
@@ -879,7 +842,6 @@ function missingEnvironmentReferences(args: {
   const environment = environmentTemplates({
     content: args.content,
     additionalEnvironment: args.additionalEnvironment,
-    connectorEnvironment: args.manualConnectorEnvironment,
   });
   const environmentMissing = missingReferencesInEnvironment({
     environment,
@@ -935,18 +897,6 @@ function assertStoredConnectorEnvironmentReferences(args: {
       `Stored connector environment is missing required values: ${missing.join(", ")}`,
     );
   }
-}
-
-function allowedManualGrantConnectorTypes(args: {
-  readonly manualGrantTypes: readonly ConnectorType[];
-  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
-}): readonly ConnectorType[] {
-  if (!args.allowedConnectorTypes) {
-    return args.manualGrantTypes;
-  }
-  return args.manualGrantTypes.filter((type) => {
-    return args.allowedConnectorTypes?.includes(type);
-  });
 }
 
 function hasExplicitFrameworkApiKey(
@@ -1452,25 +1402,12 @@ async function loadPersistedRunEnvironmentSnapshot(
     readonly orgId: string;
     readonly userId: string;
     readonly content: AgentComposeContent;
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
   },
 ): Promise<PersistedRunEnvironmentSnapshot> {
   return await db.transaction(async (tx) => {
     await tx.execute(
       sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
     );
-    const secretNameRows = await tx
-      .select({
-        name: secretsTable.name,
-      })
-      .from(secretsTable)
-      .where(
-        and(
-          eq(secretsTable.orgId, args.orgId),
-          eq(secretsTable.type, "user"),
-          eq(secretsTable.userId, args.userId),
-        ),
-      );
     const variableRows = await tx
       .select({
         name: variables.name,
@@ -1489,41 +1426,13 @@ async function loadPersistedRunEnvironmentSnapshot(
         ),
       );
 
-    const userSecretNames = new Set(
-      secretNameRows.map((row) => {
-        return row.name;
-      }),
-    );
-    const userVariableNames = new Set(
-      variableRows.flatMap((row) => {
-        return row.userId === args.userId ? [row.name] : [];
-      }),
-    );
-
-    const snapshotWithoutSecrets = {
-      variables: variableRows,
-      manualGrantConnectorTypes: deriveConnectedManualGrantMethods(
-        userSecretNames,
-        userVariableNames,
-      ).map((method) => {
-        return method.type;
-      }),
-    };
-    const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
-      allowedManualGrantConnectorTypes({
-        manualGrantTypes: snapshotWithoutSecrets.manualGrantConnectorTypes,
-        allowedConnectorTypes: args.allowedConnectorTypes,
-      }),
-    );
     const environment = firstAgent(args.content)?.environment;
     const referencedSecretNames = environment
       ? extractAndGroupVariables(environment).secrets.map((ref) => {
           return ref.name;
         })
       : [];
-    const secretNamesToLoad = [
-      ...new Set([...referencedSecretNames, ...dynamicConnectorSecretNames]),
-    ];
+    const secretNamesToLoad = [...new Set(referencedSecretNames)];
     const secretRows =
       secretNamesToLoad.length > 0
         ? await tx
@@ -1546,7 +1455,7 @@ async function loadPersistedRunEnvironmentSnapshot(
             )
         : [];
 
-    return { ...snapshotWithoutSecrets, secrets: secretRows };
+    return { variables: variableRows, secrets: secretRows };
   });
 }
 
@@ -1568,10 +1477,20 @@ function buildMergedVariables(args: {
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+function userOwnedConnectorSecretNames(): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const type of CONNECTOR_TYPE_KEYS) {
+    const fields = getConnectorManualGrantFieldNames(type);
+    for (const name of fields?.secrets ?? []) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
 async function buildReferencedSecrets(args: {
   readonly content: AgentComposeContent;
   readonly runSecrets: Record<string, string> | undefined;
-  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
   readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
   readonly featureSwitchContext: FeatureSwitchContext;
 }): Promise<Record<string, string> | undefined> {
@@ -1581,23 +1500,17 @@ async function buildReferencedSecrets(args: {
         return ref.name;
       })
     : [];
-  const manualGrantTypes = args.persistedEnvironment.manualGrantConnectorTypes;
-  const dynamicConnectorSecretNames = connectorEnvironmentSecretTemplateNames(
-    allowedManualGrantConnectorTypes({
-      manualGrantTypes,
-      allowedConnectorTypes: args.allowedConnectorTypes,
-    }),
-  );
-  if (referencedNames.length === 0 && dynamicConnectorSecretNames.size === 0) {
+  if (referencedNames.length === 0) {
     return args.runSecrets;
   }
 
-  // Manual grant secrets can be consumed by firewall auth templates even when
-  // the compose environment never references them. Connector-owned secrets are
-  // still scoped by filterDbSecretsByConnectorPermissions below.
   const orgSecrets: Record<string, string> = {};
   const userSecrets: Record<string, string> = {};
+  const connectorSecretNames = userOwnedConnectorSecretNames();
   for (const row of args.persistedEnvironment.secrets) {
+    if (connectorSecretNames.has(row.name)) {
+      continue;
+    }
     const target =
       row.userId === ORG_SENTINEL_USER_ID ? orgSecrets : userSecrets;
     target[row.name] = await decryptStoredSecretValue(
@@ -1606,72 +1519,14 @@ async function buildReferencedSecrets(args: {
     );
   }
 
-  const filteredSecrets = filterDbSecretsByConnectorPermissions({
-    dbSecrets: { ...orgSecrets, ...userSecrets },
-    allManualGrantTypes: manualGrantTypes,
-    allowedConnectorTypes: args.allowedConnectorTypes,
-  });
-  const connectorSecrets =
-    referencedNames.length === 0
-      ? filterRecordKeys(filteredSecrets, dynamicConnectorSecretNames)
-      : filteredSecrets;
-  const merged = { ...connectorSecrets, ...args.runSecrets };
+  const merged = { ...orgSecrets, ...userSecrets, ...args.runSecrets };
   return Object.keys(merged).length > 0 ? merged : undefined;
-}
-
-function filterDbSecretsByConnectorPermissions(args: {
-  readonly dbSecrets: Record<string, string>;
-  readonly allManualGrantTypes: readonly ConnectorType[];
-  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
-}): Record<string, string> | undefined {
-  if (Object.keys(args.dbSecrets).length === 0) {
-    return undefined;
-  }
-  if (!args.allowedConnectorTypes) {
-    return args.dbSecrets;
-  }
-
-  const allConnectorEnvNames = getConnectorProvidedEnvNames([
-    ...args.allManualGrantTypes,
-  ]);
-  const allowedManualGrantTypes = args.allManualGrantTypes.filter((type) => {
-    return args.allowedConnectorTypes?.includes(type);
-  });
-  const allowedConnectorEnvNames = getConnectorProvidedEnvNames(
-    allowedManualGrantTypes,
-  );
-  const filtered: Record<string, string> = {};
-
-  for (const [name, value] of Object.entries(args.dbSecrets)) {
-    if (allConnectorEnvNames.has(name) && !allowedConnectorEnvNames.has(name)) {
-      continue;
-    }
-    filtered[name] = value;
-  }
-
-  return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
 function compactRecord(
   values: Record<string, string>,
 ): Record<string, string> | undefined {
   return Object.keys(values).length > 0 ? values : undefined;
-}
-
-function filterRecordKeys(
-  values: Record<string, string> | undefined,
-  keys: ReadonlySet<string>,
-): Record<string, string> | undefined {
-  if (!values) {
-    return undefined;
-  }
-  const filtered: Record<string, string> = {};
-  for (const [key, value] of Object.entries(values)) {
-    if (keys.has(key)) {
-      filtered[key] = value;
-    }
-  }
-  return compactRecord(filtered);
 }
 
 function mergeRecords(
@@ -1737,7 +1592,6 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     secretConnectorMap: undefined,
     connectorTypes: [],
     storedEnvironment: undefined,
-    manualEnvironment: undefined,
   };
 }
 
@@ -1912,7 +1766,7 @@ function resolveStoredConnectorState(
   return { secrets, vars, secretConnectorMap };
 }
 
-async function loadOauthConnectorContext(
+async function loadStoredConnectorContext(
   db: Db,
   args: {
     readonly orgId: string;
@@ -1968,7 +1822,6 @@ async function loadOauthConnectorContext(
       return row.connectorType;
     }),
     storedEnvironment: compactRecord(requirements.environment),
-    manualEnvironment: undefined,
   };
 }
 
@@ -2697,7 +2550,6 @@ function validateCompose(
     readonly additionalEnvironment?: Record<string, string>;
     readonly storedConnectorEnvironment?: Record<string, string>;
     readonly connectorVars?: Record<string, string>;
-    readonly manualConnectorEnvironment?: Record<string, string>;
   },
 ): { readonly framework: SupportedFramework } | CreateRunErrorResult {
   const framework = resolveFramework(content);
@@ -2716,7 +2568,6 @@ function validateCompose(
       additionalEnvironment: options?.additionalEnvironment,
       storedConnectorEnvironment: options?.storedConnectorEnvironment,
       connectorVars: options?.connectorVars,
-      manualConnectorEnvironment: options?.manualConnectorEnvironment,
     });
     if (missing.length > 0) {
       return badRequestMessage(
@@ -2985,7 +2836,6 @@ async function buildStoredExecutionContext(args: {
           environmentFirewalls: permissions?.environmentFirewalls,
           storedConnectorEnvironment: args.connectorContext.storedEnvironment,
           connectorVars: args.connectorContext.vars,
-          manualConnectorEnvironment: args.connectorContext.manualEnvironment,
         }),
         ...args.extraEnvironment,
       },
@@ -3594,7 +3444,6 @@ async function loadRunConnectorContexts(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly manualGrantConnectorTypes: readonly ConnectorType[];
     readonly allowedConnectorTypes?: readonly ConnectorType[];
     readonly allowedCustomConnectorIds?: readonly string[];
   },
@@ -3603,8 +3452,8 @@ async function loadRunConnectorContexts(
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
 }> {
-  const [oauthConnectorContext, customConnectorContext] = await Promise.all([
-    loadOauthConnectorContext(db, {
+  const [storedConnectorContext, customConnectorContext] = await Promise.all([
+    loadStoredConnectorContext(db, {
       orgId: args.orgId,
       userId: args.userId,
       allowedConnectorTypes: args.allowedConnectorTypes,
@@ -3617,28 +3466,13 @@ async function loadRunConnectorContexts(
       featureSwitchContext,
     }),
   ]);
-  const allowedManualGrantTypes = args.allowedConnectorTypes
-    ? args.manualGrantConnectorTypes.filter((type) => {
-        return args.allowedConnectorTypes?.includes(type);
-      })
-    : args.manualGrantConnectorTypes;
   return {
-    connectorContext: {
-      ...oauthConnectorContext,
-      manualEnvironment: connectorEnvironmentTemplates(allowedManualGrantTypes),
-      connectorTypes: [
-        ...new Set([
-          ...oauthConnectorContext.connectorTypes,
-          ...allowedManualGrantTypes,
-        ]),
-      ],
-    },
+    connectorContext: storedConnectorContext,
     customConnectorContext,
   };
 }
 
 async function buildResolvedRunBody(args: {
-  readonly runArgs: CreateAgentRunArgs;
   readonly initialBody: CreateRunBody;
   readonly resolved: ResolvedCompose;
   readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
@@ -3666,7 +3500,6 @@ async function buildResolvedRunBody(args: {
   const mergedSecrets = await buildReferencedSecrets({
     content: args.resolved.content,
     runSecrets: body.secrets,
-    allowedConnectorTypes: args.runArgs.allowedConnectorTypes,
     persistedEnvironment: args.persistedEnvironment,
     featureSwitchContext: args.featureSwitchContext,
   });
@@ -3707,7 +3540,6 @@ function validateRunEnvironmentReferences(args: {
       additionalEnvironment: args.modelProvider?.environment,
       storedConnectorEnvironment: args.connectorContext.storedEnvironment,
       connectorVars: args.connectorContext.vars,
-      manualConnectorEnvironment: args.connectorContext.manualEnvironment,
     },
   );
 
@@ -3760,12 +3592,10 @@ async function prepareRunContext(
     orgId: args.orgId,
     userId: args.userId,
     content: resolved.content,
-    allowedConnectorTypes: args.allowedConnectorTypes,
   });
   signal.throwIfAborted();
 
   const body = await buildResolvedRunBody({
-    runArgs: args,
     initialBody,
     resolved,
     persistedEnvironment,
@@ -3804,15 +3634,7 @@ async function prepareRunContext(
     : requestedFramework;
 
   const { connectorContext, customConnectorContext } =
-    await loadRunConnectorContexts(
-      db,
-      {
-        ...args,
-        manualGrantConnectorTypes:
-          persistedEnvironment.manualGrantConnectorTypes,
-      },
-      featureSwitchContext,
-    );
+    await loadRunConnectorContexts(db, args, featureSwitchContext);
   signal.throwIfAborted();
 
   const validation = validateRunEnvironmentReferences({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -25,10 +25,8 @@ import {
 import {
   getConnectorAuthMethod,
   getConnectorAuthMethodEnvBindings,
-  getConnectorManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
-  CONNECTOR_TYPE_KEYS,
   connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -1477,17 +1475,6 @@ function buildMergedVariables(args: {
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function userOwnedConnectorSecretNames(): ReadonlySet<string> {
-  const names = new Set<string>();
-  for (const type of CONNECTOR_TYPE_KEYS) {
-    const fields = getConnectorManualGrantFieldNames(type);
-    for (const name of fields?.secrets ?? []) {
-      names.add(name);
-    }
-  }
-  return names;
-}
-
 async function buildReferencedSecrets(args: {
   readonly content: AgentComposeContent;
   readonly runSecrets: Record<string, string> | undefined;
@@ -1506,11 +1493,7 @@ async function buildReferencedSecrets(args: {
 
   const orgSecrets: Record<string, string> = {};
   const userSecrets: Record<string, string> = {};
-  const connectorSecretNames = userOwnedConnectorSecretNames();
   for (const row of args.persistedEnvironment.secrets) {
-    if (connectorSecretNames.has(row.name)) {
-      continue;
-    }
     const target =
       row.userId === ORG_SENTINEL_USER_ID ? orgSecrets : userSecrets;
     target[row.name] = await decryptStoredSecretValue(

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -9,7 +9,6 @@ import type {
   UpdateGithubLabelListenerBody,
 } from "@vm0/api-contracts/contracts/integrations-github";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
-import { getConnectorProvidedEnvNames } from "@vm0/connectors/connector-utils";
 import {
   agentComposes,
   agentComposeVersions,
@@ -1079,16 +1078,11 @@ export const getGithubInstallation$ = command(
       ]);
     signal.throwIfAborted();
 
-    const connectorProvidedEnvNames = getConnectorProvidedEnvNames(
-      connectorList.connectors.map((connector) => {
-        return connector.type;
-      }),
-    );
     const existingSecretNames = new Set([
       ...secretList.secrets.map((secret) => {
         return secret.name;
       }),
-      ...connectorProvidedEnvNames,
+      ...connectorList.connectorProvidedEnvNames,
     ]);
     const existingVarNames = new Set(
       variableList.variables.map((variable) => {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -7,19 +7,15 @@ import type {
 import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   connectorAuthMethodHasOAuthGrant,
-  deriveConnectedManualGrantMethod,
-  deriveConnectedManualGrantMethods,
   getAvailableConnectorAuthMethods,
+  getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNames,
   getConnectorOAuthClient,
-  getConnectorProvidedEnvNames,
   getConnectorSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
   getScopeDiff,
-  isConnectorAuthMethodAvailable,
-  type ConnectedManualGrantMethod,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -145,23 +141,6 @@ function storedConnectorTypeIsVisible(
   );
 }
 
-function manualGrantConnectorResponse(
-  method: ConnectedManualGrantMethod,
-): ConnectorResponse {
-  return {
-    id: null,
-    type: method.type,
-    authMethod: method.authMethod,
-    externalId: null,
-    externalUsername: null,
-    externalEmail: null,
-    oauthScopes: null,
-    needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
-  };
-}
-
 function apiTokenManualGrantFields(
   type: ConnectorType,
 ): Record<string, ConnectorManualGrantFieldConfig> | null {
@@ -257,74 +236,13 @@ function prepareApiTokenConnect(
   };
 }
 
-async function loadUserManualGrantFieldNameSets(
-  db: Db | ReadonlyDb,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-  },
-): Promise<{
-  readonly secretNames: Set<string>;
-  readonly variableNames: Set<string>;
-}> {
-  const [userSecretRows, userVariableRows] = await Promise.all([
-    db
-      .select({ name: secrets.name })
-      .from(secrets)
-      .where(
-        and(
-          eq(secrets.orgId, args.orgId),
-          eq(secrets.userId, args.userId),
-          eq(secrets.type, "user"),
-        ),
-      ),
-    db
-      .select({ name: variables.name })
-      .from(variables)
-      .where(
-        and(
-          eq(variables.orgId, args.orgId),
-          eq(variables.userId, args.userId),
-          eq(variables.type, "user"),
-        ),
-      ),
-  ]);
-
-  return {
-    secretNames: new Set(
-      userSecretRows.map((row) => {
-        return row.name;
-      }),
-    ),
-    variableNames: new Set(
-      userVariableRows.map((row) => {
-        return row.name;
-      }),
-    ),
-  };
-}
-
-function manualGrantConnectorMethods(args: {
-  readonly orgId: string;
-  readonly userId: string;
-}): Computed<Promise<readonly ConnectedManualGrantMethod[]>> {
-  return computed(
-    async (get): Promise<readonly ConnectedManualGrantMethod[]> => {
-      const db = get(db$);
-      const { secretNames, variableNames } =
-        await loadUserManualGrantFieldNameSets(db, args);
-      return deriveConnectedManualGrantMethods(secretNames, variableNames);
-    },
-  );
-}
-
 export function zeroConnectorList(args: {
   readonly orgId: string;
   readonly userId: string;
 }): Computed<Promise<ConnectorListResponse>> {
   return computed(async (get): Promise<ConnectorListResponse> => {
     const db = get(db$);
-    const [oauthRows, derivedMethods, overrides] = await Promise.all([
+    const [storedRows, overrides] = await Promise.all([
       db
         .select({
           id: connectors.id,
@@ -345,7 +263,6 @@ export function zeroConnectorList(args: {
             eq(connectors.userId, args.userId),
           ),
         ),
-      get(manualGrantConnectorMethods(args)),
       get(userFeatureSwitchOverrides(args.orgId, args.userId)),
     ]);
     const featureStates = getAllFeatureStates({
@@ -354,7 +271,7 @@ export function zeroConnectorList(args: {
       overrides,
     });
 
-    const dbConnectors: ConnectorResponse[] = oauthRows.flatMap((row) => {
+    const connectorList: ConnectorResponse[] = storedRows.flatMap((row) => {
       const parsed = connectorTypeSchema.safeParse(row.type);
       if (!parsed.success) {
         return [];
@@ -365,44 +282,32 @@ export function zeroConnectorList(args: {
       return [storedConnectorRowToResponse(row, parsed.data)];
     });
 
-    const dbTypes = new Set(
-      dbConnectors.map((connector) => {
-        return connector.type;
-      }),
-    );
-    // Use a fixed timestamp for derived connectors — they are inferred from
-    // secrets/variables rather than explicitly created, so a stable sentinel
-    // value keeps shadow comparisons deterministic.
-    const derivedConnectors: ConnectorResponse[] = derivedMethods
-      .filter((method) => {
-        return !dbTypes.has(method.type);
-      })
-      .filter((method) => {
-        return isConnectorAuthMethodAvailable(
-          method.type,
-          method.authMethod,
-          featureStates,
-        );
-      })
-      .map((method) => {
-        return manualGrantConnectorResponse(method);
-      });
-
-    const connectorList = [...dbConnectors, ...derivedConnectors];
     return {
       connectors: connectorList,
       configuredTypes: getRuntimeAvailableConnectorTypes((name) => {
         return optionalEnv(name);
       }),
       connectorProvidedEnvNames: [
-        ...getConnectorProvidedEnvNames(
-          connectorList.map((connector) => {
-            return connector.type;
-          }),
-        ),
+        ...connectorProvidedEnvNamesForStoredConnectors(connectorList),
       ],
     };
   });
+}
+
+function connectorProvidedEnvNamesForStoredConnectors(
+  connectorList: readonly ConnectorResponse[],
+): Set<string> {
+  const provided = new Set<string>();
+  for (const connector of connectorList) {
+    const envBindings = getConnectorAuthMethodEnvBindings(
+      connector.type,
+      connector.authMethod,
+    );
+    for (const envName of Object.keys(envBindings)) {
+      provided.add(envName);
+    }
+  }
+  return provided;
 }
 
 function storedConnectorByType(args: {
@@ -444,23 +349,6 @@ function storedConnectorByType(args: {
   });
 }
 
-function manualGrantMethodByType(args: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly type: ConnectorType;
-}): Computed<Promise<ConnectedManualGrantMethod | null>> {
-  return computed(async (get): Promise<ConnectedManualGrantMethod | null> => {
-    const db = get(db$);
-    const { secretNames, variableNames } =
-      await loadUserManualGrantFieldNameSets(db, args);
-    return deriveConnectedManualGrantMethod(
-      args.type,
-      secretNames,
-      variableNames,
-    );
-  });
-}
-
 export function zeroConnectorByType(args: {
   readonly orgId: string;
   readonly userId: string;
@@ -485,37 +373,8 @@ export function zeroConnectorByType(args: {
         return storedConnector;
       }
     }
-    const manualGrantMethod = await get(manualGrantMethodByType(args));
-    if (!manualGrantMethod) {
-      return null;
-    }
-    if (
-      !isConnectorAuthMethodAvailable(
-        args.type,
-        manualGrantMethod.authMethod,
-        featureStates,
-      )
-    ) {
-      return null;
-    }
-    return manualGrantConnectorResponse(manualGrantMethod);
+    return null;
   });
-}
-
-async function revokeExistingConnectorToken(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly type: ConnectorType;
-  readonly featureSwitchContext: FeatureSwitchContext;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  const pending = await loadPendingOAuthRevoke(args);
-  if (!pending) {
-    return;
-  }
-
-  await revokePendingOAuthToken({ pending, signal: args.signal });
 }
 
 async function loadPendingOAuthRevoke(args: {
@@ -582,58 +441,6 @@ async function revokePendingOAuthToken(args: {
     }),
   );
   args.signal.throwIfAborted();
-}
-
-async function hasManualGrantConnectorLocalState(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly fields: ManualGrantFieldNames | null;
-  readonly signal: AbortSignal;
-}): Promise<boolean> {
-  if (!args.fields) {
-    return false;
-  }
-
-  if (args.fields.secrets.length > 0) {
-    const [secret] = await args.db
-      .select({ id: secrets.id })
-      .from(secrets)
-      .where(
-        and(
-          eq(secrets.orgId, args.orgId),
-          eq(secrets.userId, args.userId),
-          eq(secrets.type, "user"),
-          inArray(secrets.name, [...args.fields.secrets]),
-        ),
-      )
-      .limit(1);
-    args.signal.throwIfAborted();
-    if (secret) {
-      return true;
-    }
-  }
-
-  if (args.fields.variables.length > 0) {
-    const [variable] = await args.db
-      .select({ id: variables.id })
-      .from(variables)
-      .where(
-        and(
-          eq(variables.orgId, args.orgId),
-          eq(variables.userId, args.userId),
-          eq(variables.type, "user"),
-          inArray(variables.name, [...args.fields.variables]),
-        ),
-      )
-      .limit(1);
-    args.signal.throwIfAborted();
-    if (variable) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 async function deleteManualGrantConnectorLocalState(args: {
@@ -703,84 +510,80 @@ export const deleteZeroConnectorLocalState$ = command(
       userId: args.userId,
       overrides: featureSwitchOverrides,
     } satisfies FeatureSwitchContext;
-    let deleted = false;
 
-    const [existing] = await writeDb
-      .select({ id: connectors.id, authMethod: connectors.authMethod })
-      .from(connectors)
-      .where(
-        and(
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.type, args.type),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
+    const deleteResult = await writeDb.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ id: connectors.id, authMethod: connectors.authMethod })
+        .from(connectors)
+        .where(
+          and(
+            eq(connectors.orgId, args.orgId),
+            eq(connectors.userId, args.userId),
+            eq(connectors.type, args.type),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      signal.throwIfAborted();
 
-    const fields = getConnectorManualGrantFieldNames(args.type);
-    const hasManualGrantState = existing
-      ? false
-      : await hasManualGrantConnectorLocalState({
-          db: writeDb,
-          orgId: args.orgId,
-          userId: args.userId,
-          fields,
-          signal,
-        });
-    if (!existing && !hasManualGrantState) {
-      return false;
-    }
-
-    if (existing) {
-      if (connectorAuthMethodHasOAuthGrant(args.type, existing.authMethod)) {
-        await revokeExistingConnectorToken({
-          db: writeDb,
-          orgId: args.orgId,
-          userId: args.userId,
-          type: args.type,
-          featureSwitchContext,
-          signal,
-        });
+      if (!existing) {
+        return { deleted: false, pendingOAuthRevoke: null };
       }
 
-      await writeDb.delete(connectors).where(eq(connectors.id, existing.id));
+      const pendingOAuthRevoke = connectorAuthMethodHasOAuthGrant(
+        args.type,
+        existing.authMethod,
+      )
+        ? await loadPendingOAuthRevoke({
+            db: tx,
+            orgId: args.orgId,
+            userId: args.userId,
+            type: args.type,
+            featureSwitchContext,
+            signal,
+          })
+        : null;
       signal.throwIfAborted();
-      deleted = true;
 
-      await deleteConnectorScopedSecretNames(writeDb, {
+      await tx.delete(connectors).where(eq(connectors.id, existing.id));
+      signal.throwIfAborted();
+
+      await deleteConnectorScopedSecretNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
         names: getConnectorSecretNames(args.type, existing.authMethod),
         signal,
       });
-      await deleteConnectorScopedVariableNames(writeDb, {
+      await deleteConnectorScopedVariableNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
         names: getConnectorVariableNames(args.type, existing.authMethod),
         signal,
       });
+
+      return { deleted: true, pendingOAuthRevoke };
+    });
+    signal.throwIfAborted();
+
+    if (!deleteResult.deleted) {
+      return false;
     }
 
-    deleted =
-      (await deleteManualGrantConnectorLocalState({
-        db: writeDb,
-        orgId: args.orgId,
-        userId: args.userId,
-        fields,
+    if (deleteResult.pendingOAuthRevoke) {
+      await revokePendingOAuthToken({
+        pending: deleteResult.pendingOAuthRevoke,
         signal,
-      })) || deleted;
-
-    if (deleted) {
-      await publishUserSignal([args.userId], "connector:changed");
-      signal.throwIfAborted();
+      });
     }
 
-    return deleted;
+    await publishUserSignal([args.userId], "connector:changed");
+    signal.throwIfAborted();
+
+    return true;
   },
 );
 
-async function upsertApiTokenUserSecret(
+async function upsertApiTokenConnectorSecret(
   db: Db,
   args: {
     readonly orgId: string;
@@ -797,7 +600,7 @@ async function upsertApiTokenUserSecret(
       name: args.name,
       encryptedValue: args.encryptedValue,
       description: null,
-      type: "user",
+      type: "connector",
     })
     .onConflictDoUpdate({
       target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
@@ -809,7 +612,7 @@ async function upsertApiTokenUserSecret(
     });
 }
 
-async function upsertApiTokenVariable(
+async function upsertApiTokenConnectorVariable(
   db: Db,
   args: {
     readonly orgId: string;
@@ -826,7 +629,7 @@ async function upsertApiTokenVariable(
       name: args.name,
       value: args.value,
       description: null,
-      type: "user",
+      type: "connector",
     })
     .onConflictDoUpdate({
       target: [
@@ -841,6 +644,61 @@ async function upsertApiTokenVariable(
         updatedAt: nowDate(),
       },
     });
+}
+
+async function upsertApiTokenConnectorRow(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: ConnectorType;
+  },
+): Promise<StoredConnectorRow> {
+  const updatedAt = nowDate();
+  const [row] = await db
+    .insert(connectors)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      authMethod: "api-token",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      tokenExpiresAt: null,
+      needsReconnect: false,
+    })
+    .onConflictDoUpdate({
+      target: [connectors.orgId, connectors.userId, connectors.type],
+      set: {
+        authMethod: "api-token",
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: null,
+        tokenExpiresAt: null,
+        needsReconnect: false,
+        updatedAt,
+      },
+    })
+    .returning({
+      id: connectors.id,
+      authMethod: connectors.authMethod,
+      externalId: connectors.externalId,
+      externalUsername: connectors.externalUsername,
+      externalEmail: connectors.externalEmail,
+      oauthScopes: connectors.oauthScopes,
+      needsReconnect: connectors.needsReconnect,
+      createdAt: connectors.createdAt,
+      updatedAt: connectors.updatedAt,
+    });
+
+  if (!row) {
+    throw new Error("Failed to upsert API-token connector");
+  }
+
+  return row;
 }
 
 async function deleteUserSecretNames(
@@ -941,7 +799,7 @@ async function deleteConnectorScopedVariableNames(
   args.signal.throwIfAborted();
 }
 
-async function deleteExistingStoredConnectorForApiTokenConnect(
+async function cleanupExistingStoredConnectorForApiTokenConnect(
   db: Db,
   args: {
     readonly orgId: string;
@@ -982,8 +840,6 @@ async function deleteExistingStoredConnectorForApiTokenConnect(
       })
     : null;
 
-  await db.delete(connectors).where(eq(connectors.id, existing.id));
-  args.signal.throwIfAborted();
   await deleteConnectorScopedSecretNames(db, {
     orgId: args.orgId,
     userId: args.userId,
@@ -1054,10 +910,11 @@ export const connectApiTokenConnector$ = command(
 
     const writeDb = set(writeDb$);
     let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
+    let connectorRow: StoredConnectorRow | null = null;
 
     await writeDb.transaction(async (tx) => {
       pendingOAuthRevoke =
-        await deleteExistingStoredConnectorForApiTokenConnect(tx, {
+        await cleanupExistingStoredConnectorForApiTokenConnect(tx, {
           orgId: args.orgId,
           userId: args.userId,
           type: args.type,
@@ -1065,13 +922,13 @@ export const connectApiTokenConnector$ = command(
           signal,
         });
 
-      await deleteUserSecretNames(tx, {
+      await deleteConnectorScopedSecretNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
         names: omittedSecretNames,
         signal,
       });
-      await deleteVariableNames(tx, {
+      await deleteConnectorScopedVariableNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
         names: omittedVariableNames,
@@ -1079,7 +936,7 @@ export const connectApiTokenConnector$ = command(
       });
 
       for (const field of encryptedSecrets) {
-        await upsertApiTokenUserSecret(tx, {
+        await upsertApiTokenConnectorSecret(tx, {
           orgId: args.orgId,
           userId: args.userId,
           name: field.name,
@@ -1089,7 +946,7 @@ export const connectApiTokenConnector$ = command(
       }
 
       for (const field of preparedResult.prepared.variableValues) {
-        await upsertApiTokenVariable(tx, {
+        await upsertApiTokenConnectorVariable(tx, {
           orgId: args.orgId,
           userId: args.userId,
           name: field.name,
@@ -1097,8 +954,32 @@ export const connectApiTokenConnector$ = command(
         });
         signal.throwIfAborted();
       }
+
+      connectorRow = await upsertApiTokenConnectorRow(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+      });
+      signal.throwIfAborted();
+
+      await deleteUserSecretNames(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        names: preparedResult.prepared.configuredSecretNames,
+        signal,
+      });
+      await deleteVariableNames(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        names: preparedResult.prepared.configuredVariableNames,
+        signal,
+      });
     });
     signal.throwIfAborted();
+
+    if (!connectorRow) {
+      throw new Error("Expected API-token connector upsert to return a row");
+    }
 
     if (pendingOAuthRevoke) {
       await revokePendingOAuthToken({ pending: pendingOAuthRevoke, signal });
@@ -1109,10 +990,7 @@ export const connectApiTokenConnector$ = command(
 
     return {
       status: "connected",
-      connector: manualGrantConnectorResponse({
-        type: args.type,
-        authMethod: "api-token",
-      }),
+      connector: storedConnectorRowToResponse(connectorRow, args.type),
     };
   },
 );
@@ -1241,6 +1119,133 @@ async function upsertExtraOAuthConnectorSecrets(args: {
   }
 }
 
+async function loadExistingConnectorAuthMethod(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: ConnectorType;
+    readonly signal: AbortSignal;
+  },
+): Promise<string | null> {
+  const [existingConnector] = await db
+    .select({ authMethod: connectors.authMethod })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.type, args.type),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+  return existingConnector?.authMethod ?? null;
+}
+
+async function upsertOAuthConnectorRow(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: OAuthGrantConnectorType;
+    readonly userInfo: ExternalUserInfo;
+    readonly oauthScopes: readonly string[];
+    readonly tokenExpiresAt: Date | null;
+    readonly signal: AbortSignal;
+  },
+): Promise<StoredConnectorRow> {
+  const [connectorRow] = await db
+    .insert(connectors)
+    .values({
+      userId: args.userId,
+      type: args.type,
+      authMethod: "oauth",
+      externalId: args.userInfo.id,
+      externalUsername: args.userInfo.username,
+      externalEmail: args.userInfo.email,
+      oauthScopes: JSON.stringify(args.oauthScopes),
+      tokenExpiresAt: args.tokenExpiresAt,
+      needsReconnect: false,
+      orgId: args.orgId,
+    })
+    .onConflictDoUpdate({
+      target: [connectors.orgId, connectors.userId, connectors.type],
+      set: {
+        authMethod: "oauth",
+        externalId: args.userInfo.id,
+        externalUsername: args.userInfo.username,
+        externalEmail: args.userInfo.email,
+        oauthScopes: JSON.stringify(args.oauthScopes),
+        tokenExpiresAt: args.tokenExpiresAt,
+        needsReconnect: false,
+        updatedAt: nowDate(),
+      },
+    })
+    .returning({
+      id: connectors.id,
+      authMethod: connectors.authMethod,
+      externalId: connectors.externalId,
+      externalUsername: connectors.externalUsername,
+      externalEmail: connectors.externalEmail,
+      oauthScopes: connectors.oauthScopes,
+      needsReconnect: connectors.needsReconnect,
+      createdAt: connectors.createdAt,
+      updatedAt: connectors.updatedAt,
+    });
+  args.signal.throwIfAborted();
+
+  if (!connectorRow) {
+    throw new Error("Failed to upsert connector");
+  }
+
+  return connectorRow;
+}
+
+async function deleteObsoleteConnectorScopedStateForOAuthConnect(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: OAuthGrantConnectorType;
+    readonly existingAuthMethod: string | null;
+    readonly signal: AbortSignal;
+  },
+): Promise<void> {
+  if (!args.existingAuthMethod || args.existingAuthMethod === "oauth") {
+    return;
+  }
+
+  const oauthSecretNames = new Set(getConnectorSecretNames(args.type, "oauth"));
+  const obsoleteSecretNames = getConnectorSecretNames(
+    args.type,
+    args.existingAuthMethod,
+  ).filter((name) => {
+    return !oauthSecretNames.has(name);
+  });
+  const oauthVariableNames = new Set(
+    getConnectorVariableNames(args.type, "oauth"),
+  );
+  const obsoleteVariableNames = getConnectorVariableNames(
+    args.type,
+    args.existingAuthMethod,
+  ).filter((name) => {
+    return !oauthVariableNames.has(name);
+  });
+  await deleteConnectorScopedSecretNames(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    names: obsoleteSecretNames,
+    signal: args.signal,
+  });
+  await deleteConnectorScopedVariableNames(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    names: obsoleteVariableNames,
+    signal: args.signal,
+  });
+}
+
 export const upsertOAuthConnector$ = command(
   async (
     { get, set },
@@ -1276,6 +1281,12 @@ export const upsertOAuthConnector$ = command(
         : undefined,
     });
     const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
+    const existingAuthMethod = await loadExistingConnectorAuthMethod(writeDb, {
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      signal,
+    });
 
     const featureSwitchContext = await get(
       userFeatureSwitchContext(args.orgId, args.userId),
@@ -1315,39 +1326,23 @@ export const upsertOAuthConnector$ = command(
     });
     signal.throwIfAborted();
 
-    const [connectorRow] = await writeDb
-      .insert(connectors)
-      .values({
-        userId: args.userId,
-        type: args.type,
-        authMethod: "oauth",
-        externalId: args.userInfo.id,
-        externalUsername: args.userInfo.username,
-        externalEmail: args.userInfo.email,
-        oauthScopes: JSON.stringify(args.oauthScopes),
-        tokenExpiresAt,
-        needsReconnect: false,
-        orgId: args.orgId,
-      })
-      .onConflictDoUpdate({
-        target: [connectors.orgId, connectors.userId, connectors.type],
-        set: {
-          authMethod: "oauth",
-          externalId: args.userInfo.id,
-          externalUsername: args.userInfo.username,
-          externalEmail: args.userInfo.email,
-          oauthScopes: JSON.stringify(args.oauthScopes),
-          tokenExpiresAt,
-          needsReconnect: false,
-          updatedAt: nowDate(),
-        },
-      })
-      .returning();
-    signal.throwIfAborted();
+    const connectorRow = await upsertOAuthConnectorRow(writeDb, {
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      userInfo: args.userInfo,
+      oauthScopes: args.oauthScopes,
+      tokenExpiresAt,
+      signal,
+    });
 
-    if (!connectorRow) {
-      throw new Error("Failed to upsert connector");
-    }
+    await deleteObsoleteConnectorScopedStateForOAuthConnect(writeDb, {
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      existingAuthMethod,
+      signal,
+    });
 
     await deleteManualGrantConnectorLocalState({
       db: writeDb,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -67,8 +67,15 @@ type StoredConnectorRow = {
   readonly updatedAt: Date;
 };
 
+interface ConnectorScopedCredentialNames {
+  readonly secretNames: ReadonlySet<string>;
+  readonly variableNames: ReadonlySet<string>;
+}
+
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
+const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
+const CONNECTOR_VAR_REF_PREFIX = "$vars.";
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
 interface ExternalUserInfo {
@@ -100,6 +107,11 @@ type ConnectApiTokenConnectorResult =
 interface EncryptedApiTokenSecret {
   readonly name: string;
   readonly encryptedValue: string;
+}
+
+interface OmittedApiTokenFieldNames {
+  readonly omittedSecretNames: readonly string[];
+  readonly omittedVariableNames: readonly string[];
 }
 
 interface EncryptedOAuthConnectorSecret {
@@ -179,6 +191,33 @@ function formatApiTokenFieldList(names: readonly string[]): string {
   return [...names].sort().join(", ");
 }
 
+function throwCapturedAbort(error: unknown): void {
+  if (error !== null) {
+    throw error;
+  }
+}
+
+async function finalizeConnectorStateChangeAfterCommit(args: {
+  readonly userId: string;
+  readonly pendingOAuthRevoke: PendingOAuthRevoke | null;
+  readonly signal: AbortSignal;
+  readonly postCommitAbort: unknown;
+}): Promise<void> {
+  let postCommitAbort = args.postCommitAbort;
+  if (args.pendingOAuthRevoke) {
+    await revokePendingOAuthToken({ pending: args.pendingOAuthRevoke });
+    if (args.signal.aborted) {
+      postCommitAbort ??= args.signal.reason;
+    }
+  }
+
+  await publishUserSignal([args.userId], "connector:changed");
+  if (args.signal.aborted) {
+    postCommitAbort ??= args.signal.reason;
+  }
+  throwCapturedAbort(postCommitAbort);
+}
+
 function prepareApiTokenConnect(
   type: ConnectorType,
   values: Readonly<Record<string, string>>,
@@ -255,35 +294,98 @@ function prepareApiTokenConnect(
   };
 }
 
+async function encryptApiTokenSecrets(args: {
+  readonly secretValues: readonly PreparedApiTokenField[];
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly signal: AbortSignal;
+}): Promise<readonly EncryptedApiTokenSecret[]> {
+  const encryptedSecrets: EncryptedApiTokenSecret[] = [];
+  for (const field of args.secretValues) {
+    encryptedSecrets.push({
+      name: field.name,
+      encryptedValue: await encryptStoredSecretValue(
+        field.value,
+        args.featureSwitchContext,
+      ),
+    });
+    args.signal.throwIfAborted();
+  }
+  return encryptedSecrets;
+}
+
+function omittedApiTokenFieldNames(
+  prepared: PreparedApiTokenConnect,
+): OmittedApiTokenFieldNames {
+  const submittedSecretNames = new Set(
+    prepared.secretValues.map((field) => {
+      return field.name;
+    }),
+  );
+  const submittedVariableNames = new Set(
+    prepared.variableValues.map((field) => {
+      return field.name;
+    }),
+  );
+  return {
+    omittedSecretNames: prepared.configuredSecretNames.filter((name) => {
+      return !submittedSecretNames.has(name);
+    }),
+    omittedVariableNames: prepared.configuredVariableNames.filter((name) => {
+      return !submittedVariableNames.has(name);
+    }),
+  };
+}
+
 export function zeroConnectorList(args: {
   readonly orgId: string;
   readonly userId: string;
 }): Computed<Promise<ConnectorListResponse>> {
   return computed(async (get): Promise<ConnectorListResponse> => {
     const db = get(db$);
-    const [storedRows, overrides] = await Promise.all([
-      db
-        .select({
-          id: connectors.id,
-          type: connectors.type,
-          authMethod: connectors.authMethod,
-          externalId: connectors.externalId,
-          externalUsername: connectors.externalUsername,
-          externalEmail: connectors.externalEmail,
-          oauthScopes: connectors.oauthScopes,
-          needsReconnect: connectors.needsReconnect,
-          createdAt: connectors.createdAt,
-          updatedAt: connectors.updatedAt,
-        })
-        .from(connectors)
-        .where(
-          and(
-            eq(connectors.orgId, args.orgId),
-            eq(connectors.userId, args.userId),
+    const [storedRows, connectorSecretRows, connectorVariableRows, overrides] =
+      await Promise.all([
+        db
+          .select({
+            id: connectors.id,
+            type: connectors.type,
+            authMethod: connectors.authMethod,
+            externalId: connectors.externalId,
+            externalUsername: connectors.externalUsername,
+            externalEmail: connectors.externalEmail,
+            oauthScopes: connectors.oauthScopes,
+            needsReconnect: connectors.needsReconnect,
+            createdAt: connectors.createdAt,
+            updatedAt: connectors.updatedAt,
+          })
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, args.orgId),
+              eq(connectors.userId, args.userId),
+            ),
           ),
-        ),
-      get(userFeatureSwitchOverrides(args.orgId, args.userId)),
-    ]);
+        db
+          .select({ name: secrets.name })
+          .from(secrets)
+          .where(
+            and(
+              eq(secrets.orgId, args.orgId),
+              eq(secrets.userId, args.userId),
+              eq(secrets.type, "connector"),
+            ),
+          ),
+        db
+          .select({ name: variables.name })
+          .from(variables)
+          .where(
+            and(
+              eq(variables.orgId, args.orgId),
+              eq(variables.userId, args.userId),
+              eq(variables.type, "connector"),
+            ),
+          ),
+        get(userFeatureSwitchOverrides(args.orgId, args.userId)),
+      ]);
     const featureStates = getAllFeatureStates({
       userId: args.userId,
       orgId: args.orgId,
@@ -300,6 +402,18 @@ export function zeroConnectorList(args: {
       }
       return [storedConnectorRowToResponse(row, parsed.data)];
     });
+    const connectorScopedCredentialNames: ConnectorScopedCredentialNames = {
+      secretNames: new Set(
+        connectorSecretRows.map((row) => {
+          return row.name;
+        }),
+      ),
+      variableNames: new Set(
+        connectorVariableRows.map((row) => {
+          return row.name;
+        }),
+      ),
+    };
 
     return {
       connectors: connectorList,
@@ -307,7 +421,10 @@ export function zeroConnectorList(args: {
         return optionalEnv(name);
       }),
       connectorProvidedEnvNames: [
-        ...connectorProvidedEnvNamesForStoredConnectors(connectorList),
+        ...connectorProvidedEnvNamesForStoredConnectors(
+          connectorList,
+          connectorScopedCredentialNames,
+        ),
       ],
     };
   });
@@ -315,6 +432,7 @@ export function zeroConnectorList(args: {
 
 function connectorProvidedEnvNamesForStoredConnectors(
   connectorList: readonly ConnectorResponse[],
+  connectorScopedCredentialNames: ConnectorScopedCredentialNames,
 ): Set<string> {
   const provided = new Set<string>();
   for (const connector of connectorList) {
@@ -322,7 +440,23 @@ function connectorProvidedEnvNamesForStoredConnectors(
       connector.type,
       connector.authMethod,
     );
-    for (const envName of Object.keys(envBindings)) {
+    for (const [envName, valueRef] of Object.entries(envBindings)) {
+      if (
+        valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX) &&
+        !connectorScopedCredentialNames.secretNames.has(
+          valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length),
+        )
+      ) {
+        continue;
+      }
+      if (
+        valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX) &&
+        !connectorScopedCredentialNames.variableNames.has(
+          valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length),
+        )
+      ) {
+        continue;
+      }
       provided.add(envName);
     }
   }
@@ -439,7 +573,6 @@ async function loadPendingOAuthRevoke(args: {
 
 async function revokePendingOAuthToken(args: {
   readonly pending: PendingOAuthRevoke;
-  readonly signal: AbortSignal;
 }): Promise<void> {
   const oauthClient = getConnectorOAuthClient(args.pending.type, optionalEnv);
   if (!oauthClient) {
@@ -459,7 +592,6 @@ async function revokePendingOAuthToken(args: {
       },
     }),
   );
-  args.signal.throwIfAborted();
 }
 
 async function deleteManualGrantConnectorLocalState(args: {
@@ -530,6 +662,7 @@ export const deleteZeroConnectorLocalState$ = command(
       overrides: featureSwitchOverrides,
     } satisfies FeatureSwitchContext;
 
+    let postCommitAbort: unknown = null;
     const deleteResult = await writeDb.transaction(async (tx) => {
       await lockConnectorState(tx, {
         orgId: args.orgId,
@@ -589,20 +722,21 @@ export const deleteZeroConnectorLocalState$ = command(
 
       return { deleted: true, pendingOAuthRevoke };
     });
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort ??= signal.reason;
+    }
 
     if (!deleteResult.deleted) {
+      throwCapturedAbort(postCommitAbort);
       return false;
     }
 
-    if (deleteResult.pendingOAuthRevoke) {
-      await revokePendingOAuthToken({
-        pending: deleteResult.pendingOAuthRevoke,
-        signal,
-      });
-    }
-
-    await publishUserSignal([args.userId], "connector:changed");
+    await finalizeConnectorStateChangeAfterCommit({
+      userId: args.userId,
+      pendingOAuthRevoke: deleteResult.pendingOAuthRevoke,
+      signal,
+      postCommitAbort,
+    });
     signal.throwIfAborted();
 
     return true;
@@ -903,40 +1037,19 @@ export const connectApiTokenConnector$ = command(
     );
     signal.throwIfAborted();
 
-    const encryptedSecrets: EncryptedApiTokenSecret[] = [];
-    for (const field of preparedResult.prepared.secretValues) {
-      encryptedSecrets.push({
-        name: field.name,
-        encryptedValue: await encryptStoredSecretValue(
-          field.value,
-          featureSwitchContext,
-        ),
-      });
-      signal.throwIfAborted();
-    }
-
-    const submittedSecretNames = new Set(
-      preparedResult.prepared.secretValues.map((field) => {
-        return field.name;
-      }),
-    );
-    const submittedVariableNames = new Set(
-      preparedResult.prepared.variableValues.map((field) => {
-        return field.name;
-      }),
-    );
-    const omittedSecretNames =
-      preparedResult.prepared.configuredSecretNames.filter((name) => {
-        return !submittedSecretNames.has(name);
-      });
-    const omittedVariableNames =
-      preparedResult.prepared.configuredVariableNames.filter((name) => {
-        return !submittedVariableNames.has(name);
-      });
+    const encryptedSecrets = await encryptApiTokenSecrets({
+      secretValues: preparedResult.prepared.secretValues,
+      featureSwitchContext,
+      signal,
+    });
+    signal.throwIfAborted();
+    const { omittedSecretNames, omittedVariableNames } =
+      omittedApiTokenFieldNames(preparedResult.prepared);
 
     const writeDb = set(writeDb$);
     let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
     let connectorRow: StoredConnectorRow | null = null;
+    let postCommitAbort: unknown = null;
 
     await writeDb.transaction(async (tx) => {
       await lockConnectorState(tx, {
@@ -1008,17 +1121,20 @@ export const connectApiTokenConnector$ = command(
         signal,
       });
     });
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort ??= signal.reason;
+    }
 
     if (!connectorRow) {
       throw new Error("Expected API-token connector upsert to return a row");
     }
 
-    if (pendingOAuthRevoke) {
-      await revokePendingOAuthToken({ pending: pendingOAuthRevoke, signal });
-    }
-
-    await publishUserSignal([args.userId], "connector:changed");
+    await finalizeConnectorStateChangeAfterCommit({
+      userId: args.userId,
+      pendingOAuthRevoke,
+      signal,
+      postCommitAbort,
+    });
     signal.throwIfAborted();
 
     return {
@@ -1156,6 +1272,49 @@ async function encryptExtraOAuthConnectorSecrets(args: {
     args.signal.throwIfAborted();
   }
   return encryptedSecrets;
+}
+
+async function encryptOAuthConnectorSecretSet(args: {
+  readonly type: OAuthGrantConnectorType;
+  readonly accessSecretName: string;
+  readonly accessToken: string;
+  readonly refreshSecretName: string | undefined;
+  readonly refreshToken: string | null | undefined;
+  readonly extraSecrets: readonly (readonly [string, string])[];
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly signal: AbortSignal;
+}): Promise<readonly EncryptedOAuthConnectorSecret[]> {
+  const encryptedOAuthSecrets: EncryptedOAuthConnectorSecret[] = [
+    await encryptedOAuthConnectorSecret({
+      name: args.accessSecretName,
+      value: args.accessToken,
+      description: `OAuth token for ${args.type} connector`,
+      featureSwitchContext: args.featureSwitchContext,
+    }),
+  ];
+  args.signal.throwIfAborted();
+
+  if (args.refreshToken && args.refreshSecretName) {
+    encryptedOAuthSecrets.push(
+      await encryptedOAuthConnectorSecret({
+        name: args.refreshSecretName,
+        value: args.refreshToken,
+        description: `OAuth refresh token for ${args.type} connector`,
+        featureSwitchContext: args.featureSwitchContext,
+      }),
+    );
+    args.signal.throwIfAborted();
+  }
+
+  encryptedOAuthSecrets.push(
+    ...(await encryptExtraOAuthConnectorSecrets({
+      type: args.type,
+      extraSecrets: args.extraSecrets,
+      featureSwitchContext: args.featureSwitchContext,
+      signal: args.signal,
+    })),
+  );
+  return encryptedOAuthSecrets;
 }
 
 async function upsertOAuthConnectorSecrets(args: {
@@ -1347,38 +1506,20 @@ export const upsertOAuthConnector$ = command(
     );
     signal.throwIfAborted();
 
-    const encryptedOAuthSecrets: EncryptedOAuthConnectorSecret[] = [
-      await encryptedOAuthConnectorSecret({
-        name: secretMetadata.accessSecretName,
-        value: args.accessToken,
-        description: `OAuth token for ${args.type} connector`,
-        featureSwitchContext,
-      }),
-    ];
+    const encryptedOAuthSecrets = await encryptOAuthConnectorSecretSet({
+      type: args.type,
+      accessSecretName: secretMetadata.accessSecretName,
+      accessToken: args.accessToken,
+      refreshSecretName: args.refreshSecretName,
+      refreshToken: args.refreshToken,
+      extraSecrets,
+      featureSwitchContext,
+      signal,
+    });
     signal.throwIfAborted();
 
-    if (args.refreshToken && args.refreshSecretName) {
-      encryptedOAuthSecrets.push(
-        await encryptedOAuthConnectorSecret({
-          name: args.refreshSecretName,
-          value: args.refreshToken,
-          description: `OAuth refresh token for ${args.type} connector`,
-          featureSwitchContext,
-        }),
-      );
-      signal.throwIfAborted();
-    }
-
-    encryptedOAuthSecrets.push(
-      ...(await encryptExtraOAuthConnectorSecrets({
-        type: args.type,
-        extraSecrets,
-        featureSwitchContext,
-        signal,
-      })),
-    );
-
     const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
+    let postCommitAbort: unknown = null;
     const connectorRow = await writeDb.transaction(async (tx) => {
       await lockConnectorState(tx, {
         orgId: args.orgId,
@@ -1431,9 +1572,16 @@ export const upsertOAuthConnector$ = command(
 
       return row;
     });
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort ??= signal.reason;
+    }
 
-    await publishUserSignal([args.userId], "connector:changed");
+    await finalizeConnectorStateChangeAfterCommit({
+      userId: args.userId,
+      pendingOAuthRevoke: null,
+      signal,
+      postCommitAbort,
+    });
     signal.throwIfAborted();
 
     return {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -38,7 +38,7 @@ import {
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
@@ -106,6 +106,19 @@ interface PendingOAuthRevoke {
   readonly type: OAuthGrantConnectorType;
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
+}
+
+async function lockConnectorState(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: ConnectorType;
+  },
+): Promise<void> {
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('connector_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type}))`,
+  );
 }
 
 function parseOauthScopes(value: string | null): string[] | null {
@@ -512,6 +525,13 @@ export const deleteZeroConnectorLocalState$ = command(
     } satisfies FeatureSwitchContext;
 
     const deleteResult = await writeDb.transaction(async (tx) => {
+      await lockConnectorState(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+      });
+      signal.throwIfAborted();
+
       const [existing] = await tx
         .select({ id: connectors.id, authMethod: connectors.authMethod })
         .from(connectors)
@@ -913,6 +933,13 @@ export const connectApiTokenConnector$ = command(
     let connectorRow: StoredConnectorRow | null = null;
 
     await writeDb.transaction(async (tx) => {
+      await lockConnectorState(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+      });
+      signal.throwIfAborted();
+
       pendingOAuthRevoke =
         await cleanupExistingStoredConnectorForApiTokenConnect(tx, {
           orgId: args.orgId,
@@ -1280,76 +1307,87 @@ export const upsertOAuthConnector$ = command(
         ? secretMetadata.refreshSecretName
         : undefined,
     });
-    const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
-    const existingAuthMethod = await loadExistingConnectorAuthMethod(writeDb, {
-      orgId: args.orgId,
-      userId: args.userId,
-      type: args.type,
-      signal,
-    });
-
     const featureSwitchContext = await get(
       userFeatureSwitchContext(args.orgId, args.userId),
     );
     signal.throwIfAborted();
 
-    await upsertConnectorSecret(writeDb, {
-      orgId: args.orgId,
-      userId: args.userId,
-      name: secretMetadata.accessSecretName,
-      value: args.accessToken,
-      description: `OAuth token for ${args.type} connector`,
-      featureSwitchContext,
-    });
-    signal.throwIfAborted();
-
-    if (args.refreshToken && args.refreshSecretName) {
-      await upsertConnectorSecret(writeDb, {
+    const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
+    const connectorRow = await writeDb.transaction(async (tx) => {
+      await lockConnectorState(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        name: args.refreshSecretName,
-        value: args.refreshToken,
-        description: `OAuth refresh token for ${args.type} connector`,
+        type: args.type,
+      });
+      signal.throwIfAborted();
+
+      const existingAuthMethod = await loadExistingConnectorAuthMethod(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+        signal,
+      });
+
+      await upsertConnectorSecret(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        name: secretMetadata.accessSecretName,
+        value: args.accessToken,
+        description: `OAuth token for ${args.type} connector`,
         featureSwitchContext,
       });
       signal.throwIfAborted();
-    }
 
-    await upsertExtraOAuthConnectorSecrets({
-      db: writeDb,
-      orgId: args.orgId,
-      userId: args.userId,
-      type: args.type,
-      extraSecrets,
-      featureSwitchContext,
-      signal,
-    });
-    signal.throwIfAborted();
+      if (args.refreshToken && args.refreshSecretName) {
+        await upsertConnectorSecret(tx, {
+          orgId: args.orgId,
+          userId: args.userId,
+          name: args.refreshSecretName,
+          value: args.refreshToken,
+          description: `OAuth refresh token for ${args.type} connector`,
+          featureSwitchContext,
+        });
+        signal.throwIfAborted();
+      }
 
-    const connectorRow = await upsertOAuthConnectorRow(writeDb, {
-      orgId: args.orgId,
-      userId: args.userId,
-      type: args.type,
-      userInfo: args.userInfo,
-      oauthScopes: args.oauthScopes,
-      tokenExpiresAt,
-      signal,
-    });
+      await upsertExtraOAuthConnectorSecrets({
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+        extraSecrets,
+        featureSwitchContext,
+        signal,
+      });
+      signal.throwIfAborted();
 
-    await deleteObsoleteConnectorScopedStateForOAuthConnect(writeDb, {
-      orgId: args.orgId,
-      userId: args.userId,
-      type: args.type,
-      existingAuthMethod,
-      signal,
-    });
+      const row = await upsertOAuthConnectorRow(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+        userInfo: args.userInfo,
+        oauthScopes: args.oauthScopes,
+        tokenExpiresAt,
+        signal,
+      });
 
-    await deleteManualGrantConnectorLocalState({
-      db: writeDb,
-      orgId: args.orgId,
-      userId: args.userId,
-      fields: manualGrantFields,
-      signal,
+      await deleteObsoleteConnectorScopedStateForOAuthConnect(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+        existingAuthMethod,
+        signal,
+      });
+
+      await deleteManualGrantConnectorLocalState({
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        fields: manualGrantFields,
+        signal,
+      });
+
+      return row;
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -67,9 +67,8 @@ type StoredConnectorRow = {
   readonly updatedAt: Date;
 };
 
-interface ConnectorScopedCredentialNames {
+interface ConnectorScopedSecretNames {
   readonly secretNames: ReadonlySet<string>;
-  readonly variableNames: ReadonlySet<string>;
 }
 
 const oauthScopesSchema = z.array(z.string());
@@ -341,50 +340,39 @@ export function zeroConnectorList(args: {
 }): Computed<Promise<ConnectorListResponse>> {
   return computed(async (get): Promise<ConnectorListResponse> => {
     const db = get(db$);
-    const [storedRows, connectorSecretRows, connectorVariableRows, overrides] =
-      await Promise.all([
-        db
-          .select({
-            id: connectors.id,
-            type: connectors.type,
-            authMethod: connectors.authMethod,
-            externalId: connectors.externalId,
-            externalUsername: connectors.externalUsername,
-            externalEmail: connectors.externalEmail,
-            oauthScopes: connectors.oauthScopes,
-            needsReconnect: connectors.needsReconnect,
-            createdAt: connectors.createdAt,
-            updatedAt: connectors.updatedAt,
-          })
-          .from(connectors)
-          .where(
-            and(
-              eq(connectors.orgId, args.orgId),
-              eq(connectors.userId, args.userId),
-            ),
+    const [storedRows, connectorSecretRows, overrides] = await Promise.all([
+      db
+        .select({
+          id: connectors.id,
+          type: connectors.type,
+          authMethod: connectors.authMethod,
+          externalId: connectors.externalId,
+          externalUsername: connectors.externalUsername,
+          externalEmail: connectors.externalEmail,
+          oauthScopes: connectors.oauthScopes,
+          needsReconnect: connectors.needsReconnect,
+          createdAt: connectors.createdAt,
+          updatedAt: connectors.updatedAt,
+        })
+        .from(connectors)
+        .where(
+          and(
+            eq(connectors.orgId, args.orgId),
+            eq(connectors.userId, args.userId),
           ),
-        db
-          .select({ name: secrets.name })
-          .from(secrets)
-          .where(
-            and(
-              eq(secrets.orgId, args.orgId),
-              eq(secrets.userId, args.userId),
-              eq(secrets.type, "connector"),
-            ),
+        ),
+      db
+        .select({ name: secrets.name })
+        .from(secrets)
+        .where(
+          and(
+            eq(secrets.orgId, args.orgId),
+            eq(secrets.userId, args.userId),
+            eq(secrets.type, "connector"),
           ),
-        db
-          .select({ name: variables.name })
-          .from(variables)
-          .where(
-            and(
-              eq(variables.orgId, args.orgId),
-              eq(variables.userId, args.userId),
-              eq(variables.type, "connector"),
-            ),
-          ),
-        get(userFeatureSwitchOverrides(args.orgId, args.userId)),
-      ]);
+        ),
+      get(userFeatureSwitchOverrides(args.orgId, args.userId)),
+    ]);
     const featureStates = getAllFeatureStates({
       userId: args.userId,
       orgId: args.orgId,
@@ -401,14 +389,9 @@ export function zeroConnectorList(args: {
       }
       return [storedConnectorRowToResponse(row, parsed.data)];
     });
-    const connectorScopedCredentialNames: ConnectorScopedCredentialNames = {
+    const connectorScopedSecretNames: ConnectorScopedSecretNames = {
       secretNames: new Set(
         connectorSecretRows.map((row) => {
-          return row.name;
-        }),
-      ),
-      variableNames: new Set(
-        connectorVariableRows.map((row) => {
           return row.name;
         }),
       ),
@@ -422,7 +405,7 @@ export function zeroConnectorList(args: {
       connectorProvidedEnvNames: [
         ...connectorProvidedEnvNamesForStoredConnectors(
           connectorList,
-          connectorScopedCredentialNames,
+          connectorScopedSecretNames,
         ),
       ],
     };
@@ -431,7 +414,7 @@ export function zeroConnectorList(args: {
 
 function connectorProvidedEnvNamesForStoredConnectors(
   connectorList: readonly ConnectorResponse[],
-  connectorScopedCredentialNames: ConnectorScopedCredentialNames,
+  connectorScopedSecretNames: ConnectorScopedSecretNames,
 ): Set<string> {
   const provided = new Set<string>();
   for (const connector of connectorList) {
@@ -444,7 +427,7 @@ function connectorProvidedEnvNamesForStoredConnectors(
         continue;
       }
       const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
-      if (!connectorScopedCredentialNames.secretNames.has(secretName)) {
+      if (!connectorScopedSecretNames.secretNames.has(secretName)) {
         continue;
       }
       provided.add(envName);

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -75,7 +75,6 @@ interface ConnectorScopedCredentialNames {
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
-const CONNECTOR_VAR_REF_PREFIX = "$vars.";
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
 interface ExternalUserInfo {
@@ -441,20 +440,11 @@ function connectorProvidedEnvNamesForStoredConnectors(
       connector.authMethod,
     );
     for (const [envName, valueRef] of Object.entries(envBindings)) {
-      if (
-        valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX) &&
-        !connectorScopedCredentialNames.secretNames.has(
-          valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length),
-        )
-      ) {
+      if (!valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
         continue;
       }
-      if (
-        valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX) &&
-        !connectorScopedCredentialNames.variableNames.has(
-          valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length),
-        )
-      ) {
+      const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+      if (!connectorScopedCredentialNames.secretNames.has(secretName)) {
         continue;
       }
       provided.add(envName);

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -102,6 +102,12 @@ interface EncryptedApiTokenSecret {
   readonly encryptedValue: string;
 }
 
+interface EncryptedOAuthConnectorSecret {
+  readonly name: string;
+  readonly encryptedValue: string;
+  readonly description: string;
+}
+
 interface PendingOAuthRevoke {
   readonly type: OAuthGrantConnectorType;
   readonly encryptedAccessToken: string;
@@ -1022,27 +1028,38 @@ export const connectApiTokenConnector$ = command(
   },
 );
 
-async function upsertConnectorSecret(
+async function encryptedOAuthConnectorSecret(args: {
+  readonly name: string;
+  readonly value: string;
+  readonly description: string;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<EncryptedOAuthConnectorSecret> {
+  return {
+    name: args.name,
+    encryptedValue: await encryptStoredSecretValue(
+      args.value,
+      args.featureSwitchContext,
+    ),
+    description: args.description,
+  };
+}
+
+async function upsertConnectorEncryptedSecret(
   db: Db,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly name: string;
-    readonly value: string;
+    readonly encryptedValue: string;
     readonly description: string;
-    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(
-    args.value,
-    args.featureSwitchContext,
-  );
   await db
     .insert(secrets)
     .values({
       userId: args.userId,
       name: args.name,
-      encryptedValue,
+      encryptedValue: args.encryptedValue,
       type: "connector",
       description: args.description,
       orgId: args.orgId,
@@ -1050,7 +1067,7 @@ async function upsertConnectorSecret(
     .onConflictDoUpdate({
       target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
       set: {
-        encryptedValue,
+        encryptedValue: args.encryptedValue,
         description: args.description,
         updatedAt: nowDate(),
       },
@@ -1120,27 +1137,45 @@ function validateExtraOAuthConnectorSecrets(args: {
   return extraSecrets;
 }
 
-async function upsertExtraOAuthConnectorSecrets(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
+async function encryptExtraOAuthConnectorSecrets(args: {
   readonly type: OAuthGrantConnectorType;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
+}): Promise<readonly EncryptedOAuthConnectorSecret[]> {
+  const encryptedSecrets: EncryptedOAuthConnectorSecret[] = [];
+  for (const [name, value] of args.extraSecrets) {
+    encryptedSecrets.push(
+      await encryptedOAuthConnectorSecret({
+        name,
+        value,
+        description: `OAuth connector secret for ${args.type}: ${name}`,
+        featureSwitchContext: args.featureSwitchContext,
+      }),
+    );
+    args.signal.throwIfAborted();
+  }
+  return encryptedSecrets;
+}
+
+async function upsertOAuthConnectorSecrets(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly secrets: readonly EncryptedOAuthConnectorSecret[];
+  readonly signal: AbortSignal;
 }): Promise<void> {
-  if (args.extraSecrets.length === 0) {
+  if (args.secrets.length === 0) {
     return;
   }
 
-  for (const [name, value] of args.extraSecrets) {
-    await upsertConnectorSecret(args.db, {
+  for (const secret of args.secrets) {
+    await upsertConnectorEncryptedSecret(args.db, {
       orgId: args.orgId,
       userId: args.userId,
-      name,
-      value,
-      description: `OAuth connector secret for ${args.type}: ${name}`,
-      featureSwitchContext: args.featureSwitchContext,
+      name: secret.name,
+      encryptedValue: secret.encryptedValue,
+      description: secret.description,
     });
     args.signal.throwIfAborted();
   }
@@ -1312,6 +1347,37 @@ export const upsertOAuthConnector$ = command(
     );
     signal.throwIfAborted();
 
+    const encryptedOAuthSecrets: EncryptedOAuthConnectorSecret[] = [
+      await encryptedOAuthConnectorSecret({
+        name: secretMetadata.accessSecretName,
+        value: args.accessToken,
+        description: `OAuth token for ${args.type} connector`,
+        featureSwitchContext,
+      }),
+    ];
+    signal.throwIfAborted();
+
+    if (args.refreshToken && args.refreshSecretName) {
+      encryptedOAuthSecrets.push(
+        await encryptedOAuthConnectorSecret({
+          name: args.refreshSecretName,
+          value: args.refreshToken,
+          description: `OAuth refresh token for ${args.type} connector`,
+          featureSwitchContext,
+        }),
+      );
+      signal.throwIfAborted();
+    }
+
+    encryptedOAuthSecrets.push(
+      ...(await encryptExtraOAuthConnectorSecrets({
+        type: args.type,
+        extraSecrets,
+        featureSwitchContext,
+        signal,
+      })),
+    );
+
     const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
     const connectorRow = await writeDb.transaction(async (tx) => {
       await lockConnectorState(tx, {
@@ -1328,35 +1394,11 @@ export const upsertOAuthConnector$ = command(
         signal,
       });
 
-      await upsertConnectorSecret(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        name: secretMetadata.accessSecretName,
-        value: args.accessToken,
-        description: `OAuth token for ${args.type} connector`,
-        featureSwitchContext,
-      });
-      signal.throwIfAborted();
-
-      if (args.refreshToken && args.refreshSecretName) {
-        await upsertConnectorSecret(tx, {
-          orgId: args.orgId,
-          userId: args.userId,
-          name: args.refreshSecretName,
-          value: args.refreshToken,
-          description: `OAuth refresh token for ${args.type} connector`,
-          featureSwitchContext,
-        });
-        signal.throwIfAborted();
-      }
-
-      await upsertExtraOAuthConnectorSecrets({
+      await upsertOAuthConnectorSecrets({
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
-        type: args.type,
-        extraSecrets,
-        featureSwitchContext,
+        secrets: encryptedOAuthSecrets,
         signal,
       });
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -4,7 +4,6 @@ import type {
   TelegramBotStatus,
   TelegramLinkStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
-import { getConnectorProvidedEnvNames } from "@vm0/connectors/connector-utils";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
@@ -277,16 +276,11 @@ function telegramEnvironment(args: {
       get(userVariables({ orgId: args.orgId, userId: args.userId })),
       get(zeroConnectorList({ orgId: args.orgId, userId: args.userId })),
     ]);
-    const connectorProvidedEnvNames = getConnectorProvidedEnvNames(
-      connectorList.connectors.map((connector) => {
-        return connector.type;
-      }),
-    );
     const existingSecretNames = new Set([
       ...secretList.secrets.map((secret) => {
         return secret.name;
       }),
-      ...connectorProvidedEnvNames,
+      ...connectorList.connectorProvidedEnvNames,
     ]);
     const existingVarNames = new Set(
       variableList.variables.map((variable) => {

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
@@ -16,7 +16,7 @@ import { connectCommand } from "../connect";
 
 function connectorResponse(type: string) {
   return {
-    id: null,
+    id: "00000000-0000-4000-8000-000000000001",
     type,
     authMethod: "api-token",
     externalId: null,
@@ -24,8 +24,8 @@ function connectorResponse(type: string) {
     externalEmail: null,
     oauthScopes: null,
     needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -11,7 +11,7 @@ function connector(
   externalUsername: string | null = `${type}-user`,
 ) {
   return {
-    id: null,
+    id: "00000000-0000-4000-8000-000000000001",
     type,
     authMethod: "api-token",
     externalId: `${type}-external-id`,

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -25,7 +25,7 @@ function defaultAvailableConnectors() {
 
 function connectorApiTokenResponse(type: string) {
   return {
-    id: null,
+    id: "00000000-0000-4000-8000-000000000001",
     type,
     authMethod: "api-token",
     externalId: null,
@@ -33,8 +33,8 @@ function connectorApiTokenResponse(type: string) {
     externalEmail: null,
     oauthScopes: null,
     needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -66,7 +66,7 @@ function defaultOauthDeviceAuthSessionStartResponse(
 
 function createMockApiTokenConnector(type: ConnectorType): ConnectorResponse {
   return {
-    id: null,
+    id: crypto.randomUUID(),
     type,
     authMethod: "api-token",
     externalId: null,
@@ -74,8 +74,8 @@ function createMockApiTokenConnector(type: ConnectorType): ConnectorResponse {
     externalEmail: null,
     oauthScopes: null,
     needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -781,7 +781,7 @@ describe("submitManualCredentials$", () => {
       mockApi(zeroConnectorApiTokenContract.connect, ({ body, respond }) => {
         submitted = body.values;
         return respond(200, {
-          id: null,
+          id: crypto.randomUUID(),
           type: "strapi",
           authMethod: "api-token",
           externalId: null,
@@ -789,8 +789,8 @@ describe("submitManualCredentials$", () => {
           externalEmail: null,
           oauthScopes: null,
           needsReconnect: false,
-          createdAt: "1970-01-01T00:00:00.000Z",
-          updatedAt: "1970-01-01T00:00:00.000Z",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
         });
       }),
     );

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -84,7 +84,7 @@ function mockConnectorOauthStart() {
 
 function apiTokenConnectorResponse(type: ConnectorType) {
   return {
-    id: null,
+    id: crypto.randomUUID(),
     type,
     authMethod: "api-token" as const,
     externalId: null,
@@ -92,8 +92,8 @@ function apiTokenConnectorResponse(type: ConnectorType) {
     externalEmail: null,
     oauthScopes: null,
     needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -61,7 +61,7 @@ function mockConnectors(
 
 function apiTokenConnectorResponse(type: ConnectorType) {
   return {
-    id: null,
+    id: crypto.randomUUID(),
     type,
     authMethod: "api-token" as const,
     externalId: null,
@@ -69,8 +69,8 @@ function apiTokenConnectorResponse(type: ConnectorType) {
     externalEmail: null,
     oauthScopes: null,
     needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -6,7 +6,7 @@ import { connectorTypeSchema } from "@vm0/connectors/connectors";
  * Connector response schema
  */
 export const connectorResponseSchema = z.object({
-  id: z.uuid().nullable(),
+  id: z.uuid(),
   type: connectorTypeSchema,
   authMethod: z.string(),
   externalId: z.string().nullable(),

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -712,7 +712,6 @@ export {
   getConnectorSecretNames,
   getConnectorEnvBindings,
   getConnectorEnvNamesForSecret,
-  getConnectorProvidedEnvNames,
   getConnectorTypeForSecretName,
   isGoogleOAuthConnector,
   hasRequiredScopes,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -32,7 +32,6 @@ import {
   getConnectorDeviceAuthGrantConfig,
   getConnectorTypeForSecretName,
   getConnectorEnvBindings,
-  getConnectorProvidedEnvNames,
   getConnectorOAuthClient,
   getConnectorOAuthScopes,
   getConnectorManualGrantFieldNames,
@@ -1696,25 +1695,6 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(runtimeAvailableTypes).toStrictEqual(
       [...runtimeAvailableTypes].sort(),
     );
-  });
-});
-
-describe("getConnectorProvidedEnvNames", () => {
-  it("returns environment names for API-token-only connector", () => {
-    const names = getConnectorProvidedEnvNames(["axiom"]);
-    expect(names.has("AXIOM_TOKEN")).toBe(true);
-  });
-
-  it("returns environment names for OAuth connector", () => {
-    const names = getConnectorProvidedEnvNames(["github"]);
-    expect(names.has("GH_TOKEN")).toBe(true);
-    expect(names.has("GITHUB_TOKEN")).toBe(true);
-  });
-
-  it("does not return variable-backed environment names", () => {
-    const names = getConnectorProvidedEnvNames(["gitlab"]);
-    expect(names.has("GITLAB_TOKEN")).toBe(true);
-    expect(names.has("GITLAB_HOST")).toBe(false);
   });
 });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1710,6 +1710,12 @@ describe("getConnectorProvidedEnvNames", () => {
     expect(names.has("GH_TOKEN")).toBe(true);
     expect(names.has("GITHUB_TOKEN")).toBe(true);
   });
+
+  it("does not return variable-backed environment names", () => {
+    const names = getConnectorProvidedEnvNames(["gitlab"]);
+    expect(names.has("GITLAB_TOKEN")).toBe(true);
+    expect(names.has("GITLAB_HOST")).toBe(false);
+  });
 });
 
 describe("getConnectorOAuthScopes - google-meet scopes", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -25,7 +25,6 @@ import {
 import {
   getAvailableConnectorAuthMethods,
   getConfiguredConnectorAuthMethods,
-  deriveConnectedManualGrantMethods,
   hasRequiredScopes,
   getConnectorAuthCodeGrantConfig,
   getConnectorAuthMethodEnvBindings,
@@ -308,30 +307,6 @@ describe("connector auth method config", () => {
       variables: ["GITLAB_HOST"],
     });
     expect(getConnectorManualGrantFieldNames("github")).toBeNull();
-  });
-
-  it("derives connected manual grant methods from required fields", () => {
-    expect(
-      deriveConnectedManualGrantMethods(
-        new Set(["ATLASSIAN_TOKEN"]),
-        new Set(["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"]),
-      ),
-    ).toContainEqual({ type: "atlassian", authMethod: "api-token" });
-    expect(
-      deriveConnectedManualGrantMethods(
-        new Set(["ATLASSIAN_TOKEN"]),
-        new Set(["ATLASSIAN_EMAIL"]),
-      ),
-    ).not.toContainEqual({ type: "atlassian", authMethod: "api-token" });
-    const connected = deriveConnectedManualGrantMethods(
-      new Set(["GITHUB_ACCESS_TOKEN"]),
-      new Set(),
-    );
-    expect(
-      connected.some((method) => {
-        return method.type === "github";
-      }),
-    ).toBe(false);
   });
 });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -11,6 +11,8 @@ import {
   it,
 } from "vitest";
 import {
+  CONNECTOR_TYPES,
+  CONNECTOR_TYPE_KEYS,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
@@ -306,6 +308,38 @@ describe("connector auth method config", () => {
       variables: ["GITLAB_HOST"],
     });
     expect(getConnectorManualGrantFieldNames("github")).toBeNull();
+  });
+
+  it("keeps connector-scoped secret and variable names globally unique", () => {
+    const secretOwners = new Map<string, string[]>();
+    const variableOwners = new Map<string, string[]>();
+
+    for (const type of CONNECTOR_TYPE_KEYS) {
+      for (const authMethod of Object.keys(CONNECTOR_TYPES[type].authMethods)) {
+        for (const name of getConnectorSecretNames(type, authMethod)) {
+          secretOwners.set(name, [
+            ...(secretOwners.get(name) ?? []),
+            `${type}:${authMethod}`,
+          ]);
+        }
+        for (const name of getConnectorVariableNames(type, authMethod)) {
+          variableOwners.set(name, [
+            ...(variableOwners.get(name) ?? []),
+            `${type}:${authMethod}`,
+          ]);
+        }
+      }
+    }
+
+    const duplicateSecrets = [...secretOwners].filter(([, owners]) => {
+      return owners.length > 1;
+    });
+    const duplicateVariables = [...variableOwners].filter(([, owners]) => {
+      return owners.length > 1;
+    });
+
+    expect(duplicateSecrets).toStrictEqual([]);
+    expect(duplicateVariables).toStrictEqual([]);
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -51,8 +51,7 @@ export function getConfiguredConnectorAuthMethods(
  *   feature-switch filtering.
  * - Runtime available connector types are connector types the current server
  *   environment can offer as connection candidates.
- * - User connected connector types come from persisted rows or inferred manual
- *   credential state from user secrets and variables.
+ * - User connected connector types come from persisted connector rows.
  * - Runtime injection happens later when a run receives environment entries, secrets,
  *   variables, and firewall context.
  */
@@ -94,11 +93,6 @@ export interface ManualGrantFieldNames {
   readonly variables: readonly string[];
 }
 
-export interface ConnectedManualGrantMethod {
-  readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
-}
-
 function manualGrantFieldNames(
   fields: Record<string, ConnectorManualGrantFieldConfig>,
 ): ManualGrantFieldNames {
@@ -112,26 +106,6 @@ function manualGrantFieldNames(
     }
   }
   return { secrets: secretNames, variables: variableNames };
-}
-
-function requiredManualGrantFieldNames(
-  fields: Record<string, ConnectorManualGrantFieldConfig>,
-): ManualGrantFieldNames {
-  const secretNames: string[] = [];
-  const variableNames: string[] = [];
-  for (const [name, cfg] of Object.entries(fields)) {
-    if (!cfg.required) continue;
-    if (cfg.storage === "variable") {
-      variableNames.push(name);
-    } else {
-      secretNames.push(name);
-    }
-  }
-  return { secrets: secretNames, variables: variableNames };
-}
-
-function hasRequiredManualGrantFields(fields: ManualGrantFieldNames): boolean {
-  return fields.secrets.length > 0 || fields.variables.length > 0;
 }
 
 export function getConnectorManualGrantFieldNames(
@@ -157,59 +131,6 @@ export function getConnectorManualGrantFieldNames(
     return null;
   }
   return { secrets: [...secretNames], variables: [...variableNames] };
-}
-
-export function deriveConnectedManualGrantMethod(
-  type: ConnectorType,
-  userSecretNames: Set<string>,
-  userVariableNames?: Set<string>,
-): ConnectedManualGrantMethod | null {
-  const varNames = userVariableNames ?? new Set<string>();
-
-  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
-    const method = getConnectorAuthMethod(type, authMethod);
-    if (method?.grant.kind !== "manual") {
-      continue;
-    }
-    const requiredFields = requiredManualGrantFieldNames(method.grant.fields);
-    if (!hasRequiredManualGrantFields(requiredFields)) {
-      continue;
-    }
-    const secretsOk = requiredFields.secrets.every((name) => {
-      return userSecretNames.has(name);
-    });
-    const variablesOk = requiredFields.variables.every((name) => {
-      return varNames.has(name);
-    });
-    if (secretsOk && variablesOk) {
-      return {
-        type,
-        authMethod,
-      };
-    }
-  }
-
-  return null;
-}
-
-export function deriveConnectedManualGrantMethods(
-  userSecretNames: Set<string>,
-  userVariableNames?: Set<string>,
-): ConnectedManualGrantMethod[] {
-  const connected: ConnectedManualGrantMethod[] = [];
-
-  for (const type of CONNECTOR_TYPE_KEYS) {
-    const method = deriveConnectedManualGrantMethod(
-      type,
-      userSecretNames,
-      userVariableNames,
-    );
-    if (method) {
-      connected.push(method);
-    }
-  }
-
-  return connected;
 }
 
 function connectorAccessEnvBindings(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,7 +1,6 @@
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
   type ConnectorAccessConfig,
@@ -643,36 +642,6 @@ export function getConnectorEnvNamesForSecret(
   }
 
   return null;
-}
-
-/**
- * Get the set of secret-backed environment names that connected connectors can
- * provide. Used by pre-run checks to exclude connector-provided secrets from
- * "missing" lists.
- *
- * Example: getConnectorProvidedEnvNames(["github"])
- * → Set { "GH_TOKEN", "GITHUB_TOKEN" }
- */
-export function getConnectorProvidedEnvNames(
-  connectedTypes: string[],
-): Set<string> {
-  const provided = new Set<string>();
-
-  for (const rawType of connectedTypes) {
-    const parsed = connectorTypeSchema.safeParse(rawType);
-    if (!parsed.success) {
-      continue;
-    }
-    const envBindings = getConnectorEnvBindings(parsed.data);
-    for (const [envName, valueRef] of Object.entries(envBindings)) {
-      if (!valueRef.startsWith("$secrets.")) {
-        continue;
-      }
-      provided.add(envName);
-    }
-  }
-
-  return provided;
 }
 
 export function hasConnectorAuthCodeGrant(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -646,8 +646,9 @@ export function getConnectorEnvNamesForSecret(
 }
 
 /**
- * Get the set of environment names that connected connectors can provide.
- * Used by pre-run checks to exclude connector-provided secrets from "missing" lists.
+ * Get the set of secret-backed environment names that connected connectors can
+ * provide. Used by pre-run checks to exclude connector-provided secrets from
+ * "missing" lists.
  *
  * Example: getConnectorProvidedEnvNames(["github"])
  * → Set { "GH_TOKEN", "GITHUB_TOKEN" }
@@ -663,7 +664,10 @@ export function getConnectorProvidedEnvNames(
       continue;
     }
     const envBindings = getConnectorEnvBindings(parsed.data);
-    for (const envName of Object.keys(envBindings)) {
+    for (const [envName, valueRef] of Object.entries(envBindings)) {
+      if (!valueRef.startsWith("$secrets.")) {
+        continue;
+      }
       provided.add(envName);
     }
   }

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -226,7 +226,6 @@ export {
   getConnectorSecretNames,
   getConnectorEnvBindings,
   getConnectorEnvNamesForSecret,
-  getConnectorProvidedEnvNames,
   getConnectorTypeForSecretName,
   isGoogleOAuthConnector,
   hasRequiredScopes,

--- a/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
+++ b/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
@@ -435,6 +435,44 @@ describe("migration 0408 api-token connector cutover", () => {
     ]);
   });
 
+  it("skips connectors when a required variable is absent", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(secrets).values([
+      {
+        orgId,
+        userId,
+        name: "AGORA_CUSTOMER_ID",
+        encryptedValue: "encrypted-customer-id",
+        type: "user",
+      },
+      {
+        orgId,
+        userId,
+        name: "AGORA_CUSTOMER_SECRET",
+        encryptedValue: "encrypted-customer-secret",
+        type: "user",
+      },
+    ]);
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([]);
+    expect(await readSecretState({ orgId, userId })).toStrictEqual([
+      {
+        name: "AGORA_CUSTOMER_ID",
+        encryptedValue: "encrypted-customer-id",
+        type: "user",
+      },
+      {
+        name: "AGORA_CUSTOMER_SECRET",
+        encryptedValue: "encrypted-customer-secret",
+        type: "user",
+      },
+    ]);
+    expect(await readVariableState({ orgId, userId })).toStrictEqual([]);
+  });
+
   it("skips incomplete required fields", async () => {
     const orgId = uniqueId("org");
     const userId = uniqueId("user");

--- a/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
+++ b/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
@@ -1,11 +1,76 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { and, eq, sql } from "drizzle-orm";
+import { CONNECTOR_TYPE_KEYS } from "@vm0/connectors/connectors";
+import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { db, uniqueId } from "../test-db";
 
 const ORG_SENTINEL_USER_ID = "__org__";
+
+interface ApiTokenMigrationField {
+  readonly connectorType: string;
+  readonly fieldName: string;
+  readonly storage: string;
+  readonly required: boolean;
+}
+
+function apiTokenMigrationFieldKey(field: ApiTokenMigrationField): string {
+  return [field.connectorType, field.fieldName, field.storage].join("\0");
+}
+
+function sortApiTokenMigrationFields(
+  fields: readonly ApiTokenMigrationField[],
+): readonly ApiTokenMigrationField[] {
+  return [...fields].sort((left, right) => {
+    return apiTokenMigrationFieldKey(left).localeCompare(
+      apiTokenMigrationFieldKey(right),
+    );
+  });
+}
+
+function apiTokenMigrationFieldsFromSql(): readonly ApiTokenMigrationField[] {
+  const sqlText = readFileSync(
+    new URL(
+      "../../migrations/0410_api_token_connector_cutover.sql",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const fieldPattern =
+    /\('([^']+)', '([^']+)', '(secret|variable)', (true|false)\)/gu;
+  return sortApiTokenMigrationFields(
+    [...sqlText.matchAll(fieldPattern)].map((match) => {
+      return {
+        connectorType: match[1]!,
+        fieldName: match[2]!,
+        storage: match[3]!,
+        required: match[4] === "true",
+      };
+    }),
+  );
+}
+
+function apiTokenRegistryFields(): readonly ApiTokenMigrationField[] {
+  const fields: ApiTokenMigrationField[] = [];
+  for (const connectorType of [...CONNECTOR_TYPE_KEYS].sort()) {
+    const method = getConnectorAuthMethod(connectorType, "api-token");
+    if (method?.grant.kind !== "manual") {
+      continue;
+    }
+    for (const [fieldName, field] of Object.entries(method.grant.fields)) {
+      fields.push({
+        connectorType,
+        fieldName,
+        storage: field.storage ?? "secret",
+        required: field.required,
+      });
+    }
+  }
+  return sortApiTokenMigrationFields(fields);
+}
 
 async function runScopedApiTokenConnectorCutover(args: {
   readonly orgId: string;
@@ -263,7 +328,13 @@ async function readVariableState(args: {
     .orderBy(variables.name, variables.type);
 }
 
-describe("migration 0408 api-token connector cutover", () => {
+describe("migration 0410 api-token connector cutover", () => {
+  it("keeps the full migration field list in sync with the connector registry", () => {
+    expect(apiTokenMigrationFieldsFromSql()).toStrictEqual(
+      apiTokenRegistryFields(),
+    );
+  });
+
   it("migrates complete required secret rows and preserves unrelated user rows", async () => {
     const orgId = uniqueId("org");
     const userId = uniqueId("user");

--- a/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
+++ b/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
+import { db, uniqueId } from "../test-db";
+
+async function runScopedApiTokenConnectorCutover(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<void> {
+  await db.execute(sql`
+    WITH api_token_fields(connector_type, field_name, storage, required) AS (
+      VALUES
+        ('agora', 'AGORA_APP_CERTIFICATE', 'secret', false),
+        ('agora', 'AGORA_APP_ID', 'variable', true),
+        ('agora', 'AGORA_CUSTOMER_ID', 'secret', true),
+        ('agora', 'AGORA_CUSTOMER_SECRET', 'secret', true),
+        ('gitlab', 'GITLAB_HOST', 'variable', false),
+        ('gitlab', 'GITLAB_TOKEN', 'secret', true),
+        ('openai', 'OPENAI_TOKEN', 'secret', true)
+    ),
+    required_field_counts AS (
+      SELECT
+        connector_type,
+        COUNT(*) FILTER (WHERE required) AS required_count
+      FROM api_token_fields
+      GROUP BY connector_type
+    ),
+    legacy_field_presence AS (
+      SELECT
+        fields.connector_type,
+        user_secrets.org_id,
+        user_secrets.user_id,
+        fields.field_name,
+        fields.storage,
+        fields.required
+      FROM api_token_fields fields
+      JOIN secrets user_secrets
+        ON fields.storage = 'secret'
+       AND user_secrets.type = 'user'
+       AND user_secrets.name = fields.field_name
+       AND user_secrets.org_id = ${args.orgId}
+       AND user_secrets.user_id = ${args.userId}
+
+      UNION ALL
+
+      SELECT
+        fields.connector_type,
+        user_variables.org_id,
+        user_variables.user_id,
+        fields.field_name,
+        fields.storage,
+        fields.required
+      FROM api_token_fields fields
+      JOIN variables user_variables
+        ON fields.storage = 'variable'
+       AND user_variables.type = 'user'
+       AND user_variables.name = fields.field_name
+       AND user_variables.org_id = ${args.orgId}
+       AND user_variables.user_id = ${args.userId}
+    ),
+    eligible_legacy_connectors AS (
+      SELECT
+        presence.connector_type,
+        presence.org_id,
+        presence.user_id
+      FROM legacy_field_presence presence
+      JOIN required_field_counts counts
+        ON counts.connector_type = presence.connector_type
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM connectors existing_connector
+        WHERE existing_connector.org_id = presence.org_id
+          AND existing_connector.user_id = presence.user_id
+          AND existing_connector.type = presence.connector_type
+      )
+      GROUP BY
+        presence.connector_type,
+        presence.org_id,
+        presence.user_id,
+        counts.required_count
+      HAVING COUNT(DISTINCT presence.field_name) FILTER (WHERE presence.required) = counts.required_count
+         AND counts.required_count > 0
+    ),
+    migrated_connectors AS (
+      INSERT INTO connectors (
+        org_id,
+        user_id,
+        type,
+        auth_method,
+        needs_reconnect,
+        created_at,
+        updated_at
+      )
+      SELECT
+        eligible.org_id,
+        eligible.user_id,
+        eligible.connector_type,
+        'api-token',
+        false,
+        NOW(),
+        NOW()
+      FROM eligible_legacy_connectors eligible
+      ON CONFLICT (org_id, user_id, type) DO NOTHING
+      RETURNING org_id, user_id, type
+    ),
+    copied_secrets AS (
+      INSERT INTO secrets (
+        org_id,
+        user_id,
+        name,
+        encrypted_value,
+        description,
+        type,
+        created_at,
+        updated_at
+      )
+      SELECT
+        source.org_id,
+        source.user_id,
+        source.name,
+        source.encrypted_value,
+        source.description,
+        'connector',
+        source.created_at,
+        source.updated_at
+      FROM migrated_connectors migrated
+      JOIN api_token_fields fields
+        ON fields.connector_type = migrated.type
+       AND fields.storage = 'secret'
+      JOIN secrets source
+        ON source.org_id = migrated.org_id
+       AND source.user_id = migrated.user_id
+       AND source.type = 'user'
+       AND source.name = fields.field_name
+      ON CONFLICT (org_id, user_id, name, type) DO UPDATE SET
+        encrypted_value = EXCLUDED.encrypted_value,
+        description = EXCLUDED.description,
+        updated_at = EXCLUDED.updated_at
+      RETURNING org_id, user_id, name
+    ),
+    copied_variables AS (
+      INSERT INTO variables (
+        org_id,
+        user_id,
+        name,
+        value,
+        description,
+        type,
+        created_at,
+        updated_at
+      )
+      SELECT
+        source.org_id,
+        source.user_id,
+        source.name,
+        source.value,
+        source.description,
+        'connector',
+        source.created_at,
+        source.updated_at
+      FROM migrated_connectors migrated
+      JOIN api_token_fields fields
+        ON fields.connector_type = migrated.type
+       AND fields.storage = 'variable'
+      JOIN variables source
+        ON source.org_id = migrated.org_id
+       AND source.user_id = migrated.user_id
+       AND source.type = 'user'
+       AND source.name = fields.field_name
+      ON CONFLICT (org_id, user_id, type, name) DO UPDATE SET
+        value = EXCLUDED.value,
+        description = EXCLUDED.description,
+        updated_at = EXCLUDED.updated_at
+      RETURNING org_id, user_id, name
+    ),
+    deleted_legacy_secrets AS (
+      DELETE FROM secrets legacy
+      USING copied_secrets copied
+      WHERE legacy.org_id = copied.org_id
+        AND legacy.user_id = copied.user_id
+        AND legacy.name = copied.name
+        AND legacy.type = 'user'
+      RETURNING legacy.id
+    ),
+    deleted_legacy_variables AS (
+      DELETE FROM variables legacy
+      USING copied_variables copied
+      WHERE legacy.org_id = copied.org_id
+        AND legacy.user_id = copied.user_id
+        AND legacy.name = copied.name
+        AND legacy.type = 'user'
+      RETURNING legacy.id
+    )
+    SELECT
+      (SELECT COUNT(*) FROM migrated_connectors) AS migrated_connectors,
+      (SELECT COUNT(*) FROM copied_secrets) AS copied_secrets,
+      (SELECT COUNT(*) FROM copied_variables) AS copied_variables,
+      (SELECT COUNT(*) FROM deleted_legacy_secrets) AS deleted_legacy_secrets,
+      (SELECT COUNT(*) FROM deleted_legacy_variables) AS deleted_legacy_variables
+  `);
+}
+
+async function readConnectorTypes(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<readonly { readonly type: string; readonly authMethod: string }[]> {
+  return await db
+    .select({ type: connectors.type, authMethod: connectors.authMethod })
+    .from(connectors)
+    .where(
+      and(eq(connectors.orgId, args.orgId), eq(connectors.userId, args.userId)),
+    )
+    .orderBy(connectors.type);
+}
+
+async function readSecretState(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<
+  readonly {
+    readonly name: string;
+    readonly encryptedValue: string;
+    readonly type: string;
+  }[]
+> {
+  return await db
+    .select({
+      name: secrets.name,
+      encryptedValue: secrets.encryptedValue,
+      type: secrets.type,
+    })
+    .from(secrets)
+    .where(and(eq(secrets.orgId, args.orgId), eq(secrets.userId, args.userId)))
+    .orderBy(secrets.name, secrets.type);
+}
+
+async function readVariableState(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<
+  readonly {
+    readonly name: string;
+    readonly value: string;
+    readonly type: string;
+  }[]
+> {
+  return await db
+    .select({
+      name: variables.name,
+      value: variables.value,
+      type: variables.type,
+    })
+    .from(variables)
+    .where(
+      and(eq(variables.orgId, args.orgId), eq(variables.userId, args.userId)),
+    )
+    .orderBy(variables.name, variables.type);
+}
+
+describe("migration 0408 api-token connector cutover", () => {
+  it("migrates complete required secret rows and preserves unrelated user rows", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(secrets).values([
+      {
+        orgId,
+        userId,
+        name: "OPENAI_TOKEN",
+        encryptedValue: "encrypted-openai",
+        type: "user",
+      },
+      {
+        orgId,
+        userId,
+        name: "UNRELATED_SECRET",
+        encryptedValue: "encrypted-unrelated",
+        type: "user",
+      },
+    ]);
+    await db.insert(variables).values({
+      orgId,
+      userId,
+      name: "UNRELATED_VAR",
+      value: "unrelated",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([
+      { type: "openai", authMethod: "api-token" },
+    ]);
+    expect(await readSecretState({ orgId, userId })).toStrictEqual([
+      {
+        name: "OPENAI_TOKEN",
+        encryptedValue: "encrypted-openai",
+        type: "connector",
+      },
+      {
+        name: "UNRELATED_SECRET",
+        encryptedValue: "encrypted-unrelated",
+        type: "user",
+      },
+    ]);
+    expect(await readVariableState({ orgId, userId })).toStrictEqual([
+      { name: "UNRELATED_VAR", value: "unrelated", type: "user" },
+    ]);
+  });
+
+  it("copies present optional fields for complete connectors", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(secrets).values({
+      orgId,
+      userId,
+      name: "GITLAB_TOKEN",
+      encryptedValue: "encrypted-gitlab",
+      type: "user",
+    });
+    await db.insert(variables).values({
+      orgId,
+      userId,
+      name: "GITLAB_HOST",
+      value: "gitlab.example.com",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([
+      { type: "gitlab", authMethod: "api-token" },
+    ]);
+    expect(await readSecretState({ orgId, userId })).toStrictEqual([
+      {
+        name: "GITLAB_TOKEN",
+        encryptedValue: "encrypted-gitlab",
+        type: "connector",
+      },
+    ]);
+    expect(await readVariableState({ orgId, userId })).toStrictEqual([
+      { name: "GITLAB_HOST", value: "gitlab.example.com", type: "connector" },
+    ]);
+  });
+
+  it("migrates mixed secret and variable requirements with optional secrets", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(secrets).values([
+      {
+        orgId,
+        userId,
+        name: "AGORA_APP_CERTIFICATE",
+        encryptedValue: "encrypted-certificate",
+        type: "user",
+      },
+      {
+        orgId,
+        userId,
+        name: "AGORA_CUSTOMER_ID",
+        encryptedValue: "encrypted-customer-id",
+        type: "user",
+      },
+      {
+        orgId,
+        userId,
+        name: "AGORA_CUSTOMER_SECRET",
+        encryptedValue: "encrypted-customer-secret",
+        type: "user",
+      },
+    ]);
+    await db.insert(variables).values({
+      orgId,
+      userId,
+      name: "AGORA_APP_ID",
+      value: "agora-app-id",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([
+      { type: "agora", authMethod: "api-token" },
+    ]);
+    expect(await readSecretState({ orgId, userId })).toStrictEqual([
+      {
+        name: "AGORA_APP_CERTIFICATE",
+        encryptedValue: "encrypted-certificate",
+        type: "connector",
+      },
+      {
+        name: "AGORA_CUSTOMER_ID",
+        encryptedValue: "encrypted-customer-id",
+        type: "connector",
+      },
+      {
+        name: "AGORA_CUSTOMER_SECRET",
+        encryptedValue: "encrypted-customer-secret",
+        type: "connector",
+      },
+    ]);
+    expect(await readVariableState({ orgId, userId })).toStrictEqual([
+      { name: "AGORA_APP_ID", value: "agora-app-id", type: "connector" },
+    ]);
+  });
+
+  it("skips incomplete required fields", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(variables).values({
+      orgId,
+      userId,
+      name: "GITLAB_HOST",
+      value: "gitlab.example.com",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([]);
+    expect(await readVariableState({ orgId, userId })).toStrictEqual([
+      { name: "GITLAB_HOST", value: "gitlab.example.com", type: "user" },
+    ]);
+  });
+
+  it("skips users with an existing connector row and keeps legacy rows untouched", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(connectors).values({
+      orgId,
+      userId,
+      type: "openai",
+      authMethod: "oauth",
+    });
+    await db.insert(secrets).values({
+      orgId,
+      userId,
+      name: "OPENAI_TOKEN",
+      encryptedValue: "encrypted-openai",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([
+      { type: "openai", authMethod: "oauth" },
+    ]);
+    expect(await readSecretState({ orgId, userId })).toStrictEqual([
+      {
+        name: "OPENAI_TOKEN",
+        encryptedValue: "encrypted-openai",
+        type: "user",
+      },
+    ]);
+  });
+});

--- a/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
+++ b/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
@@ -348,6 +348,32 @@ describe("migration 0408 api-token connector cutover", () => {
     ]);
   });
 
+  it("migrates complete connectors when optional fields are absent", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    await db.insert(secrets).values({
+      orgId,
+      userId,
+      name: "GITLAB_TOKEN",
+      encryptedValue: "encrypted-gitlab",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({ orgId, userId });
+
+    expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([
+      { type: "gitlab", authMethod: "api-token" },
+    ]);
+    expect(await readSecretState({ orgId, userId })).toStrictEqual([
+      {
+        name: "GITLAB_TOKEN",
+        encryptedValue: "encrypted-gitlab",
+        type: "connector",
+      },
+    ]);
+    expect(await readVariableState({ orgId, userId })).toStrictEqual([]);
+  });
+
   it("migrates mixed secret and variable requirements with optional secrets", async () => {
     const orgId = uniqueId("org");
     const userId = uniqueId("user");

--- a/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
+++ b/turbo/packages/db/src/__tests__/migrations/0410_api_token_connector_cutover.test.ts
@@ -5,6 +5,8 @@ import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { db, uniqueId } from "../test-db";
 
+const ORG_SENTINEL_USER_ID = "__org__";
+
 async function runScopedApiTokenConnectorCutover(args: {
   readonly orgId: string;
   readonly userId: string;
@@ -42,6 +44,7 @@ async function runScopedApiTokenConnectorCutover(args: {
        AND user_secrets.name = fields.field_name
        AND user_secrets.org_id = ${args.orgId}
        AND user_secrets.user_id = ${args.userId}
+       AND user_secrets.user_id <> ${ORG_SENTINEL_USER_ID}
 
       UNION ALL
 
@@ -59,6 +62,7 @@ async function runScopedApiTokenConnectorCutover(args: {
        AND user_variables.name = fields.field_name
        AND user_variables.org_id = ${args.orgId}
        AND user_variables.user_id = ${args.userId}
+       AND user_variables.user_id <> ${ORG_SENTINEL_USER_ID}
     ),
     eligible_legacy_connectors AS (
       SELECT
@@ -420,6 +424,47 @@ describe("migration 0408 api-token connector cutover", () => {
 
     expect(await readConnectorTypes({ orgId, userId })).toStrictEqual([]);
     expect(await readVariableState({ orgId, userId })).toStrictEqual([
+      { name: "GITLAB_HOST", value: "gitlab.example.com", type: "user" },
+    ]);
+  });
+
+  it("preserves org-level credential rows with connector field names", async () => {
+    const orgId = uniqueId("org");
+    await db.insert(secrets).values({
+      orgId,
+      userId: ORG_SENTINEL_USER_ID,
+      name: "GITLAB_TOKEN",
+      encryptedValue: "encrypted-org-gitlab",
+      type: "user",
+    });
+    await db.insert(variables).values({
+      orgId,
+      userId: ORG_SENTINEL_USER_ID,
+      name: "GITLAB_HOST",
+      value: "gitlab.example.com",
+      type: "user",
+    });
+
+    await runScopedApiTokenConnectorCutover({
+      orgId,
+      userId: ORG_SENTINEL_USER_ID,
+    });
+
+    expect(
+      await readConnectorTypes({ orgId, userId: ORG_SENTINEL_USER_ID }),
+    ).toStrictEqual([]);
+    expect(
+      await readSecretState({ orgId, userId: ORG_SENTINEL_USER_ID }),
+    ).toStrictEqual([
+      {
+        name: "GITLAB_TOKEN",
+        encryptedValue: "encrypted-org-gitlab",
+        type: "user",
+      },
+    ]);
+    expect(
+      await readVariableState({ orgId, userId: ORG_SENTINEL_USER_ID }),
+    ).toStrictEqual([
       { name: "GITLAB_HOST", value: "gitlab.example.com", type: "user" },
     ]);
   });

--- a/turbo/packages/db/src/migrations/0410_api_token_connector_cutover.sql
+++ b/turbo/packages/db/src/migrations/0410_api_token_connector_cutover.sql
@@ -1,0 +1,439 @@
+-- Migration facts generated from the connector registry on 2026-05-28:
+-- 211 api-token manual connectors, 262 field names, no duplicate field names.
+-- Optional fields currently exist only for agora and gitlab.
+WITH api_token_fields(connector_type, field_name, storage, required) AS (
+  VALUES
+    ('adzuna', 'ADZUNA_APP_ID', 'variable', true),
+    ('adzuna', 'ADZUNA_APP_KEY', 'secret', true),
+    ('agentmail', 'AGENTMAIL_TOKEN', 'secret', true),
+    ('agora', 'AGORA_APP_CERTIFICATE', 'secret', false),
+    ('agora', 'AGORA_APP_ID', 'variable', true),
+    ('agora', 'AGORA_CUSTOMER_ID', 'secret', true),
+    ('agora', 'AGORA_CUSTOMER_SECRET', 'secret', true),
+    ('ahrefs', 'AHREFS_TOKEN', 'secret', true),
+    ('alchemy', 'ALCHEMY_API_KEY', 'secret', true),
+    ('altium-365', 'ALTIUM365_TOKEN', 'secret', true),
+    ('altium-365', 'ALTIUM365_WORKSPACE_URL', 'variable', true),
+    ('amadeus', 'AMADEUS_API_KEY', 'secret', true),
+    ('amadeus', 'AMADEUS_API_SECRET', 'secret', true),
+    ('amplitude', 'AMPLITUDE_API_KEY', 'secret', true),
+    ('amplitude', 'AMPLITUDE_SECRET_KEY', 'secret', true),
+    ('anthropic-managed-agents', 'ANTHROPIC_MANAGED_AGENTS_TOKEN', 'secret', true),
+    ('apify', 'APIFY_TOKEN', 'secret', true),
+    ('apollo', 'APOLLO_TOKEN', 'secret', true),
+    ('atlascloud', 'ATLASCLOUD_API_KEY', 'secret', true),
+    ('atlassian', 'ATLASSIAN_DOMAIN', 'variable', true),
+    ('atlassian', 'ATLASSIAN_EMAIL', 'variable', true),
+    ('atlassian', 'ATLASSIAN_TOKEN', 'secret', true),
+    ('attio', 'ATTIO_TOKEN', 'secret', true),
+    ('aviationstack', 'AVIATIONSTACK_TOKEN', 'secret', true),
+    ('axiom', 'AXIOM_TOKEN', 'secret', true),
+    ('bentoml', 'BENTO_CLOUD_API_ENDPOINT', 'variable', true),
+    ('bentoml', 'BENTO_CLOUD_API_KEY', 'secret', true),
+    ('bfl', 'BFL_API_KEY', 'secret', true),
+    ('bitrefill', 'BITREFILL_TOKEN', 'secret', true),
+    ('bitrix', 'BITRIX_WEBHOOK_URL', 'secret', true),
+    ('bland', 'BLAND_API_KEY', 'secret', true),
+    ('brave-search', 'BRAVE_API_KEY', 'secret', true),
+    ('brevo', 'BREVO_TOKEN', 'secret', true),
+    ('brex', 'BREX_TOKEN', 'secret', true),
+    ('bright-data', 'BRIGHTDATA_TOKEN', 'secret', true),
+    ('browser-use', 'BROWSER_USE_TOKEN', 'secret', true),
+    ('browserbase', 'BROWSERBASE_PROJECT_ID', 'variable', true),
+    ('browserbase', 'BROWSERBASE_TOKEN', 'secret', true),
+    ('browserless', 'BROWSERLESS_TOKEN', 'secret', true),
+    ('browserstack', 'BROWSERSTACK_ACCESS_KEY', 'secret', true),
+    ('browserstack', 'BROWSERSTACK_USERNAME', 'secret', true),
+    ('bubblemaps', 'BUBBLEMAPS_API_KEY', 'secret', true),
+    ('buffer', 'BUFFER_TOKEN', 'secret', true),
+    ('builtwith', 'BUILTWITH_TOKEN', 'secret', true),
+    ('cal-com', 'CALCOM_TOKEN', 'secret', true),
+    ('calendly', 'CALENDLY_TOKEN', 'secret', true),
+    ('chatwoot', 'CHATWOOT_TOKEN', 'secret', true),
+    ('checkr', 'CHECKR_TOKEN', 'secret', true),
+    ('clado', 'CLADO_TOKEN', 'secret', true),
+    ('clearbit', 'CLEARBIT_TOKEN', 'secret', true),
+    ('clerk', 'CLERK_TOKEN', 'secret', true),
+    ('clickup', 'CLICKUP_TOKEN', 'secret', true),
+    ('cloudflare', 'CLOUDFLARE_TOKEN', 'secret', true),
+    ('cloudinary', 'CLOUDINARY_API_SECRET', 'secret', true),
+    ('cloudinary', 'CLOUDINARY_CLOUD_NAME', 'variable', true),
+    ('cloudinary', 'CLOUDINARY_TOKEN', 'secret', true),
+    ('coda', 'CODA_TOKEN', 'secret', true),
+    ('coingecko', 'COINGECKO_TOKEN', 'secret', true),
+    ('coresignal', 'CORESIGNAL_TOKEN', 'secret', true),
+    ('cronlytic', 'CRONLYTIC_API_KEY', 'secret', true),
+    ('cronlytic', 'CRONLYTIC_USER_ID', 'variable', true),
+    ('crustdata', 'CRUSTDATA_TOKEN', 'secret', true),
+    ('customer-io', 'CUSTOMERIO_APP_TOKEN', 'secret', true),
+    ('db9', 'DB9_API_KEY', 'secret', true),
+    ('deel', 'DEEL_TOKEN', 'secret', true),
+    ('deepseek', 'DEEPSEEK_TOKEN', 'secret', true),
+    ('defillama', 'DEFILLAMA_TOKEN', 'secret', true),
+    ('devto', 'DEVTO_TOKEN', 'secret', true),
+    ('diffbot', 'DIFFBOT_TOKEN', 'secret', true),
+    ('dify', 'DIFY_TOKEN', 'secret', true),
+    ('discord', 'DISCORD_BOT_TOKEN', 'secret', true),
+    ('discord-webhook', 'DISCORD_WEBHOOK_URL', 'secret', true),
+    ('doppler', 'DOPPLER_TOKEN', 'secret', true),
+    ('doubao', 'DOUBAO_API_KEY', 'secret', true),
+    ('drive9', 'DRIVE9_TOKEN', 'secret', true),
+    ('dropbox', 'DROPBOX_TOKEN', 'secret', true),
+    ('dropbox-sign', 'DROPBOX_SIGN_TOKEN', 'secret', true),
+    ('duffel', 'DUFFEL_TOKEN', 'secret', true),
+    ('e2b', 'E2B_TOKEN', 'secret', true),
+    ('elevenlabs', 'ELEVENLABS_TOKEN', 'secret', true),
+    ('etherscan', 'ETHERSCAN_API_KEY', 'secret', true),
+    ('etsy', 'ETSY_TOKEN', 'secret', true),
+    ('exa', 'EXA_TOKEN', 'secret', true),
+    ('explorium', 'EXPLORIUM_TOKEN', 'secret', true),
+    ('faire', 'FAIRE_TOKEN', 'secret', true),
+    ('fal', 'FAL_TOKEN', 'secret', true),
+    ('figma', 'FIGMA_TOKEN', 'secret', true),
+    ('firecrawl', 'FIRECRAWL_TOKEN', 'secret', true),
+    ('fireflies', 'FIREFLIES_TOKEN', 'secret', true),
+    ('flightaware', 'FLIGHTAWARE_TOKEN', 'secret', true),
+    ('freshdesk', 'FRESHDESK_DOMAIN', 'variable', true),
+    ('freshdesk', 'FRESHDESK_TOKEN', 'secret', true),
+    ('gamma', 'GAMMA_TOKEN', 'secret', true),
+    ('gemini', 'GEMINI_TOKEN', 'secret', true),
+    ('gitlab', 'GITLAB_HOST', 'variable', false),
+    ('gitlab', 'GITLAB_TOKEN', 'secret', true),
+    ('gong', 'GONG_ACCESS_KEY', 'secret', true),
+    ('gong', 'GONG_ACCESS_KEY_SECRET', 'secret', true),
+    ('gong', 'GONG_API_BASE', 'variable', true),
+    ('google-maps', 'GOOGLE_MAPS_TOKEN', 'secret', true),
+    ('granola', 'GRANOLA_TOKEN', 'secret', true),
+    ('greenhouse', 'GREENHOUSE_TOKEN', 'secret', true),
+    ('groq', 'GROQ_TOKEN', 'secret', true),
+    ('gumroad', 'GUMROAD_TOKEN', 'secret', true),
+    ('helicone', 'HELICONE_TOKEN', 'secret', true),
+    ('heygen', 'HEYGEN_TOKEN', 'secret', true),
+    ('honcho', 'HONCHO_API_KEY', 'secret', true),
+    ('htmlcsstoimage', 'HCTI_API_KEY', 'secret', true),
+    ('htmlcsstoimage', 'HCTI_USER_ID', 'variable', true),
+    ('hugging-face', 'HUGGING_FACE_TOKEN', 'secret', true),
+    ('hume', 'HUME_TOKEN', 'secret', true),
+    ('hunter', 'HUNTER_TOKEN', 'secret', true),
+    ('imgur', 'IMGUR_CLIENT_ID', 'secret', true),
+    ('infisical', 'INFISICAL_TOKEN', 'secret', true),
+    ('instagram', 'INSTAGRAM_BUSINESS_ACCOUNT_ID', 'variable', true),
+    ('instagram', 'INSTAGRAM_TOKEN', 'secret', true),
+    ('instantly', 'INSTANTLY_API_KEY', 'secret', true),
+    ('intercom', 'INTERCOM_TOKEN', 'secret', true),
+    ('ironclad', 'IRONCLAD_API_KEY', 'secret', true),
+    ('ironclad', 'IRONCLAD_HOST', 'variable', true),
+    ('jam', 'JAM_TOKEN', 'secret', true),
+    ('jira', 'JIRA_API_TOKEN', 'secret', true),
+    ('jira', 'JIRA_DOMAIN', 'variable', true),
+    ('jira', 'JIRA_EMAIL', 'variable', true),
+    ('jotform', 'JOTFORM_TOKEN', 'secret', true),
+    ('klaviyo', 'KLAVIYO_TOKEN', 'secret', true),
+    ('kommo', 'KOMMO_API_KEY', 'secret', true),
+    ('kommo', 'KOMMO_SUBDOMAIN', 'variable', true),
+    ('langfuse', 'LANGFUSE_PUBLIC_KEY', 'secret', true),
+    ('langfuse', 'LANGFUSE_SECRET_KEY', 'secret', true),
+    ('langsmith', 'LANGSMITH_TOKEN', 'secret', true),
+    ('lark', 'LARK_APP_ID', 'variable', true),
+    ('lark', 'LARK_TOKEN', 'secret', true),
+    ('line', 'LINE_TOKEN', 'secret', true),
+    ('loops', 'LOOPS_TOKEN', 'secret', true),
+    ('luma', 'LUMA_API_KEY', 'secret', true),
+    ('luma-ai', 'LUMA_TOKEN', 'secret', true),
+    ('mailchimp', 'MAILCHIMP_TOKEN', 'secret', true),
+    ('mailsac', 'MAILSAC_TOKEN', 'secret', true),
+    ('make', 'MAKE_TOKEN', 'secret', true),
+    ('manus', 'MANUS_TOKEN', 'secret', true),
+    ('mapbox', 'MAPBOX_TOKEN', 'secret', true),
+    ('mathpix', 'MATHPIX_APP_ID', 'variable', true),
+    ('mathpix', 'MATHPIX_APP_KEY', 'secret', true),
+    ('mem0', 'MEM0_TOKEN', 'secret', true),
+    ('mercury', 'MERCURY_TOKEN', 'secret', true),
+    ('meshy', 'MESHY_API_KEY', 'secret', true),
+    ('metabase', 'METABASE_BASE_URL', 'variable', true),
+    ('metabase', 'METABASE_TOKEN', 'secret', true),
+    ('minimax', 'MINIMAX_TOKEN', 'secret', true),
+    ('minio', 'MINIO_ENDPOINT', 'variable', true),
+    ('minio', 'MINIO_SECRET_TOKEN', 'secret', true),
+    ('minio', 'MINIO_TOKEN', 'secret', true),
+    ('miro', 'MIRO_TOKEN', 'secret', true),
+    ('mixpanel', 'MIXPANEL_PROJECT_ID', 'variable', true),
+    ('mixpanel', 'MIXPANEL_SERVICE_ACCOUNT_SECRET', 'secret', true),
+    ('mixpanel', 'MIXPANEL_SERVICE_ACCOUNT_USERNAME', 'secret', true),
+    ('moss', 'MOSS_PROJECT_ID', 'secret', true),
+    ('moss', 'MOSS_PROJECT_KEY', 'secret', true),
+    ('msg9', 'MSG9_TOKEN', 'secret', true),
+    ('n8n', 'N8N_BASE_URL', 'variable', true),
+    ('n8n', 'N8N_TOKEN', 'secret', true),
+    ('neon', 'NEON_TOKEN', 'secret', true),
+    ('novita', 'NOVITA_TOKEN', 'secret', true),
+    ('nyne', 'NYNE_API_KEY', 'secret', true),
+    ('nyne', 'NYNE_API_SECRET', 'secret', true),
+    ('onyx', 'ONYX_TOKEN', 'secret', true),
+    ('openai', 'OPENAI_TOKEN', 'secret', true),
+    ('openrouter', 'OPENROUTER_TOKEN', 'secret', true),
+    ('openweather', 'OPENWEATHER_TOKEN', 'secret', true),
+    ('pandadoc', 'PANDADOC_TOKEN', 'secret', true),
+    ('parallel', 'PARALLEL_API_KEY', 'secret', true),
+    ('pdf4me', 'PDF4ME_TOKEN', 'secret', true),
+    ('pdfco', 'PDFCO_TOKEN', 'secret', true),
+    ('pdforge', 'PDFORGE_API_KEY', 'secret', true),
+    ('people-data-labs', 'PEOPLE_DATA_LABS_API_KEY', 'secret', true),
+    ('perplexity', 'PERPLEXITY_TOKEN', 'secret', true),
+    ('pika', 'PIKA_TOKEN', 'secret', true),
+    ('pinecone', 'PINECONE_TOKEN', 'secret', true),
+    ('pipedream', 'PIPEDREAM_TOKEN', 'secret', true),
+    ('pipedrive', 'PIPEDRIVE_TOKEN', 'secret', true),
+    ('plain', 'PLAIN_TOKEN', 'secret', true),
+    ('plausible', 'PLAUSIBLE_TOKEN', 'secret', true),
+    ('podchaser', 'PODCHASER_TOKEN', 'secret', true),
+    ('porkbun', 'PORKBUN_API_KEY', 'secret', true),
+    ('porkbun', 'PORKBUN_SECRET_API_KEY', 'secret', true),
+    ('posthog', 'POSTHOG_TOKEN', 'secret', true),
+    ('printful', 'PRINTFUL_TOKEN', 'secret', true),
+    ('prisma-postgres', 'PRISMA_POSTGRES_TOKEN', 'secret', true),
+    ('productlane', 'PRODUCTLANE_TOKEN', 'secret', true),
+    ('pushinator', 'PUSHINATOR_TOKEN', 'secret', true),
+    ('qdrant', 'QDRANT_BASE_URL', 'variable', true),
+    ('qdrant', 'QDRANT_TOKEN', 'secret', true),
+    ('qiita', 'QIITA_TOKEN', 'secret', true),
+    ('railway', 'RAILWAY_TOKEN', 'secret', true),
+    ('railway-project', 'RAILWAY_PROJECT_TOKEN', 'secret', true),
+    ('reap', 'REAP_API_BASE_URL', 'variable', true),
+    ('reap', 'REAP_API_KEY', 'secret', true),
+    ('recraft', 'RECRAFT_API_TOKEN', 'secret', true),
+    ('reducto', 'REDUCTO_TOKEN', 'secret', true),
+    ('rentcast', 'RENTCAST_API_KEY', 'secret', true),
+    ('replicate', 'REPLICATE_TOKEN', 'secret', true),
+    ('reportei', 'REPORTEI_TOKEN', 'secret', true),
+    ('resend', 'RESEND_TOKEN', 'secret', true),
+    ('revenuecat', 'REVENUECAT_TOKEN', 'secret', true),
+    ('runway', 'RUNWAY_TOKEN', 'secret', true),
+    ('salesforce', 'SALESFORCE_INSTANCE', 'variable', true),
+    ('salesforce', 'SALESFORCE_TOKEN', 'secret', true),
+    ('scrapeninja', 'SCRAPENINJA_TOKEN', 'secret', true),
+    ('segment', 'SEGMENT_TOKEN', 'secret', true),
+    ('sendgrid', 'SENDGRID_TOKEN', 'secret', true),
+    ('serpapi', 'SERPAPI_TOKEN', 'secret', true),
+    ('servicenow', 'SERVICENOW_INSTANCE', 'variable', true),
+    ('servicenow', 'SERVICENOW_PASSWORD', 'secret', true),
+    ('servicenow', 'SERVICENOW_USERNAME', 'secret', true),
+    ('shopify', 'SHOPIFY_SHOP', 'variable', true),
+    ('shopify', 'SHOPIFY_TOKEN', 'secret', true),
+    ('shortio', 'SHORTIO_TOKEN', 'secret', true),
+    ('similarweb', 'SIMILARWEB_TOKEN', 'secret', true),
+    ('slack-webhook', 'SLACK_WEBHOOK_URL', 'secret', true),
+    ('snowflake', 'SNOWFLAKE_ACCOUNT', 'variable', true),
+    ('snowflake', 'SNOWFLAKE_PAT', 'secret', true),
+    ('sociavault', 'SOCIAVAULT_TOKEN', 'secret', true),
+    ('sponge', 'SPONGE_MASTER_KEY', 'secret', true),
+    ('sproutgigs', 'SPROUTGIGS_API_SECRET', 'secret', true),
+    ('sproutgigs', 'SPROUTGIGS_USER_ID', 'variable', true),
+    ('square', 'SQUARE_TOKEN', 'secret', true),
+    ('stability-ai', 'STABILITY_TOKEN', 'secret', true),
+    ('strapi', 'STRAPI_BASE_URL', 'variable', true),
+    ('strapi', 'STRAPI_TOKEN', 'secret', true),
+    ('streak', 'STREAK_TOKEN', 'secret', true),
+    ('stripe', 'STRIPE_TOKEN', 'secret', true),
+    ('supabase', 'SUPABASE_TOKEN', 'secret', true),
+    ('supadata', 'SUPADATA_TOKEN', 'secret', true),
+    ('supermemory', 'SUPERMEMORY_API_KEY', 'secret', true),
+    ('tavily', 'TAVILY_TOKEN', 'secret', true),
+    ('testrail', 'TESTRAIL_EMAIL', 'secret', true),
+    ('testrail', 'TESTRAIL_INSTANCE', 'variable', true),
+    ('testrail', 'TESTRAIL_TOKEN', 'secret', true),
+    ('ticketmaster', 'TICKETMASTER_API_KEY', 'secret', true),
+    ('tldv', 'TLDV_TOKEN', 'secret', true),
+    ('together', 'TOGETHER_TOKEN', 'secret', true),
+    ('twenty', 'TWENTY_TOKEN', 'secret', true),
+    ('twilio', 'TWILIO_ACCOUNT_SID', 'secret', true),
+    ('twilio', 'TWILIO_AUTH_TOKEN', 'secret', true),
+    ('typeform', 'TYPEFORM_TOKEN', 'secret', true),
+    ('v0', 'V0_TOKEN', 'secret', true),
+    ('wandb', 'WANDB_TOKEN', 'secret', true),
+    ('webflow', 'WEBFLOW_TOKEN', 'secret', true),
+    ('weread', 'WEREAD_TOKEN', 'secret', true),
+    ('whale-alert', 'WHALE_ALERT_API_KEY', 'secret', true),
+    ('wix', 'WIX_TOKEN', 'secret', true),
+    ('workos', 'WORKOS_TOKEN', 'secret', true),
+    ('wrike', 'WRIKE_TOKEN', 'secret', true),
+    ('youtube', 'YOUTUBE_TOKEN', 'secret', true),
+    ('zapier', 'ZAPIER_TOKEN', 'secret', true),
+    ('zapsign', 'ZAPSIGN_TOKEN', 'secret', true),
+    ('zendesk', 'ZENDESK_API_TOKEN', 'secret', true),
+    ('zendesk', 'ZENDESK_EMAIL', 'variable', true),
+    ('zendesk', 'ZENDESK_SUBDOMAIN', 'variable', true),
+    ('zep', 'ZEP_TOKEN', 'secret', true),
+    ('zeptomail', 'ZEPTOMAIL_TOKEN', 'secret', true)
+),
+required_field_counts AS (
+  SELECT
+    connector_type,
+    COUNT(*) FILTER (WHERE required) AS required_count
+  FROM api_token_fields
+  GROUP BY connector_type
+),
+legacy_field_presence AS (
+  SELECT
+    fields.connector_type,
+    user_secrets.org_id,
+    user_secrets.user_id,
+    fields.field_name,
+    fields.storage,
+    fields.required
+  FROM api_token_fields fields
+  JOIN secrets user_secrets
+    ON fields.storage = 'secret'
+   AND user_secrets.type = 'user'
+   AND user_secrets.name = fields.field_name
+
+  UNION ALL
+
+  SELECT
+    fields.connector_type,
+    user_variables.org_id,
+    user_variables.user_id,
+    fields.field_name,
+    fields.storage,
+    fields.required
+  FROM api_token_fields fields
+  JOIN variables user_variables
+    ON fields.storage = 'variable'
+   AND user_variables.type = 'user'
+   AND user_variables.name = fields.field_name
+),
+eligible_legacy_connectors AS (
+  SELECT
+    presence.connector_type,
+    presence.org_id,
+    presence.user_id
+  FROM legacy_field_presence presence
+  JOIN required_field_counts counts
+    ON counts.connector_type = presence.connector_type
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM connectors existing_connector
+    WHERE existing_connector.org_id = presence.org_id
+      AND existing_connector.user_id = presence.user_id
+      AND existing_connector.type = presence.connector_type
+  )
+  GROUP BY
+    presence.connector_type,
+    presence.org_id,
+    presence.user_id,
+    counts.required_count
+  HAVING COUNT(DISTINCT presence.field_name) FILTER (WHERE presence.required) = counts.required_count
+     AND counts.required_count > 0
+),
+migrated_connectors AS (
+  INSERT INTO connectors (
+    org_id,
+    user_id,
+    type,
+    auth_method,
+    needs_reconnect,
+    created_at,
+    updated_at
+  )
+  SELECT
+    eligible.org_id,
+    eligible.user_id,
+    eligible.connector_type,
+    'api-token',
+    false,
+    NOW(),
+    NOW()
+  FROM eligible_legacy_connectors eligible
+  ON CONFLICT (org_id, user_id, type) DO NOTHING
+  RETURNING org_id, user_id, type
+),
+copied_secrets AS (
+  INSERT INTO secrets (
+    org_id,
+    user_id,
+    name,
+    encrypted_value,
+    description,
+    type,
+    created_at,
+    updated_at
+  )
+  SELECT
+    source.org_id,
+    source.user_id,
+    source.name,
+    source.encrypted_value,
+    source.description,
+    'connector',
+    source.created_at,
+    source.updated_at
+  FROM migrated_connectors migrated
+  JOIN api_token_fields fields
+    ON fields.connector_type = migrated.type
+   AND fields.storage = 'secret'
+  JOIN secrets source
+    ON source.org_id = migrated.org_id
+   AND source.user_id = migrated.user_id
+   AND source.type = 'user'
+   AND source.name = fields.field_name
+  ON CONFLICT (org_id, user_id, name, type) DO UPDATE SET
+    encrypted_value = EXCLUDED.encrypted_value,
+    description = EXCLUDED.description,
+    updated_at = EXCLUDED.updated_at
+  RETURNING org_id, user_id, name
+),
+copied_variables AS (
+  INSERT INTO variables (
+    org_id,
+    user_id,
+    name,
+    value,
+    description,
+    type,
+    created_at,
+    updated_at
+  )
+  SELECT
+    source.org_id,
+    source.user_id,
+    source.name,
+    source.value,
+    source.description,
+    'connector',
+    source.created_at,
+    source.updated_at
+  FROM migrated_connectors migrated
+  JOIN api_token_fields fields
+    ON fields.connector_type = migrated.type
+   AND fields.storage = 'variable'
+  JOIN variables source
+    ON source.org_id = migrated.org_id
+   AND source.user_id = migrated.user_id
+   AND source.type = 'user'
+   AND source.name = fields.field_name
+  ON CONFLICT (org_id, user_id, type, name) DO UPDATE SET
+    value = EXCLUDED.value,
+    description = EXCLUDED.description,
+    updated_at = EXCLUDED.updated_at
+  RETURNING org_id, user_id, name
+),
+deleted_legacy_secrets AS (
+  DELETE FROM secrets legacy
+  USING copied_secrets copied
+  WHERE legacy.org_id = copied.org_id
+    AND legacy.user_id = copied.user_id
+    AND legacy.name = copied.name
+    AND legacy.type = 'user'
+  RETURNING legacy.id
+),
+deleted_legacy_variables AS (
+  DELETE FROM variables legacy
+  USING copied_variables copied
+  WHERE legacy.org_id = copied.org_id
+    AND legacy.user_id = copied.user_id
+    AND legacy.name = copied.name
+    AND legacy.type = 'user'
+  RETURNING legacy.id
+)
+SELECT 1;
+

--- a/turbo/packages/db/src/migrations/0410_api_token_connector_cutover.sql
+++ b/turbo/packages/db/src/migrations/0410_api_token_connector_cutover.sql
@@ -286,6 +286,7 @@ legacy_field_presence AS (
     ON fields.storage = 'secret'
    AND user_secrets.type = 'user'
    AND user_secrets.name = fields.field_name
+   AND user_secrets.user_id <> '__org__'
 
   UNION ALL
 
@@ -301,6 +302,7 @@ legacy_field_presence AS (
     ON fields.storage = 'variable'
    AND user_variables.type = 'user'
    AND user_variables.name = fields.field_name
+   AND user_variables.user_id <> '__org__'
 ),
 eligible_legacy_connectors AS (
   SELECT
@@ -436,4 +438,3 @@ deleted_legacy_variables AS (
   RETURNING legacy.id
 )
 SELECT 1;
-

--- a/turbo/packages/db/src/migrations/meta/0410_snapshot.json
+++ b/turbo/packages/db/src/migrations/meta/0410_snapshot.json
@@ -1,0 +1,11951 @@
+{
+  "id": "2d56a77c-cb76-4223-9340-63c167670091",
+  "prevId": "f89e1388-97ef-4f2c-9944-f834333e6cf4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_volumes": {
+          "name": "additional_volumes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_reuse_result": {
+          "name": "sandbox_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_session": {
+          "name": "idx_agent_runs_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_completed_org_user": {
+          "name": "idx_agent_runs_completed_org_user",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"completed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": [
+            "agent_compose_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_session_id_agent_sessions_id_fk": {
+          "name": "agent_runs_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose": {
+          "name": "idx_agent_sessions_user_compose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_messages": {
+      "name": "agentphone_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_message_id": {
+          "name": "agentphone_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_messages_agentphone_message": {
+          "name": "idx_agentphone_messages_agentphone_message",
+          "columns": [
+            {
+              "expression": "agentphone_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_webhook_id": {
+          "name": "idx_agentphone_messages_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "webhook_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_handle_created": {
+          "name": "idx_agentphone_messages_handle_created",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_user_link": {
+          "name": "idx_agentphone_messages_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_messages",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_thread_sessions": {
+      "name": "agentphone_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_thread_sessions_link_root": {
+          "name": "idx_agentphone_thread_sessions_link_root",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_thread_sessions_user_link": {
+          "name": "idx_agentphone_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_agent_preferences": {
+      "name": "agentphone_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "agentphone_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentphone_user_agent_preferences_pkey": {
+          "name": "agentphone_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_links": {
+      "name": "agentphone_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_user_links_phone_handle": {
+          "name": "idx_agentphone_user_links_phone_handle",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_vm0_org": {
+          "name": "idx_agentphone_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_org": {
+          "name": "idx_agentphone_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_verification_send_cooldowns": {
+      "name": "agentphone_verification_send_cooldowns",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentphone_verification_send_cooldowns_pkey": {
+          "name": "agentphone_verification_send_cooldowns_pkey",
+          "columns": [
+            "scope",
+            "scope_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archived_task_runs": {
+      "name": "archived_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_run_id": {
+          "name": "archived_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_archived_task_runs_unique": {
+          "name": "idx_archived_task_runs_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_generation_jobs": {
+      "name": "built_in_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_built_in_generation_jobs_user_created": {
+          "name": "idx_built_in_generation_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_org_status": {
+          "name": "idx_built_in_generation_jobs_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_run": {
+          "name": "idx_built_in_generation_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "built_in_generation_jobs_run_id_agent_runs_id_fk": {
+          "name": "built_in_generation_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "built_in_generation_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokes_message_id": {
+          "name": "revokes_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupts_run_id": {
+          "name": "interrupts_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_lifecycle_event": {
+          "name": "run_lifecycle_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_id": {
+          "name": "run_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_files": {
+          "name": "attach_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_file_metadata": {
+          "name": "attach_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_thread_created": {
+          "name": "idx_chat_messages_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_run_id": {
+          "name": "idx_chat_messages_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_revokes_message_id_unique": {
+          "name": "chat_messages_revokes_message_id_unique",
+          "columns": [
+            {
+              "expression": "revokes_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_interrupts_run_id_unique": {
+          "name": "chat_messages_interrupts_run_id_unique",
+          "columns": [
+            {
+              "expression": "interrupts_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_seq_unique": {
+          "name": "chat_messages_run_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_lifecycle_unique": {
+          "name": "chat_messages_run_lifecycle_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_messages\".\"run_lifecycle_event\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_revokes_message_id_chat_messages_id_fk": {
+          "name": "chat_messages_revokes_message_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "revokes_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_interrupts_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_interrupts_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "interrupts_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_schedule_run_id": {
+          "name": "source_schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read": {
+          "name": "idx_chat_threads_user_last_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read_message": {
+          "name": "idx_chat_threads_user_last_read_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_pinned": {
+          "name": "idx_chat_threads_user_compose_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_last_message": {
+          "name": "idx_chat_threads_user_compose_last_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshots": {
+          "name": "artifact_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_command_audit_events": {
+      "name": "computer_use_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_command_audit_command": {
+          "name": "idx_computer_use_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_org_user": {
+          "name": "idx_computer_use_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_created": {
+          "name": "idx_computer_use_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_command_audit_events_command_id_computer_use_commands_id_fk": {
+          "name": "computer_use_command_audit_events_command_id_computer_use_commands_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_commands": {
+      "name": "computer_use_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_commands_host_status": {
+          "name": "idx_computer_use_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_org_user": {
+          "name": "idx_computer_use_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_created": {
+          "name": "idx_computer_use_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_commands_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_commands_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_commands",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"accessibility\":false,\"screenRecording\":false}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_token_hash": {
+          "name": "idx_computer_use_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_last_seen": {
+          "name": "idx_computer_use_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_device_authorization_sessions": {
+      "name": "connector_oauth_device_authorization_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_oauth_device_authorization_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_user_authorization'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri_complete": {
+          "name": "verification_uri_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_device_authorization_sessions_token": {
+          "name": "idx_connector_oauth_device_authorization_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_owner_status": {
+          "name": "idx_connector_oauth_device_authorization_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_expiration": {
+          "name": "idx_connector_oauth_device_authorization_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_states": {
+      "name": "connector_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_context": {
+          "name": "oauth_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_states_state": {
+          "name": "idx_connector_oauth_states_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_user_org": {
+          "name": "idx_connector_oauth_states_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_expires_at": {
+          "name": "idx_connector_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_starter_grant": {
+          "name": "uq_credit_expires_starter_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'starter_grant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_auth_handoff_codes": {
+      "name": "desktop_auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_auth_handoff_codes_expires": {
+          "name": "idx_desktop_auth_handoff_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_auth_handoff_codes_user_created": {
+          "name": "idx_desktop_auth_handoff_codes_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_auth_handoff_codes_code_hash_unique": {
+          "name": "desktop_auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ble_session_nonce": {
+          "name": "ble_session_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_token_hash": {
+          "name": "poll_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_token_id": {
+          "name": "cli_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_slack_mock_call_log": {
+      "name": "e2e_slack_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_slack_mock_call_log_created_at": {
+          "name": "idx_e2e_slack_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_slack_mock_call_log_method": {
+          "name": "idx_e2e_slack_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_telegram_mock_call_log": {
+      "name": "e2e_telegram_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_telegram_mock_call_log_created_at": {
+          "name": "idx_e2e_telegram_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_method": {
+          "name": "idx_e2e_telegram_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_chat_id": {
+          "name": "idx_e2e_telegram_mock_call_log_chat_id",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": [
+            "email_thread_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_agent_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_org": {
+          "name": "idx_github_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_label_listeners": {
+      "name": "github_label_listeners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name_normalized": {
+          "name": "label_name_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created_by_me'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_label_listeners_installation_label": {
+          "name": "idx_github_label_listeners_installation_label",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_label_listeners_org": {
+          "name": "idx_github_label_listeners_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_label_listeners_installation": {
+          "name": "idx_github_label_listeners_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_label_listeners_installation_id_github_installations_id_fk": {
+          "name": "github_label_listeners_installation_id_github_installations_id_fk",
+          "tableFrom": "github_label_listeners",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_label_listeners_compose_id_agent_composes_id_fk": {
+          "name": "github_label_listeners_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_label_listeners",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_deployments": {
+      "name": "hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_deployments_site": {
+          "name": "idx_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_org": {
+          "name": "idx_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_status": {
+          "name": "idx_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_sites": {
+      "name": "hosted_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_run_id": {
+          "name": "created_from_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_sites_org": {
+          "name": "idx_hosted_sites_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_slug": {
+          "name": "idx_hosted_sites_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_public_slug": {
+          "name": "idx_hosted_sites_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_daily": {
+      "name": "insights_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_insights_daily_org_user_date": {
+          "name": "uq_insights_daily_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insights_daily_org_user_date_desc": {
+          "name": "idx_insights_daily_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_auth_sessions": {
+      "name": "model_provider_auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "model_provider_auth_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initializing'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_url": {
+          "name": "approval_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_provider_auth_sessions_owner_status": {
+          "name": "idx_model_provider_auth_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_expiration": {
+          "name": "idx_model_provider_auth_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_sandbox": {
+          "name": "idx_model_provider_auth_sessions_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_auth_sessions\".\"sandbox_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_one_default_per_user": {
+          "name": "idx_model_providers_one_default_per_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stat": {
+      "name": "model_stat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hour_start": {
+          "name": "hour_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "org_count": {
+          "name": "org_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_count": {
+          "name": "user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_stat_hour_model_provider": {
+          "name": "uq_model_stat_hour_model_provider",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_hour_start": {
+          "name": "idx_model_stat_hour_start",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_model_hour": {
+          "name": "idx_model_stat_model_hour",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_secrets": {
+      "name": "org_custom_connector_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_secrets_connector": {
+          "name": "idx_org_custom_connector_secrets_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_user": {
+          "name": "idx_org_custom_connector_secrets_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_connector_user": {
+          "name": "idx_org_custom_connector_secrets_connector_user",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connectors": {
+      "name": "org_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefixes": {
+          "name": "prefixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_template": {
+          "name": "header_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connectors_org": {
+          "name": "idx_org_custom_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_org_slug": {
+          "name": "idx_org_custom_connectors_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capture_network_bodies_remaining": {
+          "name": "capture_network_bodies_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pro-suspend'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_payment_pending": {
+          "name": "onboarding_payment_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agent_composes_id_fk": {
+          "name": "org_metadata_default_agent_id_agent_composes_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_model_policies": {
+      "name": "org_model_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_provider_type": {
+          "name": "default_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_model_policies_org_model": {
+          "name": "idx_org_model_policies_org_model",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_one_default_per_org": {
+          "name": "idx_org_model_policies_one_default_per_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_provider": {
+          "name": "idx_org_model_policies_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_model_policies_model_provider_id_model_providers_id_fk": {
+          "name": "org_model_policies_model_provider_id_model_providers_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_model_policies_credential_scope": {
+          "name": "chk_org_model_policies_credential_scope",
+          "value": "credential_scope IN ('org', 'member')"
+        },
+        "chk_org_model_policies_member_scope_no_provider_id": {
+          "name": "chk_org_model_policies_member_scope_no_provider_id",
+          "value": "credential_scope <> 'member' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_builtin_route_no_provider_id": {
+          "name": "chk_org_model_policies_builtin_route_no_provider_id",
+          "value": "default_provider_type <> 'vm0' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_member_scope_oauth_provider": {
+          "name": "chk_org_model_policies_member_scope_oauth_provider",
+          "value": "credential_scope <> 'member' OR default_provider_type IN ('claude-code-oauth-token', 'codex-oauth-token')"
+        },
+        "chk_org_model_policies_oauth_provider_member_scope": {
+          "name": "chk_org_model_policies_oauth_provider_member_scope",
+          "value": "default_provider_type NOT IN ('claude-code-oauth-token', 'codex-oauth-token') OR credential_scope = 'member'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_promo_redemption": {
+      "name": "org_promo_redemption",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_promo_redemption": {
+          "name": "uq_org_promo_redemption",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_access_requests": {
+      "name": "permission_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_ref": {
+          "name": "connector_ref",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_permission_access_requests_agent_status": {
+          "name": "idx_permission_access_requests_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_permission_access_requests_org": {
+          "name": "idx_permission_access_requests_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_access_requests_agent_id_zero_agents_id_fk": {
+          "name": "permission_access_requests_agent_id_zero_agents_id_fk",
+          "tableFrom": "permission_access_requests",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_subscriptions_user_id": {
+          "name": "idx_push_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_push_subscriptions_endpoint": {
+          "name": "idx_push_subscriptions_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_built_in_admissions": {
+      "name": "run_built_in_admissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_run_builtin_admissions_run_status": {
+          "name": "idx_run_builtin_admissions_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_run_created": {
+          "name": "idx_run_builtin_admissions_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_expires_at": {
+          "name": "idx_run_builtin_admissions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_built_in_admissions_run_id_agent_runs_id_fk": {
+          "name": "run_built_in_admissions_run_id_agent_runs_id_fk",
+          "tableFrom": "run_built_in_admissions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_uploaded_files": {
+      "name": "run_uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_uploaded_files_run": {
+          "name": "idx_run_uploaded_files_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_run_source_external": {
+          "name": "idx_run_uploaded_files_run_source_external",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_source_external": {
+          "name": "idx_run_uploaded_files_source_external",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_uploaded_files_run_id_agent_runs_id_fk": {
+          "name": "run_uploaded_files_run_id_agent_runs_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_session_id_unclaimed_idx": {
+          "name": "runner_job_queue_session_id_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL AND session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_state": {
+      "name": "runner_state",
+      "schema": "",
+      "columns": {
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_name": {
+          "name": "runner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiles": {
+          "name": "profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_vcpu": {
+          "name": "total_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_memory_mb": {
+          "name": "total_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_vcpu": {
+          "name": "allocated_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_memory_mb": {
+          "name": "allocated_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "held_session_states": {
+          "name": "held_session_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_state_group_idx": {
+          "name": "runner_state_group_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_state_last_seen_idx": {
+          "name": "runner_state_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": [
+            "slack_workspace_id"
+          ],
+          "columnsTo": [
+            "slack_workspace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_agent_preferences": {
+      "name": "slack_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "slack_user_agent_preferences_pkey": {
+          "name": "slack_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_owner": {
+          "name": "idx_telegram_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_org_id": {
+          "name": "official_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_user_link_id": {
+          "name": "official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_width": {
+          "name": "file_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_height": {
+          "name": "file_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_duration": {
+          "name": "file_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_unique": {
+          "name": "idx_telegram_messages_official_unique",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_chat": {
+          "name": "idx_telegram_messages_official_chat",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_messages_one_owner": {
+          "name": "chk_telegram_messages_one_owner",
+          "value": "(installation_id IS NOT NULL) <> (official_org_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_official_user_links": {
+      "name": "telegram_official_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_official_user_links_tg_user": {
+          "name": "idx_telegram_official_user_links_tg_user",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_vm0_org": {
+          "name": "idx_telegram_official_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_org": {
+          "name": "idx_telegram_official_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_official_user_link_id": {
+          "name": "telegram_official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_chat_official_link": {
+          "name": "idx_telegram_thread_sessions_chat_official_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_official_user_link": {
+          "name": "idx_telegram_thread_sessions_official_user_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "telegram_official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_thread_sessions_one_owner": {
+          "name": "chk_telegram_thread_sessions_one_owner",
+          "value": "(telegram_user_link_id IS NOT NULL) <> (telegram_official_user_link_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_agent_preferences": {
+      "name": "telegram_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "telegram_user_agent_preferences_pkey": {
+          "name": "telegram_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_user_links_vm0_installation": {
+          "name": "idx_telegram_user_links_vm0_installation",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_event": {
+      "name": "usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "billing_error": {
+          "name": "billing_error",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_usage_event_idempotency_key": {
+          "name": "uq_usage_event_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_run_id": {
+          "name": "idx_usage_event_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_status": {
+          "name": "idx_usage_event_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_created": {
+          "name": "idx_usage_event_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_model_created": {
+          "name": "idx_usage_event_model_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"kind\" = 'model'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_user_status_processed": {
+          "name": "idx_usage_event_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_processed_org_user": {
+          "name": "idx_usage_event_processed_org_user",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"status\" = 'processed' AND \"usage_event\".\"processed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_run_id_agent_runs_id_fk": {
+          "name": "usage_event_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_pricing": {
+      "name": "usage_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_size": {
+          "name": "unit_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pricing_kind_provider_category": {
+          "name": "uq_usage_pricing_kind_provider_category",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_count": {
+      "name": "user_behavior_count",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behavior_key": {
+          "name": "behavior_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_behavior_count_org_id_user_id_behavior_key_pk": {
+          "name": "user_behavior_count_org_id_user_id_behavior_key_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "behavior_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique": {
+          "name": "idx_user_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_custom_connectors": {
+      "name": "user_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_custom_connectors_unique": {
+          "name": "idx_user_custom_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_custom_connectors_agent_user": {
+          "name": "idx_user_custom_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_custom_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_custom_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk": {
+          "name": "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_switches": {
+      "name": "user_feature_switches",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "switches": {
+          "name": "switches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_feature_switches_org_id_user_id_pk": {
+          "name": "user_feature_switches_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_type_name": {
+          "name": "idx_variables_org_user_type_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_schedules": {
+      "name": "zero_agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_schedules_zero_agent": {
+          "name": "idx_zero_agent_schedules_zero_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_org": {
+          "name": "idx_zero_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_agent_name_org_user": {
+          "name": "idx_zero_agent_schedules_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_next_run": {
+          "name": "idx_zero_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_user_org": {
+          "name": "idx_zero_agent_schedules_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_schedules_agent_id_agent_composes_id_fk": {
+          "name": "zero_agent_schedules_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_model_provider_id_model_providers_id_fk": {
+          "name": "zero_agent_schedules_model_provider_id_model_providers_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "zero_agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_policies": {
+          "name": "permission_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unknown_permission_policies": {
+          "name": "unknown_permission_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_skills": {
+          "name": "custom_skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agents_id_agent_composes_id_fk": {
+          "name": "zero_agents_id_agent_composes_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agents_model_provider_id_model_providers_id_fk": {
+          "name": "zero_agents_model_provider_id_model_providers_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_runs": {
+      "name": "zero_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_agent_id": {
+          "name": "trigger_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_zero_runs_schedule": {
+          "name": "idx_zero_runs_schedule",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_runs_chat_thread_id": {
+          "name": "idx_zero_runs_chat_thread_id",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "chat_thread_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_runs_id_agent_runs_id_fk": {
+          "name": "zero_runs_id_agent_runs_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_runs_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "zero_runs_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_trigger_agent_id_agent_composes_id_fk": {
+          "name": "zero_runs_trigger_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "trigger_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "zero_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_skills": {
+      "name": "zero_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_skills_org_name": {
+          "name": "idx_zero_skills_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_skills_org": {
+          "name": "idx_zero_skills_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_oauth_device_authorization_session_status": {
+      "name": "connector_oauth_device_authorization_session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_user_authorization",
+        "polling",
+        "complete",
+        "denied",
+        "expired",
+        "error"
+      ]
+    },
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "approved",
+        "consumed",
+        "expired",
+        "denied"
+      ]
+    },
+    "public.model_provider_auth_session_status": {
+      "name": "model_provider_auth_session_status",
+      "schema": "public",
+      "values": [
+        "initializing",
+        "awaiting_user_approval",
+        "completing",
+        "imported",
+        "expired",
+        "cancelled",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/packages/db/src/migrations/meta/_journal.json
+++ b/turbo/packages/db/src/migrations/meta/_journal.json
@@ -2871,6 +2871,13 @@
       "when": 1779949024714,
       "tag": "0409_mushy_cammi",
       "breakpoints": true
+    },
+    {
+      "idx": 410,
+      "version": "7",
+      "when": 1779949024715,
+      "tag": "0410_api_token_connector_cutover",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- migrate legacy API-token user secrets/variables into connector rows and connector-owned state
- make API-token connect/list/get/delete and run runtime injection rely on stored connector rows only
- update API, CLI, platform, connector utility, and migration tests for real API-token connector ids

## Tests
- pnpm -F api check-types
- pnpm -F @vm0/db check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/db test:migration-consistency
- pnpm -F @vm0/db exec vitest run src/__tests__/migrations/0405_api_token_connector_cutover.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F @vm0/cli exec vitest run src/commands/zero/connector/__tests__/connect.test.ts src/commands/zero/generate/__tests__/lister.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-chat-page.test.tsx src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
- pnpm -F api lint
- pnpm -F @vm0/db lint
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/app lint
- pnpm knip
- pre-commit: pnpm check-types

Closes #15170
