### PR TITLE
feat(web): add 3 new illustration styles to gallery

### DIFF
--- a/turbo/apps/web/app/[locale]/illustration/data.ts
+++ b/turbo/apps/web/app/[locale]/illustration/data.ts
@@ -19,11 +19,7 @@ export const ILLUSTRATION_STYLES: readonly IllustrationStyle[] = [
     sample: "ref-l1-lupo.png",
     width: 1024,
     height: 1536,
-    refs: [
-      "ref-l1-lupo.png",
-      "ref-l1-petit-pain.png",
-      "ref-l2-fleur-fern.png",
-    ],
+    refs: ["ref-l1-lupo.png", "ref-l1-petit-pain.png", "ref-l2-fleur-fern.png"],
   },
   {
     slug: "tiny-wanderer",

--- a/turbo/apps/web/app/[locale]/illustration/data.ts
+++ b/turbo/apps/web/app/[locale]/illustration/data.ts
@@ -12,6 +12,46 @@ export interface IllustrationStyle {
 
 export const ILLUSTRATION_STYLES: readonly IllustrationStyle[] = [
   {
+    slug: "ink-storefront",
+    title: "Ink Storefront",
+    image: "ink-storefront.png",
+    cover: "refs/ink-storefront/ref-l1-lupo.png",
+    sample: "ref-l1-lupo.png",
+    width: 1024,
+    height: 1536,
+    refs: [
+      "ref-l1-lupo.png",
+      "ref-l1-petit-pain.png",
+      "ref-l2-fleur-fern.png",
+    ],
+  },
+  {
+    slug: "tiny-wanderer",
+    title: "Tiny Wanderer",
+    image: "tiny-wanderer.jpg",
+    cover: "refs/tiny-wanderer/varA.jpg",
+    sample: "varA.jpg",
+    width: 512,
+    height: 768,
+    refs: ["varA.jpg", "varB.jpg", "varC.jpg", "varD.jpg"],
+  },
+  {
+    slug: "crowd-ink",
+    title: "Crowd Ink",
+    image: "crowd-ink.png",
+    cover: "refs/crowd-ink/anchor.png",
+    sample: "anchor.png",
+    width: 1536,
+    height: 1024,
+    refs: [
+      "anchor.png",
+      "sample-cafe.png",
+      "sample-office.png",
+      "sample-picnic.png",
+      "sample-subway.png",
+    ],
+  },
+  {
     slug: "cozy-parlor",
     title: "Cozy Parlor",
     image: "cozy-parlor.jpg",


### PR DESCRIPTION
## Summary
- Adds the three latest illustration styles to `/[locale]/illustration` so the gallery stays in sync with `vm0-skills` register:
  - **Ink Storefront** — boutique fineliner storefronts on warm cream paper (vm0-skills PR #239)
  - **Tiny Wanderer** — contemplative bande-dessinée landscape with a tiny human dwarfed by the panorama (vm0-skills PR #238)
  - **Crowd Ink** — hand-drawn editorial crowd vignettes with flat 3-color spot fills (vm0-skills PR #237)
- All three are inserted at the top of `ILLUSTRATION_STYLES` in `turbo/apps/web/app/[locale]/illustration/data.ts`, matching the existing new-first ordering.

## Skipped
- `vm0-illustration` (registered via #14949) — its `vm0-skills/illustration-template/vm0-illustration/` folder only contains `SKILL.md`, no image refs yet. Will add once reference variants are checked in.

## Heads-up — asset host backlog (separate)
- The gallery is served from `quiet-moments-gallery-715f6d07.sites.vm0.io`, which currently hosts assets for only the original 24 styles. The four entries added in PR #15216 (cozy-parlor, iberian-vignette, shadow-pop, jade-blockprint) also still need their images uploaded; these three new ones extend that backlog. Tiles will render 404 covers until the static site is re-published with the new assets — happy to follow up separately when ready.

## Test plan
- [ ] \`pnpm dev\` and open \`/en/illustration\` — three new tiles appear at the top of the masonry grid
- [ ] Lightbox opens with the listed sample for each style, and the refs strip cycles through every variation
- [ ] \`Pieces\` count in the masthead shows \`31 styles\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)