### PR TITLE
refactor: remove orphan active run count duplication

### DIFF
--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -432,9 +432,7 @@ pub(super) async fn cleanup_panicked_job(
                 sandbox_id = %sandbox_id,
                 "outer job task panicked before sandbox ownership was proven; leaving active run visible for orphan reconciliation"
             );
-            ownership
-                .active_ownership_unknown(&orphaned_active_runs, run)
-                .await;
+            ownership.active_ownership_unknown(&orphaned_active_runs, run);
         }
     }
 }
@@ -819,7 +817,7 @@ mod tests {
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert!(active_runs.is_empty());
-        assert_eq!(fixture.orphans.len().await, 0);
+        assert_eq!(fixture.orphans.len(), 0);
     }
 
     #[tokio::test]
@@ -842,7 +840,7 @@ mod tests {
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert_eq!(active_runs, vec![run_id.to_string()]);
-        assert_eq!(fixture.orphans.len().await, 1);
+        assert_eq!(fixture.orphans.len(), 1);
     }
 
     #[tokio::test]
@@ -865,7 +863,7 @@ mod tests {
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert!(active_runs.is_empty());
-        assert_eq!(fixture.orphans.len().await, 0);
+        assert_eq!(fixture.orphans.len(), 0);
     }
 
     #[tokio::test]
@@ -893,7 +891,7 @@ mod tests {
             status_active_run_records(&fixture.status_path).await,
             vec![(run_id.to_string(), current_sandbox_id.to_string())],
         );
-        assert_eq!(fixture.orphans.len().await, 0);
+        assert_eq!(fixture.orphans.len(), 0);
     }
 
     #[tokio::test]
@@ -935,6 +933,6 @@ mod tests {
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert_eq!(idle_sessions, vec!["sess-idle-owned-cleanup"]);
         assert!(active_runs.is_empty());
-        assert_eq!(fixture.orphans.len().await, 0);
+        assert_eq!(fixture.orphans.len(), 0);
     }
 }

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -1,7 +1,7 @@
 //! Orphan active-run reconciliation for `runner start`.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use sandbox::SandboxId;
 use tracing::{info, warn};
