### PR TITLE
fix: label sandbox file operation errors

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2956,6 +2956,48 @@ mod tests {
         exec_seq: u32,
     }
 
+    fn test_sandbox_with_state(state: SandboxState) -> FirecrackerSandbox {
+        let id = sandbox::SandboxId::new_v4();
+        let base_dir = std::env::temp_dir().join("sandbox-fc-operation-entrypoint-test");
+        let (state_tx, _) = watch::channel(state);
+
+        FirecrackerSandbox {
+            config: sandbox::SandboxConfig {
+                id,
+                resources: test_resources(),
+                device_rate_limits: None,
+            },
+            factory_config: FirecrackerConfig {
+                binary_path: base_dir.join("firecracker"),
+                kernel_path: base_dir.join("vmlinux"),
+                rootfs_path: base_dir.join("rootfs.ext4"),
+                base_dir: base_dir.clone(),
+                profile: "test".into(),
+                proxy_port: None,
+                dns_port: None,
+                snapshot: None,
+            },
+            id: id.to_string(),
+            sandbox_paths: SandboxPaths::new(base_dir.join("workspace")),
+            sock_paths: SockPaths::new(base_dir.join("sock")),
+            network: SandboxNetwork::from_lease(NetnsLease::new_for_test("test-ns")),
+            cow_device: None,
+            device_rate_limits: None,
+            runtime: SandboxRuntimeHandles::default(),
+            process_group_pid: None,
+            state: Arc::new(AtomicU8::new(state as u8)),
+            state_publish_lock: Arc::new(Mutex::new(())),
+            state_tx,
+            guest: Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>)),
+            park_coordinator: ParkCoordinator::new(),
+            leak_tx: None,
+            delete_workspace_on_leak_cleanup: true,
+            destroyed: true,
+            is_parked: false,
+            park_fence: None,
+        }
+    }
+
     async fn connect_mock_guest(vsock_path: &str) -> UnixStream {
         let listener_path = format!("{vsock_path}_{}", vsock_proto::VSOCK_PORT);
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -3510,6 +3552,31 @@ mod tests {
             }
             other => panic!("expected invalid state error, got {other:?}"),
         }
+    }
+
+    async fn assert_file_entrypoints_invalid_state(
+        sandbox: &FirecrackerSandbox,
+        expected_state: &str,
+    ) {
+        let read_err = sandbox
+            .read_file("/tmp/system.log", 1024)
+            .await
+            .unwrap_err();
+        assert_invalid_state_operation(read_err, SandboxOperation::ReadFile, expected_state);
+
+        let copy_err = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                Path::new("unused-copy-target"),
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_invalid_state_operation(copy_err, SandboxOperation::CopyFile, expected_state);
     }
 
     fn mark_coordinator_parked(coordinator: &ParkCoordinator) {
@@ -4941,6 +5008,35 @@ mod tests {
             );
         }
         coordinator
