### PR TITLE
fix(web): expose /illustration as a public route in clerk middleware

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -99,6 +99,22 @@ describe("proxy middleware: public routes", () => {
     expect(clerkState.protectedPaths).toEqual([]);
   });
 
+  it("keeps locale-prefixed illustration gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/illustration");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("keeps locale-less illustration gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/illustration");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
   it("keeps locale-prefixed docs index public", async () => {
     const request = new NextRequest("https://www.vm0.ai/en/docs");
 

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -39,6 +39,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/web-design",
   "/showcase",
   "/:locale/showcase",
+  "/illustration",
+  "/:locale/illustration",
   "/terms-of-use",
   "/privacy-policy",
   "/support",


### PR DESCRIPTION
## Summary

- Add `/illustration` and `/:locale/illustration` to the Clerk public-route allowlist in `turbo/apps/web/proxy.ts`.
- Cover both with a proxy public-routes test mirroring the existing showcase/docs cases.

The illustration gallery at `/[locale]/illustration` is a public marketing page (also already listed in `app/sitemap.ts`), but it was missing from `isPublicRoute`. Signed-out visitors got `x-clerk-auth-reason: protect-rewrite` and a 404 instead of the gallery.

Closes #15294

## Test plan

- [x] `turbo/apps/web/__tests__/proxy.public-routes.test.ts` updated with locale-prefixed and locale-less `/illustration` cases
- [ ] CI green on lint + tests
- [ ] After deploy, verify `https://www.vm0.ai/en/illustration` returns 200 for signed-out users