### PR TITLE
ci: run secret sync on hosted tools

### DIFF
--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -35,35 +35,37 @@ jobs:
     if: github.ref == 'refs/heads/main' && inputs.scope == 'development'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
 
-      - name: Decode GitHub App private key
-        id: github-app-private-key
+      - name: Install secret sync tools
         shell: bash
-        env:
-          VM0_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [[ -z "${VM0_GITHUB_APP_PRIVATE_KEY:-}" ]]; then
-            echo "::error::VM0_GITHUB_APP_PRIVATE_KEY is required to create a GitHub App token"
-            exit 1
-          fi
-
-          private_key="$(printf '%s' "$VM0_GITHUB_APP_PRIVATE_KEY" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)"
-          echo "::add-mask::$private_key"
-          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+            | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+          sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/debian/debsig/1password.pol \
+            | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol >/dev/null
+          sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends 1password-cli jq
+          op --version
+          jq --version
+          gh --version
 
       - name: Create repository secret token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.VM0_GITHUB_APP_ID }}
-          private-key: ${{ steps.github-app-private-key.outputs.private-key }}
+          private-key: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
           permission-secrets: write
 
       - name: Build development bundle
@@ -100,36 +102,38 @@ jobs:
     if: github.ref == 'refs/heads/main' && inputs.scope == 'production'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     permissions:
       contents: read
     environment: production
     steps:
       - uses: actions/checkout@v6
 
-      - name: Decode GitHub App private key
-        id: github-app-private-key
+      - name: Install secret sync tools
         shell: bash
-        env:
-          VM0_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [[ -z "${VM0_GITHUB_APP_PRIVATE_KEY:-}" ]]; then
-            echo "::error::VM0_GITHUB_APP_PRIVATE_KEY is required to create a GitHub App token"
-            exit 1
-          fi
-
-          private_key="$(printf '%s' "$VM0_GITHUB_APP_PRIVATE_KEY" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)"
-          echo "::add-mask::$private_key"
-          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+            | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+          sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/debian/debsig/1password.pol \
+            | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol >/dev/null
+          sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+          curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+            | sudo gpg --batch --yes --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends 1password-cli jq
+          op --version
+          jq --version
+          gh --version
 
       - name: Create environment secret token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.VM0_GITHUB_APP_ID }}
-          private-key: ${{ steps.github-app-private-key.outputs.private-key }}
+          private-key: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
           permission-environments: write
 
       - name: Build production bundle


### PR DESCRIPTION
## Summary
- remove the custom toolchain container from the connector OAuth secret sync workflow
- install the required 1Password CLI and jq tools on the hosted runner
- pass the GitHub App private key directly to create-github-app-token instead of base64-decoding it

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/sync-connector-oauth-client-secrets.yml
- bash -n .github/scripts/build-connector-oauth-client-secrets-bundle.sh .github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
- .github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
- git diff --check