### PR TITLE
ci: sync connector oauth secret bundle

### DIFF
--- a/.github/scripts/build-connector-oauth-client-secrets-bundle.sh
+++ b/.github/scripts/build-connector-oauth-client-secrets-bundle.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MAX_GITHUB_SECRET_BYTES=49152
+
+readonly EXPECTED_KEYS=(
+  AIRTABLE_OAUTH_CLIENT_SECRET
+  ASANA_OAUTH_CLIENT_SECRET
+  CANVA_OAUTH_CLIENT_SECRET
+  CLOSE_OAUTH_CLIENT_SECRET
+  DEEL_OAUTH_CLIENT_SECRET
+  DOCUSIGN_OAUTH_CLIENT_SECRET
+  DROPBOX_OAUTH_CLIENT_SECRET
+  FIGMA_OAUTH_CLIENT_SECRET
+  GH_OAUTH_CLIENT_SECRET
+  GOOGLE_OAUTH_CLIENT_SECRET
+  GUMROAD_OAUTH_CLIENT_SECRET
+  AHREFS_OAUTH_CLIENT_SECRET
+  HUBSPOT_OAUTH_CLIENT_SECRET
+  INTERVALS_ICU_OAUTH_CLIENT_SECRET
+  LINEAR_OAUTH_CLIENT_SECRET
+  NEON_OAUTH_CLIENT_SECRET
+  META_ADS_OAUTH_CLIENT_SECRET
+  MERCURY_OAUTH_CLIENT_SECRET
+  MICROSOFT_OAUTH_CLIENT_SECRET
+  MONDAY_OAUTH_CLIENT_SECRET
+  NOTION_OAUTH_CLIENT_SECRET
+  POSTHOG_OAUTH_CLIENT_SECRET
+  REDDIT_OAUTH_CLIENT_SECRET
+  SENTRY_OAUTH_CLIENT_SECRET
+  SLACK_OAUTH_CLIENT_SECRET
+  SPOTIFY_OAUTH_CLIENT_SECRET
+  STRAVA_OAUTH_CLIENT_SECRET
+  STRIPE_OAUTH_CLIENT_SECRET
+  SUPABASE_OAUTH_CLIENT_SECRET
+  TODOIST_OAUTH_CLIENT_SECRET
+  VERCEL_OAUTH_CLIENT_SECRET
+  WEBFLOW_OAUTH_CLIENT_SECRET
+  XERO_OAUTH_CLIENT_SECRET
+  X_OAUTH_CLIENT_SECRET
+)
+
+error() {
+  echo "::error::$*"
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    error "${name} is required"
+    exit 1
+  fi
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "$2"
+    exit 1
+  fi
+}
+
+mask_value() {
+  if [[ "${GITHUB_ACTIONS:-}" != "true" || -z "$1" ]]; then
+    return
+  fi
+
+  local value="$1"
+  value="${value//'%'/'%25'}"
+  value="${value//$'\r'/'%0D'}"
+  value="${value//$'\n'/'%0A'}"
+  echo "::add-mask::$value"
+}
+
+op_item_for_key() {
+  local key="$1"
+  case "$key" in
+    GH_OAUTH_CLIENT_SECRET)
+      printf 'github'
+      ;;
+    *_OAUTH_CLIENT_SECRET)
+      local prefix="${key%_OAUTH_CLIENT_SECRET}"
+      printf '%s' "$prefix" | tr '[:upper:]_' '[:lower:]-'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+require_env VAULT_NAME
+require_env OUTPUT_FILE
+require_env OP_SERVICE_ACCOUNT_TOKEN
+require_tool op "1Password CLI (op) is not installed"
+require_tool jq "jq is not installed"
+
+case "$VAULT_NAME" in
+  Development | Production) ;;
+  *)
+    error "VAULT_NAME must be Development or Production"
+    exit 1
+    ;;
+esac
+
+bundle_tmp="$(mktemp)"
+next_tmp="$(mktemp)"
+trap 'rm -f "$bundle_tmp" "$next_tmp"' EXIT
+
+printf '{}\n' > "$bundle_tmp"
+
+failures=0
+bundled=0
+
+for key in "${EXPECTED_KEYS[@]}"; do
+  if ! item="$(op_item_for_key "$key")"; then
+    error "No 1Password item mapping for ${key}"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  ref="op://${VAULT_NAME}/${item}/${key}"
+  if ! value="$(op read "$ref" 2>/dev/null)"; then
+    error "${key} is missing or unreadable from 1Password (${ref})"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if [[ -z "$value" ]]; then
+    error "${key} is empty in 1Password (${ref})"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  mask_value "$value"
+
+  jq --arg key "$key" --arg value "$value" '. + {($key): $value}' "$bundle_tmp" > "$next_tmp"
+  mv "$next_tmp" "$bundle_tmp"
+  bundled=$((bundled + 1))
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  error "${failures} connector OAuth client secret value(s) failed validation"
+  exit 1
+fi
+
+if ! bundle_json="$(jq -c -e . "$bundle_tmp")"; then
+  error "generated connector OAuth client secret bundle is not valid JSON"
+  exit 1
+fi
+
+bundle_bytes="$(printf '%s' "$bundle_json" | wc -c | tr -d '[:space:]')"
+if [[ "$bundle_bytes" -gt "$MAX_GITHUB_SECRET_BYTES" ]]; then
+  error "connector OAuth client secret bundle is ${bundle_bytes} bytes; GitHub secret limit is ${MAX_GITHUB_SECRET_BYTES} bytes"
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+printf '%s' "$bundle_json" > "$OUTPUT_FILE"
+chmod 600 "$OUTPUT_FILE"
+
+echo "Bundled ${bundled} connector OAuth client secret entries from ${VAULT_NAME} into ${OUTPUT_FILE} (${bundle_bytes} bytes)"

