### PR TITLE
feat: register vm0:image-style:crowd-ink in open design registry

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/resource-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/resource-registry.ts
@@ -3303,6 +3303,19 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     },
   },
   {
+    id: "image-style:crowd-ink",
+    kind: "image-style",
+    name: "Crowd Ink",
+    description:
+      "Hand-drawn editorial crowd illustration — sketchy black ink contours over flat 3-color spot fills on pure white, scene-as-metaphor composition.",
+    desc: 'Hand-drawn editorial crowd illustration style — confident sketchy black ink contour lines with slightly irregular weight, flat 3-color spot fills sitting under or beside the ink lines (edges allowed to misregister slightly), on a PURE WHITE background (never cream). Fine-line backdrop drawn lighter than the foreground figures, scattered atmospheric marks in negative space (birds / leaves / steam / confetti / dots), and a scene-as-metaphor composition with a cast that varies per piece. Six dials per brief — palette (tested families: urban editorial / cool transit / warm natural / cozy interior), scene metaphor, complexity (L2 small group of 3–5 / L3 full crowd of 8–10), cast, backdrop, atmospheric motif. Trigger when the user says /crowd-ink, asks for a "crowd-ink illustration", "editorial crowd scene", "hand-drawn ink-and-spot-color illustration", "New-Yorker-style crowd vignette", or briefs with palette + scene metaphor + complexity level.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/crowd-ink",
+    },
+  },
+  {
     id: "image-style:ink-storefront",
     kind: "image-style",
     name: "Ink Storefront",


### PR DESCRIPTION
## Summary

Registers the new **crowd-ink** styled illustration template as a selectable image style in the Open Design registry. The resource itself ships in vm0-skills PR #237.

- **ID:** `vm0:image-style:crowd-ink`
- **Source:** `vm0-ai/vm0-skills:illustration-template/crowd-ink` (@ `main`)
- **Display name:** Crowd Ink
- **Selection description:** Hand-drawn editorial crowd illustration — sketchy black ink contours over flat 3-color spot fills on pure white, scene-as-metaphor composition.

## Style summary

Hand-drawn editorial crowd illustration. Locked frame: confident sketchy black ink contour lines, flat 3-color spot fills on **pure white** (never cream — this was a hard rule from the forging session), fine-line backdrop drawn lighter than foreground, scattered atmospheric marks in negative space. Scene-as-metaphor composition with a cast that varies per piece.

Six dials: palette (tested families: urban editorial / cool transit / warm natural / cozy interior), scene metaphor, complexity (L2 small group of 3–5 / L3 full crowd of 8–10), cast, backdrop, atmospheric motif.

## Validation

- `pnpm --filter @vm0/cli check-types` passes locally on the rebased branch.
- Registry entry follows the established shape for `vm0:image-style:*` entries (no removed fields, ID prefix matches `VM0_SKILLS_REPO`).
- Selection description is 137 characters.

## Paired resource PR

- vm0-skills: https://github.com/vm0-ai/vm0-skills/pull/237

## Test prompts used in forging

1. Anchor: bus stop crowd (L3, urban editorial palette) — confirmed white background, sketchy ink, 3-color discipline.
2. Open-plan office (L3, urban editorial palette) — interior B2B scene.
3. Park picnic (L2, warm natural palette) — smaller cast, outdoor.
4. Subway interior (L3, cool transit palette) — palette flex test.
5. Café conversation (L2, cozy interior palette) — intimate scene.
6. Smoke test: team standup (L2, urban editorial palette, fresh scene) — held the style cleanly.