### PR TITLE
feat: add Claude Opus 4.8 model page

### DIFF
--- a/turbo/apps/web/app/[locale]/models/data.ts
+++ b/turbo/apps/web/app/[locale]/models/data.ts
@@ -93,6 +93,36 @@ export function isReasoningModel(m: ModelEntry): m is ReasoningModelEntry {
 
 export const MODELS: ModelEntry[] = [
   {
+    slug: "claude-opus-4-8",
+    modelId: "claude-opus-4-8",
+    name: "Claude Opus 4.8",
+    vendor: "Anthropic",
+    category: "reasoning",
+    multiplier: 1.7,
+    contextWindowK: 1000,
+    promptCaching: true,
+    modalities: ["Text", "Vision", "Code"],
+    releasedToVm0: "May 28, 2026",
+    pricing: {
+      inputUsd: 5,
+      outputUsd: 25,
+      cacheReadUsd: 0.5,
+      cacheWriteUsd: 6.25,
+    },
+    vm0Tier: "core",
+    byoKeyLabel: "Anthropic API key",
+    defaultFor: [],
+    comparisonSlugs: [
+      "Claude Opus 4.7",
+      "Claude Sonnet 4.6",
+      "GPT-5.5",
+      "Gemini 3.1 Pro",
+      "DeepSeek V4 Pro",
+    ],
+    alternativeSlugs: ["claude-opus-4-7", "claude-sonnet-4-6", "gpt-5-5"],
+  },
+
+  {
     slug: "claude-opus-4-7",
     modelId: "claude-opus-4-7",
     name: "Claude Opus 4.7",
@@ -113,13 +143,13 @@ export const MODELS: ModelEntry[] = [
     byoKeyLabel: "Anthropic API key",
     defaultFor: [],
     comparisonSlugs: [
+      "Claude Opus 4.8",
       "Claude Sonnet 4.6",
       "Claude Opus 4.6",
       "Kimi K2.6",
       "DeepSeek V4 Pro",
-      "GPT-5.2 / Gemini 3 Pro",
     ],
-    alternativeSlugs: ["claude-sonnet-4-6", "kimi-k2-6", "deepseek-v4-pro"],
+    alternativeSlugs: ["claude-opus-4-8", "claude-sonnet-4-6", "kimi-k2-6"],
   },
 
   {

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -3917,6 +3917,240 @@
     "generationAccessHeading": "{name} auf VM0 nutzen",
     "generationAccessBody": "VM0-Agenten können {name} im Rahmen eines Agent-Runs aufrufen, abgerechnet über VM0-Credits. Der oben gelistete Preis ist der Anbieter-Listenpreis; VM0 reicht diesen mit der Standard-Credit-Umrechnung weiter.",
     "content": {
+      "claude-opus-4-8": {
+        "name": "Claude Opus 4.8",
+        "pageTitle": "Claude Opus 4.8",
+        "tagline": "Anthropics neuestes Flaggschiff. Veröffentlicht am 28. Mai 2026 mit stärkerem agentischen Coding, dynamischen Workflows, die hunderte parallele Subagenten ausfächern, und einem 3× günstigeren Fast-Mode zum gleichen regulären Preis wie Opus 4.7.",
+        "cardIntro": "Anthropics neuestes Claude 4-Flaggschiff. Führt SWE-bench Pro und OSWorld-Verified bei Release, mit dynamischen Workflows und einem 3× günstigeren Fast-Mode.",
+        "metaTitle": "Claude Opus 4.8: Benchmarks, Preise & Fähigkeiten",
+        "metaDescription": "Claude Opus 4.8 im Test. Anthropics Flaggschiff vom 28. Mai 2026 mit 1M-Token-Kontext, Max-Effort-Thinking, dynamischen Workflows, $5/$25 Vendor-Preisen und Benchmark-Vorteilen gegenüber Opus 4.7 bei SWE-bench Pro, OSWorld-Verified, MCP-Atlas, BrowseComp, USAMO und GraphWalks Langkontext-Recall.",
+        "summary": "Claude Opus 4.8 ist Anthropics Flaggschiff-Release vom 28. Mai 2026 — ein direktes Upgrade von Opus 4.7 zum gleichen Vendor-Listenpreis von $5/$25. Es erzielt die höchsten Werte für SWE-bench Pro (69,2%), OSWorld-Verified (83,4%), MCP-Atlas (82,2%) und Humanity's Last Exam (57,9% mit Tools), die Anthropic je ausgeliefert hat, und ist das erste Modell, das die All-Pass-Schwelle von 10% beim Legal-Agent-Standard durchbricht.\n\nDie zwei strukturellen Änderungen, die man kennen sollte, sind dynamische Workflows (eine Aufgabe planen und in einer Session über hunderte parallele Subagenten ausfächern) und ein Fast-Mode-Preiscut auf 2,5× Geschwindigkeit bei $10/$50 pro 1M Token — dreimal günstiger als Fast Mode bei früheren Claude-Modellen. Effort-Levels erweitern sich auf high (Standard), extra und max. Anthropic selbst bezeichnet den Release als \"bescheidene, aber spürbare Verbesserung\" und nicht als Sprung.",
+        "releaseDate": "28. Mai 2026",
+        "familyPosition": "Spitzenmodell der Claude 4-Familie. Anthropics empfohlener Standard für neue Agenten; läuft mit dem gleichen ×1,7 Multiplikator wie Opus 4.7.",
+        "background": [
+          "Claude Opus 4.8 wurde am 28. Mai 2026 als neues Anthropic-Flaggschiff veröffentlicht, 41 Tage nach Opus 4.7. Es zielt auf die gleichen Coding-, Agentic-Skill-, Reasoning- und Wissensarbeit-Workloads wie 4.7 ab, zum gleichen regulären Listenpreis ($5 Input / $25 Output pro 1M Token) und mit dem gleichen VM0-Multiplikator (×1,7). Anthropic positioniert den Release als \"bescheidene, aber spürbare Verbesserung gegenüber dem Vorgänger\" und nicht als Stufensprung.",
+          "Zwei strukturelle Änderungen sind für VM0-Nutzer relevant. Erstens: dynamische Workflows — das Modell kann eine Aufgabe planen und in einer einzigen Session über hunderte parallele Subagenten ausfächern, was Anthropic als Schritt in Richtung Codebase-weiter Migrationen über hunderttausende Codezeilen in einem Run beschreibt. Zweitens: Fast Mode bei 2,5× Geschwindigkeit kostet jetzt $10 / $50 pro 1M Token — dreimal günstiger als Fast Mode bei früheren Claude-Modellen. Effort-Levels erweitern sich auf drei Stufen: high (Standard), extra (xhigh in Claude Code) und max.",
+          "Unabhängige Quellen (LLM Stats, VentureBeat, Vellum) bestätigen die relative Reihenfolge gegenüber 4.7 und der Konkurrenz: 4.8 gewinnt in jeder Zelle von Anthropics veröffentlichtem Vergleichssatz außer Terminal-Bench 2.1, wo GPT-5.5 mit 78,2% gegenüber 74,6% von 4.8 weiterhin führt. Der Sprung von 4.7 auf 4.8 bei SWE-bench Pro beträgt +4,9 Punkte; bei USAMO 2026 sind es +27,4; beim neuen 1M-Token GraphWalks Langkontext-F1 sind es +27,8. Absolute Werte sind als Richtungsangaben zu verstehen — SWE-bench Verified nähert sich bei allen Frontier-Modellen der Sättigung."
+        ],
+        "architecture": "Opus 4.8 behält das 1M-Token-Kontextfenster und den 128K Max-Output von Opus 4.7 bei, abgerechnet zum Standard-Input-Preis über das gesamte Fenster. Die Effort-Steuerung erweitert sich auf drei Stufen: high (neuer Standard), extra (xhigh in Claude Code) und max. Die Messages API akzeptiert nun System-Einträge mitten in der Konversation, ohne das Prompt Caching zu unterbrechen. Dynamische Workflows lassen Claude in einer einzigen Session hunderte parallele Subagenten planen und dispatchen. Fast Mode läuft mit ~2,5× Standardgeschwindigkeit für $10 / $50 pro 1M Token. Multimodale Eingaben über Text, Vision und Code bleiben unverändert.",
+        "specs": [
+          {
+            "label": "Familie",
+            "value": "Claude 4 Generation"
+          },
+          {
+            "label": "Modalitäten",
+            "value": "Text, Bild, Code"
+          },
+          {
+            "label": "Sprachen",
+            "value": "Englisch-zentriert, mehrsprachig"
+          },
+          {
+            "label": "Prompt Caching",
+            "value": "Unterstützt (Anthropic)"
+          },
+          {
+            "label": "Kontextfenster",
+            "value": "1M Token"
+          },
+          {
+            "label": "Max Output",
+            "value": "Bis zu 128K Token"
+          },
+          {
+            "label": "Effort Levels",
+            "value": "High (Standard) / Extra / Max"
+          },
+          {
+            "label": "Listenpreis",
+            "value": "$5 Input / $25 Output pro 1M (Fast Mode $10/$50, 2,5× Geschwindigkeit)"
+          }
+        ],
+        "benchmarksNote": "Vom Anbieter gemeldete Werte aus Anthropics Opus 4.8 System Card, mit Vergleichen gegen Opus 4.7, GPT-5.5 und Gemini 3.1 Pro bei Max-Effort und 5-Trial-Mittelwerten. 4.8 führt in sechs von sieben Zellen, die Anthropic veröffentlicht; GPT-5.5 behält die Spitze bei Terminal-Bench 2.1. SWE-bench Verified nähert sich bei allen Frontier-Modellen der Sättigung — der härtere SWE-bench Pro-Datensatz ist das belastbarere Signal.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "88.6%",
+            "note": "vom Anbieter gemeldet; gegenüber 87,6% von Opus 4.7"
+          },
+          {
+            "name": "SWE-bench Pro",
+            "score": "69.2%",
+            "note": "führt das Feld (4.7: 64,3%, GPT-5.5: 58,6%, Gemini 3.1 Pro: 54,2%)"
+          },
+          {
+            "name": "Terminal-Bench 2.1",
+            "score": "74.6%",
+            "note": "gegenüber 66,1% von 4.7 auf 2.0; GPT-5.5 führt hier mit 78,2%"
+          },
+          {
+            "name": "OSWorld-Verified (computer use)",
+            "score": "83.4%",
+            "note": "führt das Feld (4.7: 82,8%, GPT-5.5: 78,7%)"
+          },
+          {
+            "name": "Online-Mind2Web (browser agent)",
+            "score": "84%",
+            "note": "vom Anbieter gemeldet"
+          },
+          {
+            "name": "MCP-Atlas",
+            "score": "82.2%",
+            "note": "gegenüber 77,3% von Opus 4.7"
+          },
+          {
+            "name": "BrowseComp (single-agent)",
+            "score": "84.3%",
+            "note": "gegenüber 79,3% von Opus 4.7"
+          },
+          {
+            "name": "GraphWalks long-context F1 (1M tokens)",
+            "score": "68.1%",
+            "note": "gegenüber 40,3% von Opus 4.7"
+          },
+          {
+            "name": "Humanity's Last Exam (with tools)",
+            "score": "57.9%",
+            "note": "49,8% ohne Tools; führt das Feld"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~93%",
+            "note": "unverändert gegenüber 4.7 — bei Frontier-Modellen gesättigt"
+          },
+          {
+            "name": "USAMO 2026 (math)",
+            "score": "96.7%",
+            "note": "gegenüber 69,3% von Opus 4.7"
+          },
+          {
+            "name": "GDPval-AA (knowledge work)",
+            "score": "1890 Elo",
+            "note": "führt (4.7: 1753, GPT-5.5: 1769)"
+          },
+          {
+            "name": "Finance Agent v2",
+            "score": "53.9%",
+            "note": "führt das Feld"
+          },
+          {
+            "name": "Legal-agent all-pass",
+            "score": ">10%",
+            "note": "erstes Modell, das diese Schwelle durchbricht"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Dynamische Workflows",
+            "body": "Die neue Headline-Fähigkeit. Opus 4.8 kann eine Aufgabe planen und dann hunderte parallele Subagenten innerhalb derselben Session ausführen — Anthropic positioniert dies als Weg zu Codebase-weiten Migrationen über hunderttausende Zeilen in einem Run. Auf VM0 bedeutet das: Ein einziger Agent-Run kann Fan-out-Arbeit orchestrieren, die zuvor externes Scheduling erforderte."
+          },
+          {
+            "title": "Code-Änderungen im ersten Versuch",
+            "body": "Anthropic berichtet, dass Opus 4.8 beim Code-Review etwa viermal seltener Fehler übersieht als 4.7, und der Sprung von +4,9 Punkten bei SWE-bench Pro (69,2% vs 64,3%) bestätigt das im härteren, weniger gesättigten Coding-Set. Wähle 4.8 für Patches, die über viele Dateien hinweg sauber greifen müssen."
+          },
+          {
+            "title": "Langkontext-Recall",
+            "body": "GraphWalks F1 bei 1M Token springt von 40,3% auf 68,1% — der größte Einzelbenchmark-Gewinn des Releases. Das 1M-Token-Fenster ist jetzt tatsächlich am oberen Ende seines Bereichs nutzbar, nicht nur nominell."
+          },
+          {
+            "title": "Ehrlichkeit und Überkonfidenz",
+            "body": "Anthropic berichtet eine mehr als zehnfache Reduktion der Überkonfidenz gegenüber 4.7, 0% beim unkritischen Melden fehlerhafter Ergebnisse (eine Premiere für die Claude-Familie) und eine 3,7%-Rate beim Versäumnis, wichtige Ereignisse an den Nutzer zu eskalieren. Die Misalignment-Inzidenz liegt bei ~1,9 und ist damit faktisch gleichauf mit Anthropics bestausgerichtetem Mythos Preview."
+          },
+          {
+            "title": "Geschwindigkeit und Fast Mode",
+            "body": "Die Standardgeschwindigkeit ist vergleichbar mit Opus 4.7. Die Preisänderung ist die Schlagzeile: Fast Mode bei 2,5× Geschwindigkeit kostet $10 / $50 pro 1M Token — dreimal günstiger als Fast Mode bei früheren Claude-Modellen. Lohnt sich für Orchestrierungs-Schritte, bei denen Wall-Clock-Latenz zählt."
+          },
+          {
+            "title": "Prompt-Injection-Hinweis",
+            "body": "Anthropics System Card weist darauf hin, dass 4.8 etwas weniger robust gegen agentische Prompt Injection ist als 4.7 — Gray-Swan-Red-Teaming zeigt eine Attack-Success-Rate von ~9,6% gegenüber 6,0% bei 4.7. Teams, die 4.8 in Pipelines mit untrusted Input betreiben, sollten ihren Sandboxing-Ansatz prüfen."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "Die Codebase-weite Migration, die früher einen Sprint brauchte",
+            "body": "Übergib Opus 4.8 eine Migration, die einige hundert Dateien berührt — ORM-Swap, Framework-Versionssprung, Sicherheits-Fix über einen Monorepo — und lass dynamische Workflows die Arbeit innerhalb einer Session auf parallele Subagenten ausfächern. Der +4,9-Punkte-Sprung bei SWE-bench Pro und die vierfache Reduktion übersehener Fehler beim Code-Review zahlen sich genau bei dieser Art von Run aus."
+          },
+          {
+            "title": "Der 1M-Token-Research-Run, der tatsächlich zusammenhält",
+            "body": "Wirf einen 200-seitigen Vertragsentwurf, drei Wettbewerber-Proposals und die juristischen Gutachten des letzten Quartals ins Fenster und bitte Opus 4.8, jede Klausel zu markieren, die strenger als marktüblich ist. Der Sprung von 40,3% auf 68,1% bei GraphWalks 1M ist es, der diese Art von Cross-Document-Synthese neu zuverlässig macht."
+          },
+          {
+            "title": "Der Agent-Orchestrator, der nicht über seine Arbeit lügt",
+            "body": "Nutze 4.8 als Planer, der eine Anfrage in zehn Schritte zerlegt, jeden Schritt an günstigere Sub-Agenten dispatcht und das Ergebnis zurückmeldet. Die 0%-Rate beim unkritischen Melden fehlerhafter Ergebnisse, kombiniert mit der zehnfachen Reduktion der Überkonfidenz, ist der Grund, warum Produktionsteams für 4.8 greifen, wenn der Selbstreport des Agents vertrauenswürdig sein muss."
+          },
+          {
+            "title": "Der latenzkritische Flow, der sich im Fast Mode endlich rechnet",
+            "body": "Fast Mode bei 2,5× Geschwindigkeit kostete früher dreimal so viel wie heute ($10/$50 pro 1M gegenüber der vorherigen Stufe). Für interaktive Copilots, On-Call-Summarizer oder jeden Schritt, bei dem Wall-Clock-Latenz das Erlebnis dominiert, ist Fast-Mode 4.8 jetzt die Standardwahl in der Claude-Familie."
+          }
+        ],
+        "avoidFor": "Verzichte auf Opus 4.8 bei Hochvolumen-Routinearbeit, bei der Sonnet 4.6 die gleiche Qualitätsschwelle zu einem Bruchteil der Kosten erreicht, bei latenzkritischen Chat-Antworten, bei denen Haiku 4.5 deutlich schneller ist, bei agentischem Terminal-Coding, wo GPT-5.5 weiterhin Terminal-Bench 2.1 anführt (78,2% vs 74,6% bei 4.8), sowie bei Pipelines, die untrusted Input ohne Sandboxing aufnehmen — die Prompt-Injection-Robustheit von 4.8 ist leicht schwächer als die von 4.7.",
+        "comparisons": [
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "Gleicher ×1,7 Multiplikator, gleiches Kontextfenster, gleicher regulärer Preis. Opus 4.8 führt in jeder Zelle, die Anthropic veröffentlicht (SWE-bench Verified +1, SWE-bench Pro +4,9, OSWorld-Verified +0,6, MCP-Atlas +4,9, BrowseComp +5,0, GraphWalks 1M +27,8, USAMO +27,4). Der Tradeoff ist ein leicht schwächeres Prompt-Injection-Profil (~9,6% Attack-Success-Rate gegenüber 6,0%). Migriere neue Agenten auf 4.8; pinne 4.7 nur, wenn du dagegen validiert hast und keine Regressionen neu fahren willst."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Sonnet 4.6 (×1) bleibt das Arbeitspferd-Default für die meisten Agent-Schleifen. Eskaliere zu Opus 4.8, wenn Sonnet bei hartem Reasoning, Langkontext-Recall oder Code-Änderungen im ersten Versuch sichtbar scheitert — meist als Planer, der an Subagenten auf Sonnet- oder Haiku-Niveau delegiert. Mit dynamischen Workflows ist Opus 4.8 als Orchestrator + Sonnet 4.6 als Worker das neue empfohlene Muster."
+          },
+          {
+            "vs": "GPT-5.5",
+            "body": "Opus 4.8 führt in sechs von sieben Zellen in Anthropics Vergleichssatz, mit den größten Abständen bei SWE-bench Pro (69,2% vs 58,6%) und OSWorld-Verified (83,4% vs 78,7%). GPT-5.5 behält die Führung bei Terminal-Bench 2.1 (78,2% vs 74,6%). Wähle 4.8 für Cross-File-Coding und Computer-Use-Agenten; wähle GPT-5.5 speziell, wenn terminalgetriebene Arbeit dominiert."
+          },
+          {
+            "vs": "Gemini 3.1 Pro",
+            "body": "Opus 4.8 führt mit großem Abstand bei SWE-bench Pro (+15,0) und OSWorld-Verified (+7,2). Die beiden Modelle bleiben bei gesättigten Wissenschafts-Benchmarks wie GPQA Diamond im Rauschen gleichauf. Default ist 4.8 für agentische Arbeit; ziehe Gemini in Betracht, wenn du Googles Tool-Integration brauchst."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro (×0,3) bleibt die kostenoptimierte Wahl, wenn der reine Token-Preis die Entscheidung dominiert. Opus 4.8 behält die Führung bei Tool-Routing-Zuverlässigkeit, Langkontext-Recall, Alignment-Metriken und Computer Use — der Grund, warum die meisten englischsprachigen Enterprise-Agenten trotz des Preisabstands weiterhin standardmäßig auf 4.8 setzen."
+          }
+        ],
+        "verdict": "Der neue Standard für neue Agenten in der Claude-Familie. Migriere von 4.7, sobald du neu validieren kannst; setze ihn direkt als Default für frische Arbeit. Behalte Sonnet 4.6 als günstigeres Arbeitspferd darunter.",
+        "faqs": [
+          {
+            "q": "Wann wurde Claude Opus 4.8 veröffentlicht?",
+            "a": "Anthropic hat Opus 4.8 am 28. Mai 2026 veröffentlicht, 41 Tage nach Opus 4.7. Es ist heute über Claude-Produkte, die Claude API (Model-ID `claude-opus-4-8`), Amazon Bedrock, Google Cloud Vertex AI, Microsoft Foundry und VM0 verfügbar."
+          },
+          {
+            "q": "Wie verhält sich der Preis von Opus 4.8 zu 4.7?",
+            "a": "Der reguläre Preis ist identisch: $5 pro 1M Input-Token, $25 pro 1M Output-Token, $0,50 pro 1M gecachten Input. Die Änderung betrifft Fast Mode, jetzt $10 / $50 pro 1M Token bei 2,5× Geschwindigkeit — dreimal günstiger als Fast Mode bei früheren Claude-Modellen."
+          },
+          {
+            "q": "Was sind dynamische Workflows?",
+            "a": "Eine neue Fähigkeit, mit der Opus 4.8 eine Aufgabe planen und dann hunderte parallele Subagenten in einer einzigen Session ausführen kann. Anthropic positioniert dies als Weg zu Codebase-weiten Migrationen über hunderttausende Codezeilen in einem einzigen Agent-Run."
+          },
+          {
+            "q": "Welche Effort-Levels unterstützt Opus 4.8?",
+            "a": "Drei Stufen: high (neuer Standard), extra (xhigh in Claude Code) und max. Höhere Einstellungen verbrauchen mehr Token fürs Reasoning, bevor eine Antwort erzeugt wird; niedrigere Einstellungen bevorzugen Geschwindigkeit und Rate-Limit-Effizienz."
+          },
+          {
+            "q": "Sollte ich von Opus 4.7 auf 4.8 migrieren?",
+            "a": "Ja für neue Arbeit — gleicher Multiplikator, gleicher regulärer Preis, stärkeres Verhalten in jeder veröffentlichten Vergleichszelle außer Terminal-Bench 2.1. Migriere fixierte Produktionsagenten erst nach einem Regressionsdurchlauf und prüfe dein Sandboxing, wenn der Agent untrusted Input verarbeitet (4.8 ist leicht weniger robust gegen Prompt Injection als 4.7)."
+          },
+          {
+            "q": "Unterstützt Opus 4.8 Prompt Caching?",
+            "a": "Ja. Gecachter Input wird mit $0,50 pro 1M Token abgerechnet, ein 10×-Rabatt auf den gecachten Anteil. Die Messages API akzeptiert nun auch System-Einträge mitten in der Konversation, ohne den Cache zu unterbrechen."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Vorheriges Flaggschiff; leicht robuster gegen Prompt Injection"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Günstigerer Standard für die meisten Agent-Schleifen"
+          },
+          {
+            "slug": "gpt-5-5",
+            "reason": "Führt Terminal-Bench 2.1 für agentisches Terminal-Coding"
+          }
+        ],
+        "routingNotes": "On VM0, Opus 4.8 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code. It is also included in the default org model policy.",
+        "vm0Notes": "Prompt caching is enabled by default through VM0, which substantially cuts the cost of repeated system prompts, tool definitions, and pasted reference documents on agents that issue many turns from the same prefix. There are no VM0-side timeout overrides for Opus 4.8; the model uses Anthropic's default API timeouts. Sonnet 4.6 stays the platform default for new agents, so the standard pattern is to keep cheap tiers running everywhere and route only the hardest steps to Opus 4.8."
+      },
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
         "pageTitle": "Claude Opus 4.7",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -3917,6 +3917,240 @@
     "generationAccessHeading": "Using {name} on VM0",
     "generationAccessBody": "VM0 agents can call {name} as part of an agent run, billed against your VM0 credits. The list price above is what the upstream provider charges; VM0 passes that through with the standard credit conversion.",
     "content": {
+      "claude-opus-4-8": {
+        "name": "Claude Opus 4.8",
+        "pageTitle": "Claude Opus 4.8",
+        "tagline": "Anthropic's newest flagship. Released May 28, 2026 with stronger agentic coding, dynamic workflows that fan out hundreds of parallel subagents, and a 3× cheaper fast mode at the same regular price as Opus 4.7.",
+        "cardIntro": "Anthropic's newest Claude 4 flagship. Leads SWE-bench Pro and OSWorld-Verified at release, with dynamic workflows and a 3× cheaper fast mode.",
+        "metaTitle": "Claude Opus 4.8: Benchmarks, Pricing & Capabilities",
+        "metaDescription": "Claude Opus 4.8 review. Anthropic's May 28, 2026 flagship with 1M-token context, max-effort thinking, dynamic workflows, $5/$25 vendor pricing, and benchmark gains over Opus 4.7 on SWE-bench Pro, OSWorld-Verified, MCP-Atlas, BrowseComp, USAMO, and GraphWalks long-context recall.",
+        "summary": "Claude Opus 4.8 is Anthropic's flagship release on May 28, 2026, a direct upgrade to Opus 4.7 at the same $5/$25 vendor list price. It posts the highest SWE-bench Pro (69.2%), OSWorld-Verified (83.4%), MCP-Atlas (82.2%), and Humanity's Last Exam (57.9% with tools) scores Anthropic has ever shipped, and is the first model to break 10% on the legal-agent all-pass standard.\n\nThe two structural changes worth knowing about are dynamic workflows (plan a job, fan it out across hundreds of parallel subagents in a single session) and a fast-mode pricing cut to 2.5× speed at $10/$50 per 1M tokens — three times cheaper than fast mode on prior Claude models. Effort levels expand to high (default), extra, and max. Anthropic itself frames the release as a \"modest but tangible improvement\" rather than a leap.",
+        "releaseDate": "May 28, 2026",
+        "familyPosition": "Top-tier of the Claude 4 family. Anthropic's recommended default for new agents; ships at the same ×1.7 multiplier as Opus 4.7.",
+        "background": [
+          "Claude Opus 4.8 was released on May 28, 2026 as Anthropic's new flagship, 41 days after Opus 4.7. It targets the same coding, agentic-skills, reasoning, and knowledge-work workloads as 4.7, at the same regular list price ($5 input / $25 output per 1M tokens) and the same VM0 multiplier (×1.7). Anthropic positions the release as a \"modest but tangible improvement on its predecessor\" rather than a step-change.",
+          "Two structural changes matter for VM0 users. First, dynamic workflows: the model can plan a task and fan it out across hundreds of parallel subagents in a single session, which Anthropic describes as a step toward handling codebase-scale migrations across hundreds of thousands of lines of code in one run. Second, fast mode at 2.5× speed is now $10 / $50 per 1M tokens — three times cheaper than fast mode on prior Claude models. Effort levels expand to three tiers: high (default), extra (xhigh in Claude Code), and max.",
+          "Independent reads (LLM Stats, VentureBeat, Vellum) corroborate the relative ordering against 4.7 and competitors: 4.8 wins on every cell of Anthropic's published comparison set except Terminal-Bench 2.1, where GPT-5.5 still leads (78.2% vs 4.8's 74.6%). The 4.7-to-4.8 jump on SWE-bench Pro is +4.9 points; on USAMO 2026 it is +27.4; on the new 1M-token GraphWalks long-context F1 it is +27.8. Treat absolute scores as directional — SWE-bench Verified is approaching saturation across all frontier models."
+        ],
+        "architecture": "Opus 4.8 keeps the 1M-token context window and 128K max output from Opus 4.7, billed at standard input pricing across the entire window. Effort control expands to three levels: high (the new default), extra (xhigh inside Claude Code), and max. The Messages API now accepts system entries mid-conversation without breaking prompt caching. Dynamic workflows let Claude plan and dispatch hundreds of parallel subagents in a single session. Fast mode runs at ~2.5× standard speed for $10 / $50 per 1M tokens. Multimodal inputs across text, vision, and code are unchanged.",
+        "specs": [
+          {
+            "label": "Family",
+            "value": "Claude 4 generation"
+          },
+          {
+            "label": "Modalities",
+            "value": "Text, vision, code"
+          },
+          {
+            "label": "Languages",
+            "value": "English-first, multilingual"
+          },
+          {
+            "label": "Prompt caching",
+            "value": "Supported (Anthropic)"
+          },
+          {
+            "label": "Context window",
+            "value": "1M tokens"
+          },
+          {
+            "label": "Max output",
+            "value": "Up to 128K tokens"
+          },
+          {
+            "label": "Effort levels",
+            "value": "High (default) / Extra / Max"
+          },
+          {
+            "label": "Vendor list price",
+            "value": "$5 input / $25 output per 1M (fast mode $10/$50, 2.5× speed)"
+          }
+        ],
+        "benchmarksNote": "Vendor-reported scores from Anthropic's Opus 4.8 system card, with comparisons against Opus 4.7, GPT-5.5, and Gemini 3.1 Pro at max effort and 5-trial averages. 4.8 leads in six of seven cells Anthropic publishes; GPT-5.5 retains the lead on Terminal-Bench 2.1. SWE-bench Verified is approaching saturation across all frontier models — the harder SWE-bench Pro set is the more durable signal.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "88.6%",
+            "note": "vendor-reported; up from Opus 4.7's 87.6%"
+          },
+          {
+            "name": "SWE-bench Pro",
+            "score": "69.2%",
+            "note": "leads the field (4.7: 64.3%, GPT-5.5: 58.6%, Gemini 3.1 Pro: 54.2%)"
+          },
+          {
+            "name": "Terminal-Bench 2.1",
+            "score": "74.6%",
+            "note": "up from 4.7's 66.1% on 2.0; GPT-5.5 leads here at 78.2%"
+          },
+          {
+            "name": "OSWorld-Verified (computer use)",
+            "score": "83.4%",
+            "note": "leads the field (4.7: 82.8%, GPT-5.5: 78.7%)"
+          },
+          {
+            "name": "Online-Mind2Web (browser agent)",
+            "score": "84%",
+            "note": "vendor-reported"
+          },
+          {
+            "name": "MCP-Atlas",
+            "score": "82.2%",
+            "note": "up from Opus 4.7's 77.3%"
+          },
+          {
+            "name": "BrowseComp (single-agent)",
+            "score": "84.3%",
+            "note": "up from Opus 4.7's 79.3%"
+          },
+          {
+            "name": "GraphWalks long-context F1 (1M tokens)",
+            "score": "68.1%",
+            "note": "up from Opus 4.7's 40.3%"
+          },
+          {
+            "name": "Humanity's Last Exam (with tools)",
+            "score": "57.9%",
+            "note": "49.8% without tools; leads the field"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~93%",
+            "note": "flat vs 4.7 — saturated across frontier models"
+          },
+          {
+            "name": "USAMO 2026 (math)",
+            "score": "96.7%",
+            "note": "up from Opus 4.7's 69.3%"
+          },
+          {
+            "name": "GDPval-AA (knowledge work)",
+            "score": "1890 Elo",
+            "note": "leads (4.7: 1753, GPT-5.5: 1769)"
+          },
+          {
+            "name": "Finance Agent v2",
+            "score": "53.9%",
+            "note": "leads the field"
+          },
+          {
+            "name": "Legal-agent all-pass",
+            "score": ">10%",
+            "note": "first model to break this standard"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Dynamic workflows",
+            "body": "The headline new capability. Opus 4.8 can plan a task and then run hundreds of parallel subagents within the same session — Anthropic positions this as the path to codebase-scale migrations across hundreds of thousands of lines in one run. On VM0, this means a single agent run can orchestrate fan-out work that previously required external scheduling."
+          },
+          {
+            "title": "First-attempt code edits",
+            "body": "Anthropic reports Opus 4.8 is around four times less likely than 4.7 to overlook flaws when reviewing code, and the +4.9 point SWE-bench Pro jump (69.2% vs 64.3%) backs that up on the harder, less-saturated coding set. Pick 4.8 for patches that have to apply cleanly across many files."
+          },
+          {
+            "title": "Long-context recall",
+            "body": "GraphWalks F1 at 1M tokens jumps from 40.3% to 68.1% — the biggest single-benchmark gain in the release. The 1M-token window is now actually usable at the high end of its range, not just nominal."
+          },
+          {
+            "title": "Honesty and overconfidence",
+            "body": "Anthropic reports a more than ten-fold reduction in overconfidence versus 4.7, 0% on uncritically reporting flawed results (a first for the Claude family), and a 3.7% rate of failing to raise important events to the user. Misalignment incidence is ~1.9, effectively tied with Anthropic's best-aligned Mythos Preview."
+          },
+          {
+            "title": "Speed and fast mode",
+            "body": "Standard speed is comparable to Opus 4.7. The pricing change is the headline: fast mode at 2.5× speed costs $10 / $50 per 1M tokens, three times cheaper than fast mode on prior Claude models. Worth using for orchestration steps where wall-clock latency matters."
+          },
+          {
+            "title": "Prompt-injection caveat",
+            "body": "Anthropic's system card notes 4.8 is somewhat less robust to agentic prompt injection than 4.7 — Gray Swan red-teaming shows a ~9.6% attack-success rate versus 6.0% on 4.7. Teams running 4.8 in pipelines that handle untrusted input should review their sandboxing approach."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "The codebase-scale migration that used to need a sprint",
+            "body": "Hand Opus 4.8 a migration that touches a few hundred files — ORM swap, framework version bump, security fix across a monorepo — and let dynamic workflows fan the work out to parallel subagents within one session. The +4.9 point SWE-bench Pro jump and the four-fold reduction in missed flaws on code review are what cash out on this kind of run."
+          },
+          {
+            "title": "The 1M-token research run that actually holds together",
+            "body": "Drop a 200-page contract draft, three competitor proposals, and last quarter's legal opinions into the window, then ask Opus 4.8 to flag every clause that's tighter than market. GraphWalks at 1M jumping from 40.3% to 68.1% is what makes this kind of cross-document synthesis newly reliable."
+          },
+          {
+            "title": "The agent orchestrator that doesn't lie about its work",
+            "body": "Use 4.8 as the planner that breaks a request into ten steps, dispatches each to cheaper sub-agents, and reports the result. The 0% rate on uncritically reporting flawed results, combined with the ten-fold drop in overconfidence, is the reason production teams reach for 4.8 when the agent's own self-report has to be trustworthy."
+          },
+          {
+            "title": "The latency-sensitive flow that finally pencils out on fast mode",
+            "body": "Fast mode at 2.5× speed used to cost three times what it does now ($10/$50 per 1M vs the prior tier). For interactive copilots, on-call summarisers, or any step where wall-clock latency dominates the experience, fast-mode 4.8 is now the default choice in the Claude family."
+          }
+        ],
+        "avoidFor": "Skip Opus 4.8 on high-volume routine work where Sonnet 4.6 hits the same quality bar at a fraction of the cost, on latency-critical chat replies where Haiku 4.5 is much faster, on agentic terminal coding where GPT-5.5 still leads Terminal-Bench 2.1 (78.2% vs 4.8's 74.6%), and on pipelines that ingest untrusted input without sandboxing — 4.8's prompt-injection robustness is slightly weaker than 4.7's.",
+        "comparisons": [
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "Same ×1.7 multiplier, same context window, same regular price. Opus 4.8 leads on every cell Anthropic publishes (SWE-bench Verified +1, SWE-bench Pro +4.9, OSWorld-Verified +0.6, MCP-Atlas +4.9, BrowseComp +5.0, GraphWalks 1M +27.8, USAMO +27.4). The trade-off is a slightly weaker prompt-injection profile (~9.6% attack-success rate vs 6.0%). Migrate new agents to 4.8; pin 4.7 only if you've validated against it and don't want to re-run regressions."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Sonnet 4.6 (×1) is still the workhorse default for most agent loops. Promote to Opus 4.8 when Sonnet visibly fails on hard reasoning, long-context recall, or first-attempt code edits — usually as the planner that delegates to Sonnet- or Haiku-tier sub-agents. With dynamic workflows, Opus 4.8 as orchestrator + Sonnet 4.6 as workers is the new recommended pattern."
+          },
+          {
+            "vs": "GPT-5.5",
+            "body": "Opus 4.8 leads on six of seven cells in Anthropic's comparison set, with the biggest gaps on SWE-bench Pro (69.2% vs 58.6%) and OSWorld-Verified (83.4% vs 78.7%). GPT-5.5 keeps the lead on Terminal-Bench 2.1 (78.2% vs 74.6%). Pick 4.8 for cross-file coding and computer-use agents; pick GPT-5.5 specifically when terminal-driven work dominates."
+          },
+          {
+            "vs": "Gemini 3.1 Pro",
+            "body": "Opus 4.8 leads by wide margins on SWE-bench Pro (+15.0) and OSWorld-Verified (+7.2). The two models stay within noise on saturated science benchmarks like GPQA Diamond. Default to 4.8 for agentic work; consider Gemini specifically when you need Google's tool integration story."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro (×0.3) remains the cost-optimised pick when raw token price dominates the decision. Opus 4.8 retains the lead on tool-routing reliability, long-context recall, alignment metrics, and computer-use, which is why most enterprise English-language agents still default to 4.8 despite the price gap."
+          }
+        ],
+        "verdict": "The new default for new agents in the Claude family. Migrate from 4.7 when you can re-validate; default to it directly for fresh work. Keep Sonnet 4.6 as the cheaper workhorse beneath it.",
+        "faqs": [
+          {
+            "q": "When was Claude Opus 4.8 released?",
+            "a": "Anthropic released Opus 4.8 on May 28, 2026, 41 days after Opus 4.7. It is available today across Claude products, the Claude API (model id `claude-opus-4-8`), Amazon Bedrock, Google Cloud Vertex AI, Microsoft Foundry, and VM0."
+          },
+          {
+            "q": "How does Opus 4.8 pricing compare to 4.7?",
+            "a": "Regular pricing is identical: $5 per 1M input tokens, $25 per 1M output tokens, $0.50 per 1M cached input. The change is fast mode, now $10 / $50 per 1M tokens at 2.5× speed — three times cheaper than fast mode on prior Claude models."
+          },
+          {
+            "q": "What are dynamic workflows?",
+            "a": "A new capability that lets Opus 4.8 plan a task and then run hundreds of parallel subagents within a single session. Anthropic positions this as the path to codebase-scale migrations across hundreds of thousands of lines of code in one agent run."
+          },
+          {
+            "q": "What effort levels does Opus 4.8 support?",
+            "a": "Three levels: high (the new default), extra (xhigh in Claude Code), and max. Higher settings spend more tokens on reasoning before producing a response; lower settings favour speed and rate-limit efficiency."
+          },
+          {
+            "q": "Should I migrate from Opus 4.7 to 4.8?",
+            "a": "Yes for new work — same multiplier, same regular price, stronger behaviour across every published comparison cell except Terminal-Bench 2.1. Migrate pinned production agents only after running them through your regression suite, and review your sandboxing if the agent ingests untrusted input (4.8 is slightly less robust to prompt injection than 4.7)."
+          },
+          {
+            "q": "Does Opus 4.8 support prompt caching?",
+            "a": "Yes. Cached input bills at $0.50 per 1M tokens, a 10× discount on the cached portion. The Messages API now also accepts system entries mid-conversation without breaking the cache."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Previous flagship; slightly more robust to prompt injection"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Cheaper default for most agent loops"
+          },
+          {
+            "slug": "gpt-5-5",
+            "reason": "Leads Terminal-Bench 2.1 for agentic terminal coding"
+          }
+        ],
+        "routingNotes": "On VM0, Opus 4.8 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code. It is also included in the default org model policy.",
+        "vm0Notes": "Prompt caching is enabled by default through VM0, which substantially cuts the cost of repeated system prompts, tool definitions, and pasted reference documents on agents that issue many turns from the same prefix. There are no VM0-side timeout overrides for Opus 4.8; the model uses Anthropic's default API timeouts. Sonnet 4.6 stays the platform default for new agents, so the standard pattern is to keep cheap tiers running everywhere and route only the hardest steps to Opus 4.8."
+      },
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
         "pageTitle": "Claude Opus 4.7",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -3917,6 +3917,240 @@
     "generationAccessHeading": "Usar {name} en VM0",
     "generationAccessBody": "Los agentes de VM0 pueden invocar {name} como parte de una ejecución de agente, facturado contra tus créditos VM0. El precio listado arriba es lo que cobra el proveedor upstream; VM0 lo traslada con la conversión estándar de créditos.",
     "content": {
+      "claude-opus-4-8": {
+        "name": "Claude Opus 4.8",
+        "pageTitle": "Claude Opus 4.8",
+        "tagline": "El nuevo modelo insignia de Anthropic. Lanzado el 28 de mayo de 2026 con codificación agéntica más fuerte, flujos de trabajo dinámicos que despliegan cientos de subagentes en paralelo y un modo rápido 3× más barato al mismo precio regular que Opus 4.7.",
+        "cardIntro": "El más nuevo modelo insignia Claude 4 de Anthropic. Lidera SWE-bench Pro y OSWorld-Verified al lanzamiento, con flujos de trabajo dinámicos y un modo rápido 3× más barato.",
+        "metaTitle": "Claude Opus 4.8: Benchmarks, Precios y Capacidades",
+        "metaDescription": "Reseña de Claude Opus 4.8. El modelo insignia de Anthropic del 28 de mayo de 2026 con contexto de 1M tokens, pensamiento de máximo esfuerzo, flujos de trabajo dinámicos, precios de proveedor de $5/$25 y mejoras de benchmark sobre Opus 4.7 en SWE-bench Pro, OSWorld-Verified, MCP-Atlas, BrowseComp, USAMO y recuperación de contexto largo GraphWalks.",
+        "summary": "Claude Opus 4.8 es el lanzamiento insignia de Anthropic del 28 de mayo de 2026, una actualización directa de Opus 4.7 al mismo precio de lista del proveedor de $5/$25. Registra las puntuaciones más altas que Anthropic haya lanzado en SWE-bench Pro (69,2%), OSWorld-Verified (83,4%), MCP-Atlas (82,2%) y Humanity's Last Exam (57,9% con herramientas), y es el primer modelo en superar el 10% en el estándar all-pass de agente legal.\n\nLos dos cambios estructurales que vale la pena conocer son los flujos de trabajo dinámicos (planificar un trabajo y desplegarlo en cientos de subagentes paralelos en una sola sesión) y un recorte de precio del modo rápido a 2,5× de velocidad por $10/$50 por 1M tokens — tres veces más barato que el modo rápido de modelos Claude anteriores. Los niveles de esfuerzo se expanden a high (predeterminado), extra y max. Anthropic mismo presenta el lanzamiento como una \"mejora modesta pero tangible\" en lugar de un salto.",
+        "releaseDate": "28 de mayo de 2026",
+        "familyPosition": "Nivel superior de la familia Claude 4. El predeterminado recomendado por Anthropic para nuevos agentes; se lanza con el mismo multiplicador ×1,7 que Opus 4.7.",
+        "background": [
+          "Claude Opus 4.8 se lanzó el 28 de mayo de 2026 como el nuevo modelo insignia de Anthropic, 41 días después de Opus 4.7. Apunta a las mismas cargas de trabajo de codificación, habilidades agénticas, razonamiento y trabajo de conocimiento que 4.7, al mismo precio de lista regular ($5 entrada / $25 salida por 1M tokens) y el mismo multiplicador de VM0 (×1,7). Anthropic posiciona el lanzamiento como una \"mejora modesta pero tangible sobre su predecesor\" en lugar de un cambio escalonado.",
+          "Dos cambios estructurales importan para los usuarios de VM0. Primero, los flujos de trabajo dinámicos: el modelo puede planificar una tarea y desplegarla en cientos de subagentes paralelos en una sola sesión, lo que Anthropic describe como un paso hacia el manejo de migraciones a escala de código base de cientos de miles de líneas de código en una sola ejecución. Segundo, el modo rápido a 2,5× de velocidad ahora cuesta $10 / $50 por 1M tokens — tres veces más barato que el modo rápido de modelos Claude anteriores. Los niveles de esfuerzo se expanden a tres escalones: high (predeterminado), extra (xhigh en Claude Code) y max.",
+          "Las lecturas independientes (LLM Stats, VentureBeat, Vellum) corroboran el orden relativo frente a 4.7 y los competidores: 4.8 gana en cada celda del conjunto de comparación publicado por Anthropic excepto Terminal-Bench 2.1, donde GPT-5.5 sigue liderando (78,2% vs 74,6% de 4.8). El salto de 4.7 a 4.8 en SWE-bench Pro es de +4,9 puntos; en USAMO 2026 es de +27,4; en el nuevo F1 de contexto largo GraphWalks de 1M tokens es de +27,8. Trata las puntuaciones absolutas como direccionales — SWE-bench Verified se está acercando a la saturación en todos los modelos frontera."
+        ],
+        "architecture": "Opus 4.8 mantiene la ventana de contexto de 1M tokens y la salida máxima de 128K de Opus 4.7, facturada a precio de entrada estándar en toda la ventana. El control de esfuerzo se expande a tres niveles: high (el nuevo predeterminado), extra (xhigh dentro de Claude Code) y max. La API de Messages ahora acepta entradas de sistema a mitad de conversación sin romper el caché de prompts. Los flujos de trabajo dinámicos permiten a Claude planificar y despachar cientos de subagentes paralelos en una sola sesión. El modo rápido funciona a ~2,5× la velocidad estándar por $10 / $50 por 1M tokens. Las entradas multimodales a través de texto, visión y código no cambian.",
+        "specs": [
+          {
+            "label": "Familia",
+            "value": "Generación Claude 4"
+          },
+          {
+            "label": "Modalidades",
+            "value": "Texto, visión, código"
+          },
+          {
+            "label": "Idiomas",
+            "value": "Inglés primero, multilingüe"
+          },
+          {
+            "label": "Caché de prompts",
+            "value": "Soportado (Anthropic)"
+          },
+          {
+            "label": "Ventana de contexto",
+            "value": "1M tokens"
+          },
+          {
+            "label": "Salida máxima",
+            "value": "Hasta 128K tokens"
+          },
+          {
+            "label": "Niveles de esfuerzo",
+            "value": "High (predeterminado) / Extra / Max"
+          },
+          {
+            "label": "Precio de lista",
+            "value": "$5 entrada / $25 salida por 1M (modo rápido $10/$50, 2,5× velocidad)"
+          }
+        ],
+        "benchmarksNote": "Puntuaciones reportadas por el proveedor de la system card de Opus 4.8 de Anthropic, con comparaciones contra Opus 4.7, GPT-5.5 y Gemini 3.1 Pro a esfuerzo máximo y promedios de 5 intentos. 4.8 lidera en seis de las siete celdas que Anthropic publica; GPT-5.5 conserva el liderazgo en Terminal-Bench 2.1. SWE-bench Verified se está acercando a la saturación en todos los modelos frontera — el conjunto más difícil SWE-bench Pro es la señal más duradera.",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "88.6%",
+            "note": "reportado por el proveedor; sube desde 87,6% de Opus 4.7"
+          },
+          {
+            "name": "SWE-bench Pro",
+            "score": "69.2%",
+            "note": "lidera el campo (4.7: 64,3%, GPT-5.5: 58,6%, Gemini 3.1 Pro: 54,2%)"
+          },
+          {
+            "name": "Terminal-Bench 2.1",
+            "score": "74.6%",
+            "note": "sube desde 66,1% de 4.7 en 2.0; GPT-5.5 lidera aquí con 78,2%"
+          },
+          {
+            "name": "OSWorld-Verified (computer use)",
+            "score": "83.4%",
+            "note": "lidera el campo (4.7: 82,8%, GPT-5.5: 78,7%)"
+          },
+          {
+            "name": "Online-Mind2Web (browser agent)",
+            "score": "84%",
+            "note": "reportado por el proveedor"
+          },
+          {
+            "name": "MCP-Atlas",
+            "score": "82.2%",
+            "note": "sube desde 77,3% de Opus 4.7"
+          },
+          {
+            "name": "BrowseComp (single-agent)",
+            "score": "84.3%",
+            "note": "sube desde 79,3% de Opus 4.7"
+          },
+          {
+            "name": "GraphWalks long-context F1 (1M tokens)",
+            "score": "68.1%",
+            "note": "sube desde 40,3% de Opus 4.7"
+          },
+          {
+            "name": "Humanity's Last Exam (with tools)",
+            "score": "57.9%",
+            "note": "49,8% sin herramientas; lidera el campo"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~93%",
+            "note": "sin cambios vs 4.7 — saturado en modelos frontera"
+          },
+          {
+            "name": "USAMO 2026 (math)",
+            "score": "96.7%",
+            "note": "sube desde 69,3% de Opus 4.7"
+          },
+          {
+            "name": "GDPval-AA (knowledge work)",
+            "score": "1890 Elo",
+            "note": "lidera (4.7: 1753, GPT-5.5: 1769)"
+          },
+          {
+            "name": "Finance Agent v2",
+            "score": "53.9%",
+            "note": "lidera el campo"
+          },
+          {
+            "name": "Legal-agent all-pass",
+            "score": ">10%",
+            "note": "primer modelo en superar este estándar"
+          }
+        ],
+        "performance": [
+          {
+            "title": "Flujos de trabajo dinámicos",
+            "body": "La nueva capacidad estrella. Opus 4.8 puede planificar una tarea y luego ejecutar cientos de subagentes paralelos dentro de la misma sesión — Anthropic posiciona esto como el camino hacia migraciones a escala de código base de cientos de miles de líneas en una sola ejecución. En VM0, esto significa que una sola ejecución de agente puede orquestar trabajo de fan-out que antes requería programación externa."
+          },
+          {
+            "title": "Ediciones de código al primer intento",
+            "body": "Anthropic reporta que Opus 4.8 tiene alrededor de cuatro veces menos probabilidades que 4.7 de pasar por alto fallos al revisar código, y el salto de +4,9 puntos en SWE-bench Pro (69,2% vs 64,3%) respalda eso en el conjunto de codificación más difícil y menos saturado. Elige 4.8 para parches que deben aplicarse limpiamente en muchos archivos."
+          },
+          {
+            "title": "Recuperación de contexto largo",
+            "body": "GraphWalks F1 a 1M tokens salta de 40,3% a 68,1% — la mayor ganancia en un solo benchmark del lanzamiento. La ventana de 1M tokens ahora es realmente utilizable en el extremo superior de su rango, no solo nominalmente."
+          },
+          {
+            "title": "Honestidad y exceso de confianza",
+            "body": "Anthropic reporta una reducción de más de diez veces en el exceso de confianza frente a 4.7, 0% en reportar acríticamente resultados defectuosos (un primero para la familia Claude) y una tasa del 3,7% de no plantear eventos importantes al usuario. La incidencia de desalineación es ~1,9, prácticamente empatada con el Mythos Preview mejor alineado de Anthropic."
+          },
+          {
+            "title": "Velocidad y modo rápido",
+            "body": "La velocidad estándar es comparable a Opus 4.7. El cambio de precio es el titular: el modo rápido a 2,5× de velocidad cuesta $10 / $50 por 1M tokens, tres veces más barato que el modo rápido de modelos Claude anteriores. Vale la pena usarlo para pasos de orquestación donde importa la latencia de reloj de pared."
+          },
+          {
+            "title": "Advertencia sobre inyección de prompts",
+            "body": "La system card de Anthropic nota que 4.8 es algo menos robusto a la inyección de prompts agéntica que 4.7 — el red-teaming de Gray Swan muestra una tasa de éxito de ataque de ~9,6% frente al 6,0% en 4.7. Los equipos que ejecutan 4.8 en pipelines que manejan entradas no confiables deberían revisar su enfoque de sandboxing."
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "La migración a escala de código base que solía necesitar un sprint",
+            "body": "Pásale a Opus 4.8 una migración que toca unos cientos de archivos — cambio de ORM, salto de versión de framework, corrección de seguridad en un monorepo — y deja que los flujos de trabajo dinámicos desplieguen el trabajo a subagentes paralelos dentro de una sola sesión. El salto de +4,9 puntos en SWE-bench Pro y la reducción cuádruple de fallos pasados por alto en la revisión de código son lo que rinde frutos en este tipo de ejecución."
+          },
+          {
+            "title": "La ejecución de investigación de 1M tokens que realmente se sostiene",
+            "body": "Suelta un borrador de contrato de 200 páginas, tres propuestas de competidores y las opiniones legales del último trimestre en la ventana, luego pide a Opus 4.8 que marque cada cláusula más restrictiva que el mercado. GraphWalks a 1M saltando de 40,3% a 68,1% es lo que hace que este tipo de síntesis entre documentos sea recientemente confiable."
+          },
+          {
+            "title": "El orquestador de agentes que no miente sobre su trabajo",
+            "body": "Usa 4.8 como el planificador que divide una solicitud en diez pasos, despacha cada uno a subagentes más baratos y reporta el resultado. La tasa del 0% en reportar acríticamente resultados defectuosos, combinada con la caída de diez veces en exceso de confianza, es la razón por la que los equipos de producción recurren a 4.8 cuando el autoinforme del propio agente debe ser confiable."
+          },
+          {
+            "title": "El flujo sensible a la latencia que finalmente cuadra en modo rápido",
+            "body": "El modo rápido a 2,5× de velocidad solía costar tres veces lo que cuesta ahora ($10/$50 por 1M frente al nivel anterior). Para copilotos interactivos, resumidores on-call o cualquier paso donde la latencia de reloj de pared domine la experiencia, el modo rápido de 4.8 ahora es la elección predeterminada en la familia Claude."
+          }
+        ],
+        "avoidFor": "Evita Opus 4.8 en trabajo rutinario de alto volumen donde Sonnet 4.6 alcanza la misma calidad a una fracción del costo, en respuestas de chat sensibles a la latencia donde Haiku 4.5 es mucho más rápido, en codificación agéntica de terminal donde GPT-5.5 sigue liderando Terminal-Bench 2.1 (78,2% vs 74,6% de 4.8), y en pipelines que ingieren entradas no confiables sin sandboxing — la robustez de 4.8 a la inyección de prompts es ligeramente más débil que la de 4.7.",
+        "comparisons": [
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "Mismo multiplicador ×1,7, misma ventana de contexto, mismo precio regular. Opus 4.8 lidera en cada celda que Anthropic publica (SWE-bench Verified +1, SWE-bench Pro +4,9, OSWorld-Verified +0,6, MCP-Atlas +4,9, BrowseComp +5,0, GraphWalks 1M +27,8, USAMO +27,4). El compromiso es un perfil de inyección de prompts ligeramente más débil (tasa de éxito de ataque ~9,6% vs 6,0%). Migra nuevos agentes a 4.8; fija 4.7 solo si has validado contra él y no quieres reejecutar regresiones."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Sonnet 4.6 (×1) sigue siendo el caballo de batalla predeterminado para la mayoría de bucles de agente. Promueve a Opus 4.8 cuando Sonnet falla visiblemente en razonamiento difícil, recuperación de contexto largo o ediciones de código al primer intento — usualmente como el planificador que delega a subagentes de nivel Sonnet o Haiku. Con flujos de trabajo dinámicos, Opus 4.8 como orquestador + Sonnet 4.6 como trabajadores es el nuevo patrón recomendado."
+          },
+          {
+            "vs": "GPT-5.5",
+            "body": "Opus 4.8 lidera en seis de las siete celdas del conjunto de comparación de Anthropic, con las mayores brechas en SWE-bench Pro (69,2% vs 58,6%) y OSWorld-Verified (83,4% vs 78,7%). GPT-5.5 conserva el liderazgo en Terminal-Bench 2.1 (78,2% vs 74,6%). Elige 4.8 para codificación entre archivos y agentes de uso de computadora; elige GPT-5.5 específicamente cuando domine el trabajo en terminal."
+          },
+          {
+            "vs": "Gemini 3.1 Pro",
+            "body": "Opus 4.8 lidera por amplios márgenes en SWE-bench Pro (+15,0) y OSWorld-Verified (+7,2). Los dos modelos se mantienen dentro del ruido en benchmarks científicos saturados como GPQA Diamond. Predetermina 4.8 para trabajo agéntico; considera Gemini específicamente cuando necesites la historia de integración de herramientas de Google."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro (×0,3) sigue siendo la elección optimizada en costo cuando el precio bruto por token domina la decisión. Opus 4.8 conserva el liderazgo en fiabilidad de enrutamiento de herramientas, recuperación de contexto largo, métricas de alineación y uso de computadora, razón por la cual la mayoría de agentes empresariales en inglés siguen defaulteando a 4.8 a pesar de la brecha de precio."
+          }
+        ],
+        "verdict": "El nuevo predeterminado para nuevos agentes en la familia Claude. Migra desde 4.7 cuando puedas revalidar; defaultea directamente a él para trabajo nuevo. Mantén Sonnet 4.6 como el caballo de batalla más barato debajo.",
+        "faqs": [
+          {
+            "q": "¿Cuándo se lanzó Claude Opus 4.8?",
+            "a": "Anthropic lanzó Opus 4.8 el 28 de mayo de 2026, 41 días después de Opus 4.7. Está disponible hoy en los productos Claude, la API de Claude (model id `claude-opus-4-8`), Amazon Bedrock, Google Cloud Vertex AI, Microsoft Foundry y VM0."
+          },
+          {
+            "q": "¿Cómo se compara el precio de Opus 4.8 con 4.7?",
+            "a": "El precio regular es idéntico: $5 por 1M tokens de entrada, $25 por 1M tokens de salida, $0,50 por 1M de entrada cacheada. El cambio es el modo rápido, ahora $10 / $50 por 1M tokens a 2,5× de velocidad — tres veces más barato que el modo rápido de modelos Claude anteriores."
+          },
+          {
+            "q": "¿Qué son los flujos de trabajo dinámicos?",
+            "a": "Una nueva capacidad que permite a Opus 4.8 planificar una tarea y luego ejecutar cientos de subagentes paralelos dentro de una sola sesión. Anthropic posiciona esto como el camino hacia migraciones a escala de código base de cientos de miles de líneas de código en una sola ejecución de agente."
+          },
+          {
+            "q": "¿Qué niveles de esfuerzo soporta Opus 4.8?",
+            "a": "Tres niveles: high (el nuevo predeterminado), extra (xhigh en Claude Code) y max. Los ajustes más altos gastan más tokens en razonamiento antes de producir una respuesta; los ajustes más bajos favorecen la velocidad y la eficiencia del límite de tasa."
+          },
+          {
+            "q": "¿Debería migrar de Opus 4.7 a 4.8?",
+            "a": "Sí para trabajo nuevo — mismo multiplicador, mismo precio regular, comportamiento más fuerte en cada celda de comparación publicada excepto Terminal-Bench 2.1. Migra los agentes de producción fijados solo después de ejecutarlos en tu suite de regresión, y revisa tu sandboxing si el agente ingiere entradas no confiables (4.8 es ligeramente menos robusto a la inyección de prompts que 4.7)."
+          },
+          {
+            "q": "¿Opus 4.8 soporta caché de prompts?",
+            "a": "Sí. La entrada cacheada se factura a $0,50 por 1M tokens, un descuento de 10× sobre la porción cacheada. La API de Messages ahora también acepta entradas de sistema a mitad de conversación sin romper el caché."
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "Modelo insignia anterior; ligeramente más robusto a la inyección de prompts"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Predeterminado más barato para la mayoría de bucles de agente"
+          },
+          {
+            "slug": "gpt-5-5",
+            "reason": "Lidera Terminal-Bench 2.1 para codificación agéntica de terminal"
+          }
+        ],
+        "routingNotes": "En VM0, Opus 4.8 se enruta directamente a la API Messages de Anthropic y se expone de tres formas: a través del pool de créditos VM0 Managed, a través de una clave API directa de Anthropic, y a través del proveedor OAuth de Claude Code para equipos ya autenticados con Claude Code. También está incluido en la política de modelos predeterminada de la organización.",
+        "vm0Notes": "El caché de prompts está habilitado por defecto a través de VM0, lo que reduce sustancialmente el costo de prompts de sistema repetidos, definiciones de herramientas y documentos de referencia pegados en agentes que emiten muchos turnos desde el mismo prefijo. No hay anulaciones de timeout del lado de VM0 para Opus 4.8; el modelo usa los timeouts de API predeterminados de Anthropic. Sonnet 4.6 sigue siendo el predeterminado de la plataforma para nuevos agentes, por lo que el patrón estándar es mantener niveles baratos ejecutándose en todas partes y enrutar solo los pasos más difíciles a Opus 4.8."
+      },
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
         "pageTitle": "Claude Opus 4.7",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -3917,6 +3917,240 @@
     "generationAccessHeading": "VM0 で {name} を使う",
     "generationAccessBody": "VM0 のエージェントはエージェント実行の一部として {name} を呼び出すことができ、VM0 クレジットで請求されます。上記の定価はアップストリーム・プロバイダーが課金する金額で、VM0 は標準のクレジット換算で透過的に転送します。",
     "content": {
+      "claude-opus-4-8": {
+        "name": "Claude Opus 4.8",
+        "pageTitle": "Claude Opus 4.8",
+        "tagline": "Anthropicの最新フラッグシップ。2026年5月28日リリース。より強力なエージェンティックコーディング、1セッションで数百の並列サブエージェントを展開する動的ワークフロー、そしてOpus 4.7と同じ通常価格で3倍安価なファストモードを提供します。",
+        "cardIntro": "Anthropicの最新Claude 4フラッグシップ。リリース時点でSWE-bench ProとOSWorld-Verifiedをリード。動的ワークフローと3倍安価なファストモードを搭載。",
+        "metaTitle": "Claude Opus 4.8: ベンチマーク、価格、性能",
+        "metaDescription": "Claude Opus 4.8のレビュー。Anthropicが2026年5月28日にリリースしたフラッグシップ。1Mトークンコンテキスト、最大努力思考、動的ワークフロー、ベンダー価格$5/$25、SWE-bench Pro、OSWorld-Verified、MCP-Atlas、BrowseComp、USAMO、GraphWalks長文コンテキスト再現でOpus 4.7からのベンチマーク向上。",
+        "summary": "Claude Opus 4.8は、Anthropicが2026年5月28日にリリースしたフラッグシップで、Opus 4.7と同じベンダー定価$5/$25での直接的なアップグレードです。AnthropicがこれまでにリリースしたSWE-bench Pro（69.2%）、OSWorld-Verified（83.4%）、MCP-Atlas（82.2%）、Humanity's Last Exam（ツール使用で57.9%）の最高スコアを記録し、リーガルエージェントall-pass標準で10%を突破した初のモデルでもあります。\n\n知っておくべき構造的変更は2つあります。動的ワークフロー（ジョブを計画し、1セッション内で数百の並列サブエージェントに展開）と、ファストモード価格の引き下げ（2.5倍速度で$10/$50/1Mトークン — 従来のClaudeモデルのファストモードより3倍安価）です。努力レベルはhigh（デフォルト）、extra、maxに拡張されました。Anthropic自身、このリリースを大きな飛躍ではなく「控えめだが実感できる改善」と位置付けています。",
+        "releaseDate": "2026年5月28日",
+        "familyPosition": "Claude 4ファミリーの最上位。Anthropicが新規エージェントに推奨するデフォルト。Opus 4.7と同じ×1.7倍数で提供。",
+        "background": [
+          "Claude Opus 4.8は、Opus 4.7から41日後の2026年5月28日に、Anthropicの新フラッグシップとしてリリースされました。4.7と同じコーディング、エージェンティックスキル、推論、ナレッジワークのワークロードを対象とし、同じ通常定価（入力$5 / 出力$25 /1Mトークン）と同じVM0倍数（×1.7）で提供されます。Anthropicはこのリリースを段階的な変化ではなく「前世代に対する控えめだが実感できる改善」と位置付けています。",
+          "VM0ユーザーにとって重要な構造的変更は2つあります。1つ目は動的ワークフロー：モデルがタスクを計画し、1セッション内で数百の並列サブエージェントに展開できる機能で、Anthropicはこれを数十万行規模のコードベース移行を1回の実行で扱う方向への一歩と位置付けています。2つ目は2.5倍速のファストモードが$10 / $50/1Mトークンになったこと — 従来のClaudeモデルのファストモードより3倍安価です。努力レベルは3段階に拡張されました：high（デフォルト）、extra（Claude Codeではxhigh）、max。",
+          "独立系の評価（LLM Stats、VentureBeat、Vellum）は、4.7や競合モデルに対する相対順位を裏付けています。4.8はAnthropicが公開した比較表のすべてのセルで勝利していますが、Terminal-Bench 2.1ではGPT-5.5が依然として首位（78.2%対4.8の74.6%）です。SWE-bench Proでの4.7から4.8への上昇は+4.9ポイント、USAMO 2026では+27.4、新しい1MトークンGraphWalks長文コンテキストF1では+27.8です。絶対スコアは方向性として扱ってください — SWE-bench Verifiedはすべてのフロンティアモデルで飽和に近づいています。"
+        ],
+        "architecture": "Opus 4.8はOpus 4.7の1Mトークンコンテキストウィンドウと128Kの最大出力を維持し、ウィンドウ全体で標準入力価格で課金されます。努力制御は3段階に拡張されました：high（新しいデフォルト）、extra（Claude Code内ではxhigh）、max。Messages APIは会話の途中でシステムエントリを受け付けるようになり、プロンプトキャッシュを壊しません。動的ワークフローにより、Claudeは1セッション内で数百の並列サブエージェントを計画し、ディスパッチできます。ファストモードは標準の約2.5倍の速度で$10 / $50/1Mトークンで動作します。テキスト、ビジョン、コードのマルチモーダル入力は変更ありません。",
+        "specs": [
+          {
+            "label": "ファミリー",
+            "value": "Claude 4世代"
+          },
+          {
+            "label": "モダリティ",
+            "value": "テキスト、画像、コード"
+          },
+          {
+            "label": "言語",
+            "value": "英語中心、多言語対応"
+          },
+          {
+            "label": "プロンプトキャッシュ",
+            "value": "サポート（Anthropic）"
+          },
+          {
+            "label": "コンテキストウィンドウ",
+            "value": "1Mトークン"
+          },
+          {
+            "label": "最大出力",
+            "value": "最大128Kトークン"
+          },
+          {
+            "label": "努力レベル",
+            "value": "High（デフォルト） / Extra / Max"
+          },
+          {
+            "label": "ベンダー定価",
+            "value": "入力$5 / 出力$25 /1M（ファストモード$10/$50、2.5倍速度）"
+          }
+        ],
+        "benchmarksNote": "AnthropicのOpus 4.8システムカードからのベンダー報告スコアで、Opus 4.7、GPT-5.5、Gemini 3.1 Proとの最大努力・5試行平均での比較です。4.8はAnthropicが公開する7セル中6セルでリードし、Terminal-Bench 2.1のみGPT-5.5がリードを維持しています。SWE-bench Verifiedはすべてのフロンティアモデルで飽和に近づいています — より難しいSWE-bench Proセットがより持続的なシグナルです。",
+        "benchmarks": [
+          {
+            "name": "SWE-bench Verified",
+            "score": "88.6%",
+            "note": "ベンダー報告；Opus 4.7の87.6%から向上"
+          },
+          {
+            "name": "SWE-bench Pro",
+            "score": "69.2%",
+            "note": "フィールドリーダー（4.7: 64.3%、GPT-5.5: 58.6%、Gemini 3.1 Pro: 54.2%）"
+          },
+          {
+            "name": "Terminal-Bench 2.1",
+            "score": "74.6%",
+            "note": "4.7の2.0での66.1%から向上；ここではGPT-5.5が78.2%でリード"
+          },
+          {
+            "name": "OSWorld-Verified (computer use)",
+            "score": "83.4%",
+            "note": "フィールドリーダー（4.7: 82.8%、GPT-5.5: 78.7%）"
+          },
+          {
+            "name": "Online-Mind2Web (browser agent)",
+            "score": "84%",
+            "note": "ベンダー報告"
+          },
+          {
+            "name": "MCP-Atlas",
+            "score": "82.2%",
+            "note": "Opus 4.7の77.3%から向上"
+          },
+          {
+            "name": "BrowseComp (single-agent)",
+            "score": "84.3%",
+            "note": "Opus 4.7の79.3%から向上"
+          },
+          {
+            "name": "GraphWalks long-context F1 (1M tokens)",
+            "score": "68.1%",
+            "note": "Opus 4.7の40.3%から向上"
+          },
+          {
+            "name": "Humanity's Last Exam (with tools)",
+            "score": "57.9%",
+            "note": "ツールなしで49.8%；フィールドリーダー"
+          },
+          {
+            "name": "GPQA Diamond",
+            "score": "~93%",
+            "note": "4.7と横ばい — フロンティアモデル全体で飽和"
+          },
+          {
+            "name": "USAMO 2026 (math)",
+            "score": "96.7%",
+            "note": "Opus 4.7の69.3%から向上"
+          },
+          {
+            "name": "GDPval-AA (knowledge work)",
+            "score": "1890 Elo",
+            "note": "リード（4.7: 1753、GPT-5.5: 1769）"
+          },
+          {
+            "name": "Finance Agent v2",
+            "score": "53.9%",
+            "note": "フィールドリーダー"
+          },
+          {
+            "name": "Legal-agent all-pass",
+            "score": ">10%",
+            "note": "この標準を突破した初のモデル"
+          }
+        ],
+        "performance": [
+          {
+            "title": "動的ワークフロー",
+            "body": "目玉となる新機能です。Opus 4.8はタスクを計画し、同じセッション内で数百の並列サブエージェントを実行できます — Anthropicはこれを数十万行規模のコードベース移行を1回の実行で扱う道筋として位置付けています。VM0上では、これは単一のエージェント実行で、以前は外部のスケジューリングが必要だったファンアウト作業をオーケストレーションできることを意味します。"
+          },
+          {
+            "title": "一発でのコード編集",
+            "body": "AnthropicはOpus 4.8がコードレビューで欠陥を見逃す可能性が4.7の約4分の1になったと報告しており、SWE-bench Proでの+4.9ポイントの向上（69.2%対64.3%）が、より難しく飽和していないコーディングセットでそれを裏付けています。多くのファイルにわたってクリーンに適用される必要があるパッチには4.8を選択してください。"
+          },
+          {
+            "title": "長文コンテキスト再現",
+            "body": "1MトークンでのGraphWalks F1が40.3%から68.1%に跳ね上がりました — リリース中最大の単一ベンチマークでの向上です。1Mトークンウィンドウは名目上だけでなく、範囲の上限でも実際に使用可能になりました。"
+          },
+          {
+            "title": "誠実さと過信",
+            "body": "Anthropicは4.7に対して過信が10倍以上減少し、欠陥のある結果を無批判に報告する率が0%（Claudeファミリー初）、重要なイベントをユーザーに伝えそびれる率が3.7%と報告しています。ミスアラインメント発生率は約1.9で、Anthropicの最も整合性の高いMythos Previewと実質的に並んでいます。"
+          },
+          {
+            "title": "速度とファストモード",
+            "body": "標準速度はOpus 4.7と同等です。価格変更が見出しです：2.5倍速度のファストモードが$10 / $50/1Mトークンで、従来のClaudeモデルのファストモードより3倍安価です。実時間レイテンシが重要なオーケストレーションステップに使う価値があります。"
+          },
+          {
+            "title": "プロンプトインジェクションの注意点",
+            "body": "Anthropicのシステムカードは、4.8がエージェンティックなプロンプトインジェクションに対して4.7よりやや堅牢性が低いと指摘しています — Gray Swanのレッドチーミングでは攻撃成功率が4.7の6.0%に対して約9.6%です。信頼できない入力を扱うパイプラインで4.8を運用するチームは、サンドボックス化のアプローチを見直すべきです。"
+          }
+        ],
+        "bestForExamples": [
+          {
+            "title": "かつてスプリントが必要だったコードベース規模の移行",
+            "body": "Opus 4.8に数百ファイルにわたる移行を渡し — ORM切り替え、フレームワークのバージョンアップ、モノレポ全体のセキュリティ修正など — 動的ワークフローで1セッション内の並列サブエージェントに作業を展開させてください。SWE-bench Proでの+4.9ポイントの向上と、コードレビューでの見落としの4分の1への減少が、まさにこの種の実行で実を結びます。"
+          },
+          {
+            "title": "実際に筋が通る1Mトークンのリサーチ実行",
+            "body": "200ページの契約書ドラフト、3つの競合提案、前四半期の法務意見書をウィンドウに投入し、Opus 4.8に市場標準より厳しいすべての条項にフラグを立ててもらいます。1MでのGraphWalksが40.3%から68.1%に跳ね上がったことが、この種のクロスドキュメント統合を新たに信頼できるものにしています。"
+          },
+          {
+            "title": "自分の作業について嘘をつかないエージェントオーケストレーター",
+            "body": "4.8をプランナーとして使用し、リクエストを10ステップに分割し、各ステップをより安価なサブエージェントにディスパッチし、結果を報告させます。欠陥のある結果を無批判に報告する率が0%、過信が10倍減少したことが、エージェント自身のセルフレポートが信頼に足る必要がある場合に本番チームが4.8に手を伸ばす理由です。"
+          },
+          {
+            "title": "ファストモードでようやく採算が合うレイテンシ重視のフロー",
+            "body": "2.5倍速度のファストモードは、以前は現在の3倍のコストがかかっていました（$10/$50/1M対前ティア）。インタラクティブなコパイロット、オンコール要約、または実時間レイテンシが体験を左右するあらゆるステップで、ファストモードの4.8は今やClaudeファミリーのデフォルト選択肢です。"
+          }
+        ],
+        "avoidFor": "Sonnet 4.6が一部のコストで同じ品質基準を満たす大量ルーチン作業、Haiku 4.5が遥かに高速なレイテンシ重視のチャット応答、GPT-5.5がTerminal-Bench 2.1で依然としてリードするエージェンティックターミナルコーディング（78.2%対4.8の74.6%）、サンドボックス化なしで信頼できない入力を取り込むパイプライン（4.8のプロンプトインジェクション耐性は4.7よりわずかに弱い）では、Opus 4.8の使用を避けてください。",
+        "comparisons": [
+          {
+            "vs": "Claude Opus 4.7",
+            "body": "同じ×1.7倍数、同じコンテキストウィンドウ、同じ通常価格。Opus 4.8はAnthropicが公開するすべてのセルでリードしています（SWE-bench Verified +1、SWE-bench Pro +4.9、OSWorld-Verified +0.6、MCP-Atlas +4.9、BrowseComp +5.0、GraphWalks 1M +27.8、USAMO +27.4）。トレードオフはわずかに弱いプロンプトインジェクションプロファイル（攻撃成功率約9.6%対6.0%）です。新規エージェントは4.8に移行し、検証済みでリグレッション再実行を避けたい場合のみ4.7を固定してください。"
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Sonnet 4.6（×1）は依然としてほとんどのエージェントループのワークホースデフォルトです。Sonnetが難しい推論、長文コンテキスト再現、一発のコード編集で明らかに失敗する場合にOpus 4.8に昇格させてください — 通常はSonnetやHaikuレベルのサブエージェントに委任するプランナーとして使用します。動的ワークフローにより、オーケストレーターとしてのOpus 4.8 + ワーカーとしてのSonnet 4.6が新しい推奨パターンです。"
+          },
+          {
+            "vs": "GPT-5.5",
+            "body": "Opus 4.8はAnthropicの比較セットの7セル中6セルでリードしており、最大の差はSWE-bench Pro（69.2%対58.6%）とOSWorld-Verified（83.4%対78.7%）です。GPT-5.5はTerminal-Bench 2.1（78.2%対74.6%）でリードを維持しています。クロスファイルコーディングとコンピュータ操作エージェントには4.8、ターミナル駆動の作業が支配的な場合は特にGPT-5.5を選んでください。"
+          },
+          {
+            "vs": "Gemini 3.1 Pro",
+            "body": "Opus 4.8はSWE-bench Pro（+15.0）とOSWorld-Verified（+7.2）で大きな差でリードしています。GPQA Diamondのような飽和した科学ベンチマークでは両モデルがノイズ範囲内に留まります。エージェンティックな作業には4.8をデフォルトに、Googleのツール統合ストーリーが必要な場合は特にGeminiを検討してください。"
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro（×0.3）は、生のトークン価格が意思決定を支配する場合のコスト最適化選択肢として依然有効です。Opus 4.8はツールルーティングの信頼性、長文コンテキスト再現、アラインメント指標、コンピュータ操作でリードを維持しており、ほとんどの英語エンタープライズエージェントが価格差にもかかわらず4.8をデフォルトとし続ける理由です。"
+          }
+        ],
+        "verdict": "Claudeファミリーの新規エージェントの新しいデフォルト。再検証可能になり次第4.7から移行し、新規作業には直接これをデフォルトにしてください。Sonnet 4.6はその下のより安価なワークホースとして維持してください。",
+        "faqs": [
+          {
+            "q": "Claude Opus 4.8はいつリリースされましたか？",
+            "a": "AnthropicはOpus 4.7から41日後の2026年5月28日にOpus 4.8をリリースしました。Claude製品、Claude API（モデルID `claude-opus-4-8`）、Amazon Bedrock、Google Cloud Vertex AI、Microsoft Foundry、VM0で本日より利用可能です。"
+          },
+          {
+            "q": "Opus 4.8の価格は4.7と比べてどうですか？",
+            "a": "通常価格は同一です：入力1Mトークンあたり$5、出力1Mトークンあたり$25、キャッシュ入力1Mトークンあたり$0.50。変更点はファストモードで、2.5倍速度で$10 / $50/1Mトークンになりました — 従来のClaudeモデルのファストモードより3倍安価です。"
+          },
+          {
+            "q": "動的ワークフローとは何ですか？",
+            "a": "Opus 4.8がタスクを計画し、1セッション内で数百の並列サブエージェントを実行できる新機能です。Anthropicはこれを、1回のエージェント実行で数十万行規模のコードベース移行を扱う道筋として位置付けています。"
+          },
+          {
+            "q": "Opus 4.8はどの努力レベルをサポートしていますか？",
+            "a": "3つのレベル：high（新しいデフォルト）、extra（Claude Codeではxhigh）、max。高い設定では応答を生成する前に推論により多くのトークンを使い、低い設定では速度とレートリミット効率を優先します。"
+          },
+          {
+            "q": "Opus 4.7から4.8に移行すべきですか？",
+            "a": "新規作業ははい — 同じ倍数、同じ通常価格、Terminal-Bench 2.1を除く公開されたすべての比較セルでより強力な挙動を示します。固定された本番エージェントはリグレッションスイートを通した後に移行し、エージェントが信頼できない入力を取り込む場合はサンドボックス化を見直してください（4.8は4.7よりプロンプトインジェクションへの堅牢性がわずかに弱いです）。"
+          },
+          {
+            "q": "Opus 4.8はプロンプトキャッシュをサポートしていますか？",
+            "a": "はい。キャッシュ入力は1Mトークンあたり$0.50で課金され、キャッシュ部分に対する10倍の割引です。Messages APIは会話の途中でシステムエントリを受け付けるようになり、キャッシュを壊しません。"
+          }
+        ],
+        "alternatives": [
+          {
+            "slug": "claude-opus-4-7",
+            "reason": "前世代のフラッグシップ。プロンプトインジェクションにわずかに堅牢。"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "ほとんどのエージェントループ向けのより安価なデフォルト。"
+          },
+          {
+            "slug": "gpt-5-5",
+            "reason": "エージェンティックターミナルコーディングでTerminal-Bench 2.1をリード。"
+          }
+        ],
+        "routingNotes": "On VM0, Opus 4.8 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code. It is also included in the default org model policy.",
+        "vm0Notes": "Prompt caching is enabled by default through VM0, which substantially cuts the cost of repeated system prompts, tool definitions, and pasted reference documents on agents that issue many turns from the same prefix. There are no VM0-side timeout overrides for Opus 4.8; the model uses Anthropic's default API timeouts. Sonnet 4.6 stays the platform default for new agents, so the standard pattern is to keep cheap tiers running everywhere and route only the hardest steps to Opus 4.8."
+      },
       "claude-opus-4-7": {
         "name": "Claude Opus 4.7",
         "pageTitle": "Claude Opus 4.7",


### PR DESCRIPTION
## Summary

Adds a `/models/claude-opus-4-8` detail page and lists Opus 4.8 on the `/models` index across all four locales (en, de, es, ja). Anthropic released Opus 4.8 on 2026-05-28, at the same vendor list price ($5/$25 per 1M) and same VM0 credit multiplier (×1.7) as Opus 4.7. The model is already wired up in `packages/api-contracts/src/contracts/model-providers.ts` (`SUPPORTED_RUN_MODELS`, `VM0_MODEL_TO_PROVIDER`, multiplier table) and `apps/api/src/scripts/dev-seed.ts` (pricing) — this PR is web-only marketing copy.

### What the page covers
- Release facts: 2026-05-28, same regular pricing as 4.7, fast mode now $10/$50 at 2.5× speed (3× cheaper than prior fast mode), three effort levels (high default / extra / max), dynamic workflows for hundreds of parallel subagents in one session.
- System-card benchmarks against Opus 4.7, GPT-5.5, and Gemini 3.1 Pro: SWE-bench Verified 88.6%, SWE-bench Pro 69.2% (leads), Terminal-Bench 2.1 74.6% (GPT-5.5 still leads here at 78.2%), OSWorld-Verified 83.4% (leads), MCP-Atlas 82.2%, BrowseComp 84.3%, GraphWalks 1M 68.1%, HLE 57.9% with tools (leads), USAMO 96.7%, GDPval-AA 1890 Elo (leads).
- Caveat from the system card: agentic prompt-injection robustness is slightly weaker than 4.7 (~9.6% attack-success rate vs 6.0%). Recommends sandboxing review for pipelines that ingest untrusted input.

### Files changed
- `turbo/apps/web/app/[locale]/models/data.ts` — new entry at position 0; updates Opus 4.7's `comparisonSlugs` / `alternativeSlugs` to include 4.8.
- `turbo/apps/web/messages/{en,de,es,ja}.json` — adds `content.claude-opus-4-8.*` keys, mirroring the shape of the existing 4.7 entry. Translations were done by an LLM-assisted pass following the existing locale tone.

### Local verification
- Prettier check: clean on all five files.
- ESLint: clean on `data.ts` and all `models/` page components.
- `tsc --noEmit` on `apps/web`: clean.
- `knip --workspace web`: clean.
- JSON parses cleanly in all four locale files; key shape and array lengths for `claude-opus-4-8` exactly match `claude-opus-4-7` across en/de/es/ja.
- Did not run `vitest`: the sandbox has no Postgres so the global-setup blocks the run. The relevant test (`models/__tests__/data.test.ts`) only asserts unique slugs/modelIds and that every reasoning modelId exists in `VM0_MODEL_TO_PROVIDER`; both hold by inspection (`claude-opus-4-8` is already in that map per `model-providers.ts`).

## Test plan

- [ ] Pull the branch and run `pnpm vitest` from `turbo/apps/web` to confirm the data test passes against a real DB.
- [ ] Visit `/en/models` → confirm Opus 4.8 appears at the top of the lineup card grid.
- [ ] Visit `/en/models/claude-opus-4-8` → confirm hero copy, specs, benchmarks, performance, comparisons, FAQs, and the "Alternatives" row render with the new content.
- [ ] Spot-check `/de/models/claude-opus-4-8`, `/es/models/claude-opus-4-8`, `/ja/models/claude-opus-4-8` for translation quality before merge — these were drafted with LLM assistance and benefit from a native pass.
- [ ] Confirm OG image, breadcrumb JSON-LD, and FAQ JSON-LD render on the detail page.
- [ ] Spot-check that the Opus 4.7 page still renders and now shows 4.8 in its comparison/alternatives row.