### PR TITLE
fix: harden ably protocol frame decoding

### DIFF
--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -128,7 +128,34 @@ pub fn decode_msg(data: &[u8]) -> Result<ProtocolMessage, Error> {
         code: error_code::BAD_REQUEST,
         message: format!("msgpack decode error: {e}"),
     })?;
-    let json = rmpv_to_json(value);
+    if cursor.position() != data.len() as u64 {
+        return Err(Error::Protocol {
+            code: error_code::BAD_REQUEST,
+            message: "msgpack frame has trailing bytes".to_string(),
+        });
+    }
+
+    let map = match value {
+        rmpv::Value::Map(map) => map,
+        _ => {
+            return Err(Error::Protocol {
+                code: error_code::BAD_REQUEST,
+                message: "protocol message must be a map".to_string(),
+            });
+        }
+    };
+
+    if !map
+        .iter()
+        .any(|(key, _)| matches!(key, rmpv::Value::String(key) if key.as_str() == Some("action")))
+    {
+        return Err(Error::Protocol {
+            code: error_code::BAD_REQUEST,
+            message: "protocol message missing action".to_string(),
+        });
+    }
+
+    let json = rmpv_to_json(rmpv::Value::Map(map));
     serde_json::from_value(json).map_err(|e| Error::Protocol {
         code: error_code::BAD_REQUEST,
         message: format!("message decode error: {e}"),

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -1,9 +1,12 @@
-use std::error::Error;
+use std::error::Error as StdError;
 use std::io;
 
-use ably_subscriber::protocol::{AblyMessage, ProtocolMessage, action, decode_msg};
+use ably_subscriber::{
+    Error as AblyError,
+    protocol::{AblyMessage, ProtocolMessage, action, decode_msg, error_code},
+};
 
-type TestResult<T = ()> = Result<T, Box<dyn Error>>;
+type TestResult<T = ()> = Result<T, Box<dyn StdError>>;
 
 fn str_value(value: &str) -> rmpv::Value {
     rmpv::Value::from(value)
@@ -17,6 +20,19 @@ fn encode_value(value: rmpv::Value) -> TestResult<Vec<u8>> {
     let mut data = Vec::new();
     rmpv::encode::write_value(&mut data, &value)?;
     Ok(data)
+}
+
+fn expect_bad_request(data: &[u8]) -> TestResult {
+    match decode_msg(data) {
+        Err(AblyError::Protocol { code, .. }) => {
+            assert_eq!(code, error_code::BAD_REQUEST);
+            Ok(())
+        }
+        Err(err) => {
+            Err(io::Error::other(format!("expected BAD_REQUEST protocol error, got {err}")).into())
+        }
+        Ok(_) => Err(io::Error::other("expected BAD_REQUEST protocol error").into()),
+    }
 }
 
 fn message_named(name: &str) -> rmpv::Value {
@@ -40,6 +56,82 @@ fn single_message(decoded: &ProtocolMessage) -> TestResult<&AblyMessage> {
         );
     };
     Ok(message)
+}
+
+#[test]
+fn decode_msg_rejects_empty_payload() -> TestResult {
+    expect_bad_request(&[])
+}
+
+#[test]
+fn decode_msg_rejects_truncated_msgpack_payloads() -> TestResult {
+    expect_bad_request(&[0x81])?;
+    expect_bad_request(&[0x91])
+}
+
+#[test]
+fn decode_msg_rejects_non_map_roots() -> TestResult {
+    let payloads = vec![
+        rmpv::Value::Nil,
+        rmpv::Value::from(1),
+        str_value("not-map"),
+        rmpv::Value::Array(Vec::new()),
+    ];
+
+    for payload in payloads {
+        let encoded = encode_value(payload)?;
+        expect_bad_request(&encoded)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_rejects_missing_action() -> TestResult {
+    let payload = rmpv::Value::Map(vec![field("messages", rmpv::Value::Array(Vec::new()))]);
+    let encoded = encode_value(payload)?;
+
+    expect_bad_request(&encoded)?;
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_rejects_field_type_mismatches() -> TestResult {
+    let action_as_string = rmpv::Value::Map(vec![field("action", str_value("15"))]);
+    let encoded = encode_value(action_as_string)?;
+    expect_bad_request(&encoded)?;
+
+    let messages_as_string = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field("messages", str_value("not-array")),
+    ]);
+    let encoded = encode_value(messages_as_string)?;
+    expect_bad_request(&encoded)?;
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_rejects_trailing_bytes() -> TestResult {
+    let payload = rmpv::Value::Map(vec![field("action", rmpv::Value::from(action::HEARTBEAT))]);
+    let mut encoded = encode_value(payload)?;
+    encoded.push(0xc0);
+
+    expect_bad_request(&encoded)?;
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_accepts_unknown_numeric_action() -> TestResult {
+    let payload = rmpv::Value::Map(vec![field("action", rmpv::Value::from(123_456))]);
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert_eq!(decoded.action, 123_456);
+
+    Ok(())
 }
 
 #[test]

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -49,7 +49,7 @@ fn single_message(decoded: &ProtocolMessage) -> TestResult<&AblyMessage> {
     let messages = decoded
         .messages
         .as_deref()
-        .ok_or_else(|| io::Error::other("messages are present"))?;
+        .ok_or_else(|| io::Error::other("messages are missing"))?;
     let [message] = messages else {
         return Err(
             io::Error::other(format!("expected one message, got {}", messages.len())).into(),


### PR DESCRIPTION
## Summary

- reject MessagePack frames with trailing bytes before protocol conversion
- require decoded Ably protocol frames to be map roots with an `action` key
- add malformed frame integration coverage for empty, truncated, non-map, missing-action, type-mismatch, trailing-byte, and unknown numeric action cases

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test protocol_decode`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber protocol`
- `cargo fmt --manifest-path crates/ably-subscriber/Cargo.toml --check`
- `cargo clippy --manifest-path crates/ably-subscriber/Cargo.toml --tests -- -D warnings`
- `cargo clippy --all-targets --all-features` from `crates/`
- `git diff --check`

Fixes #15241
