### PR TITLE
refactor(desktop): extract accessibility settle policy and add tests

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Test desktop
         run: pnpm -F @vm0/desktop test
 
+      - name: Test native helper
+        run: pnpm -F @vm0/desktop test:native
+
       - name: Resolve PR preview desktop URL
         id: preview
         if: github.event_name == 'pull_request'

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -3508,55 +3508,22 @@ func captureAccessibilityElements(
     return (elements, nodeCount, truncationReasons)
 }
 
-func appendAccessibilityFingerprint(_ node: [String: Any], into out: inout String) {
-    out += (node["id"] as? String) ?? ""
-    out += "|"
-    out += (node["role"] as? String) ?? ""
-    if let bounds = node["bounds"] as? [String: Double] {
-        out += "|\(Int(bounds["x"] ?? 0)),\(Int(bounds["y"] ?? 0)),"
-        out += "\(Int(bounds["width"] ?? 0)),\(Int(bounds["height"] ?? 0))"
-    }
-    out += ";"
-    if let children = node["children"] as? [[String: Any]] {
-        for child in children {
-            appendAccessibilityFingerprint(child, into: &out)
-        }
-    }
-}
-
-func accessibilityElementsFingerprint(_ elements: [[String: Any]]) -> String {
-    var out = ""
-    for element in elements {
-        appendAccessibilityFingerprint(element, into: &out)
-    }
-    return out
-}
-
 // Re-capture the accessibility tree until its structure stabilizes. Element ids
 // are positional tree paths, so a snapshot taken while a menu is still animating
 // open returns ids that shift before the agent can act on them. Polling until the
-// fingerprint stops changing keeps post-action snapshots actionable.
+// fingerprint stops changing keeps post-action snapshots actionable. The loop
+// control lives in ComputerUseHelperCore so it can be exercised deterministically
+// in tests.
 func settledAccessibilityElements(
     _ root: AXUIElement
 ) -> (elements: [[String: Any]], nodeCount: Int, truncationReasons: [String]) {
-    let requiredStablePasses = 3
-    let pollInterval: useconds_t = 120_000
-    let deadline = Date().addingTimeInterval(1.6)
-    var latest = captureAccessibilityElements(root)
-    var previousFingerprint = accessibilityElementsFingerprint(latest.elements)
-    var stablePasses = 1
-    while stablePasses < requiredStablePasses, Date() < deadline {
-        usleep(pollInterval)
-        latest = captureAccessibilityElements(root)
-        let fingerprint = accessibilityElementsFingerprint(latest.elements)
-        if fingerprint == previousFingerprint {
-            stablePasses += 1
-        } else {
-            stablePasses = 1
-            previousFingerprint = fingerprint
-        }
-    }
-    return latest
+    return settleCapture(
+        policy: .postAction,
+        now: { Date().timeIntervalSinceReferenceDate },
+        sleep: { usleep($0) },
+        capture: { captureAccessibilityElements(root) },
+        fingerprint: { accessibilityElementsFingerprint($0.elements) }
+    )
 }
 
 func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/AccessibilitySettlePolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/AccessibilitySettlePolicy.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Tuning for the post-action accessibility settle loop.
