### PR TITLE
fix: ignore blank chat assistant output

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -784,6 +784,78 @@ describe("POST /api/internal/callbacks/chat", () => {
     await clearAllDetached();
   });
 
+  it("uses result fallback when Axiom also has blank assistant text", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    completedOutputEvents([
+      {
+        eventType: "assistant",
+        sequenceNumber: 0,
+        eventData: {
+          message: { content: [{ type: "text", text: "" }] },
+        },
+      },
+      {
+        eventType: "result",
+        sequenceNumber: 1,
+        eventData: { result: "RESULT=579" },
+      },
+    ]);
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    const assistantMessages = (await listMessages(fixture.threadId)).filter(
+      (message) => {
+        return message.role === "assistant";
+      },
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]).toMatchObject({
+      sequenceNumber: 1,
+      content: "RESULT=579",
+    });
+    await clearAllDetached();
+  });
+
+  it("uses result fallback when existing streamed assistant output is blank", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    await insertAssistantEventMessages(fixture, fixture.runId, [
+      { sequenceNumber: 0, content: "" },
+    ]);
+    completedOutputEvents([
+      {
+        eventType: "result",
+        sequenceNumber: 1,
+        eventData: { result: "Recovered result" },
+      },
+    ]);
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    const assistantMessages = (await listMessages(fixture.threadId)).filter(
+      (message) => {
+        return message.role === "assistant";
+      },
+    );
+    expect(
+      assistantMessages.map((message) => {
+        return message.content;
+      }),
+    ).toStrictEqual(["", "Recovered result"]);
+    await clearAllDetached();
+  });
+
   it("does not insert a result fallback when assistant output already exists", async () => {
     const fixture = await track(seedChatCallbackFixture());
     await insertAssistantEventMessages(fixture, fixture.runId, [

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -825,7 +825,7 @@ describe("POST /api/internal/callbacks/chat", () => {
   it("uses result fallback when existing streamed assistant output is blank", async () => {
     const fixture = await track(seedChatCallbackFixture());
     await insertAssistantEventMessages(fixture, fixture.runId, [
-      { sequenceNumber: 0, content: "" },
+      { sequenceNumber: 0, content: "\n\t" },
     ]);
     completedOutputEvents([
       {
@@ -852,7 +852,7 @@ describe("POST /api/internal/callbacks/chat", () => {
       assistantMessages.map((message) => {
         return message.content;
       }),
-    ).toStrictEqual(["", "Recovered result"]);
+    ).toStrictEqual(["\n\t", "Recovered result"]);
     await clearAllDetached();
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -811,7 +811,7 @@ describe("POST /api/internal/callbacks/chat", () => {
     expect(response.status).toBe(200);
     const assistantMessages = (await listMessages(fixture.threadId)).filter(
       (message) => {
-        return message.role === "assistant";
+        return message.role === "assistant" && message.sequenceNumber !== null;
       },
     );
     expect(assistantMessages).toHaveLength(1);
@@ -845,7 +845,7 @@ describe("POST /api/internal/callbacks/chat", () => {
     expect(response.status).toBe(200);
     const assistantMessages = (await listMessages(fixture.threadId)).filter(
       (message) => {
-        return message.role === "assistant";
+        return message.role === "assistant" && message.sequenceNumber !== null;
       },
     );
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-event-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-event-consumers.test.ts
@@ -280,6 +280,23 @@ describe("POST /api/internal/event-consumers/chat-assistant", () => {
     expect(context.mocks.ably.publish).not.toHaveBeenCalled();
   });
 
+  it("returns zero for blank assistant text events", async () => {
+    const fixture = await seedChatThreadRun();
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId: fixture.runId,
+      events: [buildAssistantEvent(1, "")],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 0 });
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual(
+      [],
+    );
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
   it("returns zero when the run is not tied to a chat thread", async () => {
     const fixture = await trackChatFixture(
       store.set(seedZeroChatThread$, {}, context.signal),
@@ -359,6 +376,22 @@ describe("POST /api/internal/event-consumers/chat-assistant", () => {
     const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
       runId: fixture.runId,
       events: [buildCodexCommandExecutionEvent(1)],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 0 });
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual(
+      [],
+    );
+  });
+
+  it("ignores blank Codex agent_message item.completed events", async () => {
+    const fixture = await seedChatThreadRun();
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId: fixture.runId,
+      events: [buildCodexAgentMessageEvent(1, "   ")],
       context: { userId: fixture.userId, orgId: fixture.orgId },
     });
 

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
@@ -326,7 +326,7 @@ async function latestEventBackedAssistantMessage(
         eq(chatMessages.role, "assistant"),
         isNotNull(chatMessages.sequenceNumber),
         isNotNull(chatMessages.content),
-        sql<boolean>`length(btrim(${chatMessages.content})) > 0`,
+        sql<boolean>`NOT (${chatMessages.content} ~ '^[[:space:]]*$')`,
       ),
     )
     .orderBy(desc(chatMessages.sequenceNumber))

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
@@ -217,7 +217,9 @@ function extractAnthropicContent(
   blocks: readonly ContentBlock[],
 ): string | null {
   const parts = blocks.flatMap((block) => {
-    return block.type === "text" && typeof block.text === "string"
+    return block.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.trim().length > 0
       ? [block.text]
       : [];
   });
@@ -231,7 +233,7 @@ function extractCodexAgentMessageContent(item: CodexItem): string | null {
   if (
     item.type !== "agent_message" ||
     typeof item.text !== "string" ||
-    item.text.length === 0
+    item.text.trim().length === 0
   ) {
     return null;
   }
@@ -323,6 +325,8 @@ async function latestEventBackedAssistantMessage(
         eq(chatMessages.runId, runId),
         eq(chatMessages.role, "assistant"),
         isNotNull(chatMessages.sequenceNumber),
+        isNotNull(chatMessages.content),
+        sql<boolean>`length(btrim(${chatMessages.content})) > 0`,
       ),
     )
     .orderBy(desc(chatMessages.sequenceNumber))

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts
@@ -28,7 +28,11 @@ function anthropicMessageText(event: AgentEvent): string | null {
   const parts: string[] = [];
   for (const block of content) {
     const record = recordOf(block);
-    if (record?.type === "text" && typeof record.text === "string") {
+    if (
+      record?.type === "text" &&
+      typeof record.text === "string" &&
+      record.text.trim().length > 0
+    ) {
       parts.push(record.text);
     }
   }
@@ -46,7 +50,7 @@ function codexAgentMessageText(event: AgentEvent): string | null {
   if (
     item?.type !== "agent_message" ||
     typeof item.text !== "string" ||
-    item.text.length === 0
+    item.text.trim().length === 0
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Ignore blank Anthropic and Codex assistant text when persisting chat assistant messages
- Allow terminal chat callbacks to fall back to result output when existing assistant output is blank
- Add regression coverage for blank assistant events and result fallback

## Verification
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest src/signals/routes/__tests__/internal-callbacks-chat.test.ts src/signals/routes/__tests__/internal-event-consumers.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm exec prettier --check apps/api/src/signals/routes/internal-callbacks-chat.ts apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts apps/api/src/signals/routes/__tests__/internal-event-consumers.test.ts
- git diff --check
- lefthook pre-commit: prettier, knip, turbo check-types