--- a/.github/scripts/build-connector-oauth-client-secrets-bundle.sh
+++ b/.github/scripts/build-connector-oauth-client-secrets-bundle.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 
 readonly MAX_GITHUB_SECRET_BYTES=49152
 

--- a/.github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
+++ b/.github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
@@ -38,6 +38,24 @@ assert_json_value() {
   fi
 }
 
+assert_file_does_not_end_with_newline() {
+  local file=$1
+  local last_byte
+  last_byte="$(tail -c 1 "$file" | od -An -t x1 | tr -d '[:space:]')"
+  if [[ "$last_byte" == "0a" ]]; then
+    fail "expected ${file} to contain compact JSON without trailing newline"
+  fi
+}
+
+assert_file_mode() {
+  local file=$1 expected=$2
+  local actual
+  actual="$(stat -c '%a' "$file")"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "expected ${file} mode ${expected}, got ${actual}"
+  fi
+}
+
 mkdir -p "${TMPDIR}/bin"
 cat > "${TMPDIR}/bin/op" <<'BASH'
 #!/usr/bin/env bash
@@ -117,17 +135,19 @@ success_output="$(
 )"
 assert_contains "$success_output" "Bundled 34 connector OAuth client secret entries from Development"
 jq -c -e . "$success_bundle" >/dev/null
+if [[ "$(jq 'length' "$success_bundle")" != "34" ]]; then
+  fail "expected bundle to contain 34 connector OAuth client secret entries"
+fi
 assert_json_value "$success_bundle" GH_OAUTH_CLIENT_SECRET secret-Development-GH_OAUTH_CLIENT_SECRET
 assert_json_value "$success_bundle" GOOGLE_OAUTH_CLIENT_SECRET secret-Development-GOOGLE_OAUTH_CLIENT_SECRET
 assert_json_value "$success_bundle" SLACK_OAUTH_CLIENT_SECRET secret-Development-SLACK_OAUTH_CLIENT_SECRET
 assert_json_value "$success_bundle" META_ADS_OAUTH_CLIENT_SECRET secret-Development-META_ADS_OAUTH_CLIENT_SECRET
