### PR TITLE
feat: add chat permission action blocks

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
@@ -215,6 +215,32 @@ describe("parseBodyRenderBlocks", () => {
     });
   });
 
+  it("renders permission URLs as permission action blocks", () => {
+    const url =
+      "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow";
+
+    const { cleanContent, blocks } = parseBodyRenderBlocks(url, {
+      previews: false,
+    });
+
+    expect(cleanContent).toBe("");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "permission-action",
+      id: "permission-action-1",
+      connectorRef: "vercel",
+      agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+      permission: "projects:write",
+      action: "allow",
+      method: null,
+      path: null,
+      reason: null,
+      search: "ref=vercel&permission=projects%3Awrite&action=allow",
+      originalUrl: url,
+      href: "/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+    });
+  });
+
   it("does not render external connector authorize URLs as action blocks", () => {
     const url =
       "https://evil.example/connectors/strapi/authorize?agentId=4f189ea8-ada2-416d-83a9-9c25ddb960c9";

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -2,9 +2,13 @@ import { computed, type Computed } from "ccstate";
 import {
   createConnectorActionBlock,
   parseConnectorAuthorizeUrl,
-  type ConnectorActionDescriptor,
   type ConnectorActionBlock,
 } from "./connector-action-block.ts";
+import {
+  createPermissionActionBlock,
+  parsePermissionActionUrl,
+  type PermissionActionBlock,
+} from "./permission-action-block.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,7 +42,8 @@ export type BodyRenderBlock =
         text$?: Computed<Promise<string>>;
       };
     }
-  | ConnectorActionBlock;
+  | ConnectorActionBlock
+  | PermissionActionBlock;
 
 type ChatAttachmentKind = BodyPreviewKind;
 
@@ -496,7 +501,7 @@ function extractPreviewUrlFromLine(line: string): ExtractedPreviewUrl | null {
   return null;
 }
 
