### PR TITLE
feat: register shadow-pop styled template resource

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -3117,6 +3117,19 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
       path: "illustration-template/jade-blockprint",
     },
   },
+  {
+    id: "vm0:image-style:shadow-pop",
+    kind: "image-style",
+    name: "Shadow Pop",
+    description:
+      "Bright flat-vector illustration with offset black shape shadows, white dashed stitching, palette confetti, and transparent PNG output.",
+    desc: 'Bright flat-vector editorial illustration style — every colored shape sits in front of an offset black silhouette of itself (the signature depth trick, no outlines on the fills), with white hand-drawn dashed stitching, scattered palette-colored sparkle confetti, and a fully transparent PNG background so the piece drops cleanly onto any surface. Five dials per brief — palette (default / berry-pop / tropical / citrus-cobalt), scene metaphor, complexity (L1 / L2 / L3), confetti density, and subject domain. Trigger when user says /shadow-pop, asks for a "shadow-pop illustration", a "bright flat-vector illustration with offset shadow", an "in-app illustration with offset shadow trick", or briefs in the style of the included reference images.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/shadow-pop",
+    },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Registers the **shadow-pop** image-style resource under `vm0:image-style:shadow-pop`, sourced from `vm0-ai/vm0-skills:illustration-template/shadow-pop`.

shadow-pop is a bright flat-vector editorial illustration style where an offset black silhouette behind every colored shape replaces outlines entirely (the signature depth trick), with white hand-drawn dashed stitching, palette-colored sparkle confetti, and a fully transparent PNG background — so the piece drops cleanly onto any surface (blog covers, marketing cards, in-app spot illustrations, empty states, dashboard tiles).

Five dials per brief: palette (default / berry-pop / tropical / citrus-cobalt), scene metaphor, complexity (L1 / L2 / L3), confetti density, and subject domain.

## Registry diff

Adds one entry at the end of the image-style cluster:

- `id`: vm0:image-style:shadow-pop
- `kind`: image-style
- `name`: Shadow Pop
- `description` (≤150-char selection sentence)
- `desc` (longer description with trigger phrasing)
- `source`: { repo: VM0_SKILLS_REPO, ref: VM0_SKILLS_REF, path: \"illustration-template/shadow-pop\" }

## Linked PR

Resource source: https://github.com/vm0-ai/vm0-skills/pull/234

## Test plan

- [ ] CI: lint-types green on the rebased commit
- [ ] CI: build-cli green on the rebased commit
- [ ] Smoke test: \`zero generate image --style vm0:image-style:shadow-pop ...\` resolves and produces output
- [ ] Smoke test: output respects locked frame (transparent PNG, offset shadow, no outlines, palette confetti)

Generated with Claude Code