+            .abort_prepare_park(&attempt)
+            .expect("abort prepare park");
+    }
+
+    #[tokio::test]
+    async fn file_operation_entrypoints_preserve_operation_context_for_start_rejections() {
+        for (state, expected_state) in [
+            (SandboxState::Created, "created"),
+            (SandboxState::Running, "running"),
+        ] {
+            let sandbox = test_sandbox_with_state(state);
+
+            assert_file_entrypoints_invalid_state(&sandbox, expected_state).await;
+        }
+
+        let sandbox = test_sandbox_with_state(SandboxState::Running);
+        let attempt = sandbox
+            .park_coordinator
+            .begin_prepare_park()
+            .expect("begin prepare park");
+
+        assert_file_entrypoints_invalid_state(
+            &sandbox,
+            "ClosingForPark { attempt_id: ParkAttemptId(1) }",
+        )
+        .await;
+
+        sandbox
+            .park_coordinator
             .abort_prepare_park(&attempt)
             .expect("abort prepare park");
     }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1898,7 +1898,7 @@ impl Sandbox for FirecrackerSandbox {
     }
 
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
-        let operation = SandboxOperation::Exec;
+        let operation = SandboxOperation::ReadFile;
 
         self.run_bounded_guest_operation(operation, |guest| async move {
             guest.read_file(path, max_bytes, 5000).await
@@ -1912,7 +1912,7 @@ impl Sandbox for FirecrackerSandbox {
         host_path: &Path,
         options: CopyFileOptions,
     ) -> sandbox::Result<CopyFileResult> {
-        let operation = SandboxOperation::Exec;
+        let operation = SandboxOperation::CopyFile;
         let timeout_ms = options.timeout_ms();
 
         self.run_bounded_guest_operation(operation, |guest| async move {
@@ -4822,6 +4822,8 @@ mod tests {
     fn operation_error_classifies_observed_backend_crash_for_all_operations() {
         for operation in [
             SandboxOperation::Exec,
+            SandboxOperation::ReadFile,
+            SandboxOperation::CopyFile,
             SandboxOperation::WriteFile,
             SandboxOperation::StartProcess,
             SandboxOperation::ProcessControl,
@@ -4841,6 +4843,8 @@ mod tests {
     fn unavailable_guest_classifies_observed_backend_crash_for_all_operations() {
         for operation in [
             SandboxOperation::Exec,
+            SandboxOperation::ReadFile,
+            SandboxOperation::CopyFile,
             SandboxOperation::WriteFile,
             SandboxOperation::StartProcess,
             SandboxOperation::ProcessControl,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2980,7 +2980,10 @@ mod tests {
             id: id.to_string(),
             sandbox_paths: SandboxPaths::new(base_dir.join("workspace")),
             sock_paths: SockPaths::new(base_dir.join("sock")),
-            network: SandboxNetwork::from_lease(NetnsLease::new_for_test("test-ns")),
+            network: SandboxNetwork {
+                info: NetnsLease::new_for_test("test-ns").into_info_for_test(),
+                lease: None,
+            },
             cow_device: None,
             device_rate_limits: None,
             runtime: SandboxRuntimeHandles::default(),

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3495,14 +3495,18 @@ mod tests {
         }
     }
 
-    fn assert_invalid_state_operation(error: SandboxError, expected_operation: SandboxOperation) {
+    fn assert_invalid_state_operation(
+        error: SandboxError,
+        expected_operation: SandboxOperation,
+        expected_state: &str,
+    ) {
         match error {
             SandboxError::InvalidState { context, state, .. } => {
                 assert_eq!(
                     context,
                     SandboxInvalidStateContext::Operation(expected_operation)
                 );
-                assert_eq!(state, "created");
+                assert_eq!(state, expected_state);
             }
             other => panic!("expected invalid state error, got {other:?}"),
         }
@@ -4889,8 +4893,31 @@ mod tests {
             let err =
                 FirecrackerSandbox::operation_unavailable_error(operation, SandboxState::Created);
 
-            assert_invalid_state_operation(err, operation);
+            assert_invalid_state_operation(err, operation, "created");
         }
+    }
+
+    #[test]
+    fn operation_gate_closed_preserves_file_operation_context() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("begin prepare park");
+        let gate_state = coordinator.state();
+
+        for operation in [SandboxOperation::ReadFile, SandboxOperation::CopyFile] {
+            let err =
+                FirecrackerSandbox::operation_gate_closed_error(operation, gate_state.clone());
+
+            assert_invalid_state_operation(
+                err,
+                operation,
+                "ClosingForPark { attempt_id: ParkAttemptId(1) }",
+            );
+        }
+        coordinator
+            .abort_prepare_park(&attempt)
+            .expect("abort prepare park");
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3479,10 +3479,32 @@ mod tests {
         }
     }
 
-    fn assert_operation_reason(error: SandboxError, expected: SandboxOperationReason) {
+    fn assert_operation_error(
+        error: SandboxError,
+        expected_operation: SandboxOperation,
+        expected_reason: SandboxOperationReason,
+    ) {
         match error {
-            SandboxError::Operation { reason, .. } => assert_eq!(reason, expected),
+            SandboxError::Operation {
+                operation, reason, ..
+            } => {
+                assert_eq!(operation, expected_operation);
+                assert_eq!(reason, expected_reason);
+            }
             other => panic!("expected operation error, got {other:?}"),
+        }
+    }
+
+    fn assert_invalid_state_operation(error: SandboxError, expected_operation: SandboxOperation) {
+        match error {
+            SandboxError::InvalidState { context, state, .. } => {
+                assert_eq!(
+                    context,
+                    SandboxInvalidStateContext::Operation(expected_operation)
+                );
+                assert_eq!(state, "created");
+            }
+            other => panic!("expected invalid state error, got {other:?}"),
         }
     }
 
@@ -4526,7 +4548,11 @@ mod tests {
             false,
         );
 
-        assert_operation_reason(err, SandboxOperationReason::Timeout);
+        assert_operation_error(
+            err,
+            SandboxOperation::WaitProcess,
+            SandboxOperationReason::Timeout,
+        );
     }
 
     #[test]
@@ -4537,7 +4563,7 @@ mod tests {
             false,
         );
 
-        assert_operation_reason(err, SandboxOperationReason::Guest);
+        assert_operation_error(err, SandboxOperation::Exec, SandboxOperationReason::Guest);
     }
 
     #[test]
@@ -4835,7 +4861,7 @@ mod tests {
                 true,
             );
 
-            assert_operation_reason(err, SandboxOperationReason::BackendCrashed);
+            assert_operation_error(err, operation, SandboxOperationReason::BackendCrashed);
         }
     }
 
@@ -4853,7 +4879,17 @@ mod tests {
             let err =
                 FirecrackerSandbox::operation_unavailable_error(operation, SandboxState::Crashed);
 
-            assert_operation_reason(err, SandboxOperationReason::BackendCrashed);
+            assert_operation_error(err, operation, SandboxOperationReason::BackendCrashed);
+        }
+    }
+
+    #[test]
+    fn unavailable_guest_preserves_file_operation_context_for_not_running_state() {
+        for operation in [SandboxOperation::ReadFile, SandboxOperation::CopyFile] {
+            let err =
+                FirecrackerSandbox::operation_unavailable_error(operation, SandboxState::Created);
+
+            assert_invalid_state_operation(err, operation);
         }
     }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -4571,6 +4571,25 @@ mod tests {
     }
 
     #[test]
+    fn operation_error_preserves_file_operation_context_for_guest_failures() {
+        for operation in [SandboxOperation::ReadFile, SandboxOperation::CopyFile] {
+            let timeout = FirecrackerSandbox::operation_error(
+                operation,
+                io::Error::new(io::ErrorKind::TimedOut, "operation timed out"),
+                false,
+            );
+            let guest = FirecrackerSandbox::operation_error(
+                operation,
+                io::Error::new(io::ErrorKind::BrokenPipe, "connection closed"),
+                false,
+            );
+
+            assert_operation_error(timeout, operation, SandboxOperationReason::Timeout);
+            assert_operation_error(guest, operation, SandboxOperationReason::Guest);
+        }
+    }
+
+    #[test]
     fn process_timeout_policy_maps_zero_to_none_and_millis_to_duration() {
         assert_eq!(process_timeout_policy(0), ExecTimeoutPolicy::None);
         assert_eq!(
@@ -4888,12 +4907,18 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_guest_preserves_file_operation_context_for_not_running_state() {
+    fn unavailable_guest_preserves_file_operation_context_for_non_crashed_states() {
         for operation in [SandboxOperation::ReadFile, SandboxOperation::CopyFile] {
-            let err =
-                FirecrackerSandbox::operation_unavailable_error(operation, SandboxState::Created);
+            for (state, expected_state) in [
+                (SandboxState::Created, "created"),
+                (SandboxState::Running, "running"),
+                (SandboxState::Stopping, "stopping"),
+                (SandboxState::Stopped, "stopped"),
+            ] {
+                let err = FirecrackerSandbox::operation_unavailable_error(operation, state);
 
-            assert_invalid_state_operation(err, operation, "created");
+                assert_invalid_state_operation(err, operation, expected_state);
+            }
         }
     }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -906,7 +906,7 @@ impl Sandbox for MockSandbox {
             });
         if max_bytes == 0 {
             return Err(SandboxError::Operation {
-                operation: SandboxOperation::Exec,
+                operation: SandboxOperation::ReadFile,
                 reason: SandboxOperationReason::Other,
                 message: "mock read_file max_bytes must be positive".into(),
             });
@@ -921,7 +921,7 @@ impl Sandbox for MockSandbox {
             && bytes.len() as u64 > max_bytes
         {
             return Err(SandboxError::Operation {
-                operation: SandboxOperation::Exec,
+                operation: SandboxOperation::ReadFile,
                 reason: SandboxOperationReason::Other,
                 message: format!("mock read_file exceeded {max_bytes} bytes"),
             });
@@ -946,14 +946,14 @@ impl Sandbox for MockSandbox {
             });
         if options.max_bytes == 0 {
             return Err(SandboxError::Operation {
-                operation: SandboxOperation::Exec,
+                operation: SandboxOperation::CopyFile,
                 reason: SandboxOperationReason::Other,
                 message: "mock copy_file max_bytes must be positive".into(),
             });
         }
         if options.timeout.is_zero() {
             return Err(SandboxError::Operation {
-                operation: SandboxOperation::Exec,
+                operation: SandboxOperation::CopyFile,
                 reason: SandboxOperationReason::Other,
                 message: "mock copy_file timeout must be positive".into(),
             });
@@ -969,7 +969,7 @@ impl Sandbox for MockSandbox {
         };
         if bytes.len() as u64 > options.max_bytes {
             return Err(SandboxError::Operation {
-                operation: SandboxOperation::Exec,
+                operation: SandboxOperation::CopyFile,
                 reason: SandboxOperationReason::Other,
                 message: format!("mock copy_file exceeded {} bytes", options.max_bytes),
             });
@@ -1449,6 +1449,26 @@ mod tests {
         }
     }
 
+    fn assert_operation_error(
+        error: SandboxError,
+        expected_operation: SandboxOperation,
+        expected_reason: SandboxOperationReason,
+        expected_message: &str,
+    ) {
+        match error {
+            SandboxError::Operation {
+                operation,
+                reason,
+                message,
+            } => {
+                assert_eq!(operation, expected_operation);
+                assert_eq!(reason, expected_reason);
+                assert!(message.contains(expected_message), "got: {message}");
+            }
+            other => panic!("expected operation error, got {other:?}"),
+        }
+    }
+
     fn test_timeout() -> Duration {
         Duration::from_secs(5)
     }
@@ -1672,7 +1692,12 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(err.to_string().contains("exceeded 3 bytes"));
+        assert_operation_error(
+            err,
+            SandboxOperation::CopyFile,
+            SandboxOperationReason::Other,
+            "exceeded 3 bytes",
+        );
         assert!(!path.exists());
     }
 
@@ -1696,7 +1721,12 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("max_bytes must be positive"));
+        assert_operation_error(
+            err,
+            SandboxOperation::CopyFile,
+            SandboxOperationReason::Other,
+            "max_bytes must be positive",
+        );
         assert!(!path.exists());
 
         let err = sandbox
@@ -1711,7 +1741,12 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("timeout must be positive"));
+        assert_operation_error(
+            err,
+            SandboxOperation::CopyFile,
+            SandboxOperationReason::Other,
+            "timeout must be positive",
+        );
         assert!(!path.exists());
     }
 
@@ -1750,7 +1785,12 @@ mod tests {
 
         let err = sandbox.read_file("/tmp/system.log", 3).await.unwrap_err();
 
-        assert!(err.to_string().contains("exceeded 3 bytes"));
+        assert_operation_error(
+            err,
+            SandboxOperation::ReadFile,
+            SandboxOperationReason::Other,
+            "exceeded 3 bytes",
+        );
     }
 
     #[tokio::test]
@@ -1759,7 +1799,12 @@ mod tests {
 
         let err = sandbox.read_file("/tmp/system.log", 0).await.unwrap_err();
 
-        assert!(err.to_string().contains("max_bytes must be positive"));
+        assert_operation_error(
+            err,
+            SandboxOperation::ReadFile,
+            SandboxOperationReason::Other,
+            "max_bytes must be positive",
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -84,6 +84,10 @@ impl fmt::Display for SandboxInitializationPhase {
 pub enum SandboxOperation {
     /// [`Sandbox::exec`](crate::Sandbox::exec).
     Exec,
+    /// [`Sandbox::read_file`](crate::Sandbox::read_file).
+    ReadFile,
+    /// [`Sandbox::copy_file`](crate::Sandbox::copy_file).
+    CopyFile,
     /// [`Sandbox::write_file`](crate::Sandbox::write_file).
     WriteFile,
     /// [`Sandbox::start_process`](crate::Sandbox::start_process).
@@ -98,6 +102,8 @@ impl fmt::Display for SandboxOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Exec => f.write_str("exec"),
+            Self::ReadFile => f.write_str("read file"),
+            Self::CopyFile => f.write_str("copy file"),
             Self::WriteFile => f.write_str("write file"),
             Self::StartProcess => f.write_str("start process"),
             Self::ProcessControl => f.write_str("process control"),

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -98,3 +98,26 @@ fn display_includes_category_and_message() {
     assert!(text.contains("backend crashed"), "got: {text}");
     assert!(text.contains("firecracker process crashed"), "got: {text}");
 }
+
+#[test]
+fn display_includes_file_operation_labels() {
+    let read_err = SandboxError::Operation {
+        operation: SandboxOperation::ReadFile,
+        reason: SandboxOperationReason::Guest,
+        message: "missing diagnostics".into(),
+    };
+    let copy_err = SandboxError::Operation {
+        operation: SandboxOperation::CopyFile,
+        reason: SandboxOperationReason::Timeout,
+        message: "copy timed out".into(),
+    };
+
+    assert!(
+        read_err.to_string().contains("sandbox read file failed"),
+        "got: {read_err}"
+    );
+    assert!(
+        copy_err.to_string().contains("sandbox copy file failed"),
+        "got: {copy_err}"
+    );
+}

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -111,6 +111,16 @@ fn display_includes_file_operation_labels() {
         reason: SandboxOperationReason::Timeout,
         message: "copy timed out".into(),
     };
+    let read_state_err = SandboxError::InvalidState {
+        context: SandboxInvalidStateContext::Operation(SandboxOperation::ReadFile),
+        state: "created".into(),
+        message: "sandbox not running".into(),
+    };
+    let copy_state_err = SandboxError::InvalidState {
+        context: SandboxInvalidStateContext::Operation(SandboxOperation::CopyFile),
+        state: "stopped".into(),
+        message: "sandbox not running".into(),
+    };
 
     assert!(
         read_err.to_string().contains("sandbox read file failed"),
@@ -119,5 +129,17 @@ fn display_includes_file_operation_labels() {
     assert!(
         copy_err.to_string().contains("sandbox copy file failed"),
         "got: {copy_err}"
+    );
+    assert!(
+        read_state_err
+            .to_string()
+            .contains("invalid state for read file operation"),
+        "got: {read_state_err}"
+    );
+    assert!(
+        copy_state_err
+            .to_string()
+            .contains("invalid state for copy file operation"),
+        "got: {copy_state_err}"
     );
 }


### PR DESCRIPTION
## Summary

- Add `ReadFile` and `CopyFile` sandbox operation labels.
- Use those labels in both real Firecracker sandbox file operations and mock file-operation errors.
- Strengthen tests so file-operation errors assert structured operation fields, not only formatted text.

## Risk / Compatibility

- Error display text for affected file-operation failures changes from `sandbox exec failed ...` to `sandbox read file failed ...` / `sandbox copy file failed ...`.
- Metrics or logs grouped by operation text may now classify these failures under file-operation buckets instead of `exec`.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `git diff --check`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- pre-commit: Rust `cargo-fmt`, `cargo-clippy`, `cargo-doc`

Fixes #15250
