### PR TITLE
fix: require kms secret envelopes

### DIFF
--- a/turbo/apps/api/src/__tests__/setup.ts
+++ b/turbo/apps/api/src/__tests__/setup.ts
@@ -1,5 +1,11 @@
 import { resetApiTestMocks } from "./mocks";
-import { afterAll, afterEach, beforeAll } from "vitest";
+import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
 import {
   type Dispatcher,
   getGlobalDispatcher,
@@ -7,9 +13,14 @@ import {
   setGlobalDispatcher,
 } from "undici";
 
-import { clearMockedEnv } from "../lib/env";
+import { clearMockedEnv, mockEnv } from "../lib/env";
 import { clearMockNow } from "../lib/time";
 import { server } from "../mocks/server";
+import {
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+  type SecretKmsClient,
+} from "../signals/services/crypto.utils";
 import { clearAllDetached } from "../signals/utils";
 
 // msw's FetchInterceptor monkey-patches globalThis.fetch, so it does not see
@@ -36,6 +47,35 @@ const undiciState = (() => {
   };
 })();
 
+type MockKmsCommand = GenerateDataKeyCommand | DecryptCommand;
+type MockKmsResponse = GenerateDataKeyCommandOutput | DecryptCommandOutput;
+
+const testDataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+function createApiTestKmsClient(): SecretKmsClient {
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(command: MockKmsCommand): Promise<MockKmsResponse> {
+    if (command instanceof GenerateDataKeyCommand) {
+      return Promise.resolve({
+        $metadata: {},
+        KeyId: command.input.KeyId,
+        CiphertextBlob: Buffer.from(
+          `encrypted-data-key:${command.input.KeyId}`,
+          "utf8",
+        ),
+        Plaintext: testDataKey,
+      });
+    }
+
+    return Promise.resolve({ $metadata: {}, Plaintext: testDataKey });
+  }
+
+  return { send };
+}
+
 export function useUndiciMock(): MockAgent {
   if (undiciState.activeMock) {
     return undiciState.activeMock;
@@ -54,9 +94,15 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
 });
 
