### PR TITLE
fix(sandbox-fc): surface control socket scan errors

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -620,9 +620,10 @@ fn resolve_control_socket_in(
         let control_sock = SockPaths::new(sock_parent.join(sandbox_id.to_string())).control_sock();
         return match control_sock.try_exists() {
             Ok(true) => Ok(control_sock),
-            Ok(false) => Err(SandboxControlError::NotFound(format!(
-                "no running sandbox matches '{input}' (no control.sock found)"
-            ))),
+            Ok(false) => {
+                let _entries = read_control_socket_parent(sock_parent)?;
+                Err(control_socket_not_found(input))
+            }
             Err(e) => Err(SandboxControlError::Connection(format!(
                 "cannot check {}: {e}",
                 control_sock.display()
@@ -630,12 +631,7 @@ fn resolve_control_socket_in(
         };
     }
 
-    let entries = std::fs::read_dir(sock_parent).map_err(|e| {
-        SandboxControlError::Connection(format!(
-            "cannot read {}: {e} (is a sandbox running?)",
-            sock_parent.display()
-        ))
-    })?;
+    let entries = read_control_socket_parent(sock_parent)?;
 
     let mut matches: Vec<(String, PathBuf)> = Vec::new();
     for entry in entries {
@@ -666,9 +662,7 @@ fn resolve_control_socket_in(
     }
 
     match matches.as_slice() {
-        [] => Err(SandboxControlError::NotFound(format!(
-            "no running sandbox matches '{input}' (no control.sock found)"
-        ))),
+        [] => Err(control_socket_not_found(input)),
         [single] => Ok(single.1.clone()),
         _ => {
             let ids: Vec<&str> = matches.iter().map(|(id, _)| id.as_str()).collect();
@@ -678,6 +672,21 @@ fn resolve_control_socket_in(
             )))
         }
     }
+}
+
+fn read_control_socket_parent(sock_parent: &Path) -> Result<std::fs::ReadDir, SandboxControlError> {
+    std::fs::read_dir(sock_parent).map_err(|e| {
+        SandboxControlError::Connection(format!(
+            "cannot read {}: {e} (is a sandbox running?)",
+            sock_parent.display()
+        ))
+    })
+}
+
+fn control_socket_not_found(input: &str) -> SandboxControlError {
+    SandboxControlError::NotFound(format!(
+        "no running sandbox matches '{input}' (no control.sock found)"
+    ))
 }
 
 #[cfg(test)]
@@ -1377,6 +1386,17 @@ mod tests {
         let missing = dir.path().join("missing");
 
         let err = resolve_control_socket_in(&missing, "nonexistent-id-12345").unwrap_err();
+
+        assert!(matches!(err, SandboxControlError::Connection(_)));
+    }
+
+    #[test]
+    fn resolve_control_socket_full_id_missing_parent_returns_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing");
+        let sandbox_id = SandboxId::new_v4();
+
+        let err = resolve_control_socket_in(&missing, &sandbox_id.to_string()).unwrap_err();
 
         assert!(matches!(err, SandboxControlError::Connection(_)));
     }

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use sandbox::{RemoteExecResult, SandboxControl, SandboxControlError};
+use sandbox::{RemoteExecResult, SandboxControl, SandboxControlError, SandboxId};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
@@ -616,6 +616,20 @@ fn resolve_control_socket_in(
     sock_parent: &Path,
     input: &str,
 ) -> Result<PathBuf, SandboxControlError> {
+    if let Ok(sandbox_id) = input.parse::<SandboxId>() {
+        let control_sock = SockPaths::new(sock_parent.join(sandbox_id.to_string())).control_sock();
+        return match control_sock.try_exists() {
+            Ok(true) => Ok(control_sock),
+            Ok(false) => Err(SandboxControlError::NotFound(format!(
+                "no running sandbox matches '{input}' (no control.sock found)"
+            ))),
+            Err(e) => Err(SandboxControlError::Connection(format!(
+                "cannot check {}: {e}",
+                control_sock.display()
+            ))),
+        };
+    }
+
     let entries = std::fs::read_dir(sock_parent).map_err(|e| {
         SandboxControlError::Connection(format!(
             "cannot read {}: {e} (is a sandbox running?)",
@@ -624,7 +638,13 @@ fn resolve_control_socket_in(
     })?;
 
     let mut matches: Vec<(String, PathBuf)> = Vec::new();
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            SandboxControlError::Connection(format!(
+                "cannot read entry in {}: {e}",
+                sock_parent.display()
+            ))
+        })?;
         let name = entry.file_name();
         let Some(name_str) = name.to_str() else {
             continue;
@@ -633,8 +653,15 @@ fn resolve_control_socket_in(
             continue;
         }
         let control_sock = SockPaths::new(entry.path()).control_sock();
-        if control_sock.exists() {
-            matches.push((name_str.to_owned(), control_sock));
+        match control_sock.try_exists() {
+            Ok(true) => matches.push((name_str.to_owned(), control_sock)),
+            Ok(false) => {}
+            Err(e) => {
+                return Err(SandboxControlError::Connection(format!(
+                    "cannot check {}: {e}",
+                    control_sock.display()
+                )));
+            }
         }
     }
 
@@ -656,6 +683,7 @@ fn resolve_control_socket_in(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::symlink;
     use std::os::unix::net::UnixListener as StdUnixListener;
 
     use crate::park_coordinator::{CoordinatorState, ParkCoordinator};
@@ -1365,6 +1393,34 @@ mod tests {
     }
 
     #[test]
+    fn resolve_control_socket_full_id_returns_exact_socket_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_id = SandboxId::new_v4();
+
+        let (control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join(sandbox_id.to_string()));
+        let (_sibling_control_sock, _sibling_listener) =
+            bind_control_socket_for_test(&sock_parent.join(format!("{sandbox_id}-suffix")));
+
+        let resolved = resolve_control_socket_in(&sock_parent, &sandbox_id.to_string()).unwrap();
+
+        assert_eq!(resolved, control_sock);
+    }
+
+    #[test]
+    fn resolve_control_socket_full_id_without_socket_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_id = SandboxId::new_v4();
+        std::fs::create_dir_all(sock_parent.join(sandbox_id.to_string())).unwrap();
+
+        let err = resolve_control_socket_in(&sock_parent, &sandbox_id.to_string()).unwrap_err();
+
+        assert!(matches!(err, SandboxControlError::NotFound(_)));
+    }
+
+    #[test]
     fn resolve_control_socket_single_match_returns_socket_path() {
         let dir = tempfile::tempdir().unwrap();
         let sock_parent = dir.path().join("sock");
@@ -1380,6 +1436,23 @@ mod tests {
         let resolved = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap();
 
         assert_eq!(resolved, control_sock);
+    }
+
+    #[test]
+    fn resolve_control_socket_prefix_socket_check_error_returns_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_dir = sock_parent.join("sandbox-aa-loop");
+        std::fs::create_dir_all(&sandbox_dir).unwrap();
+        let control_sock = SockPaths::new(sandbox_dir).control_sock();
+        symlink("control.sock", &control_sock).unwrap();
+
+        let err = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap_err();
+
+        let SandboxControlError::Connection(message) = err else {
+            panic!("expected connection error");
+        };
+        assert!(message.contains(&control_sock.display().to_string()));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -604,8 +604,8 @@ impl SandboxControl for FirecrackerControl {
 
 /// Find the control socket for a given sandbox ID (full UUID or prefix).
 ///
-/// Scans the runtime socket directory for directories matching the prefix
-/// that contain a `control.sock` file.
+/// Full UUIDs resolve through the exact socket path. Prefixes scan the runtime
+/// socket directory for matching directories that contain a `control.sock` file.
 fn resolve_control_socket(input: &str) -> Result<PathBuf, SandboxControlError> {
     let runtime = RuntimePaths::new();
     let sock_parent = runtime.sock_base();
@@ -1418,6 +1418,24 @@ mod tests {
         let err = resolve_control_socket_in(&sock_parent, &sandbox_id.to_string()).unwrap_err();
 
         assert!(matches!(err, SandboxControlError::NotFound(_)));
+    }
+
+    #[test]
+    fn resolve_control_socket_full_id_socket_check_error_returns_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_id = SandboxId::new_v4();
+        let sandbox_dir = sock_parent.join(sandbox_id.to_string());
+        std::fs::create_dir_all(&sandbox_dir).unwrap();
+        let control_sock = SockPaths::new(sandbox_dir).control_sock();
+        symlink("control.sock", &control_sock).unwrap();
+
+        let err = resolve_control_socket_in(&sock_parent, &sandbox_id.to_string()).unwrap_err();
+
+        let SandboxControlError::Connection(message) = err else {
+            panic!("expected connection error");
+        };
+        assert!(message.contains(&control_sock.display().to_string()));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -648,6 +648,15 @@ fn resolve_control_socket_in(
         if !name_str.starts_with(input) {
             continue;
         }
+        let file_type = entry.file_type().map_err(|e| {
+            SandboxControlError::Connection(format!(
+                "cannot inspect {}: {e}",
+                entry.path().display()
+            ))
+        })?;
+        if !file_type.is_dir() {
+            continue;
+        }
         let control_sock = SockPaths::new(entry.path()).control_sock();
         match control_sock.try_exists() {
             Ok(true) => matches.push((name_str.to_owned(), control_sock)),
@@ -1553,6 +1562,19 @@ mod tests {
         let non_utf8_name = std::ffi::OsString::from_vec(b"sandbox-aa-\xff".to_vec());
         let (_ignored_control_sock, _ignored_listener) =
             bind_control_socket_for_test(&sock_parent.join(non_utf8_name));
+
+        let resolved = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap();
+
+        assert_eq!(resolved, control_sock);
+    }
+
+    #[test]
+    fn resolve_control_socket_prefix_ignores_matching_non_directory_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let (control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join("sandbox-aa-live"));
+        std::fs::write(sock_parent.join("sandbox-aa-file"), b"not a directory").unwrap();
 
         let resolved = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap();
 

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -692,6 +692,7 @@ fn control_socket_not_found(input: &str) -> SandboxControlError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::ffi::OsStringExt;
     use std::os::unix::fs::symlink;
     use std::os::unix::net::UnixListener as StdUnixListener;
 
@@ -1541,6 +1542,21 @@ mod tests {
             panic!("expected connection error");
         };
         assert!(message.contains(&control_sock.display().to_string()));
+    }
+
+    #[test]
+    fn resolve_control_socket_prefix_ignores_non_utf8_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let (control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join("sandbox-aa-live"));
+        let non_utf8_name = std::ffi::OsString::from_vec(b"sandbox-aa-\xff".to_vec());
+        let (_ignored_control_sock, _ignored_listener) =
+            bind_control_socket_for_test(&sock_parent.join(non_utf8_name));
+
+        let resolved = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap();
+
+        assert_eq!(resolved, control_sock);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1439,6 +1439,20 @@ mod tests {
     }
 
     #[test]
+    fn resolve_control_socket_full_id_uses_canonical_socket_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_id = SandboxId::new_v4();
+        let (control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join(sandbox_id.to_string()));
+        let uppercase_id = sandbox_id.to_string().to_ascii_uppercase();
+
+        let resolved = resolve_control_socket_in(&sock_parent, &uppercase_id).unwrap();
+
+        assert_eq!(resolved, control_sock);
+    }
+
+    #[test]
     fn resolve_control_socket_full_id_ignores_sibling_socket_check_error() {
         let dir = tempfile::tempdir().unwrap();
         let sock_parent = dir.path().join("sock");

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1459,6 +1459,19 @@ mod tests {
     }
 
     #[test]
+    fn resolve_control_socket_full_id_without_socket_ignores_prefix_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_id = SandboxId::new_v4();
+        let (_sibling_control_sock, _sibling_listener) =
+            bind_control_socket_for_test(&sock_parent.join(format!("{sandbox_id}-suffix")));
+
+        let err = resolve_control_socket_in(&sock_parent, &sandbox_id.to_string()).unwrap_err();
+
+        assert!(matches!(err, SandboxControlError::NotFound(_)));
+    }
+
+    #[test]
     fn resolve_control_socket_full_id_socket_check_error_returns_connection() {
         let dir = tempfile::tempdir().unwrap();
         let sock_parent = dir.path().join("sock");

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1429,6 +1429,24 @@ mod tests {
     }
 
     #[test]
+    fn resolve_control_socket_full_id_ignores_sibling_socket_check_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let sandbox_id = SandboxId::new_v4();
+
+        let (control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join(sandbox_id.to_string()));
+        let sibling_dir = sock_parent.join(format!("{sandbox_id}-loop"));
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+        let sibling_control_sock = SockPaths::new(sibling_dir).control_sock();
+        symlink("control.sock", &sibling_control_sock).unwrap();
+
+        let resolved = resolve_control_socket_in(&sock_parent, &sandbox_id.to_string()).unwrap();
+
+        assert_eq!(resolved, control_sock);
+    }
+
+    #[test]
     fn resolve_control_socket_full_id_without_socket_returns_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let sock_parent = dir.path().join("sock");
@@ -1480,6 +1498,25 @@ mod tests {
     fn resolve_control_socket_prefix_socket_check_error_returns_connection() {
         let dir = tempfile::tempdir().unwrap();
         let sock_parent = dir.path().join("sock");
+        let sandbox_dir = sock_parent.join("sandbox-aa-loop");
+        std::fs::create_dir_all(&sandbox_dir).unwrap();
+        let control_sock = SockPaths::new(sandbox_dir).control_sock();
+        symlink("control.sock", &control_sock).unwrap();
+
+        let err = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap_err();
+
+        let SandboxControlError::Connection(message) = err else {
+            panic!("expected connection error");
+        };
+        assert!(message.contains(&control_sock.display().to_string()));
+    }
+
+    #[test]
+    fn resolve_control_socket_prefix_socket_check_error_prevents_partial_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let (_valid_control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join("sandbox-aa-live"));
         let sandbox_dir = sock_parent.join("sandbox-aa-loop");
         std::fs::create_dir_all(&sandbox_dir).unwrap();
         let control_sock = SockPaths::new(sandbox_dir).control_sock();

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1582,6 +1582,25 @@ mod tests {
     }
 
     #[test]
+    fn resolve_control_socket_prefix_ignores_matching_symlinked_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_parent = dir.path().join("sock");
+        let (control_sock, _listener) =
+            bind_control_socket_for_test(&sock_parent.join("sandbox-aa-live"));
+        let (_linked_control_sock, _linked_listener) =
+            bind_control_socket_for_test(&dir.path().join("linked-target"));
+        symlink(
+            dir.path().join("linked-target"),
+            sock_parent.join("sandbox-aa-link"),
+        )
+        .unwrap();
+
+        let resolved = resolve_control_socket_in(&sock_parent, "sandbox-aa-").unwrap();
+
+        assert_eq!(resolved, control_sock);
+    }
+
+    #[test]
     fn resolve_control_socket_multiple_matches_returns_ambiguous() {
         let dir = tempfile::tempdir().unwrap();
         let sock_parent = dir.path().join("sock");


### PR DESCRIPTION
## Summary

- resolve full sandbox IDs through the exact control socket path instead of scanning sibling runtime entries
- surface prefix scan entry errors and candidate `control.sock` metadata errors as `SandboxControlError::Connection`
- add regression coverage for exact-ID resolution, missing exact sockets, and `try_exists()` error handling

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc resolve_control_socket`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `git diff --check`
- `./turbo/node_modules/.bin/commitlint --config commitlint.config.mjs --from HEAD~1 --to HEAD`

Note: the first commit passed the Rust pre-commit hooks. While adding the follow-up test commit, the full crates pre-commit hook failed outside this PR's change surface in `guest-agent` / AWS smithy dependency compilation after concurrent `cargo-doc` and `cargo-clippy` target-cache use. The targeted `sandbox-fc` test, format, and clippy checks above pass.

Closes #15251