+///
+/// Element ids in app-state snapshots are positional tree paths, so a snapshot
+/// captured while a menu is still animating open returns ids that shift before
+/// the agent can act on them. The settle loop re-captures the tree until its
+/// structure fingerprint stops changing, keeping post-action snapshots
+/// actionable.
+public struct AccessibilitySettlePolicy: Sendable {
+    /// Number of consecutive identical fingerprints required to treat the tree
+    /// as settled.
+    public let requiredStablePasses: Int
+    /// Delay between re-capture attempts, in microseconds.
+    public let pollIntervalMicroseconds: UInt32
+    /// Upper bound on the total time spent waiting for the tree to settle, in
+    /// seconds. Reached when the tree never stabilizes (e.g. a perpetually
+    /// animating element).
+    public let timeoutSeconds: TimeInterval
+
+    public init(
+        requiredStablePasses: Int,
+        pollIntervalMicroseconds: UInt32,
+        timeoutSeconds: TimeInterval
+    ) {
+        self.requiredStablePasses = requiredStablePasses
+        self.pollIntervalMicroseconds = pollIntervalMicroseconds
+        self.timeoutSeconds = timeoutSeconds
+    }
+
+    /// Defaults applied to snapshots captured immediately after a write action.
+    public static let postAction = AccessibilitySettlePolicy(
+        requiredStablePasses: 3,
+        pollIntervalMicroseconds: 120_000,
+        timeoutSeconds: 1.6
+    )
+}
+
+/// Re-capture a value until its fingerprint stays identical for
+/// `policy.requiredStablePasses` consecutive captures, or until the policy
+/// timeout elapses. Returns the most recent capture.
+///
+/// `now`, `sleep`, and `capture` are injected so the control flow can be
+/// exercised deterministically in tests without touching the live
+/// accessibility tree or the wall clock.
+public func settleCapture<T>(
+    policy: AccessibilitySettlePolicy,
+    now: () -> TimeInterval,
+    sleep: (UInt32) -> Void,
+    capture: () -> T,
+    fingerprint: (T) -> String
+) -> T {
+    let deadline = now() + policy.timeoutSeconds
+    var latest = capture()
+    var previousFingerprint = fingerprint(latest)
+    var stablePasses = 1
+    while stablePasses < policy.requiredStablePasses, now() < deadline {
+        sleep(policy.pollIntervalMicroseconds)
+        latest = capture()
+        let currentFingerprint = fingerprint(latest)
+        if currentFingerprint == previousFingerprint {
+            stablePasses += 1
+        } else {
+            stablePasses = 1
+            previousFingerprint = currentFingerprint
+        }
+    }
+    return latest
+}
+
+/// Append a stable, structure-only fingerprint of a single accessibility node
+/// (and its descendants) to `out`. Captures id, role, and integer bounds so
+/// that animation-driven positional shifts are detected while ignoring volatile
+/// text content.
+public func appendAccessibilityFingerprint(
+    _ node: [String: Any],
+    into out: inout String
+) {
+    out += (node["id"] as? String) ?? ""
+    out += "|"
+    out += (node["role"] as? String) ?? ""
+    if let bounds = node["bounds"] as? [String: Double] {
+        out += "|\(Int(bounds["x"] ?? 0)),\(Int(bounds["y"] ?? 0)),"
+        out += "\(Int(bounds["width"] ?? 0)),\(Int(bounds["height"] ?? 0))"
+    }
+    out += ";"
+    if let children = node["children"] as? [[String: Any]] {
+        for child in children {
+            appendAccessibilityFingerprint(child, into: &out)
+        }
+    }
+}
+
+/// Build a stable, structure-only fingerprint of a captured element list.
+public func accessibilityElementsFingerprint(_ elements: [[String: Any]]) -> String {
+    var out = ""
+    for element in elements {
+        appendAccessibilityFingerprint(element, into: &out)
+    }
+    return out
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/AccessibilitySettlePolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/AccessibilitySettlePolicyTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+
+@testable import ComputerUseHelperCore
+
+struct AccessibilitySettlePolicyTests {
+    private let policy = AccessibilitySettlePolicy(
+        requiredStablePasses: 3,
+        pollIntervalMicroseconds: 0,
+        timeoutSeconds: 1000
+    )
+
+    private func node(
+        _ id: String,
+        role: String? = nil,
+        bounds: [String: Double]? = nil,
+        name: String? = nil,
+        children: [[String: Any]]? = nil
+    ) -> [String: Any] {
+        var result: [String: Any] = ["id": id]
+        if let role { result["role"] = role }
+        if let bounds { result["bounds"] = bounds }
+        if let name { result["name"] = name }
+        if let children { result["children"] = children }
+        return result
+    }
+
+    @Test
+    func stopsAfterRequiredConsecutiveStablePasses() {
+        var captureCount = 0
+        var sleepCount = 0
+        let stable = [node("w0", role: "AXWindow")]
+
+        let result = settleCapture(
+            policy: policy,
+            now: { 0 },
+            sleep: { _ in sleepCount += 1 },
+            capture: {
+                captureCount += 1
+                return stable
+            },
+            fingerprint: accessibilityElementsFingerprint
+        )
+
+        // 1 initial capture + 2 polls to reach 3 consecutive identical passes.
+        #expect(captureCount == 3)
+        #expect(sleepCount == 2)
+        #expect(accessibilityElementsFingerprint(result) == accessibilityElementsFingerprint(stable))
+    }
+
+    @Test
+    func resetsStableCountWhenFingerprintChanges() {
+        let sequence: [[[String: Any]]] = [
+            [node("a")],
+            [node("a")],
+            [node("b")],
+            [node("b")],
+            [node("b")],
+        ]
+        var index = 0
+
+        let result = settleCapture(
+            policy: policy,
+            now: { 0 },
+            sleep: { _ in },
+            capture: {
+                let value = sequence[index]
+                index += 1
+                return value
+            },
+            fingerprint: accessibilityElementsFingerprint
+        )
+
+        // a, a, b (reset), b, b -> stabilizes only on the trailing run of three.
+        #expect(index == 5)
+        #expect(accessibilityElementsFingerprint(result) == accessibilityElementsFingerprint([node("b")]))
+    }
+
+    @Test
+    func stopsAtDeadlineWhenNeverStable() {
+        // Alternating fingerprints never stabilize; the deadline must end the loop.
+        let unstablePolicy = AccessibilitySettlePolicy(
+            requiredStablePasses: 3,
+            pollIntervalMicroseconds: 0,
+            timeoutSeconds: 2.5
+        )
+        var clock: TimeInterval = 0
+        var captureCount = 0
+
+        let result = settleCapture(
+            policy: unstablePolicy,
+            now: {
+                let value = clock
+                clock += 1
+                return value
+            },
+            sleep: { _ in },
+            capture: {
+                captureCount += 1
+                return captureCount.isMultiple(of: 2) ? [node("a")] : [node("b")]
+            },
+            fingerprint: accessibilityElementsFingerprint
+        )
+
+        // deadline = 0 + 2.5; clock yields 0 (deadline), 1, 2 (<2.5), 3 (>=2.5 -> stop).
+        #expect(captureCount == 3)
+        #expect(accessibilityElementsFingerprint(result) == accessibilityElementsFingerprint([node("b")]))
+    }
+
+    @Test
+    func fingerprintIsStableForIdenticalStructure() {
+        let bounds = ["x": 10.0, "y": 20.0, "width": 100.0, "height": 50.0]
+        let first = [node("w0", role: "AXButton", bounds: bounds)]
+        let second = [node("w0", role: "AXButton", bounds: bounds)]
+
+        #expect(
+            accessibilityElementsFingerprint(first) ==
+                accessibilityElementsFingerprint(second)
+        )
+    }
+
+    @Test
+    func fingerprintIgnoresVolatileTextContent() {
+        let bounds = ["x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0]
+        let labelled = [node("w0", role: "AXStaticText", bounds: bounds, name: "Loading…")]
+        let updated = [node("w0", role: "AXStaticText", bounds: bounds, name: "Done")]
+
+        #expect(
+            accessibilityElementsFingerprint(labelled) ==
+                accessibilityElementsFingerprint(updated)
+        )
+    }
+
+    @Test
+    func fingerprintChangesWhenStructureChanges() {
+        let base = [node("w0", role: "AXButton", bounds: ["x": 0, "y": 0, "width": 10, "height": 10])]
+        let movedBounds = [node("w0", role: "AXButton", bounds: ["x": 5, "y": 0, "width": 10, "height": 10])]
+        let differentRole = [node("w0", role: "AXMenuItem", bounds: ["x": 0, "y": 0, "width": 10, "height": 10])]
+        let differentId = [node("w1", role: "AXButton", bounds: ["x": 0, "y": 0, "width": 10, "height": 10])]
+
+        let baseFingerprint = accessibilityElementsFingerprint(base)
+        #expect(baseFingerprint != accessibilityElementsFingerprint(movedBounds))
+        #expect(baseFingerprint != accessibilityElementsFingerprint(differentRole))
+        #expect(baseFingerprint != accessibilityElementsFingerprint(differentId))
+    }
+
+    @Test
+    func fingerprintIncludesNestedChildren() {
+        let parentBounds = ["x": 0.0, "y": 0.0, "width": 100.0, "height": 100.0]
+        let childBounds = ["x": 10.0, "y": 10.0, "width": 20.0, "height": 20.0]
+        let withoutChild = [node("w0", role: "AXWindow", bounds: parentBounds)]
+        let withChild = [
+            node(
+                "w0",
+                role: "AXWindow",
+                bounds: parentBounds,
+                children: [node("w0.e0", role: "AXButton", bounds: childBounds)]
+            ),
+        ]
+
+        #expect(
+            accessibilityElementsFingerprint(withoutChild) !=
+                accessibilityElementsFingerprint(withChild)
+        )
+    }
+}

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "package": "pnpm build && electron-forge package --platform darwin",
     "start": "electron-forge start",
     "test": "vitest run",
