### PR TITLE
feat: register tiny-wanderer image style

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/open-design-registry.ts
@@ -3130,6 +3130,19 @@ const OPEN_DESIGN_REGISTRY: readonly OpenDesignRegistryEntry[] = [
       path: "illustration-template/shadow-pop",
     },
   },
+  {
+    id: "vm0:image-style:tiny-wanderer",
+    kind: "image-style",
+    name: "Tiny Wanderer",
+    description:
+      "Contemplative bande-dessinée landscape illustration — tiny human dwarfed by vast nature, ink hatching + flat color, vertical portrait canvas.",
+    desc: 'Contemplative bande-dessinée landscape illustration in a locked house style — a tiny human (or 2–3 figures) is dwarfed by a vast natural panorama, hand-drawn black ink contour + parallel/cross-hatching for clouds, rock walls, foliage, grass, and water texture, sitting on flat color blocks beneath the ink (no gradients, no airbrush). Restrained 3–5 color palette per piece including black ink, vertical portrait canvas (1024x1536, reads ~3:5). Always outdoor/wilderness. Moebius / Christophe Chabouté travel-sketchbook lineage, quiet wonder mood. Six dials per brief: palette family (sage-plains / sunset-warm / coastal-teal / cool-mist / autumn-rust / winter-pale / custom), landscape archetype (plains+clouds / mountain valley / river vista / rocky ridge / coastal cliffs / misty gorge / forest clearing / alpine pass / desert mesa / lakeshore), activity (walking / cycling / hiking / standing-and-gazing), solitude count (1 / 2 / 3), complexity (L1 single plane / L2 fore+mid / L3 full multi-plane vista), and weather/time (midday / golden hour / sunset / overcast / mist / blue hour). Trigger when user says /tiny-wanderer, asks for a "tiny wanderer illustration", "bande-dessinée landscape", "Moebius-style travel illustration", "ink-hatched vertical landscape", or briefs with a palette + landscape archetype + complexity in this house style.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/tiny-wanderer",
+    },
+  },
 ];
 
 function filterByKind(


### PR DESCRIPTION
## Summary

Adds `vm0:image-style:tiny-wanderer` to the Open Design registry, pointing at the styled-template resource in [vm0-skills#238](https://github.com/vm0-ai/vm0-skills/pull/238).

## Style

**Tiny Wanderer** — a contemplative bande-dessinée landscape illustration: a tiny human (or 2–3 figures) is dwarfed by a vast natural panorama, hand-drawn black ink contour + parallel/cross-hatching for clouds/rock/grass/water texture, sitting on flat color blocks beneath the ink. Restrained 3–5 color palette, vertical portrait canvas. Moebius / Christophe Chabouté travel-sketchbook lineage. Mood: quiet wonder.

**Six dials:** palette family · landscape archetype · activity · solitude count · complexity (L1/L2/L3) · weather/time.

## Validation

- `pnpm -F @vm0/cli check-types` — clean
- `pnpm -F @vm0/cli lint` — 0 warnings, 0 errors
- `pnpm -F @vm0/cli exec vitest run …/open-design-artifacts.test.ts` — 9 tests passed
- Skill registered locally via `zero skill create tiny-wanderer` and smoke-tested with a fresh out-of-anchor scene (autumn-rust palette, forest clearing, L2) — output is dead-on style: https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/a10868bf-a11e-4b93-8fe6-b973dbeacbc0/image-a10868bf.png

## Paired PR

- vm0-skills resource: https://github.com/vm0-ai/vm0-skills/pull/238

🤖 Generated with [Claude Code](https://claude.com/claude-code)