### PR TITLE
fix: show activity logs under zero debug

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -101,7 +101,21 @@ describe("zero sidebar", () => {
     expect(features[FeatureSwitchKey.DataExport]).toBeFalsy();
   });
 
-  it("should never show Activity logs in the sidebar regardless of ZeroDebug switch", async () => {
+  it("should hide Activity logs when ZeroDebug switch is off", async () => {
+    mockAPIs();
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.ZeroDebug]: false },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Agents")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Activity logs")).not.toBeInTheDocument();
+  });
+
+  it("should show Activity logs when ZeroDebug switch is on", async () => {
     mockAPIs();
     detachedSetupPage({
       context,
@@ -112,6 +126,6 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(screen.getByText("Agents")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Activity logs")).not.toBeInTheDocument();
+    expect(screen.getByText("Activity logs")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -8,6 +8,7 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
+  IconChartLine,
   IconLayoutGrid,
   IconCalendar,
   IconUsers,
@@ -95,6 +96,14 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     pathname: "/schedules",
     label: "Scheduled",
     icon: IconCalendar as NavIcon,
+  },
+  {
+    id: "activities",
+    activeKeys: ["activities", "activityDetail", "activityInspect"],
+    pathname: "/activities",
+    label: "Activity logs",
+    icon: IconChartLine as NavIcon,
+    featureGate: FeatureSwitchKey.ZeroDebug,
   },
 ];
 


### PR DESCRIPTION
## Summary
- restore the Activity logs sidebar entry behind the ZeroDebug feature switch
- cover both hidden and visible sidebar states in the zero sidebar test

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app check-types
- lefthook pre-commit: prettier, knip, turbo run check-types --concurrency=1