### PR TITLE
ci: normalize github app private key

### DIFF
--- a/.github/scripts/normalize-github-app-private-key.sh
+++ b/.github/scripts/normalize-github-app-private-key.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+error() {
+  echo "::error::$*"
+}
+
+mask_value() {
+  if [[ "${GITHUB_ACTIONS:-}" != "true" || -z "$1" ]]; then
+    return
+  fi
+
+  local value="$1"
+  value="${value//'%'/'%25'}"
+  value="${value//$'\r'/'%0D'}"
+  value="${value//$'\n'/'%0A'}"
+  echo "::add-mask::$value"
+}
+
+if [[ -z "${VM0_GITHUB_APP_PRIVATE_KEY:-}" ]]; then
+  error "VM0_GITHUB_APP_PRIVATE_KEY is required to create a GitHub App token"
+  exit 1
+fi
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  error "GITHUB_OUTPUT is required"
+  exit 1
+fi
+
+private_key="$(
+  python3 <<'PY'
+import base64
+import os
+import re
+import sys
+
+raw = os.environ["VM0_GITHUB_APP_PRIVATE_KEY"]
+key = raw.replace("\\n", "\n").replace("\r", "")
+
+if "-----BEGIN " not in key:
+    encoded = re.sub(r"\s+", "", key)
+    try:
+        key = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except Exception:
+        print(
+            "::error::VM0_GITHUB_APP_PRIVATE_KEY must be PEM or base64-encoded PEM",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    key = key.replace("\\n", "\n").replace("\r", "")
+
+match = re.search(
+    r"(-----BEGIN [^-]+-----)\s+(.+?)\s+(-----END [^-]+-----)",
+    key,
+    re.DOTALL,
+)
+if not match:
+    print(
+        "::error::VM0_GITHUB_APP_PRIVATE_KEY must contain a PEM private key",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+header, body, footer = match.groups()
+body = re.sub(r"\s+", "", body)
+if not body:
+    print(
+        "::error::VM0_GITHUB_APP_PRIVATE_KEY PEM body is empty",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+body_lines = "\n".join(body[index : index + 64] for index in range(0, len(body), 64))
+print(f"{header}\n{body_lines}\n{footer}")
+PY
+)"
+
+private_key_file="$(mktemp)"
+trap 'rm -f "$private_key_file"' EXIT
+printf '%s\n' "$private_key" > "$private_key_file"
+if ! openssl pkey -in "$private_key_file" -noout >/dev/null 2>&1; then
+  error "VM0_GITHUB_APP_PRIVATE_KEY is not a valid PEM private key"
+  exit 1
+fi
+
+mask_value "$private_key"
+
+{
+  echo "private-key<<GITHUB_APP_PRIVATE_KEY"
+  printf '%s\n' "$private_key"
+  echo "GITHUB_APP_PRIVATE_KEY"
+} >> "$GITHUB_OUTPUT"

--- a/.github/scripts/normalize-github-app-private-key.sh
+++ b/.github/scripts/normalize-github-app-private-key.sh
@@ -6,6 +6,13 @@ error() {
   echo "::error::$*"
 }
 
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "$2"
+    exit 1
+  fi
+}
+
 mask_value() {
   if [[ "${GITHUB_ACTIONS:-}" != "true" || -z "$1" ]]; then
     return
@@ -27,6 +34,9 @@ if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
   error "GITHUB_OUTPUT is required"
   exit 1
 fi
+
+require_tool python3 "python3 is not installed"
+require_tool openssl "OpenSSL is not installed"
 
 private_key="$(
   python3 <<'PY'
@@ -51,7 +61,7 @@ if "-----BEGIN " not in key:
     key = key.replace("\\n", "\n").replace("\r", "")
 
 match = re.search(
-    r"(-----BEGIN [^-]+-----)\s+(.+?)\s+(-----END [^-]+-----)",
+    r"(-----BEGIN [^-]+-----)\s*(.+?)\s*(-----END [^-]+-----)",
     key,
     re.DOTALL,
 )

--- a/.github/scripts/tests/normalize-github-app-private-key-test.sh
+++ b/.github/scripts/tests/normalize-github-app-private-key-test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NORMALIZER="${SCRIPT_DIR}/normalize-github-app-private-key.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local output=$1 expected=$2
+  if [[ "$output" != *"$expected"* ]]; then
+    fail "expected output to contain: ${expected}"
+  fi
+}
+
+assert_valid_output_key() {
+  local output_file=$1
+  local key_file=$2
+
+  awk '
+    /^private-key<<GITHUB_APP_PRIVATE_KEY$/ { printing = 1; next }
+    /^GITHUB_APP_PRIVATE_KEY$/ { printing = 0; next }
+    printing { print }
+  ' "$output_file" > "$key_file"
+
+  if ! grep -q '^-----BEGIN .*PRIVATE KEY-----$' "$key_file"; then
+    fail "expected normalized private key output to contain a PEM header"
+  fi
+
+  if ! grep -q '^-----END .*PRIVATE KEY-----$' "$key_file"; then
+    fail "expected normalized private key output to contain a PEM footer"
+  fi
+
+  openssl pkey -in "$key_file" -noout >/dev/null 2>&1 ||
+    fail "expected normalized private key output to be parseable by OpenSSL"
+}
+
+run_normalizer() {
+  local private_key=$1
+  local output_file=$2
+
+  env -i \
+    PATH="$PATH" \
+    VM0_GITHUB_APP_PRIVATE_KEY="$private_key" \
+    GITHUB_OUTPUT="$output_file" \
+    "$NORMALIZER"
+}
+
+private_key_file="${TMPDIR}/private-key.pem"
+openssl genrsa -traditional -out "$private_key_file" 2048 2>/dev/null
+private_key="$(cat "$private_key_file")"
+
+raw_output="${TMPDIR}/raw-output"
+run_normalizer "$private_key" "$raw_output"
+assert_valid_output_key "$raw_output" "${TMPDIR}/raw-key.pem"
+
+escaped_private_key="${private_key//$'\n'/\\n}"
+escaped_output="${TMPDIR}/escaped-output"
+run_normalizer "$escaped_private_key" "$escaped_output"
+assert_valid_output_key "$escaped_output" "${TMPDIR}/escaped-key.pem"
+
+base64_private_key="$(base64 -w 0 "$private_key_file")"
+base64_output="${TMPDIR}/base64-output"
+run_normalizer "$base64_private_key" "$base64_output"
+assert_valid_output_key "$base64_output" "${TMPDIR}/base64-key.pem"
+
+collapsed_private_key="$(tr '\n' ' ' < "$private_key_file")"
+collapsed_output="${TMPDIR}/collapsed-output"
+run_normalizer "$collapsed_private_key" "$collapsed_output"
+assert_valid_output_key "$collapsed_output" "${TMPDIR}/collapsed-key.pem"
+
+status=0
+missing_secret_output="$(
+  env -i \
+    PATH="$PATH" \
+    GITHUB_OUTPUT="${TMPDIR}/missing-secret-output" \
+    "$NORMALIZER" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing VM0_GITHUB_APP_PRIVATE_KEY case to fail"
+fi
+assert_contains "$missing_secret_output" "VM0_GITHUB_APP_PRIVATE_KEY is required"
+
+status=0
+invalid_secret_output="$(
+  run_normalizer "not a private key" "${TMPDIR}/invalid-output" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected invalid private key case to fail"
+fi
+assert_contains "$invalid_secret_output" "must be PEM or base64-encoded PEM"
+
+echo "normalize-github-app-private-key-test: ok"

--- a/.github/scripts/tests/normalize-github-app-private-key-test.sh
+++ b/.github/scripts/tests/normalize-github-app-private-key-test.sh
@@ -74,6 +74,11 @@ collapsed_output="${TMPDIR}/collapsed-output"
 run_normalizer "$collapsed_private_key" "$collapsed_output"
 assert_valid_output_key "$collapsed_output" "${TMPDIR}/collapsed-key.pem"
 
+compact_private_key="$(tr -d '\n' < "$private_key_file")"
+compact_output="${TMPDIR}/compact-output"
+run_normalizer "$compact_private_key" "$compact_output"
+assert_valid_output_key "$compact_output" "${TMPDIR}/compact-key.pem"
+
 status=0
 missing_secret_output="$(
   env -i \
@@ -94,5 +99,16 @@ if [[ "$status" -eq 0 ]]; then
   fail "expected invalid private key case to fail"
 fi
 assert_contains "$invalid_secret_output" "must be PEM or base64-encoded PEM"
+
+status=0
+invalid_pem_output="$(
+  run_normalizer \
+    "-----BEGIN RSA PRIVATE KEY-----not-a-valid-key-----END RSA PRIVATE KEY-----" \
+    "${TMPDIR}/invalid-pem-output" 2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected invalid PEM private key case to fail"
+fi
+assert_contains "$invalid_pem_output" "is not a valid PEM private key"
 
 echo "normalize-github-app-private-key-test: ok"

--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -60,12 +60,19 @@ jobs:
           jq --version
           gh --version
 
+      - name: Normalize GitHub App private key
+        id: github-app-private-key
+        shell: bash
+        env:
+          VM0_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+        run: .github/scripts/normalize-github-app-private-key.sh
+
       - name: Create repository secret token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.VM0_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+          private-key: ${{ steps.github-app-private-key.outputs.private-key }}
           permission-secrets: write
 
       - name: Build development bundle
@@ -128,12 +135,19 @@ jobs:
           jq --version
           gh --version
 
+      - name: Normalize GitHub App private key
+        id: github-app-private-key
+        shell: bash
+        env:
+          VM0_GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+        run: .github/scripts/normalize-github-app-private-key.sh
+
       - name: Create environment secret token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.VM0_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+          private-key: ${{ steps.github-app-private-key.outputs.private-key }}
           permission-environments: write
 
       - name: Build production bundle

--- a/.github/workflows/sync-connector-oauth-client-secrets.yml
+++ b/.github/workflows/sync-connector-oauth-client-secrets.yml
@@ -59,6 +59,8 @@ jobs:
           op --version
           jq --version
           gh --version
+          python3 --version
+          openssl version
 
       - name: Normalize GitHub App private key
         id: github-app-private-key
@@ -134,6 +136,8 @@ jobs:
           op --version
           jq --version
           gh --version
+          python3 --version
+          openssl version
 
       - name: Normalize GitHub App private key
         id: github-app-private-key


### PR DESCRIPTION
## Summary
- normalize VM0_GITHUB_APP_PRIVATE_KEY before passing it to create-github-app-token
- support raw PEM, escaped-newline PEM, base64 PEM, and single-line collapsed PEM formats
- validate the normalized key with OpenSSL and cover the normalizer with shell tests

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/sync-connector-oauth-client-secrets.yml
- bash -n .github/scripts/normalize-github-app-private-key.sh .github/scripts/tests/normalize-github-app-private-key-test.sh .github/scripts/build-connector-oauth-client-secrets-bundle.sh .github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
- .github/scripts/tests/normalize-github-app-private-key-test.sh
- .github/scripts/tests/build-connector-oauth-client-secrets-bundle-test.sh
- git diff --check