### PR TITLE
feat(web): use two-column layout on /web-design for larger previews

### DIFF
--- a/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
@@ -35,7 +35,7 @@ function GalleryCard({ item, locale }: { item: GalleryItem; locale: string }) {
               src={item.previewImage}
               alt={item.title}
               fill
-              sizes="(min-width: 1024px) 378px, (min-width: 768px) calc(50vw + 18px), calc(100vw + 18px)"
+              sizes="(min-width: 1200px) 600px, (min-width: 768px) calc(50vw + 18px), calc(100vw + 18px)"
               className="object-cover object-top"
             />
           </div>
@@ -79,7 +79,7 @@ export function WebDesignClient({ locale }: { locale: string }) {
             margin: "0 auto",
             padding: `0 ${PAGE_PADDING}px`,
           }}
-          className="grid grid-cols-1 items-start gap-5 md:grid-cols-2 lg:grid-cols-3"
+          className="grid grid-cols-1 items-start gap-5 md:grid-cols-2"
         >
           {GALLERY_ITEMS.map((item) => {
             return <GalleryCard key={item.slug} item={item} locale={locale} />;


### PR DESCRIPTION
## Summary
- Drop `lg:grid-cols-3` so the `/web-design` gallery stays at two columns on every breakpoint above mobile, letting each preview render larger.
- Update the `Image` `sizes` hint so Next/Image requests the bigger source for the new layout (~600px at >=1200px viewports).

## Test plan
- [ ] Visit `/en/web-design` on desktop and confirm two cards per row with larger previews.
- [ ] Resize to tablet and mobile to confirm 2-col / 1-col responsive behavior.