### PR TITLE
chore: bump Claude Code to 2.1.156

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.153"
+CLAUDE_CODE_VERSION="2.1.156"
 CODEX_CLI_VERSION="0.134.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Bump pinned Claude Code version in `crates/runner/scripts/build-template.sh` so the runner sandbox image ships the latest workflow feature.

| Package | Old Version | New Version |
|---|---|---|
| CLAUDE_CODE_VERSION | 2.1.153 | 2.1.156 |

`2.1.156` is the current `latest` on the claude-code GCS release bucket (≥ 2.1.154, which is the minimum required for the new workflow feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)