### PR TITLE
docs: document mitm pending helper counts

### DIFF
--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -11,11 +11,24 @@ def _pending_state(path: Path) -> dict:
 
 def assert_pending(
     path: Path,
+    *,
     flows: int,
     buffered: int,
     reports: int,
     flush_request_id: str | None = None,
 ) -> dict:
+    """Assert a usage pending-state JSON snapshot.
+
+    ``flows``, ``buffered``, and ``reports`` map directly to the JSON fields
+    with the same names.  ``flows`` is the number of in-flight billable flows,
+    ``buffered`` is the number of usage source events still counted as pending
+    by the usage buffer, and ``reports`` is the number of pending webhook report
+    deliveries.
+
+    When ``flush_request_id`` is provided, the snapshot must include a matching
+    ``flushRequestId`` field.  When it is omitted, ``flushRequestId`` must be
+    absent from the snapshot.
+    """
     state = _pending_state(path)
     expected_fields = {
         "pid",


### PR DESCRIPTION
## Summary

- Document the `assert_pending` pending-state helper parameters and their JSON field mapping.
- Make the pending count expectations keyword-only after `path` to prevent ambiguous positional integer calls.

Closes #15341

## Tests

- `python3 -m pytest tests/test_counters.py tests/test_addon_configuration.py tests/test_connection_hooks.py tests/test_request_handler_usage_tracking.py`
- `python3 -m ruff check tests/pending_helpers.py`
- `python3 -m ruff format --check tests/pending_helpers.py`