+assert_file_does_not_end_with_newline "$success_bundle"
+assert_file_mode "$success_bundle" 600
 
 success_log_output="$(without_mask_commands "$success_output")"
 assert_not_contains "$success_log_output" "secret-Development-GOOGLE_OAUTH_CLIENT_SECRET"
 assert_not_contains "$success_log_output" "secret-Development-SLACK_OAUTH_CLIENT_SECRET"
-if [[ "$(tail -c 1 "$success_bundle")" == $'\n' ]]; then
-  fail "expected compact JSON without trailing newline"
-fi
 
 production_bundle="${TMPDIR}/production-bundle.json"
 production_output="$(
@@ -176,6 +196,20 @@ if [[ "$status" -eq 0 ]]; then
   fail "expected missing VAULT_NAME case to fail"
 fi
 assert_contains "$missing_vault_output" "VAULT_NAME is required"
+
+status=0
+invalid_vault_output="$(
+  env -i \
+    PATH="${TMPDIR}/bin:${PATH}" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Preview \
+    OUTPUT_FILE="${TMPDIR}/invalid-vault.json" \
+    "$BUILDER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected invalid VAULT_NAME case to fail"
+fi
+assert_contains "$invalid_vault_output" "VAULT_NAME must be Development or Production"
 
 status=0
 missing_output_file_output="$(

