### PR TITLE
refactor: make runner http client config explicit

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -46,7 +46,7 @@ use crate::dns;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor::ExecutorConfig;
 use crate::host;
-use crate::http::HttpClient;
+use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
 use crate::kmsg_log;
 use crate::lock;
@@ -439,7 +439,10 @@ pub async fn run_start(
 
     // Create provider — handles discovery + claim + complete
     let cancel = CancellationToken::new();
-    let http = HttpClient::new(server.url.clone())?;
+    let http = HttpClient::new(HttpClientConfig {
+        api_url: server.url.clone(),
+        vercel_bypass: std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok(),
+    })?;
     let name = runner_config.name;
     let group = runner_config.group;
     let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -202,7 +202,11 @@ fn build_mock_run_config_with_runtime(
         exec_config: Arc::new(executor::ExecutorConfig {
             api_url: api_url.to_string(),
             registry,
-            http: crate::http::HttpClient::new(api_url.to_string()).unwrap(),
+            http: crate::http::HttpClient::new(crate::http::HttpClientConfig {
+                api_url: api_url.to_string(),
+                vercel_bypass: None,
+            })
+            .unwrap(),
             log_paths: crate::paths::LogPaths::new(log_dir),
             network_log_manager: NetworkLogManager::new(),
             network_log_drain: NetworkLogDrainCoordinator::noop(),

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2248,6 +2248,7 @@ fn normalized_cli_agent_type(cli_agent_type: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::HttpClientConfig;
     use crate::ids::RunId;
     use crate::types::{
         GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry, ResumeSession,
@@ -4422,7 +4423,11 @@ mod tests {
         ExecutorConfig {
             api_url: "http://localhost:9999".into(),
             registry: proxy::ProxyRegistryHandle::new(registry_path, lock_path),
-            http: crate::http::HttpClient::new("http://localhost:9999".into()).unwrap(),
+            http: crate::http::HttpClient::new(HttpClientConfig {
+                api_url: "http://localhost:9999".into(),
+                vercel_bypass: None,
+            })
+            .unwrap(),
             log_paths: LogPaths::new(log_dir),
             network_log_manager: NetworkLogManager::new(),
             network_log_drain: NetworkLogDrainCoordinator::noop(),
@@ -6185,7 +6190,11 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn new_telemetry() -> JobTelemetry {
-        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let http = HttpClient::new(HttpClientConfig {
+            api_url: "http://localhost".to_string(),
+            vercel_bypass: None,
+        })
+        .unwrap();
         JobTelemetry::new(http, RunId::nil(), "tok".to_string())
     }
 

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -9,6 +9,13 @@ use crate::error::{RunnerError, RunnerResult};
 
 /// Default timeout for API requests (covers large claim payloads).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+const VERCEL_BYPASS_HEADER: &str = "x-vercel-protection-bypass";
+
+/// Configuration for the shared runner API HTTP client.
+pub struct HttpClientConfig {
+    pub api_url: String,
+    pub vercel_bypass: Option<String>,
+}
 
 /// Shared HTTP client for the vm0 API. Owns the connection pool, base URL,
 /// and Vercel bypass header. Clone is a cheap Arc refcount bump.
@@ -24,21 +31,23 @@ struct Inner {
 }
 
 impl HttpClient {
-    /// Create a shared API HTTP client using `api_url` as the base URL for generated routes.
+    /// Create a shared API HTTP client using `config.api_url` as the base URL for generated routes.
     ///
-    /// The client uses the runner's default request timeout and captures
-    /// `VERCEL_AUTOMATION_BYPASS_SECRET` at construction time. When present,
-    /// that value is attached as `x-vercel-protection-bypass` on authenticated
-    /// requests.
+    /// The client uses the runner's default request timeout. When
+    /// `config.vercel_bypass` is present, that value is attached as
+    /// `x-vercel-protection-bypass` on authenticated requests.
     ///
     /// Returns an error if the underlying HTTP client cannot be built.
-    pub fn new(api_url: String) -> RunnerResult<Self> {
+    pub fn new(config: HttpClientConfig) -> RunnerResult<Self> {
+        let HttpClientConfig {
+            api_url,
+            vercel_bypass,
+        } = config;
+
         let client = Client::builder()
             .timeout(DEFAULT_TIMEOUT)
             .build()
             .map_err(|e| RunnerError::Internal(format!("http client: {e}")))?;
-
-        let vercel_bypass = std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok();
 
         info!(
             api_url = %api_url,
@@ -86,7 +95,7 @@ impl HttpClient {
         let mut req = self.inner.client.request(method, url).bearer_auth(token);
 
         if let Some(bypass) = &self.inner.vercel_bypass {
-            req = req.header("x-vercel-protection-bypass", bypass);
+            req = req.header(VERCEL_BYPASS_HEADER, bypass);
         }
 
         req
@@ -112,9 +121,17 @@ mod tests {
 
     use super::*;
 
+    fn http_client(api_url: &str) -> HttpClient {
+        HttpClient::new(HttpClientConfig {
+            api_url: api_url.to_string(),
+            vercel_bypass: None,
+        })
+        .unwrap()
+    }
+
     #[test]
     fn request_route_builds_request_from_generated_route() {
-        let http = HttpClient::new("https://api.vm0.dev/".to_string()).unwrap();
+        let http = http_client("https://api.vm0.dev/");
 
         let request = http
             .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
@@ -139,7 +156,7 @@ mod tests {
 
     #[test]
     fn request_resolved_route_builds_request_from_generated_route() {
-        let http = HttpClient::new("https://api.vm0.dev/".to_string()).unwrap();
+        let http = http_client("https://api.vm0.dev/");
 
         let request = http
             .request_resolved_route(
@@ -158,5 +175,41 @@ mod tests {
             request.url().as_str(),
             "https://api.vm0.dev/api/runners/jobs/550e8400-e29b-41d4-a716-446655440000/claim"
         );
+    }
+
+    #[test]
+    fn request_includes_vercel_bypass_header_when_configured() {
+        let http = HttpClient::new(HttpClientConfig {
+            api_url: "https://api.vm0.dev/".to_string(),
+            vercel_bypass: Some("bypass-secret".to_string()),
+        })
+        .unwrap();
+
+        let request = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get(VERCEL_BYPASS_HEADER)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "bypass-secret"
+        );
+    }
+
+    #[test]
+    fn request_excludes_vercel_bypass_header_when_not_configured() {
+        let http = http_client("https://api.vm0.dev/");
+
+        let request = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+
+        assert!(request.headers().get(VERCEL_BYPASS_HEADER).is_none());
     }
 }

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -218,12 +218,18 @@ mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
 
+    use crate::http::HttpClientConfig;
+
     use super::*;
 
     const SANDBOX_TOKEN: &str = "sandbox-token";
 
     fn http_for_server(server: &MockServer) -> HttpClient {
-        HttpClient::new(server.base_url()).unwrap()
+        HttpClient::new(HttpClientConfig {
+            api_url: server.base_url(),
+            vercel_bypass: None,
+        })
+        .unwrap()
     }
 
     fn network_log_file(dir: &tempfile::TempDir) -> std::path::PathBuf {
@@ -612,7 +618,11 @@ mod tests {
             }
         });
 
-        let http = HttpClient::new(api_url).unwrap();
+        let http = HttpClient::new(HttpClientConfig {
+            api_url,
+            vercel_bypass: None,
+        })
+        .unwrap();
         upload_network_logs(&http, RunId::nil(), SANDBOX_TOKEN, &path).await;
 
         stop_accepting.notify_one();

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -456,9 +456,15 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::task::JoinHandle;
 
+    use crate::http::HttpClientConfig;
+
     fn api_client_for_server(server: &MockServer) -> ApiClient {
         ApiClient::new(
-            HttpClient::new(server.base_url()).unwrap(),
+            HttpClient::new(HttpClientConfig {
+                api_url: server.base_url(),
+                vercel_bypass: None,
+            })
+            .unwrap(),
             "runner-token".to_string(),
         )
     }
@@ -477,7 +483,11 @@ mod tests {
     ) -> Arc<ApiProvider> {
         Arc::new(ApiProvider {
             api: ApiClient::new(
-                HttpClient::new(api_url).unwrap(),
+                HttpClient::new(HttpClientConfig {
+                    api_url,
+                    vercel_bypass: None,
+                })
+                .unwrap(),
                 "runner-token".to_string(),
             ),
             group: "default".to_string(),

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -689,14 +689,18 @@ mod tests {
     use tokio::io::AsyncWriteExt as _;
     use tokio::net::TcpListener;
 
-    use crate::http::HttpClient;
+    use crate::http::{HttpClient, HttpClientConfig};
     use crate::ids::RunId;
     use crate::types::{
         GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
     };
 
     fn new_telemetry() -> JobTelemetry {
-        let http = HttpClient::new("http://localhost:0".to_string()).unwrap();
+        let http = HttpClient::new(HttpClientConfig {
+            api_url: "http://localhost:0".to_string(),
+            vercel_bypass: None,
+        })
+        .unwrap();
         JobTelemetry::new(http, RunId::nil(), "test-token".to_string())
     }
 

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -162,6 +162,15 @@ async fn send_telemetry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::HttpClientConfig;
+
+    fn http_client() -> HttpClient {
+        HttpClient::new(HttpClientConfig {
+            api_url: "http://localhost".to_string(),
+            vercel_bypass: None,
+        })
+        .unwrap()
+    }
 
     #[test]
     fn sandbox_op_serializes_correctly() {
@@ -199,7 +208,7 @@ mod tests {
 
     #[test]
     fn new_creates_empty_telemetry() {
-        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let http = http_client();
         let telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
         assert!(telemetry.pending_ops.is_empty());
         assert!(telemetry.oldest_pending.is_none());
@@ -207,7 +216,7 @@ mod tests {
 
     #[test]
     fn record_buffers_ops() {
-        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let http = http_client();
         let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
 
         telemetry.record("vm_create", Duration::from_millis(500), true, None);
@@ -231,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_within_threshold_does_not_flush() {
-        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let http = http_client();
         let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
@@ -243,7 +252,7 @@ mod tests {
 
     #[tokio::test]
     async fn auto_flush_triggers_after_threshold() {
-        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let http = http_client();
         let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
 
         telemetry.record("op1", Duration::from_millis(10), true, None);


### PR DESCRIPTION
## Summary

- make runner `HttpClient` accept explicit `HttpClientConfig` instead of reading `VERCEL_AUTOMATION_BYPASS_SECRET` internally
- move the Vercel bypass env read to runner startup where the shared client is constructed
- add deterministic request-header tests for bypass header inclusion and omission without mutating process env

Closes #15252

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner http`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
