### PR TITLE
feat(computer-use): target press-key and type-text by snapshot window

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -465,4 +465,125 @@ describe("computer-use command visibility", () => {
       screenshotBytes,
     );
   });
+
+  it("should send press-key snapshot id and key", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    server.use(
+      http.post(
+        "http://localhost:3000/api/zero/computer-use/write-commands",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          expect(body).toMatchObject({
+            kind: "keyboard.press_key",
+            app: "Slack",
+            snapshotId: "snap_1",
+            key: "Command+L",
+            timeoutMs: 30_000,
+          });
+          return HttpResponse.json({
+            commandId: "cmd_press",
+            status: "queued",
+          });
+        },
+      ),
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/commands/cmd_press",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_press",
+            kind: "keyboard.press_key",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: { app: "Slack", snapshotId: "snap_1", key: "Command+L" },
+            result: {
+              app: "Slack",
+              action: { key: "Command+L", summary: "Pressed Command+L" },
+            },
+            timeoutMs: 30_000,
+            createdAt: "2026-05-21T10:00:00.000Z",
+            claimedAt: "2026-05-21T10:00:01.000Z",
+            completedAt: "2026-05-21T10:00:02.000Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "press-key",
+      "--app",
+      "Slack",
+      "--snapshot-id",
+      "snap_1",
+      "--key",
+      "Command+L",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain('"status": "succeeded"');
+    expect(output).toContain('"summary": "Pressed Command+L"');
+  });
+
+  it("should send type-text snapshot id and text", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    server.use(
+      http.post(
+        "http://localhost:3000/api/zero/computer-use/write-commands",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          expect(body).toMatchObject({
+            kind: "keyboard.type_text",
+            app: "Slack",
+            snapshotId: "snap_1",
+            text: "Hello",
+            timeoutMs: 30_000,
+          });
+          return HttpResponse.json({
+            commandId: "cmd_type",
+            status: "queued",
+          });
+        },
+      ),
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/commands/cmd_type",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_type",
+            kind: "keyboard.type_text",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: { app: "Slack", snapshotId: "snap_1", text: "Hello" },
+            result: { app: "Slack", action: { summary: "Typed text" } },
+            timeoutMs: 30_000,
+            createdAt: "2026-05-21T10:00:00.000Z",
+            claimedAt: "2026-05-21T10:00:01.000Z",
+            completedAt: "2026-05-21T10:00:02.000Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "type-text",
+      "--app",
+      "Slack",
+      "--snapshot-id",
+      "snap_1",
+      "--text",
+      "Hello",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain('"status": "succeeded"');
+    expect(output).toContain('"summary": "Typed text"');
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -54,10 +54,12 @@ interface ComputerUsePerformActionOptions extends ComputerUseAppOptions {
 }
 
 interface ComputerUseTypeTextOptions extends ComputerUseAppOptions {
+  readonly snapshotId?: string;
   readonly text: string;
 }
 
 interface ComputerUsePressKeyOptions extends ComputerUseAppOptions {
+  readonly snapshotId?: string;
   readonly key: string;
 }
 
@@ -85,6 +87,10 @@ Notes:
   set-value when you need deterministic accessibility value assignment.
   press-key accepts xdotool-style names such as shift+semicolon, Control_L+J,
   ctrl+alt+n, and BackSpace, plus existing macOS-style forms such as Command+L.
+  type-text and press-key accept the same --snapshot-id as the element actions:
+  pass it to deliver keyboard input to that snapshot's window. Without it, the
+  most relevant window for the app is picked, which is ambiguous for multi-window
+  apps.
 
 Examples:
   List available apps:
@@ -99,11 +105,11 @@ Examples:
   Click screenshot coordinate (320, 240) from snapshot desktop_abc:
     zero computer-use click --app Safari --snapshot-id desktop_abc --x 320 --y 240
 
-  Type text into the current focus in Safari:
-    zero computer-use type-text --app Safari --text "Hello"
+  Type text into the snapshot desktop_abc window in Safari:
+    zero computer-use type-text --app Safari --snapshot-id desktop_abc --text "Hello"
 
-  Press a keyboard shortcut:
-    zero computer-use press-key --app Safari --key shift+semicolon
+  Press a keyboard shortcut in the snapshot desktop_abc window:
+    zero computer-use press-key --app Safari --snapshot-id desktop_abc --key shift+semicolon
 
   Open an app without activating the current foreground app:
     zero computer-use open-app --app Things`;
@@ -530,11 +536,13 @@ const typeTextCommand = appOption(
     new Command()
       .name("type-text")
       .description("Type literal keyboard input into the target app")
+      .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
       .requiredOption("--text <text>", "Text to type")
       .action(
         withErrorHandler(async (options: ComputerUseTypeTextOptions) => {
           await runWriteCommand("keyboard.type_text", options, {
             app: options.app,
+            ...(options.snapshotId ? { snapshotId: options.snapshotId } : {}),
             text: options.text,
           });
         }),
@@ -547,6 +555,7 @@ const pressKeyCommand = appOption(
     new Command()
       .name("press-key")
       .description("Send a background key or key combination to the target app")
+      .option("--snapshot-id <id>", "Snapshot id returned by get-app-state")
       .requiredOption(
         "--key <key>",
         "Key or xdotool-style combination, for example Command+K, shift+semicolon, or Control_L+J",
@@ -555,6 +564,7 @@ const pressKeyCommand = appOption(
         withErrorHandler(async (options: ComputerUsePressKeyOptions) => {
           await runWriteCommand("keyboard.press_key", options, {
             app: options.app,
+            ...(options.snapshotId ? { snapshotId: options.snapshotId } : {}),
             key: options.key,
           });
         }),

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -2389,17 +2389,47 @@ func snapshotWindowTarget(
     return target
 }
 
-func performWithRequiredBackgroundTarget<T>(
-    appName: String,
-    preferredScreenPoint: CGPoint? = nil,
-    _ action: (WindowTarget) throws -> T
-) throws -> T {
+func resolveBackgroundWindowTarget(appName: String) throws -> WindowTarget {
     let app = try resolveRunningApp(named: appName)
-    guard let target = resolveWindowTarget(app: app, preferredScreenPoint: preferredScreenPoint) else {
+    guard let target = resolveWindowTarget(app: app) else {
         throw windowTargetUnavailableFailure(appName: appName, pid: app.processIdentifier)
     }
+    return target
+}
 
-    return try action(target)
+// Keyboard dispatch is addressed to a concrete window via postToPid, so it must
+// target the same window the agent inspected. When a snapshotId is supplied we
+// pin to that snapshot's window (matching click/scroll); otherwise we fall back
+// to the heuristic best window for the app. The snapshot windowFrame is not
+// enforced here because keyboard input has no screenshot-coordinate dependency,
+// so a window that merely moved should still receive the key.
+func resolveKeyboardWindowTarget(
+    appName: String,
+    snapshotId: String?,
+    session: ComputerUseRuntimeSession?
+) throws -> WindowTarget {
+    guard let snapshotId else {
+        return try resolveBackgroundWindowTarget(appName: appName)
+    }
+    guard let session else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Snapshot targeting requires a runtime session snapshot: \(snapshotId)"
+        )
+    }
+    let metadata = try session.snapshot(appName: appName, snapshotId: snapshotId)
+    let windowId = optionalInt(metadata, "windowId")
+    let windowFrame = try optionalRectPayload(metadata, "windowFrame")
+    let preferredScreenPoint = windowFrame.map { frame in
+        CGPoint(x: frame.midX, y: frame.midY)
+    } ?? .zero
+    return try snapshotWindowTarget(
+        appName: appName,
+        snapshotId: snapshotId,
+        preferredScreenPoint: preferredScreenPoint,
+        windowId: windowId,
+        windowFrame: nil
+    )
 }
 
 func showVisualPointerIfTargetPointVisible(app: NSRunningApplication, point: CGPoint) -> Bool {
@@ -4097,7 +4127,8 @@ func postParsedKeyPress(_ parsed: ParsedKeyPress, to target: WindowTarget) throw
 func performBackgroundKeyPress(
     appName: String,
     parsed: ParsedKeyPress,
-    foregroundRecovery: ForegroundRecoveryPolicy
+    foregroundRecovery: ForegroundRecoveryPolicy,
+    resolveTarget: () throws -> WindowTarget
 ) throws -> [String: Any] {
     func currentSpaceKeyPress() throws -> [String: Any] {
         return try withFrontmostPreservation(
@@ -4105,11 +4136,9 @@ func performBackgroundKeyPress(
             dispatchTarget: "app_process",
             inputRisk: "background_app_shortcut"
         ) {
-            let targetPID = try performWithRequiredBackgroundTarget(appName: appName) { target in
-                try postParsedKeyPress(parsed, to: target)
-                return target.pid
-            }
-            return (targetPID: targetPID, result: ["normalizedKey": parsed.normalizedKey])
+            let target = try resolveTarget()
+            try postParsedKeyPress(parsed, to: target)
+            return (targetPID: target.pid, result: ["normalizedKey": parsed.normalizedKey])
         }
     }
 
@@ -4123,7 +4152,6 @@ func performBackgroundKeyPress(
         }
     }
 
-    let app = try resolveRunningApp(named: appName)
     return try withForegroundRecovery(
         appName: appName,
         policy: foregroundRecovery,
@@ -4131,12 +4159,7 @@ func performBackgroundKeyPress(
         dispatchMode: "foreground_keyboard_event",
         dispatchTarget: "app_process",
         inputRisk: "foreground_app_shortcut",
-        resolveTarget: {
-            guard let target = resolveWindowTarget(app: app) else {
-                throw windowTargetUnavailableFailure(appName: appName, pid: app.processIdentifier)
-            }
-            return target
-        }
+        resolveTarget: resolveTarget
     ) { _ in
         try postForegroundParsedKeyPress(parsed)
         return ["normalizedKey": parsed.normalizedKey]
@@ -4146,7 +4169,8 @@ func performBackgroundKeyPress(
 func performBackgroundTextInput(
     appName: String,
     inputText: String,
-    foregroundRecovery: ForegroundRecoveryPolicy
+    foregroundRecovery: ForegroundRecoveryPolicy,
+    resolveTarget: () throws -> WindowTarget
 ) throws -> [String: Any] {
     func currentSpaceTextInput() throws -> [String: Any] {
         return try withFrontmostPreservation(
@@ -4154,12 +4178,10 @@ func performBackgroundTextInput(
             dispatchTarget: "app_process",
             inputRisk: "background_app_text"
         ) {
-            let targetPID = try performWithRequiredBackgroundTarget(appName: appName) { target in
-                let dispatcher = AddressedEventDispatcher(target: target)
-                try dispatcher.postText(inputText)
-                return target.pid
-            }
-            return (targetPID: targetPID, result: ["characterCount": inputText.count])
+            let target = try resolveTarget()
+            let dispatcher = AddressedEventDispatcher(target: target)
+            try dispatcher.postText(inputText)
+            return (targetPID: target.pid, result: ["characterCount": inputText.count])
         }
     }
 
@@ -4173,7 +4195,6 @@ func performBackgroundTextInput(
         }
     }
 
-    let app = try resolveRunningApp(named: appName)
     return try withForegroundRecovery(
         appName: appName,
         policy: foregroundRecovery,
@@ -4181,12 +4202,7 @@ func performBackgroundTextInput(
         dispatchMode: "foreground_keyboard_text",
         dispatchTarget: "app_process",
         inputRisk: "foreground_app_text",
-        resolveTarget: {
-            guard let target = resolveWindowTarget(app: app) else {
-                throw windowTargetUnavailableFailure(appName: appName, pid: app.processIdentifier)
-            }
-            return target
-        }
+        resolveTarget: resolveTarget
     ) { _ in
         try postForegroundText(inputText)
         return ["characterCount": inputText.count]
@@ -4491,28 +4507,34 @@ func handleElementPerformAction(_ request: [String: Any], session: ComputerUseRu
     }
 }
 
-func handleTypeText(_ request: [String: Any]) throws -> [String: Any] {
+func handleTypeText(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let inputText = try requiredString(request, "text")
     let policy = try foregroundRecoveryPolicy(request)
+    let snapshotId = optionalString(request, "snapshotId")
     return try performBackgroundTextInput(
         appName: appName,
         inputText: inputText,
         foregroundRecovery: policy
-    )
+    ) {
+        try resolveKeyboardWindowTarget(appName: appName, snapshotId: snapshotId, session: session)
+    }
 }
 
-func handlePressKey(_ request: [String: Any]) throws -> [String: Any] {
+func handlePressKey(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let key = try requiredString(request, "key")
     let parsed = try parseKeyPress(key)
     let policy = try foregroundRecoveryPolicy(request)
+    let snapshotId = optionalString(request, "snapshotId")
 
     return try performBackgroundKeyPress(
         appName: appName,
         parsed: parsed,
         foregroundRecovery: policy
-    )
+    ) {
+        try resolveKeyboardWindowTarget(appName: appName, snapshotId: snapshotId, session: session)
+    }
 }
 
 func handleScrollElement(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
@@ -4601,9 +4623,9 @@ func handle(_ request: [String: Any], session: ComputerUseRuntimeSession?) throw
     case "element.perform_action":
         return try handleElementPerformAction(request, session: session)
     case "keyboard.type_text":
-        return try handleTypeText(request)
+        return try handleTypeText(request, session: session)
     case "keyboard.press_key":
-        return try handlePressKey(request)
+        return try handlePressKey(request, session: session)
     case "element.scroll":
         return try handleScrollElement(request, session: session)
     default:

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1631,11 +1631,13 @@ async function performElementAction(
 async function typeText(
   app: string,
   text: string,
+  snapshotId: string | null,
   nativeBackend: ComputerUseNativeBackend,
   foregroundRecovery: ComputerUseNativeForegroundRecoveryPolicy,
 ): Promise<ComputerUseCommandExecutionResult> {
   const result = await nativeBackend.typeText({
     app,
+    ...(snapshotId ? { snapshotId } : {}),
     text,
     foregroundRecovery,
   });
@@ -1652,10 +1654,16 @@ async function typeText(
 async function pressKey(
   app: string,
   key: string,
+  snapshotId: string | null,
   nativeBackend: ComputerUseNativeBackend,
   foregroundRecovery: ComputerUseNativeForegroundRecoveryPolicy,
 ): Promise<ComputerUseCommandSuccess> {
-  const result = await nativeBackend.pressKey({ app, key, foregroundRecovery });
+  const result = await nativeBackend.pressKey({
+    app,
+    ...(snapshotId ? { snapshotId } : {}),
+    key,
+    foregroundRecovery,
+  });
   const { normalizedKey, ...nativeResult } = result;
   return {
     status: "succeeded",
@@ -1888,6 +1896,7 @@ export async function executeComputerUseCommand(
     }
     if (command.kind === "keyboard.type_text") {
       const text = payloadString(command.payload, "text");
+      const snapshotId = payloadString(command.payload, "snapshotId");
       const foregroundRecovery = payloadForegroundRecoveryPolicy(
         command.payload,
       );
@@ -1901,6 +1910,7 @@ export async function executeComputerUseCommand(
               return await typeText(
                 app,
                 text,
+                snapshotId,
                 nativeBackend,
                 foregroundRecovery,
               );
@@ -1910,6 +1920,7 @@ export async function executeComputerUseCommand(
     }
     if (command.kind === "keyboard.press_key") {
       const key = payloadString(command.payload, "key");
+      const snapshotId = payloadString(command.payload, "snapshotId");
       const foregroundRecovery = payloadForegroundRecoveryPolicy(
         command.payload,
       );
@@ -1923,6 +1934,7 @@ export async function executeComputerUseCommand(
               return await pressKey(
                 app,
                 key,
+                snapshotId,
                 nativeBackend,
                 foregroundRecovery,
               );

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -545,11 +545,13 @@ describe("computer use native backend", () => {
       });
       await backend.typeText({
         app: "Safari",
+        snapshotId: "snap_1",
         text: "hello",
         foregroundRecovery: "never",
       });
       await backend.pressKey({
         app: "Safari",
+        snapshotId: "snap_1",
         key: "cmd+k",
         foregroundRecovery: "always",
       });
@@ -580,9 +582,11 @@ describe("computer use native backend", () => {
         foregroundRecovery: "on-window-unavailable",
       });
       expect(requests[2]?.payload).toMatchObject({
+        snapshotId: "snap_1",
         foregroundRecovery: "never",
       });
       expect(requests[3]?.payload).toMatchObject({
+        snapshotId: "snap_1",
         foregroundRecovery: "always",
       });
     } finally {

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -98,11 +98,13 @@ export interface ComputerUseNativeBackend {
   }) => Promise<ComputerUseNativeActionResult>;
   readonly typeText: (args: {
     readonly app: string;
+    readonly snapshotId?: string;
     readonly text: string;
     readonly foregroundRecovery?: ComputerUseNativeForegroundRecoveryPolicy;
   }) => Promise<ComputerUseNativeTypeTextResult>;
   readonly pressKey: (args: {
     readonly app: string;
+    readonly snapshotId?: string;
     readonly key: string;
     readonly foregroundRecovery?: ComputerUseNativeForegroundRecoveryPolicy;
   }) => Promise<ComputerUseNativePressKeyResult>;

--- a/turbo/apps/desktop/src/vm0-computer.ts
+++ b/turbo/apps/desktop/src/vm0-computer.ts
@@ -116,8 +116,8 @@ function usage(): string {
   vm0-computer scroll --app APP (--element-index N | --element ID) --direction up|down|left|right [--snapshot-id ID] [--pages N] [--timeout SECONDS] [--daemon-dir DIR]
   vm0-computer set-value --app APP (--element-index N | --element ID) --value VALUE [--timeout SECONDS] [--daemon-dir DIR]
   vm0-computer perform-action --app APP (--element-index N | --element ID) --action ACTION [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer type-text --app APP --text TEXT [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer press-key --app APP --key KEY [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]`;
+  vm0-computer type-text --app APP --text TEXT [--snapshot-id ID] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer press-key --app APP --key KEY [--snapshot-id ID] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]`;
 }
 
 function fail(message: string, code = 1): never {

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -2229,4 +2229,75 @@ describe("computer use desktop runtime", () => {
       foregroundRecovery: "on-window-unavailable",
     });
   });
+
+  it("forwards the snapshot id to the native backend for press-key", async () => {
+    const pressKey = vi.fn<ComputerUseNativeBackend["pressKey"]>();
+    pressKey.mockResolvedValue({
+      ...nativeDispatchResult(
+        "background_keyboard_event",
+        "app_process",
+        "background_app_shortcut",
+      ),
+      normalizedKey: "Command+K",
+    });
+    await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "keyboard.press_key",
+        payload: { app: "Safari", snapshotId: "snap_1", key: "Command+K" },
+      },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        nativeBackend: createNativeBackend({
+          pressKey,
+          getAppState: async (app, snapshotId) => {
+            return nativeAppStateWithScreenshot(app, snapshotId);
+          },
+        }),
+      },
+    );
+
+    expect(pressKey).toHaveBeenCalledWith({
+      app: "Safari",
+      snapshotId: "snap_1",
+      key: "Command+K",
+      foregroundRecovery: "on-window-unavailable",
+    });
+  });
+
+  it("forwards the snapshot id to the native backend for type-text", async () => {
+    const typeText = vi.fn<ComputerUseNativeBackend["typeText"]>();
+    typeText.mockResolvedValue(
+      nativeDispatchResult(
+        "background_keyboard_text",
+        "app_process",
+        "background_app_text",
+      ),
+    );
+    await executeComputerUseCommand(
+      {
+        id: "cmd_1",
+        kind: "keyboard.type_text",
+        payload: { app: "Safari", snapshotId: "snap_1", text: "hello" },
+      },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        nativeBackend: createNativeBackend({
+          typeText,
+          getAppState: async (app, snapshotId) => {
+            return nativeAppStateWithScreenshot(app, snapshotId);
+          },
+        }),
+      },
+    );
+
+    expect(typeText).toHaveBeenCalledWith({
+      app: "Safari",
+      snapshotId: "snap_1",
+      text: "hello",
+      foregroundRecovery: "on-window-unavailable",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`press-key` and `type-text` resolved the target window by an **app-name heuristic** (`resolveWindowTarget(app:)`), while `click`/`scroll`/`set-value`/`perform-action` pin the exact window via `--snapshot-id`. Keyboard input is already addressed to a concrete window over `postToPid` (not the global HID tap), so it does not leak into the user's foreground app — but on a **multi-window app** the heuristic can route the keystroke to a *different window of the same app* than the one the agent inspected.

This adds the same optional `--snapshot-id` to `press-key` and `type-text`. When supplied, keyboard dispatch is pinned to that snapshot's window (via the existing `snapshotWindowTarget`); when omitted, behavior is unchanged (heuristic fallback). This matches how the element actions already work, and mirrors the scoped/per-window keyboard routing used by `trycua/cua` (cua-driver) and `EYHN/kwwk-computer-use-core`.

The snapshot's `windowFrame` is intentionally **not** enforced for keyboard (unlike click, which depends on screenshot coordinates): the window is matched by `windowId`, so a window that merely moved still receives the key, while a closed/absent window still errors clearly.

## Changes

- **CLI** (`apps/cli`): add `--snapshot-id` to `press-key`/`type-text`, forward it in the write-command payload, and document it in help text/examples.
- **Desktop host** (`apps/desktop`): thread `snapshotId` from the command payload through `executeComputerUseCommand` → `typeText`/`pressKey` → native backend; add `snapshotId?` to the backend interface (the bridge already forwards extra payload fields).
- **Native helper** (`main.swift`): `handleTypeText`/`handlePressKey` read `snapshotId` and resolve the target via a new `resolveKeyboardWindowTarget` (snapshot window when provided, heuristic otherwise). `performBackgroundKeyPress`/`performBackgroundTextInput` now take an injected target resolver, used by both the background and foreground-recovery paths. Removed the now-unused `performWithRequiredBackgroundTarget`.
- **`vm0-computer`**: document `[--snapshot-id ID]` for `type-text`/`press-key` (the parser already forwarded it).

No contract change needed — `snapshotId` was already part of the shared write-command payload schema.

## Testing

- CLI integration tests assert the `--snapshot-id` is sent in the write-command body for both `press-key` and `type-text`.
- Host tests assert `snapshotId` is forwarded to the native backend for both commands; native-bridge tests assert it reaches the helper payload.
- Native Swift helper builds and tests pass; full `@vm0/cli` (1205) and `@vm0/desktop` (103) suites pass; lint, type-check, knip, format all clean.

Fixes #15280

🤖 Generated with [Claude Code](https://claude.com/claude-code)