### PR TITLE
fix: log malformed data-only anthropic sse events

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -112,13 +112,18 @@ class _AnthropicMessagesSseUsageHandler:
 
         result = extractor.finish()
         if not result.complete:
+            event_type = event_name
+            if event_type is None:
+                data_type = extractor.observed_scalar_for_diagnostics(("type",))
+                if isinstance(data_type, str):
+                    event_type = data_type
             if (
-                event_name is not None
-                and event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
+                event_type is not None
+                and event_type in _ANTHROPIC_MESSAGES_USAGE_EVENTS
                 and result.error
                 and self._on_parse_error is not None
             ):
-                self._on_parse_error(event_name, result.error)
+                self._on_parse_error(event_type, result.error)
             return
 
         event_type = event_name

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -224,6 +224,15 @@ class JsonSelectiveExtractor:
             else:
                 i = self._consume_main(chunk, i)
 
+    def observed_scalar_for_diagnostics(self, path: Path) -> object | None:
+        """Return one completed selected scalar for diagnostics only.
+
+        This may expose a scalar observed before a later parse error. Callers
+        must not use it for billing or normal extraction; ``finish().values``
+        remains the authoritative complete-document result.
+        """
+        return self.values.get(path)
+
     def finish(self) -> JsonExtractionResult:
         """Finalize the current document and return the extraction result.
 

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -207,6 +207,14 @@ class TestAnthropicSseUsageExtractor:
         assert parse_errors == []
         assert usage == {}
 
+    def test_data_only_malformed_duplicate_type_does_not_use_stale_type(self):
+        parse, usage, parse_errors = _create_parser_with_parse_errors()
+
+        parse(b'data: {"type":"message_start","type":"message_delta\n\n')
+
+        assert parse_errors == []
+        assert usage == {}
+
     def test_empty_chunks(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()
         parse(b"")

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -7,6 +7,16 @@ from usage import (
 )
 
 
+def _create_parser_with_parse_errors():
+    parse_errors: list[tuple[str, str]] = []
+
+    def record_parse_error(event: str, error: str) -> None:
+        parse_errors.append((event, error))
+
+    parse, usage = create_anthropic_messages_sse_usage_extractor(on_parse_error=record_parse_error)
+    return parse, usage, parse_errors
+
+
 class TestAnthropicSseUsageExtractor:
     """Tests for the incremental SSE usage parser."""
 
@@ -152,6 +162,50 @@ class TestAnthropicSseUsageExtractor:
         parse(b'data: {"type":"message_delta","usage":{"output_tokens":250}}\n\n')
         assert usage["tokens.input"] == 40
         assert usage["tokens.output"] == 250
+
+    @pytest.mark.parametrize("event_type", ["message_start", "message_delta"])
+    def test_data_only_malformed_usage_event_reports_parse_error(self, event_type):
+        parse, usage, parse_errors = _create_parser_with_parse_errors()
+
+        parse(
+            b'data: {"type":"' + event_type.encode("utf-8") + b'","message":{"id":"msg_1","mod\n\n'
+        )
+
+        assert usage == {}
+        assert len(parse_errors) == 1
+        event, error = parse_errors[0]
+        assert event == event_type
+        assert isinstance(error, str)
+        assert error
+
+    def test_data_only_malformed_usage_event_recovers_for_next_event(self):
+        parse, usage, parse_errors = _create_parser_with_parse_errors()
+
+        parse(b'data: {"type":"message_start","message":{"id":"msg_1","mod\n\n')
+        parse(
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":58}}}\n\n'
+        )
+
+        assert len(parse_errors) == 1
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 58
+
+    def test_data_only_malformed_event_without_completed_type_stays_quiet(self):
+        parse, usage, parse_errors = _create_parser_with_parse_errors()
+
+        parse(b'data: {"type":"message_start\n\n')
+
+        assert parse_errors == []
+        assert usage == {}
+
+    def test_data_only_malformed_non_usage_event_stays_quiet(self):
+        parse, usage, parse_errors = _create_parser_with_parse_errors()
+
+        parse(b'data: {"type":"content_block_delta","delta":{"text":\n\n')
+
+        assert parse_errors == []
+        assert usage == {}
 
     def test_empty_chunks(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -198,6 +198,17 @@ def test_constructor_copies_observation_config():
     assert result.object_present == set()
 
 
+def test_diagnostic_scalar_can_observe_completed_value_in_incomplete_json():
+    extractor = JsonSelectiveExtractor(scalar_fields={("type",): ScalarField("string")})
+
+    extractor.feed(b'{"type":"message_start","message":{"id":"msg_1","mod')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.values == {}
+    assert extractor.observed_scalar_for_diagnostics(("type",)) == "message_start"
+
+
 def test_common_extraction_matches_json_loads_across_chunk_sizes():
     payloads = [
         (

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -209,6 +209,17 @@ def test_diagnostic_scalar_can_observe_completed_value_in_incomplete_json():
     assert extractor.observed_scalar_for_diagnostics(("type",)) == "message_start"
 
 
+def test_diagnostic_scalar_does_not_return_stale_duplicate_value():
+    extractor = JsonSelectiveExtractor(scalar_fields={("type",): ScalarField("string")})
+
+    extractor.feed(b'{"type":"message_start","type":"message_delta')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.values == {}
+    assert extractor.observed_scalar_for_diagnostics(("type",)) is None
+
+
 def test_common_extraction_matches_json_loads_across_chunk_sizes():
     payloads = [
         (

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -377,7 +377,7 @@ class TestModelProviderStreamUsage:
             event="response.completed",
         )
 
-    def test_full_pipeline_eventless_incomplete_sse_does_not_warn(
+    def test_full_pipeline_eventless_incomplete_anthropic_usage_sse_warns(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
     ):
         flow = _model_provider_sse_flow(
@@ -402,7 +402,11 @@ class TestModelProviderStreamUsage:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         mock_opener.open.assert_not_called()
-        assert _model_sse_parse_warnings(flow) == []
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="anthropic_messages_sse",
+            event="message_start",
+        )
 
     def test_full_pipeline_anthropic_non_usage_incomplete_sse_does_not_warn(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor


### PR DESCRIPTION
## Summary

- add a narrow diagnostic scalar accessor to `JsonSelectiveExtractor` without changing incomplete-result semantics
- use the observed data-level `type` to log malformed Anthropic data-only SSE usage events
- cover parser and full pipeline behavior for data-only malformed Anthropic SSE payloads

## Tests

- `pytest tests/test_json_selective.py tests/test_anthropic_messages.py tests/test_model_provider_stream_usage.py tests/test_response_streaming.py`
- `ruff check src tests`
- `ruff format --check src tests`
- `basedpyright`

Closes #15266