+    "test:native": "node scripts/test-native-helper.js",
     "vm0-computer": "pnpm build:cli && node dist/vm0-computer.js"
   },
   "dependencies": {

--- a/turbo/apps/desktop/scripts/test-native-helper.js
+++ b/turbo/apps/desktop/scripts/test-native-helper.js
@@ -1,0 +1,16 @@
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+if (process.platform !== "darwin") {
+  console.log(
+    `Skipping native helper tests on ${process.platform} (macOS-only).`,
+  );
+  process.exit(0);
+}
+
+const appRoot = path.resolve(__dirname, "..");
+const packageRoot = path.join(appRoot, "native", "computer-use-helper");
+
+execFileSync("swift", ["test", "--package-path", packageRoot], {
+  stdio: "inherit",
+});


### PR DESCRIPTION
## Summary
Follow-up to #15324, addressing the two non-blocking P2 notes from that review:

1. **Magic numbers → named constants.** The post-action settle loop's inline `3` / `120_000` / `1.6` now live in a named `AccessibilitySettlePolicy` (`requiredStablePasses` / `pollIntervalMicroseconds` / `timeoutSeconds`) with a `.postAction` default.
2. **Settle loop had no automated test (only `swift build`).** The loop control and the structure fingerprint are extracted into `ComputerUseHelperCore` as a generic, injectable `settleCapture(policy:now:sleep:capture:fingerprint:)`, so the behavior is exercised deterministically without the live AX tree or the wall clock. Added Swift tests + wired `swift test` into CI so it actually gates.

## Changes
- **`AccessibilitySettlePolicy.swift`** (new, Core): policy struct + `.postAction` default; generic `settleCapture` driver; the `appendAccessibilityFingerprint` / `accessibilityElementsFingerprint` pure functions (moved out of `main.swift`).
- **`main.swift`**: `settledAccessibilityElements` is now a thin wrapper that injects `Date`/`usleep` into `settleCapture`. No behavior change.
- **`AccessibilitySettlePolicyTests.swift`** (new): covers stable-pass termination (3 consecutive identical → stop), reset-on-change, deadline fallback when never stable, and fingerprint semantics (structure-sensitive, ignores volatile text, includes nested children).
- **CI**: `test:native` script (darwin-guarded, mirrors `build-native-helper.js`) + a "Test native helper" step in `desktop.yml` after "Test desktop". Previously `swift test` ran nowhere — even the existing `WindowVisibilityPolicyTests` were local-only; this closes that gap too.

## Test plan
- [x] `pnpm -F @vm0/desktop test:native` → 12 Swift tests pass (7 new + 5 existing), in 2 suites
- [x] `swift build -c release` (helper compiles, Swift 6)
- [x] `pnpm -F @vm0/desktop check-types`
- [x] `pnpm -F @vm0/desktop lint`
- [x] `pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts` (57 pass — prior settle integration test still green)
- [x] `pnpm format`, `pnpm knip --workspace apps/desktop`

Refs #15277

🤖 Generated with [Claude Code](https://claude.com/claude-code)