### PR TITLE
test: fix codex zero byok assistant content polling

### DIFF
--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -73,7 +73,10 @@ disable_codex_beta() {
 }
 
 # Poll /api/zero/chat-threads/:id/messages until the newest assistant row
-# reaches a terminal status. On success, exports:
+# reaches a terminal status. Completed runs also append a null-content
+# lifecycle marker, so LAST_MSG_CONTENT comes from the latest non-blank
+# assistant content row for the same run.
+# On success, exports:
 #   LAST_RUN_ID      — runId of the assistant message
 #   LAST_MSG_CONTENT — content text
 # Usage: wait_for_chat_assistant_done <thread_id> [timeout_seconds]
@@ -95,7 +98,16 @@ wait_for_chat_assistant_done() {
                     run_id=$(printf '%s' "$body" \
                         | jq -r '[.messages[] | select(.role == "assistant")] | last | .runId // ""')
                     content=$(printf '%s' "$body" \
-                        | jq -r '[.messages[] | select(.role == "assistant")] | last | .content // ""')
+                        | jq -r --arg runId "$run_id" '
+                            [
+                                .messages[]
+                                | select(.role == "assistant")
+                                | select((.runId // "") == $runId)
+                                | select((.content // "") | test("\\S"))
+                            ]
+                            | last
+                            | .content // ""
+                        ')
                     export LAST_RUN_ID="$run_id"
                     export LAST_MSG_CONTENT="$content"
                     echo "# wait_for_chat_assistant_done: terminal=$status_value run=$run_id ($((SECONDS - start))s)" >&2

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -100,9 +100,10 @@ teardown_file() {
     [[ -n "$THREAD_ID" ]] || fail "Could not extract thread id from chat/messages response"
     export THREAD_ID
 
-    # Wait for the assistant message to terminate. Resets LAST_RUN_ID +
-    # LAST_MSG_CONTENT to the assistant row's runId/content. Also called
-    # without `run` so its exports survive the subshell boundary.
+    # Wait for the assistant message to terminate. Resets LAST_RUN_ID to the
+    # terminal assistant row's runId and LAST_MSG_CONTENT to that run's latest
+    # non-blank assistant content. Also called without `run` so its exports
+    # survive the subshell boundary.
     wait_for_chat_assistant_done "$THREAD_ID"
 
     # Assert: real codex produced the expected sentinel.


### PR DESCRIPTION
## Summary
- keep waiting for the terminal assistant row in the Codex Zero BYOK smoke helper
- read LAST_MSG_CONTENT from the latest non-blank assistant content for the same run
- avoid treating the null-content completed lifecycle marker as the assistant answer

## Testing
- bash -n e2e/helpers/codex-zero.bash
- git diff --check
- jq sample covering a completed lifecycle marker after RESULT=579

Note: shellcheck is not installed in the local container.