--- a/.github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
+++ b/.github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILDER="${SCRIPT_DIR}/build-connector-oauth-client-secrets-bundle.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local output=$1 expected=$2
+  if [[ "$output" != *"$expected"* ]]; then
+    fail "expected output to contain: ${expected}"
+  fi
+}
+
+assert_not_contains() {
+  local output=$1 unexpected=$2
+  if [[ "$output" == *"$unexpected"* ]]; then
+    fail "expected output not to contain: ${unexpected}"
+  fi
+}
+
+without_mask_commands() {
+  grep -v '^::add-mask::' <<< "$1" || true
+}
+
+assert_json_value() {
+  local file=$1 key=$2 expected=$3
+  local actual
+  actual="$(jq -r --arg key "$key" '.[$key] // ""' "$file")"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "expected ${key} to be ${expected}, got ${actual}"
+  fi
+}
+
+mkdir -p "${TMPDIR}/bin"
+cat > "${TMPDIR}/bin/op" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+item_for_key() {
+  local key="$1"
+  case "$key" in
+    GH_OAUTH_CLIENT_SECRET)
+      printf 'github'
+      ;;
+    *_OAUTH_CLIENT_SECRET)
+      local prefix="${key%_OAUTH_CLIENT_SECRET}"
+      printf '%s' "$prefix" | tr '[:upper:]_' '[:lower:]-'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [[ "$1" == "read" ]]; then
+  ref="$2"
+  path="${ref#op://}"
+  vault="${path%%/*}"
+  rest="${path#*/}"
+  item="${rest%%/*}"
+  key="${rest#*/}"
+
+  expected_item="$(item_for_key "$key")"
+  if [[ "$item" != "$expected_item" ]]; then
+    echo "expected item ${expected_item} for ${key}, got ${item}" >&2
+    exit 1
+  fi
+
+  case "${OP_STUB_MODE:-success}:${key}" in
+    missing:GOOGLE_OAUTH_CLIENT_SECRET)
+      echo "missing field" >&2
+      exit 1
+      ;;
+    empty:GOOGLE_OAUTH_CLIENT_SECRET)
+      exit 0
+      ;;
+    large:GOOGLE_OAUTH_CLIENT_SECRET)
+      printf 'x%.0s' {1..50000}
+      exit 0
+      ;;
+  esac
+
+  printf 'secret-%s-%s' "$vault" "$key"
+  exit 0
+fi
+
+echo "unexpected op invocation: $*" >&2
+exit 1
+BASH
+chmod +x "${TMPDIR}/bin/op"
+
+mkdir -p "${TMPDIR}/no-op-bin"
+ln -s "$(command -v bash)" "${TMPDIR}/no-op-bin/bash"
+
+run_builder() {
+  local output_file="$1"
+  env -i \
+    PATH="${TMPDIR}/bin:${PATH}" \
+    GITHUB_ACTIONS="${GITHUB_ACTIONS:-}" \
+    OP_STUB_MODE="${OP_STUB_MODE:-}" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME="${VAULT_NAME:-Development}" \
+    OUTPUT_FILE="$output_file" \
+    "$BUILDER"
+}
+
+success_bundle="${TMPDIR}/bundle.json"
+success_output="$(
+  GITHUB_ACTIONS=true run_builder "$success_bundle"
+)"
+assert_contains "$success_output" "Bundled 34 connector OAuth client secret entries from Development"
+jq -c -e . "$success_bundle" >/dev/null
+assert_json_value "$success_bundle" GH_OAUTH_CLIENT_SECRET secret-Development-GH_OAUTH_CLIENT_SECRET
+assert_json_value "$success_bundle" GOOGLE_OAUTH_CLIENT_SECRET secret-Development-GOOGLE_OAUTH_CLIENT_SECRET
+assert_json_value "$success_bundle" SLACK_OAUTH_CLIENT_SECRET secret-Development-SLACK_OAUTH_CLIENT_SECRET
+assert_json_value "$success_bundle" META_ADS_OAUTH_CLIENT_SECRET secret-Development-META_ADS_OAUTH_CLIENT_SECRET
+
+success_log_output="$(without_mask_commands "$success_output")"
+assert_not_contains "$success_log_output" "secret-Development-GOOGLE_OAUTH_CLIENT_SECRET"
+assert_not_contains "$success_log_output" "secret-Development-SLACK_OAUTH_CLIENT_SECRET"
+if [[ "$(tail -c 1 "$success_bundle")" == $'\n' ]]; then
+  fail "expected compact JSON without trailing newline"
+fi
+
+production_bundle="${TMPDIR}/production-bundle.json"
+production_output="$(
+  VAULT_NAME=Production run_builder "$production_bundle"
+)"
+assert_contains "$production_output" "from Production"
+assert_json_value "$production_bundle" GOOGLE_OAUTH_CLIENT_SECRET secret-Production-GOOGLE_OAUTH_CLIENT_SECRET
+
+status=0
+missing_op_output="$(
+  env -i \
+    PATH="${TMPDIR}/no-op-bin" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Development \
+    OUTPUT_FILE="${TMPDIR}/missing-op.json" \
+    "$BUILDER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing op case to fail"
+fi
+assert_contains "$missing_op_output" "1Password CLI (op) is not installed"
+
+status=0
+missing_jq_output="$(
+  env -i \
+    PATH="${TMPDIR}/bin:${TMPDIR}/no-op-bin" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Development \
+    OUTPUT_FILE="${TMPDIR}/missing-jq.json" \
+    "$BUILDER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing jq case to fail"
+fi
+assert_contains "$missing_jq_output" "jq is not installed"
+
+status=0
+missing_vault_output="$(
+  env -i \
+    PATH="${TMPDIR}/bin:${PATH}" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    OUTPUT_FILE="${TMPDIR}/missing-vault.json" \
+    "$BUILDER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing VAULT_NAME case to fail"
+fi
+assert_contains "$missing_vault_output" "VAULT_NAME is required"
+
+status=0
+missing_output_file_output="$(
+  env -i \
+    PATH="${TMPDIR}/bin:${PATH}" \
+    OP_SERVICE_ACCOUNT_TOKEN=test-token \
+    VAULT_NAME=Development \
+    "$BUILDER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing OUTPUT_FILE case to fail"
+fi
+assert_contains "$missing_output_file_output" "OUTPUT_FILE is required"
+
+status=0
+missing_token_output="$(
+  env -i \
+    PATH="${TMPDIR}/bin:${PATH}" \
+    VAULT_NAME=Development \
+    OUTPUT_FILE="${TMPDIR}/missing-token.json" \
+    "$BUILDER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing OP_SERVICE_ACCOUNT_TOKEN case to fail"
+fi
+assert_contains "$missing_token_output" "OP_SERVICE_ACCOUNT_TOKEN is required"
+
+status=0
+missing_secret_output="$(
+  OP_STUB_MODE=missing run_builder "${TMPDIR}/missing-secret.json" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing 1Password field case to fail"
+fi
+assert_contains "$missing_secret_output" "GOOGLE_OAUTH_CLIENT_SECRET is missing or unreadable from 1Password"
+assert_contains "$missing_secret_output" "connector OAuth client secret value(s) failed validation"
+
+status=0
+empty_secret_output="$(
+  OP_STUB_MODE=empty run_builder "${TMPDIR}/empty-secret.json" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected empty 1Password field case to fail"
+fi
+assert_contains "$empty_secret_output" "GOOGLE_OAUTH_CLIENT_SECRET is empty in 1Password"
+
+status=0
+large_bundle_output="$(
+  OP_STUB_MODE=large run_builder "${TMPDIR}/large-bundle.json" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected oversized bundle case to fail"
+fi
+assert_contains "$large_bundle_output" "GitHub secret limit is 49152 bytes"
+
+echo "build-connector-oauth-client-secrets-bundle-test: ok"

