### PR TITLE
fix(desktop): settle accessibility tree before post-action snapshots

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1587,6 +1587,10 @@ func foregroundRecoveryPolicy(_ request: [String: Any]) throws -> ForegroundReco
     return policy
 }
 
+func optionalBool(_ request: [String: Any], _ key: String) -> Bool {
+    return (request[key] as? NSNumber)?.boolValue ?? false
+}
+
 func rectPayload(_ request: [String: Any], _ key: String) throws -> CGRect {
     guard let record = request[key] as? [String: Any],
           let x = record["x"] as? NSNumber,
@@ -3471,20 +3475,9 @@ func handlePermissionsRequestScreenRecording() -> [String: Any] {
     return computerUsePermissionState()
 }
 
-func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
-    let appName = try requiredString(request, "app")
-    let snapshotId = optionalString(request, "snapshotId") ?? UUID().uuidString.lowercased()
-
-    guard let runningApp = findRunningApp(named: appName) else {
-        throw HelperFailure(
-            code: "app_not_found",
-            message: "App is not running: \(appName)"
-        )
-    }
-
-    let root = AXUIElementCreateApplication(runningApp.processIdentifier)
-    enableBestEffortAccessibilityModes(root)
-
+func captureAccessibilityElements(
+    _ root: AXUIElement
+) -> (elements: [[String: Any]], nodeCount: Int, truncationReasons: [String]) {
     var nodeCount = 0
     var truncationReasons: [String] = []
     let windows = attributeArray(root, kAXWindowsAttribute as CFString)
@@ -3512,6 +3505,80 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
     {
         elements.append(menuBarSnapshot)
     }
+    return (elements, nodeCount, truncationReasons)
+}
+
+func appendAccessibilityFingerprint(_ node: [String: Any], into out: inout String) {
+    out += (node["id"] as? String) ?? ""
+    out += "|"
+    out += (node["role"] as? String) ?? ""
+    if let bounds = node["bounds"] as? [String: Double] {
+        out += "|\(Int(bounds["x"] ?? 0)),\(Int(bounds["y"] ?? 0)),"
+        out += "\(Int(bounds["width"] ?? 0)),\(Int(bounds["height"] ?? 0))"
+    }
+    out += ";"
+    if let children = node["children"] as? [[String: Any]] {
+        for child in children {
+            appendAccessibilityFingerprint(child, into: &out)
+        }
+    }
+}
+
+func accessibilityElementsFingerprint(_ elements: [[String: Any]]) -> String {
+    var out = ""
+    for element in elements {
+        appendAccessibilityFingerprint(element, into: &out)
+    }
+    return out
+}
+
+// Re-capture the accessibility tree until its structure stabilizes. Element ids
+// are positional tree paths, so a snapshot taken while a menu is still animating
+// open returns ids that shift before the agent can act on them. Polling until the
+// fingerprint stops changing keeps post-action snapshots actionable.
+func settledAccessibilityElements(
+    _ root: AXUIElement
+) -> (elements: [[String: Any]], nodeCount: Int, truncationReasons: [String]) {
+    let requiredStablePasses = 3
+    let pollInterval: useconds_t = 120_000
+    let deadline = Date().addingTimeInterval(1.6)
+    var latest = captureAccessibilityElements(root)
+    var previousFingerprint = accessibilityElementsFingerprint(latest.elements)
+    var stablePasses = 1
+    while stablePasses < requiredStablePasses, Date() < deadline {
+        usleep(pollInterval)
+        latest = captureAccessibilityElements(root)
+        let fingerprint = accessibilityElementsFingerprint(latest.elements)
+        if fingerprint == previousFingerprint {
+            stablePasses += 1
+        } else {
+            stablePasses = 1
+            previousFingerprint = fingerprint
+        }
+    }
+    return latest
+}
+
+func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
+    let appName = try requiredString(request, "app")
+    let snapshotId = optionalString(request, "snapshotId") ?? UUID().uuidString.lowercased()
+
+    guard let runningApp = findRunningApp(named: appName) else {
+        throw HelperFailure(
+            code: "app_not_found",
+            message: "App is not running: \(appName)"
+        )
+    }
+
+    let root = AXUIElementCreateApplication(runningApp.processIdentifier)
+    enableBestEffortAccessibilityModes(root)
+
+    let captured = optionalBool(request, "settle")
+        ? settledAccessibilityElements(root)
+        : captureAccessibilityElements(root)
+    let nodeCount = captured.nodeCount
+    let truncationReasons = captured.truncationReasons
+    var elements = captured.elements
     let indexed = indexedSnapshotElements(elements)
     elements = indexed.elements
 

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1299,10 +1299,11 @@ async function getAppState(
   app: string,
   nativeBackend: ComputerUseNativeBackend,
   snapshotStore: ComputerUseSnapshotStore,
+  settle = false,
 ): Promise<ComputerUseCommandExecutionResult> {
   const id = snapshotId();
   const snapshot = normalizeAccessibilitySnapshot(
-    await nativeBackend.getAppState(app, id),
+    await nativeBackend.getAppState(app, id, settle),
   );
   const indexed = indexedAccessibilitySnapshot(snapshot);
   const screenshot = nativeAppStateScreenshot(indexed.snapshot);
@@ -1346,6 +1347,7 @@ async function withPostActionAppState(args: {
     args.app,
     args.nativeBackend,
     args.snapshotStore,
+    true,
   );
   if (appStateResult.status === "failed") {
     return appStateResult;

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -67,6 +67,7 @@ export interface ComputerUseNativeBackend {
   readonly getAppState: (
     app: string,
     snapshotId: string,
+    settle?: boolean,
   ) => Promise<AccessibilityAppStateSnapshot>;
   readonly openApp: (app: string) => Promise<ComputerUseNativeActionResult>;
   readonly clickElement: (args: {
@@ -621,8 +622,13 @@ export function createComputerUseNativeBackend(
       const result = await run({ kind: "apps.list" });
       return resultAppRecords(result);
     },
-    getAppState: async (app, snapshotId) => {
-      const result = await run({ kind: "app.state", app, snapshotId });
+    getAppState: async (app, snapshotId, settle) => {
+      const result = await run({
+        kind: "app.state",
+        app,
+        snapshotId,
+        ...(settle ? { settle: true } : {}),
+      });
       return result as unknown as AccessibilityAppStateSnapshot;
     },
     openApp: async (app) => {

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1448,6 +1448,68 @@ describe("computer use desktop runtime", () => {
     expect(result.result.visibleText).toContain("Can you see this?");
   });
 
+  it("requests a settled snapshot after write actions but not for explicit app state", async () => {
+    const postActionGetAppState = vi.fn<
+      ComputerUseNativeBackend["getAppState"]
+    >(async (app, snapshotId) => {
+      return {
+        app,
+        snapshotId,
+        ...nativeScreenshotFields({ screenshotSourceName: "Inbox" }),
+        windowTitle: "Inbox",
+        elements: [{ id: "w0", role: "AXWindow", name: "Inbox" }],
+      };
+    });
+    const clickResult = await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "element.click",
+        payload: { app: "Things", elementId: "sidebar.inbox" },
+      },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        nativeBackend: createNativeBackend({
+          getAppState: postActionGetAppState,
+        }),
+      },
+    );
+    expect(clickResult.status).toBe("succeeded");
+    expect(postActionGetAppState).toHaveBeenCalledWith(
+      "Things",
+      expect.any(String),
+      true,
+    );
+
+    const explicitGetAppState = vi.fn<ComputerUseNativeBackend["getAppState"]>(
+      async (app, snapshotId) => {
+        return {
+          app,
+          snapshotId,
+          ...nativeScreenshotFields({ screenshotSourceName: "Inbox" }),
+          windowTitle: "Inbox",
+          elements: [{ id: "w0", role: "AXWindow", name: "Inbox" }],
+        };
+      },
+    );
+    const stateResult = await executeComputerUseCommand(
+      { id: "cmd_2", kind: "app.state", payload: { app: "Things" } },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        nativeBackend: createNativeBackend({
+          getAppState: explicitGetAppState,
+        }),
+      },
+    );
+    expect(stateResult.status).toBe("succeeded");
+    expect(explicitGetAppState).toHaveBeenCalledWith(
+      "Things",
+      expect.any(String),
+      false,
+    );
+  });
+
   it("resolves normalized element indexes to native element ids", async () => {
     const snapshotStore = new ComputerUseSnapshotStore();
     const clickElement = vi.fn<ComputerUseNativeBackend["clickElement"]>();


### PR DESCRIPTION
## Summary
- Post-action app-state snapshots were captured with **zero delay** after a write action. Element ids are positional AX-tree paths resolved live at action time, so a snapshot taken while a menu was still animating open returned ids that shifted before the agent could act on them — surfacing as `accessibility_unavailable: Element not found` (see #15277).
- Added a **settle loop** in the native helper: for post-action snapshots, re-capture the AX tree until its structure fingerprint stays identical for 3 consecutive passes (120ms poll, 1600ms cap), then build the final snapshot + screenshot once. Mirrors the kwwk `captureSettledSnapshot` approach.
- Threaded a `settle` flag from `withPostActionAppState` → TS native backend → helper `app.state` command. Explicit `get-app-state` requests are unchanged (no added latency).

## Why
Agents naturally do `get-state → click dropdown → click menu item`. The menu-opening click returned a fresh snapshot, but that snapshot was captured mid-animation, so its menu-item ids were unstable. Settling on a stable fingerprint makes post-action snapshots actionable for the immediate follow-up.

## Implementation notes
- `main.swift`: factored `captureAccessibilityElements`, added `accessibilityElementsFingerprint` (id + role + bounds, recursive) and `settledAccessibilityElements`; `handleAppState` gates on the request `settle` flag. Screenshot is only captured once, after the tree settles.
- Fingerprint instability (e.g. a perpetually animating element) falls back to the 1600ms timeout, matching kwwk.

## Test plan
- [x] `pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/computer-use-native.test.ts` — new test asserts post-action `element.click` requests `settle=true` while explicit `app.state` requests `settle=false`
- [x] `swift build -c release` (helper compiles, Swift 6)
- [x] `pnpm -F @vm0/desktop check-types`
- [x] `pnpm -F @vm0/desktop lint`
- [x] `pnpm format`
- [x] `pnpm knip --workspace apps/desktop`

Refs #15277

🤖 Generated with [Claude Code](https://claude.com/claude-code)