### PR TITLE
feat: add gen to seed skills

### DIFF
--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -25,6 +25,7 @@ export const SEED_SKILLS: readonly string[] = [
   "escalation-brief",
   "flux-analysis",
   "gaap-reporting",
+  "gen",
   "issue-triage",
   "journal-entries",
   "kb-authoring",


### PR DESCRIPTION
## Summary
- Add the new `gen` skill to the default Zero seed skill list

## Context
- `gen` was added to `vm0-ai/vm0-skills` in https://github.com/vm0-ai/vm0-skills/pull/232

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core test`
- `pnpm -F @vm0/core lint`
- `pnpm exec prettier --check packages/core/src/zero-seed-skills.ts`
- `git diff --check`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm -F api exec vitest run src/signals/routes/__tests__/cron-sync-skills.test.ts`

Note: the API test initially failed before local Postgres/schema setup (`ECONNREFUSED`, then missing `skills` relation). After initializing Postgres and running `pnpm -F @vm0/db db:migrate`, the targeted test passed.