@@ -29,52 +29,40 @@ struct OrphanedActiveRunState {
 /// Claimed runs whose outer task is gone but whose VM ownership is uncertain.
 #[derive(Clone)]
 pub(super) struct OrphanedActiveRuns {
-    inner: Arc<tokio::sync::Mutex<BTreeMap<RunId, OrphanedActiveRunState>>>,
-    len: Arc<std::sync::atomic::AtomicUsize>,
+    inner: Arc<Mutex<BTreeMap<RunId, OrphanedActiveRunState>>>,
 }
 
 impl OrphanedActiveRuns {
     pub(super) fn new() -> Self {
         Self {
-            inner: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
-            len: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            inner: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.len.load(std::sync::atomic::Ordering::Acquire) == 0
+        self.lock().is_empty()
     }
 
-    pub(super) async fn insert(&self, run_id: RunId, sandbox_id: SandboxId) {
+    pub(super) fn insert(&self, run_id: RunId, sandbox_id: SandboxId) {
         let state = OrphanedActiveRunState {
             sandbox_id,
             absent_scans: 0,
         };
-        let mut runs = self.inner.lock().await;
-        match runs.entry(run_id) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(state);
-                self.len.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-            }
-            std::collections::btree_map::Entry::Occupied(mut entry) => {
-                entry.insert(state);
-            }
-        }
+        self.lock().insert(run_id, state);
     }
 
-    pub(super) async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
-        let mut runs = self.inner.lock().await;
+    pub(super) fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
+        let mut runs = self.lock();
         let removed =
             matches!(runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
         if removed {
             runs.remove(&run_id);
-            self.len.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
         }
         removed
     }
 
-    async fn reset_absent_scans_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
-        let mut runs = self.inner.lock().await;
+    fn reset_absent_scans_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
+        let mut runs = self.lock();
         if let Some(current) = runs.get_mut(&run_id)
             && current.sandbox_id == sandbox_id
         {
@@ -82,8 +70,8 @@ impl OrphanedActiveRuns {
         }
     }
 
-    async fn mark_absent_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> Option<u8> {
-        let mut runs = self.inner.lock().await;
+    fn mark_absent_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> Option<u8> {
+        let mut runs = self.lock();
         let current = runs.get_mut(&run_id)?;
         if current.sandbox_id != sandbox_id {
             return None;
@@ -92,10 +80,8 @@ impl OrphanedActiveRuns {
         Some(current.absent_scans)
     }
 
-    async fn snapshot(&self) -> Vec<OrphanedActiveRun> {
-        self.inner
-            .lock()
-            .await
+    fn snapshot(&self) -> Vec<OrphanedActiveRun> {
+        self.lock()
             .iter()
             .map(|(&run_id, state)| OrphanedActiveRun {
                 run_id,
@@ -105,8 +91,14 @@ impl OrphanedActiveRuns {
     }
 
     #[cfg(test)]
-    pub(super) async fn len(&self) -> usize {
-        self.inner.lock().await.len()
+    pub(super) fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, BTreeMap<RunId, OrphanedActiveRunState>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -135,7 +127,7 @@ pub(super) async fn reap_orphaned_active_runs(
     mode: OrphanReapMode,
     process_discovery_override: Option<&OrphanReapProcessDiscovery>,
 ) {
-    let records = orphaned_active_runs.snapshot().await;
+    let records = orphaned_active_runs.snapshot();
     if records.is_empty() {
         return;
     }
@@ -265,9 +257,7 @@ async fn reap_orphaned_active_runs_with_firecrackers(
     for record in records {
         let sandbox_id = record.sandbox_id.to_string();
         if process::firecracker_process_exists_for_sandbox_id(firecrackers, &sandbox_id) {
-            orphaned_active_runs
-                .reset_absent_scans_if_matching(record.run_id, record.sandbox_id)
-                .await;
+            orphaned_active_runs.reset_absent_scans_if_matching(record.run_id, record.sandbox_id);
             warn!(
                 run_id = %record.run_id,
                 sandbox_id = %record.sandbox_id,
@@ -285,9 +275,8 @@ async fn reap_orphaned_active_runs_with_firecrackers(
             continue;
         }
 
-        let Some(absent_scans) = orphaned_active_runs
-            .mark_absent_if_matching(record.run_id, record.sandbox_id)
-            .await
+        let Some(absent_scans) =
+            orphaned_active_runs.mark_absent_if_matching(record.run_id, record.sandbox_id)
         else {
             continue;
         };
@@ -362,7 +351,7 @@ mod tests {
 
         async fn add_active_orphan(&self, run_id: RunId, sandbox_id: SandboxId) {
             self.status.add_run(run_id, sandbox_id).await;
-            self.orphans.insert(run_id, sandbox_id).await;
+            self.orphans.insert(run_id, sandbox_id);
         }
 
         async fn park_idle_candidate(
@@ -457,7 +446,7 @@ mod tests {
             absent_scans_before_remove: u8,
         ) {
             self.reap_records_with_firecrackers(
-                self.orphans.snapshot().await,
+                self.orphans.snapshot(),
                 firecrackers,
                 discovery_incomplete_for_current_runner,
                 absent_scans_before_remove,
@@ -505,7 +494,7 @@ mod tests {
         }
 
         async fn assert_orphans(&self, expected: &[(RunId, SandboxId)]) {
-            let remaining = self.orphans.snapshot().await;
+            let remaining = self.orphans.snapshot();
             let mut remaining = remaining
                 .iter()
                 .map(|record| (record.run_id.to_string(), record.sandbox_id.to_string()))
@@ -520,7 +509,7 @@ mod tests {
         }
 
         async fn assert_orphan_count(&self, expected: usize) {
-            assert_eq!(self.orphans.len().await, expected);
+            assert_eq!(self.orphans.len(), expected);
         }
 
         async fn status_idle_vms_and_active_runs(
@@ -577,7 +566,7 @@ mod tests {
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
         fixture.add_active_orphan(run_id, stale_sandbox_id).await;
-        let stale_records = fixture.orphans.snapshot().await;
+        let stale_records = fixture.orphans.snapshot();
 
         fixture.add_active_orphan(run_id, current_sandbox_id).await;
 
@@ -612,7 +601,7 @@ mod tests {
             )
             .await;
         fixture.add_active_orphan(run_id, stale_sandbox_id).await;
-        let stale_records = fixture.orphans.snapshot().await;
+        let stale_records = fixture.orphans.snapshot();
 
         fixture.add_active_orphan(run_id, current_sandbox_id).await;
 

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -510,6 +510,7 @@ mod tests {
 
         async fn assert_orphan_count(&self, expected: usize) {
             assert_eq!(self.orphans.len(), expected);
+            assert_eq!(self.orphans.is_empty(), expected == 0);
         }
 
         async fn status_idle_vms_and_active_runs(

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -76,14 +76,12 @@ impl<'a> OwnershipTransitions<'a> {
     }
 
     /// Ownership is uncertain after panic; keep active status visible and track as orphan.
-    pub(super) async fn active_ownership_unknown(
+    pub(super) fn active_ownership_unknown(
         &self,
         orphaned_active_runs: &OrphanedActiveRuns,
         run: RunSandbox,
     ) {
-        orphaned_active_runs
-            .insert(run.run_id, run.sandbox_id)
-            .await;
+        orphaned_active_runs.insert(run.run_id, run.sandbox_id);
     }
 
     /// Idle pool now proves ownership for these orphan records.
@@ -103,10 +101,7 @@ impl<'a> OwnershipTransitions<'a> {
             if !idle_snapshot_contains_sandbox_id(&idle_snapshot, run.sandbox_id) {
                 continue;
             }
-            if !orphaned_active_runs
-                .remove_if_matching(run.run_id, run.sandbox_id)
-                .await
-            {
+            if !orphaned_active_runs.remove_if_matching(run.run_id, run.sandbox_id) {
                 continue;
             }
             if !refreshed_idle_status {
@@ -129,10 +124,7 @@ impl<'a> OwnershipTransitions<'a> {
         orphaned_active_runs: &OrphanedActiveRuns,
         run: RunSandbox,
     ) -> bool {
-        if !orphaned_active_runs
-            .remove_if_matching(run.run_id, run.sandbox_id)
-            .await
-        {
+        if !orphaned_active_runs.remove_if_matching(run.run_id, run.sandbox_id) {
             return false;
         }
         self.remove_matching_active(run).await
@@ -269,9 +261,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        transitions
-            .active_ownership_unknown(&orphans, RunSandbox::new(run_id, sandbox_id))
-            .await;
+        transitions.active_ownership_unknown(&orphans, RunSandbox::new(run_id, sandbox_id));
 
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&status_path).await;
@@ -279,7 +269,7 @@ mod tests {
             active_runs,
             vec![(run_id.to_string(), sandbox_id.to_string())]
         );
-        assert_eq!(orphans.len().await, 1);
+        assert_eq!(orphans.len(), 1);
     }
 
     #[tokio::test]
@@ -293,9 +283,9 @@ mod tests {
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, stale_sandbox_id).await;
-        orphans.insert(run_id, stale_sandbox_id).await;
+        orphans.insert(run_id, stale_sandbox_id);
         status.add_run(run_id, current_sandbox_id).await;
-        orphans.insert(run_id, current_sandbox_id).await;
+        orphans.insert(run_id, current_sandbox_id);
 
         let reconciled = transitions
             .orphan_reconciled_idle_owned(
@@ -312,7 +302,7 @@ mod tests {
             active_runs,
             vec![(run_id.to_string(), current_sandbox_id.to_string())]
         );
-        assert_eq!(orphans.len().await, 1);
+        assert_eq!(orphans.len(), 1);
     }
 
     #[tokio::test]
@@ -326,7 +316,7 @@ mod tests {
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, stale_sandbox_id).await;
-        orphans.insert(run_id, stale_sandbox_id).await;
+        orphans.insert(run_id, stale_sandbox_id);
         status.add_run(run_id, current_sandbox_id).await;
 
         assert!(
@@ -341,7 +331,7 @@ mod tests {
             active_runs,
             vec![(run_id.to_string(), current_sandbox_id.to_string())]
         );
-        assert_eq!(orphans.len().await, 0);
+        assert_eq!(orphans.len(), 0);
     }
 
     #[tokio::test]
@@ -355,7 +345,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let idle_sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id);
 
         let reconciled = transitions
             .orphan_reconciled_idle_owned(
@@ -372,6 +362,6 @@ mod tests {
             active_runs,
             vec![(run_id.to_string(), sandbox_id.to_string())]
         );
-        assert_eq!(orphans.len().await, 1);
+        assert_eq!(orphans.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- Replace `OrphanedActiveRuns` dual bookkeeping with one synchronized `BTreeMap` state.
- Keep `is_empty()` exact and synchronous for existing `tokio::select!` guards.
- Make orphan map mutations synchronous and update runner cleanup/reaper tests accordingly.

Fixes #15244

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::orphan_reap`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::ownership`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::job_spawn`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p runner outer_job_panic`
