### PR TITLE
ci: require github app id for secret sync

### DIFF
--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -62,7 +62,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.VM0_GITHUB_APP_ID || vars.VM0_GITHUB_APP_CLIENT_ID }}
+          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
           private-key: ${{ steps.github-app-private-key.outputs.private-key }}
           permission-secrets: write
 
@@ -128,7 +128,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.VM0_GITHUB_APP_ID || vars.VM0_GITHUB_APP_CLIENT_ID }}
+          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
           private-key: ${{ steps.github-app-private-key.outputs.private-key }}
           permission-environments: write
 


### PR DESCRIPTION
## Summary

- remove the fallback from `VM0_GITHUB_APP_ID` to `VM0_GITHUB_APP_CLIENT_ID` in the connector OAuth secret sync workflow
- rely on the repo-level development `VM0_GITHUB_APP_ID=2994435` variable that was added separately
- keep GitHub App OAuth client id out of the installation-token path

## Tests

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/sync-connector-oauth-client-secrets.yml`
- `bash -n .github/scripts/build-connector-oauth-client-secrets-bundle.sh .github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh && .github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh && git diff --check origin/main...HEAD`