+beforeEach(() => {
+  mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+  setSecretKmsClientForTests(createApiTestKmsClient());
+});
+
 afterEach(async () => {
   await clearAllDetached();
   clearMockNow();
+  resetSecretKmsClientForTests();
   clearMockedEnv();
   resetApiTestMocks();
   server.resetHandlers();

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -34,7 +34,6 @@ import { createApp } from "../../../app-factory";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { decryptSecretsMap } from "../../services/crypto.utils";
 import { now, nowDate } from "../../external/time";
 import {
   createFixtureTracker,
@@ -49,7 +48,10 @@ import {
   deleteOrgModelProviders$,
   seedOrgModelProvider$,
 } from "./helpers/zero-model-providers";
-import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  decryptSecretsMapForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -575,7 +577,9 @@ describe("POST /api/agent/runs", () => {
       MY_VAR: "value",
       API_KEY: "secret-value",
     });
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toStrictEqual({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toStrictEqual({
       API_KEY: "secret-value",
     });
     expect(executionContext.storageManifest.storages).toMatchObject([
@@ -640,7 +644,9 @@ describe("POST /api/agent/runs", () => {
       readonly encryptedSecrets: string | null;
     };
     expect(executionContext.environment.API_KEY).toBe("persisted-secret-value");
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toStrictEqual({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toStrictEqual({
       API_KEY: "persisted-secret-value",
     });
   });
@@ -820,7 +826,7 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.environment.MERCURY_TOKEN).toBe(
       "CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafe",
     );
-    const decryptedSecrets = decryptSecretsMap(
+    const decryptedSecrets = decryptSecretsMapForTests(
       executionContext.encryptedSecrets,
     );
     expect(decryptedSecrets).toMatchObject({
@@ -987,7 +993,9 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.environment.USER_ZENDESK_SUBDOMAIN).toBe(
       "user-subdomain",
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       ZENDESK_API_TOKEN: "connector-zendesk-token",
     });
     const zendesk = executionContext.firewalls.find((firewall) => {
@@ -1124,7 +1132,9 @@ describe("POST /api/agent/runs", () => {
     const executionContext = job?.executionContext as {
       readonly encryptedSecrets: string | null;
     };
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       WEREAD_TOKEN: "weread-real-token",
       DECLARED_SECRET: "declared-value",
     });
@@ -1180,7 +1190,9 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.environment.WEREAD_TOKEN).toBe(
       "wrk-CoffeeSafeLocalCoffeeSafeLocalCoffee",
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toStrictEqual({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toStrictEqual({
       WEREAD_TOKEN: "weread-real-token",
     });
     expect(
@@ -1238,7 +1250,9 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.environment.GITHUB_TOKEN).toBe(
       "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",
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       GITHUB_TOKEN: "github-real-token",
     });
   });
@@ -1291,7 +1305,9 @@ describe("POST /api/agent/runs", () => {
       ),
       ANTHROPIC_MODEL: "claude-sonnet-4-6",
     });
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       ANTHROPIC_API_KEY: "test-secret-value",
     });
     expect(executionContext.billableFirewalls).toStrictEqual([]);
@@ -1346,7 +1362,9 @@ describe("POST /api/agent/runs", () => {
       OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
       OPENAI_MODEL: "openai/gpt-5.5",
     });
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       OPENROUTER_API_KEY: "test-secret-value",
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -25,10 +25,6 @@ import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import {
-  decryptSecretValue,
-  decryptSecretsMap,
-} from "../../services/crypto.utils";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
 import {
@@ -36,6 +32,10 @@ import {
   signSandboxJwtForTests,
   verifyZeroToken,
 } from "../../auth/tokens";
+import {
+  decryptSecretForTests,
+  decryptSecretsMapForTests,
+} from "./helpers/encrypt-secret";
 
 interface PatFixture {
   readonly token: string;
@@ -911,7 +911,7 @@ describe("POST /api/v1/chat-threads/messages", () => {
     expect(callback.url).toBe(
       "http://localhost:3000/api/internal/callbacks/chat",
     );
-    expect(decryptSecretValue(callback.encryptedSecret)).toHaveLength(64);
+    expect(decryptSecretForTests(callback.encryptedSecret)).toHaveLength(64);
     expect(callback.payload).toStrictEqual({
       threadId: response.body.threadId,
       agentId: agent.composeId,
@@ -978,7 +978,7 @@ describe("POST /api/v1/chat-threads/messages", () => {
         ? (job.executionContext as { encryptedSecrets: string })
             .encryptedSecrets
         : null;
-    const secrets = decryptSecretsMap(encryptedSecrets);
+    const secrets = decryptSecretsMapForTests(encryptedSecrets);
     expect(secrets?.ZERO_TOKEN).toMatch(/^vm0_sandbox_/);
     const zeroAuth = verifyZeroToken(secrets!.ZERO_TOKEN!);
     expect(zeroAuth?.userId).toBe(pat.userId);

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -37,7 +37,7 @@ import { signPatJwtForTests, signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { now, nowDate } from "../../external/time";
 import { DEFAULT_TEST_EMAIL } from "../../services/cli-auth.service";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import { decryptSecretForTests } from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -524,7 +524,7 @@ describe("CLI auth routes", () => {
       )
       .limit(1);
 
-    return row ? decryptSecretValue(row.encryptedValue) : undefined;
+    return row ? decryptSecretForTests(row.encryptedValue) : undefined;
   }
 
   async function findConnectorSecret(args: {
@@ -546,7 +546,7 @@ describe("CLI auth routes", () => {
       )
       .limit(1);
 
-    return row ? decryptSecretValue(row.encryptedValue) : undefined;
+    return row ? decryptSecretForTests(row.encryptedValue) : undefined;
   }
 
   async function readConnectorState(args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -25,8 +25,8 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { decryptSecretForTests } from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -1016,7 +1016,7 @@ async function findDecryptedSecret(args: {
   readonly name: string;
 }): Promise<string | undefined> {
   const secret = await findSecret(args);
-  return secret ? decryptSecretValue(secret.encryptedValue) : undefined;
+  return secret ? decryptSecretForTests(secret.encryptedValue) : undefined;
 }
 
 interface ProviderSuccessCase {
@@ -1536,7 +1536,7 @@ describe("GET /api/connectors/:type/callback", () => {
       name: "GITHUB_ACCESS_TOKEN",
     });
     expect(secret).toBeDefined();
-    expect(decryptSecretValue(secret!.encryptedValue)).toBe("github-token");
+    expect(decryptSecretForTests(secret!.encryptedValue)).toBe("github-token");
 
     const db = store.set(writeDb$);
     const [session] = await db
@@ -1998,7 +1998,7 @@ describe("GET /api/connectors/:type/callback", () => {
       name: "TEST_OAUTH_ACCESS_TOKEN",
     });
     expect(secret).toBeDefined();
-    expect(decryptSecretValue(secret!.encryptedValue)).toBe(
+    expect(decryptSecretForTests(secret!.encryptedValue)).toBe(
       "dynamic-access-token",
     );
   });
@@ -2068,7 +2068,7 @@ describe("GET /api/connectors/:type/callback", () => {
       name: "SLACK_ACCESS_TOKEN",
     });
     expect(secret).toBeDefined();
-    expect(decryptSecretValue(secret!.encryptedValue)).toBe(
+    expect(decryptSecretForTests(secret!.encryptedValue)).toBe(
       "xoxp-stored-token",
     );
   });
@@ -2114,10 +2114,10 @@ describe("GET /api/connectors/:type/callback", () => {
     });
     expect(accessSecret).toBeDefined();
     expect(refreshSecret).toBeDefined();
-    expect(decryptSecretValue(accessSecret!.encryptedValue)).toBe(
+    expect(decryptSecretForTests(accessSecret!.encryptedValue)).toBe(
       "notion-access",
     );
-    expect(decryptSecretValue(refreshSecret!.encryptedValue)).toBe(
+    expect(decryptSecretForTests(refreshSecret!.encryptedValue)).toBe(
       "notion-refresh",
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -22,7 +22,7 @@ import { now, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import { decryptPersistentSecretValue } from "../../services/crypto.utils";
 import { signGithubConnectParams } from "../../services/github-oauth.service";
 import {
   deleteUsageInsightFixture$,
@@ -817,9 +817,12 @@ describe("GitHub OAuth API routes", () => {
     expect(installations[0]!.defaultComposeId).toBe(fixture.composeId);
     expect(installations[0]!.targetId).toBe(targetId);
     expect(installations[0]!.adminGithubUserId).toBe(targetId);
-    expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
-      "ghs_remote_installation_token",
-    );
+    await expect(
+      decryptPersistentSecretValue(installations[0]!.encryptedAccessToken!, {
+        orgId: installations[0]!.orgId,
+        userId: fixture.userId,
+      }),
+    ).resolves.toBe("ghs_remote_installation_token");
     const links = await findLinksForUser(fixture.userId);
     expect(links).toHaveLength(1);
   });
@@ -994,9 +997,12 @@ describe("GitHub OAuth API routes", () => {
       orgId: fixture.orgId,
       defaultComposeId: fixture.composeId,
     });
-    expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
-      "ghs_callback_installation_token",
-    );
+    await expect(
+      decryptPersistentSecretValue(installations[0]!.encryptedAccessToken!, {
+        orgId: installations[0]!.orgId,
+        userId: fixture.userId,
+      }),
+    ).resolves.toBe("ghs_callback_installation_token");
     const links = await findLinksForUser(fixture.userId);
     expect(links).toHaveLength(1);
     expect(links[0]!.githubUserId).toBe(targetId);
@@ -1038,9 +1044,12 @@ describe("GitHub OAuth API routes", () => {
     expect(location.searchParams.get("github")).toBe("connected");
     const installations = await findInstallationByRemoteId(installationId);
     expect(installations).toHaveLength(1);
-    expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
-      "ghs_setup_code_installation_token",
-    );
+    await expect(
+      decryptPersistentSecretValue(installations[0]!.encryptedAccessToken!, {
+        orgId: installations[0]!.orgId,
+        userId: fixture.userId,
+      }),
+    ).resolves.toBe("ghs_setup_code_installation_token");
     const links = await findLinksForUser(fixture.userId);
     expect(links).toHaveLength(1);
     expect(links[0]!.githubUserId).toBe(githubUserId);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/encrypt-secret.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/encrypt-secret.ts
@@ -1,19 +1,110 @@
-import { createCipheriv, randomBytes } from "node:crypto";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 import { env } from "../../../../lib/env";
+import { STORED_SECRET_ENVELOPE_PREFIX } from "../../../services/crypto.utils";
+
+const TEST_KMS_KEY_ID = "alias/vm0-secrets-test";
+const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
 export function encryptSecretForTests(plaintext: string): string {
-  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const cipher = createCipheriv("aes-256-gcm", TEST_DATA_KEY, iv, {
+    authTagLength: 16,
+  });
   const data = Buffer.concat([
     cipher.update(plaintext, "utf8"),
     cipher.final(),
   ]);
   const authTag = cipher.getAuthTag();
-  return [
-    iv.toString("base64"),
-    authTag.toString("base64"),
-    data.toString("base64"),
-  ].join(":");
+  return `${STORED_SECRET_ENVELOPE_PREFIX}${Buffer.from(
+    JSON.stringify({
+      v: 1,
+      kind: "stored-secret",
+      kms: {
+        keyId: TEST_KMS_KEY_ID,
+        encryptedDataKey: Buffer.from(
+          `encrypted-data-key:${TEST_KMS_KEY_ID}`,
+          "utf8",
+        ).toString("base64"),
+        iv: iv.toString("base64"),
+        authTag: authTag.toString("base64"),
+        ciphertext: data.toString("base64"),
+      },
+    }),
+    "utf8",
+  ).toString("base64url")}`;
+}
+
+function decryptLegacySecretForTests(encrypted: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const [ivBase64, authTagBase64, dataBase64] = encrypted.split(":");
+  if (!ivBase64 || !authTagBase64 || !dataBase64) {
+    throw new Error("Invalid encrypted data format");
+  }
+
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    key,
+    Buffer.from(ivBase64, "base64"),
+    { authTagLength: 16 },
+  );
+  decipher.setAuthTag(Buffer.from(authTagBase64, "base64"));
+
+  return Buffer.concat([
+    decipher.update(Buffer.from(dataBase64, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+export function decryptSecretForTests(encrypted: string): string {
+  if (!encrypted.startsWith(STORED_SECRET_ENVELOPE_PREFIX)) {
+    return decryptLegacySecretForTests(encrypted);
+  }
+
+  const payload = encrypted.slice(STORED_SECRET_ENVELOPE_PREFIX.length);
+  const envelope = JSON.parse(
+    Buffer.from(payload, "base64url").toString("utf8"),
+  ) as {
+    readonly kms?: {
+      readonly iv?: string;
+      readonly authTag?: string;
+      readonly ciphertext: string;
+    };
+    readonly legacy?: string;
+  };
+  if (!envelope.kms) {
+    if (!envelope.legacy) {
+      throw new Error("Stored secret test envelope has no decryptable data");
+    }
+    return decryptLegacySecretForTests(envelope.legacy);
+  }
+  if (!envelope.kms.iv || !envelope.kms.authTag) {
+    throw new Error("Stored secret test envelope is not data-key encrypted");
+  }
+
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    TEST_DATA_KEY,
+    Buffer.from(envelope.kms.iv, "base64"),
+    { authTagLength: 16 },
+  );
+  decipher.setAuthTag(Buffer.from(envelope.kms.authTag, "base64"));
+
+  return Buffer.concat([
+    decipher.update(Buffer.from(envelope.kms.ciphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+export function decryptSecretsMapForTests(
+  encryptedData: string | null,
+): Record<string, string> | null {
+  if (!encryptedData) {
+    return null;
+  }
+
+  return JSON.parse(decryptSecretForTests(encryptedData)) as Record<
+    string,
+    string
+  >;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -23,8 +23,8 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { signPatJwtForTests, verifySandboxToken } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
-import { encryptSecretValue } from "../../services/crypto.utils";
 import { createFixtureTracker } from "./helpers/zero-route-test";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   deleteUsageInsightFixture$,
   seedCompose$,
@@ -75,7 +75,7 @@ function runnerHeartbeatBody(runnerId: string) {
 }
 
 function encryptedSecretsMap(values: Record<string, string>): string {
-  return encryptSecretValue(JSON.stringify(values));
+  return encryptSecretForTests(JSON.stringify(values));
 }
 
 function modelProviderSecretPlaceholder(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -25,11 +25,6 @@ import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import {
-  decryptSecretValue,
-  encryptSecretValue,
-  encryptSecretsMap,
-} from "../../services/crypto.utils";
-import {
   deleteUsageInsightFixture$,
   seedCompose$,
   seedRun$,
@@ -37,6 +32,10 @@ import {
   type UsageInsightFixture,
 } from "./helpers/zero-usage-insight";
 import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  decryptSecretForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -76,11 +75,7 @@ function authHeaders(fixture: {
 }
 
 function encryptedSecrets(values: Record<string, string>): string {
-  const encrypted = encryptSecretsMap(values);
-  if (!encrypted) {
-    throw new Error("encryptSecretsMap returned null for non-empty secrets");
-  }
-  return encrypted;
+  return encryptSecretForTests(JSON.stringify(values));
 }
 
 function secretTemplate(name: string): string {
@@ -152,7 +147,7 @@ async function seedSecret(args: {
     orgId: args.orgId,
     userId: args.userId,
     name: args.name,
-    encryptedValue: encryptSecretValue(args.value),
+    encryptedValue: encryptSecretForTests(args.value),
     type: args.type,
   });
 }
@@ -222,7 +217,7 @@ async function readSecret(args: {
       ),
     )
     .limit(1);
-  return row ? decryptSecretValue(row.encryptedValue) : null;
+  return row ? decryptSecretForTests(row.encryptedValue) : null;
 }
 
 async function seedNotionConnector(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -37,10 +37,6 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { generateZeroToken, verifyZeroToken } from "../../auth/tokens";
-import {
-  decryptSecretValue,
-  decryptSecretsMap,
-} from "../../services/crypto.utils";
 import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
@@ -49,7 +45,11 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  decryptSecretForTests,
+  decryptSecretsMapForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -298,7 +298,7 @@ async function runExecutionSecrets(runId: string) {
     .from(runnerJobQueue)
     .where(eq(runnerJobQueue.runId, runId))
     .limit(1);
-  return decryptSecretsMap(
+  return decryptSecretsMapForTests(
     encryptedSecretsFromExecutionContext(job?.executionContext),
   );
 }
@@ -534,7 +534,7 @@ describe("POST /api/zero/chat/messages", () => {
     expect(callback?.url).toBe(
       "http://localhost:3000/api/internal/callbacks/chat",
     );
-    expect(decryptSecretValue(callback!.encryptedSecret)).toHaveLength(64);
+    expect(decryptSecretForTests(callback!.encryptedSecret)).toHaveLength(64);
     expect(callback?.payload).toStrictEqual({
       threadId: response.body.threadId,
       agentId: fixture.agentId,
@@ -1326,7 +1326,9 @@ describe("POST /api/zero/chat/messages", () => {
       ANTHROPIC_API_KEY: anthropicPlaceholder,
       ANTHROPIC_MODEL: "claude-sonnet-4-6",
     });
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(decrypted?.ANTHROPIC_API_KEY).toStrictEqual(expect.any(String));
     expect(decrypted?.ANTHROPIC_API_KEY).not.toBe(anthropicPlaceholder);
     expect(executionContext.billableFirewalls).toContain(
@@ -1382,7 +1384,9 @@ describe("POST /api/zero/chat/messages", () => {
       ANTHROPIC_MODEL: "deepseek-v4-pro",
     });
     expect(executionContext.environment.ANTHROPIC_API_KEY).toBeUndefined();
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       DEEPSEEK_API_KEY: "selected-deepseek-key",
     });
   });
@@ -1495,7 +1499,9 @@ describe("POST /api/zero/chat/messages", () => {
     expect(executionContext.environment.ANTHROPIC_MODEL).toBe(
       "deepseek-v4-pro",
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       DEEPSEEK_API_KEY: "org-deepseek-key",
     });
   });
@@ -1614,7 +1620,9 @@ describe("POST /api/zero/chat/messages", () => {
     expect(executionContext.environment.ANTHROPIC_MODEL).toBe(
       "claude-sonnet-4-6",
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       ANTHROPIC_API_KEY: "org-anthropic-key",
     });
   });
@@ -1668,7 +1676,9 @@ describe("POST /api/zero/chat/messages", () => {
       OPENAI_MODEL: "gpt-5.5",
     });
     expect(executionContext.environment.ANTHROPIC_API_KEY).toBeUndefined();
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       OPENAI_API_KEY: "vm0-key-gpt-5.5",
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-claude-code-device-auth.test.ts
@@ -14,7 +14,7 @@ import { clearMockedEnv, mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import {
-  decryptSecretValue,
+  decryptStoredSecretValue,
   inspectPersistentSecretCiphertext,
   resetSecretKmsClientForTests,
   setSecretKmsClientForTests,
@@ -118,7 +118,7 @@ async function claudeCodeSecret(args: {
       ),
     )
     .limit(1);
-  return secret ? decryptSecretValue(secret.encryptedValue) : null;
+  return secret ? await decryptStoredSecretValue(secret.encryptedValue) : null;
 }
 
 function stateFromBrowserUrl(browserUrl: string): string {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-codex-device-auth.test.ts
@@ -15,7 +15,7 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import {
-  decryptSecretValue,
+  decryptStoredSecretValue,
   inspectPersistentSecretCiphertext,
   resetSecretKmsClientForTests,
   setSecretKmsClientForTests,
@@ -219,7 +219,7 @@ async function chatgptSecret(args: {
       ),
     )
     .limit(1);
-  return secret ? decryptSecretValue(secret.encryptedValue) : null;
+  return secret ? await decryptStoredSecretValue(secret.encryptedValue) : null;
 }
 
 describe("Codex device auth routes", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
@@ -17,7 +17,7 @@ import { afterEach } from "vitest";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
-import { encryptSecretValue } from "../../services/crypto.utils";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -300,14 +300,14 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
         orgId: fixture.orgId,
         userId: fixture.userId,
         name: "STRIPE_ACCESS_TOKEN",
-        encryptedValue: encryptSecretValue("stripe-access-token"),
+        encryptedValue: encryptSecretForTests("stripe-access-token"),
         type: "connector",
       },
       {
         orgId: fixture.orgId,
         userId: fixture.userId,
         name: "STRIPE_REFRESH_TOKEN",
-        encryptedValue: encryptSecretValue("stripe-refresh-token"),
+        encryptedValue: encryptSecretForTests("stripe-refresh-token"),
         type: "connector",
       },
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -17,10 +17,10 @@ import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
-import { encryptSecretValue } from "../../services/crypto.utils";
 import { writeDb$ } from "../../external/db";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testContext } from "../../../__tests__/test-helpers";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -654,7 +654,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
       userId,
       name: "GITHUB_ACCESS_TOKEN",
       type: "connector",
-      encryptedValue: encryptSecretValue("gh-access-token"),
+      encryptedValue: encryptSecretForTests("gh-access-token"),
     });
 
     let revokeAuthorization: string | null = null;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -20,8 +20,8 @@ import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import {
   decryptPersistentSecretValue,
-  decryptSecretValue,
-  encryptSecretValue,
+  decryptStoredSecretValue,
+  encryptPersistentSecretValue,
   inspectPersistentSecretCiphertext,
   resetSecretKmsClientForTests,
   setSecretKmsClientForTests,
@@ -109,15 +109,16 @@ async function cleanupUser(userId: string, orgId: string) {
     );
 }
 
-function encryptedProviderState(args: {
+async function encryptedProviderState(args: {
   readonly connectorType?: "test-oauth-device" | "slock";
   readonly deviceCode: string;
-}): string {
-  return encryptSecretValue(
+}): Promise<string> {
+  return await encryptPersistentSecretValue(
     JSON.stringify({
       connectorType: args.connectorType ?? "test-oauth-device",
       deviceCode: args.deviceCode,
     }),
+    {},
   );
 }
 
@@ -330,7 +331,7 @@ async function createSession(args: {
       connectorType: args.connectorType ?? "test-oauth-device",
       status: args.status ?? "awaiting_user_authorization",
       sessionTokenHash: sessionTokenHash(sessionToken),
-      encryptedProviderState: encryptedProviderState({
+      encryptedProviderState: await encryptedProviderState({
         connectorType: args.connectorType ?? "test-oauth-device",
         deviceCode: args.deviceCode,
       }),
@@ -394,7 +395,7 @@ async function connectorSecretValue(
         eq(secrets.name, name),
       ),
     );
-  return secret ? decryptSecretValue(secret.encryptedValue) : null;
+  return secret ? await decryptStoredSecretValue(secret.encryptedValue) : null;
 }
 
 describe("OAuth device authorization connector routes", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-secret-set.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-secret-set.test.ts
@@ -10,7 +10,7 @@ import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-s
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import { decryptStoredSecretValue } from "../../services/crypto.utils";
 import {
   deleteCustomConnectorOrg$,
   seedCustomConnectorOrg$,
@@ -47,7 +47,7 @@ describe("PUT /api/zero/custom-connectors/:id/secret", () => {
     });
   });
 
-  it("stores per-user secret and round-trips through decryptSecretValue", async () => {
+  it("stores per-user secret and round-trips through decryptStoredSecretValue", async () => {
     const fixture = await track(
       store.set(seedCustomConnectorOrg$, {}, context.signal),
     );
@@ -75,7 +75,9 @@ describe("PUT /api/zero/custom-connectors/:id/secret", () => {
     expect(row).toBeDefined();
     expect(row!.userId).toBe(fixture.userId);
     expect(row!.orgId).toBe(fixture.orgId);
-    expect(decryptSecretValue(row!.encryptedValue)).toBe("sk_live_xyz");
+    await expect(decryptStoredSecretValue(row!.encryptedValue)).resolves.toBe(
+      "sk_live_xyz",
+    );
 
     const listClient = setupApp({ context })(zeroCustomConnectorsContract);
     const listResponse = await accept(
@@ -130,6 +132,8 @@ describe("PUT /api/zero/custom-connectors/:id/secret", () => {
       .from(orgCustomConnectorSecrets)
       .where(eq(orgCustomConnectorSecrets.userId, memberUserId));
     expect(row).toBeDefined();
-    expect(decryptSecretValue(row!.encryptedValue)).toBe("member-token");
+    await expect(decryptStoredSecretValue(row!.encryptedValue)).resolves.toBe(
+      "member-token",
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -35,10 +35,12 @@ import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
-import { decryptSecretValue } from "../../services/crypto.utils";
 import { clearAllDetached } from "../../utils";
 import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
-import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  decryptSecretForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -1045,7 +1047,7 @@ describe("POST /api/telegram/register", () => {
     if (!installation) {
       throw new Error("Expected Telegram installation to exist");
     }
-    expect(decryptSecretValue(installation.encryptedBotToken)).toBe(
+    expect(decryptSecretForTests(installation.encryptedBotToken)).toBe(
       NEW_BOT_TOKEN,
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
@@ -9,7 +9,7 @@ import { secrets } from "@vm0/db/schema/secret";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import { decryptStoredSecretValue } from "../../services/crypto.utils";
 import {
   deleteUserModelProviders$,
   type UserModelProviderFixture,
@@ -154,7 +154,9 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
           eq(secrets.name, "CLAUDE_CODE_OAUTH_TOKEN"),
         ),
       );
-    expect(decryptSecretValue(row!.encryptedValue)).toBe("sk-ant-test");
+    await expect(decryptStoredSecretValue(row!.encryptedValue)).resolves.toBe(
+      "sk-ant-test",
+    );
   });
 
   it("updates an existing personal provider with 200", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
@@ -13,8 +13,10 @@ import { secrets } from "@vm0/db/schema/secret";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
-import { decryptSecretValue } from "../../services/crypto.utils";
-import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  decryptSecretForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
 import {
   deleteOrgModelProviders$,
   seedOrgModelProvider$,
@@ -111,7 +113,7 @@ async function findOrgModelProviderSecret(
     )
     .limit(1);
 
-  return row ? decryptSecretValue(row.encryptedValue) : undefined;
+  return row ? decryptSecretForTests(row.encryptedValue) : undefined;
 }
 
 async function insertOrgModelProviderSecret(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -50,7 +50,6 @@ import {
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
 import { mockNow } from "../../../lib/time";
-import { decryptSecretsMap } from "../../services/crypto.utils";
 import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { mockOptionalEnv } from "../../../lib/env";
 import {
@@ -61,7 +60,10 @@ import {
   deleteOrgModelProviders$,
   seedOrgModelProvider$,
 } from "./helpers/zero-model-providers";
-import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  decryptSecretsMapForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
 import {
   deleteUsageInsightFixture$,
   seedUsageInsightFixture$,
@@ -546,7 +548,9 @@ describe("POST /api/zero/runs", () => {
     ]);
     expect(executionContext.environment.ZERO_AGENT_ID).toBe(agent.agentId);
 
-    const secrets = decryptSecretsMap(executionContext.encryptedSecrets);
+    const secrets = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(secrets?.ZERO_TOKEN).toBeDefined();
     const auth = verifyZeroToken(secrets!.ZERO_TOKEN!);
     expect(auth).toMatchObject({
@@ -668,7 +672,7 @@ describe("POST /api/zero/runs", () => {
       [FeatureSwitchKey.ComputerUse]: true,
       [FeatureSwitchKey.SandboxIoLimiters]: true,
     });
-    const zeroToken = decryptSecretsMap(
+    const zeroToken = decryptSecretsMapForTests(
       executionContext.encryptedSecrets ?? null,
     )?.ZERO_TOKEN;
     expect(zeroToken).toBeDefined();
@@ -812,7 +816,9 @@ describe("POST /api/zero/runs", () => {
       ),
       ANTHROPIC_MODEL: "claude-opus-4-6",
     });
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     // Local dev databases may already have dev-seeded exact keys.
     if (!hasExistingExactKey) {
       expect(decrypted?.ANTHROPIC_API_KEY).toBe("sk-vm0-managed");
@@ -886,7 +892,9 @@ describe("POST /api/zero/runs", () => {
       ANTHROPIC_MODEL: "MiniMax-M2.7",
       ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic",
     });
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     // Local dev databases may already have dev-seeded vendor keys.
     if (existingVendorKeys.length === 0) {
       expect(decrypted?.MINIMAX_API_KEY).toBe("sk-vm0-fallback");
@@ -984,7 +992,9 @@ describe("POST /api/zero/runs", () => {
       ),
       OPENAI_MODEL: "gpt-5.4",
     });
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(decrypted).toMatchObject({
       CHATGPT_ACCESS_TOKEN: "chatgpt-access",
       CHATGPT_ACCOUNT_ID: "workspace-id",
@@ -1084,7 +1094,9 @@ describe("POST /api/zero/runs", () => {
     expect(
       executionContext.environment.CLAUDE_CODE_OAUTH_TOKEN,
     ).toBeUndefined();
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       ANTHROPIC_API_KEY: "test-secret-value",
     });
     expect(executionContext.billableFirewalls).toStrictEqual([]);
@@ -1213,7 +1225,9 @@ describe("POST /api/zero/runs", () => {
       readonly encryptedSecrets: string | null;
     };
     expect(executionContext.environment.EXTERNAL_TOKEN).toBe("user-secret");
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       SHARED_TOKEN: "user-secret",
     });
   });
@@ -1257,7 +1271,9 @@ describe("POST /api/zero/runs", () => {
       readonly firewalls?: readonly { readonly name: string }[];
     };
     expect(executionContext.environment.AXIOM_TOKEN).toBe("xaat-user-secret");
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       AXIOM_TOKEN: "xaat-user-secret",
     });
     expect(
@@ -1305,7 +1321,7 @@ describe("POST /api/zero/runs", () => {
       readonly firewalls?: readonly { readonly name: string }[];
     };
     expect(
-      decryptSecretsMap(executionContext.encryptedSecrets)?.AXIOM_TOKEN,
+      decryptSecretsMapForTests(executionContext.encryptedSecrets)?.AXIOM_TOKEN,
     ).toBeUndefined();
     expect(
       executionContext.firewalls?.some((firewall) => {
@@ -1366,7 +1382,9 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.environment.AXIOM_TOKEN).toBe(
       "xaat-c0ffee5a-fe10-ca1c-0ffe-e5afe10ca1c0",
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       AXIOM_TOKEN: "xaat-approved",
     });
   });
@@ -1418,7 +1436,9 @@ describe("POST /api/zero/runs", () => {
       connectorSecretPlaceholder("gitlab", "GITLAB_TOKEN"),
     );
     expect(executionContext.environment.GITLAB_HOST).toBeUndefined();
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       GITLAB_TOKEN: "glpat-token",
     });
   });
@@ -1482,7 +1502,9 @@ describe("POST /api/zero/runs", () => {
       readonly firewalls: readonly { readonly name: string }[];
       readonly billableFirewalls: readonly string[];
     };
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(executionContext.environment.X_TOKEN).toBe(
       connectorSecretPlaceholder("x", "X_TOKEN"),
     );
@@ -1566,7 +1588,9 @@ describe("POST /api/zero/runs", () => {
     const executionContext = job?.executionContext as {
       readonly encryptedSecrets: string | null;
     };
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(decrypted).toMatchObject({ X_TOKEN: "x-access" });
     expect(decrypted).not.toHaveProperty("COMPUTER_CONNECTOR_BRIDGE_TOKEN");
   });
@@ -1636,7 +1660,9 @@ describe("POST /api/zero/runs", () => {
     );
     expect(executionContext.environment).not.toHaveProperty("LARK_TOKEN");
     expect(executionContext.environment).not.toHaveProperty("LARK_APP_ID");
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(decrypted).toMatchObject({ BASE44_TOKEN: "base44-access" });
     expect(decrypted).not.toHaveProperty("BASE44_REFRESH_TOKEN");
     expect(executionContext.secretConnectorMap).toMatchObject({
@@ -1724,7 +1750,9 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.environment.SLOCK_SERVER_ID).toBe(
       slockFirewall.placeholders?.SLOCK_SERVER_ID,
     );
-    const decrypted = decryptSecretsMap(executionContext.encryptedSecrets);
+    const decrypted = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
     expect(decrypted).toMatchObject({
       SLOCK_TOKEN: "slock-access",
       SLOCK_SERVER_ID: "slock-server-id",
@@ -1787,7 +1815,9 @@ describe("POST /api/zero/runs", () => {
       readonly secretConnectorMap: Record<string, string> | null;
       readonly firewalls: readonly { readonly name: string }[];
     };
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       GOOGLE_ADS_TOKEN: "google-ads-access",
       GOOGLE_ADS_DEVELOPER_TOKEN: "developer-token",
     });
@@ -1866,7 +1896,9 @@ describe("POST /api/zero/runs", () => {
     expect(firewall?.apis[0]?.auth?.headers?.Authorization).toBe(
       `Bearer \${{ secrets.${secretKey} }}`,
     );
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       [secretKey]: "custom-secret",
     });
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -17,9 +17,9 @@ import { testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
-import { decryptSecretsMap } from "../../services/crypto.utils";
 import { clearAllDetached } from "../../utils";
 import { createFixtureTracker } from "./helpers/zero-route-test";
+import { decryptSecretsMapForTests } from "./helpers/encrypt-secret";
 import {
   clearSlackWebhookAgentHeadVersion$,
   countSlackWebhookConnections$,
@@ -1258,7 +1258,9 @@ describe("POST /api/zero/slack/events", () => {
       ),
       OPENAI_MODEL: "gpt-5.5",
     });
-    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
       OPENAI_API_KEY: "vm0-key-gpt-5.5",
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
@@ -18,7 +18,7 @@ import {
   type SlackConnectFixture,
 } from "./helpers/zero-slack-connect";
 import { createFixtureTracker } from "./helpers/zero-route-test";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import { decryptPersistentSecretValue } from "../../services/crypto.utils";
 
 const context = testContext();
 const store = createStore();
@@ -495,9 +495,9 @@ describe("Slack OAuth API routes", () => {
         botUserId: "B_TEST",
         botScopes: JSON.stringify(["chat:write", "channels:read"]),
       });
-      expect(decryptSecretValue(installation!.encryptedBotToken)).toBe(
-        "xoxb-test-token",
-      );
+      await expect(
+        decryptPersistentSecretValue(installation!.encryptedBotToken, {}),
+      ).resolves.toBe("xoxb-test-token");
       expect(context.mocks.slack.oauth.v2.access).toHaveBeenCalledWith(
         expect.objectContaining({
           redirect_uri: `${WEB_ORIGIN}/api/zero/slack/oauth/callback`,
@@ -707,9 +707,9 @@ describe("Slack OAuth API routes", () => {
         context.signal,
       );
       expect(installation).toMatchObject({ orgId: originalOrgId });
-      expect(decryptSecretValue(installation!.encryptedBotToken)).toBe(
-        "xoxb-test-bot-token",
-      );
+      await expect(
+        decryptPersistentSecretValue(installation!.encryptedBotToken, {}),
+      ).resolves.toBe("xoxb-test-bot-token");
       const connection = await store.set(
         findSlackOrgConnection$,
         {
@@ -762,9 +762,9 @@ describe("Slack OAuth API routes", () => {
           "users:read",
         ]),
       });
-      expect(decryptSecretValue(installation!.encryptedBotToken)).toBe(
-        "xoxb-refreshed-token",
-      );
+      await expect(
+        decryptPersistentSecretValue(installation!.encryptedBotToken, {}),
+      ).resolves.toBe("xoxb-refreshed-token");
     });
 
     it("creates a single connection across duplicate platform installs", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
@@ -112,16 +112,11 @@ describe("stored secret encryption", () => {
     resetSecretKmsClientForTests();
   });
 
-  it("keeps legacy AES when KMS is not configured", async () => {
-    const encrypted = await encryptStoredSecretValue("secret-value");
+  it("requires KMS configuration when writing stored secrets", async () => {
+    clearMockedEnv();
 
-    expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
-      format: "legacy",
-      hasLegacy: true,
-      hasKms: false,
-    });
-    await expect(decryptStoredSecretValue(encrypted)).resolves.toBe(
-      "secret-value",
+    await expect(encryptStoredSecretValue("secret-value")).rejects.toThrow(
+      "SECRETS_KMS_KEY_ID is required for KMS secret encryption",
     );
     expect(fakeKmsClient.calls).toHaveLength(0);
   });
@@ -161,13 +156,13 @@ describe("stored secret encryption", () => {
     );
   });
 
-  it("keeps reading legacy-only ciphertext by default until cleanup finishes", async () => {
+  it("rejects legacy-only stored ciphertext by default", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = encryptSecretValue("secret-value");
 
-    await expect(decryptStoredSecretValue(encrypted)).resolves.toBe(
-      "secret-value",
+    await expect(decryptStoredSecretValue(encrypted)).rejects.toThrow(
+      "Stored secret ciphertext does not include KMS data",
     );
   });
 
@@ -236,16 +231,11 @@ describe("stored secret encryption", () => {
     });
   });
 
-  it("keeps persistent secrets legacy-only when KMS is not configured", async () => {
-    const encrypted = await encryptPersistentSecretValue("bot-token", {});
+  it("requires KMS configuration when writing persistent secrets", async () => {
+    clearMockedEnv();
 
-    expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
-      format: "legacy",
-      hasLegacy: true,
-      hasKms: false,
-    });
-    await expect(decryptPersistentSecretValue(encrypted, {})).resolves.toBe(
-      "bot-token",
+    await expect(encryptPersistentSecretValue("bot-token", {})).rejects.toThrow(
+      "SECRETS_KMS_KEY_ID is required for KMS secret encryption",
     );
     expect(fakeKmsClient.calls).toHaveLength(0);
   });

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -339,10 +339,6 @@ export async function encryptStoredSecretValue(
   plaintext: string,
   _ctx: FeatureSwitchContext = {},
 ): Promise<string> {
-  if (!env("SECRETS_KMS_KEY_ID")) {
-    return encryptSecretValue(plaintext);
-  }
-
   return await encryptStoredSecretValueWithMode(plaintext, "kms");
 }
 
@@ -350,7 +346,7 @@ export async function decryptStoredSecretValue(
   encrypted: string,
   _ctx: FeatureSwitchContext = {},
 ): Promise<string> {
-  return await decryptStoredSecretValueWithMode(encrypted, "prefer-kms");
+  return await decryptStoredSecretValueWithMode(encrypted, "kms-only");
 }
 
 export async function encryptStoredSecretsMap(
@@ -403,10 +399,6 @@ export async function encryptPersistentSecretValue(
   plaintext: string,
   _ctx: FeatureSwitchContext,
 ): Promise<string> {
-  if (!env("SECRETS_KMS_KEY_ID")) {
-    return encryptSecretValue(plaintext);
-  }
-
   return await encryptPersistentSecretValueWithMode(plaintext, "kms");
 }
 
@@ -414,7 +406,7 @@ export async function decryptPersistentSecretValue(
   encrypted: string,
   _ctx: FeatureSwitchContext,
 ): Promise<string> {
-  return await decryptPersistentSecretValueWithMode(encrypted, "prefer-kms");
+  return await decryptPersistentSecretValueWithMode(encrypted, "kms-only");
 }
 
 export async function encryptPersistentSecretsMap(
@@ -517,26 +509,4 @@ export function decryptSecretValue(encrypted: string): string {
   ]);
 
   return decrypted.toString("utf8");
-}
-
-export function decryptSecretsMap(
-  encryptedData: string | null,
-): Record<string, string> | null {
-  if (!encryptedData) {
-    return null;
-  }
-
-  return secretsMapSchema.parse(
-    JSON.parse(decryptSecretValue(encryptedData)) as unknown,
-  );
-}
-
-export function encryptSecretsMap(
-  secrets: Record<string, string> | null | undefined,
-): string | null {
-  if (!secrets) {
-    return null;
-  }
-
-  return encryptSecretValue(JSON.stringify(secrets));
 }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -178,7 +178,14 @@
     "scripts/analyze-rewind.mjs",
     "scripts/dump-rewind-chains.mjs"
   ],
-  "ignoreDependencies": ["@commitlint/cli", "@vm0/firewalls-generator"],
+  "ignoreDependencies": [
+    "@commitlint/cli",
+    "@vm0/firewalls-generator",
+    "oxlint",
+    "oxlint-tsgolint",
+    "playwright"
+  ],
+  "ignoreBinaries": ["oxlint", "vite"],
   "ignoreWorkspaces": [],
   "ignoreUnresolved": ["\\.generated$"]
 }


### PR DESCRIPTION
## Summary
- Require KMS envelopes for stored and persistent secret runtime reads/writes.
- Keep legacy single-value AES helpers for device-auth/session tokens that are not stored/persistent secrets.
- Update API tests to use a deterministic fake KMS client and KMS-shaped secret envelopes.
- Add knip ignores for lint/browser tooling so the CI knip job does not flag package-script tools as unused.

## Verification
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts src/signals/services/__tests__/runner-dispatch.service.test.ts`
- `pnpm -F api test`
- `pnpm knip --workspace api`
- `pnpm knip`
