### PR TITLE
perf(mitm-addon): transfer usage webhook payload ownership

### DIFF
--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -7,7 +7,6 @@ delivery if the executor has been shut down (drain/shutdown race) so
 reports are not silently lost.
 """
 
-import copy
 import json
 import time
 import urllib.error
@@ -169,24 +168,26 @@ def _enqueue_webhook(
     proxy_log_path: str,
     log_type: str,
 ) -> None:
-    """Submit webhook POST to the thread pool.  Copies payload to avoid mutation.
+    """Submit webhook POST to the thread pool.
+
+    The caller transfers ownership of ``payload`` to webhook delivery and
+    must not mutate it after enqueue.
 
     If the executor has already been shut down (drain/shutdown race),
     falls back to synchronous delivery so the report is not silently lost.
     """
-    copied = copy.deepcopy(payload)
     _log_webhook_entry(
         proxy_log_path,
         "info",
         f"Webhook POST to {url} enqueued",
         url,
         log_type,
-        copied,
+        payload,
     )
     increment_pending_reports()
     try:
         usage_executor.submit(
-            _post_webhook_with_retry, url, sandbox_token, copied, proxy_log_path, log_type
+            _post_webhook_with_retry, url, sandbox_token, payload, proxy_log_path, log_type
         )
     except RuntimeError:
         # Executor shut down (done() already called during drain).
@@ -197,7 +198,7 @@ def _enqueue_webhook(
             type=log_type,
             url=url,
         )
-        _post_webhook_with_retry(url, sandbox_token, copied, proxy_log_path, log_type)
+        _post_webhook_with_retry(url, sandbox_token, payload, proxy_log_path, log_type)
     except Exception:
         decrement_pending_reports()
         raise

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -137,33 +137,6 @@ class TestUsagePendingCounter:
         usage.write_pending_snapshot(flush_request_id="request-2")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
 
-    def test_enqueue_deep_copies_nested_payload(self):
-        payload = {
-            "runId": "run-1",
-            "events": [{"category": "tokens.input", "quantity": 1}],
-        }
-
-        try:
-            with patch.object(usage.webhook.usage_executor, "submit") as mock_submit:
-                usage.webhook._enqueue_webhook(
-                    "https://api.vm0.ai/api/webhooks/agent/usage-event",
-                    "tok",
-                    payload,
-                    "",
-                    "usage_event",
-                )
-
-            copied_payload = mock_submit.call_args.args[3]
-            payload["events"][0]["quantity"] = 999
-            payload["events"].append({"category": "tokens.output", "quantity": 2})
-
-            assert copied_payload == {
-                "runId": "run-1",
-                "events": [{"category": "tokens.input", "quantity": 1}],
-            }
-        finally:
-            usage.counters.decrement_pending_reports()
-
     def test_enqueue_logs_payload_collisions_under_payload(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
         payload = {


### PR DESCRIPTION
## Summary
- remove generic `copy.deepcopy` from usage webhook enqueue
- document that `_enqueue_webhook` takes ownership of the payload for async delivery
- remove the internal test that asserted post-enqueue nested mutation isolation

## Testing
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_counters.py tests/test_webhook.py tests/test_usage_buffer.py`
- `/tmp/vm0-mitm-addon-venv/bin/ruff check .`
- `/tmp/vm0-mitm-addon-venv/bin/ruff format --check .`
- `/tmp/vm0-mitm-addon-venv/bin/basedpyright -p . --pythonpath /tmp/vm0-mitm-addon-venv/bin/python`
- `git diff --check`

Closes #15343