--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -1,0 +1,117 @@
+name: Sync Connector OAuth Client Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Secret scope to sync"
+        required: true
+        type: choice
+        options:
+          - development
+          - production
+        default: development
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  validate-ref:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      contents: read
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Run this workflow from the main branch"
+            exit 1
+          fi
+
+  sync-development:
+    needs: validate-ref
+    if: github.ref == 'refs/heads/main' && inputs.scope == 'development'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build development bundle
+        id: bundle
+        shell: bash
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          VAULT_NAME: Development
+        run: |
+          set -euo pipefail
+          bundle="${RUNNER_TEMP}/connector-oauth-client-secrets-development.json"
+          OUTPUT_FILE="$bundle" .github/scripts/build-connector-oauth-client-secrets-bundle.sh
+          echo "file=$bundle" >> "$GITHUB_OUTPUT"
+
+      - name: Write development secret
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUNDLE_FILE: ${{ steps.bundle.outputs.file }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::GH_TOKEN is required to update CONNECTOR_OAUTH_CLIENT_SECRETS"
+            exit 1
+          fi
+
+          if ! gh secret set CONNECTOR_OAUTH_CLIENT_SECRETS --repo "$GITHUB_REPOSITORY" < "$BUNDLE_FILE"; then
+            echo "::error::Failed to update repository secret CONNECTOR_OAUTH_CLIENT_SECRETS with GITHUB_TOKEN"
+            exit 1
+          fi
+
+  sync-production:
+    needs: validate-ref
+    if: github.ref == 'refs/heads/main' && inputs.scope == 'production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+    permissions:
+      contents: read
+      actions: write
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build production bundle
+        id: bundle
+        shell: bash
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          VAULT_NAME: Production
+        run: |
+          set -euo pipefail
+          bundle="${RUNNER_TEMP}/connector-oauth-client-secrets-production.json"
+          OUTPUT_FILE="$bundle" .github/scripts/build-connector-oauth-client-secrets-bundle.sh
+          echo "file=$bundle" >> "$GITHUB_OUTPUT"
+
+      - name: Write production secret
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUNDLE_FILE: ${{ steps.bundle.outputs.file }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::GH_TOKEN is required to update CONNECTOR_OAUTH_CLIENT_SECRETS"
+            exit 1
+          fi
+
+          if ! gh secret set CONNECTOR_OAUTH_CLIENT_SECRETS --repo "$GITHUB_REPOSITORY" --env production < "$BUNDLE_FILE"; then
+            echo "::error::Failed to update production environment secret CONNECTOR_OAUTH_CLIENT_SECRETS with GITHUB_TOKEN"
+            exit 1
+          fi

--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -62,7 +62,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
+          app-id: ${{ vars.VM0_GITHUB_APP_ID || vars.VM0_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ steps.github-app-private-key.outputs.private-key }}
           permission-secrets: write
 
@@ -128,7 +128,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
+          app-id: ${{ vars.VM0_GITHUB_APP_ID || vars.VM0_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ steps.github-app-private-key.outputs.private-key }}
           permission-environments: write
 

--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   validate-ref:
@@ -40,9 +39,32 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
-      actions: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Decode GitHub App private key
+        id: github-app-private-key
+        shell: bash
+        env:
+          VM0_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${VM0_GITHUB_APP_PRIVATE_KEY:-}" ]]; then
+            echo "::error::VM0_GITHUB_APP_PRIVATE_KEY is required to create a GitHub App token"
+            exit 1
+          fi
+
+          private_key="$(printf '%s' "$VM0_GITHUB_APP_PRIVATE_KEY" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)"
+          echo "::add-mask::$private_key"
+          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+
+      - name: Create repository secret token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
+          private-key: ${{ steps.github-app-private-key.outputs.private-key }}
+          permission-secrets: write
 
       - name: Build development bundle
         id: bundle
@@ -59,7 +81,7 @@ jobs:
       - name: Write development secret
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BUNDLE_FILE: ${{ steps.bundle.outputs.file }}
         run: |
           set -euo pipefail
@@ -69,7 +91,7 @@ jobs:
           fi
 
           if ! gh secret set CONNECTOR_OAUTH_CLIENT_SECRETS --repo "$GITHUB_REPOSITORY" < "$BUNDLE_FILE"; then
-            echo "::error::Failed to update repository secret CONNECTOR_OAUTH_CLIENT_SECRETS with GITHUB_TOKEN"
+            echo "::error::Failed to update repository secret CONNECTOR_OAUTH_CLIENT_SECRETS with the GitHub App token"
             exit 1
           fi
 
@@ -82,10 +104,33 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
-      actions: write
     environment: production
     steps:
       - uses: actions/checkout@v6
+
+      - name: Decode GitHub App private key
+        id: github-app-private-key
+        shell: bash
+        env:
+          VM0_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${VM0_GITHUB_APP_PRIVATE_KEY:-}" ]]; then
+            echo "::error::VM0_GITHUB_APP_PRIVATE_KEY is required to create a GitHub App token"
+            exit 1
+          fi
+
+          private_key="$(printf '%s' "$VM0_GITHUB_APP_PRIVATE_KEY" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)"
+          echo "::add-mask::$private_key"
+          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+
+      - name: Create environment secret token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
+          private-key: ${{ steps.github-app-private-key.outputs.private-key }}
+          permission-environments: write
 
       - name: Build production bundle
         id: bundle
@@ -102,7 +147,7 @@ jobs:
       - name: Write production secret
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BUNDLE_FILE: ${{ steps.bundle.outputs.file }}
         run: |
           set -euo pipefail
@@ -112,6 +157,6 @@ jobs:
           fi
 
           if ! gh secret set CONNECTOR_OAUTH_CLIENT_SECRETS --repo "$GITHUB_REPOSITORY" --env production < "$BUNDLE_FILE"; then
-            echo "::error::Failed to update production environment secret CONNECTOR_OAUTH_CLIENT_SECRETS with GITHUB_TOKEN"
+            echo "::error::Failed to update production environment secret CONNECTOR_OAUTH_CLIENT_SECRETS with the GitHub App token"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- add a manual workflow to sync `CONNECTOR_OAUTH_CLIENT_SECRETS` from 1Password for development and production scopes
- add a bundle builder that reads managed connector OAuth client secrets, masks values, validates JSON, and enforces the GitHub secret size limit
- add shell coverage with a stubbed `op` CLI for success, mapping, validation, and log-safety cases

Fixes #15230

## Tests

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh && for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`
- `actionlint .github/workflows/sync-connector-oauth-client-secrets.yml`
