### PR TITLE
fix: clarify computer-use app resolution

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -171,6 +171,10 @@ describe("computer-use command visibility", () => {
     expect(helpOutput).toContain("Workflow:");
     expect(helpOutput).toContain("zero computer-use list-apps");
     expect(helpOutput).toContain("zero computer-use get-app-state --app <app>");
+    expect(helpOutput).toContain("bundle id");
+    expect(helpOutput).toContain("app path");
+    expect(helpOutput).toContain("com.apple.Safari");
+    expect(helpOutput).toContain("/Applications/Safari.app");
     expect(helpOutput).toContain("--snapshot-id desktop_abc --element-index 7");
     expect(helpOutput).toContain("/tmp/vm0/computer-use");
     expect(helpOutput).toContain("overwrites the same files");
@@ -185,6 +189,15 @@ describe("computer-use command visibility", () => {
     const text = await formatComputerUseResultForConsole({
       app: "Slack/Test App",
       snapshotId: "desktop_test_snapshot",
+      appResolution: {
+        requested: "Slack/Test App",
+        matchedBy: "localized_name_exact",
+        name: "Slack/Test App",
+        bundleId: "com.tinyspeck.slackmacgap",
+        appPath: "/Applications/Slack.app",
+        running: true,
+        pid: 42,
+      },
       appState,
       screenshot: `data:image/png;base64,${screenshotBase64}`,
       screenshotSource: "window",
@@ -193,6 +206,15 @@ describe("computer-use command visibility", () => {
     const parsed = JSON.parse(text) as Record<string, unknown>;
     expect(parsed.status).toBe("succeeded");
     expect(parsed.snapshotId).toBe("desktop_test_snapshot");
+    expect(parsed.appResolution).toStrictEqual({
+      requested: "Slack/Test App",
+      matchedBy: "localized_name_exact",
+      name: "Slack/Test App",
+      bundleId: "com.tinyspeck.slackmacgap",
+      appPath: "/Applications/Slack.app",
+      running: true,
+      pid: 42,
+    });
     expect(parsed.screenshot).toBe(TEST_SCREENSHOT_PATH);
     expect(parsed.appState).toBe(TEST_APP_STATE_PATH);
     expect(text).not.toContain("screenshotSource");

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -66,7 +66,8 @@ const DATA_URL_PATTERN = /^data:([^;,]+);base64,(.*)$/s;
 const COMPUTER_USE_HELP_TEXT = `
 Workflow:
   1. Start the Zero Desktop app and make sure Computer Use is online.
-  2. Run "zero computer-use list-apps" to find the target app name or bundle id.
+  2. Run "zero computer-use list-apps" to find the target app name, bundle id,
+     or app path. Prefer bundle id when app-name matching is ambiguous.
   3. Run "zero computer-use get-app-state --app <app>" to get a screenshot,
      snapshotId, visible element indexes, and accessibility state.
   4. Prefer element actions with --snapshot-id and --element-index. Use --x/--y
@@ -78,6 +79,8 @@ Workflow:
      overwrites the same files.
 
 Notes:
+  APP accepts an app name such as Safari, a bundle id such as com.apple.Safari,
+  or an app path such as /Applications/Safari.app.
   Write commands are sent to the connected Desktop host and may wait for local
   approval before they run. Coordinate fallbacks use screenshot coordinates from
   get-app-state; pass the matching --snapshot-id when acting on a prior snapshot.
@@ -279,9 +282,20 @@ function compactActionResult(
       typeof value === "boolean"
     ) {
       compact[key] = value;
+    } else if (key === "appResolution" && isRecord(value)) {
+      compact[key] = value;
     }
   }
   return compact;
+}
+
+function errorDetailsText(
+  details: Record<string, unknown> | undefined,
+): string {
+  if (!details) {
+    return "";
+  }
+  return `\n${JSON.stringify({ details }, null, 2)}`;
 }
 
 export async function formatComputerUseResultForConsole(
@@ -304,6 +318,10 @@ export async function formatComputerUseResultForConsole(
   if (screenshot) {
     const screenshotPath = await writeScreenshotDataUrl(result, screenshot);
     printable.screenshot = screenshotPath ?? screenshot;
+  }
+  const appResolution = result.appResolution;
+  if (isRecord(appResolution)) {
+    printable.appResolution = appResolution;
   }
   const action = result.action;
   if (isRecord(action)) {
@@ -347,7 +365,7 @@ async function waitForCommand(
     if (command.status === "failed") {
       throw new Error(
         command.error
-          ? `${command.error.code}: ${command.error.message}`
+          ? `${command.error.code}: ${command.error.message}${errorDetailsText(command.error.details)}`
           : "Computer-use command failed",
       );
     }
@@ -410,7 +428,10 @@ function addTargetOptions(command: Command): Command {
 }
 
 function appOption(command: Command): Command {
-  return command.requiredOption("--app <name>", "Target app name or bundle id");
+  return command.requiredOption(
+    "--app <app>",
+    "Target app name, bundle id, or app path",
+  );
 }
 
 const listAppsCommand = addTargetOptions(

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -3,9 +3,16 @@ import ApplicationServices
 import Darwin
 import Foundation
 
-struct HelperFailure: Error {
+struct HelperFailure: Error, @unchecked Sendable {
     let code: String
     let message: String
+    let details: [String: Any]?
+
+    init(code: String, message: String, details: [String: Any]? = nil) {
+        self.code = code
+        self.message = message
+        self.details = details
+    }
 }
 
 struct SnapshotLimits {
@@ -407,6 +414,11 @@ struct WindowTarget {
     let windowNumber: Int
     let title: String?
     let frame: CGRect
+}
+
+struct RunningAppResolution {
+    let app: NSRunningApplication
+    let matchedBy: String
 }
 
 struct WindowScreenshot {
@@ -1413,7 +1425,43 @@ func optionalRectPayload(_ request: [String: Any], _ key: String) throws -> CGRe
     return try rectPayload(request, key)
 }
 
-func findRunningApp(named appName: String) -> NSRunningApplication? {
+func standardizedApplicationPath(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.hasPrefix("/") || trimmed.hasPrefix("~") else {
+        return nil
+    }
+    let expanded = (trimmed as NSString).expandingTildeInPath
+    return URL(fileURLWithPath: expanded).standardizedFileURL.path
+}
+
+func runningApplicationPath(_ app: NSRunningApplication) -> String? {
+    return app.bundleURL?.standardizedFileURL.path
+}
+
+func appResolutionRecord(requested appName: String, app: NSRunningApplication, matchedBy: String) -> [String: Any] {
+    var record: [String: Any] = [
+        "requested": appName,
+        "matchedBy": matchedBy,
+        "running": true,
+        "pid": Int(app.processIdentifier),
+    ]
+    if let name = app.localizedName, !name.isEmpty {
+        record["name"] = name
+    }
+    if let bundleId = app.bundleIdentifier, !bundleId.isEmpty {
+        record["bundleId"] = bundleId
+    }
+    if let appPath = runningApplicationPath(app), !appPath.isEmpty {
+        record["appPath"] = appPath
+    }
+    return record
+}
+
+func appResolutionRecord(requested appName: String, resolution: RunningAppResolution) -> [String: Any] {
+    return appResolutionRecord(requested: appName, app: resolution.app, matchedBy: resolution.matchedBy)
+}
+
+func runningAppResolution(named appName: String) -> RunningAppResolution? {
     let apps = NSWorkspace.shared.runningApplications.filter { app in
         !app.isTerminated
     }
@@ -1421,25 +1469,46 @@ func findRunningApp(named appName: String) -> NSRunningApplication? {
     if let exactBundle = apps.first(where: { app in
         app.bundleIdentifier == appName
     }) {
-        return exactBundle
+        return RunningAppResolution(app: exactBundle, matchedBy: "bundle_id_exact")
     }
 
     let normalized = appName.lowercased()
     if let bundleMatch = apps.first(where: { app in
         app.bundleIdentifier?.lowercased() == normalized
     }) {
-        return bundleMatch
+        return RunningAppResolution(app: bundleMatch, matchedBy: "bundle_id_case_insensitive")
+    }
+
+    if let requestedPath = standardizedApplicationPath(appName) {
+        if let exactPath = apps.first(where: { app in
+            runningApplicationPath(app) == requestedPath
+        }) {
+            return RunningAppResolution(app: exactPath, matchedBy: "app_path_exact")
+        }
+        let normalizedPath = requestedPath.lowercased()
+        if let pathMatch = apps.first(where: { app in
+            runningApplicationPath(app)?.lowercased() == normalizedPath
+        }) {
+            return RunningAppResolution(app: pathMatch, matchedBy: "app_path_case_insensitive")
+        }
     }
 
     if let exactName = apps.first(where: { app in
         app.localizedName == appName
     }) {
-        return exactName
+        return RunningAppResolution(app: exactName, matchedBy: "localized_name_exact")
     }
 
-    return apps.first { app in
+    guard let nameMatch = apps.first(where: { app in
         app.localizedName?.lowercased() == normalized
+    }) else {
+        return nil
     }
+    return RunningAppResolution(app: nameMatch, matchedBy: "localized_name_case_insensitive")
+}
+
+func findRunningApp(named appName: String) -> NSRunningApplication? {
+    return runningAppResolution(named: appName)?.app
 }
 
 func resolveRunningApp(named appName: String) throws -> NSRunningApplication {
@@ -1963,14 +2032,27 @@ func waitForWindowTarget(app: NSRunningApplication, timeout: TimeInterval = 3) -
     return resolveWindowTarget(app: app)
 }
 
-func backgroundTargetUnavailableMessage(appName: String) -> String {
-    return "Unable to resolve a background window target for \(appName)"
+func backgroundTargetUnavailableMessage(appName: String, appResolution: [String: Any]? = nil) -> String {
+    guard let appResolution else {
+        return "Unable to resolve a background window target for \(appName)"
+    }
+    let matchedBy = appResolution["matchedBy"] as? String ?? "unknown"
+    let target = (appResolution["bundleId"] as? String) ??
+        (appResolution["appPath"] as? String) ??
+        (appResolution["name"] as? String) ??
+        appName
+    if let pid = appResolution["pid"] as? Int {
+        return "Unable to resolve a background window target for \(appName) (resolved by \(matchedBy) to \(target), pid \(pid))"
+    }
+    return "Unable to resolve a background window target for \(appName) (resolved by \(matchedBy) to \(target))"
 }
 
-func windowTargetUnavailableFailure(appName: String) -> HelperFailure {
+func windowTargetUnavailableFailure(appName: String, appResolution: [String: Any]? = nil) -> HelperFailure {
+    let details = appResolution.map { ["appResolution": $0] }
     return HelperFailure(
         code: "window_unavailable",
-        message: backgroundTargetUnavailableMessage(appName: appName)
+        message: backgroundTargetUnavailableMessage(appName: appName, appResolution: appResolution),
+        details: details
     )
 }
 
@@ -2892,12 +2974,14 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
     let appName = try requiredString(request, "app")
     let snapshotId = optionalString(request, "snapshotId") ?? UUID().uuidString.lowercased()
 
-    guard let runningApp = findRunningApp(named: appName) else {
+    guard let resolution = runningAppResolution(named: appName) else {
         throw HelperFailure(
             code: "app_not_found",
             message: "App is not running: \(appName)"
         )
     }
+    let runningApp = resolution.app
+    let appResolution = appResolutionRecord(requested: appName, resolution: resolution)
 
     let root = AXUIElementCreateApplication(runningApp.processIdentifier)
     enableBestEffortAccessibilityModes(root)
@@ -2942,6 +3026,7 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
         "nodeCount": nodeCount,
         "truncated": !truncationReasons.isEmpty,
         "truncationReasons": truncationReasons,
+        "appResolution": appResolution,
     ]
     if let focusedElementIndex = indexed.focusedElementIndex {
         response["focusedElementIndex"] = focusedElementIndex
@@ -2956,7 +3041,7 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
         response["windowTitle"] = windowTitle
     }
     guard let target = resolveWindowTarget(app: runningApp, root: root) else {
-        throw windowTargetUnavailableFailure(appName: appName)
+        throw windowTargetUnavailableFailure(appName: appName, appResolution: appResolution)
     }
     let screenshot = try BackgroundWindowScreenshot.capture(windowNumber: target.windowNumber)
     let sourceName = target.title ??
@@ -2984,9 +3069,20 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
         dispatchTarget: "target_app",
         inputRisk: "background_app_launch"
     ) {
-        let runningApp = findRunningApp(named: appName)
+        let runningResolution = runningAppResolution(named: appName)
+        let runningApp = runningResolution?.app
         if let runningApp, resolveWindowTarget(app: runningApp) != nil {
-            return (targetPID: runningApp.processIdentifier, result: ["windowReady": true])
+            return (
+                targetPID: runningApp.processIdentifier,
+                result: [
+                    "windowReady": true,
+                    "appResolution": appResolutionRecord(
+                        requested: appName,
+                        app: runningApp,
+                        matchedBy: runningResolution?.matchedBy ?? "running_app"
+                    ),
+                ]
+            )
         }
 
         let appURL = runningApp.flatMap { app in
@@ -3007,6 +3103,8 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
             throw HelperFailure(code: "app_open_failed", message: "Unable to find launched app: \(appName)")
         }
 
+        var appResolution = appResolutionRecord(requested: appName, app: launchedApp, matchedBy: "launch_result")
+
         if waitForWindowTarget(app: launchedApp, timeout: 2) == nil {
             if let appURL {
                 targetApp = try openApplication(at: appURL, named: appName, activates: true) ?? launchedApp
@@ -3015,13 +3113,22 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
             }
         }
 
-        guard let appWithWindow = targetApp,
-              waitForWindowTarget(app: appWithWindow, timeout: 3) != nil
-        else {
-            throw windowTargetUnavailableFailure(appName: appName)
+        guard let appWithWindow = targetApp else {
+            throw windowTargetUnavailableFailure(appName: appName, appResolution: appResolution)
         }
 
-        return (targetPID: appWithWindow.processIdentifier, result: ["windowReady": true])
+        appResolution = appResolutionRecord(requested: appName, app: appWithWindow, matchedBy: "launch_result")
+        guard waitForWindowTarget(app: appWithWindow, timeout: 3) != nil else {
+            throw windowTargetUnavailableFailure(appName: appName, appResolution: appResolution)
+        }
+
+        return (
+            targetPID: appWithWindow.processIdentifier,
+            result: [
+                "windowReady": true,
+                "appResolution": appResolution,
+            ]
+        )
     }
 }
 
@@ -3680,6 +3787,17 @@ func writeJSONObject(_ object: [String: Any]) throws {
     FileHandle.standardOutput.write(Data("\n".utf8))
 }
 
+func errorResponseObject(for failure: HelperFailure) -> [String: Any] {
+    var error: [String: Any] = [
+        "code": failure.code,
+        "message": failure.message,
+    ]
+    if let details = failure.details {
+        error["details"] = details
+    }
+    return error
+}
+
 func responseObject(for request: [String: Any], session: ComputerUseRuntimeSession?) -> [String: Any] {
     var response: [String: Any]
     do {
@@ -3692,10 +3810,7 @@ func responseObject(for request: [String: Any], session: ComputerUseRuntimeSessi
     } catch let failure as HelperFailure {
         response = [
             "status": "failed",
-            "error": [
-                "code": failure.code,
-                "message": failure.message,
-            ],
+            "error": errorResponseObject(for: failure),
         ]
     } catch {
         response = [
@@ -3732,10 +3847,7 @@ func runOneShot() {
     } catch let failure as HelperFailure {
         try? writeJSONObject([
             "status": "failed",
-            "error": [
-                "code": failure.code,
-                "message": failure.message,
-            ],
+            "error": errorResponseObject(for: failure),
         ])
     } catch {
         try? writeJSONObject([
@@ -3766,10 +3878,7 @@ func runStdioSession() {
             } catch let failure as HelperFailure {
                 try? writeJSONObject([
                     "status": "failed",
-                    "error": [
-                        "code": failure.code,
-                        "message": failure.message,
-                    ],
+                    "error": errorResponseObject(for: failure),
                 ])
             } catch {
                 try? writeJSONObject([

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -101,6 +101,7 @@ export interface AccessibilityAppStateSnapshot {
   readonly bundleId?: string;
   readonly pid?: number;
   readonly appPath?: string;
+  readonly appResolution?: Record<string, unknown>;
   readonly windowTitle?: string;
   readonly windowId?: number;
   readonly windowFrame?: ComputerUseCoordinateBounds;
@@ -163,6 +164,7 @@ export interface ComputerUseCommandFailure {
       | "app_open_failed"
       | "unsupported_command";
     readonly message: string;
+    readonly details?: Record<string, unknown>;
   };
 }
 
@@ -1295,8 +1297,9 @@ async function withPostActionAppState(args: {
   readonly nativeBackend: ComputerUseNativeBackend;
   readonly snapshotStore: ComputerUseSnapshotStore;
 }): Promise<ComputerUseCommandExecutionResult> {
+  const resolvedApp = appSelectorFromActionResult(args.actionResult.result);
   const appStateResult = await getAppState(
-    args.app,
+    resolvedApp ?? args.app,
     args.nativeBackend,
     args.snapshotStore,
   );
@@ -1310,6 +1313,32 @@ async function withPostActionAppState(args: {
       action: args.actionResult.result,
     },
   };
+}
+
+function appSelectorFromActionResult(
+  result: Record<string, unknown>,
+): string | null {
+  const resolution = result.appResolution;
+  if (!isRecordValue(resolution)) {
+    return null;
+  }
+  const bundleId = resolution.bundleId;
+  if (typeof bundleId === "string" && bundleId.trim().length > 0) {
+    return bundleId;
+  }
+  const appPath = resolution.appPath;
+  if (typeof appPath === "string" && appPath.trim().length > 0) {
+    return appPath;
+  }
+  const name = resolution.name;
+  if (typeof name === "string" && name.trim().length > 0) {
+    return name;
+  }
+  return null;
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function executeWriteActionWithPostActionState(args: {
@@ -1862,6 +1891,7 @@ export async function executeComputerUseCommand(
         error: {
           code: error.code,
           message: error.message,
+          ...(error.details ? { details: error.details } : {}),
         },
       };
     }

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -75,6 +75,15 @@ function responseFor(request) {
       result: {
         app: request.payload.app,
         snapshotId: request.payload.snapshotId,
+        appResolution: {
+          requested: request.payload.app,
+          matchedBy: "localized_name_exact",
+          name: "Safari",
+          bundleId: "com.apple.Safari",
+          appPath: "/Applications/Safari.app",
+          running: true,
+          pid: 42
+        },
         elements: [
           {
             index: 0,
@@ -121,6 +130,24 @@ function responseFor(request) {
       status: "succeeded",
       result: {
         normalizedKey: request.payload.key
+      }
+    };
+  }
+  if (request.kind === "app.open") {
+    return {
+      id: request.id,
+      status: "succeeded",
+      result: {
+        appResolution: {
+          requested: request.payload.app,
+          matchedBy: "localized_name_exact",
+          name: "Safari",
+          bundleId: "com.apple.Safari",
+          appPath: "/Applications/Safari.app",
+          running: true,
+          pid: 42
+        },
+        windowReady: true
       }
     };
   }
@@ -368,6 +395,49 @@ describe("computer use native backend", () => {
     }
   });
 
+  it("preserves native error details", async () => {
+    const helper = await createHelper({
+      status: "failed",
+      error: {
+        code: "window_unavailable",
+        message:
+          "Unable to resolve a background window target for Google Chrome",
+        details: {
+          appResolution: {
+            requested: "Google Chrome",
+            matchedBy: "localized_name_exact",
+            name: "Google Chrome",
+            bundleId: "com.google.Chrome",
+            appPath: "/Applications/Google Chrome.app",
+            running: true,
+            pid: 42,
+          },
+        },
+      },
+    });
+
+    try {
+      const backend = createComputerUseNativeBackend({
+        helperPath: helper.helperPath,
+        mode: "oneshot",
+      });
+
+      await expect(
+        backend.getAppState("Google Chrome", "desktop_test"),
+      ).rejects.toMatchObject({
+        code: "window_unavailable",
+        details: {
+          appResolution: {
+            requested: "Google Chrome",
+            bundleId: "com.google.Chrome",
+          },
+        },
+      });
+    } finally {
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
   it("reads normalized key names from the native helper", async () => {
     const helper = await createHelper({
       status: "succeeded",
@@ -522,6 +592,11 @@ describe("computer use native backend", () => {
       expect(output).toMatchObject({
         status: "succeeded",
         snapshotId: expect.stringMatching(/^desktop_/),
+        appResolution: {
+          requested: "Safari",
+          matchedBy: "localized_name_exact",
+          bundleId: "com.apple.Safari",
+        },
         appState: expect.stringMatching(
           /^\/tmp\/vm0\/computer-use\/Safari-desktop_[a-z0-9]+\.appState\.txt$/,
         ),
@@ -689,6 +764,13 @@ describe("computer use native backend", () => {
         "keyboard.type_text",
         "keyboard.press_key",
       ]);
+      const openRequestIndex = requests.findIndex((request) => {
+        return request.kind === "app.open";
+      });
+      expect(requests[openRequestIndex + 1]).toMatchObject({
+        kind: "app.state",
+        payload: { app: "com.apple.Safari" },
+      });
       expect(publicCommandRequests[2]?.payload).toMatchObject({
         app: "Safari",
         elementId: "w0.e0",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -120,6 +120,7 @@ interface ComputerUseNativeFailureResponse {
   readonly error?: {
     readonly code?: unknown;
     readonly message?: unknown;
+    readonly details?: unknown;
   };
 }
 
@@ -142,6 +143,7 @@ export class ComputerUseNativeHelperError extends Error {
   constructor(
     readonly code: ComputerUseNativeErrorCode,
     message: string,
+    readonly details?: Record<string, unknown>,
   ) {
     super(message);
     this.name = "ComputerUseNativeHelperError";
@@ -172,6 +174,12 @@ function responseErrorMessage(value: unknown): string {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : "Native Computer Use helper failed";
+}
+
+function responseErrorDetails(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
 }
 
 function parseHelperResponse(output: string): ComputerUseNativeResponse {
@@ -389,6 +397,7 @@ async function runComputerUseHelper(
           throw new ComputerUseNativeHelperError(
             responseErrorCode(response.error?.code),
             responseErrorMessage(response.error?.message),
+            responseErrorDetails(response.error?.details),
           );
         }
         resolve(resultRecord(response.result ?? {}, request.kind));
@@ -549,6 +558,7 @@ class ComputerUseNativeRuntimeClient {
           new ComputerUseNativeHelperError(
             responseErrorCode(response.error?.code),
             responseErrorMessage(response.error?.message),
+            responseErrorDetails(response.error?.details),
           ),
         );
         return;

--- a/turbo/apps/desktop/src/vm0-computer.ts
+++ b/turbo/apps/desktop/src/vm0-computer.ts
@@ -117,7 +117,10 @@ function usage(): string {
   vm0-computer set-value --app APP (--element-index N | --element ID) --value VALUE [--timeout SECONDS] [--daemon-dir DIR]
   vm0-computer perform-action --app APP (--element-index N | --element ID) --action ACTION [--timeout SECONDS] [--daemon-dir DIR]
   vm0-computer type-text --app APP --text TEXT [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer press-key --app APP --key KEY [--timeout SECONDS] [--daemon-dir DIR]`;
+  vm0-computer press-key --app APP --key KEY [--timeout SECONDS] [--daemon-dir DIR]
+
+APP accepts an app name, bundle id, or app path. Use list-apps to inspect all
+available selectors, and prefer bundle id when app-name matching is ambiguous.`;
 }
 
 function fail(message: string, code = 1): never {
@@ -428,9 +431,18 @@ function compactActionResult(
       typeof value === "boolean"
     ) {
       compact[key] = value;
+    } else if (key === "appResolution" && isJsonObject(value)) {
+      compact[key] = value;
     }
   }
   return compact;
+}
+
+function errorDetailsText(details: unknown): string {
+  if (!isJsonObject(details)) {
+    return "";
+  }
+  return `\n${JSON.stringify({ details }, null, 2)}`;
 }
 
 async function formatComputerUseResultForConsole(
@@ -453,6 +465,10 @@ async function formatComputerUseResultForConsole(
   if (screenshot) {
     const screenshotPath = await writeScreenshotDataUrl(result, screenshot);
     printable.screenshot = screenshotPath ?? screenshot;
+  }
+  const appResolution = result.appResolution;
+  if (isJsonObject(appResolution)) {
+    printable.appResolution = appResolution;
   }
   const action = result.action;
   if (isJsonObject(action)) {
@@ -625,7 +641,9 @@ async function runCommandThroughDaemon(
         typeof error.code === "string" &&
         typeof error.message === "string"
       ) {
-        fail(`${error.code}: ${error.message}`);
+        fail(
+          `${error.code}: ${error.message}${errorDetailsText(error.details)}`,
+        );
       }
       fail("Computer-use command failed");
     }

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -265,6 +265,7 @@ const computerUseWriteCommandCreateBodySchema =
 const computerUseCommandErrorSchema = z.object({
   code: computerUseCommandErrorCodeSchema,
   message: z.string(),
+  details: z.record(z.string(), z.unknown()).optional(),
 });
 
 const computerUseCommandResultSchema = z.record(z.string(), z.unknown());


### PR DESCRIPTION
## Summary
- support app paths as running app selectors in the native Computer Use helper
- return `appResolution` diagnostics for app state/open-app success and window-target failures
- use the resolved bundle id/path when reading post-action app state after open-app
- update `zero computer-use` and `vm0-computer` help text for app name, bundle id, and app path selectors

## Validation
- `swift build --package-path turbo/apps/desktop/native/computer-use-helper -c release`
- `pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/computer-use-native.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm knip --workspace @vm0/desktop`
- `pnpm knip --workspace @vm0/cli`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/desktop build:cli`

## Manual validation
- `vm0-computer get-app-state --app 'Google Chrome'` succeeds and reports `appResolution.matchedBy: localized_name_exact`
- `vm0-computer get-app-state --app com.google.Chrome` succeeds and reports `appResolution.matchedBy: bundle_id_exact`
- `vm0-computer get-app-state --app '/Applications/Google Chrome.app'` succeeds and reports `appResolution.matchedBy: app_path_exact`
- `vm0-computer open-app --app 'Google Chrome'` succeeds, preserves the original action resolution, and reads post-action state through the resolved bundle id

Closes #15275
