### PR TITLE
fix: improve computer use table traversal

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -28,7 +28,7 @@ struct ChildSource: Sendable {
 
 let limits = SnapshotLimits()
 
-let childSources = [
+let resolvableChildSources = [
     ChildSource(attribute: kAXChildrenAttribute as String, prefix: "e"),
     ChildSource(attribute: "AXRows", prefix: "r"),
     ChildSource(attribute: "AXContents", prefix: "c"),
@@ -41,15 +41,29 @@ let childSources = [
     ChildSource(attribute: "AXSelectedCells", prefix: "l"),
 ]
 
-let visibleCollectionChildSources = [
-    ChildSource(attribute: "AXVisibleRows", prefix: "a"),
-    ChildSource(attribute: "AXVisibleCells", prefix: "b"),
-    ChildSource(attribute: "AXVisibleColumns", prefix: "d"),
-    ChildSource(attribute: "AXSelectedRows", prefix: "q"),
-    ChildSource(attribute: "AXSelectedCells", prefix: "l"),
-    ChildSource(attribute: "AXSelectedChildren", prefix: "s"),
-    ChildSource(attribute: "AXVisibleChildren", prefix: "v"),
+let defaultTraversalChildSources = [
+    ChildSource(attribute: kAXChildrenAttribute as String, prefix: "e"),
     ChildSource(attribute: "AXContents", prefix: "c"),
+    ChildSource(attribute: "AXVisibleChildren", prefix: "v"),
+]
+
+let tableVisibleRowChildSources = [
+    ChildSource(attribute: "AXVisibleRows", prefix: "a"),
+]
+
+let tableRowFallbackChildSources = [
+    ChildSource(attribute: "AXRows", prefix: "r"),
+]
+
+let tableCellFallbackChildSources = [
+    ChildSource(attribute: "AXVisibleCells", prefix: "b"),
+]
+
+let collectionTraversalChildSources = [
+    ChildSource(attribute: "AXVisibleRows", prefix: "a"),
+    ChildSource(attribute: kAXChildrenAttribute as String, prefix: "e"),
+    ChildSource(attribute: "AXContents", prefix: "c"),
+    ChildSource(attribute: "AXVisibleChildren", prefix: "v"),
 ]
 
 func appSnapshotKey(_ appName: String) -> String {
@@ -2297,27 +2311,52 @@ func prefixedChildren(
         }
 }
 
-func elementUsesVisibleCollectionSources(_ element: AXUIElement) -> Bool {
-    guard let role = role(element),
-          role == "AXList" || role == "AXOutline" || role == "AXTable"
-    else {
-        return false
+func candidates(from element: AXUIElement, sources: [ChildSource]) -> [ChildEntry] {
+    return sources.flatMap { source in
+        prefixedChildren(element, source.attribute as CFString, source.prefix)
     }
-    return !attributeArray(element, "AXVisibleRows" as CFString).isEmpty ||
-        !attributeArray(element, "AXVisibleCells" as CFString).isEmpty ||
-        !attributeArray(element, "AXVisibleColumns" as CFString).isEmpty ||
-        !attributeArray(element, "AXSelectedChildren" as CFString).isEmpty ||
-        !attributeArray(element, "AXSelectedRows" as CFString).isEmpty ||
-        !attributeArray(element, "AXSelectedCells" as CFString).isEmpty
+}
+
+func firstAvailableCandidates(from element: AXUIElement, sourceGroups: [[ChildSource]]) -> [ChildEntry] {
+    for sources in sourceGroups {
+        let children = candidates(from: element, sources: sources)
+        if !children.isEmpty {
+            return children
+        }
+    }
+    return []
+}
+
+func traversalChildCandidates(_ element: AXUIElement) -> [ChildEntry] {
+    switch role(element) {
+    case "AXTable":
+        return firstAvailableCandidates(
+            from: element,
+            sourceGroups: [
+                tableVisibleRowChildSources,
+                tableRowFallbackChildSources,
+                tableCellFallbackChildSources,
+                defaultTraversalChildSources,
+            ]
+        )
+    case "AXList", "AXOutline":
+        return firstAvailableCandidates(
+            from: element,
+            sourceGroups: collectionTraversalChildSources.map { source in [source] }
+        )
+    default:
+        return firstAvailableCandidates(
+            from: element,
+            sourceGroups: [
+                Array(defaultTraversalChildSources.prefix(2)),
+                Array(defaultTraversalChildSources.suffix(1)),
+            ]
+        )
+    }
 }
 
 func collectChildren(_ element: AXUIElement) -> [ChildEntry] {
-    let sources = elementUsesVisibleCollectionSources(element)
-        ? visibleCollectionChildSources
-        : childSources
-    let candidates = sources.flatMap { source in
-        prefixedChildren(element, source.attribute as CFString, source.prefix)
-    }
+    let candidates = traversalChildCandidates(element)
 
     var seenElements = Set<CFHashCode>()
     var seen = Set<String>()
@@ -2352,8 +2391,13 @@ func describe(
     id: String,
     depth: Int,
     nodeCount: inout Int,
-    truncationReasons: inout [String]
+    truncationReasons: inout [String],
+    ancestry: Set<CFHashCode> = []
 ) -> [String: Any]? {
+    let elementHash = CFHash(element)
+    if ancestry.contains(elementHash) {
+        return nil
+    }
     if nodeCount >= limits.maxNodes {
         markTruncated(&truncationReasons, "max_nodes")
         return nil
@@ -2445,13 +2489,16 @@ func describe(
         return node
     }
 
+    var childAncestry = ancestry
+    childAncestry.insert(elementHash)
     let children = collectChildren(element).compactMap { child in
         describe(
             child.element,
             id: "\(id).\(child.segment)",
             depth: depth + 1,
             nodeCount: &nodeCount,
-            truncationReasons: &truncationReasons
+            truncationReasons: &truncationReasons,
+            ancestry: childAncestry
         )
     }
     if !children.isEmpty {
@@ -2478,7 +2525,7 @@ func resolveIndex(_ segment: Substring) throws -> Int {
 
 func childForSegment(_ element: AXUIElement, _ segment: Substring) throws -> AXUIElement {
     let index = try resolveIndex(segment)
-    guard let source = childSources.first(where: { source in
+    guard let source = resolvableChildSources.first(where: { source in
         segment.hasPrefix(source.prefix)
     }) else {
         throw HelperFailure(
@@ -3476,7 +3523,10 @@ func runStdioSession() {
             }
             do {
                 let request = try parseRequestData(Data(trimmed.utf8))
-                try writeJSONObject(responseObject(for: request, session: session))
+                let response = DispatchQueue.main.sync {
+                    responseObject(for: request, session: session)
+                }
+                try writeJSONObject(response)
             } catch let failure as HelperFailure {
                 try? writeJSONObject([
                     "status": "failed",

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -739,14 +739,19 @@ function indexAccessibilitySnapshot(
 ): IndexedAccessibilitySnapshot {
   let nextIndex = 0;
   const elementIdsByIndex: string[] = [];
-  let focusedElementIndex = snapshot.focusedElementIndex;
+  let focusedElementIndex: number | undefined;
 
   const indexElement = (
     element: AccessibilityElementSnapshot,
   ): AccessibilityElementSnapshot => {
     const index = nextIndex;
     nextIndex += 1;
-    elementIdsByIndex[index] = element.id;
+    const elementId =
+      element.id ??
+      (element.index !== undefined
+        ? snapshot.elementIdsByIndex?.[element.index]
+        : undefined);
+    elementIdsByIndex[index] = elementId ?? "";
     if (focusedElementIndex === undefined && element.focused === true) {
       focusedElementIndex = index;
     }
@@ -769,6 +774,7 @@ function indexAccessibilitySnapshot(
     snapshot: {
       ...snapshot,
       elements,
+      elementIdsByIndex,
       ...(focusedElementIndex !== undefined ? { focusedElementIndex } : {}),
     },
     elementIdsByIndex,
@@ -776,28 +782,10 @@ function indexAccessibilitySnapshot(
   };
 }
 
-function nativeIndexedAccessibilitySnapshot(
-  snapshot: AccessibilityAppStateSnapshot,
-): IndexedAccessibilitySnapshot | null {
-  if (!snapshot.elementIdsByIndex) {
-    return null;
-  }
-  return {
-    snapshot,
-    elementIdsByIndex: snapshot.elementIdsByIndex,
-    ...(snapshot.focusedElementIndex !== undefined
-      ? { focusedElementIndex: snapshot.focusedElementIndex }
-      : {}),
-  };
-}
-
 function indexedAccessibilitySnapshot(
   snapshot: AccessibilityAppStateSnapshot,
 ): IndexedAccessibilitySnapshot {
-  return (
-    nativeIndexedAccessibilitySnapshot(snapshot) ??
-    indexAccessibilitySnapshot(snapshot)
-  );
+  return indexAccessibilitySnapshot(snapshot);
 }
 
 const ROLE_LABELS: Readonly<Record<string, string>> = Object.freeze({
@@ -1396,7 +1384,14 @@ function resolveElementTarget(args: {
   if ("status" in snapshot) {
     return snapshot;
   }
+  const elementId = snapshot.elementIdsByIndex?.[args.elementIndex];
+  if (!elementId) {
+    return unsupportedCommand(
+      `Element index ${args.elementIndex.toString()} was not found in snapshot ${snapshot.snapshotId}`,
+    );
+  }
   return {
+    elementId,
     elementIndex: args.elementIndex,
     snapshotId: snapshot.snapshotId,
   };

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -968,6 +968,91 @@ describe("computer use desktop runtime", () => {
     expect(text).toContain("\t\t\t4 text release-notify");
   });
 
+  it("renders browser table row and cell content for model targeting", () => {
+    const snapshot = normalizeAccessibilitySnapshot({
+      app: "Google Chrome",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "Members | VM0 | Cloudflare",
+          children: [
+            {
+              id: "w0.e0",
+              role: "AXWebArea",
+              roleDescription: "HTML content",
+              name: "Members | VM0 | Cloudflare",
+              children: [
+                {
+                  id: "w0.e0.e0",
+                  role: "AXTable",
+                  children: [
+                    {
+                      id: "w0.e0.e0.r0",
+                      role: "AXRow",
+                      children: [
+                        {
+                          id: "w0.e0.e0.r0.c0",
+                          role: "AXCell",
+                          children: [
+                            {
+                              id: "w0.e0.e0.r0.c0.t0",
+                              role: "AXStaticText",
+                              value: "Individual Domains",
+                            },
+                          ],
+                        },
+                        {
+                          id: "w0.e0.e0.r0.c1",
+                          role: "AXCell",
+                          children: [
+                            {
+                              id: "w0.e0.e0.r0.c1.t0",
+                              role: "AXStaticText",
+                              value: "Domain DNS",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      id: "w0.e0.e0.r1",
+                      role: "AXRow",
+                      children: [
+                        {
+                          id: "w0.e0.e0.r1.c0",
+                          role: "AXCell",
+                          children: [
+                            {
+                              id: "w0.e0.e0.r1.c0.t0",
+                              role: "AXStaticText",
+                              value:
+                                "Cloudflare Zero Trust; Load Balancer; Cloudflare Access",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const text = renderAccessibilityTree(snapshot);
+
+    expect(text).toContain("table");
+    expect(text).toContain("row");
+    expect(text).toContain("cell");
+    expect(text).toContain("Individual Domains");
+    expect(text).toContain("Domain DNS");
+    expect(text).toContain("Cloudflare Zero Trust; Load Balancer");
+  });
+
   it("marks accessibility snapshots truncated at the output node budget", () => {
     const snapshot = {
       app: "Slack",
@@ -1288,7 +1373,7 @@ describe("computer use desktop runtime", () => {
     expect(result.result.visibleText).toContain("Can you see this?");
   });
 
-  it("passes model-facing element indexes to the native runtime session", async () => {
+  it("resolves normalized element indexes to native element ids", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();
     clickElement.mockResolvedValue(
@@ -1315,13 +1400,20 @@ describe("computer use desktop runtime", () => {
               children: [
                 {
                   id: "w0.e0",
-                  role: "AXButton",
-                  name: "Open",
-                  actions: ["AXPress"],
+                  role: "AXGroup",
+                  children: [
+                    {
+                      id: "w0.e0.e0",
+                      role: "AXButton",
+                      name: "Open",
+                      actions: ["AXPress"],
+                    },
+                  ],
                 },
               ],
             },
           ],
+          elementIdsByIndex: ["w0", "w0.e0", "w0.e0.e0"],
         };
       },
     });
@@ -1378,6 +1470,7 @@ describe("computer use desktop runtime", () => {
     expect(click.status).toBe("succeeded");
     expect(clickElement).toHaveBeenCalledWith({
       app: "Safari",
+      elementId: "w0.e0.e0",
       snapshotId,
       elementIndex: 1,
       button: "left",


### PR DESCRIPTION
## Summary
- make native Computer Use AX traversal role-aware so Chrome tables prefer rows over cell/column projections
- avoid selected/column projection recursion and add an ancestry guard for repeated AX elements
- reindex normalized snapshots before resolving model-facing element indexes to native element IDs
- run native helper serve-mode commands on the main queue to match one-shot AppKit/AX behavior

Fixes #15234
Related to #14952

## Validation
- pnpm format
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/computer-use-native.test.ts
- pnpm -F @vm0/desktop build:native
- pnpm -F @vm0/desktop build:cli
- vm0-computer daemon smoke against Google Chrome Cloudflare page: appState contains Individual Domains, Domain DNS, and Cloudflare Access with no truncation reasons