-function extractConnectorActionFromLine(line: string): string | null {
+function extractActionUrlFromLine(line: string): string | null {
   const candidate = stripMarkdownLineDecorations(line);
   const markdownLinkMatch = candidate.match(
     new RegExp(String.raw`^\[([^\]]+)\]\((${URL_TOKEN_PATTERN})\)$`),
@@ -521,11 +526,29 @@ function extractConnectorActionFromLine(line: string): string | null {
   return urls.length === 1 ? urls[0]! : null;
 }
 
-function parseConnectorActionFromLine(
+function createActionBlockFromLine(
   line: string,
-): ConnectorActionDescriptor | null {
-  const url = extractConnectorActionFromLine(line);
-  return url ? parseConnectorAuthorizeUrl(url) : null;
+  id: (type: BodyRenderBlock["type"]) => string,
+): ConnectorActionBlock | PermissionActionBlock | null {
+  const url = extractActionUrlFromLine(line);
+  if (!url) {
+    return null;
+  }
+
+  const connectorAction = parseConnectorAuthorizeUrl(url);
+  if (connectorAction) {
+    return createConnectorActionBlock(id("connector-action"), connectorAction);
+  }
+
+  const permissionAction = parsePermissionActionUrl(url);
+  if (permissionAction) {
+    return createPermissionActionBlock(
+      id("permission-action"),
+      permissionAction,
+    );
+  }
+
+  return null;
 }
 
 function splitMarkdownTableRow(line: string): string[] | null {
@@ -680,15 +703,10 @@ export function parseBodyRenderBlocks(
       continue;
     }
 
-    const connectorAction = parseConnectorActionFromLine(line);
-    if (connectorAction) {
+    const actionBlock = createActionBlockFromLine(line, nextBlockId);
+    if (actionBlock) {
       flushMarkdownBuffer();
-      blocks.push(
-        createConnectorActionBlock(
-          nextBlockId("connector-action"),
-          connectorAction,
-        ),
-      );
+      blocks.push(actionBlock);
       continue;
     }
 

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -3,7 +3,7 @@ import {
   type FirewallConnectorType,
 } from "@vm0/connectors/firewalls";
 
-export type PermissionAction = "allow" | "deny";
+type PermissionAction = "allow" | "deny";
 
 export interface PermissionActionDescriptor {
   agentId: string;

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -1,0 +1,91 @@
+import {
+  isFirewallConnectorType,
+  type FirewallConnectorType,
+} from "@vm0/connectors/firewalls";
+
+export type PermissionAction = "allow" | "deny";
+
+export interface PermissionActionDescriptor {
+  agentId: string;
+  connectorRef: FirewallConnectorType;
+  permission: string;
+  action: PermissionAction;
+  method: string | null;
+  path: string | null;
+  reason: string | null;
+  search: string;
+  originalUrl: string;
+}
+
+export type PermissionActionBlock = PermissionActionDescriptor & {
+  type: "permission-action";
+  id: string;
+  href: string;
+};
+
+function permissionActionHref(descriptor: PermissionActionDescriptor): string {
+  const path = `/agents/${encodeURIComponent(descriptor.agentId)}/permissions`;
+  return descriptor.search ? `${path}?${descriptor.search}` : path;
+}
+
+const PERMISSION_ACTION_BASE_URL = "https://app.vm0.ai";
+
+function isPermissionAction(value: string): value is PermissionAction {
+  return value === "allow" || value === "deny";
+}
+
+export function parsePermissionActionUrl(
+  value: string,
+): PermissionActionDescriptor | null {
+  if (!URL.canParse(value, PERMISSION_ACTION_BASE_URL)) {
+    return null;
+  }
+
+  const url = new URL(value, PERMISSION_ACTION_BASE_URL);
+  if (url.origin !== PERMISSION_ACTION_BASE_URL) {
+    return null;
+  }
+
+  const match = url.pathname.match(/^\/agents\/([^/]+)\/permissions$/);
+  const agentId = match?.[1];
+  const connectorRef = url.searchParams.get("ref");
+  const permission = url.searchParams.get("permission");
+  const action = url.searchParams.get("action") ?? "allow";
+  const method = url.searchParams.get("method");
+  const path = url.searchParams.get("path");
+  const reason = url.searchParams.get("reason");
+
+  if (
+    !agentId ||
+    !connectorRef ||
+    !isFirewallConnectorType(connectorRef) ||
+    !permission ||
+    !isPermissionAction(action)
+  ) {
+    return null;
+  }
+
+  return {
+    agentId,
+    connectorRef,
+    permission,
+    action,
+    method,
+    path,
+    reason,
+    search: url.searchParams.toString(),
+    originalUrl: value,
+  };
+}
+
+export function createPermissionActionBlock(
+  id: string,
+  descriptor: PermissionActionDescriptor,
+): PermissionActionBlock {
+  return {
+    type: "permission-action",
+    id,
+    ...descriptor,
+    href: permissionActionHref(descriptor),
+  };
+}

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 import {
   permissionAccessRequestsCreateContract,
   permissionAccessRequestsListContract,
@@ -107,6 +107,38 @@ export function extractPermissions(ref: string): Permission[] {
 
 const internalRequestsReload$ = state(0);
 
+type PermissionRequestAction = "allow" | "deny";
+
+interface MatchingPermissionAccessRequest {
+  id: string;
+  connectorRef: string;
+  permission: string;
+  action: PermissionRequestAction;
+  status: "pending" | "approved" | "rejected";
+  createdAt: string;
+}
+
+function findMatchingPermissionRequest(
+  requests: readonly MatchingPermissionAccessRequest[],
+  ref: string,
+  permission: string,
+  action: PermissionRequestAction,
+): MatchingPermissionAccessRequest | null {
+  const match = requests
+    .filter((r) => {
+      return (
+        r.connectorRef === ref &&
+        r.permission === permission &&
+        r.action === action &&
+        (r.status === "pending" || r.status === "rejected")
+      );
+    })
+    .sort((a, b) => {
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+  return match[0] ?? null;
+}
+
 /** Fetch a specific request by ID (request mode) */
 export const permissionRequestById$ = computed(async (get) => {
   get(internalRequestsReload$);
@@ -133,23 +165,54 @@ export const permissionExistingRequest$ = computed(async (get) => {
   }
   const client = get(zeroClient$)(permissionAccessRequestsListContract);
   const result = await accept(client.list({ query: { agentId } }), [200]);
-  // Find latest pending/rejected request for this ref+permission+action
-  // Note: the API contract uses `firewallRef` (DB/external name); internally
-  // this layer refers to it as `permissionRef` (user-facing name).
-  const match = result.body
-    .filter((r) => {
-      return (
-        r.connectorRef === ref &&
-        r.permission === permission &&
-        r.action === action &&
-        (r.status === "pending" || r.status === "rejected")
-      );
-    })
-    .sort((a, b) => {
-      return b.createdAt.localeCompare(a.createdAt);
-    });
-  return match[0] ?? null;
+  return findMatchingPermissionRequest(result.body, ref, permission, action);
 });
+
+interface ExistingRequestByActionParams {
+  agentId: string;
+  connectorRef: string;
+  permission: string;
+  action: PermissionRequestAction;
+  enabled: boolean;
+}
+
+function createPermissionExistingRequestByActionFactory(): (
+  params: ExistingRequestByActionParams,
+) => Computed<Promise<MatchingPermissionAccessRequest | null>> {
+  const cache = new Map<
+    string,
+    Computed<Promise<MatchingPermissionAccessRequest | null>>
+  >();
+  return (params) => {
+    const key = JSON.stringify(params);
+    const existing = cache.get(key);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = computed(async (get) => {
+      get(internalRequestsReload$);
+      if (!params.enabled) {
+        return null;
+      }
+      const client = get(zeroClient$)(permissionAccessRequestsListContract);
+      const result = await accept(
+        client.list({ query: { agentId: params.agentId } }),
+        [200],
+      );
+      return findMatchingPermissionRequest(
+        result.body,
+        params.connectorRef,
+        params.permission,
+        params.action,
+      );
+    });
+    cache.set(key, atom$);
+    return atom$;
+  };
+}
+
+export const permissionExistingRequestByAction =
+  createPermissionExistingRequestByActionFactory();
 
 // ---------------------------------------------------------------------------
 // URL: update request ID in URL

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -4,18 +4,26 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  click,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 import { updateChatArtifacts } from "../../../mocks/mock-helpers.ts";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import {
+  permissionAccessRequestsCreateContract,
+  type PermissionAccessRequestResponse,
   zeroAgentPermissionPoliciesContract,
   zeroAgentsByIdContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
+import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
@@ -47,6 +55,28 @@ beforeEach(() => {
 });
 
 describe("zero chat thread page display - permission action card", () => {
+  function pendingPermissionRequest(
+    overrides: Partial<PermissionAccessRequestResponse> = {},
+  ): PermissionAccessRequestResponse {
+    return {
+      id: "d0000000-0000-4000-a000-000000000001",
+      agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+      connectorRef: "vercel",
+      permission: "projects:write",
+      action: "allow",
+      method: null,
+      path: null,
+      reason: "Need access",
+      status: "pending",
+      requesterUserId: "test-user-123",
+      requesterName: "Test User",
+      resolvedBy: null,
+      resolvedAt: null,
+      createdAt: "2026-03-10T00:00:00Z",
+      ...overrides,
+    };
+  }
+
   it("executes permission URLs as permission actions for admins", async () => {
     let updatedPolicies: unknown;
 
@@ -116,6 +146,140 @@ describe("zero chat thread page display - permission action card", () => {
       });
     });
     expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+  });
+
+  it("rejects unknown permissions before updating policies", async () => {
+    let updateCalled = false;
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=unknown%3Apermission&action=allow",
+          runId: "run-unknown-permission-action",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(
+        zeroAgentPermissionPoliciesContract.update,
+        ({ body, respond }) => {
+          updateCalled = true;
+          return respond(200, {
+            agentId: body.agentId,
+            ownerId: "test-user-123",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: body.policies,
+            customSkills: [],
+            modelProviderId: null,
+            selectedModel: null,
+            preferPersonalProvider: false,
+          });
+        },
+      ),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    const button = queryAllByRoleFast("button", card).find((element) => {
+      return element.textContent === "Unknown permission";
+    });
+    expect(button).toBeDefined();
+    expect(button).toBeDisabled();
+
+    click(button!);
+
+    expect(updateCalled).toBeFalsy();
+  });
+
+  it("does not create duplicate requests when a member already has a request", async () => {
+    let createCalled = false;
+
+    setMockOrg({ role: "member" });
+    setMockPermissionRequests([pendingPermissionRequest()]);
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+          runId: "run-existing-permission-request",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(permissionAccessRequestsCreateContract.create, ({ respond }) => {
+        createCalled = true;
+        return respond(201, pendingPermissionRequest());
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    await waitFor(() => {
+      expect(
+        queryAllByRoleFast("button", card).some((element) => {
+          return element.textContent === "Request sent";
+        }),
+      ).toBeTruthy();
+    });
+    const button = queryAllByRoleFast("button", card).find((element) => {
+      return element.textContent === "Request sent";
+    });
+    expect(button).toBeDefined();
+    expect(button).toBeDisabled();
+
+    click(button!);
+
+    expect(createCalled).toBeFalsy();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -9,6 +9,10 @@ import { mockApi } from "../../../mocks/msw-contract.ts";
 import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 import { updateChatArtifacts } from "../../../mocks/mock-helpers.ts";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  zeroAgentPermissionPoliciesContract,
+  zeroAgentsByIdContract,
+} from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
@@ -40,6 +44,79 @@ beforeEach(() => {
       });
     }),
   );
+});
+
+describe("zero chat thread page display - permission action card", () => {
+  it("executes permission URLs as permission actions for admins", async () => {
+    let updatedPolicies: unknown;
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+          runId: "run-permission-action",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(
+        zeroAgentPermissionPoliciesContract.update,
+        ({ body, respond }) => {
+          updatedPolicies = body.policies;
+          return respond(200, {
+            agentId: body.agentId,
+            ownerId: "test-user-123",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: body.policies,
+            customSkills: [],
+            modelProviderId: null,
+            selectedModel: null,
+            preferPersonalProvider: false,
+          });
+        },
+      ),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(within(card).getByText("Vercel permissions")).toBeInTheDocument();
+    expect(within(card).getByText("Allow projects:write")).toBeInTheDocument();
+    click(await within(card).findByText("Confirm"));
+
+    await waitFor(() => {
+      expect(updatedPolicies).toStrictEqual({
+        vercel: { policies: { "projects:write": "allow" } },
+      });
+    });
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+  });
 });
 
 // CHAT-D-036: Attachment image previews render in ChatMessageRow

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -160,6 +160,8 @@ import {
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agentById } from "../../signals/agent.ts";
 import {
+  extractPermissions,
+  permissionExistingRequestByAction,
   saveAdminFocusedPolicy$,
   submitAccessRequest$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
@@ -2632,6 +2634,86 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
   );
 }
 
+interface PermissionActionButtonState {
+  hasAgent: boolean;
+  hasPermission: boolean;
+  loading: boolean;
+  saving: boolean;
+  saveDone: boolean;
+  submitDone: boolean;
+  alreadyApplied: boolean;
+  canManagePermissions: boolean;
+  existingRequestStatus: "pending" | "approved" | "rejected" | null;
+}
+
+function permissionActionButtonLabel(
+  state: PermissionActionButtonState,
+  action: "allow" | "deny",
+): string {
+  if (state.loading) {
+    return "Checking permissions";
+  }
+  if (!state.hasPermission) {
+    return "Unknown permission";
+  }
+  if (state.saveDone || state.alreadyApplied) {
+    return action === "allow" ? "Permissions updated" : "Permission denied";
+  }
+  if (state.existingRequestStatus === "pending") {
+    return "Request sent";
+  }
+  if (state.existingRequestStatus === "approved") {
+    return "Permissions updated";
+  }
+  if (state.existingRequestStatus === "rejected") {
+    return "Request denied";
+  }
+  if (state.submitDone) {
+    return "Request sent";
+  }
+  if (state.saving) {
+    return state.canManagePermissions ? "Saving..." : "Requesting...";
+  }
+  return state.canManagePermissions ? "Confirm" : "Request approval";
+}
+
+function permissionActionButtonDisabled(
+  state: PermissionActionButtonState,
+): boolean {
+  return (
+    state.loading ||
+    state.saving ||
+    state.alreadyApplied ||
+    state.saveDone ||
+    state.submitDone ||
+    !state.hasAgent ||
+    !state.hasPermission ||
+    Boolean(state.existingRequestStatus)
+  );
+}
+
+function PermissionActionButton({
+  state,
+  action,
+  onClick,
+}: {
+  state: PermissionActionButtonState;
+  action: "allow" | "deny";
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={permissionActionButtonDisabled(state)}
+      onClick={onClick}
+      className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent sm:w-auto"
+    >
+      {state.saving && <IconLoader2 size={15} className="animate-spin" />}
+      {permissionActionButtonLabel(state, action)}
+    </button>
+  );
+}
+
 function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const pageSignal = useGet(pageSignal$);
   const config = CONNECTOR_TYPES[block.connectorRef];
@@ -2639,14 +2721,32 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const adminLoadable = useLoadable(isOrgAdmin$);
   const [saveLoadable, savePolicy] = useLoadableSet(saveAdminFocusedPolicy$);
   const [submitLoadable, submitRequest] = useLoadableSet(submitAccessRequest$);
-  const actionLabel = block.action === "allow" ? "Allow" : "Deny";
-  const loading =
-    agentLoadable.state === "loading" || adminLoadable.state === "loading";
-  const saving =
-    saveLoadable.state === "loading" || submitLoadable.state === "loading";
   const canManagePermissions =
     adminLoadable.state === "hasData" && adminLoadable.data;
+  const existingRequestLoadable = useLoadable(
+    permissionExistingRequestByAction({
+      agentId: block.agentId,
+      connectorRef: block.connectorRef,
+      permission: block.permission,
+      action: block.action,
+      enabled: adminLoadable.state === "hasData" && !canManagePermissions,
+    }),
+  );
+  const focusedPermission = extractPermissions(block.connectorRef).find((p) => {
+    return p.name === block.permission;
+  });
+  const actionLabel = block.action === "allow" ? "Allow" : "Deny";
+  const loading =
+    agentLoadable.state === "loading" ||
+    adminLoadable.state === "loading" ||
+    existingRequestLoadable.state === "loading";
+  const saving =
+    saveLoadable.state === "loading" || submitLoadable.state === "loading";
   const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
+  const existingRequest =
+    existingRequestLoadable.state === "hasData"
+      ? existingRequestLoadable.data
+      : null;
   const resolved = agent
     ? resolveFirewallPolicies(agent.permissionPolicies, [block.connectorRef])
     : null;
@@ -2655,9 +2755,28 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const alreadyApplied = Boolean(agent) && effectivePolicy === block.action;
   const finished =
     saveLoadable.state === "hasData" || submitLoadable.state === "hasData";
+  const buttonState: PermissionActionButtonState = {
+    hasAgent: Boolean(agent),
+    hasPermission: Boolean(focusedPermission),
+    loading,
+    saving,
+    saveDone: saveLoadable.state === "hasData",
+    submitDone: submitLoadable.state === "hasData",
+    alreadyApplied,
+    canManagePermissions,
+    existingRequestStatus: existingRequest?.status ?? null,
+  };
 
   const handlePermissionAction = () => {
-    if (!agent || loading || saving || alreadyApplied || finished) {
+    if (
+      !agent ||
+      !focusedPermission ||
+      existingRequest ||
+      loading ||
+      saving ||
+      alreadyApplied ||
+      finished
+    ) {
       return;
     }
 
@@ -2667,7 +2786,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
           {
             agentId: block.agentId,
             ref: block.connectorRef,
-            permissionName: block.permission,
+            permissionName: focusedPermission.name,
             action: block.action,
             agentFirewallPolicies: agent.permissionPolicies,
           },
@@ -2683,7 +2802,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
         {
           agentId: block.agentId,
           connectorRef: block.connectorRef,
-          permission: block.permission,
+          permission: focusedPermission.name,
           action: block.action,
           method: block.method ?? undefined,
           path: block.path ?? undefined,
@@ -2694,24 +2813,6 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       Reason.DomCallback,
     );
   };
-
-  const buttonLabel = (() => {
-    if (loading) {
-      return "Checking permissions";
-    }
-    if (saveLoadable.state === "hasData" || alreadyApplied) {
-      return block.action === "allow"
-        ? "Permissions updated"
-        : "Permission denied";
-    }
-    if (submitLoadable.state === "hasData") {
-      return "Request sent";
-    }
-    if (saving) {
-      return canManagePermissions ? "Saving..." : "Requesting...";
-    }
-    return canManagePermissions ? "Confirm" : "Request approval";
-  })();
 
   return (
     <div
@@ -2727,19 +2828,15 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
             {config.label} permissions
           </div>
           <div className="mt-0.5 line-clamp-2 text-xs leading-5 text-muted-foreground">
-            {actionLabel} {block.permission}
+            {actionLabel} {focusedPermission?.name ?? block.permission}
           </div>
         </div>
       </div>
-      <button
-        type="button"
-        disabled={loading || saving || alreadyApplied || finished || !agent}
+      <PermissionActionButton
+        state={buttonState}
+        action={block.action}
         onClick={handlePermissionAction}
-        className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent sm:w-auto"
-      >
-        {saving && <IconLoader2 size={15} className="animate-spin" />}
-        {buttonLabel}
-      </button>
+      />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -9,6 +9,7 @@ import {
   useSet,
   useLastLoadable,
   useLastResolved,
+  useLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -60,6 +61,7 @@ import emptyArtifactImg from "./assets/empty-artifact.webp";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import { hasConnectorAuthCodeGrant } from "@vm0/connectors/connector-utils";
+import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
@@ -103,6 +105,7 @@ import {
   completeChatConnectorActionConnect$,
   type ConnectorActionBlock,
 } from "../../signals/chat-page/connector-action-block.ts";
+import type { PermissionActionBlock } from "../../signals/chat-page/permission-action-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
@@ -155,6 +158,11 @@ import {
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
+import { agentById } from "../../signals/agent.ts";
+import {
+  saveAdminFocusedPolicy$,
+  submitAccessRequest$,
+} from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
   billingStatusAsync$,
   type CreditCheckoutSelection,
@@ -2522,6 +2530,10 @@ function BodyContentBlocks({
           return <ConnectorActionCard key={block.id} block={block} />;
         }
 
+        if (block.type === "permission-action") {
+          return <PermissionActionCard key={block.id} block={block} />;
+        }
+
         if (block.preview.kind === "image") {
           return (
             <ChatImagePreviewLink
@@ -2615,6 +2627,118 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
       >
         {activating && <IconLoader2 size={15} className="animate-spin" />}
         {complete ? "Connected" : "Connect"}
+      </button>
+    </div>
+  );
+}
+
+function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
+  const pageSignal = useGet(pageSignal$);
+  const config = CONNECTOR_TYPES[block.connectorRef];
+  const agentLoadable = useLastLoadable(agentById(block.agentId));
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const [saveLoadable, savePolicy] = useLoadableSet(saveAdminFocusedPolicy$);
+  const [submitLoadable, submitRequest] = useLoadableSet(submitAccessRequest$);
+  const actionLabel = block.action === "allow" ? "Allow" : "Deny";
+  const loading =
+    agentLoadable.state === "loading" || adminLoadable.state === "loading";
+  const saving =
+    saveLoadable.state === "loading" || submitLoadable.state === "loading";
+  const canManagePermissions =
+    adminLoadable.state === "hasData" && adminLoadable.data;
+  const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
+  const resolved = agent
+    ? resolveFirewallPolicies(agent.permissionPolicies, [block.connectorRef])
+    : null;
+  const effectivePolicy =
+    resolved?.[block.connectorRef]?.policies[block.permission] ?? "allow";
+  const alreadyApplied = Boolean(agent) && effectivePolicy === block.action;
+  const finished =
+    saveLoadable.state === "hasData" || submitLoadable.state === "hasData";
+
+  const handlePermissionAction = () => {
+    if (!agent || loading || saving || alreadyApplied || finished) {
+      return;
+    }
+
+    if (canManagePermissions) {
+      detach(
+        savePolicy(
+          {
+            agentId: block.agentId,
+            ref: block.connectorRef,
+            permissionName: block.permission,
+            action: block.action,
+            agentFirewallPolicies: agent.permissionPolicies,
+          },
+          pageSignal,
+        ),
+        Reason.DomCallback,
+      );
+      return;
+    }
+
+    detach(
+      submitRequest(
+        {
+          agentId: block.agentId,
+          connectorRef: block.connectorRef,
+          permission: block.permission,
+          action: block.action,
+          method: block.method ?? undefined,
+          path: block.path ?? undefined,
+          reason: block.reason ?? undefined,
+        },
+        pageSignal,
+      ),
+      Reason.DomCallback,
+    );
+  };
+
+  const buttonLabel = (() => {
+    if (loading) {
+      return "Checking permissions";
+    }
+    if (saveLoadable.state === "hasData" || alreadyApplied) {
+      return block.action === "allow"
+        ? "Permissions updated"
+        : "Permission denied";
+    }
+    if (submitLoadable.state === "hasData") {
+      return "Request sent";
+    }
+    if (saving) {
+      return canManagePermissions ? "Saving..." : "Requesting...";
+    }
+    return canManagePermissions ? "Confirm" : "Request approval";
+  })();
+
+  return (
+    <div
+      data-testid="permission-action-card"
+      className="flex min-h-[88px] w-full flex-col gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
+          <ConnectorIcon type={block.connectorRef} size={22} />
+        </div>
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-foreground">
+            {config.label} permissions
+          </div>
+          <div className="mt-0.5 line-clamp-2 text-xs leading-5 text-muted-foreground">
+            {actionLabel} {block.permission}
+          </div>
+        </div>
+      </div>
+      <button
+        type="button"
+        disabled={loading || saving || alreadyApplied || finished || !agent}
+        onClick={handlePermissionAction}
+        className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent sm:w-auto"
+      >
+        {saving && <IconLoader2 size={15} className="animate-spin" />}
+        {buttonLabel}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Parse agent permission URLs in chat messages into a new permission action block
- Render an inline review card that preserves the permission URL query params
- Cover parser and chat-thread rendering behavior with tests

## Verification
- pnpm -F @vm0/app test src/signals/chat-page/__tests__/parse-body-blocks.test.ts src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint