### PR TITLE
refactor: derive connector checks from lifecycle config

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -1825,7 +1825,7 @@ describe("CLI auth routes", () => {
       });
     });
 
-    it("rejects connector types that do not use OAuth", async () => {
+    it("rejects connector types without an auth-code or device-auth grant", async () => {
       const userId = trackUser(`user_${randomUUID()}`);
       const orgId = trackOrg(`org_${randomUUID()}`);
       await seedOrgMembership({ orgId, userId, slug: "connector-non-oauth" });
@@ -1844,7 +1844,8 @@ describe("CLI auth routes", () => {
       );
 
       expect(response.body).toStrictEqual({
-        error: "cloudinary connector does not use OAuth",
+        error:
+          "cloudinary connector does not use an auth-code or device-auth grant",
       });
       await expect(
         readConnectorState({ orgId, userId, type: "cloudinary" }),

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 import type {
+  AuthCodeGrantConnectorType,
   ConnectorOAuthClientConfig,
-  OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
@@ -390,7 +390,7 @@ function mockSlackOAuth(options: {
 }
 
 interface ProviderMockOptions {
-  readonly type: OAuthGrantConnectorType;
+  readonly type: AuthCodeGrantConnectorType;
   readonly accessToken?: string;
   readonly refreshToken?: string | null;
   readonly expiresIn?: number;
@@ -871,7 +871,7 @@ function mockXeroProvider(options: ResolvedProviderMockOptions): void {
 
 function mockProviderOAuth(options: ProviderMockOptions): void {
   const providerMockers: Partial<
-    Record<OAuthGrantConnectorType, ProviderMocker>
+    Record<AuthCodeGrantConnectorType, ProviderMocker>
   > = {
     github: (resolvedOptions) => {
       mockGitHubOAuth({
@@ -1020,7 +1020,7 @@ async function findDecryptedSecret(args: {
 }
 
 interface ProviderSuccessCase {
-  readonly type: OAuthGrantConnectorType;
+  readonly type: AuthCodeGrantConnectorType;
   readonly externalId: string;
   readonly externalUsername: string;
   readonly externalEmail: string | null;
@@ -1161,7 +1161,7 @@ const providerSuccessCases = [
   },
 ] as const satisfies readonly ProviderSuccessCase[];
 
-function hasFetchableUserInfo(type: OAuthGrantConnectorType): boolean {
+function hasFetchableUserInfo(type: AuthCodeGrantConnectorType): boolean {
   return type !== "notion" && type !== "sentry" && type !== "intervals-icu";
 }
 
@@ -1259,7 +1259,7 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.searchParams.get("message")).toBe("Unknown connector type");
   });
 
-  it("redirects non-OAuth callbacks to the connector error page", async () => {
+  it("redirects callbacks without an auth-code or device-auth grant to the connector error page", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
@@ -1278,7 +1278,7 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.pathname).toBe("/connector/error");
     expect(url.searchParams.get("type")).toBe("cloudinary");
     expect(url.searchParams.get("message")).toBe(
-      "cloudinary connector does not use OAuth",
+      "cloudinary connector does not use an auth-code or device-auth grant",
     );
   });
 
@@ -1386,7 +1386,7 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.pathname).toBe("/connector/error");
     expect(url.searchParams.get("type")).toBe("test-oauth-device");
     expect(url.searchParams.get("message")).toBe(
-      "test-oauth-device connector does not use authorization-code OAuth",
+      "test-oauth-device connector does not use an auth-code grant",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1259,7 +1259,7 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.searchParams.get("message")).toBe("Unknown connector type");
   });
 
-  it("redirects callbacks without an auth-code or device-auth grant to the connector error page", async () => {
+  it("redirects callbacks without an auth-code grant to the connector error page", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
@@ -1278,7 +1278,7 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.pathname).toBe("/connector/error");
     expect(url.searchParams.get("type")).toBe("cloudinary");
     expect(url.searchParams.get("message")).toBe(
-      "cloudinary connector does not use an auth-code or device-auth grant",
+      "cloudinary connector does not use an auth-code grant",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1259,6 +1259,29 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.searchParams.get("message")).toBe("Unknown connector type");
   });
 
+  it("redirects non-OAuth callbacks to the connector error page", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "cloudinary",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("type")).toBe("cloudinary");
+    expect(url.searchParams.get("message")).toBe(
+      "cloudinary connector does not use OAuth",
+    );
+  });
+
   it("redirects OAuth provider errors and clears OAuth cookies", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -929,7 +929,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     });
   });
 
-  it("returns 400 when starting OAuth for a connector without an auth-code or device-auth grant", async () => {
+  it("returns 400 when starting OAuth for a connector without an auth-code grant", async () => {
     const response = await requestOauthStart("serpapi", {
       authenticated: true,
     });
@@ -937,8 +937,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message:
-          "serpapi connector does not use an auth-code or device-auth grant",
+        message: "serpapi connector does not use an auth-code grant",
         code: "BAD_REQUEST",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -313,8 +313,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
-      error:
-        "test-oauth-device connector does not use authorization-code OAuth",
+      error: "test-oauth-device connector does not use an auth-code grant",
     });
   });
 
@@ -930,7 +929,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     });
   });
 
-  it("returns 400 when starting OAuth for a non-OAuth connector", async () => {
+  it("returns 400 when starting OAuth for a connector without an auth-code or device-auth grant", async () => {
     const response = await requestOauthStart("serpapi", {
       authenticated: true,
     });
@@ -938,7 +937,8 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "serpapi connector does not use OAuth",
+        message:
+          "serpapi connector does not use an auth-code or device-auth grant",
         code: "BAD_REQUEST",
       },
     });
@@ -957,8 +957,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message:
-          "test-oauth-device connector does not use authorization-code OAuth",
+        message: "test-oauth-device connector does not use an auth-code grant",
         code: "BAD_REQUEST",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -596,7 +596,7 @@ describe("OAuth device authorization connector routes", () => {
     });
   });
 
-  it("rejects authorization-code OAuth connectors", async () => {
+  it("rejects auth-code grant connectors", async () => {
     await setupUser();
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,
@@ -612,11 +612,11 @@ describe("OAuth device authorization connector routes", () => {
     );
 
     expect(response.body.error.message).toBe(
-      "github connector does not support OAuth device authorization",
+      "github connector does not support a device-auth grant",
     );
   });
 
-  it("rejects non-OAuth connectors", async () => {
+  it("rejects connector without an auth-code or device-auth grants", async () => {
     await setupUser();
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,
@@ -632,7 +632,7 @@ describe("OAuth device authorization connector routes", () => {
     );
 
     expect(response.body.error.message).toBe(
-      "cloudinary connector does not use OAuth",
+      "cloudinary connector does not use an auth-code or device-auth grant",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -616,6 +616,26 @@ describe("OAuth device authorization connector routes", () => {
     );
   });
 
+  it("rejects non-OAuth connectors", async () => {
+    await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "cloudinary" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "cloudinary connector does not use OAuth",
+    );
+  });
+
   it("rejects disabled OAuth auth methods", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
@@ -45,6 +45,20 @@ async function seedGithubConnector(args: {
   });
 }
 
+async function seedStripeApiTokenConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    userId: args.userId,
+    orgId: args.orgId,
+    type: "stripe",
+    authMethod: "api-token",
+    oauthScopes: null,
+  });
+}
+
 async function deleteConnectorsByOrg(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
   await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
@@ -155,6 +169,31 @@ describe("GET /api/zero/connectors/:type/scope-diff", () => {
       removedScopes: [],
       currentScopes: GITHUB_CURRENT_SCOPES,
       storedScopes: GITHUB_CURRENT_SCOPES,
+    });
+  });
+
+  it("returns an empty diff for selected manual auth methods on mixed connectors", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedStripeApiTokenConnector({ orgId, userId });
+    mocks.clerk.session(userId, orgId);
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "stripe" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes: [],
+      storedScopes: [],
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
@@ -106,6 +106,38 @@ describe("POST /api/zero/connectors/:type/sessions", () => {
     expect(rows).toStrictEqual([]);
   });
 
+  it("rejects connector sessions for connectors without an auth-code grant", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "test-oauth-device connector does not use an auth-code grant",
+      code: "BAD_REQUEST",
+    });
+
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({ id: connectorSessions.id })
+      .from(connectorSessions)
+      .where(
+        and(
+          eq(connectorSessions.userId, userId),
+          eq(connectorSessions.type, "test-oauth-device"),
+        ),
+      );
+    expect(rows).toStrictEqual([]);
+  });
+
   it("returns 401 when unauthenticated", async () => {
     const client = setupApp({ context })(zeroConnectorSessionsContract);
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -9,7 +9,8 @@ import {
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
   getConnectorOAuthSecretMetadata,
-  hasConnectorOAuthProvider,
+  hasConnectorAuthCodeGrantProvider,
+  hasConnectorDeviceAuthGrantProvider,
 } from "@vm0/connectors/auth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -211,7 +212,10 @@ const createTestConnector$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    if (!hasConnectorOAuthProvider(connectorType)) {
+    if (
+      !hasConnectorAuthCodeGrantProvider(connectorType) &&
+      !hasConnectorDeviceAuthGrantProvider(connectorType)
+    ) {
       return stringError(400, `${connectorType} connector does not use OAuth`);
     }
     const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -7,8 +7,9 @@ import {
   cliAuthTestTokenContract,
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import {
+  type AuthCodeGrantConnectorType,
   connectorTypeSchema,
-  type OAuthGrantConnectorType,
+  type DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
 import {
@@ -215,15 +216,20 @@ const createTestConnector$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    let oauthConnectorType: OAuthGrantConnectorType;
+    let grantConnectorType:
+      | AuthCodeGrantConnectorType
+      | DeviceAuthGrantConnectorType;
     if (hasConnectorAuthCodeGrant(connectorType)) {
-      oauthConnectorType = connectorType;
+      grantConnectorType = connectorType;
     } else if (hasConnectorDeviceAuthGrant(connectorType)) {
-      oauthConnectorType = connectorType;
+      grantConnectorType = connectorType;
     } else {
-      return stringError(400, `${connectorType} connector does not use OAuth`);
+      return stringError(
+        400,
+        `${connectorType} connector does not use an auth-code or device-auth grant`,
+      );
     }
-    const secretMetadata = getConnectorOAuthSecretMetadata(oauthConnectorType);
+    const secretMetadata = getConnectorOAuthSecretMetadata(grantConnectorType);
     const refreshSecretName = secretMetadata.isRefreshable
       ? secretMetadata.refreshSecretName
       : undefined;
@@ -232,12 +238,12 @@ const createTestConnector$ = command(
       {
         orgId,
         userId,
-        type: oauthConnectorType,
+        type: grantConnectorType,
         accessToken: bodyResult.data.accessToken,
         userInfo: {
-          id: `e2e-test-${oauthConnectorType}`,
-          username: `e2e-${oauthConnectorType}`,
-          email: `e2e-${oauthConnectorType}@test.vm0.ai`,
+          id: `e2e-test-${grantConnectorType}`,
+          username: `e2e-${grantConnectorType}`,
+          email: `e2e-${grantConnectorType}@test.vm0.ai`,
         },
         oauthScopes: [],
         refreshToken: bodyResult.data.refreshToken,

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -6,12 +6,15 @@ import {
   cliAuthTestEnableConnectorContract,
   cliAuthTestTokenContract,
 } from "@vm0/api-contracts/contracts/cli-auth-test";
-import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthSecretMetadata,
-  hasConnectorAuthCodeGrantProvider,
-  hasConnectorDeviceAuthGrantProvider,
-} from "@vm0/connectors/auth-providers";
+  connectorTypeSchema,
+  type OAuthGrantConnectorType,
+} from "@vm0/connectors/connectors";
+import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
+import {
+  hasConnectorAuthCodeGrant,
+  hasConnectorDeviceAuthGrant,
+} from "@vm0/connectors/connector-utils";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
 import { modelProviders } from "@vm0/db/schema/model-provider";
@@ -212,13 +215,15 @@ const createTestConnector$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    if (
-      !hasConnectorAuthCodeGrantProvider(connectorType) &&
-      !hasConnectorDeviceAuthGrantProvider(connectorType)
-    ) {
+    let oauthConnectorType: OAuthGrantConnectorType;
+    if (hasConnectorAuthCodeGrant(connectorType)) {
+      oauthConnectorType = connectorType;
+    } else if (hasConnectorDeviceAuthGrant(connectorType)) {
+      oauthConnectorType = connectorType;
+    } else {
       return stringError(400, `${connectorType} connector does not use OAuth`);
     }
-    const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
+    const secretMetadata = getConnectorOAuthSecretMetadata(oauthConnectorType);
     const refreshSecretName = secretMetadata.isRefreshable
       ? secretMetadata.refreshSecretName
       : undefined;
@@ -227,12 +232,12 @@ const createTestConnector$ = command(
       {
         orgId,
         userId,
-        type: connectorType,
+        type: oauthConnectorType,
         accessToken: bodyResult.data.accessToken,
         userInfo: {
-          id: `e2e-test-${connectorType}`,
-          username: `e2e-${connectorType}`,
-          email: `e2e-${connectorType}@test.vm0.ai`,
+          id: `e2e-test-${oauthConnectorType}`,
+          username: `e2e-${oauthConnectorType}`,
+          email: `e2e-${oauthConnectorType}@test.vm0.ai`,
         },
         oauthScopes: [],
         refreshToken: bodyResult.data.refreshToken,

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -1,12 +1,14 @@
 import {
+  getConnectorAuthMethodIdForGrantKind,
   getConnectorOAuthClient,
   hasConnectorAuthCodeGrant,
   type ConnectorEnvReader,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import type {
-  ConnectorType,
   AuthCodeGrantConnectorType,
+  ConnectorAuthMethodId,
+  ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorOAuthAuthUrl,
@@ -31,6 +33,7 @@ type ResolveConnectorAuthCodeStartTypeResult =
   | {
       readonly ok: true;
       readonly type: AuthCodeGrantConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
     }
   | {
       readonly ok: false;
@@ -47,7 +50,11 @@ export function resolveConnectorAuthCodeStartType(
   if (!hasConnectorAuthCodeGrant(type)) {
     return { ok: false, reason: "missing_auth_code_grant" };
   }
-  return { ok: true, type };
+  const authMethod = getConnectorAuthMethodIdForGrantKind(type, "auth-code");
+  if (!authMethod) {
+    throw new Error(`${type} connector has no auth-code auth method`);
+  }
+  return { ok: true, type, authMethod };
 }
 
 // Prepare only synchronous auth-code start data. Callers must resolve the route's

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -1,7 +1,6 @@
 import {
   getConnectorOAuthClient,
   hasConnectorAuthCodeGrant,
-  hasConnectorDeviceAuthGrant,
   type ConnectorEnvReader,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
@@ -35,9 +34,7 @@ type ResolveConnectorAuthCodeStartTypeResult =
     }
   | {
       readonly ok: false;
-      readonly reason:
-        | "missing_auth_code_grant"
-        | "unsupported_auth_code_grant";
+      readonly reason: "missing_auth_code_grant";
     };
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
@@ -48,9 +45,6 @@ export function resolveConnectorAuthCodeStartType(
   type: ConnectorType,
 ): ResolveConnectorAuthCodeStartTypeResult {
   if (!hasConnectorAuthCodeGrant(type)) {
-    if (hasConnectorDeviceAuthGrant(type)) {
-      return { ok: false, reason: "unsupported_auth_code_grant" };
-    }
     return { ok: false, reason: "missing_auth_code_grant" };
   }
   return { ok: true, type };

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -16,7 +16,7 @@ import {
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
 
-type PrepareResolvedConnectorOAuthStartResult =
+type PrepareResolvedConnectorAuthCodeStartResult =
   | {
       readonly ok: true;
       readonly state: string;
@@ -56,15 +56,15 @@ export function resolveConnectorAuthCodeStartType(
   return { ok: true, type };
 }
 
-// Prepare only synchronous OAuth start data. Callers must resolve the route's
+// Prepare only synchronous auth-code start data. Callers must resolve the route's
 // ConnectorType first so connectors without interactive grants keep their
 // route-specific errors, then build the provider authorization URL at the
 // normal async commit point.
-export function prepareResolvedConnectorOAuthStart(args: {
+export function prepareResolvedConnectorAuthCodeStart(args: {
   readonly type: AuthCodeGrantConnectorType;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
-}): PrepareResolvedConnectorOAuthStartResult {
+}): PrepareResolvedConnectorAuthCodeStartResult {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
   const oauthClient = getConnectorOAuthClient(args.type, args.readEnv);
@@ -80,7 +80,7 @@ export function prepareResolvedConnectorOAuthStart(args: {
   };
 }
 
-export async function buildResolvedConnectorOAuthAuthResult(args: {
+export async function buildResolvedConnectorAuthCodeAuthUrl(args: {
   readonly type: AuthCodeGrantConnectorType;
   readonly oauthClient: ConnectorOAuthClient;
   readonly redirectUri: string;

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -36,7 +36,7 @@ type ResolveConnectorAuthCodeStartTypeResult =
   | {
       readonly ok: false;
       readonly reason:
-        | "missing_auth_code_or_device_auth_grant"
+        | "missing_auth_code_grant"
         | "unsupported_auth_code_grant";
     };
 
@@ -51,7 +51,7 @@ export function resolveConnectorAuthCodeStartType(
     if (hasConnectorDeviceAuthGrant(type)) {
       return { ok: false, reason: "unsupported_auth_code_grant" };
     }
-    return { ok: false, reason: "missing_auth_code_or_device_auth_grant" };
+    return { ok: false, reason: "missing_auth_code_grant" };
   }
   return { ok: true, type };
 }

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -11,7 +11,6 @@ import type {
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorOAuthAuthUrl,
-  hasConnectorAuthCodeGrantProvider,
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 
@@ -38,7 +37,6 @@ type ResolveConnectorOAuthStartTypeResult =
       readonly ok: false;
       readonly reason:
         | "connector_does_not_use_oauth"
-        | "oauth_provider_not_configured"
         | "unsupported_oauth_flow";
     };
 
@@ -54,9 +52,6 @@ export function resolveConnectorOAuthStartType(
       return { ok: false, reason: "unsupported_oauth_flow" };
     }
     return { ok: false, reason: "connector_does_not_use_oauth" };
-  }
-  if (!hasConnectorAuthCodeGrantProvider(type)) {
-    return { ok: false, reason: "oauth_provider_not_configured" };
   }
   return { ok: true, type };
 }

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -36,8 +36,8 @@ type ResolveConnectorOAuthStartTypeResult =
   | {
       readonly ok: false;
       readonly reason:
-        | "connector_does_not_use_oauth"
-        | "unsupported_oauth_flow";
+        | "missing_auth_code_or_device_auth_grant"
+        | "unsupported_auth_code_grant";
     };
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
@@ -49,15 +49,15 @@ export function resolveConnectorOAuthStartType(
 ): ResolveConnectorOAuthStartTypeResult {
   if (!hasConnectorAuthCodeGrant(type)) {
     if (hasConnectorDeviceAuthGrant(type)) {
-      return { ok: false, reason: "unsupported_oauth_flow" };
+      return { ok: false, reason: "unsupported_auth_code_grant" };
     }
-    return { ok: false, reason: "connector_does_not_use_oauth" };
+    return { ok: false, reason: "missing_auth_code_or_device_auth_grant" };
   }
   return { ok: true, type };
 }
 
 // Prepare only synchronous OAuth start data. Callers must resolve the route's
-// ConnectorType first so non-OAuth connectors keep their route-specific errors,
+// ConnectorType first so connector without an auth-code or device-auth grants keep their route-specific errors,
 // then build the provider authorization URL at the normal async commit point.
 export function prepareResolvedConnectorOAuthStart(args: {
   readonly type: AuthCodeGrantConnectorType;

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -28,7 +28,7 @@ type PrepareResolvedConnectorOAuthStartResult =
       readonly reason: "oauth_not_configured";
     };
 
-type ResolveConnectorOAuthStartTypeResult =
+type ResolveConnectorAuthCodeStartTypeResult =
   | {
       readonly ok: true;
       readonly type: AuthCodeGrantConnectorType;
@@ -44,9 +44,9 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
   return typeof result === "string" ? { url: result } : result;
 }
 
-export function resolveConnectorOAuthStartType(
+export function resolveConnectorAuthCodeStartType(
   type: ConnectorType,
-): ResolveConnectorOAuthStartTypeResult {
+): ResolveConnectorAuthCodeStartTypeResult {
   if (!hasConnectorAuthCodeGrant(type)) {
     if (hasConnectorDeviceAuthGrant(type)) {
       return { ok: false, reason: "unsupported_auth_code_grant" };
@@ -57,8 +57,9 @@ export function resolveConnectorOAuthStartType(
 }
 
 // Prepare only synchronous OAuth start data. Callers must resolve the route's
-// ConnectorType first so connector without an auth-code or device-auth grants keep their route-specific errors,
-// then build the provider authorization URL at the normal async commit point.
+// ConnectorType first so connectors without interactive grants keep their
+// route-specific errors, then build the provider authorization URL at the
+// normal async commit point.
 export function prepareResolvedConnectorOAuthStart(args: {
   readonly type: AuthCodeGrantConnectorType;
   readonly origin: string;

--- a/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-start.ts
@@ -1,7 +1,7 @@
 import {
   getConnectorOAuthClient,
-  hasConnectorOAuthGrant,
   hasConnectorAuthCodeGrant,
+  hasConnectorDeviceAuthGrant,
   type ConnectorEnvReader,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
@@ -11,7 +11,7 @@ import type {
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorOAuthAuthUrl,
-  hasConnectorOAuthProvider,
+  hasConnectorAuthCodeGrantProvider,
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 
@@ -49,14 +49,14 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
 export function resolveConnectorOAuthStartType(
   type: ConnectorType,
 ): ResolveConnectorOAuthStartTypeResult {
-  if (!hasConnectorOAuthGrant(type)) {
+  if (!hasConnectorAuthCodeGrant(type)) {
+    if (hasConnectorDeviceAuthGrant(type)) {
+      return { ok: false, reason: "unsupported_oauth_flow" };
+    }
     return { ok: false, reason: "connector_does_not_use_oauth" };
   }
-  if (!hasConnectorOAuthProvider(type)) {
+  if (!hasConnectorAuthCodeGrantProvider(type)) {
     return { ok: false, reason: "oauth_provider_not_configured" };
-  }
-  if (!hasConnectorAuthCodeGrant(type)) {
-    return { ok: false, reason: "unsupported_oauth_flow" };
   }
   return { ok: true, type };
 }

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -6,7 +6,6 @@ import {
   hasConnectorAuthCodeGrant,
   getConnectorOAuthClient,
   getConnectorAuthCodeGrantConfig,
-  hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -213,12 +212,13 @@ function resolveOAuthConnectorType(
 
   const connectorType = typeResult.data;
   if (!hasConnectorAuthCodeGrant(connectorType)) {
-    const message = hasConnectorDeviceAuthGrant(connectorType)
-      ? `${type} connector does not use an auth-code grant`
-      : `${type} connector does not use an auth-code or device-auth grant`;
     return {
       ok: false,
-      response: redirectWithError(origin, type, message),
+      response: redirectWithError(
+        origin,
+        type,
+        `${type} connector does not use an auth-code grant`,
+      ),
     };
   }
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -5,7 +5,7 @@ import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/con
 import {
   hasConnectorAuthCodeGrant,
   getConnectorOAuthClient,
-  getConnectorAuthMethodGrantScopes,
+  getConnectorAuthCodeGrantConfig,
   hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -15,7 +15,6 @@ import {
 import {
   exchangeConnectorOAuthCode,
   getConnectorOAuthSecretMetadata,
-  hasConnectorAuthCodeGrantProvider,
   type OAuthTokenResult,
 } from "@vm0/connectors/auth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -197,7 +196,7 @@ async function exchangeTokenForConnector(args: {
 function getRequestedScopes(
   connectorType: AuthCodeGrantConnectorType,
 ): readonly string[] {
-  return getConnectorAuthMethodGrantScopes(connectorType, "oauth");
+  return getConnectorAuthCodeGrantConfig(connectorType).scopes;
 }
 
 function resolveOAuthConnectorType(
@@ -220,16 +219,6 @@ function resolveOAuthConnectorType(
     return {
       ok: false,
       response: redirectWithError(origin, type, message),
-    };
-  }
-  if (!hasConnectorAuthCodeGrantProvider(connectorType)) {
-    return {
-      ok: false,
-      response: redirectWithError(
-        origin,
-        type,
-        `${type} OAuth provider is not configured`,
-      ),
     };
   }
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -5,17 +5,17 @@ import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/con
 import {
   hasConnectorAuthCodeGrant,
   getConnectorOAuthClient,
-  getConnectorOAuthScopes,
+  getConnectorAuthMethodGrantScopes,
+  hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
   type AuthCodeGrantConnectorType,
-  type OAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorOAuthCode,
   getConnectorOAuthSecretMetadata,
-  hasConnectorOAuthProvider,
+  hasConnectorAuthCodeGrantProvider,
   type OAuthTokenResult,
 } from "@vm0/connectors/auth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -197,7 +197,7 @@ async function exchangeTokenForConnector(args: {
 function getRequestedScopes(
   connectorType: AuthCodeGrantConnectorType,
 ): readonly string[] {
-  return getConnectorOAuthScopes(connectorType);
+  return getConnectorAuthMethodGrantScopes(connectorType, "oauth");
 }
 
 function resolveOAuthConnectorType(
@@ -213,23 +213,22 @@ function resolveOAuthConnectorType(
   }
 
   const connectorType = typeResult.data;
-  if (!hasConnectorOAuthProvider(connectorType)) {
+  if (!hasConnectorAuthCodeGrant(connectorType)) {
+    const message = hasConnectorDeviceAuthGrant(connectorType)
+      ? `${type} connector does not use authorization-code OAuth`
+      : `${type} connector does not use OAuth`;
     return {
       ok: false,
-      response: redirectWithError(
-        origin,
-        type,
-        `${type} connector does not use OAuth`,
-      ),
+      response: redirectWithError(origin, type, message),
     };
   }
-  if (!hasConnectorAuthCodeGrant(connectorType)) {
+  if (!hasConnectorAuthCodeGrantProvider(connectorType)) {
     return {
       ok: false,
       response: redirectWithError(
         origin,
         type,
-        `${type} connector does not use authorization-code OAuth`,
+        `${type} OAuth provider is not configured`,
       ),
     };
   }
@@ -325,7 +324,7 @@ async function markConnectorSessionError(
 
 async function linkGithubIntegrationAfterConnectorConnect(args: {
   readonly db: Db;
-  readonly connectorType: OAuthGrantConnectorType;
+  readonly connectorType: AuthCodeGrantConnectorType;
   readonly identity: CallbackIdentity;
   readonly token: OAuthTokenResult;
   readonly signal: AbortSignal;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -214,8 +214,8 @@ function resolveOAuthConnectorType(
   const connectorType = typeResult.data;
   if (!hasConnectorAuthCodeGrant(connectorType)) {
     const message = hasConnectorDeviceAuthGrant(connectorType)
-      ? `${type} connector does not use authorization-code OAuth`
-      : `${type} connector does not use OAuth`;
+      ? `${type} connector does not use an auth-code grant`
+      : `${type} connector does not use an auth-code or device-auth grant`;
     return {
       ok: false,
       response: redirectWithError(origin, type, message),

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -166,10 +166,10 @@ function connectorOAuthStartRedirectResponse(args: {
   return response;
 }
 
-function connectorMissingInteractiveGrantResponse(type: string) {
+function connectorMissingAuthCodeGrantResponse(type: string) {
   return jsonResponse(
     {
-      error: `${type} connector does not use an auth-code or device-auth grant`,
+      error: `${type} connector does not use an auth-code grant`,
     },
     400,
   );
@@ -361,10 +361,8 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const authCodeStartType = resolveConnectorAuthCodeStartType(type);
     if (!authCodeStartType.ok) {
-      if (
-        authCodeStartType.reason === "missing_auth_code_or_device_auth_grant"
-      ) {
-        return connectorMissingInteractiveGrantResponse(type);
+      if (authCodeStartType.reason === "missing_auth_code_grant") {
+        return connectorMissingAuthCodeGrantResponse(type);
       }
       return unsupportedAuthCodeGrantResponse(type);
     }
@@ -436,11 +434,9 @@ const startConnectorOauthInner$ = command(
 
     const authCodeStartType = resolveConnectorAuthCodeStartType(type);
     if (!authCodeStartType.ok) {
-      if (
-        authCodeStartType.reason === "missing_auth_code_or_device_auth_grant"
-      ) {
+      if (authCodeStartType.reason === "missing_auth_code_grant") {
         return badRequestMessage(
-          `${type} connector does not use an auth-code or device-auth grant`,
+          `${type} connector does not use an auth-code grant`,
         );
       }
       return badRequestMessage(unsupportedAuthCodeGrantMessage(type));

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -373,7 +373,12 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       userConnectorAvailability(auth.orgId, auth.userId),
     );
     signal.throwIfAborted();
-    if (!availability.isAuthMethodAvailable(authCodeStartType.type, "oauth")) {
+    if (
+      !availability.isAuthMethodAvailable(
+        authCodeStartType.type,
+        authCodeStartType.authMethod,
+      )
+    ) {
       return jsonResponse({ error: `${type} connector is not available` }, 403);
     }
 
@@ -438,7 +443,12 @@ const startConnectorOauthInner$ = command(
       userConnectorAvailability(auth.orgId, auth.userId),
     );
     signal.throwIfAborted();
-    if (!availability.isAuthMethodAvailable(authCodeStartType.type, "oauth")) {
+    if (
+      !availability.isAuthMethodAvailable(
+        authCodeStartType.type,
+        authCodeStartType.authMethod,
+      )
+    ) {
       return connectorUnavailable(type);
     }
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -178,10 +178,6 @@ function unsupportedOAuthFlowResponse(type: string) {
   return jsonResponse({ error: unsupportedOAuthFlowMessage(type) }, 400);
 }
 
-function missingOAuthProviderResponse(type: string) {
-  return jsonResponse({ error: `${type} OAuth provider not configured` }, 500);
-}
-
 function internalServerError(message: string) {
   return {
     status: 500 as const,
@@ -363,10 +359,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       if (startType.reason === "connector_does_not_use_oauth") {
         return connectorDoesNotUseOAuthResponse(type);
       }
-      if (startType.reason === "unsupported_oauth_flow") {
-        return unsupportedOAuthFlowResponse(type);
-      }
-      return missingOAuthProviderResponse(type);
+      return unsupportedOAuthFlowResponse(type);
     }
 
     if (!auth.orgId) {
@@ -439,10 +432,7 @@ const startConnectorOauthInner$ = command(
       if (startType.reason === "connector_does_not_use_oauth") {
         return badRequestMessage(`${type} connector does not use OAuth`);
       }
-      if (startType.reason === "unsupported_oauth_flow") {
-        return badRequestMessage(unsupportedOAuthFlowMessage(type));
-      }
-      return internalServerError(`${type} OAuth provider not configured`);
+      return badRequestMessage(unsupportedOAuthFlowMessage(type));
     }
 
     if (!auth.orgId) {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -166,16 +166,21 @@ function connectorOAuthStartRedirectResponse(args: {
   return response;
 }
 
-function connectorDoesNotUseOAuthResponse(type: string) {
-  return jsonResponse({ error: `${type} connector does not use OAuth` }, 400);
+function connectorMissingInteractiveGrantResponse(type: string) {
+  return jsonResponse(
+    {
+      error: `${type} connector does not use an auth-code or device-auth grant`,
+    },
+    400,
+  );
 }
 
-function unsupportedOAuthFlowMessage(type: string): string {
-  return `${type} connector does not use authorization-code OAuth`;
+function unsupportedAuthCodeGrantMessage(type: string): string {
+  return `${type} connector does not use an auth-code grant`;
 }
 
-function unsupportedOAuthFlowResponse(type: string) {
-  return jsonResponse({ error: unsupportedOAuthFlowMessage(type) }, 400);
+function unsupportedAuthCodeGrantResponse(type: string) {
+  return jsonResponse({ error: unsupportedAuthCodeGrantMessage(type) }, 400);
 }
 
 function internalServerError(message: string) {
@@ -356,10 +361,10 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const startType = resolveConnectorOAuthStartType(type);
     if (!startType.ok) {
-      if (startType.reason === "connector_does_not_use_oauth") {
-        return connectorDoesNotUseOAuthResponse(type);
+      if (startType.reason === "missing_auth_code_or_device_auth_grant") {
+        return connectorMissingInteractiveGrantResponse(type);
       }
-      return unsupportedOAuthFlowResponse(type);
+      return unsupportedAuthCodeGrantResponse(type);
     }
 
     if (!auth.orgId) {
@@ -429,10 +434,12 @@ const startConnectorOauthInner$ = command(
 
     const startType = resolveConnectorOAuthStartType(type);
     if (!startType.ok) {
-      if (startType.reason === "connector_does_not_use_oauth") {
-        return badRequestMessage(`${type} connector does not use OAuth`);
+      if (startType.reason === "missing_auth_code_or_device_auth_grant") {
+        return badRequestMessage(
+          `${type} connector does not use an auth-code or device-auth grant`,
+        );
       }
-      return badRequestMessage(unsupportedOAuthFlowMessage(type));
+      return badRequestMessage(unsupportedAuthCodeGrantMessage(type));
     }
 
     if (!auth.orgId) {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -58,7 +58,7 @@ import {
 import {
   buildResolvedConnectorOAuthAuthResult,
   prepareResolvedConnectorOAuthStart,
-  resolveConnectorOAuthStartType,
+  resolveConnectorAuthCodeStartType,
 } from "./connector-oauth-start";
 
 const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
@@ -359,9 +359,11 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       return jsonResponse(auth.body, auth.status);
     }
 
-    const startType = resolveConnectorOAuthStartType(type);
-    if (!startType.ok) {
-      if (startType.reason === "missing_auth_code_or_device_auth_grant") {
+    const authCodeStartType = resolveConnectorAuthCodeStartType(type);
+    if (!authCodeStartType.ok) {
+      if (
+        authCodeStartType.reason === "missing_auth_code_or_device_auth_grant"
+      ) {
         return connectorMissingInteractiveGrantResponse(type);
       }
       return unsupportedAuthCodeGrantResponse(type);
@@ -384,12 +386,12 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       userConnectorAvailability(auth.orgId, auth.userId),
     );
     signal.throwIfAborted();
-    if (!availability.isAuthMethodAvailable(startType.type, "oauth")) {
+    if (!availability.isAuthMethodAvailable(authCodeStartType.type, "oauth")) {
       return jsonResponse({ error: `${type} connector is not available` }, 403);
     }
 
     const prepared = prepareResolvedConnectorOAuthStart({
-      type: startType.type,
+      type: authCodeStartType.type,
       origin,
       readEnv: optionalEnv,
     });
@@ -397,7 +399,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
     const authResult = await buildResolvedConnectorOAuthAuthResult({
-      type: startType.type,
+      type: authCodeStartType.type,
       oauthClient: prepared.oauthClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
@@ -432,9 +434,11 @@ const startConnectorOauthInner$ = command(
     const auth = get(authContext$);
     const type = params.type;
 
-    const startType = resolveConnectorOAuthStartType(type);
-    if (!startType.ok) {
-      if (startType.reason === "missing_auth_code_or_device_auth_grant") {
+    const authCodeStartType = resolveConnectorAuthCodeStartType(type);
+    if (!authCodeStartType.ok) {
+      if (
+        authCodeStartType.reason === "missing_auth_code_or_device_auth_grant"
+      ) {
         return badRequestMessage(
           `${type} connector does not use an auth-code or device-auth grant`,
         );
@@ -452,13 +456,13 @@ const startConnectorOauthInner$ = command(
       userConnectorAvailability(auth.orgId, auth.userId),
     );
     signal.throwIfAborted();
-    if (!availability.isAuthMethodAvailable(startType.type, "oauth")) {
+    if (!availability.isAuthMethodAvailable(authCodeStartType.type, "oauth")) {
       return connectorUnavailable(type);
     }
 
     const origin = getConnectorOAuthOrigin(request);
     const prepared = prepareResolvedConnectorOAuthStart({
-      type: startType.type,
+      type: authCodeStartType.type,
       origin,
       readEnv: optionalEnv,
     });
@@ -466,7 +470,7 @@ const startConnectorOauthInner$ = command(
       return internalServerError(`${type} OAuth not configured`);
     }
     const authResult = await buildResolvedConnectorOAuthAuthResult({
-      type: startType.type,
+      type: authCodeStartType.type,
       oauthClient: prepared.oauthClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
@@ -483,7 +487,7 @@ const startConnectorOauthInner$ = command(
     const writeDb = set(writeDb$);
     await writeDb.insert(connectorOauthStates).values({
       state: prepared.state,
-      type: startType.type,
+      type: authCodeStartType.type,
       userId: auth.userId,
       orgId: auth.orgId,
       redirectUri: prepared.redirectUri,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -56,10 +56,10 @@ import {
   connectorOAuthRedirectResponse,
 } from "./connector-oauth-route-state";
 import {
-  buildResolvedConnectorOAuthAuthResult,
-  prepareResolvedConnectorOAuthStart,
+  buildResolvedConnectorAuthCodeAuthUrl,
+  prepareResolvedConnectorAuthCodeStart,
   resolveConnectorAuthCodeStartType,
-} from "./connector-oauth-start";
+} from "./connector-auth-code-start";
 
 const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
 const CONNECTOR_SESSION_POLL_INTERVAL_SECONDS = 5;
@@ -390,7 +390,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       return jsonResponse({ error: `${type} connector is not available` }, 403);
     }
 
-    const prepared = prepareResolvedConnectorOAuthStart({
+    const prepared = prepareResolvedConnectorAuthCodeStart({
       type: authCodeStartType.type,
       origin,
       readEnv: optionalEnv,
@@ -398,7 +398,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     if (!prepared.ok) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
-    const authResult = await buildResolvedConnectorOAuthAuthResult({
+    const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
       oauthClient: prepared.oauthClient,
       redirectUri: prepared.redirectUri,
@@ -461,7 +461,7 @@ const startConnectorOauthInner$ = command(
     }
 
     const origin = getConnectorOAuthOrigin(request);
-    const prepared = prepareResolvedConnectorOAuthStart({
+    const prepared = prepareResolvedConnectorAuthCodeStart({
       type: authCodeStartType.type,
       origin,
       readEnv: optionalEnv,
@@ -469,7 +469,7 @@ const startConnectorOauthInner$ = command(
     if (!prepared.ok) {
       return internalServerError(`${type} OAuth not configured`);
     }
-    const authResult = await buildResolvedConnectorOAuthAuthResult({
+    const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
       oauthClient: prepared.oauthClient,
       redirectUri: prepared.redirectUri,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -504,11 +504,23 @@ const createConnectorSessionInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(zeroConnectorSessionsContract.create));
+    const authCodeStartType = resolveConnectorAuthCodeStartType(params.type);
+    if (!authCodeStartType.ok) {
+      return badRequestMessage(
+        `${params.type} connector does not use an auth-code grant`,
+      );
+    }
+
     const availability = await get(
       userConnectorAvailability(auth.orgId, auth.userId),
     );
     signal.throwIfAborted();
-    if (!availability.isAuthMethodAvailable(params.type, "oauth")) {
+    if (
+      !availability.isAuthMethodAvailable(
+        authCodeStartType.type,
+        authCodeStartType.authMethod,
+      )
+    ) {
       return connectorUnavailable(params.type);
     }
 
@@ -522,7 +534,7 @@ const createConnectorSessionInner$ = command(
       .insert(connectorSessions)
       .values({
         code,
-        type: params.type,
+        type: authCodeStartType.type,
         userId: auth.userId,
         status: "pending",
         expiresAt,
@@ -539,9 +551,9 @@ const createConnectorSessionInner$ = command(
       body: {
         id: session.id,
         code,
-        type: params.type,
+        type: authCodeStartType.type,
         status: "pending" as const,
-        verificationUrl: `/api/connectors/${params.type}/authorize?session=${session.id}`,
+        verificationUrl: `/api/connectors/${authCodeStartType.type}/authorize?session=${session.id}`,
         expiresIn: CONNECTOR_SESSION_TTL_SECONDS,
         interval: CONNECTOR_SESSION_POLL_INTERVAL_SECONDS,
       },

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -175,14 +175,6 @@ function connectorMissingAuthCodeGrantResponse(type: string) {
   );
 }
 
-function unsupportedAuthCodeGrantMessage(type: string): string {
-  return `${type} connector does not use an auth-code grant`;
-}
-
-function unsupportedAuthCodeGrantResponse(type: string) {
-  return jsonResponse({ error: unsupportedAuthCodeGrantMessage(type) }, 400);
-}
-
 function internalServerError(message: string) {
   return {
     status: 500 as const,
@@ -361,10 +353,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const authCodeStartType = resolveConnectorAuthCodeStartType(type);
     if (!authCodeStartType.ok) {
-      if (authCodeStartType.reason === "missing_auth_code_grant") {
-        return connectorMissingAuthCodeGrantResponse(type);
-      }
-      return unsupportedAuthCodeGrantResponse(type);
+      return connectorMissingAuthCodeGrantResponse(type);
     }
 
     if (!auth.orgId) {
@@ -434,12 +423,9 @@ const startConnectorOauthInner$ = command(
 
     const authCodeStartType = resolveConnectorAuthCodeStartType(type);
     if (!authCodeStartType.ok) {
-      if (authCodeStartType.reason === "missing_auth_code_grant") {
-        return badRequestMessage(
-          `${type} connector does not use an auth-code grant`,
-        );
-      }
-      return badRequestMessage(unsupportedAuthCodeGrantMessage(type));
+      return badRequestMessage(
+        `${type} connector does not use an auth-code grant`,
+      );
     }
 
     if (!auth.orgId) {

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -11,13 +11,13 @@ import type {
 } from "@vm0/connectors/connectors";
 import {
   getConnectorOAuthClient,
-  hasConnectorOAuthGrant,
+  hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
-  hasConnectorOAuthProvider,
+  hasConnectorDeviceAuthGrantProvider,
   pollConnectorOAuthDeviceAuth,
   startConnectorOAuthDeviceAuth,
 } from "@vm0/connectors/auth-providers";
@@ -182,16 +182,16 @@ function resolveDeviceAuthType(
   | DeviceAuthGrantConnectorType
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof internalServerError> {
-  if (!hasConnectorOAuthGrant(type)) {
-    return badRequestMessage(`${type} connector does not use OAuth`);
-  }
-  if (!hasConnectorOAuthProvider(type)) {
-    return internalServerError(`${type} OAuth provider is not configured`);
-  }
   if (!hasConnectorDeviceAuthGrant(type)) {
+    if (!hasConnectorAuthCodeGrant(type)) {
+      return badRequestMessage(`${type} connector does not use OAuth`);
+    }
     return badRequestMessage(
       `${type} connector does not support OAuth device authorization`,
     );
+  }
+  if (!hasConnectorDeviceAuthGrantProvider(type)) {
+    return internalServerError(`${type} OAuth provider is not configured`);
   }
   return type;
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -17,7 +17,6 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
-  hasConnectorDeviceAuthGrantProvider,
   pollConnectorOAuthDeviceAuth,
   startConnectorOAuthDeviceAuth,
 } from "@vm0/connectors/auth-providers";
@@ -189,9 +188,6 @@ function resolveDeviceAuthType(
     return badRequestMessage(
       `${type} connector does not support OAuth device authorization`,
     );
-  }
-  if (!hasConnectorDeviceAuthGrantProvider(type)) {
-    return internalServerError(`${type} OAuth provider is not configured`);
   }
   return type;
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -183,10 +183,12 @@ function resolveDeviceAuthType(
   | ReturnType<typeof internalServerError> {
   if (!hasConnectorDeviceAuthGrant(type)) {
     if (!hasConnectorAuthCodeGrant(type)) {
-      return badRequestMessage(`${type} connector does not use OAuth`);
+      return badRequestMessage(
+        `${type} connector does not use an auth-code or device-auth grant`,
+      );
     }
     return badRequestMessage(
-      `${type} connector does not support OAuth device authorization`,
+      `${type} connector does not support a device-auth grant`,
     );
   }
   return type;

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -6,10 +6,12 @@ import type {
   ConnectorOauthDeviceAuthSessionStartResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
+  ConnectorAuthMethodId,
   ConnectorType,
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  getConnectorAuthMethodIdForGrantKind,
   getConnectorOAuthClient,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
@@ -92,6 +94,11 @@ type PollClaimedSessionArgs = {
   readonly persistConnector: (args: {
     readonly result: OAuthDeviceAuthCompleteResult;
   }) => Promise<ConnectorResponse>;
+};
+
+type ResolvedDeviceAuthType = {
+  readonly type: DeviceAuthGrantConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
 };
 
 const connectorOauthDeviceAuthDisabled = Object.freeze({
@@ -178,7 +185,7 @@ function isFreshPollingSession(
 function resolveDeviceAuthType(
   type: ConnectorType,
 ):
-  | DeviceAuthGrantConnectorType
+  | ResolvedDeviceAuthType
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof internalServerError> {
   if (!hasConnectorDeviceAuthGrant(type)) {
@@ -191,7 +198,11 @@ function resolveDeviceAuthType(
       `${type} connector does not support a device-auth grant`,
     );
   }
-  return type;
+  const authMethod = getConnectorAuthMethodIdForGrantKind(type, "device-auth");
+  if (!authMethod) {
+    throw new Error(`${type} connector has no device-auth auth method`);
+  }
+  return { type, authMethod };
 }
 
 function resolveRequiredOAuthClient(
@@ -678,7 +689,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     signal: AbortSignal,
   ) => {
     const resolvedType = resolveDeviceAuthType(args.type);
-    if (typeof resolvedType !== "string") {
+    if ("status" in resolvedType) {
       return resolvedType;
     }
 
@@ -687,17 +698,22 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     );
     signal.throwIfAborted();
 
-    if (!availability.isAuthMethodAvailable(resolvedType, "oauth")) {
+    if (
+      !availability.isAuthMethodAvailable(
+        resolvedType.type,
+        resolvedType.authMethod,
+      )
+    ) {
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const oauthClient = resolveRequiredOAuthClient(resolvedType);
+    const oauthClient = resolveRequiredOAuthClient(resolvedType.type);
     if ("status" in oauthClient) {
       return oauthClient;
     }
 
     const startResult = await startConnectorOAuthDeviceAuth({
-      type: resolvedType,
+      type: resolvedType.type,
       oauthClient,
     });
     signal.throwIfAborted();
@@ -709,7 +725,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
     const encryptedProviderState = await encryptPersistentSecretValue(
       JSON.stringify({
-        connectorType: resolvedType,
+        connectorType: resolvedType.type,
         deviceCode: startResult.deviceCode,
       }),
       {
@@ -724,13 +740,13 @@ export const startConnectorOauthDeviceAuthSession$ = command(
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
-        type: resolvedType,
+        type: resolvedType.type,
       });
       await markActiveSessionsSuperseded({
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
-        type: resolvedType,
+        type: resolvedType.type,
         now,
       });
       return await tx
@@ -738,7 +754,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
         .values({
           orgId: args.orgId,
           userId: args.userId,
-          connectorType: resolvedType,
+          connectorType: resolvedType.type,
           status: "awaiting_user_authorization",
           sessionTokenHash: sessionTokenHash(sessionToken),
           encryptedProviderState,
@@ -763,7 +779,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     const body: ConnectorOauthDeviceAuthSessionStartResponse = {
       sessionId: session.id,
       sessionToken,
-      type: resolvedType,
+      type: resolvedType.type,
       status: "pending",
       userCode: startResult.userCode,
       verificationUri: startResult.verificationUri,
@@ -788,7 +804,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
     signal: AbortSignal,
   ) => {
     const resolvedType = resolveDeviceAuthType(args.type);
-    if (typeof resolvedType !== "string") {
+    if ("status" in resolvedType) {
       return resolvedType;
     }
 
@@ -797,11 +813,16 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
     );
     signal.throwIfAborted();
 
-    if (!availability.isAuthMethodAvailable(resolvedType, "oauth")) {
+    if (
+      !availability.isAuthMethodAvailable(
+        resolvedType.type,
+        resolvedType.authMethod,
+      )
+    ) {
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const oauthClient = resolveRequiredOAuthClient(resolvedType);
+    const oauthClient = resolveRequiredOAuthClient(resolvedType.type);
     if ("status" in oauthClient) {
       return oauthClient;
     }
@@ -811,7 +832,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      type: resolvedType,
+      type: resolvedType.type,
       sessionId: args.sessionId,
       sessionToken: args.sessionToken,
       signal,
@@ -827,7 +848,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
             zeroConnectorByType({
               orgId: args.orgId,
               userId: args.userId,
-              type: resolvedType,
+              type: resolvedType.type,
               includeHiddenStoredConnector: true,
             }),
           );
@@ -872,19 +893,21 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      type: resolvedType,
+      type: resolvedType.type,
       oauthClient,
       session: claimedSession,
       claimStartedAt,
       signal,
       persistConnector: async ({ result }) => {
-        const secretMetadata = getConnectorOAuthSecretMetadata(resolvedType);
+        const secretMetadata = getConnectorOAuthSecretMetadata(
+          resolvedType.type,
+        );
         const connectorResult = await set(
           upsertOAuthConnector$,
           {
             orgId: args.orgId,
             userId: args.userId,
-            type: resolvedType,
+            type: resolvedType.type,
             accessToken: result.token.accessToken,
             userInfo: result.token.userInfo,
             oauthScopes: result.token.scopes,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -117,7 +117,7 @@ interface EncryptedOAuthConnectorSecret {
   readonly description: string;
 }
 
-interface PendingOAuthRevoke {
+interface PendingConnectorTokenRevoke {
   readonly type: OAuthGrantConnectorType;
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
@@ -196,13 +196,13 @@ function throwCapturedAbort(error: unknown): void {
 
 async function finalizeConnectorStateChangeAfterCommit(args: {
   readonly userId: string;
-  readonly pendingOAuthRevoke: PendingOAuthRevoke | null;
+  readonly pendingTokenRevoke: PendingConnectorTokenRevoke | null;
   readonly signal: AbortSignal;
   readonly postCommitAbort: unknown;
 }): Promise<void> {
   let postCommitAbort = args.postCommitAbort;
-  if (args.pendingOAuthRevoke) {
-    await revokePendingOAuthToken({ pending: args.pendingOAuthRevoke });
+  if (args.pendingTokenRevoke) {
+    await revokePendingConnectorToken({ pending: args.pendingTokenRevoke });
     if (args.signal.aborted) {
       postCommitAbort ??= args.signal.reason;
     }
@@ -502,14 +502,14 @@ export function zeroConnectorByType(args: {
   });
 }
 
-async function loadPendingOAuthRevoke(args: {
+async function loadPendingConnectorTokenRevoke(args: {
   readonly db: Db | ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
   readonly type: OAuthGrantConnectorType;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
-}): Promise<PendingOAuthRevoke | null> {
+}): Promise<PendingConnectorTokenRevoke | null> {
   const connectorType = args.type;
   const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
   const accessTokenName = secretMetadata.accessSecretName;
@@ -539,8 +539,8 @@ async function loadPendingOAuthRevoke(args: {
   };
 }
 
-async function revokePendingOAuthToken(args: {
-  readonly pending: PendingOAuthRevoke;
+async function revokePendingConnectorToken(args: {
+  readonly pending: PendingConnectorTokenRevoke;
 }): Promise<void> {
   const oauthClient = getConnectorOAuthClient(args.pending.type, optionalEnv);
   if (!oauthClient) {
@@ -654,14 +654,14 @@ export const deleteZeroConnectorLocalState$ = command(
       signal.throwIfAborted();
 
       if (!existing) {
-        return { deleted: false, pendingOAuthRevoke: null };
+        return { deleted: false, pendingTokenRevoke: null };
       }
 
-      let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
+      let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
       if (
         connectorAuthMethodSupportsTokenRevoke(args.type, existing.authMethod)
       ) {
-        pendingOAuthRevoke = await loadPendingOAuthRevoke({
+        pendingTokenRevoke = await loadPendingConnectorTokenRevoke({
           db: tx,
           orgId: args.orgId,
           userId: args.userId,
@@ -688,7 +688,7 @@ export const deleteZeroConnectorLocalState$ = command(
         signal,
       });
 
-      return { deleted: true, pendingOAuthRevoke };
+      return { deleted: true, pendingTokenRevoke };
     });
     if (signal.aborted) {
       postCommitAbort ??= signal.reason;
@@ -701,7 +701,7 @@ export const deleteZeroConnectorLocalState$ = command(
 
     await finalizeConnectorStateChangeAfterCommit({
       userId: args.userId,
-      pendingOAuthRevoke: deleteResult.pendingOAuthRevoke,
+      pendingTokenRevoke: deleteResult.pendingTokenRevoke,
       signal,
       postCommitAbort,
     });
@@ -936,7 +936,7 @@ async function cleanupExistingStoredConnectorForApiTokenConnect(
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly signal: AbortSignal;
   },
-): Promise<PendingOAuthRevoke | null> {
+): Promise<PendingConnectorTokenRevoke | null> {
   const [existing] = await db
     .select({ id: connectors.id, authMethod: connectors.authMethod })
     .from(connectors)
@@ -954,9 +954,9 @@ async function cleanupExistingStoredConnectorForApiTokenConnect(
     return null;
   }
 
-  let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
+  let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
   if (connectorAuthMethodSupportsTokenRevoke(args.type, existing.authMethod)) {
-    pendingOAuthRevoke = await loadPendingOAuthRevoke({
+    pendingTokenRevoke = await loadPendingConnectorTokenRevoke({
       db,
       orgId: args.orgId,
       userId: args.userId,
@@ -979,7 +979,7 @@ async function cleanupExistingStoredConnectorForApiTokenConnect(
     signal: args.signal,
   });
 
-  return pendingOAuthRevoke;
+  return pendingTokenRevoke;
 }
 
 export const connectApiTokenConnector$ = command(
@@ -1013,7 +1013,7 @@ export const connectApiTokenConnector$ = command(
       omittedApiTokenFieldNames(preparedResult.prepared);
 
     const writeDb = set(writeDb$);
-    let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
+    let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
     let connectorRow: StoredConnectorRow | null = null;
     let postCommitAbort: unknown = null;
 
@@ -1025,7 +1025,7 @@ export const connectApiTokenConnector$ = command(
       });
       signal.throwIfAborted();
 
-      pendingOAuthRevoke =
+      pendingTokenRevoke =
         await cleanupExistingStoredConnectorForApiTokenConnect(tx, {
           orgId: args.orgId,
           userId: args.userId,
@@ -1097,7 +1097,7 @@ export const connectApiTokenConnector$ = command(
 
     await finalizeConnectorStateChangeAfterCommit({
       userId: args.userId,
-      pendingOAuthRevoke,
+      pendingTokenRevoke,
       signal,
       postCommitAbort,
     });
@@ -1544,7 +1544,7 @@ export const upsertOAuthConnector$ = command(
 
     await finalizeConnectorStateChangeAfterCommit({
       userId: args.userId,
-      pendingOAuthRevoke: null,
+      pendingTokenRevoke: null,
       signal,
       postCommitAbort,
     });

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -29,6 +29,7 @@ import {
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type OAuthGrantConnectorType,
+  type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getAllFeatureStates,
@@ -118,7 +119,7 @@ interface EncryptedOAuthConnectorSecret {
 }
 
 interface PendingConnectorTokenRevoke {
-  readonly type: OAuthGrantConnectorType;
+  readonly type: TokenRevokeConnectorType;
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
@@ -506,7 +507,7 @@ async function loadPendingConnectorTokenRevoke(args: {
   readonly db: Db | ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: OAuthGrantConnectorType;
+  readonly type: TokenRevokeConnectorType;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingConnectorTokenRevoke | null> {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -6,8 +6,9 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
-  connectorAuthMethodHasOAuthGrant,
+  connectorAuthMethodSupportsTokenRevoke,
   getAvailableConnectorAuthMethods,
+  getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNames,
@@ -15,12 +16,11 @@ import {
   getConnectorSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
-  getScopeDiff,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
-  hasConnectorOAuthProvider,
+  hasConnectorTokenRevokeProvider,
   revokeConnectorOAuthToken,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -511,7 +511,7 @@ async function loadPendingOAuthRevoke(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingOAuthRevoke | null> {
-  if (!hasConnectorOAuthProvider(args.type)) {
+  if (!hasConnectorTokenRevokeProvider(args.type)) {
     return null;
   }
 
@@ -662,7 +662,7 @@ export const deleteZeroConnectorLocalState$ = command(
         return { deleted: false, pendingOAuthRevoke: null };
       }
 
-      const pendingOAuthRevoke = connectorAuthMethodHasOAuthGrant(
+      const pendingOAuthRevoke = connectorAuthMethodSupportsTokenRevoke(
         args.type,
         existing.authMethod,
       )
@@ -959,7 +959,7 @@ async function cleanupExistingStoredConnectorForApiTokenConnect(
     return null;
   }
 
-  const pendingOAuthRevoke = connectorAuthMethodHasOAuthGrant(
+  const pendingOAuthRevoke = connectorAuthMethodSupportsTokenRevoke(
     args.type,
     existing.authMethod,
   )
@@ -1575,7 +1575,11 @@ export function zeroConnectorScopeDiff(args: {
     if (!connector) {
       return null;
     }
-    return getScopeDiff(args.type, connector.oauthScopes);
+    return getConnectorAuthMethodScopeDiff(
+      args.type,
+      connector.authMethod,
+      connector.oauthScopes,
+    );
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -20,7 +20,6 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
-  hasConnectorTokenRevokeProvider,
   revokeConnectorOAuthToken,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -507,14 +506,10 @@ async function loadPendingOAuthRevoke(args: {
   readonly db: Db | ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorType;
+  readonly type: OAuthGrantConnectorType;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingOAuthRevoke | null> {
-  if (!hasConnectorTokenRevokeProvider(args.type)) {
-    return null;
-  }
-
   const connectorType = args.type;
   const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
   const accessTokenName = secretMetadata.accessSecretName;
@@ -662,19 +657,19 @@ export const deleteZeroConnectorLocalState$ = command(
         return { deleted: false, pendingOAuthRevoke: null };
       }
 
-      const pendingOAuthRevoke = connectorAuthMethodSupportsTokenRevoke(
-        args.type,
-        existing.authMethod,
-      )
-        ? await loadPendingOAuthRevoke({
-            db: tx,
-            orgId: args.orgId,
-            userId: args.userId,
-            type: args.type,
-            featureSwitchContext,
-            signal,
-          })
-        : null;
+      let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
+      if (
+        connectorAuthMethodSupportsTokenRevoke(args.type, existing.authMethod)
+      ) {
+        pendingOAuthRevoke = await loadPendingOAuthRevoke({
+          db: tx,
+          orgId: args.orgId,
+          userId: args.userId,
+          type: args.type,
+          featureSwitchContext,
+          signal,
+        });
+      }
       signal.throwIfAborted();
 
       await tx.delete(connectors).where(eq(connectors.id, existing.id));
@@ -959,19 +954,17 @@ async function cleanupExistingStoredConnectorForApiTokenConnect(
     return null;
   }
 
-  const pendingOAuthRevoke = connectorAuthMethodSupportsTokenRevoke(
-    args.type,
-    existing.authMethod,
-  )
-    ? await loadPendingOAuthRevoke({
-        db,
-        orgId: args.orgId,
-        userId: args.userId,
-        type: args.type,
-        featureSwitchContext: args.featureSwitchContext,
-        signal: args.signal,
-      })
-    : null;
+  let pendingOAuthRevoke: PendingOAuthRevoke | null = null;
+  if (connectorAuthMethodSupportsTokenRevoke(args.type, existing.authMethod)) {
+    pendingOAuthRevoke = await loadPendingOAuthRevoke({
+      db,
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      featureSwitchContext: args.featureSwitchContext,
+      signal: args.signal,
+    });
+  }
 
   await deleteConnectorScopedSecretNames(db, {
     orgId: args.orgId,

--- a/turbo/apps/cli/src/commands/zero/connector/connected-as.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connected-as.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { hasRequiredScopes } from "@vm0/connectors/connector-utils";
+import { hasRequiredConnectorAuthMethodScopes } from "@vm0/connectors/connector-utils";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 
 type Connector = ConnectorListResponse["connectors"][number];
@@ -18,9 +18,11 @@ export function renderConnectedAsCell(
   if (connector.needsReconnect) {
     return chalk.yellow(`${identity} (reconnect needed)`);
   }
-  const scopeMismatch =
-    connector.authMethod === "oauth" &&
-    !hasRequiredScopes(connector.type, connector.oauthScopes);
+  const scopeMismatch = !hasRequiredConnectorAuthMethodScopes(
+    connector.type,
+    connector.authMethod,
+    connector.oauthScopes,
+  );
   if (scopeMismatch) {
     return chalk.yellow(`${identity} (permissions update available)`);
   }

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -7,8 +7,8 @@ import {
   connectorTypeSchema,
 } from "@vm0/connectors/connectors";
 import {
-  getScopeDiff,
-  hasRequiredScopes,
+  getConnectorAuthMethodScopeDiff,
+  hasRequiredConnectorAuthMethodScopes,
 } from "@vm0/connectors/connector-utils";
 import { getZeroConnector, searchZeroConnectors } from "../../../lib/api";
 import { formatDateTime } from "../../../lib/domain/schedule-utils";
@@ -62,10 +62,17 @@ function printConnectorDetails(
     }
 
     if (
-      connector.authMethod === "oauth" &&
-      !hasRequiredScopes(type, connector.oauthScopes)
+      !hasRequiredConnectorAuthMethodScopes(
+        type,
+        connector.authMethod,
+        connector.oauthScopes,
+      )
     ) {
-      const diff = getScopeDiff(type, connector.oauthScopes);
+      const diff = getConnectorAuthMethodScopeDiff(
+        type,
+        connector.authMethod,
+        connector.oauthScopes,
+      );
       console.log(
         `${"Permissions:".padEnd(LABEL_WIDTH)}${chalk.yellow("update available")}`,
       );

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -475,9 +475,7 @@ describe("connectConnectorOAuthAuthCode$", () => {
         {},
         context.signal,
       ),
-    ).rejects.toThrow(
-      "test-oauth-device does not use authorization-code OAuth",
-    );
+    ).rejects.toThrow("test-oauth-device does not use an auth-code grant");
 
     expect(open).not.toHaveBeenCalled();
     expect(startCalled).toBeFalsy();

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -11,10 +11,9 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthMethod,
-  connectorAuthMethodHasOAuthGrant,
   getConfiguredConnectorAuthMethods,
   getConnectorTags,
-  hasRequiredScopes,
+  hasRequiredConnectorAuthMethodScopes,
   isGoogleOAuthConnector,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
@@ -79,7 +78,7 @@ export interface ConnectorTypeWithStatus {
   availableAuthMethods: ConnectorAuthMethodId[];
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;
-  /** True if stored OAuth scopes don't cover all currently required scopes. */
+  /** True if stored grant scopes don't cover all currently required scopes. */
   scopeMismatch: boolean;
   /** True if OAuth token refresh failed and user needs to reconnect. */
   needsReconnect: boolean;
@@ -163,13 +162,13 @@ function buildConnectorTypeStatus(params: {
     return !!method?.featureFlag && method.showExperimentalLabel !== false;
   });
   const connected = params.connector !== null;
-  const connectedAuthMethodHasOAuthGrant =
-    params.connector !== null &&
-    connectorAuthMethodHasOAuthGrant(params.type, params.connector.authMethod);
   const scopeMismatch =
     params.connector !== null &&
-    connectedAuthMethodHasOAuthGrant &&
-    !hasRequiredScopes(params.type, params.connector.oauthScopes);
+    !hasRequiredConnectorAuthMethodScopes(
+      params.type,
+      params.connector.authMethod,
+      params.connector.oauthScopes,
+    );
 
   return {
     type: params.type,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1072,7 +1072,7 @@ const resetOAuthAuthCodeConnectorPopupSignal$ = resetSignal();
 
 function assertConnectorUsesOAuthAuthCode(type: ConnectorType): void {
   if (!hasConnectorAuthCodeGrant(type)) {
-    throw new Error(`${type} does not use authorization-code OAuth`);
+    throw new Error(`${type} does not use an auth-code grant`);
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -131,7 +131,7 @@ function connectorOAuthDeviceAuthFlowIsActive(
   );
 }
 
-function connectedConnectorUsesOAuthGrant(
+function connectedConnectorUsesInteractiveGrant(
   item: ConnectorTypeWithStatus,
 ): boolean {
   return item.connector
@@ -202,9 +202,9 @@ function ManualCredentialForm({
 
   return (
     <div className="flex flex-col gap-3">
-      {item.connected && connectedConnectorUsesOAuthGrant(item) && (
+      {item.connected && connectedConnectorUsesInteractiveGrant(item) && (
         <p className="text-xs text-amber-600">
-          This will replace your current OAuth connection.
+          This will replace your current connected account.
         </p>
       )}
       {method.helpText && <ConnectorHelpText text={method.helpText} />}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -18,7 +18,7 @@ import {
 } from "@vm0/connectors/connectors";
 import type { ReactElement } from "react";
 import {
-  connectorAuthMethodHasOAuthGrant,
+  connectorAuthMethodHasGrantKind,
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
   hasConnectorAuthCodeGrant,
@@ -131,11 +131,20 @@ function connectorOAuthDeviceAuthFlowIsActive(
   );
 }
 
-function connectedConnectorHasOAuthGrant(
+function connectedConnectorUsesOAuthGrant(
   item: ConnectorTypeWithStatus,
 ): boolean {
   return item.connector
-    ? connectorAuthMethodHasOAuthGrant(item.type, item.connector.authMethod)
+    ? connectorAuthMethodHasGrantKind(
+        item.type,
+        item.connector.authMethod,
+        "auth-code",
+      ) ||
+        connectorAuthMethodHasGrantKind(
+          item.type,
+          item.connector.authMethod,
+          "device-auth",
+        )
     : false;
 }
 
@@ -193,7 +202,7 @@ function ManualCredentialForm({
 
   return (
     <div className="flex flex-col gap-3">
-      {item.connected && connectedConnectorHasOAuthGrant(item) && (
+      {item.connected && connectedConnectorUsesOAuthGrant(item) && (
         <p className="text-xs text-amber-600">
           This will replace your current OAuth connection.
         </p>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -18,7 +18,6 @@ import {
 } from "@vm0/connectors/connectors";
 import type { ReactElement } from "react";
 import {
-  connectorAuthMethodHasGrantKind,
   getConnectorAuthMethod,
   isGoogleOAuthConnector,
   hasConnectorAuthCodeGrant,
@@ -131,23 +130,6 @@ function connectorOAuthDeviceAuthFlowIsActive(
   );
 }
 
-function connectedConnectorUsesInteractiveGrant(
-  item: ConnectorTypeWithStatus,
-): boolean {
-  return item.connector
-    ? connectorAuthMethodHasGrantKind(
-        item.type,
-        item.connector.authMethod,
-        "auth-code",
-      ) ||
-        connectorAuthMethodHasGrantKind(
-          item.type,
-          item.connector.authMethod,
-          "device-auth",
-        )
-    : false;
-}
-
 // ---------------------------------------------------------------------------
 // Manual credentials form (shown inside connect modal)
 // ---------------------------------------------------------------------------
@@ -157,7 +139,6 @@ function ManualCredentialForm({
   authMethod,
   method,
   grant,
-  item,
   onSuccess,
   showPermissionDialogOnConnect,
   submit,
@@ -167,7 +148,6 @@ function ManualCredentialForm({
   authMethod: ConnectorAuthMethodId;
   method: ConnectorAuthMethodConfig;
   grant: ConnectorManualGrantConfig;
-  item: ConnectorTypeWithStatus;
   onSuccess: () => void | Promise<void>;
   showPermissionDialogOnConnect: boolean;
   submit: SubmitManualCredentialsFn;
@@ -202,11 +182,6 @@ function ManualCredentialForm({
 
   return (
     <div className="flex flex-col gap-3">
-      {item.connected && connectedConnectorUsesInteractiveGrant(item) && (
-        <p className="text-xs text-amber-600">
-          This will replace your current connected account.
-        </p>
-      )}
       {method.helpText && <ConnectorHelpText text={method.helpText} />}
       {secretEntries.map(([name, secretConfig]) => {
         return (
@@ -486,7 +461,6 @@ function ManualCredentialConnectMethodContent(
       authMethod={props.authMethod}
       method={props.method}
       grant={props.method.grant}
-      item={props.item}
       onSuccess={props.onSuccess}
       showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
       submit={props.submitManualCredentials}

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -228,8 +228,8 @@ export const zeroConnectorsSearchContract = c.router({
 });
 
 /**
- * Zero contract for POST /api/zero/connectors/:type/sessions
- * Proxies to POST /api/connectors/:type/sessions (OAuth device flow)
+ * Zero contract for POST /api/zero/connectors/:type/sessions.
+ * Creates an auth-code connector handoff session.
  */
 export const zeroConnectorSessionsContract = c.router({
   create: {
@@ -244,7 +244,7 @@ export const zeroConnectorSessionsContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
     },
-    summary: "Create connector session for device flow (zero proxy)",
+    summary: "Create connector session for auth-code handoff",
   },
 });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -56,7 +56,6 @@ import {
   buildConnectorOAuthAuthUrl,
   hasConnectorAuthCodeGrantProvider,
   hasConnectorDeviceAuthGrantProvider,
-  hasConnectorTokenRevokeProvider,
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
   refreshConnectorOAuthToken,
@@ -428,15 +427,12 @@ describe("connector grant provider capability checks", () => {
     expect(connectorAuthMethodSupportsTokenRevoke("github", "oauth")).toBe(
       true,
     );
-    expect(hasConnectorTokenRevokeProvider("github")).toBe(true);
     expect(connectorAuthMethodSupportsTokenRevoke("notion", "oauth")).toBe(
       false,
     );
-    expect(hasConnectorTokenRevokeProvider("notion")).toBe(false);
     expect(connectorAuthMethodSupportsTokenRevoke("stripe", "api-token")).toBe(
       false,
     );
-    expect(hasConnectorTokenRevokeProvider("stripe")).toBe(false);
   });
 
   it("exposes connector OAuth secret metadata without provider access", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -25,9 +25,14 @@ import {
   type AuthCodeGrantConnectorType,
 } from "../connectors";
 import {
+  connectorAuthMethodSupportsTokenRevoke,
+  connectorAuthMethodHasGrantKind,
   getAvailableConnectorAuthMethods,
+  getConnectorAuthMethodGrantScopes,
+  getConnectorAuthMethodScopeDiff,
   getConfiguredConnectorAuthMethods,
   hasRequiredScopes,
+  hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthCodeGrantConfig,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
@@ -40,7 +45,6 @@ import {
   getRuntimeAvailableConnectorTypes,
   getConnectorSecretNames,
   getConnectorVariableNames,
-  hasConnectorOAuthGrant,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorOAuthClient,
@@ -50,7 +54,9 @@ import {
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorOAuthAuthUrl,
-  hasConnectorOAuthProvider,
+  hasConnectorAuthCodeGrantProvider,
+  hasConnectorDeviceAuthGrantProvider,
+  hasConnectorTokenRevokeProvider,
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
   refreshConnectorOAuthToken,
@@ -69,6 +75,10 @@ function getApiTokenManualGrantFields(
     return undefined;
   }
   return method.grant.fields;
+}
+
+function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
+  return hasConnectorAuthCodeGrant(type) || hasConnectorDeviceAuthGrant(type);
 }
 
 const server = setupServer();
@@ -209,6 +219,9 @@ type ConnectorConfigAuthMethodIds<Config extends ConnectorConfig> = Extract<
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
     expect(hasRequiredScopes("cloudinary", null)).toBe(true);
+    expect(
+      hasRequiredConnectorAuthMethodScopes("cloudinary", "api-token", null),
+    ).toBe(true);
   });
 
   it("returns true when connector has empty required scopes", () => {
@@ -247,6 +260,55 @@ describe("hasRequiredScopes", () => {
         "user",
       ]),
     ).toBe(true);
+  });
+
+  it("checks required scopes from the selected auth method grant", () => {
+    expect(
+      connectorAuthMethodHasGrantKind("github", "oauth", "auth-code"),
+    ).toBe(true);
+    expect(getConnectorAuthMethodGrantScopes("github", "oauth")).toStrictEqual([
+      "repo",
+      "project",
+      "workflow",
+    ]);
+    expect(hasRequiredConnectorAuthMethodScopes("github", "oauth", null)).toBe(
+      false,
+    );
+    expect(
+      hasRequiredConnectorAuthMethodScopes("github", "oauth", [
+        "repo",
+        "project",
+        "workflow",
+      ]),
+    ).toBe(true);
+    expect(
+      hasRequiredConnectorAuthMethodScopes("test-oauth-device", "oauth", []),
+    ).toBe(false);
+    expect(
+      hasRequiredConnectorAuthMethodScopes("test-oauth-device", "oauth", [
+        "read",
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not require OAuth scopes for selected manual grants", () => {
+    expect(
+      connectorAuthMethodHasGrantKind("stripe", "api-token", "manual"),
+    ).toBe(true);
+    expect(
+      getConnectorAuthMethodGrantScopes("stripe", "api-token"),
+    ).toStrictEqual([]);
+    expect(
+      hasRequiredConnectorAuthMethodScopes("stripe", "api-token", null),
+    ).toBe(true);
+    expect(
+      getConnectorAuthMethodScopeDiff("stripe", "api-token", null),
+    ).toStrictEqual({
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes: [],
+      storedScopes: [],
+    });
   });
 });
 
@@ -343,17 +405,38 @@ describe("connector auth method config", () => {
   });
 });
 
-describe("hasConnectorOAuthProvider", () => {
-  it("matches exactly the connector types that declare OAuth grants", () => {
-    const oauthConnectorTypes = new Set<ConnectorType>(
-      connectorTypeSchema.options.filter(hasConnectorOAuthGrant),
+describe("connector grant provider capability checks", () => {
+  it("matches exactly the connector types that declare auth-code and device-auth grants", () => {
+    const authCodeGrantTypes = new Set<ConnectorType>(
+      connectorTypeSchema.options.filter(hasConnectorAuthCodeGrant),
+    );
+    const deviceAuthGrantTypes = new Set<ConnectorType>(
+      connectorTypeSchema.options.filter(hasConnectorDeviceAuthGrant),
     );
 
     for (const type of connectorTypeSchema.options) {
-      expect(hasConnectorOAuthProvider(type)).toBe(
-        oauthConnectorTypes.has(type),
+      expect(hasConnectorAuthCodeGrantProvider(type)).toBe(
+        authCodeGrantTypes.has(type),
+      );
+      expect(hasConnectorDeviceAuthGrantProvider(type)).toBe(
+        deviceAuthGrantTypes.has(type),
       );
     }
+  });
+
+  it("detects token revoke support from provider capability", () => {
+    expect(connectorAuthMethodSupportsTokenRevoke("github", "oauth")).toBe(
+      true,
+    );
+    expect(hasConnectorTokenRevokeProvider("github")).toBe(true);
+    expect(connectorAuthMethodSupportsTokenRevoke("notion", "oauth")).toBe(
+      false,
+    );
+    expect(hasConnectorTokenRevokeProvider("notion")).toBe(false);
+    expect(connectorAuthMethodSupportsTokenRevoke("stripe", "api-token")).toBe(
+      false,
+    );
+    expect(hasConnectorTokenRevokeProvider("stripe")).toBe(false);
   });
 
   it("exposes connector OAuth secret metadata without provider access", () => {
@@ -1410,7 +1493,7 @@ describe("getConnectorEnvBindings", () => {
     //   envBindings: values -> declared OAuth connector secrets
     //   api-token secrets:  XXX_TOKEN (if api-token auth method exists)
     for (const type of connectorTypeSchema.options) {
-      if (!hasConnectorOAuthGrant(type)) continue;
+      if (!hasConnectorAuthorizationGrant(type)) continue;
 
       const oauthSecrets = getConnectorSecretNames(type, "oauth");
       const prefix = oauthSecrets
@@ -1506,7 +1589,7 @@ describe("getConnectorEnvBindings", () => {
 
   it("api-token-only connectors expose all secrets via envBindings with same name", () => {
     for (const type of connectorTypeSchema.options) {
-      if (hasConnectorOAuthGrant(type)) continue;
+      if (hasConnectorAuthorizationGrant(type)) continue;
       const fields = getApiTokenManualGrantFields(type);
       if (!fields) continue;
 
@@ -1704,7 +1787,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
 
   it("includes active OAuth connectors when their runtime env is configured", () => {
     const activeOAuthTypes = connectorTypeSchema.options.filter(
-      hasConnectorOAuthGrant,
+      hasConnectorAuthorizationGrant,
     );
 
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(() => {
@@ -1815,7 +1898,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
   });
 
   it("returns undefined for connectors without OAuth grants", () => {
-    expect(hasConnectorOAuthGrant("axiom")).toBe(false);
+    expect(hasConnectorAuthorizationGrant("axiom")).toBe(false);
     expect(getConnectorOAuthScopes("axiom")).toStrictEqual([]);
     expect(getConnectorAuthCodeGrantConfig("base44")).toBeUndefined();
     expect(getConnectorDeviceAuthGrantConfig("github")).toBeUndefined();

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -29,6 +29,7 @@ import {
   connectorAuthMethodHasGrantKind,
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethodGrantScopes,
+  getConnectorAuthMethodIdForGrantKind,
   getConnectorAuthMethodScopeDiff,
   getConfiguredConnectorAuthMethods,
   hasRequiredScopes,
@@ -262,6 +263,19 @@ describe("hasRequiredScopes", () => {
   });
 
   it("checks required scopes from the selected auth method grant", () => {
+    expect(getConnectorAuthMethodIdForGrantKind("github", "auth-code")).toBe(
+      "oauth",
+    );
+    expect(
+      getConnectorAuthMethodIdForGrantKind("test-oauth-device", "device-auth"),
+    ).toBe("oauth");
+    expect(getConnectorAuthMethodIdForGrantKind("stripe", "manual")).toBe(
+      "api-token",
+    );
+    expect(
+      getConnectorAuthMethodIdForGrantKind("github", "manual"),
+    ).toBeUndefined();
+
     expect(
       connectorAuthMethodHasGrantKind("github", "oauth", "auth-code"),
     ).toBe(true);

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -219,15 +219,41 @@ const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap
     "test-oauth-device": testOauthDeviceProvider,
   };
 
-const CONNECTOR_OAUTH_PROVIDERS = {
-  ...AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS,
-  ...DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS,
-};
-
 export function hasConnectorOAuthProvider(
   type: string,
 ): type is OAuthGrantConnectorType {
-  return Object.hasOwn(CONNECTOR_OAUTH_PROVIDERS, type);
+  return (
+    hasConnectorAuthCodeGrantProvider(type) ||
+    hasConnectorDeviceAuthGrantProvider(type)
+  );
+}
+
+export function hasConnectorAuthCodeGrantProvider(
+  type: string,
+): type is AuthCodeGrantConnectorType {
+  return Object.hasOwn(AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS, type);
+}
+
+export function hasConnectorDeviceAuthGrantProvider(
+  type: string,
+): type is DeviceAuthGrantConnectorType {
+  return Object.hasOwn(DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS, type);
+}
+
+export function hasConnectorTokenRevokeProvider(
+  type: string,
+): type is OAuthGrantConnectorType {
+  if (hasConnectorAuthCodeGrantProvider(type)) {
+    return (
+      AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type].revoke.kind === "token-revoke"
+    );
+  }
+  if (hasConnectorDeviceAuthGrantProvider(type)) {
+    return (
+      DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type].revoke.kind === "token-revoke"
+    );
+  }
+  return false;
 }
 
 export function getConnectorOAuthSecretMetadata(
@@ -239,19 +265,19 @@ export function getConnectorOAuthSecretMetadata(
 export function getConnectorOAuthSecretMetadata(
   type: string,
 ): ConnectorOAuthSecretMetadata | undefined {
-  if (!hasConnectorOAuthProvider(type)) {
-    return undefined;
-  }
-
-  if (hasConnectorAuthCodeGrant(type)) {
+  if (hasConnectorAuthCodeGrantProvider(type)) {
     return getAuthProviderSecretMetadata(
       AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type],
     );
   }
 
-  return getAuthProviderSecretMetadata(
-    DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type],
-  );
+  if (hasConnectorDeviceAuthGrantProvider(type)) {
+    return getAuthProviderSecretMetadata(
+      DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type],
+    );
+  }
+
+  return undefined;
 }
 
 export async function buildConnectorOAuthAuthUrl<

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -240,22 +240,6 @@ export function hasConnectorDeviceAuthGrantProvider(
   return Object.hasOwn(DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS, type);
 }
 
-export function hasConnectorTokenRevokeProvider(
-  type: string,
-): type is OAuthGrantConnectorType {
-  if (hasConnectorAuthCodeGrantProvider(type)) {
-    return (
-      AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type].revoke.kind === "token-revoke"
-    );
-  }
-  if (hasConnectorDeviceAuthGrantProvider(type)) {
-    return (
-      DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type].revoke.kind === "token-revoke"
-    );
-  }
-  return false;
-}
-
 export function getConnectorOAuthSecretMetadata(
   type: OAuthGrantConnectorType,
 ): ConnectorOAuthSecretMetadata;

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 import { getConnectorOAuthClient } from "../../../../connector-utils";
-import { hasConnectorOAuthProvider } from "../../../connector-auth";
+import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
 
@@ -10,8 +10,8 @@ const USER_INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
 
 describe("connector/providers/google-ads", () => {
   describe("googleAdsProvider", () => {
-    it("registers google-ads as an OAuth connector type", () => {
-      expect(hasConnectorOAuthProvider("google-ads")).toBe(true);
+    it("registers google-ads as an auth-code grant provider", () => {
+      expect(hasConnectorAuthCodeGrantProvider("google-ads")).toBe(true);
     });
 
     it("buildAuthUrl builds Google OAuth URL with Google Ads and userinfo scopes", () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 import { getConnectorOAuthClient } from "../../../../connector-utils";
-import { hasConnectorOAuthProvider } from "../../../connector-auth";
+import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
@@ -138,8 +138,8 @@ describe("connector/providers/meta-ads", () => {
   });
 
   describe("metaAdsProvider", () => {
-    it("registers meta-ads as an OAuth connector type", () => {
-      expect(hasConnectorOAuthProvider("meta-ads")).toBe(true);
+    it("registers meta-ads as an auth-code grant provider", () => {
+      expect(hasConnectorAuthCodeGrantProvider("meta-ads")).toBe(true);
     });
 
     it("buildAuthUrl delegates to buildMetaAdsAuthorizationUrl", () => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -8,6 +8,8 @@ import {
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorEnvBindings,
   type ConnectorGenerationType,
+  type ConnectorGrantConfig,
+  type ConnectorGrantKind,
   type ConnectorOAuthClientConfig,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
@@ -155,14 +157,14 @@ function authMethodAccessPriority(method: ConnectorAuthMethodConfig): number {
   }
 }
 
-type ConnectorOAuthGrantConfig =
+type ConnectorGrantConfigWithScopes =
   | ConnectorAuthCodeGrantConfig
   | ConnectorDeviceAuthGrantConfig;
 
-function isConnectorOAuthGrantConfig(
+function isConnectorGrantConfigWithScopes(
   method: ConnectorAuthMethodConfig,
 ): method is ConnectorAuthMethodConfig & {
-  readonly grant: ConnectorOAuthGrantConfig;
+  readonly grant: ConnectorGrantConfigWithScopes;
 } {
   switch (method.grant.kind) {
     case "auth-code":
@@ -176,40 +178,41 @@ function isConnectorOAuthGrantConfig(
 
 function getConnectorOAuthGrantConfig(
   type: OAuthGrantConnectorType,
-): ConnectorOAuthGrantConfig;
+): ConnectorGrantConfigWithScopes;
 function getConnectorOAuthGrantConfig(
   type: ConnectorType,
-): ConnectorOAuthGrantConfig | undefined;
+): ConnectorGrantConfigWithScopes | undefined;
 function getConnectorOAuthGrantConfig(
   type: ConnectorType,
-): ConnectorOAuthGrantConfig | undefined {
+): ConnectorGrantConfigWithScopes | undefined {
   for (const method of connectorAuthMethodValues(type)) {
-    if (isConnectorOAuthGrantConfig(method)) {
+    if (isConnectorGrantConfigWithScopes(method)) {
       return method.grant;
     }
   }
   return undefined;
 }
 
-export function hasConnectorOAuthGrant(
-  type: ConnectorType,
-): type is OAuthGrantConnectorType {
-  return getConnectorOAuthGrantConfig(type) !== undefined;
-}
-
-export function connectorAuthMethodHasOAuthGrant(
+export function connectorAuthMethodHasGrantKind(
   type: ConnectorType,
   authMethod: string,
+  grantKind: ConnectorGrantKind,
 ): boolean {
   const method = getConnectorAuthMethod(type, authMethod);
-  switch (method?.grant.kind) {
+  return method?.grant.kind === grantKind;
+}
+
+function connectorGrantScopes(
+  grant: ConnectorGrantConfig | undefined,
+): readonly string[] {
+  switch (grant?.kind) {
     case "auth-code":
     case "device-auth":
-      return true;
+      return grant.scopes;
     case "manual":
     case "managed":
     case undefined:
-      return false;
+      return [];
   }
 }
 
@@ -258,7 +261,32 @@ export function getConnectorDeviceAuthGrantConfig(
 }
 
 export function getConnectorOAuthScopes(type: ConnectorType): string[] {
-  return [...(getConnectorOAuthGrantConfig(type)?.scopes ?? [])];
+  return [...connectorGrantScopes(getConnectorOAuthGrantConfig(type))];
+}
+
+export function getConnectorAuthMethodGrantScopes(
+  type: ConnectorType,
+  authMethod: string,
+): string[] {
+  return [
+    ...connectorGrantScopes(getConnectorAuthMethod(type, authMethod)?.grant),
+  ];
+}
+
+export function connectorAuthMethodHasGrantScopes(
+  type: ConnectorType,
+  authMethod: string,
+): boolean {
+  return getConnectorAuthMethodGrantScopes(type, authMethod).length > 0;
+}
+
+export function connectorAuthMethodSupportsTokenRevoke(
+  type: ConnectorType,
+  authMethod: string,
+): boolean {
+  return (
+    getConnectorAuthMethod(type, authMethod)?.revoke.kind === "token-revoke"
+  );
 }
 
 export function getConnectorGenerationTypes(
@@ -656,21 +684,14 @@ export function hasConnectorDeviceAuthGrant(
   return getConnectorDeviceAuthGrantConfig(type) !== undefined;
 }
 
-/**
- * Check if stored OAuth scopes cover all required scopes for a connector type.
- * Returns true if no OAuth config exists (non-OAuth connector) or all required scopes are present.
- * Returns false if storedScopes is null (legacy connector) or missing any required scope.
- */
-export function hasRequiredScopes(
-  connectorType: ConnectorType,
+function hasRequiredGrantScopes(
+  requiredScopes: readonly string[],
   storedScopes: string[] | null,
 ): boolean {
-  const scopes = getConnectorOAuthGrantConfig(connectorType)?.scopes;
-  if (!scopes) return true;
-  if (scopes.length === 0) return true;
+  if (requiredScopes.length === 0) return true;
   if (!storedScopes) return false;
   const storedSet = new Set(storedScopes);
-  return scopes.every((s) => {
+  return requiredScopes.every((s) => {
     return storedSet.has(s);
   });
 }
@@ -685,13 +706,10 @@ export interface ScopeDiff {
   storedScopes: string[];
 }
 
-export function getScopeDiff(
-  connectorType: ConnectorType,
+function scopeDiff(
+  currentScopes: readonly string[],
   storedScopes: string[] | null,
 ): ScopeDiff {
-  const currentScopes = [
-    ...(getConnectorOAuthGrantConfig(connectorType)?.scopes ?? []),
-  ];
   const stored = storedScopes ?? [];
   const storedSet = new Set(stored);
   const currentSet = new Set(currentScopes);
@@ -703,9 +721,56 @@ export function getScopeDiff(
     removedScopes: stored.filter((s) => {
       return !currentSet.has(s);
     }),
-    currentScopes,
+    currentScopes: [...currentScopes],
     storedScopes: stored,
   };
+}
+
+/**
+ * Check if stored scopes cover all currently required scopes for the first
+ * scope-bearing grant on a connector type.
+ */
+export function hasRequiredScopes(
+  connectorType: ConnectorType,
+  storedScopes: string[] | null,
+): boolean {
+  return hasRequiredGrantScopes(
+    getConnectorOAuthScopes(connectorType),
+    storedScopes,
+  );
+}
+
+export function hasRequiredConnectorAuthMethodScopes(
+  connectorType: ConnectorType,
+  authMethod: string,
+  storedScopes: string[] | null,
+): boolean {
+  return hasRequiredGrantScopes(
+    getConnectorAuthMethodGrantScopes(connectorType, authMethod),
+    storedScopes,
+  );
+}
+
+/**
+ * Compute the diff between currently required scopes and stored scopes for the
+ * first scope-bearing grant on a connector type.
+ */
+export function getScopeDiff(
+  connectorType: ConnectorType,
+  storedScopes: string[] | null,
+): ScopeDiff {
+  return scopeDiff(getConnectorOAuthScopes(connectorType), storedScopes);
+}
+
+export function getConnectorAuthMethodScopeDiff(
+  connectorType: ConnectorType,
+  authMethod: string,
+  storedScopes: string[] | null,
+): ScopeDiff {
+  return scopeDiff(
+    getConnectorAuthMethodGrantScopes(connectorType, authMethod),
+    storedScopes,
+  );
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -16,6 +16,7 @@ import {
   type OAuthGrantConnectorType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
+  type TokenRevokeConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors";
@@ -288,7 +289,7 @@ export function getConnectorAuthMethodGrantScopes(
 export function connectorAuthMethodSupportsTokenRevoke(
   type: ConnectorType,
   authMethod: string,
-): type is OAuthGrantConnectorType {
+): type is TokenRevokeConnectorType {
   return (
     getConnectorAuthMethod(type, authMethod)?.revoke.kind === "token-revoke"
   );

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -273,17 +273,10 @@ export function getConnectorAuthMethodGrantScopes(
   ];
 }
 
-export function connectorAuthMethodHasGrantScopes(
-  type: ConnectorType,
-  authMethod: string,
-): boolean {
-  return getConnectorAuthMethodGrantScopes(type, authMethod).length > 0;
-}
-
 export function connectorAuthMethodSupportsTokenRevoke(
   type: ConnectorType,
   authMethod: string,
-): boolean {
+): type is OAuthGrantConnectorType {
   return (
     getConnectorAuthMethod(type, authMethod)?.revoke.kind === "token-revoke"
   );

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -74,6 +74,18 @@ export function getConnectorAuthMethod(
   return undefined;
 }
 
+export function getConnectorAuthMethodIdForGrantKind(
+  type: ConnectorType,
+  grantKind: ConnectorGrantKind,
+): ConnectorAuthMethodId | undefined {
+  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+    if (getConnectorAuthMethod(type, authMethod)?.grant.kind === grantKind) {
+      return authMethod;
+    }
+  }
+  return undefined;
+}
+
 function connectorAuthMethodValues(
   type: ConnectorType,
 ): ConnectorAuthMethodConfig[] {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -946,6 +946,8 @@ export type OAuthGrantConnectorType = ConnectorTypesByGrantKind<
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;
 export type DeviceAuthGrantConnectorType =
   ConnectorTypesByGrantKind<"device-auth">;
+export type TokenRevokeConnectorType =
+  ConnectorTypesByRevokeKind<"token-revoke">;
 
 export type ConnectorInvalidDefaultAuthMethodType<
   Configs extends Record<string, ConnectorConfig>,


### PR DESCRIPTION
## Summary
- replace upper-layer OAuth connector classification with grant/access capability checks
- derive scope mismatch and scope diff from the stored connector auth method
- derive callback requested scopes from auth-code grant config instead of a hard-coded auth method
- express route/device-auth unsupported cases in grant terms instead of generic OAuth connector checks
- remove redundant provider-map fallback checks from upper-layer routes/services while keeping OAuth provider/client/token logic scoped to provider and data services

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/cli-auth.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/cli-auth.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
- pnpm -F @vm0/cli exec vitest run src/commands/zero/connector/__tests__/status.test.ts src/commands/zero/connector/__tests__/search.test.ts
- commit hook: prettier, knip, full pnpm check-types

## Notes
- Full pnpm vitest was run once before local DB migration and failed on stale schema errors, Linux desktop native helper limitations, and an unrelated network-insights date test. After running pnpm -F @vm0/db db:migrate, the connector-related targeted suites above passed. The network-insights file still fails independently on the three Yesterday/date-window assertions.

Closes #15327