### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.32",
- "hyper 1.9.0",
+ "hyper 1.10.0",
  "hyper-rustls",
  "hyper-util",
  "indexmap",
@@ -1558,7 +1558,7 @@ dependencies = [
  "headers",
  "http 1.4.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.0",
  "hyper-util",
  "path-tree",
  "regex",
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1636,7 +1636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper 1.9.0",
+ "hyper 1.10.0",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -1657,7 +1657,7 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2469,7 +2469,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4321,18 +4321,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Routine Rust dependency update via `cargo update`. 3 packages updated, 0 test regressions.

## Updated Dependencies

| Package | Old | New |
|---|---|---|
| hyper | 1.9.0 | 1.10.0 |
| zerocopy | 0.8.48 | 0.8.49 |
| zerocopy-derive | 0.8.48 | 0.8.49 |

## Dependencies That Could Not Be Updated

- **generic-array** v0.14.7 → v0.14.9 — blocked by upstream transitive dependency chain (`block-buffer` → `digest` → `sha1` / `crypto-common`). Not directly controllable from workspace `Cargo.toml`.

## Manual Version Bumps

None required. All workspace dependencies use compatible semver ranges (`"1"`, `"0.4"`, etc.) and `cargo update` resolved the latest compatible versions automatically.

## Test Status

**Pass** — all tests pass with 0 failures across all workspace crates:

- `runner`: 1287 passed, 1 ignored (unit) + 10 passed (integration)
- `guest-write-file`: 75 passed (unit) + 26 passed, 1 ignored (integration)
- `guest-agent`: 75 passed (unit) + 27 passed (integration)
- All other crates (ably-subscriber, agent-diagnostics, api-contracts, guest-common, guest-download, guest-init, guest-mock-claude, guest-mock-codex, guest-reseed, nbd-cow, process-control-ipc, sandbox, sandbox-fc, sandbox-mock, vsock-guest, vsock-host, vsock-proto, vsock-test): all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)