### PR TITLE
feat: register ink-storefront image style

### DIFF
--- a/turbo/apps/cli/src/commands/zero/shared/resource-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/resource-registry.ts
@@ -3289,6 +3289,19 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
       path: "illustration-template/iberian-vignette",
     },
   },
+  {
+    id: "image-style:ink-storefront",
+    kind: "image-style",
+    name: "Ink Storefront",
+    description:
+      "Single-color hand-drawn ink fineliner illustration of a small storefront on warm cream paper — hand-lettered shop sign, foliage, and street props.",
+    desc: 'Boutique-poster illustration style — a single-color hand-drawn ink line drawing of a small storefront (café, boulangerie, florist, bookshop, ramen, wine bar, barber, record store, etc.) seen from street level on warm cream paper #f4ecd8. Locked frame: portrait 1024x1536, monochromatic ink with occasional double-stroke shadow under awnings and signs, a hand-lettered shop sign baked into the building, foliage and at least one small street prop (bike, A-frame chalkboard, planters, lanterns, café tables, dog/cat at the door), and a faint horizontal sidewalk line across the bottom. No solid color fills, no shading, no gradients. Seven dials per brief — ink color, shop name + subtitle, archetype, perspective (flat facade vs 3/4 corner), foreground props, foliage density, and complexity (L1 single facade / L2 small scene / L3 full vignette). Trigger when user says /ink-storefront, asks for a "shopfront illustration", "storefront poster", "boutique fineliner illustration", "café line drawing", or briefs with a shop name + ink color + archetype in this house style.',
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "illustration-template/ink-storefront",
+    },
+  },
 ];
 
 function filterByKind(kind: ResourceKind): readonly RegistryEntry[] {


### PR DESCRIPTION
## Summary

Adds an `OpenDesignRegistryEntry` for `vm0:image-style:ink-storefront`, a locked fineliner illustration style for small storefronts on warm cream paper.

- **Registry ID:** `vm0:image-style:ink-storefront`
- **Source:** `vm0-ai/vm0-skills@main:illustration-template/ink-storefront`
- **Companion (resource):** vm0-ai/vm0-skills#239

## Style summary

- Single-color hand-drawn ink line drawing of a small storefront (café, boulangerie, florist, bookshop, ramen, wine bar, barber, record store…)
- Locked frame: portrait 1024×1536, monochromatic ink on cream paper #f4ecd8, hand-lettered shop sign, foliage and at least one street prop, faint sidewalk line, no fills or shading
- Seven dials: ink color, shop name + subtitle, archetype, perspective, foreground props, foliage density, complexity (L1 / L2 / L3)

## Validation

Local checks all green:

- [x] pnpm --filter @vm0/cli check-types
- [x] pnpm --filter @vm0/cli lint
- [x] pnpm --filter @vm0/cli exec vitest run open-design — 9/9 passed
- [x] pnpm exec prettier --check
- [x] pnpm --filter @vm0/cli build produces the CLI dist
- [x] node dist/zero.js generate image --style vm0:image-style:ink-storefront --prompt "..." --json resolves the new entry and emits a source-selection packet with the expected id, name, description, desc, and source fields

## Anchor reference

Confirmed Variation A (L1 boulangerie, cobalt blue, flat facade):
https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/34f36eb1-ad28-4d13-94d2-2cd444765517/image-34f36eb1.png

## Test plan

- [ ] After both PRs merge, run zero generate image --style vm0:image-style:ink-storefront --prompt "..." against shipped CLI
- [ ] Confirm the resolved SKILL.md from vm0-skills@main matches the locked spec and the output honors every locked frame element

🤖 Generated with [Claude Code](https://claude.com/claude-code)