### PR TITLE
feat: add zoom toolbar to sidebar image preview

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -221,3 +221,65 @@ describe("chatArtifactSidebar: fullscreen toggle", () => {
     expect(search()).not.toContain("artifact-fullscreen=");
   });
 });
+
+describe("chatArtifactSidebar: image preview zoom controls", () => {
+  function renderImageSidebar() {
+    setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fphoto.png");
+    renderWithStore(
+      <ArtifactSidebar
+        artifactRef={{
+          source: "url",
+          url: "https://example.com/photo.png",
+          kind: "image",
+          filename: "photo.png",
+        }}
+      />,
+    );
+  }
+
+  it("renders the zoom toolbar on the image body at 100%", () => {
+    renderImageSidebar();
+    expect(
+      screen.getByTestId("artifact-sidebar-image-zoom-controls"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("artifact-sidebar-image-zoom-level").textContent,
+    ).toBe("100%");
+  });
+
+  it("zooms in, zooms out, and resets back to 100%", () => {
+    renderImageSidebar();
+    const zoomIn = screen.getByTestId("artifact-sidebar-image-zoom-in");
+    const zoomOut = screen.getByTestId("artifact-sidebar-image-zoom-out");
+    const reset = screen.getByTestId("artifact-sidebar-image-zoom-reset");
+    const level = screen.getByTestId("artifact-sidebar-image-zoom-level");
+
+    fireEvent.click(zoomIn);
+    expect(level.textContent).toBe("125%");
+    fireEvent.click(zoomIn);
+    expect(level.textContent).toBe("150%");
+
+    fireEvent.click(reset);
+    expect(level.textContent).toBe("100%");
+
+    fireEvent.click(zoomOut);
+    expect(level.textContent).toBe("75%");
+  });
+
+  it("disables zoom out at min zoom and zoom in at max zoom", () => {
+    renderImageSidebar();
+    const zoomIn = screen.getByTestId("artifact-sidebar-image-zoom-in");
+    const zoomOut = screen.getByTestId("artifact-sidebar-image-zoom-out");
+
+    // Step is 0.25; min is 0.5 (so 2 outs from 1 reaches min), max is 3 (8 ins).
+    for (let i = 0; i < 2; i += 1) {
+      fireEvent.click(zoomOut);
+    }
+    expect(zoomOut).toBeDisabled();
+
+    for (let i = 0; i < 10; i += 1) {
+      fireEvent.click(zoomIn);
+    }
+    expect(zoomIn).toBeDisabled();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -7,6 +7,9 @@ import {
   IconExternalLink,
   IconLoader2,
   IconX,
+  IconZoomIn,
+  IconZoomOut,
+  IconZoomReset,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
@@ -28,6 +31,15 @@ import {
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
+import {
+  IMAGE_LIGHTBOX_MAX_ZOOM,
+  IMAGE_LIGHTBOX_MIN_ZOOM,
+  imageLightboxImageRef$,
+  imageLightboxState$,
+  resetImageLightboxZoom$,
+  zoomImageLightboxIn$,
+  zoomImageLightboxOut$,
+} from "../../signals/view-component-state.ts";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — page-level pane for previewing the artifact pointed to
@@ -392,6 +404,10 @@ function ArtifactCsvBody({
   );
 }
 
+function isImageLightboxZoomAtReset(zoom: number): boolean {
+  return Math.abs(zoom - 1) < 0.001;
+}
+
 function ArtifactImageBody({
   url,
   filename,
@@ -399,14 +415,93 @@ function ArtifactImageBody({
   url: string;
   filename: string;
 }) {
+  // The sidebar image preview and the legacy full-screen lightbox are mutually
+  // exclusive (chatArtifactSidebar feature switch routes image clicks to one
+  // or the other), so the lightbox zoom state is reused here. The `key={url}`
+  // on the img remounts it on artifact change, which triggers the onRef
+  // reset that wipes any stale zoom level.
+  const { zoom } = useGet(imageLightboxState$);
+  const setImageRef = useSet(imageLightboxImageRef$);
+  const zoomIn = useSet(zoomImageLightboxIn$);
+  const zoomOut = useSet(zoomImageLightboxOut$);
+  const resetZoom = useSet(resetImageLightboxZoom$);
+
   return (
-    <div className="flex h-full items-center justify-center bg-muted/20 p-4">
+    <div className="relative flex h-full items-center justify-center overflow-auto bg-muted/20 p-4">
       <img
+        key={url}
+        ref={setImageRef}
         src={url}
         alt={filename}
-        className="max-h-full max-w-full object-contain"
+        style={{ transform: `scale(${String(zoom)})` }}
+        className="max-h-full max-w-full object-contain transition-transform duration-150"
         data-testid="artifact-sidebar-body-image"
       />
+      <ArtifactImageZoomControls
+        zoom={zoom}
+        zoomIn={zoomIn}
+        zoomOut={zoomOut}
+        resetZoom={resetZoom}
+      />
+    </div>
+  );
+}
+
+function ArtifactImageZoomControls({
+  zoom,
+  zoomIn,
+  zoomOut,
+  resetZoom,
+}: {
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetZoom: () => void;
+}) {
+  return (
+    <div
+      className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full bg-foreground/80 p-1 text-background shadow-lg backdrop-blur-sm"
+      data-testid="artifact-sidebar-image-zoom-controls"
+    >
+      <button
+        type="button"
+        onClick={zoomOut}
+        disabled={zoom <= IMAGE_LIGHTBOX_MIN_ZOOM}
+        className="rounded-full p-1.5 transition-colors hover:bg-background/20 disabled:pointer-events-none disabled:opacity-40"
+        aria-label="Zoom out"
+        title="Zoom out"
+        data-testid="artifact-sidebar-image-zoom-out"
+      >
+        <IconZoomOut size={18} stroke={2} />
+      </button>
+      <span
+        className="min-w-10 text-center text-xs font-medium tabular-nums"
+        data-testid="artifact-sidebar-image-zoom-level"
+      >
+        {Math.round(zoom * 100)}%
+      </span>
+      <button
+        type="button"
+        onClick={zoomIn}
+        disabled={zoom >= IMAGE_LIGHTBOX_MAX_ZOOM}
+        className="rounded-full p-1.5 transition-colors hover:bg-background/20 disabled:pointer-events-none disabled:opacity-40"
+        aria-label="Zoom in"
+        title="Zoom in"
+        data-testid="artifact-sidebar-image-zoom-in"
+      >
+        <IconZoomIn size={18} stroke={2} />
+      </button>
+      <button
+        type="button"
+        onClick={resetZoom}
+        disabled={isImageLightboxZoomAtReset(zoom)}
+        className="rounded-full p-1.5 transition-colors hover:bg-background/20 disabled:pointer-events-none disabled:opacity-40"
+        aria-label="Reset zoom"
+        title="Reset zoom"
+        data-testid="artifact-sidebar-image-zoom-reset"
+      >
+        <IconZoomReset size={18} stroke={2} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a zoom in / zoom out / reset toolbar on top of the artifact sidebar's image preview, restoring the capability the legacy full-screen lightbox had.
- Copy link, download, fullscreen, and close already live in the sidebar header (`ArtifactSidebarHeader`), so the floating toolbar only covers the genuinely missing controls — zoom — and the image overlay stays uncluttered.
- Reuses the existing `imageLightbox*` zoom signals: the sidebar and legacy lightbox are gated by the `ChatArtifactSidebar` feature switch and never co-exist for image previews, so they can share state without conflict. A `key={url}` on the `<img>` element forces a remount on artifact change, which fires the existing `onRef` reset and wipes any stale zoom level.

## Visuals (from the linked issue)

Reference for the toolbar controls being ported over:

![Original toolbar](https://github.com/vm0-ai/vm0/releases/download/web-v12.399.0/toolbar_tools.png)

Sidebar before this change (no zoom affordance, can't enlarge):

![Sidebar before](https://github.com/vm0-ai/vm0/releases/download/web-v12.399.0/sidebar_preview.png)

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run zero-artifact-sidebar` → 13 passed (10 existing + 3 new for the zoom toolbar).
- [x] `pnpm -F @vm0/app exec eslint` on touched files → clean.
- [x] `pnpm -F @vm0/app exec tsc --noEmit` → clean.
- [ ] Manual smoke: open a chat with the `ChatArtifactSidebar` switch on, click an image attachment, verify the zoom pill appears at the bottom, `+` / `-` / reset behave correctly, and the level resets when switching to a different image.

Closes #15348