### PR TITLE
fix(platform): treat unset permission policy as not-applied in chat card

### DIFF
--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -17,7 +17,7 @@ import { delay } from "signal-timers";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$, replaceSearchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
-import { agentById } from "../agent.ts";
+import { agentById, reloadAgentById$ } from "../agent.ts";
 
 // ---------------------------------------------------------------------------
 // Route params
@@ -241,6 +241,7 @@ const saveFirewallPolicies$ = command(
     set(internalAgentReload$, (prev) => {
       return prev + 1;
     });
+    set(reloadAgentById$);
   },
 );
 
@@ -264,6 +265,7 @@ const resolveAccessRequest$ = command(
     set(internalAgentReload$, (prev) => {
       return prev + 1;
     });
+    set(reloadAgentById$);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -148,6 +148,85 @@ describe("zero chat thread page display - permission action card", () => {
     expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
   });
 
+  it("offers Confirm when the requested permission has no explicit stored policy", async () => {
+    let updatedPolicies: unknown;
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=dns%3Aread&action=allow",
+          runId: "run-permission-action-defaulted",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(
+        zeroAgentPermissionPoliciesContract.update,
+        ({ body, respond }) => {
+          updatedPolicies = body.policies;
+          return respond(200, {
+            agentId: body.agentId,
+            ownerId: "test-user-123",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            permissionPolicies: body.policies,
+            customSkills: [],
+            modelProviderId: null,
+            selectedModel: null,
+            preferPersonalProvider: false,
+          });
+        },
+      ),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(within(card).getByText("Vercel permissions")).toBeInTheDocument();
+    expect(within(card).getByText("Allow dns:read")).toBeInTheDocument();
+
+    expect(
+      within(card).queryByText("Permissions updated"),
+    ).not.toBeInTheDocument();
+    const confirm = await within(card).findByText("Confirm");
+    expect(confirm).toBeEnabled();
+    click(confirm);
+
+    await waitFor(() => {
+      expect(updatedPolicies).toStrictEqual({
+        vercel: {
+          policies: { "projects:write": "deny", "dns:read": "allow" },
+        },
+      });
+    });
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+  });
+
   it("rejects unknown permissions before updating policies", async () => {
     let updateCalled = false;
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -61,7 +61,6 @@ import emptyArtifactImg from "./assets/empty-artifact.webp";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import { hasConnectorAuthCodeGrant } from "@vm0/connectors/connector-utils";
-import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
@@ -2759,12 +2758,11 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     existingRequestLoadable.state === "hasData"
       ? existingRequestLoadable.data
       : null;
-  const resolved = agent
-    ? resolveFirewallPolicies(agent.permissionPolicies, [block.connectorRef])
-    : null;
-  const effectivePolicy =
-    resolved?.[block.connectorRef]?.policies[block.permission] ?? "allow";
-  const alreadyApplied = Boolean(agent) && effectivePolicy === block.action;
+  const storedPolicy =
+    agent?.permissionPolicies?.[block.connectorRef]?.policies?.[
+      block.permission
+    ];
+  const alreadyApplied = Boolean(agent) && storedPolicy === block.action;
   const finished =
     saveLoadable.state === "hasData" || submitLoadable.state === "hasData";
   const buttonState: PermissionActionButtonState = {


### PR DESCRIPTION
## Summary

- `PermissionActionCard` (introduced in #15239) rendered "Permissions updated" (disabled) for any "allow" action whose permission wasn't explicitly stored on the agent. `resolveFirewallPolicies` defaults missing entries to "allow" for connectors without a `DEFAULT_ALLOWED` list (e.g. Vercel), so the card mistook UI-side defaults for an actual user grant, while the firewall proxy continued to deny the request.
- Compare against the explicitly stored policy (`agent.permissionPolicies?.[ref]?.policies?.[permission]`) so unset permissions show Confirm and the click actually persists the grant.
- Bump `reloadAgentById$` after `saveFirewallPolicies$` / `resolveAccessRequest$` so the chat thread page picks up the new policy on the next render (the existing `internalAgentReload$` only refreshed the permission-allow page's local cache).

## Repro
- Agent's stored vercel policy lacks `dns:read`.
- Assistant message includes a permission-allow URL with `permission=dns:read&action=allow`.
- Before: button reads "Permissions updated" and is disabled — no way to grant.
- After: button reads "Confirm"; clicking persists `dns:read: "allow"`.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx -t "permission action card"` — 4 passed, including new \`offers Confirm when the requested permission has no explicit stored policy\`
- [x] \`pnpm -F @vm0/app exec vitest run src/views/permission-allow\` — 39 passed
- [x] \`pnpm -F @vm0/app exec tsc --noEmit\`
- [x] \`pnpm -F @vm0/app exec eslint\` on touched files
- [x] \`pnpm format\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)