### PR TITLE
refactor: resolve connector access from selected auth method

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -307,11 +307,11 @@ async def fetch_firewall_headers(
     """Resolve auth headers via server-side decryption.
 
     When secret_connector_map is provided, the auth endpoint can refresh
-    expired OAuth tokens and returns an expiresAt timestamp for TTL caching.
+    expired access tokens and returns an expiresAt timestamp for TTL caching.
     For billable firewall auth, expiresAt is also bounded by the server-side
     credit authorization lease.
 
-    When force_refresh is True, the endpoint refreshes OAuth tokens regardless
+    When force_refresh is True, the endpoint refreshes access tokens regardless
     of DB tokenExpiresAt — used after the upstream returns 401 (#9860).
 
     Uses asyncio.to_thread to avoid blocking mitmproxy's event loop.

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -306,6 +306,12 @@ async def fetch_firewall_headers(
 ) -> dict:
     """Resolve auth headers via server-side decryption.
 
+    secret_connector_map maps firewall auth secret env aliases (the `NAME` in
+    `${{ secrets.NAME }}`) to the connector or provider owner that can
+    refresh/resolve access. secret_connector_metadata_map uses the same keys to
+    add source details when the owner alone is not enough to locate access
+    storage.
+
     When secret_connector_map is provided, the auth endpoint can refresh
     expired access tokens and returns an expiresAt timestamp for TTL caching.
     For billable firewall auth, expiresAt is also bounded by the server-side

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -306,6 +306,10 @@ async def fetch_firewall_headers(
 ) -> dict:
     """Resolve auth headers via server-side decryption.
 
+    encrypted_secrets is the encrypted runtime secret namespace. After API-side
+    decryption, keys are the `NAME` in `${{ secrets.NAME }}` and values are the
+    real secret values.
+
     secret_connector_map maps firewall auth secret env aliases (the `NAME` in
     `${{ secrets.NAME }}`) to the connector or provider owner that can
     refresh/resolve access. secret_connector_metadata_map uses the same keys to

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -633,10 +633,10 @@ def response(flow: http.HTTPFlow) -> None:
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers.
     # Also request a force-refresh so the next /firewall/auth fetch refreshes
-    # the OAuth token regardless of DB tokenExpiresAt — the provider just told
+    # the access token regardless of DB tokenExpiresAt — the provider just told
     # us the token is no longer valid, overriding whatever the DB believes.
     # request_force_refresh enforces a cooldown so a persistent non-token 401
-    # can't amplify into a loop of provider OAuth refresh calls (#9860).
+    # can't amplify into a loop of provider refresh calls (#9860).
     if (
         flow.response
         and flow.response.status_code == _HTTP_STATUS_UNAUTHORIZED

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2055,7 +2055,8 @@ fn build_env_json_with_host_env(
     // Note: Connector placeholder env vars (e.g., GITHUB_TOKEN=gho_CoffeeSafeLocal...)
     // are injected by the web API into `context.environment` directly.
 
-    // Secret values (base64-encoded, comma-separated)
+    // Plain secret values (base64-encoded, comma-separated) for redaction.
+    // These are values, not names; base64 is only transport encoding.
     // Always include the sandbox token so it gets redacted in logs.
     {
         use base64::Engine as _;

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1589,6 +1589,8 @@ PY
                 source_type: "model-provider".to_string(),
                 source_user_id: Some("user-123".to_string()),
                 metadata_key: Some("codex-oauth-token".to_string()),
+                auth_method: None,
+                access_kind: None,
             },
         )]);
         let registration = VmRegistration {

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1589,8 +1589,6 @@ PY
                 source_type: "model-provider".to_string(),
                 source_user_id: Some("user-123".to_string()),
                 metadata_key: Some("codex-oauth-token".to_string()),
-                auth_method: None,
-                access_kind: None,
             },
         )]);
         let registration = VmRegistration {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -110,10 +110,6 @@ pub struct SecretConnectorMetadata {
     pub source_user_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata_key: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth_method: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub access_kind: Option<String>,
 }
 
 /// A single firewall config with its name and API entries.
@@ -454,11 +450,6 @@ mod tests {
                     "sourceType": "model-provider",
                     "sourceUserId": "user-123",
                     "metadataKey": "codex-oauth-token"
-                },
-                "GMAIL_ACCESS_TOKEN": {
-                    "sourceType": "connector",
-                    "authMethod": "oauth",
-                    "accessKind": "refresh-token"
                 }
             },
             "debugNoMockClaude": true,
@@ -488,14 +479,6 @@ mod tests {
         assert_eq!(
             metadata["CHATGPT_ACCESS_TOKEN"].source_user_id.as_deref(),
             Some("user-123")
-        );
-        assert_eq!(
-            metadata["GMAIL_ACCESS_TOKEN"].auth_method.as_deref(),
-            Some("oauth")
-        );
-        assert_eq!(
-            metadata["GMAIL_ACCESS_TOKEN"].access_kind.as_deref(),
-            Some("refresh-token")
         );
         assert!(ctx.debug_no_mock_claude.unwrap());
         assert!(ctx.debug_no_mock_codex.unwrap());

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -62,10 +62,12 @@ pub struct ExecutionContext {
     // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
-    // Maps firewall auth secret env aliases to their connector or provider owner.
+    // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`)
+    // to their connector or provider owner. Keys are env aliases, not storage secret names.
     #[serde(default)]
     pub secret_connector_map: Option<HashMap<String, String>>,
-    // Per-secret refresh metadata, forwarded to mitm-addon for owner-aware refresh
+    // Same keys as secret_connector_map; adds source details when the owner
+    // alone is not enough to locate access storage.
     #[serde(default)]
     pub secret_connector_metadata_map: Option<HashMap<String, SecretConnectorMetadata>>,
     pub cli_agent_type: String,
@@ -444,7 +446,7 @@ mod tests {
             "resumeSession": {"sessionId": "sess-1", "sessionHistory": "/tmp/history"},
             "secretValues": ["s1", "s2"],
             "encryptedSecrets": "enc-blob",
-            "secretConnectorMap": {"github": "oauth"},
+            "secretConnectorMap": {"GITHUB_TOKEN": "github"},
             "secretConnectorMetadataMap": {
                 "CHATGPT_ACCESS_TOKEN": {
                     "sourceType": "model-provider",

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -62,7 +62,7 @@ pub struct ExecutionContext {
     // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
-    // Maps access secret keys/env aliases to their connector or provider owner.
+    // Maps firewall auth secret env aliases to their connector or provider owner.
     #[serde(default)]
     pub secret_connector_map: Option<HashMap<String, String>>,
     // Per-secret refresh metadata, forwarded to mitm-addon for owner-aware refresh

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -62,7 +62,7 @@ pub struct ExecutionContext {
     // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
-    // Maps secret names to OAuth connector types for runtime token refresh
+    // Maps runtime secret/env keys to connector or provider owner keys for access resolution.
     #[serde(default)]
     pub secret_connector_map: Option<HashMap<String, String>>,
     // Per-secret refresh metadata, forwarded to mitm-addon for owner-aware refresh
@@ -110,6 +110,10 @@ pub struct SecretConnectorMetadata {
     pub source_user_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_kind: Option<String>,
 }
 
 /// A single firewall config with its name and API entries.
@@ -450,6 +454,11 @@ mod tests {
                     "sourceType": "model-provider",
                     "sourceUserId": "user-123",
                     "metadataKey": "codex-oauth-token"
+                },
+                "GMAIL_ACCESS_TOKEN": {
+                    "sourceType": "connector",
+                    "authMethod": "oauth",
+                    "accessKind": "refresh-token"
                 }
             },
             "debugNoMockClaude": true,
@@ -479,6 +488,14 @@ mod tests {
         assert_eq!(
             metadata["CHATGPT_ACCESS_TOKEN"].source_user_id.as_deref(),
             Some("user-123")
+        );
+        assert_eq!(
+            metadata["GMAIL_ACCESS_TOKEN"].auth_method.as_deref(),
+            Some("oauth")
+        );
+        assert_eq!(
+            metadata["GMAIL_ACCESS_TOKEN"].access_kind.as_deref(),
+            Some("refresh-token")
         );
         assert!(ctx.debug_no_mock_claude.unwrap());
         assert!(ctx.debug_no_mock_codex.unwrap());

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -62,7 +62,7 @@ pub struct ExecutionContext {
     // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
-    // Maps runtime secret/env keys to connector or provider owner keys for access resolution.
+    // Maps refreshable secret keys/env aliases to their connector or provider owner.
     #[serde(default)]
     pub secret_connector_map: Option<HashMap<String, String>>,
     // Per-secret refresh metadata, forwarded to mitm-addon for owner-aware refresh

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -57,9 +57,12 @@ pub struct ExecutionContext {
     pub environment: Option<HashMap<String, String>>,
     #[serde(default)]
     pub resume_session: Option<ResumeSession>,
+    // Plain secret values used only for redaction. These are values, not names.
     #[serde(default)]
     pub secret_values: Option<Vec<String>>,
-    // Forwarded to mitm-addon via proxy registry for auth resolution
+    // Encrypted runtime secret namespace forwarded to mitm-addon for auth
+    // resolution. Decrypted keys match `${{ secrets.NAME }}` names; connector
+    // and model-provider keys are env aliases, not storage secret names.
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
     // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`)

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -62,7 +62,7 @@ pub struct ExecutionContext {
     // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
-    // Maps refreshable secret keys/env aliases to their connector or provider owner.
+    // Maps access secret keys/env aliases to their connector or provider owner.
     #[serde(default)]
     pub secret_connector_map: Option<HashMap<String, String>>,
     // Per-secret refresh metadata, forwarded to mitm-addon for owner-aware refresh

--- a/docs/resource-model.md
+++ b/docs/resource-model.md
@@ -126,8 +126,8 @@ Encrypted credentials for third-party services.
 - **Storage**: Encrypted at rest (AES-256-GCM).
 - **Sub-types**:
   - `user` — user-defined secrets (e.g., custom API keys)
-  - `connector` — OAuth tokens managed by connector integrations
-  - `model-provider` — LLM provider API keys
+  - `connector` — credentials managed by connector integrations
+  - `model-provider` — LLM provider credentials
 - **Referenced in compose**: `${{ secrets.MY_SECRET }}`
 
 #### Variable

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -1191,15 +1191,17 @@ describe("POST /api/runners/*", () => {
     });
     patFixtures.push(pat);
     const encryptedSecrets = encryptedSecretsMap({
-      GMAIL_ACCESS_TOKEN: "fake-access-token",
+      CHATGPT_ACCESS_TOKEN: "fake-access-token",
     });
     const secretConnectorMap = {
-      GMAIL_ACCESS_TOKEN: "gmail",
-      GMAIL_TOKEN: "gmail",
+      CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+      CHATGPT_TOKEN: "codex-oauth-token",
     };
     const secretConnectorMetadataMap = {
-      GMAIL_ACCESS_TOKEN: {
-        sourceType: "connector" as const,
+      CHATGPT_ACCESS_TOKEN: {
+        sourceType: "model-provider" as const,
+        sourceUserId: fixture.userId,
+        metadataKey: "codex-oauth-token",
       },
     };
     const queued = await seedQueuedRun({

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -1200,6 +1200,8 @@ describe("POST /api/runners/*", () => {
     const secretConnectorMetadataMap = {
       GMAIL_ACCESS_TOKEN: {
         sourceType: "connector" as const,
+        authMethod: "oauth",
+        accessKind: "refresh-token" as const,
       },
     };
     const queued = await seedQueuedRun({

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -1200,8 +1200,6 @@ describe("POST /api/runners/*", () => {
     const secretConnectorMetadataMap = {
       GMAIL_ACCESS_TOKEN: {
         sourceType: "connector" as const,
-        authMethod: "oauth",
-        accessKind: "refresh-token" as const,
       },
     };
     const queued = await seedQueuedRun({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -297,6 +297,34 @@ async function seedExpiredTestOAuthConnector(
   });
 }
 
+async function seedStripeApiTokenConnector(
+  fixture: FirewallFixture,
+  args: { readonly token?: string } = {},
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "stripe",
+    authMethod: "api-token",
+    externalId: "stripe-account",
+    externalUsername: "stripe-account",
+    externalEmail: "stripe@example.com",
+    oauthScopes: JSON.stringify([]),
+    tokenExpiresAt: null,
+  });
+
+  if (args.token !== undefined) {
+    await seedSecret({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "STRIPE_TOKEN",
+      value: args.token,
+      type: "connector",
+    });
+  }
+}
+
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
@@ -1478,23 +1506,73 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("keeps missing static connector access secrets as missing configuration", async () => {
     const fixture = await track(seedFixture());
-    const db = store.set(writeDb$);
-    await db.insert(connectors).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      type: "stripe",
-      authMethod: "api-token",
-      externalId: "stripe-account",
-      externalUsername: "stripe-account",
-      externalEmail: "stripe@example.com",
-      oauthScopes: JSON.stringify([]),
-      tokenExpiresAt: null,
-    });
+    await seedStripeApiTokenConnector(fixture);
 
     const response = await accept(
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("STRIPE_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            STRIPE_TOKEN: "stripe",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+  });
+
+  it("loads current static connector access instead of stale encrypted access", async () => {
+    const fixture = await track(seedFixture());
+    await seedStripeApiTokenConnector(fixture, {
+      token: "current-stripe-token",
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            STRIPE_TOKEN: "stale-stripe-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("STRIPE_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            STRIPE_TOKEN: "stripe",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-stripe-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+  });
+
+  it("rejects stale encrypted static connector access when current storage is missing", async () => {
+    const fixture = await track(seedFixture());
+    await seedStripeApiTokenConnector(fixture);
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            STRIPE_TOKEN: "stale-stripe-token",
+          }),
           authHeaders: {
             Authorization: `Bearer ${secretTemplate("STRIPE_TOKEN")}`,
           },
@@ -1546,18 +1624,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("rejects encrypted connector secrets outside the selected access method", async () => {
     const fixture = await track(seedFixture());
-    const db = store.set(writeDb$);
-    await db.insert(connectors).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      type: "stripe",
-      authMethod: "api-token",
-      externalId: "stripe-account",
-      externalUsername: "stripe-account",
-      externalEmail: "stripe@example.com",
-      oauthScopes: JSON.stringify([]),
-      tokenExpiresAt: null,
-    });
+    await seedStripeApiTokenConnector(fixture);
 
     const response = await accept(
       firewallClient().resolve({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1337,6 +1337,49 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("does not use stale encrypted connector access when current selected access storage is missing", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-notion-token",
+      refreshToken: "current-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+    });
+    const db = store.set(writeDb$);
+    await db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "NOTION_ACCESS_TOKEN"),
+          eq(secrets.type, "connector"),
+        ),
+      );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_ACCESS_RESOLUTION_FAILED",
+      connectors: ["notion"],
+    });
+  });
+
   it("does not bypass missing selected connector access when the connector row is absent", async () => {
     const fixture = await track(seedFixture());
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1195,6 +1195,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           secretConnectorMap: {
             TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
           },
+          secretConnectorMetadataMap: {
+            TEST_OAUTH_ACCESS_TOKEN: {
+              sourceType: "connector",
+              authMethod: "oauth",
+              accessKind: "refresh-token",
+            },
+          },
         },
         headers: authHeaders(fixture),
       }),
@@ -1231,6 +1238,240 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "connector",
       }),
     ).resolves.toBe("new-test-oauth-refresh-token");
+  });
+
+  it("resolves a missing selected connector access secret through refresh metadata", async () => {
+    const dynamicOAuth = useDynamicTestOAuthRefresh();
+    restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;
+    const fixture = await track(seedFixture());
+    await seedExpiredTestOAuthConnector(fixture);
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
+          },
+          secretConnectorMetadataMap: {
+            TEST_OAUTH_ACCESS_TOKEN: {
+              sourceType: "connector",
+              authMethod: "oauth",
+              accessKind: "refresh-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-test-oauth-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "TEST_OAUTH_ACCESS_TOKEN",
+    ]);
+  });
+
+  it("loads a missing selected connector access secret when the stored token is current", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-notion-token",
+      refreshToken: "current-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_ACCESS_TOKEN: "notion",
+          },
+          secretConnectorMetadataMap: {
+            NOTION_ACCESS_TOKEN: {
+              sourceType: "connector",
+              authMethod: "oauth",
+              accessKind: "refresh-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-notion-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+    expect(response.body.expiresAt).toBeGreaterThan(currentSecond());
+  });
+
+  it("returns an access resolution failure when current selected connector access storage is missing", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-notion-token",
+      refreshToken: "current-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+    });
+    const db = store.set(writeDb$);
+    await db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "NOTION_ACCESS_TOKEN"),
+          eq(secrets.type, "connector"),
+        ),
+      );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_ACCESS_TOKEN: "notion",
+          },
+          secretConnectorMetadataMap: {
+            NOTION_ACCESS_TOKEN: {
+              sourceType: "connector",
+              authMethod: "oauth",
+              accessKind: "refresh-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_ACCESS_RESOLUTION_FAILED",
+      connectors: ["notion"],
+    });
+  });
+
+  it("does not bypass missing selected connector access without explicit metadata", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredNotionConnector(fixture);
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_ACCESS_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+  });
+
+  it("returns a refresh failure when selected connector refresh tokens are missing", async () => {
+    const dynamicOAuth = useDynamicTestOAuthRefresh();
+    restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;
+    const fixture = await track(seedFixture());
+    await seedExpiredTestOAuthConnector(fixture);
+    const db = store.set(writeDb$);
+    await db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "TEST_OAUTH_REFRESH_TOKEN"),
+          eq(secrets.type, "connector"),
+        ),
+      );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
+          },
+          secretConnectorMetadataMap: {
+            TEST_OAUTH_ACCESS_TOKEN: {
+              sourceType: "connector",
+              authMethod: "oauth",
+              accessKind: "refresh-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["test-oauth"],
+    });
+    expect(dynamicOAuth.refreshes).toStrictEqual([]);
+  });
+
+  it("keeps missing static connector access secrets as missing configuration", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("STRIPE_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            STRIPE_TOKEN: "stripe",
+          },
+          secretConnectorMetadataMap: {
+            STRIPE_TOKEN: {
+              sourceType: "connector",
+              authMethod: "api-token",
+              accessKind: "static",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
   });
 
   it("uses OAuth token expiry when it is earlier than billable credit lease", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1195,13 +1195,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           secretConnectorMap: {
             TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
           },
-          secretConnectorMetadataMap: {
-            TEST_OAUTH_ACCESS_TOKEN: {
-              sourceType: "connector",
-              authMethod: "oauth",
-              accessKind: "refresh-token",
-            },
-          },
         },
         headers: authHeaders(fixture),
       }),
@@ -1256,13 +1249,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           secretConnectorMap: {
             TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
           },
-          secretConnectorMetadataMap: {
-            TEST_OAUTH_ACCESS_TOKEN: {
-              sourceType: "connector",
-              authMethod: "oauth",
-              accessKind: "refresh-token",
-            },
-          },
         },
         headers: authHeaders(fixture),
       }),
@@ -1295,13 +1281,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           },
           secretConnectorMap: {
             NOTION_ACCESS_TOKEN: "notion",
-          },
-          secretConnectorMetadataMap: {
-            NOTION_ACCESS_TOKEN: {
-              sourceType: "connector",
-              authMethod: "oauth",
-              accessKind: "refresh-token",
-            },
           },
         },
         headers: authHeaders(fixture),
@@ -1346,13 +1325,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           secretConnectorMap: {
             NOTION_ACCESS_TOKEN: "notion",
           },
-          secretConnectorMetadataMap: {
-            NOTION_ACCESS_TOKEN: {
-              sourceType: "connector",
-              authMethod: "oauth",
-              accessKind: "refresh-token",
-            },
-          },
         },
         headers: authHeaders(fixture),
       }),
@@ -1365,14 +1337,42 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
-  it("does not bypass missing selected connector access without explicit metadata", async () => {
+  it("does not bypass missing selected connector access when the connector row is absent", async () => {
     const fixture = await track(seedFixture());
-    await seedExpiredNotionConnector(fixture);
 
     const response = await accept(
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_ACCESS_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+  });
+
+  it("does not use stale encrypted connector access when the connector row is absent", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_ACCESS_TOKEN: "stale-notion-token",
+          }),
           authHeaders: {
             Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
           },
@@ -1420,13 +1420,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           secretConnectorMap: {
             TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
           },
-          secretConnectorMetadataMap: {
-            TEST_OAUTH_ACCESS_TOKEN: {
-              sourceType: "connector",
-              authMethod: "oauth",
-              accessKind: "refresh-token",
-            },
-          },
         },
         headers: authHeaders(fixture),
       }),
@@ -1442,6 +1435,18 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("keeps missing static connector access secrets as missing configuration", async () => {
     const fixture = await track(seedFixture());
+    const db = store.set(writeDb$);
+    await db.insert(connectors).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      type: "stripe",
+      authMethod: "api-token",
+      externalId: "stripe-account",
+      externalUsername: "stripe-account",
+      externalEmail: "stripe@example.com",
+      oauthScopes: JSON.stringify([]),
+      tokenExpiresAt: null,
+    });
 
     const response = await accept(
       firewallClient().resolve({
@@ -1452,13 +1457,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           },
           secretConnectorMap: {
             STRIPE_TOKEN: "stripe",
-          },
-          secretConnectorMetadataMap: {
-            STRIPE_TOKEN: {
-              sourceType: "connector",
-              authMethod: "api-token",
-              accessKind: "static",
-            },
           },
         },
         headers: authHeaders(fixture),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -414,28 +414,47 @@ function configureDynamicTestOAuthRefresh(
 async function seedExpiredCodexModelProvider(
   fixture: FirewallFixture,
 ): Promise<void> {
+  await seedCodexModelProvider(fixture, {
+    accessToken: "stale-chatgpt-token",
+    refreshToken: "chatgpt-refresh-token",
+    tokenExpiresAt: new Date(now() - 60_000),
+    needsReconnect: true,
+    lastRefreshErrorCode: "refresh_token_expired",
+  });
+}
+
+async function seedCodexModelProvider(
+  fixture: FirewallFixture,
+  args: {
+    readonly accessToken: string;
+    readonly refreshToken: string;
+    readonly tokenExpiresAt: Date;
+    readonly needsReconnect: boolean;
+    readonly lastRefreshErrorCode: string | null;
+  },
+): Promise<void> {
   const db = store.set(writeDb$);
   await db.insert(modelProviders).values({
     orgId: fixture.orgId,
     userId: ORG_SENTINEL_USER_ID,
     type: "codex-oauth-token",
     authMethod: "auth_json",
-    tokenExpiresAt: new Date(now() - 60_000),
-    needsReconnect: true,
-    lastRefreshErrorCode: "refresh_token_expired",
+    tokenExpiresAt: args.tokenExpiresAt,
+    needsReconnect: args.needsReconnect,
+    lastRefreshErrorCode: args.lastRefreshErrorCode,
   });
   await seedSecret({
     orgId: fixture.orgId,
     userId: ORG_SENTINEL_USER_ID,
     name: "CHATGPT_ACCESS_TOKEN",
-    value: "stale-chatgpt-token",
+    value: args.accessToken,
     type: "model-provider",
   });
   await seedSecret({
     orgId: fixture.orgId,
     userId: ORG_SENTINEL_USER_ID,
     name: "CHATGPT_REFRESH_TOKEN",
-    value: "chatgpt-refresh-token",
+    value: args.refreshToken,
     type: "model-provider",
   });
 }
@@ -2165,6 +2184,87 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "model-provider",
       }),
     ).resolves.toBe("fresh-chatgpt-token");
+  });
+
+  it("loads a missing model-provider access secret when the stored token is current", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-chatgpt-token",
+      refreshToken: "current-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-chatgpt-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+  });
+
+  it("rejects missing model-provider access secrets outside env bindings", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-chatgpt-token",
+      refreshToken: "current-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("UNBOUND_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            UNBOUND_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            UNBOUND_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
   });
 
   it("rejects model-provider refresh metadata for another user before billable credit auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -2267,6 +2267,49 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("rejects encrypted model-provider access secrets outside env bindings", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-chatgpt-token",
+      refreshToken: "current-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            UNBOUND_TOKEN: "stale-unbound-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("UNBOUND_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            UNBOUND_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            UNBOUND_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+  });
+
   it("rejects model-provider refresh metadata for another user before billable credit auth", async () => {
     const fixture = await track(seedFixture());
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1189,13 +1189,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-notion-token",
+            NOTION_TOKEN: "stale-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1207,9 +1207,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       "Bearer fresh-notion-token",
     );
     expect(response.body.refreshedConnectors).toStrictEqual(["notion"]);
-    expect(response.body.refreshedSecrets).toStrictEqual([
-      "NOTION_ACCESS_TOKEN",
-    ]);
+    expect(response.body.refreshedSecrets).toStrictEqual(["NOTION_TOKEN"]);
     expect(response.body.expiresAt).toBeGreaterThan(currentSecond());
     await expect(
       readSecret({
@@ -1243,13 +1241,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            TEST_OAUTH_ACCESS_TOKEN: "stale-test-oauth-token",
+            TEST_OAUTH_TOKEN: "stale-test-oauth-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
           },
           secretConnectorMap: {
-            TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
+            TEST_OAUTH_TOKEN: "test-oauth",
           },
         },
         headers: authHeaders(fixture),
@@ -1268,9 +1266,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       "Bearer fresh-test-oauth-token",
     );
     expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
-    expect(response.body.refreshedSecrets).toStrictEqual([
-      "TEST_OAUTH_ACCESS_TOKEN",
-    ]);
+    expect(response.body.refreshedSecrets).toStrictEqual(["TEST_OAUTH_TOKEN"]);
     await expect(
       readSecret({
         orgId: fixture.orgId,
@@ -1300,10 +1296,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         body: {
           encryptedSecrets: encryptedSecrets({}),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
           },
           secretConnectorMap: {
-            TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
+            TEST_OAUTH_TOKEN: "test-oauth",
           },
         },
         headers: authHeaders(fixture),
@@ -1315,9 +1311,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       "Bearer fresh-test-oauth-token",
     );
     expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
-    expect(response.body.refreshedSecrets).toStrictEqual([
-      "TEST_OAUTH_ACCESS_TOKEN",
-    ]);
+    expect(response.body.refreshedSecrets).toStrictEqual(["TEST_OAUTH_TOKEN"]);
   });
 
   it("loads a missing selected connector access secret when the stored token is current", async () => {
@@ -1333,10 +1327,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         body: {
           encryptedSecrets: encryptedSecrets({}),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1376,10 +1370,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         body: {
           encryptedSecrets: encryptedSecrets({}),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1444,10 +1438,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         body: {
           encryptedSecrets: encryptedSecrets({}),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1470,13 +1464,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-notion-token",
+            NOTION_TOKEN: "stale-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1514,10 +1508,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         body: {
           encryptedSecrets: encryptedSecrets({}),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
           },
           secretConnectorMap: {
-            TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
+            TEST_OAUTH_TOKEN: "test-oauth",
           },
         },
         headers: authHeaders(fixture),
@@ -1591,7 +1585,38 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(response.body.refreshedSecrets).toStrictEqual([]);
   });
 
-  it("loads current static connector raw access secret names", async () => {
+  it("loads current static connector env aliases", async () => {
+    const fixture = await track(seedFixture());
+    await seedGithubOAuthStaticAccessConnector(fixture, {
+      accessToken: "current-github-token",
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            GITHUB_TOKEN: "stale-github-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("GITHUB_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            GITHUB_TOKEN: "github",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-github-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+  });
+
+  it("rejects static connector raw access secret names", async () => {
     const fixture = await track(seedFixture());
     await seedGithubOAuthStaticAccessConnector(fixture, {
       accessToken: "current-github-token",
@@ -1612,14 +1637,15 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         },
         headers: authHeaders(fixture),
       }),
-      [200],
+      [424],
     );
 
-    expect(response.body.headers.Authorization).toBe(
-      "Bearer current-github-token",
-    );
-    expect(response.body.refreshedConnectors).toStrictEqual([]);
-    expect(response.body.refreshedSecrets).toStrictEqual([]);
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
   });
 
   it("rejects stale encrypted static connector access when current storage is missing", async () => {
@@ -1729,13 +1755,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-notion-token",
+            NOTION_TOKEN: "stale-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
           firewallBillable: true,
         },
@@ -1770,13 +1796,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-notion-token",
+            NOTION_TOKEN: "stale-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1819,13 +1845,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-notion-token",
+            NOTION_TOKEN: "stale-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
           firewallBillable: true,
         },
@@ -1858,13 +1884,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-notion-token",
+            NOTION_TOKEN: "stale-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1901,13 +1927,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-buffered-notion-token",
+            NOTION_TOKEN: "stale-buffered-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1919,9 +1945,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       "Bearer fresh-buffered-notion-token",
     );
     expect(response.body.refreshedConnectors).toStrictEqual(["notion"]);
-    expect(response.body.refreshedSecrets).toStrictEqual([
-      "NOTION_ACCESS_TOKEN",
-    ]);
+    expect(response.body.refreshedSecrets).toStrictEqual(["NOTION_TOKEN"]);
   });
 
   it("uses the current DB token when connector expiry is still valid", async () => {
@@ -1937,13 +1961,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-snapshot-notion-token",
+            NOTION_TOKEN: "stale-snapshot-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(fixture),
@@ -1979,13 +2003,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-null-expiry-notion-token",
+            NOTION_TOKEN: "stale-null-expiry-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
         },
         headers: authHeaders(nullExpiryFixture),
@@ -2018,13 +2042,13 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            NOTION_ACCESS_TOKEN: "stale-force-notion-token",
+            NOTION_TOKEN: "stale-force-notion-token",
           }),
           authHeaders: {
-            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           },
           secretConnectorMap: {
-            NOTION_ACCESS_TOKEN: "notion",
+            NOTION_TOKEN: "notion",
           },
           forceRefresh: true,
         },

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1472,6 +1472,76 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("rejects encrypted static connector secrets after the connector is removed", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            STRIPE_TOKEN: "stale-stripe-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("STRIPE_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            STRIPE_TOKEN: "stripe",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+  });
+
+  it("rejects encrypted connector secrets outside the selected access method", async () => {
+    const fixture = await track(seedFixture());
+    const db = store.set(writeDb$);
+    await db.insert(connectors).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      type: "stripe",
+      authMethod: "api-token",
+      externalId: "stripe-account",
+      externalUsername: "stripe-account",
+      externalEmail: "stripe@example.com",
+      oauthScopes: JSON.stringify([]),
+      tokenExpiresAt: null,
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            STRIPE_ACCESS_TOKEN: "stale-oauth-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("STRIPE_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            STRIPE_ACCESS_TOKEN: "stripe",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+  });
+
   it("uses access-token expiry when it is earlier than billable credit lease", async () => {
     const fixture = await track(seedFixture());
     await seedCreditState(fixture, { credits: 10_000 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1472,7 +1472,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
-  it("uses OAuth token expiry when it is earlier than billable credit lease", async () => {
+  it("uses access-token expiry when it is earlier than billable credit lease", async () => {
     const fixture = await track(seedFixture());
     await seedCreditState(fixture, { credits: 10_000 });
     await seedExpiredNotionConnector(fixture);
@@ -1562,7 +1562,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     );
   });
 
-  it("uses billable credit lease when it is earlier than OAuth token expiry", async () => {
+  it("uses billable credit lease when it is earlier than access-token expiry", async () => {
     const fixture = await track(seedFixture());
     await seedCreditState(fixture, { credits: 10_000 });
     await seedExpiredNotionConnector(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -325,6 +325,34 @@ async function seedStripeApiTokenConnector(
   }
 }
 
+async function seedGithubOAuthStaticAccessConnector(
+  fixture: FirewallFixture,
+  args: { readonly accessToken?: string } = {},
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "github",
+    authMethod: "oauth",
+    externalId: "github-user",
+    externalUsername: "github-user",
+    externalEmail: "github@example.com",
+    oauthScopes: JSON.stringify([]),
+    tokenExpiresAt: null,
+  });
+
+  if (args.accessToken !== undefined) {
+    await seedSecret({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "GITHUB_ACCESS_TOKEN",
+      value: args.accessToken,
+      type: "connector",
+    });
+  }
+}
+
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
@@ -1558,6 +1586,37 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
     expect(response.body.headers.Authorization).toBe(
       "Bearer current-stripe-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+  });
+
+  it("loads current static connector raw access secret names", async () => {
+    const fixture = await track(seedFixture());
+    await seedGithubOAuthStaticAccessConnector(fixture, {
+      accessToken: "current-github-token",
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            GITHUB_ACCESS_TOKEN: "stale-github-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("GITHUB_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            GITHUB_ACCESS_TOKEN: "github",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-github-token",
     );
     expect(response.body.refreshedConnectors).toStrictEqual([]);
     expect(response.body.refreshedSecrets).toStrictEqual([]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1398,6 +1398,10 @@ describe("POST /api/zero/runs", () => {
     ).toMatchObject({
       AXIOM_TOKEN: "xaat-approved",
     });
+    expect(executionContext.secretConnectorMap).toStrictEqual({
+      AXIOM_TOKEN: "axiom",
+    });
+    expect(executionContext.secretConnectorMetadataMap).toBeNull();
   });
 
   it("omits missing optional API-token connector env fields", async () => {
@@ -1454,7 +1458,9 @@ describe("POST /api/zero/runs", () => {
     ).toMatchObject({
       GITLAB_TOKEN: "glpat-token",
     });
-    expect(executionContext.secretConnectorMap).toBeNull();
+    expect(executionContext.secretConnectorMap).toStrictEqual({
+      GITLAB_TOKEN: "gitlab",
+    });
     expect(executionContext.secretConnectorMetadataMap).toBeNull();
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1537,8 +1537,7 @@ describe("POST /api/zero/runs", () => {
     );
     expect(decrypted).toMatchObject({ X_TOKEN: "x-access" });
     expect(decrypted).not.toHaveProperty("X_REFRESH_TOKEN");
-    expect(executionContext.secretConnectorMap).toMatchObject({
-      X_ACCESS_TOKEN: "x",
+    expect(executionContext.secretConnectorMap).toStrictEqual({
       X_TOKEN: "x",
     });
     expect(executionContext.secretConnectorMetadataMap).toBeNull();
@@ -1550,7 +1549,7 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.billableFirewalls).toContain("x");
   });
 
-  it("maps static OAuth connector raw access secret names and aliases", async () => {
+  it("maps static OAuth connector env aliases", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
     const agent = await seedRunnableZeroAgent({ fixture: fx });
@@ -1596,8 +1595,7 @@ describe("POST /api/zero/runs", () => {
       GH_TOKEN: "gho-access",
       GITHUB_TOKEN: "gho-access",
     });
-    expect(executionContext.secretConnectorMap).toMatchObject({
-      GITHUB_ACCESS_TOKEN: "github",
+    expect(executionContext.secretConnectorMap).toStrictEqual({
       GH_TOKEN: "github",
       GITHUB_TOKEN: "github",
     });
@@ -1752,8 +1750,7 @@ describe("POST /api/zero/runs", () => {
     );
     expect(decrypted).toMatchObject({ BASE44_TOKEN: "base44-access" });
     expect(decrypted).not.toHaveProperty("BASE44_REFRESH_TOKEN");
-    expect(executionContext.secretConnectorMap).toMatchObject({
-      BASE44_ACCESS_TOKEN: "base44",
+    expect(executionContext.secretConnectorMap).toStrictEqual({
       BASE44_TOKEN: "base44",
     });
     expect(executionContext.secretConnectorMetadataMap).toBeNull();
@@ -1854,7 +1851,6 @@ describe("POST /api/zero/runs", () => {
     expect(decrypted).not.toHaveProperty("SLOCK_ACCESS_TOKEN");
     expect(decrypted).not.toHaveProperty("SLOCK_REFRESH_TOKEN");
     expect(executionContext.secretConnectorMap).toStrictEqual({
-      SLOCK_ACCESS_TOKEN: "slock",
       SLOCK_TOKEN: "slock",
     });
     expect(executionContext.secretConnectorMetadataMap).toBeNull();
@@ -1916,8 +1912,7 @@ describe("POST /api/zero/runs", () => {
       GOOGLE_ADS_TOKEN: "google-ads-access",
       GOOGLE_ADS_DEVELOPER_TOKEN: "developer-token",
     });
-    expect(executionContext.secretConnectorMap).toMatchObject({
-      GOOGLE_ADS_ACCESS_TOKEN: "google-ads",
+    expect(executionContext.secretConnectorMap).toStrictEqual({
       GOOGLE_ADS_TOKEN: "google-ads",
     });
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -883,6 +883,15 @@ describe("POST /api/zero/runs", () => {
     const executionContext = job?.executionContext as {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<
+        string,
+        {
+          readonly sourceType: string;
+          readonly authMethod?: string;
+          readonly accessKind?: string;
+        }
+      > | null;
     };
     expect(executionContext.environment).toMatchObject({
       ANTHROPIC_AUTH_TOKEN: modelProviderSecretPlaceholder(
@@ -1223,6 +1232,8 @@ describe("POST /api/zero/runs", () => {
     const executionContext = job?.executionContext as {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<string, unknown> | null;
     };
     expect(executionContext.environment.EXTERNAL_TOKEN).toBe("user-secret");
     expect(
@@ -1378,6 +1389,8 @@ describe("POST /api/zero/runs", () => {
     const executionContext = job?.executionContext as {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<string, unknown> | null;
     };
     expect(executionContext.environment.AXIOM_TOKEN).toBe(
       "xaat-c0ffee5a-fe10-ca1c-0ffe-e5afe10ca1c0",
@@ -1431,6 +1444,8 @@ describe("POST /api/zero/runs", () => {
     const executionContext = job?.executionContext as {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<string, unknown> | null;
     };
     expect(executionContext.environment.GITLAB_TOKEN).toBe(
       connectorSecretPlaceholder("gitlab", "GITLAB_TOKEN"),
@@ -1441,6 +1456,8 @@ describe("POST /api/zero/runs", () => {
     ).toMatchObject({
       GITLAB_TOKEN: "glpat-token",
     });
+    expect(executionContext.secretConnectorMap).toBeNull();
+    expect(executionContext.secretConnectorMetadataMap).toBeNull();
   });
 
   it("injects authorized OAuth connector secrets and refresh metadata", async () => {
@@ -1499,6 +1516,14 @@ describe("POST /api/zero/runs", () => {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
       readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<
+        string,
+        {
+          readonly sourceType: string;
+          readonly authMethod?: string;
+          readonly accessKind?: string;
+        }
+      > | null;
       readonly firewalls: readonly { readonly name: string }[];
       readonly billableFirewalls: readonly string[];
     };
@@ -1513,6 +1538,18 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.secretConnectorMap).toMatchObject({
       X_ACCESS_TOKEN: "x",
       X_TOKEN: "x",
+    });
+    expect(executionContext.secretConnectorMetadataMap).toMatchObject({
+      X_ACCESS_TOKEN: {
+        sourceType: "connector",
+        authMethod: "oauth",
+        accessKind: "refresh-token",
+      },
+      X_TOKEN: {
+        sourceType: "connector",
+        authMethod: "oauth",
+        accessKind: "refresh-token",
+      },
     });
     expect(
       executionContext.firewalls.map((firewall) => {
@@ -1644,6 +1681,14 @@ describe("POST /api/zero/runs", () => {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
       readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<
+        string,
+        {
+          readonly sourceType: string;
+          readonly authMethod?: string;
+          readonly accessKind?: string;
+        }
+      > | null;
       readonly firewalls: readonly {
         readonly name: string;
         readonly apis: readonly {
@@ -1668,6 +1713,18 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.secretConnectorMap).toMatchObject({
       BASE44_ACCESS_TOKEN: "base44",
       BASE44_TOKEN: "base44",
+    });
+    expect(executionContext.secretConnectorMetadataMap).toMatchObject({
+      BASE44_ACCESS_TOKEN: {
+        sourceType: "connector",
+        authMethod: "oauth",
+        accessKind: "refresh-token",
+      },
+      BASE44_TOKEN: {
+        sourceType: "connector",
+        authMethod: "oauth",
+        accessKind: "refresh-token",
+      },
     });
     const firewall = executionContext.firewalls.find((candidate) => {
       return candidate.name === "base44";
@@ -1734,6 +1791,14 @@ describe("POST /api/zero/runs", () => {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
       readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<
+        string,
+        {
+          readonly sourceType: string;
+          readonly authMethod?: string;
+          readonly accessKind?: string;
+        }
+      > | null;
       readonly firewalls: readonly {
         readonly name: string;
         readonly apis: readonly {
@@ -1762,6 +1827,18 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.secretConnectorMap).toStrictEqual({
       SLOCK_ACCESS_TOKEN: "slock",
       SLOCK_TOKEN: "slock",
+    });
+    expect(executionContext.secretConnectorMetadataMap).toStrictEqual({
+      SLOCK_ACCESS_TOKEN: {
+        sourceType: "connector",
+        authMethod: "oauth",
+        accessKind: "refresh-token",
+      },
+      SLOCK_TOKEN: {
+        sourceType: "connector",
+        authMethod: "oauth",
+        accessKind: "refresh-token",
+      },
     });
     const firewall = executionContext.firewalls.find((candidate) => {
       return candidate.name === "slock";

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1550,6 +1550,59 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.billableFirewalls).toContain("x");
   });
 
+  it("maps static OAuth connector raw access secret names and aliases", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await db.insert(userConnectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      connectorType: "github",
+    });
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "github",
+      authMethod: "oauth",
+    });
+    await db.insert(secrets).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "GITHUB_ACCESS_TOKEN",
+      encryptedValue: encryptSecretForTests("gho-access"),
+      type: "connector",
+    });
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { prompt: "github connector", agentId: agent.agentId },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+    };
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
+      GH_TOKEN: "gho-access",
+      GITHUB_TOKEN: "gho-access",
+    });
+    expect(executionContext.secretConnectorMap).toMatchObject({
+      GITHUB_ACCESS_TOKEN: "github",
+      GH_TOKEN: "github",
+      GITHUB_TOKEN: "github",
+    });
+  });
+
   it("ignores orphaned connector secrets for removed connector types", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -888,8 +888,6 @@ describe("POST /api/zero/runs", () => {
         string,
         {
           readonly sourceType: string;
-          readonly authMethod?: string;
-          readonly accessKind?: string;
         }
       > | null;
     };
@@ -1520,8 +1518,6 @@ describe("POST /api/zero/runs", () => {
         string,
         {
           readonly sourceType: string;
-          readonly authMethod?: string;
-          readonly accessKind?: string;
         }
       > | null;
       readonly firewalls: readonly { readonly name: string }[];
@@ -1539,18 +1535,7 @@ describe("POST /api/zero/runs", () => {
       X_ACCESS_TOKEN: "x",
       X_TOKEN: "x",
     });
-    expect(executionContext.secretConnectorMetadataMap).toMatchObject({
-      X_ACCESS_TOKEN: {
-        sourceType: "connector",
-        authMethod: "oauth",
-        accessKind: "refresh-token",
-      },
-      X_TOKEN: {
-        sourceType: "connector",
-        authMethod: "oauth",
-        accessKind: "refresh-token",
-      },
-    });
+    expect(executionContext.secretConnectorMetadataMap).toBeNull();
     expect(
       executionContext.firewalls.map((firewall) => {
         return firewall.name;
@@ -1685,8 +1670,6 @@ describe("POST /api/zero/runs", () => {
         string,
         {
           readonly sourceType: string;
-          readonly authMethod?: string;
-          readonly accessKind?: string;
         }
       > | null;
       readonly firewalls: readonly {
@@ -1714,18 +1697,7 @@ describe("POST /api/zero/runs", () => {
       BASE44_ACCESS_TOKEN: "base44",
       BASE44_TOKEN: "base44",
     });
-    expect(executionContext.secretConnectorMetadataMap).toMatchObject({
-      BASE44_ACCESS_TOKEN: {
-        sourceType: "connector",
-        authMethod: "oauth",
-        accessKind: "refresh-token",
-      },
-      BASE44_TOKEN: {
-        sourceType: "connector",
-        authMethod: "oauth",
-        accessKind: "refresh-token",
-      },
-    });
+    expect(executionContext.secretConnectorMetadataMap).toBeNull();
     const firewall = executionContext.firewalls.find((candidate) => {
       return candidate.name === "base44";
     });
@@ -1795,8 +1767,6 @@ describe("POST /api/zero/runs", () => {
         string,
         {
           readonly sourceType: string;
-          readonly authMethod?: string;
-          readonly accessKind?: string;
         }
       > | null;
       readonly firewalls: readonly {
@@ -1828,18 +1798,7 @@ describe("POST /api/zero/runs", () => {
       SLOCK_ACCESS_TOKEN: "slock",
       SLOCK_TOKEN: "slock",
     });
-    expect(executionContext.secretConnectorMetadataMap).toStrictEqual({
-      SLOCK_ACCESS_TOKEN: {
-        sourceType: "connector",
-        authMethod: "oauth",
-        accessKind: "refresh-token",
-      },
-      SLOCK_TOKEN: {
-        sourceType: "connector",
-        authMethod: "oauth",
-        accessKind: "refresh-token",
-      },
-    });
+    expect(executionContext.secretConnectorMetadataMap).toBeNull();
     const firewall = executionContext.firewalls.find((candidate) => {
       return candidate.name === "slock";
     });

--- a/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { OAuthGrantConnectorType } from "@vm0/connectors/connectors";
+import type { AuthorizationGrantConnectorType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { createStore } from "ccstate";
 import { inArray } from "drizzle-orm";
@@ -14,7 +14,7 @@ const store = createStore();
 
 type SeedOAuthStateInput = {
   readonly state?: string;
-  readonly type?: OAuthGrantConnectorType;
+  readonly type?: AuthorizationGrantConnectorType;
   readonly consumedAt?: Date | null;
   readonly expiresAt?: Date;
 };

--- a/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { AuthorizationGrantConnectorType } from "@vm0/connectors/connectors";
+import type { ConnectorAuthProviderType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { createStore } from "ccstate";
 import { inArray } from "drizzle-orm";
@@ -14,7 +14,7 @@ const store = createStore();
 
 type SeedOAuthStateInput = {
   readonly state?: string;
-  readonly type?: AuthorizationGrantConnectorType;
+  readonly type?: ConnectorAuthProviderType;
   readonly consumedAt?: Date | null;
   readonly expiresAt?: Date;
 };

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -347,9 +347,6 @@ interface ConnectorRuntimeContext {
   readonly secrets: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
-  readonly secretConnectorMetadataMap:
-    | Record<string, SecretConnectorMetadata>
-    | undefined;
   readonly connectorTypes: readonly ConnectorType[];
   readonly storedEnvironment: Record<string, string> | undefined;
 }
@@ -1555,24 +1552,6 @@ function filterSecretConnectorMap(args: {
   return compactRecord(filtered);
 }
 
-function filterSecretConnectorMetadataMap(args: {
-  readonly secretConnectorMap: Record<string, string> | undefined;
-  readonly secretConnectorMetadataMap:
-    | Record<string, SecretConnectorMetadata>
-    | undefined;
-}): Record<string, SecretConnectorMetadata> | undefined {
-  if (!args.secretConnectorMap || !args.secretConnectorMetadataMap) {
-    return undefined;
-  }
-
-  const filtered = Object.fromEntries(
-    Object.entries(args.secretConnectorMetadataMap).filter(([key]) => {
-      return Object.hasOwn(args.secretConnectorMap ?? {}, key);
-    }),
-  );
-  return compactRecord(filtered);
-}
-
 interface StoredConnectorRuntimeRow {
   readonly connectorType: ConnectorType;
   readonly authMethod: string;
@@ -1595,7 +1574,6 @@ interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
-  readonly secretConnectorMetadataMap: Record<string, SecretConnectorMetadata>;
   readonly environment: Record<string, string>;
 }
 
@@ -1604,7 +1582,6 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     secrets: undefined,
     vars: undefined,
     secretConnectorMap: undefined,
-    secretConnectorMetadataMap: undefined,
     connectorTypes: [],
     storedEnvironment: undefined,
   };
@@ -1762,8 +1739,6 @@ function resolveStoredConnectorState(
   const secrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
-  const secretConnectorMetadataMap: Record<string, SecretConnectorMetadata> =
-    {};
   const environment: Record<string, string> = {};
 
   for (const {
@@ -1805,17 +1780,10 @@ function resolveStoredConnectorState(
       continue;
     }
     const secretName = accessMetadata.accessToken;
-    const connectorMetadata = {
-      sourceType: "connector",
-      authMethod,
-      accessKind: accessMetadata.kind,
-    } satisfies SecretConnectorMetadata;
     secretConnectorMap[secretName] = connectorType;
-    secretConnectorMetadataMap[secretName] = connectorMetadata;
     for (const [envName, valueRef] of Object.entries(envBindings)) {
       if (valueRef === `${CONNECTOR_SECRET_REF_PREFIX}${secretName}`) {
         secretConnectorMap[envName] = connectorType;
-        secretConnectorMetadataMap[envName] = connectorMetadata;
       }
     }
   }
@@ -1824,7 +1792,6 @@ function resolveStoredConnectorState(
     secrets,
     vars,
     secretConnectorMap,
-    secretConnectorMetadataMap,
     environment,
   };
 }
@@ -1886,9 +1853,6 @@ async function loadStoredConnectorContext(
       secrets: compactRecord(resolved.secrets),
       vars: compactRecord(resolved.vars),
       secretConnectorMap: compactRecord(resolved.secretConnectorMap),
-      secretConnectorMetadataMap: compactRecord(
-        resolved.secretConnectorMetadataMap,
-      ),
       connectorTypes: allowedConnectorRows.map((row) => {
         return row.connectorType;
       }),
@@ -3041,12 +3005,6 @@ function buildStoredExecutionSecrets(args: {
       platformSecrets,
     ],
   });
-  const filteredConnectorMetadataMap = filterSecretConnectorMetadataMap({
-    secretConnectorMap: filteredConnectorMap,
-    secretConnectorMetadataMap:
-      args.connectorContext.secretConnectorMetadataMap,
-  });
-
   return {
     secrets: mergeRecords(
       args.connectorContext.secrets,
@@ -3061,10 +3019,7 @@ function buildStoredExecutionSecrets(args: {
         args.modelProvider?.secretConnectorMap,
       ) ?? null,
     secretConnectorMetadataMap:
-      mergeRecords(
-        filteredConnectorMetadataMap,
-        args.modelProvider?.secretConnectorMetadataMap,
-      ) ?? null,
+      args.modelProvider?.secretConnectorMetadataMap ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1789,6 +1789,8 @@ function resolveStoredConnectorState(
         accessMetadata.envBindings,
       )) {
         if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+          const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+          secretConnectorMap[secretName] = connectorType;
           secretConnectorMap[envName] = connectorType;
         }
       }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1093,6 +1093,9 @@ function modelProviderRefreshMaps(
   const accessSecretName = metadata.accessSecretName;
   const secretConnectorMap: Record<string, string> = {};
   const envBindings = getModelProviderEnvBindings(providerType);
+  // Firewall auth templates reference runtime env aliases (for example, the
+  // `CHATGPT_ACCESS_TOKEN` in `${{ secrets.CHATGPT_ACCESS_TOKEN }}`), so the
+  // refresh map is keyed by envName, not by the backing provider storage key.
   for (const [envName, valueRef] of Object.entries(envBindings ?? {})) {
     if (valueRef === `$secrets.${accessSecretName}`) {
       secretConnectorMap[envName] = providerType;
@@ -1774,6 +1777,8 @@ function resolveStoredConnectorState(
       connectorType,
       authMethod,
     );
+    // Firewall auth templates can only reference env aliases from envBindings;
+    // store the alias that points at the access secret, not the backing secret name.
     if (accessMetadata?.kind === "refresh-token") {
       const secretName = accessMetadata.accessToken;
       for (const [envName, valueRef] of Object.entries(envBindings)) {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1091,9 +1091,7 @@ function modelProviderRefreshMaps(
   }
 
   const accessSecretName = metadata.accessSecretName;
-  const secretConnectorMap: Record<string, string> = {
-    [accessSecretName]: providerType,
-  };
+  const secretConnectorMap: Record<string, string> = {};
   const envBindings = getModelProviderEnvBindings(providerType);
   for (const [envName, valueRef] of Object.entries(envBindings ?? {})) {
     if (valueRef === `$secrets.${accessSecretName}`) {
@@ -1778,7 +1776,6 @@ function resolveStoredConnectorState(
     );
     if (accessMetadata?.kind === "refresh-token") {
       const secretName = accessMetadata.accessToken;
-      secretConnectorMap[secretName] = connectorType;
       for (const [envName, valueRef] of Object.entries(envBindings)) {
         if (valueRef === `${CONNECTOR_SECRET_REF_PREFIX}${secretName}`) {
           secretConnectorMap[envName] = connectorType;
@@ -1789,8 +1786,6 @@ function resolveStoredConnectorState(
         accessMetadata.envBindings,
       )) {
         if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-          const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
-          secretConnectorMap[secretName] = connectorType;
           secretConnectorMap[envName] = connectorType;
         }
       }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -275,6 +275,9 @@ interface PermissionManifest {
 }
 
 interface StoredExecutionSecrets {
+  // Runtime secret namespace encrypted into executionContext.encryptedSecrets.
+  // Keys are the `NAME` in `${{ secrets.NAME }}`; connector/model-provider
+  // entries use env aliases, not backing storage secret names.
   readonly secrets: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | null;
   readonly secretConnectorMetadataMap: Record<
@@ -286,6 +289,7 @@ interface StoredExecutionSecrets {
 interface BuiltStoredExecutionContext {
   readonly context: StoredExecutionContext;
   readonly secretNames: readonly string[];
+  // Plain secret values used for run-context redaction; values, not names.
   readonly secretValues: readonly string[];
 }
 
@@ -3014,6 +3018,10 @@ function buildStoredExecutionSecrets(args: {
       platformSecrets,
     ],
   });
+  // The merged map is the runtime `secrets.NAME` namespace consumed by firewall
+  // auth and environment expansion. Stored connectors and model providers enter
+  // this map under env binding aliases; raw DB storage names stay behind the
+  // access metadata used during refresh/lookup.
   return {
     secrets: mergeRecords(
       args.connectorContext.secrets,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -24,6 +24,7 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
   getConnectorAuthMethod,
+  getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodEnvBindings,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -35,7 +36,6 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
-import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
 import { getModelProviderOAuthSecretMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
 import {
   expandHostWildcardsInBaseUrl,
@@ -347,6 +347,9 @@ interface ConnectorRuntimeContext {
   readonly secrets: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
   readonly connectorTypes: readonly ConnectorType[];
   readonly storedEnvironment: Record<string, string> | undefined;
 }
@@ -1512,16 +1515,16 @@ async function buildReferencedSecrets(args: {
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function compactRecord(
-  values: Record<string, string>,
-): Record<string, string> | undefined {
+function compactRecord<T>(
+  values: Record<string, T>,
+): Record<string, T> | undefined {
   return Object.keys(values).length > 0 ? values : undefined;
 }
 
-function mergeRecords(
-  ...records: readonly (Record<string, string> | undefined)[]
-): Record<string, string> | undefined {
-  const merged: Record<string, string> = {};
+function mergeRecords<T>(
+  ...records: readonly (Record<string, T> | undefined)[]
+): Record<string, T> | undefined {
+  const merged: Record<string, T> = {};
   for (const record of records) {
     if (record) {
       Object.assign(merged, record);
@@ -1552,6 +1555,24 @@ function filterSecretConnectorMap(args: {
   return compactRecord(filtered);
 }
 
+function filterSecretConnectorMetadataMap(args: {
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+}): Record<string, SecretConnectorMetadata> | undefined {
+  if (!args.secretConnectorMap || !args.secretConnectorMetadataMap) {
+    return undefined;
+  }
+
+  const filtered = Object.fromEntries(
+    Object.entries(args.secretConnectorMetadataMap).filter(([key]) => {
+      return Object.hasOwn(args.secretConnectorMap ?? {}, key);
+    }),
+  );
+  return compactRecord(filtered);
+}
+
 interface StoredConnectorRuntimeRow {
   readonly connectorType: ConnectorType;
   readonly authMethod: string;
@@ -1559,6 +1580,7 @@ interface StoredConnectorRuntimeRow {
 
 interface ConnectorEnvBindingSet {
   readonly connectorType: ConnectorType;
+  readonly authMethod: string;
   readonly envBindings: Record<string, string>;
   readonly optionalSecretNames: ReadonlySet<string>;
   readonly optionalVariableNames: ReadonlySet<string>;
@@ -1573,6 +1595,7 @@ interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
+  readonly secretConnectorMetadataMap: Record<string, SecretConnectorMetadata>;
   readonly environment: Record<string, string>;
 }
 
@@ -1581,6 +1604,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     secrets: undefined,
     vars: undefined,
     secretConnectorMap: undefined,
+    secretConnectorMetadataMap: undefined,
     connectorTypes: [],
     storedEnvironment: undefined,
   };
@@ -1630,6 +1654,7 @@ function connectorEnvBindingSets(
     }
     return {
       connectorType: row.connectorType,
+      authMethod: row.authMethod,
       envBindings: getConnectorAuthMethodEnvBindings(
         row.connectorType,
         row.authMethod,
@@ -1737,10 +1762,13 @@ function resolveStoredConnectorState(
   const secrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
+  const secretConnectorMetadataMap: Record<string, SecretConnectorMetadata> =
+    {};
   const environment: Record<string, string> = {};
 
   for (const {
     connectorType,
+    authMethod,
     envBindings,
     optionalSecretNames,
     optionalVariableNames,
@@ -1769,20 +1797,36 @@ function resolveStoredConnectorState(
       }
     }
 
-    const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
-    if (!secretMetadata?.isRefreshable) {
+    const accessMetadata = getConnectorAuthMethodAccessMetadata(
+      connectorType,
+      authMethod,
+    );
+    if (accessMetadata?.kind !== "refresh-token") {
       continue;
     }
-    const secretName = secretMetadata.accessSecretName;
+    const secretName = accessMetadata.accessToken;
+    const connectorMetadata = {
+      sourceType: "connector",
+      authMethod,
+      accessKind: accessMetadata.kind,
+    } satisfies SecretConnectorMetadata;
     secretConnectorMap[secretName] = connectorType;
+    secretConnectorMetadataMap[secretName] = connectorMetadata;
     for (const [envName, valueRef] of Object.entries(envBindings)) {
       if (valueRef === `${CONNECTOR_SECRET_REF_PREFIX}${secretName}`) {
         secretConnectorMap[envName] = connectorType;
+        secretConnectorMetadataMap[envName] = connectorMetadata;
       }
     }
   }
 
-  return { secrets, vars, secretConnectorMap, environment };
+  return {
+    secrets,
+    vars,
+    secretConnectorMap,
+    secretConnectorMetadataMap,
+    environment,
+  };
 }
 
 async function loadStoredConnectorContext(
@@ -1842,6 +1886,9 @@ async function loadStoredConnectorContext(
       secrets: compactRecord(resolved.secrets),
       vars: compactRecord(resolved.vars),
       secretConnectorMap: compactRecord(resolved.secretConnectorMap),
+      secretConnectorMetadataMap: compactRecord(
+        resolved.secretConnectorMetadataMap,
+      ),
       connectorTypes: allowedConnectorRows.map((row) => {
         return row.connectorType;
       }),
@@ -2994,6 +3041,11 @@ function buildStoredExecutionSecrets(args: {
       platformSecrets,
     ],
   });
+  const filteredConnectorMetadataMap = filterSecretConnectorMetadataMap({
+    secretConnectorMap: filteredConnectorMap,
+    secretConnectorMetadataMap:
+      args.connectorContext.secretConnectorMetadataMap,
+  });
 
   return {
     secrets: mergeRecords(
@@ -3009,7 +3061,10 @@ function buildStoredExecutionSecrets(args: {
         args.modelProvider?.secretConnectorMap,
       ) ?? null,
     secretConnectorMetadataMap:
-      args.modelProvider?.secretConnectorMetadataMap ?? null,
+      mergeRecords(
+        filteredConnectorMetadataMap,
+        args.modelProvider?.secretConnectorMetadataMap,
+      ) ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1776,14 +1776,21 @@ function resolveStoredConnectorState(
       connectorType,
       authMethod,
     );
-    if (accessMetadata?.kind !== "refresh-token") {
-      continue;
-    }
-    const secretName = accessMetadata.accessToken;
-    secretConnectorMap[secretName] = connectorType;
-    for (const [envName, valueRef] of Object.entries(envBindings)) {
-      if (valueRef === `${CONNECTOR_SECRET_REF_PREFIX}${secretName}`) {
-        secretConnectorMap[envName] = connectorType;
+    if (accessMetadata?.kind === "refresh-token") {
+      const secretName = accessMetadata.accessToken;
+      secretConnectorMap[secretName] = connectorType;
+      for (const [envName, valueRef] of Object.entries(envBindings)) {
+        if (valueRef === `${CONNECTOR_SECRET_REF_PREFIX}${secretName}`) {
+          secretConnectorMap[envName] = connectorType;
+        }
+      }
+    } else if (accessMetadata?.kind === "static") {
+      for (const [envName, valueRef] of Object.entries(
+        accessMetadata.envBindings,
+      )) {
+        if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+          secretConnectorMap[envName] = connectorType;
+        }
       }
     }
   }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1453,8 +1453,12 @@ async function syncSkippedTokens(
   for (const { connectorType, token } of currentTokens) {
     if (!token) {
       L.warn(
-        `[${context.auth.runId}] No DB token for skipped connector ${connectorType}, using encryptedSecrets value`,
+        `[${context.auth.runId}] No DB token for skipped connector ${connectorType}, marking access unresolved`,
       );
+      for (const envVar of context.envVarsByConnector.get(connectorType) ??
+        []) {
+        delete context.secrets[envVar];
+      }
       continue;
     }
     for (const envVar of context.envVarsByConnector.get(connectorType) ?? []) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -5,7 +5,6 @@ import {
   getConnectorOAuthClient,
   getConnectorAuthMethodAccessMetadata,
   type ConnectorAuthMethodAccessMetadata,
-  type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -19,8 +18,10 @@ import {
 } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
+  getConnectorAuthProviderClientArgs,
   hasConnectorAuthProvider,
   refreshConnectorAuthProviderAccessToken,
+  type ConnectorAuthProviderClientArgs,
   type ProviderEnv,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -249,7 +250,7 @@ type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
       readonly connectorType: ConnectorAuthProviderType;
-      readonly oauthClient: ConnectorOAuthClient;
+      readonly clientArgs: ConnectorAuthProviderClientArgs;
       readonly context: RefreshTokenContext;
     }
   | {
@@ -809,7 +810,7 @@ function prepareRefreshTokenContext(
   );
   if (!oauthClient) {
     L.debug(
-      `${args.connectorType} OAuth client not configured, skipping token refresh`,
+      `${args.connectorType} connector client not configured, skipping token refresh`,
     );
     return { ok: false, reason: "client-unconfigured" };
   }
@@ -837,7 +838,7 @@ function prepareRefreshTokenContext(
     prepared: {
       sourceType: "connector",
       connectorType: parsedConnectorType.data,
-      oauthClient,
+      clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
       context,
     },
   };
@@ -960,7 +961,7 @@ async function refreshAccessTokenForSource(
     prepared.sourceType === "connector"
       ? refreshConnectorAuthProviderAccessToken({
           type: prepared.connectorType,
-          oauthClient: prepared.oauthClient,
+          clientArgs: prepared.clientArgs,
           refreshToken: prepared.context.currentRefreshToken,
         })
       : refreshModelProviderOAuthToken({

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1119,9 +1119,15 @@ function connectorAccessSecretName(
     }
     case "static": {
       const valueRef = accessMetadata.envBindings[key];
-      return valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX) === true
-        ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
-        : undefined;
+      if (valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX) === true) {
+        return valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+      }
+      for (const candidate of Object.values(accessMetadata.envBindings)) {
+        if (candidate === `${CONNECTOR_SECRET_REF_PREFIX}${key}`) {
+          return key;
+        }
+      }
+      return undefined;
     }
     case "none": {
       return undefined;

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -338,6 +338,7 @@ interface BasicArgContext extends BasicAuthTemplateArg {
 
 const L = logger("webhook:firewall-auth");
 const ORG_SENTINEL_USER_ID = "__org__";
+const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const REFRESH_BUFFER_SECS = 60;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
@@ -1098,22 +1099,115 @@ function isSelectedAccessSecretKey(
   key: string,
   accessMetadata: ConnectorAuthMethodAccessMetadata,
 ): boolean {
+  return connectorAccessSecretName(key, accessMetadata) !== undefined;
+}
+
+function connectorAccessSecretName(
+  key: string,
+  accessMetadata: ConnectorAuthMethodAccessMetadata,
+): string | undefined {
   switch (accessMetadata.kind) {
     case "refresh-token": {
-      return (
+      if (
         key === accessMetadata.accessToken ||
         accessMetadata.envBindings[key] ===
-          `$secrets.${accessMetadata.accessToken}`
-      );
+          `${CONNECTOR_SECRET_REF_PREFIX}${accessMetadata.accessToken}`
+      ) {
+        return accessMetadata.accessToken;
+      }
+      return undefined;
     }
     case "static": {
-      return (
-        Object.hasOwn(accessMetadata.envBindings, key) &&
-        accessMetadata.envBindings[key]?.startsWith("$secrets.") === true
-      );
+      const valueRef = accessMetadata.envBindings[key];
+      return valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX) === true
+        ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
+        : undefined;
     }
     case "none": {
-      return false;
+      return undefined;
+    }
+  }
+}
+
+async function syncStaticConnectorAccessSecrets(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly secrets: Record<string, string>;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<void> {
+  if (!args.secretConnectorMap) {
+    return;
+  }
+
+  const lookups = [...args.referencedKeys].flatMap((key) => {
+    const connectorType = getOwnConnectorOwner(args.secretConnectorMap, key);
+    if (!connectorType) {
+      return [];
+    }
+    const metadata = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    );
+    if (metadata.sourceType !== "connector") {
+      return [];
+    }
+    const accessMetadata =
+      args.connectorAccessByType.get(connectorType)?.accessMetadata;
+    if (accessMetadata?.kind !== "static") {
+      return [];
+    }
+    const secretName = connectorAccessSecretName(key, accessMetadata);
+    return secretName ? [{ key, secretName }] : [];
+  });
+  if (lookups.length === 0) {
+    return;
+  }
+
+  const rows = await args.db
+    .select({
+      name: secretsTable.name,
+      encryptedValue: secretsTable.encryptedValue,
+    })
+    .from(secretsTable)
+    .where(
+      and(
+        eq(secretsTable.orgId, args.orgId),
+        eq(secretsTable.userId, args.userId),
+        eq(secretsTable.type, "connector"),
+        inArray(secretsTable.name, [
+          ...new Set(
+            lookups.map((lookup) => {
+              return lookup.secretName;
+            }),
+          ),
+        ]),
+      ),
+    );
+
+  const valuesByName = new Map<string, string>();
+  for (const row of rows) {
+    valuesByName.set(
+      row.name,
+      await decryptStoredSecretValue(
+        row.encryptedValue,
+        args.featureSwitchContext,
+      ),
+    );
+  }
+
+  for (const { key, secretName } of lookups) {
+    const value = valuesByName.get(secretName);
+    if (value === undefined) {
+      delete args.secrets[key];
+    } else {
+      args.secrets[key] = value;
     }
   }
 }
@@ -1226,6 +1320,7 @@ async function prepareFirewallAuthResolutionContext(args: {
   readonly auth: SandboxAuth;
   readonly body: FirewallAuthBody;
   readonly orgId: string;
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly secrets: Record<string, string>;
 }): Promise<
   | { readonly ok: true; readonly context: FirewallAuthResolutionContext }
@@ -1247,6 +1342,17 @@ async function prepareFirewallAuthResolutionContext(args: {
       referencedKeys: referenced.secrets,
     }),
   );
+  await syncStaticConnectorAccessSecrets({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.auth.userId,
+    secrets: args.secrets,
+    secretConnectorMap: args.body.secretConnectorMap,
+    secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+    referencedKeys: referenced.secrets,
+    connectorAccessByType,
+    featureSwitchContext: args.featureSwitchContext,
+  });
   if (
     hasUnavailableConnectorSource({
       secretConnectorMap: args.body.secretConnectorMap,
@@ -1808,6 +1914,7 @@ export async function resolveFirewallAuth(
     auth,
     body,
     orgId: decrypted.orgId,
+    featureSwitchContext: decrypted.featureSwitchContext,
     secrets: decryptedSecrets,
   });
   if (!prepared.ok) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3,9 +3,14 @@ import { Buffer } from "node:buffer";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
   getConnectorOAuthClient,
+  getConnectorAuthMethodAccessMetadata,
+  type ConnectorAuthMethodAccessMetadata,
   type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
-import type { OAuthGrantConnectorType } from "@vm0/connectors/connectors";
+import {
+  connectorTypeSchema,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
 import {
   parseBasicAuthTemplates,
   replaceBasicAuthTemplates,
@@ -14,9 +19,7 @@ import {
 } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
-  getConnectorOAuthSecretMetadata,
-  hasConnectorOAuthProvider,
-  refreshConnectorOAuthToken,
+  refreshConnectorAccessToken,
   type ProviderEnv,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -48,8 +51,12 @@ import {
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
-type OAuthSecretSource = "connector" | "model-provider";
-type SecretType = OAuthSecretSource;
+type AccessSecretSource = "connector" | "model-provider";
+type SecretType = AccessSecretSource;
+type RefreshTokenAccessMetadata = Extract<
+  ConnectorAuthMethodAccessMetadata,
+  { readonly kind: "refresh-token" }
+>;
 
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
@@ -76,7 +83,7 @@ interface RefreshResult {
 
 interface RefreshExecutionResult {
   readonly connectorType: string;
-  readonly ok: boolean;
+  readonly status: "refreshed" | "failed";
 }
 
 interface ResolveResult {
@@ -105,6 +112,60 @@ type ResolveFirewallAuthResult =
         };
       };
     };
+
+function connectorNotConfigured(): ResolveFirewallAuthResult {
+  return {
+    status: 424,
+    body: {
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    },
+  };
+}
+
+function forbiddenModelProviderOwner(): ResolveFirewallAuthResult {
+  return {
+    status: 403,
+    body: {
+      error: {
+        message: "Invalid model-provider secret owner",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+function tokenRefreshFailed(
+  failedConnectors: readonly string[],
+): ResolveFirewallAuthResult {
+  return {
+    status: 502,
+    body: {
+      error: {
+        message: `OAuth token expired and refresh failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
+        code: "TOKEN_REFRESH_FAILED",
+        connectors: failedConnectors,
+      },
+    },
+  };
+}
+
+function tokenAccessResolutionFailed(
+  failedConnectors: readonly string[],
+): ResolveFirewallAuthResult {
+  return {
+    status: 502,
+    body: {
+      error: {
+        message: `Token access resolution failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
+        code: "TOKEN_ACCESS_RESOLUTION_FAILED",
+        connectors: failedConnectors,
+      },
+    },
+  };
+}
 
 function mergeExpiresAt(
   expiresAt: number | null,
@@ -159,14 +220,16 @@ interface SecretTokenLookupArgs {
   readonly connectorType: string;
   readonly orgId: string;
   readonly userId: string;
-  readonly sourceType: OAuthSecretSource;
+  readonly sourceType: AccessSecretSource;
   readonly sourceUserId?: string;
+  readonly metadataKey?: string;
+  readonly authMethod?: string;
+  readonly accessKind?: SecretConnectorMetadata["accessKind"];
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
 interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
   readonly connectorSecrets: Record<string, string>;
-  readonly metadataKey?: string;
 }
 
 interface RefreshTokenContext {
@@ -179,7 +242,7 @@ interface RefreshTokenContext {
 type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
-      readonly connectorType: OAuthGrantConnectorType;
+      readonly connectorType: ConnectorType;
       readonly oauthClient: ConnectorOAuthClient;
       readonly context: RefreshTokenContext;
     }
@@ -188,6 +251,33 @@ type PreparedRefreshTokenContext =
       readonly providerKey: ModelProviderOAuthProviderKey;
       readonly currentEnv: ProviderEnv;
       readonly context: RefreshTokenContext;
+    };
+
+type PrepareRefreshTokenContextResult =
+  | {
+      readonly ok: true;
+      readonly prepared: PreparedRefreshTokenContext;
+    }
+  | {
+      readonly ok: false;
+      readonly reason:
+        | "client-unconfigured"
+        | "not-refreshable"
+        | "refresh-token-missing";
+    };
+
+type RefreshAccessTokenResult =
+  | {
+      readonly ok: true;
+      readonly accessToken: string;
+    }
+  | {
+      readonly ok: false;
+      readonly reason:
+        | "client-unconfigured"
+        | "not-refreshable"
+        | "refresh-failed"
+        | "refresh-token-missing";
     };
 
 interface SyncRefreshTokensArgs {
@@ -235,7 +325,9 @@ const REFRESH_BUFFER_SECS = 60;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
-function getOAuthProviderKeySourceType(providerKey: string): OAuthSecretSource {
+function getOAuthProviderKeySourceType(
+  providerKey: string,
+): AccessSecretSource {
   return isModelProviderOAuthProviderKey(providerKey)
     ? "model-provider"
     : "connector";
@@ -248,7 +340,7 @@ function modelProviderTypeForOAuthProviderKey(
 }
 
 function resolveSecretUserId(
-  sourceType: OAuthSecretSource,
+  sourceType: AccessSecretSource,
   userId: string,
   sourceUserId?: string,
 ): string {
@@ -272,7 +364,58 @@ function resolveRefreshMetadata(
         ? (metadata?.metadataKey ??
           modelProviderTypeForOAuthProviderKey(connectorType))
         : undefined,
+    authMethod: sourceType === "connector" ? metadata?.authMethod : undefined,
+    accessKind: sourceType === "connector" ? metadata?.accessKind : undefined,
   };
+}
+
+function resolveConnectorType(
+  connectorType: string,
+): ConnectorType | undefined {
+  const parsed = connectorTypeSchema.safeParse(connectorType);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function connectorAccessMetadataForSource(
+  connectorType: string,
+  metadata: Pick<
+    SecretConnectorMetadata,
+    "sourceType" | "authMethod" | "accessKind"
+  >,
+): ConnectorAuthMethodAccessMetadata | undefined {
+  if (metadata.sourceType !== "connector") {
+    return undefined;
+  }
+  const parsedConnectorType = resolveConnectorType(connectorType);
+  if (!parsedConnectorType) {
+    return undefined;
+  }
+  const authMethod = metadata.authMethod ?? "oauth";
+  const accessMetadata = getConnectorAuthMethodAccessMetadata(
+    parsedConnectorType,
+    authMethod,
+  );
+  if (!accessMetadata) {
+    return undefined;
+  }
+  if (metadata.accessKind && metadata.accessKind !== accessMetadata.kind) {
+    return undefined;
+  }
+  return accessMetadata;
+}
+
+function connectorRefreshAccessMetadataForSource(
+  connectorType: string,
+  metadata: Pick<
+    SecretConnectorMetadata,
+    "sourceType" | "authMethod" | "accessKind"
+  >,
+): RefreshTokenAccessMetadata | undefined {
+  const accessMetadata = connectorAccessMetadataForSource(
+    connectorType,
+    metadata,
+  );
+  return accessMetadata?.kind === "refresh-token" ? accessMetadata : undefined;
 }
 
 function currentProviderEnv(): ProviderEnv {
@@ -356,37 +499,46 @@ async function upsertSecretValue(
     });
 }
 
-function getRefreshSecretNameForSource(
-  connectorType: string,
-  sourceType: OAuthSecretSource,
-): string | undefined {
-  if (sourceType === "model-provider") {
-    const metadata = getModelProviderOAuthSecretMetadata(connectorType);
+function getRefreshSecretNameForSource(args: {
+  readonly connectorType: string;
+  readonly sourceType: AccessSecretSource;
+  readonly authMethod?: string;
+  readonly accessKind?: SecretConnectorMetadata["accessKind"];
+}): string | undefined {
+  if (args.sourceType === "model-provider") {
+    const metadata = getModelProviderOAuthSecretMetadata(args.connectorType);
     return metadata?.isRefreshable ? metadata.refreshSecretName : undefined;
   }
 
-  const metadata = getConnectorOAuthSecretMetadata(connectorType);
-  return metadata?.isRefreshable ? metadata.refreshSecretName : undefined;
+  return connectorRefreshAccessMetadataForSource(args.connectorType, {
+    sourceType: args.sourceType,
+    authMethod: args.authMethod,
+    accessKind: args.accessKind,
+  })?.refreshToken;
 }
 
-function getAccessSecretNameForSource(
-  connectorType: string,
-  sourceType: OAuthSecretSource,
-): string | undefined {
-  if (sourceType === "model-provider") {
-    return getModelProviderOAuthSecretMetadata(connectorType)?.accessSecretName;
+function getAccessSecretNameForSource(args: {
+  readonly connectorType: string;
+  readonly sourceType: AccessSecretSource;
+  readonly authMethod?: string;
+  readonly accessKind?: SecretConnectorMetadata["accessKind"];
+}): string | undefined {
+  if (args.sourceType === "model-provider") {
+    return getModelProviderOAuthSecretMetadata(args.connectorType)
+      ?.accessSecretName;
   }
 
-  return getConnectorOAuthSecretMetadata(connectorType)?.accessSecretName;
+  return connectorRefreshAccessMetadataForSource(args.connectorType, {
+    sourceType: args.sourceType,
+    authMethod: args.authMethod,
+    accessKind: args.accessKind,
+  })?.accessToken;
 }
 
 async function getConnectorRefreshToken(
   args: SecretTokenLookupArgs,
 ): Promise<{ readonly secretName: string; readonly token: string } | null> {
-  const secretName = getRefreshSecretNameForSource(
-    args.connectorType,
-    args.sourceType,
-  );
+  const secretName = getRefreshSecretNameForSource(args);
   if (!secretName) {
     return null;
   }
@@ -409,10 +561,7 @@ async function getConnectorRefreshToken(
 async function getConnectorAccessToken(
   args: SecretTokenLookupArgs,
 ): Promise<string | null> {
-  const secretName = getAccessSecretNameForSource(
-    args.connectorType,
-    args.sourceType,
-  );
+  const secretName = getAccessSecretNameForSource(args);
   if (!secretName) {
     return null;
   }
@@ -447,6 +596,9 @@ async function syncRefreshTokensFromDb(
         userId: args.userId,
         sourceType: metadata.sourceType,
         sourceUserId: metadata.sourceUserId,
+        metadataKey: metadata.metadataKey,
+        authMethod: metadata.authMethod,
+        accessKind: metadata.accessKind,
         featureSwitchContext: args.featureSwitchContext,
       });
     }),
@@ -543,11 +695,21 @@ async function getExpiryByProviderKey(
   metadataByConnector: Map<string, SecretConnectorMetadata>,
 ): Promise<Map<string, number | null>> {
   const connectorOnly = connectorTypes.filter((connectorType) => {
-    return getOAuthProviderKeySourceType(connectorType) === "connector";
+    return (
+      resolveRefreshMetadata(
+        connectorType,
+        metadataByConnector.get(connectorType),
+      ).sourceType === "connector"
+    );
   });
   const modelProviderOAuthProviderKeys = connectorTypes.filter(
     (connectorType) => {
-      return getOAuthProviderKeySourceType(connectorType) === "model-provider";
+      return (
+        resolveRefreshMetadata(
+          connectorType,
+          metadataByConnector.get(connectorType),
+        ).sourceType === "model-provider"
+      );
     },
   );
 
@@ -584,16 +746,16 @@ async function getExpiryByProviderKey(
 
 function prepareRefreshTokenContext(
   args: RefreshAccessTokenArgs,
-): PreparedRefreshTokenContext | null {
+): PrepareRefreshTokenContextResult {
   if (args.sourceType === "model-provider") {
     if (!isModelProviderOAuthProviderKey(args.connectorType)) {
-      return null;
+      return { ok: false, reason: "not-refreshable" };
     }
     const secretMetadata = getModelProviderOAuthSecretMetadata(
       args.connectorType,
     );
     if (!secretMetadata.isRefreshable) {
-      return null;
+      return { ok: false, reason: "not-refreshable" };
     }
     if (!args.metadataKey) {
       throw new Error(
@@ -605,7 +767,7 @@ function prepareRefreshTokenContext(
     const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
     if (!currentRefreshToken) {
       L.debug(`No ${args.connectorType} refresh token available, skipping`);
-      return null;
+      return { ok: false, reason: "refresh-token-missing" };
     }
 
     const env = currentProviderEnv();
@@ -618,7 +780,7 @@ function prepareRefreshTokenContext(
       L.debug(
         `${args.connectorType} OAuth client ID not configured, skipping token refresh`,
       );
-      return null;
+      return { ok: false, reason: "client-unconfigured" };
     }
 
     const context: RefreshTokenContext = {
@@ -633,42 +795,51 @@ function prepareRefreshTokenContext(
     };
 
     return {
-      sourceType: args.sourceType,
-      providerKey: args.connectorType,
-      currentEnv: env,
-      context,
+      ok: true,
+      prepared: {
+        sourceType: args.sourceType,
+        providerKey: args.connectorType,
+        currentEnv: env,
+        context,
+      },
     };
   }
 
-  if (!hasConnectorOAuthProvider(args.connectorType)) {
-    L.debug(`${args.connectorType} is not an OAuth connector type, skipping`);
-    return null;
+  const selectedAccess = connectorRefreshAccessMetadataForSource(
+    args.connectorType,
+    args,
+  );
+  if (!selectedAccess) {
+    L.debug(
+      `${args.connectorType} does not use refresh-token access, skipping`,
+    );
+    return { ok: false, reason: "not-refreshable" };
   }
-  const secretMetadata = getConnectorOAuthSecretMetadata(args.connectorType);
-  if (!secretMetadata.isRefreshable) {
-    return null;
+  const connectorType = resolveConnectorType(args.connectorType);
+  if (!connectorType) {
+    return { ok: false, reason: "not-refreshable" };
   }
-  const oauthClient = getConnectorOAuthClient(args.connectorType, (name) => {
+  const oauthClient = getConnectorOAuthClient(connectorType, (name) => {
     return optionalEnv(name);
   });
   if (!oauthClient) {
     L.debug(
       `${args.connectorType} OAuth client not configured, skipping token refresh`,
     );
-    return null;
+    return { ok: false, reason: "client-unconfigured" };
   }
 
-  const refreshTokenSecret = secretMetadata.refreshSecretName;
+  const refreshTokenSecret = selectedAccess.refreshToken;
   const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
   if (!currentRefreshToken) {
     L.debug(`No ${args.connectorType} refresh token available, skipping`);
-    return null;
+    return { ok: false, reason: "refresh-token-missing" };
   }
 
   const context: RefreshTokenContext = {
     refreshTokenSecret,
     currentRefreshToken,
-    accessTokenSecret: secretMetadata.accessSecretName,
+    accessTokenSecret: selectedAccess.accessToken,
     secretUserId: resolveSecretUserId(
       args.sourceType,
       args.userId,
@@ -677,10 +848,13 @@ function prepareRefreshTokenContext(
   };
 
   return {
-    sourceType: "connector",
-    connectorType: args.connectorType,
-    oauthClient,
-    context,
+    ok: true,
+    prepared: {
+      sourceType: "connector",
+      connectorType,
+      oauthClient,
+      context,
+    },
   };
 }
 
@@ -788,17 +962,18 @@ async function markRefreshFailure(
     );
 }
 
-async function refreshConnectorAccessToken(
+async function refreshAccessTokenForSource(
   args: RefreshAccessTokenArgs,
-): Promise<string | null> {
-  const prepared = prepareRefreshTokenContext(args);
-  if (!prepared) {
-    return null;
+): Promise<RefreshAccessTokenResult> {
+  const preparation = prepareRefreshTokenContext(args);
+  if (!preparation.ok) {
+    return { ok: false, reason: preparation.reason };
   }
+  const { prepared } = preparation;
 
   const refreshPromise =
     prepared.sourceType === "connector"
-      ? refreshConnectorOAuthToken({
+      ? refreshConnectorAccessToken({
           type: prepared.connectorType,
           oauthClient: prepared.oauthClient,
           refreshToken: prepared.context.currentRefreshToken,
@@ -822,7 +997,7 @@ async function refreshConnectorAccessToken(
     });
 
     await markRefreshFailure(args, prepared.context, errorCode);
-    return null;
+    return { ok: false, reason: "refresh-failed" };
   }
 
   const result = refreshResult.value;
@@ -834,7 +1009,7 @@ async function refreshConnectorAccessToken(
       result.refreshToken;
   }
   L.debug(`${args.connectorType} access token refreshed successfully`);
-  return result.accessToken;
+  return { ok: true, accessToken: result.accessToken };
 }
 
 function buildMetadataByConnector(
@@ -896,16 +1071,120 @@ const emptyRefreshResult = Object.freeze({
 
 function buildRefreshableMap(
   secretConnectorMap: Record<string, string>,
+  secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined,
   referencedKeys: Set<string>,
 ): Map<string, string> {
   const refreshable = new Map<string, string>();
   for (const key of referencedKeys) {
     const connectorType = secretConnectorMap[key];
-    if (connectorType) {
+    if (!connectorType) {
+      continue;
+    }
+    const metadata = resolveRefreshMetadata(
+      connectorType,
+      secretConnectorMetadataMap?.[key],
+    );
+    const refreshSecretName = getRefreshSecretNameForSource({
+      connectorType,
+      sourceType: metadata.sourceType,
+      authMethod: metadata.authMethod,
+      accessKind: metadata.accessKind,
+    });
+    if (refreshSecretName) {
       refreshable.set(key, connectorType);
     }
   }
   return refreshable;
+}
+
+function getOwnConnectorOwner(
+  secretConnectorMap: Record<string, string> | undefined,
+  key: string,
+): string | undefined {
+  return secretConnectorMap && Object.hasOwn(secretConnectorMap, key)
+    ? secretConnectorMap[key]
+    : undefined;
+}
+
+function isSelectedAccessSecretKey(
+  key: string,
+  accessMetadata: RefreshTokenAccessMetadata,
+): boolean {
+  return (
+    key === accessMetadata.accessToken ||
+    accessMetadata.envBindings[key] === `$secrets.${accessMetadata.accessToken}`
+  );
+}
+
+function canResolveMissingConnectorAccessSecret(args: {
+  readonly key: string;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+}): boolean {
+  const connectorType = getOwnConnectorOwner(args.secretConnectorMap, args.key);
+  const metadata = args.secretConnectorMetadataMap?.[args.key];
+  if (
+    !connectorType ||
+    metadata?.sourceType !== "connector" ||
+    !metadata.authMethod
+  ) {
+    return false;
+  }
+  const accessMetadata = connectorRefreshAccessMetadataForSource(
+    connectorType,
+    metadata,
+  );
+  return accessMetadata
+    ? isSelectedAccessSecretKey(args.key, accessMetadata)
+    : false;
+}
+
+function hasMissingUnresolvableSecrets(args: {
+  readonly secrets: Record<string, string>;
+  readonly referencedKeys: Set<string>;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+}): boolean {
+  return [...args.referencedKeys].some((key) => {
+    return (
+      !Object.hasOwn(args.secrets, key) &&
+      !canResolveMissingConnectorAccessSecret({
+        key,
+        secretConnectorMap: args.secretConnectorMap,
+        secretConnectorMetadataMap: args.secretConnectorMetadataMap,
+      })
+    );
+  });
+}
+
+function hasMissingResolvedSecrets(
+  secrets: Record<string, string>,
+  referencedKeys: Set<string>,
+): boolean {
+  return [...referencedKeys].some((key) => {
+    return !Object.hasOwn(secrets, key);
+  });
+}
+
+function missingResolvedConnectorOwners(args: {
+  readonly secrets: Record<string, string>;
+  readonly referencedKeys: Set<string>;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+}): readonly string[] {
+  const owners = new Set<string>();
+  for (const key of args.referencedKeys) {
+    if (Object.hasOwn(args.secrets, key)) {
+      continue;
+    }
+    owners.add(args.secretConnectorMap?.[key] ?? key);
+  }
+  return [...owners].sort();
 }
 
 async function findRefreshRunOrgId(
@@ -994,7 +1273,7 @@ async function refreshSelectedTokens(
         connectorType,
         context.metadataByConnector.get(connectorType),
       );
-      const freshToken = await refreshConnectorAccessToken({
+      const refreshResult = await refreshAccessTokenForSource({
         db: context.db,
         connectorType,
         orgId: context.orgId,
@@ -1002,26 +1281,29 @@ async function refreshSelectedTokens(
         sourceType: metadata.sourceType,
         sourceUserId: metadata.sourceUserId,
         metadataKey: metadata.metadataKey,
+        authMethod: metadata.authMethod,
+        accessKind: metadata.accessKind,
         connectorSecrets: context.secrets,
         featureSwitchContext: context.featureSwitchContext,
       });
-      if (!freshToken) {
+      if (!refreshResult.ok) {
         L.warn(
           `[${context.auth.runId}] Failed to refresh ${connectorType} token`,
           {
             sourceType: metadata.sourceType,
             sourceUserId: metadata.sourceUserId,
             metadataKey: metadata.metadataKey,
+            reason: refreshResult.reason,
           },
         );
-        return { connectorType, ok: false };
+        return { connectorType, status: "failed" };
       }
 
       for (const envVar of context.envVarsByConnector.get(connectorType) ??
         []) {
-        context.secrets[envVar] = freshToken;
+        context.secrets[envVar] = refreshResult.accessToken;
       }
-      return { connectorType, ok: true };
+      return { connectorType, status: "refreshed" };
     }),
   );
 }
@@ -1045,6 +1327,9 @@ async function syncSkippedTokens(
           userId: context.userId,
           sourceType: metadata.sourceType,
           sourceUserId: metadata.sourceUserId,
+          metadataKey: metadata.metadataKey,
+          authMethod: metadata.authMethod,
+          accessKind: metadata.accessKind,
           featureSwitchContext: context.featureSwitchContext,
         }),
       };
@@ -1068,11 +1353,11 @@ function summarizeRefreshResults(
   envVarsByConnector: Map<string, readonly string[]>,
 ): Pick<
   RefreshResult,
-  "refreshedConnectors" | "refreshedSecrets" | "failedConnectors"
+  "failedConnectors" | "refreshedConnectors" | "refreshedSecrets"
 > {
   const refreshedConnectors = refreshResults
     .filter((result) => {
-      return result.ok;
+      return result.status === "refreshed";
     })
     .map((result) => {
       return result.connectorType;
@@ -1084,13 +1369,17 @@ function summarizeRefreshResults(
     .sort();
   const failedConnectors = refreshResults
     .filter((result) => {
-      return !result.ok;
+      return result.status === "failed";
     })
     .map((result) => {
       return result.connectorType;
     });
 
-  return { refreshedConnectors, refreshedSecrets, failedConnectors };
+  return {
+    refreshedConnectors,
+    refreshedSecrets,
+    failedConnectors,
+  };
 }
 
 function earliestConnectorExpiry(
@@ -1113,6 +1402,7 @@ async function refreshExpiredTokens(
 ): Promise<RefreshResult> {
   const refreshable = buildRefreshableMap(
     args.secretConnectorMap,
+    args.secretConnectorMetadataMap,
     args.referencedKeys,
   );
   if (refreshable.size === 0) {
@@ -1391,22 +1681,17 @@ export async function resolveFirewallAuth(
   );
   const vars = body.vars ?? {};
 
-  const hasMissingSecrets = [...referenced.secrets].some((key) => {
-    return !Object.hasOwn(decryptedSecrets, key);
+  const hasMissingSecrets = hasMissingUnresolvableSecrets({
+    secrets: decryptedSecrets,
+    referencedKeys: referenced.secrets,
+    secretConnectorMap: body.secretConnectorMap,
+    secretConnectorMetadataMap: body.secretConnectorMetadataMap,
   });
   const hasMissingVars = [...referenced.vars].some((key) => {
     return !Object.hasOwn(vars, key);
   });
   if (hasMissingSecrets || hasMissingVars) {
-    return {
-      status: 424,
-      body: {
-        error: {
-          message: "Connector not configured",
-          code: "CONNECTOR_NOT_CONFIGURED",
-        },
-      },
-    };
+    return connectorNotConfigured();
   }
 
   if (
@@ -1418,15 +1703,7 @@ export async function resolveFirewallAuth(
       referenced.secrets,
     )
   ) {
-    return {
-      status: 403,
-      body: {
-        error: {
-          message: "Invalid model-provider secret owner",
-          code: "FORBIDDEN",
-        },
-      },
-    };
+    return forbiddenModelProviderOwner();
   }
 
   const billableCacheExpiry = await resolveBillableFirewallCacheExpiry({
@@ -1460,16 +1737,17 @@ export async function resolveFirewallAuth(
   }
 
   if (failedConnectors.length > 0) {
-    return {
-      status: 502,
-      body: {
-        error: {
-          message: `OAuth token expired and refresh failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
-          code: "TOKEN_REFRESH_FAILED",
-          connectors: failedConnectors,
-        },
-      },
-    };
+    return tokenRefreshFailed(failedConnectors);
+  }
+
+  if (hasMissingResolvedSecrets(decryptedSecrets, referenced.secrets)) {
+    return tokenAccessResolutionFailed(
+      missingResolvedConnectorOwners({
+        secrets: decryptedSecrets,
+        referencedKeys: referenced.secrets,
+        secretConnectorMap: body.secretConnectorMap,
+      }),
+    );
   }
 
   const resolved = resolveTemplates(

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -9,7 +9,7 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type ConnectorType,
+  type ConnectorAuthProviderType,
 } from "@vm0/connectors/connectors";
 import {
   parseBasicAuthTemplates,
@@ -19,7 +19,8 @@ import {
 } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
-  refreshConnectorAccessToken,
+  hasConnectorAuthProvider,
+  refreshConnectorAuthProviderAccessToken,
   type ProviderEnv,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -247,7 +248,7 @@ interface RefreshTokenContext {
 type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
-      readonly connectorType: ConnectorType;
+      readonly connectorType: ConnectorAuthProviderType;
       readonly oauthClient: ConnectorOAuthClient;
       readonly context: RefreshTokenContext;
     }
@@ -797,6 +798,9 @@ function prepareRefreshTokenContext(
   if (!parsedConnectorType.success) {
     return { ok: false, reason: "not-refreshable" };
   }
+  if (!hasConnectorAuthProvider(parsedConnectorType.data)) {
+    return { ok: false, reason: "not-refreshable" };
+  }
   const oauthClient = getConnectorOAuthClient(
     parsedConnectorType.data,
     (name) => {
@@ -954,7 +958,7 @@ async function refreshAccessTokenForSource(
 
   const refreshPromise =
     prepared.sourceType === "connector"
-      ? refreshConnectorAccessToken({
+      ? refreshConnectorAuthProviderAccessToken({
           type: prepared.connectorType,
           oauthClient: prepared.oauthClient,
           refreshToken: prepared.context.currentRefreshToken,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1109,9 +1109,8 @@ function connectorAccessSecretName(
   switch (accessMetadata.kind) {
     case "refresh-token": {
       if (
-        key === accessMetadata.accessToken ||
         accessMetadata.envBindings[key] ===
-          `${CONNECTOR_SECRET_REF_PREFIX}${accessMetadata.accessToken}`
+        `${CONNECTOR_SECRET_REF_PREFIX}${accessMetadata.accessToken}`
       ) {
         return accessMetadata.accessToken;
       }
@@ -1119,15 +1118,9 @@ function connectorAccessSecretName(
     }
     case "static": {
       const valueRef = accessMetadata.envBindings[key];
-      if (valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX) === true) {
-        return valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
-      }
-      for (const candidate of Object.values(accessMetadata.envBindings)) {
-        if (candidate === `${CONNECTOR_SECRET_REF_PREFIX}${key}`) {
-          return key;
-        }
-      }
-      return undefined;
+      return valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX) === true
+        ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
+        : undefined;
     }
     case "none": {
       return undefined;

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1303,7 +1303,7 @@ function referencedConnectorTypes(args: {
   return [...connectorTypes];
 }
 
-function hasUnavailableConnectorSource(args: {
+function hasUnavailableAccessSource(args: {
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly secretConnectorMetadataMap:
     | Record<string, SecretConnectorMetadata>
@@ -1319,16 +1319,23 @@ function hasUnavailableConnectorSource(args: {
     if (!connectorType) {
       return false;
     }
-    const sourceType = resolveRefreshMetadata(
+    const metadata = resolveRefreshMetadata(
       connectorType,
       args.secretConnectorMetadataMap?.[key],
-    ).sourceType;
+    );
+    if (metadata.sourceType === "model-provider") {
+      return (
+        modelProviderAccessSecretName({
+          key,
+          connectorType,
+          metadata,
+        }) === undefined
+      );
+    }
+
     const accessMetadata =
       args.connectorAccessByType.get(connectorType)?.accessMetadata;
-    return (
-      sourceType === "connector" &&
-      (!accessMetadata || !isSelectedAccessSecretKey(key, accessMetadata))
-    );
+    return !accessMetadata || !isSelectedAccessSecretKey(key, accessMetadata);
   });
 }
 
@@ -1393,7 +1400,7 @@ async function prepareFirewallAuthResolutionContext(args: {
     featureSwitchContext: args.featureSwitchContext,
   });
   if (
-    hasUnavailableConnectorSource({
+    hasUnavailableAccessSource({
       secretConnectorMap: args.body.secretConnectorMap,
       secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
       referencedKeys: referenced.secrets,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,5 +1,9 @@
 import { Buffer } from "node:buffer";
 
+import {
+  getModelProviderEnvBindings,
+  modelProviderTypeSchema,
+} from "@vm0/api-contracts/contracts/model-providers";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
   getConnectorOAuthClient,
@@ -1128,6 +1132,35 @@ function connectorAccessSecretName(
   }
 }
 
+function modelProviderAccessSecretName(args: {
+  readonly key: string;
+  readonly connectorType: string;
+  readonly metadata: SecretConnectorMetadata;
+}): string | undefined {
+  const secretMetadata = getModelProviderOAuthSecretMetadata(
+    args.connectorType,
+  );
+  if (!secretMetadata?.isRefreshable) {
+    return undefined;
+  }
+
+  const providerType =
+    args.metadata.metadataKey ??
+    modelProviderTypeForOAuthProviderKey(args.connectorType);
+  const parsedProviderType = providerType
+    ? modelProviderTypeSchema.safeParse(providerType)
+    : undefined;
+  if (!parsedProviderType?.success) {
+    return undefined;
+  }
+
+  const envBindings = getModelProviderEnvBindings(parsedProviderType.data);
+  return envBindings?.[args.key] ===
+    `${CONNECTOR_SECRET_REF_PREFIX}${secretMetadata.accessSecretName}`
+    ? secretMetadata.accessSecretName
+    : undefined;
+}
+
 async function syncStaticConnectorAccessSecrets(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -1211,7 +1244,7 @@ async function syncStaticConnectorAccessSecrets(args: {
   }
 }
 
-function canResolveMissingConnectorAccessSecret(args: {
+function canResolveMissingAccessSecret(args: {
   readonly key: string;
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly secretConnectorMetadataMap:
@@ -1224,10 +1257,17 @@ function canResolveMissingConnectorAccessSecret(args: {
   if (!connectorType) {
     return false;
   }
-  const sourceType = resolveRefreshMetadata(connectorType, metadata).sourceType;
-  if (sourceType !== "connector") {
-    return false;
+  const refreshMetadata = resolveRefreshMetadata(connectorType, metadata);
+  if (refreshMetadata.sourceType === "model-provider") {
+    return (
+      modelProviderAccessSecretName({
+        key: args.key,
+        connectorType,
+        metadata: refreshMetadata,
+      }) !== undefined
+    );
   }
+
   const accessMetadata =
     args.connectorAccessByType.get(connectorType)?.accessMetadata;
   if (accessMetadata?.kind !== "refresh-token") {
@@ -1304,7 +1344,7 @@ function hasMissingUnresolvableSecrets(args: {
   return [...args.referencedKeys].some((key) => {
     return (
       !Object.hasOwn(args.secrets, key) &&
-      !canResolveMissingConnectorAccessSecret({
+      !canResolveMissingAccessSecret({
         key,
         secretConnectorMap: args.secretConnectorMap,
         secretConnectorMetadataMap: args.secretConnectorMetadataMap,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -53,11 +53,6 @@ import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
 type AccessSecretSource = "connector" | "model-provider";
 type SecretType = AccessSecretSource;
-type RefreshTokenAccessMetadata = Extract<
-  ConnectorAuthMethodAccessMetadata,
-  { readonly kind: "refresh-token" }
->;
-
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
 const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
@@ -1096,12 +1091,26 @@ function getOwnConnectorOwner(
 
 function isSelectedAccessSecretKey(
   key: string,
-  accessMetadata: RefreshTokenAccessMetadata,
+  accessMetadata: ConnectorAuthMethodAccessMetadata,
 ): boolean {
-  return (
-    key === accessMetadata.accessToken ||
-    accessMetadata.envBindings[key] === `$secrets.${accessMetadata.accessToken}`
-  );
+  switch (accessMetadata.kind) {
+    case "refresh-token": {
+      return (
+        key === accessMetadata.accessToken ||
+        accessMetadata.envBindings[key] ===
+          `$secrets.${accessMetadata.accessToken}`
+      );
+    }
+    case "static": {
+      return (
+        Object.hasOwn(accessMetadata.envBindings, key) &&
+        accessMetadata.envBindings[key]?.startsWith("$secrets.") === true
+      );
+    }
+    case "none": {
+      return false;
+    }
+  }
 }
 
 function canResolveMissingConnectorAccessSecret(args: {
@@ -1176,9 +1185,11 @@ function hasUnavailableConnectorSource(args: {
       connectorType,
       args.secretConnectorMetadataMap?.[key],
     ).sourceType;
+    const accessMetadata =
+      args.connectorAccessByType.get(connectorType)?.accessMetadata;
     return (
       sourceType === "connector" &&
-      !args.connectorAccessByType.has(connectorType)
+      (!accessMetadata || !isSelectedAccessSecretKey(key, accessMetadata))
     );
   });
 }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -86,6 +86,17 @@ interface RefreshExecutionResult {
   readonly status: "refreshed" | "failed";
 }
 
+interface ReferencedAuthKeys {
+  readonly secrets: Set<string>;
+  readonly vars: Set<string>;
+}
+
+interface FirewallAuthResolutionContext {
+  readonly referenced: ReferencedAuthKeys;
+  readonly vars: Record<string, string>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+}
+
 interface ResolveResult {
   readonly status: 200;
   readonly body: {
@@ -223,8 +234,7 @@ interface SecretTokenLookupArgs {
   readonly sourceType: AccessSecretSource;
   readonly sourceUserId?: string;
   readonly metadataKey?: string;
-  readonly authMethod?: string;
-  readonly accessKind?: SecretConnectorMetadata["accessKind"];
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
@@ -287,18 +297,22 @@ interface SyncRefreshTokensArgs {
   readonly userId: string;
   readonly secrets: Record<string, string>;
   readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
 interface RefreshExpiredTokensArgs {
   readonly db: Db;
   readonly auth: SandboxAuth;
+  readonly orgId: string;
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly secrets: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
   readonly secretConnectorMetadataMap?:
     | Record<string, SecretConnectorMetadata>
     | undefined;
   readonly referencedKeys: Set<string>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly forceRefresh: boolean;
 }
 
@@ -309,8 +323,14 @@ interface RefreshBatchContext {
   readonly userId: string;
   readonly secrets: Record<string, string>;
   readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly envVarsByConnector: Map<string, readonly string[]>;
   readonly featureSwitchContext: FeatureSwitchContext;
+}
+
+interface ConnectorAccessState {
+  readonly accessMetadata: ConnectorAuthMethodAccessMetadata;
+  readonly tokenExpiresAt: number | null;
 }
 
 interface BasicArgContext extends BasicAuthTemplateArg {
@@ -364,58 +384,7 @@ function resolveRefreshMetadata(
         ? (metadata?.metadataKey ??
           modelProviderTypeForOAuthProviderKey(connectorType))
         : undefined,
-    authMethod: sourceType === "connector" ? metadata?.authMethod : undefined,
-    accessKind: sourceType === "connector" ? metadata?.accessKind : undefined,
   };
-}
-
-function resolveConnectorType(
-  connectorType: string,
-): ConnectorType | undefined {
-  const parsed = connectorTypeSchema.safeParse(connectorType);
-  return parsed.success ? parsed.data : undefined;
-}
-
-function connectorAccessMetadataForSource(
-  connectorType: string,
-  metadata: Pick<
-    SecretConnectorMetadata,
-    "sourceType" | "authMethod" | "accessKind"
-  >,
-): ConnectorAuthMethodAccessMetadata | undefined {
-  if (metadata.sourceType !== "connector") {
-    return undefined;
-  }
-  const parsedConnectorType = resolveConnectorType(connectorType);
-  if (!parsedConnectorType) {
-    return undefined;
-  }
-  const authMethod = metadata.authMethod ?? "oauth";
-  const accessMetadata = getConnectorAuthMethodAccessMetadata(
-    parsedConnectorType,
-    authMethod,
-  );
-  if (!accessMetadata) {
-    return undefined;
-  }
-  if (metadata.accessKind && metadata.accessKind !== accessMetadata.kind) {
-    return undefined;
-  }
-  return accessMetadata;
-}
-
-function connectorRefreshAccessMetadataForSource(
-  connectorType: string,
-  metadata: Pick<
-    SecretConnectorMetadata,
-    "sourceType" | "authMethod" | "accessKind"
-  >,
-): RefreshTokenAccessMetadata | undefined {
-  const accessMetadata = connectorAccessMetadataForSource(
-    connectorType,
-    metadata,
-  );
-  return accessMetadata?.kind === "refresh-token" ? accessMetadata : undefined;
 }
 
 function currentProviderEnv(): ProviderEnv {
@@ -502,37 +471,37 @@ async function upsertSecretValue(
 function getRefreshSecretNameForSource(args: {
   readonly connectorType: string;
   readonly sourceType: AccessSecretSource;
-  readonly authMethod?: string;
-  readonly accessKind?: SecretConnectorMetadata["accessKind"];
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
 }): string | undefined {
   if (args.sourceType === "model-provider") {
     const metadata = getModelProviderOAuthSecretMetadata(args.connectorType);
     return metadata?.isRefreshable ? metadata.refreshSecretName : undefined;
   }
 
-  return connectorRefreshAccessMetadataForSource(args.connectorType, {
-    sourceType: args.sourceType,
-    authMethod: args.authMethod,
-    accessKind: args.accessKind,
-  })?.refreshToken;
+  const accessMetadata = args.connectorAccessByType.get(
+    args.connectorType,
+  )?.accessMetadata;
+  return accessMetadata?.kind === "refresh-token"
+    ? accessMetadata.refreshToken
+    : undefined;
 }
 
 function getAccessSecretNameForSource(args: {
   readonly connectorType: string;
   readonly sourceType: AccessSecretSource;
-  readonly authMethod?: string;
-  readonly accessKind?: SecretConnectorMetadata["accessKind"];
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
 }): string | undefined {
   if (args.sourceType === "model-provider") {
     return getModelProviderOAuthSecretMetadata(args.connectorType)
       ?.accessSecretName;
   }
 
-  return connectorRefreshAccessMetadataForSource(args.connectorType, {
-    sourceType: args.sourceType,
-    authMethod: args.authMethod,
-    accessKind: args.accessKind,
-  })?.accessToken;
+  const accessMetadata = args.connectorAccessByType.get(
+    args.connectorType,
+  )?.accessMetadata;
+  return accessMetadata?.kind === "refresh-token"
+    ? accessMetadata.accessToken
+    : undefined;
 }
 
 async function getConnectorRefreshToken(
@@ -597,8 +566,7 @@ async function syncRefreshTokensFromDb(
         sourceType: metadata.sourceType,
         sourceUserId: metadata.sourceUserId,
         metadataKey: metadata.metadataKey,
-        authMethod: metadata.authMethod,
-        accessKind: metadata.accessKind,
+        connectorAccessByType: args.connectorAccessByType,
         featureSwitchContext: args.featureSwitchContext,
       });
     }),
@@ -611,13 +579,13 @@ async function syncRefreshTokensFromDb(
   }
 }
 
-async function getConnectorExpiry(
+async function loadConnectorAccessStates(
   db: Db,
   orgId: string,
   userId: string,
   connectorTypes: readonly string[],
-): Promise<Map<string, number | null>> {
-  const result = new Map<string, number | null>();
+): Promise<Map<string, ConnectorAccessState>> {
+  const result = new Map<string, ConnectorAccessState>();
   if (connectorTypes.length === 0) {
     return result;
   }
@@ -625,6 +593,7 @@ async function getConnectorExpiry(
   const rows = await db
     .select({
       type: connectors.type,
+      authMethod: connectors.authMethod,
       tokenExpiresAt: connectors.tokenExpiresAt,
     })
     .from(connectors)
@@ -637,12 +606,23 @@ async function getConnectorExpiry(
     );
 
   for (const row of rows) {
-    result.set(
-      row.type,
-      row.tokenExpiresAt
+    const parsed = connectorTypeSchema.safeParse(row.type);
+    if (!parsed.success) {
+      continue;
+    }
+    const accessMetadata = getConnectorAuthMethodAccessMetadata(
+      parsed.data,
+      row.authMethod,
+    );
+    if (!accessMetadata) {
+      continue;
+    }
+    result.set(row.type, {
+      accessMetadata,
+      tokenExpiresAt: row.tokenExpiresAt
         ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
         : null,
-    );
+    });
   }
   return result;
 }
@@ -687,57 +667,61 @@ async function getModelProviderExpiry(
   return result;
 }
 
-async function getExpiryByProviderKey(
-  db: Db,
-  orgId: string,
-  userId: string,
-  connectorTypes: readonly string[],
-  metadataByConnector: Map<string, SecretConnectorMetadata>,
-): Promise<Map<string, number | null>> {
-  const connectorOnly = connectorTypes.filter((connectorType) => {
+async function getExpiryByProviderKey(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorTypes: readonly string[];
+  readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+}): Promise<Map<string, number | null>> {
+  const connectorOnly = args.connectorTypes.filter((connectorType) => {
     return (
       resolveRefreshMetadata(
         connectorType,
-        metadataByConnector.get(connectorType),
+        args.metadataByConnector.get(connectorType),
       ).sourceType === "connector"
     );
   });
-  const modelProviderOAuthProviderKeys = connectorTypes.filter(
+  const modelProviderOAuthProviderKeys = args.connectorTypes.filter(
     (connectorType) => {
       return (
         resolveRefreshMetadata(
           connectorType,
-          metadataByConnector.get(connectorType),
+          args.metadataByConnector.get(connectorType),
         ).sourceType === "model-provider"
       );
     },
   );
 
-  const [connectorExpiry, modelProviderEntries] = await Promise.all([
-    getConnectorExpiry(db, orgId, userId, connectorOnly),
-    Promise.all(
-      modelProviderOAuthProviderKeys.map(async (providerKey) => {
-        const metadata = resolveRefreshMetadata(
-          providerKey,
-          metadataByConnector.get(providerKey),
-        );
-        const metadataKey =
-          metadata.metadataKey ??
-          modelProviderTypeForOAuthProviderKey(providerKey) ??
-          providerKey;
-        const expiryMap = await getModelProviderExpiry(
-          db,
-          orgId,
-          userId,
-          [metadataKey],
-          { sourceUserId: metadata.sourceUserId },
-        );
-        return [providerKey, expiryMap.get(metadataKey) ?? null] as const;
-      }),
-    ),
-  ]);
+  const modelProviderEntries = await Promise.all(
+    modelProviderOAuthProviderKeys.map(async (providerKey) => {
+      const metadata = resolveRefreshMetadata(
+        providerKey,
+        args.metadataByConnector.get(providerKey),
+      );
+      const metadataKey =
+        metadata.metadataKey ??
+        modelProviderTypeForOAuthProviderKey(providerKey) ??
+        providerKey;
+      const expiryMap = await getModelProviderExpiry(
+        args.db,
+        args.orgId,
+        args.userId,
+        [metadataKey],
+        { sourceUserId: metadata.sourceUserId },
+      );
+      return [providerKey, expiryMap.get(metadataKey) ?? null] as const;
+    }),
+  );
 
-  const merged = new Map<string, number | null>(connectorExpiry);
+  const merged = new Map<string, number | null>();
+  for (const connectorType of connectorOnly) {
+    const state = args.connectorAccessByType.get(connectorType);
+    if (state) {
+      merged.set(connectorType, state.tokenExpiresAt);
+    }
+  }
   for (const [providerKey, expiry] of modelProviderEntries) {
     merged.set(providerKey, expiry);
   }
@@ -805,23 +789,25 @@ function prepareRefreshTokenContext(
     };
   }
 
-  const selectedAccess = connectorRefreshAccessMetadataForSource(
+  const accessMetadata = args.connectorAccessByType.get(
     args.connectorType,
-    args,
-  );
-  if (!selectedAccess) {
+  )?.accessMetadata;
+  if (accessMetadata?.kind !== "refresh-token") {
     L.debug(
       `${args.connectorType} does not use refresh-token access, skipping`,
     );
     return { ok: false, reason: "not-refreshable" };
   }
-  const connectorType = resolveConnectorType(args.connectorType);
-  if (!connectorType) {
+  const parsedConnectorType = connectorTypeSchema.safeParse(args.connectorType);
+  if (!parsedConnectorType.success) {
     return { ok: false, reason: "not-refreshable" };
   }
-  const oauthClient = getConnectorOAuthClient(connectorType, (name) => {
-    return optionalEnv(name);
-  });
+  const oauthClient = getConnectorOAuthClient(
+    parsedConnectorType.data,
+    (name) => {
+      return optionalEnv(name);
+    },
+  );
   if (!oauthClient) {
     L.debug(
       `${args.connectorType} OAuth client not configured, skipping token refresh`,
@@ -829,7 +815,7 @@ function prepareRefreshTokenContext(
     return { ok: false, reason: "client-unconfigured" };
   }
 
-  const refreshTokenSecret = selectedAccess.refreshToken;
+  const refreshTokenSecret = accessMetadata.refreshToken;
   const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
   if (!currentRefreshToken) {
     L.debug(`No ${args.connectorType} refresh token available, skipping`);
@@ -839,7 +825,7 @@ function prepareRefreshTokenContext(
   const context: RefreshTokenContext = {
     refreshTokenSecret,
     currentRefreshToken,
-    accessTokenSecret: selectedAccess.accessToken,
+    accessTokenSecret: accessMetadata.accessToken,
     secretUserId: resolveSecretUserId(
       args.sourceType,
       args.userId,
@@ -851,7 +837,7 @@ function prepareRefreshTokenContext(
     ok: true,
     prepared: {
       sourceType: "connector",
-      connectorType,
+      connectorType: parsedConnectorType.data,
       oauthClient,
       context,
     },
@@ -1074,6 +1060,7 @@ function buildRefreshableMap(
   secretConnectorMetadataMap:
     | Record<string, SecretConnectorMetadata>
     | undefined,
+  connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>,
   referencedKeys: Set<string>,
 ): Map<string, string> {
   const refreshable = new Map<string, string>();
@@ -1089,8 +1076,7 @@ function buildRefreshableMap(
     const refreshSecretName = getRefreshSecretNameForSource({
       connectorType,
       sourceType: metadata.sourceType,
-      authMethod: metadata.authMethod,
-      accessKind: metadata.accessKind,
+      connectorAccessByType,
     });
     if (refreshSecretName) {
       refreshable.set(key, connectorType);
@@ -1124,23 +1110,77 @@ function canResolveMissingConnectorAccessSecret(args: {
   readonly secretConnectorMetadataMap:
     | Record<string, SecretConnectorMetadata>
     | undefined;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
 }): boolean {
   const connectorType = getOwnConnectorOwner(args.secretConnectorMap, args.key);
   const metadata = args.secretConnectorMetadataMap?.[args.key];
-  if (
-    !connectorType ||
-    metadata?.sourceType !== "connector" ||
-    !metadata.authMethod
-  ) {
+  if (!connectorType) {
     return false;
   }
-  const accessMetadata = connectorRefreshAccessMetadataForSource(
-    connectorType,
-    metadata,
-  );
-  return accessMetadata
-    ? isSelectedAccessSecretKey(args.key, accessMetadata)
-    : false;
+  const sourceType = resolveRefreshMetadata(connectorType, metadata).sourceType;
+  if (sourceType !== "connector") {
+    return false;
+  }
+  const accessMetadata =
+    args.connectorAccessByType.get(connectorType)?.accessMetadata;
+  if (accessMetadata?.kind !== "refresh-token") {
+    return false;
+  }
+  return isSelectedAccessSecretKey(args.key, accessMetadata);
+}
+
+function referencedConnectorTypes(args: {
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+}): readonly string[] {
+  if (!args.secretConnectorMap) {
+    return [];
+  }
+  const connectorTypes = new Set<string>();
+  for (const key of args.referencedKeys) {
+    const connectorType = args.secretConnectorMap[key];
+    if (!connectorType) {
+      continue;
+    }
+    const sourceType = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    ).sourceType;
+    if (sourceType === "connector") {
+      connectorTypes.add(connectorType);
+    }
+  }
+  return [...connectorTypes];
+}
+
+function hasUnavailableConnectorSource(args: {
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+}): boolean {
+  if (!args.secretConnectorMap) {
+    return false;
+  }
+  return [...args.referencedKeys].some((key) => {
+    const connectorType = args.secretConnectorMap?.[key];
+    if (!connectorType) {
+      return false;
+    }
+    const sourceType = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    ).sourceType;
+    return (
+      sourceType === "connector" &&
+      !args.connectorAccessByType.has(connectorType)
+    );
+  });
 }
 
 function hasMissingUnresolvableSecrets(args: {
@@ -1150,6 +1190,7 @@ function hasMissingUnresolvableSecrets(args: {
   readonly secretConnectorMetadataMap:
     | Record<string, SecretConnectorMetadata>
     | undefined;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
 }): boolean {
   return [...args.referencedKeys].some((key) => {
     return (
@@ -1158,9 +1199,67 @@ function hasMissingUnresolvableSecrets(args: {
         key,
         secretConnectorMap: args.secretConnectorMap,
         secretConnectorMetadataMap: args.secretConnectorMetadataMap,
+        connectorAccessByType: args.connectorAccessByType,
       })
     );
   });
+}
+
+async function prepareFirewallAuthResolutionContext(args: {
+  readonly db: Db;
+  readonly auth: SandboxAuth;
+  readonly body: FirewallAuthBody;
+  readonly orgId: string;
+  readonly secrets: Record<string, string>;
+}): Promise<
+  | { readonly ok: true; readonly context: FirewallAuthResolutionContext }
+  | { readonly ok: false; readonly response: ResolveFirewallAuthResult }
+> {
+  const referenced = collectReferencedKeys(
+    args.body.authHeaders,
+    args.body.authBase,
+    args.body.authQuery,
+  );
+  const vars = args.body.vars ?? {};
+  const connectorAccessByType = await loadConnectorAccessStates(
+    args.db,
+    args.orgId,
+    args.auth.userId,
+    referencedConnectorTypes({
+      secretConnectorMap: args.body.secretConnectorMap,
+      secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+      referencedKeys: referenced.secrets,
+    }),
+  );
+  if (
+    hasUnavailableConnectorSource({
+      secretConnectorMap: args.body.secretConnectorMap,
+      secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+      referencedKeys: referenced.secrets,
+      connectorAccessByType,
+    })
+  ) {
+    return { ok: false, response: connectorNotConfigured() };
+  }
+
+  const hasMissingSecrets = hasMissingUnresolvableSecrets({
+    secrets: args.secrets,
+    referencedKeys: referenced.secrets,
+    secretConnectorMap: args.body.secretConnectorMap,
+    secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+    connectorAccessByType,
+  });
+  const hasMissingVars = [...referenced.vars].some((key) => {
+    return !Object.hasOwn(vars, key);
+  });
+  if (hasMissingSecrets || hasMissingVars) {
+    return { ok: false, response: connectorNotConfigured() };
+  }
+
+  return {
+    ok: true,
+    context: { referenced, vars, connectorAccessByType },
+  };
 }
 
 function hasMissingResolvedSecrets(
@@ -1204,7 +1303,12 @@ async function decryptFirewallAuthSecrets(
   auth: SandboxAuth,
   encryptedSecrets: string,
 ): Promise<
-  | { readonly ok: true; readonly secrets: Record<string, string> | null }
+  | {
+      readonly ok: true;
+      readonly orgId: string;
+      readonly featureSwitchContext: FeatureSwitchContext;
+      readonly secrets: Record<string, string> | null;
+    }
   | {
       readonly ok: false;
       readonly response: ReturnType<typeof badRequestMessage>;
@@ -1226,6 +1330,8 @@ async function decryptFirewallAuthSecrets(
   );
   return {
     ok: true,
+    orgId,
+    featureSwitchContext,
     secrets: decryptedResult.ok ? decryptedResult.value : null,
   };
 }
@@ -1281,9 +1387,8 @@ async function refreshSelectedTokens(
         sourceType: metadata.sourceType,
         sourceUserId: metadata.sourceUserId,
         metadataKey: metadata.metadataKey,
-        authMethod: metadata.authMethod,
-        accessKind: metadata.accessKind,
         connectorSecrets: context.secrets,
+        connectorAccessByType: context.connectorAccessByType,
         featureSwitchContext: context.featureSwitchContext,
       });
       if (!refreshResult.ok) {
@@ -1328,8 +1433,7 @@ async function syncSkippedTokens(
           sourceType: metadata.sourceType,
           sourceUserId: metadata.sourceUserId,
           metadataKey: metadata.metadataKey,
-          authMethod: metadata.authMethod,
-          accessKind: metadata.accessKind,
+          connectorAccessByType: context.connectorAccessByType,
           featureSwitchContext: context.featureSwitchContext,
         }),
       };
@@ -1403,36 +1507,26 @@ async function refreshExpiredTokens(
   const refreshable = buildRefreshableMap(
     args.secretConnectorMap,
     args.secretConnectorMetadataMap,
+    args.connectorAccessByType,
     args.referencedKeys,
   );
   if (refreshable.size === 0) {
     return emptyRefreshResult;
   }
 
-  const orgId = await findRefreshRunOrgId(args.db, args.auth);
-  if (!orgId) {
-    L.warn(`[${args.auth.runId}] Run not found for token refresh`);
-    return emptyRefreshResult;
-  }
-
-  const featureSwitchContext = await loadUserFeatureSwitchContext(
-    args.db,
-    orgId,
-    args.auth.userId,
-  );
-
   const connectorTypes = [...new Set(refreshable.values())];
   const metadataByConnector = buildMetadataByConnector(
     refreshable,
     args.secretConnectorMetadataMap,
   );
-  const expiryMap = await getExpiryByProviderKey(
-    args.db,
-    orgId,
-    args.auth.userId,
+  const expiryMap = await getExpiryByProviderKey({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.auth.userId,
     connectorTypes,
     metadataByConnector,
-  );
+    connectorAccessByType: args.connectorAccessByType,
+  });
   const toRefresh = connectorTypesNeedingRefresh({
     connectorTypes,
     expiryMap,
@@ -1443,22 +1537,24 @@ async function refreshExpiredTokens(
   await syncRefreshTokensFromDb({
     db: args.db,
     connectorTypes: toRefresh,
-    orgId,
+    orgId: args.orgId,
     userId: args.auth.userId,
     secrets: args.secrets,
     metadataByConnector,
-    featureSwitchContext,
+    connectorAccessByType: args.connectorAccessByType,
+    featureSwitchContext: args.featureSwitchContext,
   });
 
   const context = {
     db: args.db,
     auth: args.auth,
-    orgId,
+    orgId: args.orgId,
     userId: args.auth.userId,
     secrets: args.secrets,
     metadataByConnector,
+    connectorAccessByType: args.connectorAccessByType,
     envVarsByConnector,
-    featureSwitchContext,
+    featureSwitchContext: args.featureSwitchContext,
   } satisfies RefreshBatchContext;
   const refreshResults = await refreshSelectedTokens(context, toRefresh);
   const skippedTypes = connectorTypes.filter((connectorType) => {
@@ -1467,15 +1563,28 @@ async function refreshExpiredTokens(
   await syncSkippedTokens(context, skippedTypes);
 
   const summary = summarizeRefreshResults(refreshResults, envVarsByConnector);
+  const finalConnectorAccessByType =
+    summary.refreshedConnectors.length > 0
+      ? new Map([
+          ...args.connectorAccessByType,
+          ...(await loadConnectorAccessStates(
+            args.db,
+            args.orgId,
+            args.auth.userId,
+            connectorTypes,
+          )),
+        ])
+      : args.connectorAccessByType;
   const finalExpiryMap =
     summary.refreshedConnectors.length > 0
-      ? await getExpiryByProviderKey(
-          args.db,
-          orgId,
-          args.auth.userId,
+      ? await getExpiryByProviderKey({
+          db: args.db,
+          orgId: args.orgId,
+          userId: args.auth.userId,
           connectorTypes,
           metadataByConnector,
-        )
+          connectorAccessByType: finalConnectorAccessByType,
+        })
       : expiryMap;
 
   return {
@@ -1488,7 +1597,7 @@ function collectReferencedKeys(
   authHeaders: Record<string, string>,
   authBase?: string,
   authQuery?: Record<string, string>,
-): { readonly secrets: Set<string>; readonly vars: Set<string> } {
+): ReferencedAuthKeys {
   const secretKeys = new Set<string>();
   const varKeys = new Set<string>();
   const addKey = (namespace: string, key: string): void => {
@@ -1674,25 +1783,17 @@ export async function resolveFirewallAuth(
     return badRequestMessage("Failed to decrypt secrets");
   }
 
-  const referenced = collectReferencedKeys(
-    body.authHeaders,
-    body.authBase,
-    body.authQuery,
-  );
-  const vars = body.vars ?? {};
-
-  const hasMissingSecrets = hasMissingUnresolvableSecrets({
+  const prepared = await prepareFirewallAuthResolutionContext({
+    db,
+    auth,
+    body,
+    orgId: decrypted.orgId,
     secrets: decryptedSecrets,
-    referencedKeys: referenced.secrets,
-    secretConnectorMap: body.secretConnectorMap,
-    secretConnectorMetadataMap: body.secretConnectorMetadataMap,
   });
-  const hasMissingVars = [...referenced.vars].some((key) => {
-    return !Object.hasOwn(vars, key);
-  });
-  if (hasMissingSecrets || hasMissingVars) {
-    return connectorNotConfigured();
+  if (!prepared.ok) {
+    return prepared.response;
   }
+  const { connectorAccessByType, referenced, vars } = prepared.context;
 
   if (
     body.secretConnectorMap &&
@@ -1728,6 +1829,9 @@ export async function resolveFirewallAuth(
       secretConnectorMap: body.secretConnectorMap,
       secretConnectorMetadataMap: body.secretConnectorMetadataMap,
       referencedKeys: referenced.secrets,
+      connectorAccessByType,
+      orgId: decrypted.orgId,
+      featureSwitchContext: decrypted.featureSwitchContext,
       forceRefresh: body.forceRefresh ?? false,
     });
     expiresAt = result.expiresAt;

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -155,7 +155,7 @@ function tokenRefreshFailed(
     status: 502,
     body: {
       error: {
-        message: `OAuth token expired and refresh failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
+        message: `Access token expired and refresh failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
         code: "TOKEN_REFRESH_FAILED",
         connectors: failedConnectors,
       },

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,4 +1,4 @@
-import type { AuthorizationGrantConnectorType } from "@vm0/connectors/connectors";
+import type { ConnectorAuthProviderType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
@@ -21,7 +21,7 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: AuthorizationGrantConnectorType;
+    readonly connectorType: ConnectorAuthProviderType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
@@ -55,7 +55,7 @@ export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: AuthorizationGrantConnectorType;
+    readonly connectorType: ConnectorAuthProviderType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateClaimResult> {

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,4 +1,4 @@
-import type { OAuthGrantConnectorType } from "@vm0/connectors/connectors";
+import type { AuthorizationGrantConnectorType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
@@ -21,7 +21,7 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: OAuthGrantConnectorType;
+    readonly connectorType: AuthorizationGrantConnectorType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
@@ -55,7 +55,7 @@ export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: OAuthGrantConnectorType;
+    readonly connectorType: AuthorizationGrantConnectorType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateClaimResult> {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -28,7 +28,7 @@ import {
   connectorTypeSchema,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type AuthorizationGrantConnectorType,
+  type ConnectorAuthProviderType,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -1171,7 +1171,7 @@ function connectorTokenExpiresAt(args: {
 }
 
 function allowedOAuthConnectorSecretNames(
-  type: AuthorizationGrantConnectorType,
+  type: ConnectorAuthProviderType,
 ): Set<string> {
   return new Set(getConnectorSecretNames(type, "oauth"));
 }
@@ -1187,7 +1187,7 @@ function isOAuthPrimaryTokenSecret(args: {
 }
 
 function validateExtraOAuthConnectorSecrets(args: {
-  readonly type: AuthorizationGrantConnectorType;
+  readonly type: ConnectorAuthProviderType;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
   readonly accessSecretName: string;
   readonly refreshSecretName: string | undefined;
@@ -1221,7 +1221,7 @@ function validateExtraOAuthConnectorSecrets(args: {
 }
 
 async function encryptExtraOAuthConnectorSecrets(args: {
-  readonly type: AuthorizationGrantConnectorType;
+  readonly type: ConnectorAuthProviderType;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
@@ -1242,7 +1242,7 @@ async function encryptExtraOAuthConnectorSecrets(args: {
 }
 
 async function encryptOAuthConnectorSecretSet(args: {
-  readonly type: AuthorizationGrantConnectorType;
+  readonly type: ConnectorAuthProviderType;
   readonly accessSecretName: string;
   readonly accessToken: string;
   readonly refreshSecretName: string | undefined;
@@ -1336,7 +1336,7 @@ async function upsertOAuthConnectorRow(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: AuthorizationGrantConnectorType;
+    readonly type: ConnectorAuthProviderType;
     readonly userInfo: ExternalUserInfo;
     readonly oauthScopes: readonly string[];
     readonly tokenExpiresAt: Date | null;
@@ -1395,7 +1395,7 @@ async function deleteObsoleteConnectorScopedStateForOAuthConnect(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: AuthorizationGrantConnectorType;
+    readonly type: ConnectorAuthProviderType;
     readonly existingAuthMethod: string | null;
     readonly signal: AbortSignal;
   },
@@ -1440,7 +1440,7 @@ export const upsertOAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: AuthorizationGrantConnectorType;
+      readonly type: ConnectorAuthProviderType;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -28,7 +28,7 @@ import {
   connectorTypeSchema,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type OAuthGrantConnectorType,
+  type AuthorizationGrantConnectorType,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -1171,7 +1171,7 @@ function connectorTokenExpiresAt(args: {
 }
 
 function allowedOAuthConnectorSecretNames(
-  type: OAuthGrantConnectorType,
+  type: AuthorizationGrantConnectorType,
 ): Set<string> {
   return new Set(getConnectorSecretNames(type, "oauth"));
 }
@@ -1187,7 +1187,7 @@ function isOAuthPrimaryTokenSecret(args: {
 }
 
 function validateExtraOAuthConnectorSecrets(args: {
-  readonly type: OAuthGrantConnectorType;
+  readonly type: AuthorizationGrantConnectorType;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
   readonly accessSecretName: string;
   readonly refreshSecretName: string | undefined;
@@ -1221,7 +1221,7 @@ function validateExtraOAuthConnectorSecrets(args: {
 }
 
 async function encryptExtraOAuthConnectorSecrets(args: {
-  readonly type: OAuthGrantConnectorType;
+  readonly type: AuthorizationGrantConnectorType;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
@@ -1242,7 +1242,7 @@ async function encryptExtraOAuthConnectorSecrets(args: {
 }
 
 async function encryptOAuthConnectorSecretSet(args: {
-  readonly type: OAuthGrantConnectorType;
+  readonly type: AuthorizationGrantConnectorType;
   readonly accessSecretName: string;
   readonly accessToken: string;
   readonly refreshSecretName: string | undefined;
@@ -1336,7 +1336,7 @@ async function upsertOAuthConnectorRow(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: OAuthGrantConnectorType;
+    readonly type: AuthorizationGrantConnectorType;
     readonly userInfo: ExternalUserInfo;
     readonly oauthScopes: readonly string[];
     readonly tokenExpiresAt: Date | null;
@@ -1395,7 +1395,7 @@ async function deleteObsoleteConnectorScopedStateForOAuthConnect(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: OAuthGrantConnectorType;
+    readonly type: AuthorizationGrantConnectorType;
     readonly existingAuthMethod: string | null;
     readonly signal: AbortSignal;
   },
@@ -1440,7 +1440,7 @@ export const upsertOAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: OAuthGrantConnectorType;
+      readonly type: AuthorizationGrantConnectorType;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -700,7 +700,7 @@ export {
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorType,
-  type AuthorizationGrantConnectorType,
+  type ConnectorAuthProviderType,
   type ConnectorConfig,
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -700,7 +700,7 @@ export {
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorType,
-  type OAuthGrantConnectorType,
+  type AuthorizationGrantConnectorType,
   type ConnectorConfig,
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -151,7 +151,7 @@ export const storedExecutionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
-  // Maps access secret keys/env aliases to their connector or provider owner.
+  // Maps firewall auth secret env aliases to their connector or provider owner.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema
@@ -207,7 +207,7 @@ export const executionContextSchema = z.object({
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
   encryptedSecrets: z.string().nullable(),
-  // Maps access secret keys/env aliases to their connector or provider owner.
+  // Maps firewall auth secret env aliases to their connector or provider owner.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -151,7 +151,7 @@ export const storedExecutionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
-  // Maps runtime secret/env keys to connector or provider owner keys for access resolution.
+  // Maps refreshable secret keys/env aliases to their connector or provider owner.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -207,7 +207,7 @@ export const executionContextSchema = z.object({
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
   encryptedSecrets: z.string().nullable(),
-  // Maps runtime secret/env keys to connector or provider owner keys for access resolution.
+  // Maps refreshable secret keys/env aliases to their connector or provider owner.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -135,6 +135,7 @@ export const secretConnectorMetadataSchema = z.object({
   metadataKey: z.string().optional(),
 });
 
+// Keyed by the same firewall auth secret env aliases as secretConnectorMap.
 export const secretConnectorMetadataMapSchema = z.record(
   z.string(),
   secretConnectorMetadataSchema,
@@ -151,9 +152,11 @@ export const storedExecutionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
-  // Maps firewall auth secret env aliases to their connector or provider owner.
+  // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`) to
+  // their connector or provider owner. Keys are env aliases, not storage secret names.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
-  // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
+  // Same keys as secretConnectorMap; adds source details when the owner alone
+  // is not enough to locate access storage (for example, personal model providers).
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema
     .nullable()
     .optional(),
@@ -207,9 +210,11 @@ export const executionContextSchema = z.object({
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
   encryptedSecrets: z.string().nullable(),
-  // Maps firewall auth secret env aliases to their connector or provider owner.
+  // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`) to
+  // their connector or provider owner. Keys are env aliases, not storage secret names.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
-  // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
+  // Same keys as secretConnectorMap; adds source details when the owner alone
+  // is not enough to locate access storage (for example, personal model providers).
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema
     .nullable()
     .optional(),

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -151,7 +151,10 @@ export const storedExecutionContextSchema = z.object({
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
-  encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
+  // AES-256-GCM encrypted Record<string, string>. Keys are the runtime secret
+  // names used by `${{ secrets.NAME }}`; connector/model-provider keys are env
+  // aliases, not backing storage secret names.
+  encryptedSecrets: z.string().nullable(),
   // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`) to
   // their connector or provider owner. Keys are env aliases, not storage secret names.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
@@ -207,8 +210,13 @@ export const executionContextSchema = z.object({
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
+  // Plain secret values used by the runner for redaction. These are values, not
+  // names, and are base64-encoded only when exported through VM0_SECRET_VALUES.
   secretValues: z.array(z.string()).nullable(),
-  // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
+  // AES-256-GCM encrypted Record<string, string>, passed through to mitm-addon
+  // for auth resolution. Keys are runtime secret names used by
+  // `${{ secrets.NAME }}`; connector/model-provider keys are env aliases, not
+  // backing storage secret names.
   encryptedSecrets: z.string().nullable(),
   // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`) to
   // their connector or provider owner. Keys are env aliases, not storage secret names.

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -151,7 +151,7 @@ export const storedExecutionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
-  // Maps refreshable secret keys/env aliases to their connector or provider owner.
+  // Maps access secret keys/env aliases to their connector or provider owner.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema
@@ -207,7 +207,7 @@ export const executionContextSchema = z.object({
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
   encryptedSecrets: z.string().nullable(),
-  // Maps refreshable secret keys/env aliases to their connector or provider owner.
+  // Maps access secret keys/env aliases to their connector or provider owner.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -133,8 +133,6 @@ export const secretConnectorMetadataSchema = z.object({
   sourceType: z.enum(["connector", "model-provider"]),
   sourceUserId: z.string().optional(),
   metadataKey: z.string().optional(),
-  authMethod: z.string().optional(),
-  accessKind: z.enum(["static", "refresh-token", "none"]).optional(),
 });
 
 export const secretConnectorMetadataMapSchema = z.record(

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -133,6 +133,8 @@ export const secretConnectorMetadataSchema = z.object({
   sourceType: z.enum(["connector", "model-provider"]),
   sourceUserId: z.string().optional(),
   metadataKey: z.string().optional(),
+  authMethod: z.string().optional(),
+  accessKind: z.enum(["static", "refresh-token", "none"]).optional(),
 });
 
 export const secretConnectorMetadataMapSchema = z.record(
@@ -151,7 +153,7 @@ export const storedExecutionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
-  // Maps secret names to OAuth connector types for runtime token refresh (e.g. { "GMAIL_ACCESS_TOKEN": "gmail" })
+  // Maps runtime secret/env keys to connector or provider owner keys for access resolution.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema
@@ -207,7 +209,7 @@ export const executionContextSchema = z.object({
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
   encryptedSecrets: z.string().nullable(),
-  // Maps secret names to OAuth connector types for runtime token refresh
+  // Maps runtime secret/env keys to connector or provider owner keys for access resolution.
   secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   // Per-secret refresh metadata, used when a handler needs owner-specific storage (e.g. personal model providers)
   secretConnectorMetadataMap: secretConnectorMetadataMapSchema

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -199,6 +199,8 @@ export const webhookFirewallAuthContract = c.router({
     path: "/api/webhooks/agent/firewall/auth",
     headers: authHeadersSchema,
     body: z.object({
+      // Encrypted runtime secret namespace. After decryption, keys are the
+      // `NAME` in `${{ secrets.NAME }}`.
       encryptedSecrets: z.string().min(1),
       authHeaders: z.record(z.string(), z.string()),
       authBase: z.string().optional(),

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -180,7 +180,7 @@ const firewallAuthResponseSchema = z.object({
   headers: z.record(z.string(), z.string()),
   base: z.string().optional(),
   query: z.record(z.string(), z.string()).optional(),
-  // Effective addon cache expiry as Unix seconds. OAuth token expiry is the
+  // Effective addon cache expiry as Unix seconds. Access token expiry is the
   // normal source; billable firewall auth can shorten it to force credit
   // re-authorization. Null means non-expiring only for non-billable auth.
   expiresAt: z.number().nullable(),
@@ -192,7 +192,7 @@ const firewallAuthResponseSchema = z.object({
 export const webhookFirewallAuthContract = c.router({
   /**
    * POST /api/webhooks/agent/firewall/auth
-   * Resolve firewall auth templates and refresh OAuth tokens on demand.
+   * Resolve firewall auth templates and refresh access tokens on demand.
    */
   resolve: {
     method: "POST",

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -203,7 +203,11 @@ export const webhookFirewallAuthContract = c.router({
       authHeaders: z.record(z.string(), z.string()),
       authBase: z.string().optional(),
       authQuery: z.record(z.string(), z.string()).optional(),
+      // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`)
+      // to the connector or provider owner that can refresh/resolve access.
       secretConnectorMap: z.record(z.string(), z.string()).optional(),
+      // Same keys as secretConnectorMap; adds source details when the owner
+      // alone is not enough to locate access storage.
       secretConnectorMetadataMap: secretConnectorMetadataMapSchema.optional(),
       vars: z.record(z.string(), z.string()).optional(),
       // Set by mitm from billableFirewalls. Server uses this only to bound

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -60,7 +60,7 @@ import {
   hasConnectorDeviceAuthGrantProvider,
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
-  refreshConnectorOAuthToken,
+  refreshConnectorAccessToken,
   revokeConnectorOAuthToken,
   startConnectorOAuthDeviceAuth,
 } from "../auth-providers/connector-auth";
@@ -479,12 +479,12 @@ describe("connector grant provider capability checks", () => {
     }
 
     await expect(
-      refreshConnectorOAuthToken({
+      refreshConnectorAccessToken({
         type: "github",
         oauthClient,
         refreshToken: "refresh-token",
       }),
-    ).rejects.toThrow("github OAuth provider does not support refresh");
+    ).rejects.toThrow("github connector does not support token refresh");
   });
 
   it("revokes OAuth tokens through the provider registry", async () => {
@@ -973,7 +973,7 @@ describe("connector grant provider capability checks", () => {
     });
 
     await expect(
-      refreshConnectorOAuthToken({
+      refreshConnectorAccessToken({
         type: "base44",
         oauthClient,
         refreshToken: "base44-refresh-rotation",
@@ -984,7 +984,7 @@ describe("connector grant provider capability checks", () => {
       expiresIn: 3600,
     });
     await expect(
-      refreshConnectorOAuthToken({
+      refreshConnectorAccessToken({
         type: "base44",
         oauthClient,
         refreshToken: "base44-refresh-without-rotation",
@@ -1305,7 +1305,7 @@ describe("connector grant provider capability checks", () => {
       },
     });
 
-    const refreshResult = await refreshConnectorOAuthToken({
+    const refreshResult = await refreshConnectorAccessToken({
       type: "slock",
       oauthClient,
       refreshToken: "slock-refresh-token",
@@ -1324,7 +1324,7 @@ describe("connector grant provider capability checks", () => {
     );
 
     await expect(
-      refreshConnectorOAuthToken({
+      refreshConnectorAccessToken({
         type: "slock",
         oauthClient,
         refreshToken: "slock-refresh-malformed",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -56,6 +56,7 @@ import {
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorOAuthAuthUrl,
+  getConnectorAuthProviderClientArgs,
   hasConnectorAuthCodeGrantProvider,
   hasConnectorDeviceAuthGrantProvider,
   getConnectorOAuthSecretMetadata,
@@ -481,7 +482,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "github",
-        oauthClient,
+        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "refresh-token",
       }),
     ).rejects.toThrow("github connector does not support token refresh");
@@ -975,7 +976,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "base44",
-        oauthClient,
+        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "base44-refresh-rotation",
       }),
     ).resolves.toStrictEqual({
@@ -986,7 +987,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "base44",
-        oauthClient,
+        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "base44-refresh-without-rotation",
       }),
     ).resolves.toStrictEqual({
@@ -1307,7 +1308,7 @@ describe("connector grant provider capability checks", () => {
 
     const refreshResult = await refreshConnectorAuthProviderAccessToken({
       type: "slock",
-      oauthClient,
+      clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
       refreshToken: "slock-refresh-token",
     });
     expect(refreshResult).toStrictEqual({
@@ -1326,7 +1327,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "slock",
-        oauthClient,
+        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "slock-refresh-malformed",
       }),
     ).resolves.toStrictEqual({

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1439,6 +1439,42 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       getConnectorAuthMethodAccessMetadata("stripe", "missing"),
     ).toBeUndefined();
   });
+
+  it("keeps OAuth provider secret metadata aligned with OAuth access metadata", () => {
+    for (const type of connectorTypeSchema.options) {
+      if (!hasConnectorAuthorizationGrant(type)) {
+        continue;
+      }
+
+      const providerMetadata = getConnectorOAuthSecretMetadata(type);
+      if (!providerMetadata) {
+        throw new Error(`${type}: OAuth provider metadata is missing`);
+      }
+
+      const accessMetadata = getConnectorAuthMethodAccessMetadata(
+        type,
+        "oauth",
+      );
+
+      if (providerMetadata.isRefreshable) {
+        expect(
+          accessMetadata,
+          `${type}: refreshable OAuth provider must use refresh-token access`,
+        ).toEqual(
+          expect.objectContaining({
+            kind: "refresh-token",
+            accessToken: providerMetadata.accessSecretName,
+            refreshToken: providerMetadata.refreshSecretName,
+          }),
+        );
+      } else {
+        expect(
+          accessMetadata,
+          `${type}: non-refreshable OAuth provider must not use refresh-token access`,
+        ).not.toEqual(expect.objectContaining({ kind: "refresh-token" }));
+      }
+    }
+  });
 });
 
 describe("getConnectorVariableNames", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -60,7 +60,7 @@ import {
   hasConnectorDeviceAuthGrantProvider,
   getConnectorOAuthSecretMetadata,
   pollConnectorOAuthDeviceAuth,
-  refreshConnectorAccessToken,
+  refreshConnectorAuthProviderAccessToken,
   revokeConnectorOAuthToken,
   startConnectorOAuthDeviceAuth,
 } from "../auth-providers/connector-auth";
@@ -479,7 +479,7 @@ describe("connector grant provider capability checks", () => {
     }
 
     await expect(
-      refreshConnectorAccessToken({
+      refreshConnectorAuthProviderAccessToken({
         type: "github",
         oauthClient,
         refreshToken: "refresh-token",
@@ -973,7 +973,7 @@ describe("connector grant provider capability checks", () => {
     });
 
     await expect(
-      refreshConnectorAccessToken({
+      refreshConnectorAuthProviderAccessToken({
         type: "base44",
         oauthClient,
         refreshToken: "base44-refresh-rotation",
@@ -984,7 +984,7 @@ describe("connector grant provider capability checks", () => {
       expiresIn: 3600,
     });
     await expect(
-      refreshConnectorAccessToken({
+      refreshConnectorAuthProviderAccessToken({
         type: "base44",
         oauthClient,
         refreshToken: "base44-refresh-without-rotation",
@@ -1305,7 +1305,7 @@ describe("connector grant provider capability checks", () => {
       },
     });
 
-    const refreshResult = await refreshConnectorAccessToken({
+    const refreshResult = await refreshConnectorAuthProviderAccessToken({
       type: "slock",
       oauthClient,
       refreshToken: "slock-refresh-token",
@@ -1324,7 +1324,7 @@ describe("connector grant provider capability checks", () => {
     );
 
     await expect(
-      refreshConnectorAccessToken({
+      refreshConnectorAuthProviderAccessToken({
         type: "slock",
         oauthClient,
         refreshToken: "slock-refresh-malformed",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -35,6 +35,7 @@ import {
   hasRequiredScopes,
   hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthCodeGrantConfig,
+  getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorDeviceAuthGrantConfig,
@@ -1407,6 +1408,36 @@ describe("getConnectorAuthMethodEnvBindings", () => {
 
   it("returns empty env bindings for an unknown auth method", () => {
     expect(getConnectorAuthMethodEnvBindings("ahrefs", "missing")).toEqual({});
+  });
+});
+
+describe("getConnectorAuthMethodAccessMetadata", () => {
+  it("returns refresh-token access metadata for the selected OAuth method", () => {
+    expect(getConnectorAuthMethodAccessMetadata("stripe", "oauth")).toEqual({
+      kind: "refresh-token",
+      accessToken: "STRIPE_ACCESS_TOKEN",
+      refreshToken: "STRIPE_REFRESH_TOKEN",
+      envBindings: {
+        STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
+      },
+    });
+  });
+
+  it("returns static access metadata for the selected API-token method", () => {
+    expect(getConnectorAuthMethodAccessMetadata("stripe", "api-token")).toEqual(
+      {
+        kind: "static",
+        envBindings: {
+          STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+        },
+      },
+    );
+  });
+
+  it("returns undefined for an unknown auth method", () => {
+    expect(
+      getConnectorAuthMethodAccessMetadata("stripe", "missing"),
+    ).toBeUndefined();
   });
 });
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -355,6 +355,23 @@ export async function refreshConnectorOAuthToken<
   }
 }
 
+export async function refreshConnectorAccessToken(args: {
+  readonly type: ConnectorType;
+  readonly oauthClient: ConnectorOAuthClient;
+  readonly refreshToken: string;
+}): Promise<OAuthRefreshResult> {
+  if (!hasConnectorOAuthProvider(args.type)) {
+    throw new Error(
+      `${args.type} connector does not have a refresh-token access provider`,
+    );
+  }
+  return await refreshConnectorOAuthToken({
+    type: args.type,
+    oauthClient: args.oauthClient,
+    refreshToken: args.refreshToken,
+  });
+}
+
 export async function revokeConnectorOAuthToken<
   T extends OAuthGrantConnectorType,
 >(args: {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -219,7 +219,7 @@ const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap
     "test-oauth-device": testOauthDeviceProvider,
   };
 
-function hasConnectorAuthProvider(
+export function hasConnectorAuthProvider(
   type: string,
 ): type is ConnectorAuthProviderType {
   return (
@@ -334,7 +334,7 @@ export async function pollConnectorOAuthDeviceAuth<
   } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
 
-async function refreshConnectorProviderAccessToken<
+export async function refreshConnectorAuthProviderAccessToken<
   T extends ConnectorAuthProviderType,
 >(args: {
   readonly type: T;
@@ -353,21 +353,6 @@ async function refreshConnectorProviderAccessToken<
         refreshToken: args.refreshToken,
       } as ConnectorOAuthRefreshArgs<T>);
   }
-}
-
-export async function refreshConnectorAccessToken(args: {
-  readonly type: ConnectorType;
-  readonly oauthClient: ConnectorOAuthClient;
-  readonly refreshToken: string;
-}): Promise<OAuthRefreshResult> {
-  if (!hasConnectorAuthProvider(args.type)) {
-    throw new Error(`${args.type} connector does not have an auth provider`);
-  }
-  return await refreshConnectorProviderAccessToken({
-    type: args.type,
-    oauthClient: args.oauthClient,
-    refreshToken: args.refreshToken,
-  });
 }
 
 export async function revokeConnectorOAuthToken<

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,7 +1,7 @@
 import type {
   ConnectorType,
   AuthCodeGrantConnectorType,
-  AuthorizationGrantConnectorType,
+  ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -125,7 +125,7 @@ function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   return DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type];
 }
 
-function connectorAccessProviderFor<T extends AuthorizationGrantConnectorType>(
+function connectorAccessProviderFor<T extends ConnectorAuthProviderType>(
   type: T,
 ): ConnectorAuthProviderAccess<T> {
   if (hasConnectorAuthCodeGrant(type)) {
@@ -137,7 +137,7 @@ function connectorAccessProviderFor<T extends AuthorizationGrantConnectorType>(
     .access as ConnectorAuthProviderAccess<T>;
 }
 
-function connectorRevokeProviderFor<T extends AuthorizationGrantConnectorType>(
+function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
   type: T,
 ): ConnectorAuthProviderRevoke<T> {
   if (hasConnectorAuthCodeGrant(type)) {
@@ -219,9 +219,9 @@ const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap
     "test-oauth-device": testOauthDeviceProvider,
   };
 
-function hasConnectorAuthorizationGrantProvider(
+function hasConnectorAuthProvider(
   type: string,
-): type is AuthorizationGrantConnectorType {
+): type is ConnectorAuthProviderType {
   return (
     hasConnectorAuthCodeGrantProvider(type) ||
     hasConnectorDeviceAuthGrantProvider(type)
@@ -241,7 +241,7 @@ export function hasConnectorDeviceAuthGrantProvider(
 }
 
 export function getConnectorOAuthSecretMetadata(
-  type: AuthorizationGrantConnectorType,
+  type: ConnectorAuthProviderType,
 ): ConnectorOAuthSecretMetadata;
 export function getConnectorOAuthSecretMetadata(
   type: string,
@@ -335,7 +335,7 @@ export async function pollConnectorOAuthDeviceAuth<
 }
 
 async function refreshConnectorProviderAccessToken<
-  T extends AuthorizationGrantConnectorType,
+  T extends ConnectorAuthProviderType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -360,10 +360,8 @@ export async function refreshConnectorAccessToken(args: {
   readonly oauthClient: ConnectorOAuthClient;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  if (!hasConnectorAuthorizationGrantProvider(args.type)) {
-    throw new Error(
-      `${args.type} connector does not have an authorization grant provider`,
-    );
+  if (!hasConnectorAuthProvider(args.type)) {
+    throw new Error(`${args.type} connector does not have an auth provider`);
   }
   return await refreshConnectorProviderAccessToken({
     type: args.type,
@@ -373,7 +371,7 @@ export async function refreshConnectorAccessToken(args: {
 }
 
 export async function revokeConnectorOAuthToken<
-  T extends AuthorizationGrantConnectorType,
+  T extends ConnectorAuthProviderType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -119,6 +119,11 @@ type DeviceAuthConnectorOAuthProviderMap = {
 
 export type ConnectorOAuthSecretMetadata = AuthProviderSecretMetadata;
 
+export interface ConnectorAuthProviderClientArgs {
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+}
+
 function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   type: T,
 ): DeviceAuthConnectorOAuthProviderMap[T] {
@@ -149,9 +154,9 @@ function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
     .revoke as ConnectorAuthProviderRevoke<T>;
 }
 
-function connectorOAuthClientArgs(
+function connectorAuthProviderClientArgs(
   oauthClient: ConnectorOAuthClient,
-): Pick<OAuthExchangeArgs, "clientId" | "clientSecret"> {
+): ConnectorAuthProviderClientArgs {
   if (!isStaticConnectorOAuthClient(oauthClient)) {
     return {};
   }
@@ -162,6 +167,12 @@ function connectorOAuthClientArgs(
     };
   }
   return { clientId: oauthClient.clientId };
+}
+
+export function getConnectorAuthProviderClientArgs(
+  oauthClient: ConnectorOAuthClient,
+): ConnectorAuthProviderClientArgs {
+  return connectorAuthProviderClientArgs(oauthClient);
 }
 
 const AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS: AuthCodeConnectorOAuthProviderMap = {
@@ -275,7 +286,7 @@ export async function buildConnectorOAuthAuthUrl<
   return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.buildAuthUrl({
-    ...connectorOAuthClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.oauthClient),
     redirectUri: args.redirectUri,
     state: args.state,
   } as ConnectorOAuthAuthorizeArgs<T>);
@@ -295,7 +306,7 @@ export async function exchangeConnectorOAuthCode<
   return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.exchangeCode({
-    ...connectorOAuthClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.oauthClient),
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,
@@ -314,7 +325,7 @@ export async function startConnectorOAuthDeviceAuth<
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.startDeviceAuth({
-    ...connectorOAuthClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.oauthClient),
     scopes: grant.scopes,
   } as ConnectorOAuthDeviceAuthStartArgs<T>);
 }
@@ -329,7 +340,7 @@ export async function pollConnectorOAuthDeviceAuth<
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.pollDeviceAuth({
-    ...connectorOAuthClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.oauthClient),
     deviceCode: args.deviceCode,
   } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
@@ -338,7 +349,7 @@ export async function refreshConnectorAuthProviderAccessToken<
   T extends ConnectorAuthProviderType,
 >(args: {
   readonly type: T;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly clientArgs: ConnectorAuthProviderClientArgs;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
   const access = connectorAccessProviderFor(args.type);
@@ -349,7 +360,7 @@ export async function refreshConnectorAuthProviderAccessToken<
 
     case "refresh-token":
       return await access.refreshToken({
-        ...connectorOAuthClientArgs(args.oauthClient),
+        ...args.clientArgs,
         refreshToken: args.refreshToken,
       } as ConnectorOAuthRefreshArgs<T>);
   }
@@ -370,7 +381,7 @@ export async function revokeConnectorOAuthToken<
 
     case "token-revoke":
       await revoke.revokeToken({
-        ...connectorOAuthClientArgs(args.oauthClient),
+        ...connectorAuthProviderClientArgs(args.oauthClient),
         accessToken: await args.loadAccessToken(),
       } as ConnectorOAuthRevokeArgs<T>);
       return { status: "revoked" };

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,7 +1,7 @@
 import type {
   ConnectorType,
   AuthCodeGrantConnectorType,
-  OAuthGrantConnectorType,
+  AuthorizationGrantConnectorType,
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -18,8 +18,8 @@ import {
 import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
-  OAuthConnectorAccessProvider,
-  OAuthConnectorRevokeProvider,
+  ConnectorAuthProviderAccess,
+  ConnectorAuthProviderRevoke,
 } from "./types";
 import {
   type AuthUrlResult,
@@ -125,28 +125,28 @@ function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   return DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type];
 }
 
-function connectorAccessProviderFor<T extends OAuthGrantConnectorType>(
+function connectorAccessProviderFor<T extends AuthorizationGrantConnectorType>(
   type: T,
-): OAuthConnectorAccessProvider<T> {
+): ConnectorAuthProviderAccess<T> {
   if (hasConnectorAuthCodeGrant(type)) {
     return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type]
-      .access as OAuthConnectorAccessProvider<T>;
+      .access as ConnectorAuthProviderAccess<T>;
   }
 
   return deviceAuthConnectorProviderFor(type)
-    .access as OAuthConnectorAccessProvider<T>;
+    .access as ConnectorAuthProviderAccess<T>;
 }
 
-function connectorRevokeProviderFor<T extends OAuthGrantConnectorType>(
+function connectorRevokeProviderFor<T extends AuthorizationGrantConnectorType>(
   type: T,
-): OAuthConnectorRevokeProvider<T> {
+): ConnectorAuthProviderRevoke<T> {
   if (hasConnectorAuthCodeGrant(type)) {
     return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type]
-      .revoke as OAuthConnectorRevokeProvider<T>;
+      .revoke as ConnectorAuthProviderRevoke<T>;
   }
 
   return deviceAuthConnectorProviderFor(type)
-    .revoke as OAuthConnectorRevokeProvider<T>;
+    .revoke as ConnectorAuthProviderRevoke<T>;
 }
 
 function connectorOAuthClientArgs(
@@ -221,7 +221,7 @@ const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap
 
 function hasConnectorAuthorizationGrantProvider(
   type: string,
-): type is OAuthGrantConnectorType {
+): type is AuthorizationGrantConnectorType {
   return (
     hasConnectorAuthCodeGrantProvider(type) ||
     hasConnectorDeviceAuthGrantProvider(type)
@@ -241,7 +241,7 @@ export function hasConnectorDeviceAuthGrantProvider(
 }
 
 export function getConnectorOAuthSecretMetadata(
-  type: OAuthGrantConnectorType,
+  type: AuthorizationGrantConnectorType,
 ): ConnectorOAuthSecretMetadata;
 export function getConnectorOAuthSecretMetadata(
   type: string,
@@ -335,7 +335,7 @@ export async function pollConnectorOAuthDeviceAuth<
 }
 
 async function refreshConnectorProviderAccessToken<
-  T extends OAuthGrantConnectorType,
+  T extends AuthorizationGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;
@@ -373,7 +373,7 @@ export async function refreshConnectorAccessToken(args: {
 }
 
 export async function revokeConnectorOAuthToken<
-  T extends OAuthGrantConnectorType,
+  T extends AuthorizationGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly oauthClient: ConnectorOAuthClient;

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -219,7 +219,7 @@ const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap
     "test-oauth-device": testOauthDeviceProvider,
   };
 
-export function hasConnectorOAuthProvider(
+function hasConnectorAuthorizationGrantProvider(
   type: string,
 ): type is OAuthGrantConnectorType {
   return (
@@ -334,7 +334,7 @@ export async function pollConnectorOAuthDeviceAuth<
   } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
 
-export async function refreshConnectorOAuthToken<
+async function refreshConnectorProviderAccessToken<
   T extends OAuthGrantConnectorType,
 >(args: {
   readonly type: T;
@@ -345,7 +345,7 @@ export async function refreshConnectorOAuthToken<
 
   switch (access.kind) {
     case "none":
-      throw new Error(`${args.type} OAuth provider does not support refresh`);
+      throw new Error(`${args.type} connector does not support token refresh`);
 
     case "refresh-token":
       return await access.refreshToken({
@@ -360,12 +360,12 @@ export async function refreshConnectorAccessToken(args: {
   readonly oauthClient: ConnectorOAuthClient;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  if (!hasConnectorOAuthProvider(args.type)) {
+  if (!hasConnectorAuthorizationGrantProvider(args.type)) {
     throw new Error(
-      `${args.type} connector does not have a refresh-token access provider`,
+      `${args.type} connector does not have an authorization grant provider`,
     );
   }
-  return await refreshConnectorOAuthToken({
+  return await refreshConnectorProviderAccessToken({
     type: args.type,
     oauthClient: args.oauthClient,
     refreshToken: args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,7 +1,7 @@
 import type {
   CONNECTOR_TYPES,
   ConnectorOAuthClientConfig,
-  OAuthGrantConnectorType,
+  AuthorizationGrantConnectorType,
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 
@@ -128,7 +128,7 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorOAuthClientFor<T extends OAuthGrantConnectorType> = {
+type ConnectorOAuthClientFor<T extends AuthorizationGrantConnectorType> = {
   [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
     readonly grant: {
       readonly kind: "auth-code" | "device-auth";
@@ -160,17 +160,21 @@ type TokenCredentialArgs<Client extends ConnectorOAuthClientConfig> =
       ? { readonly clientId: string }
       : NoClientCredentialArgs;
 
-export type ConnectorOAuthAuthorizeArgs<T extends OAuthGrantConnectorType> =
-  OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthAuthorizeArgs<
+  T extends AuthorizationGrantConnectorType,
+> = OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthExchangeArgs<T extends OAuthGrantConnectorType> =
-  OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthExchangeArgs<
+  T extends AuthorizationGrantConnectorType,
+> = OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthRefreshArgs<T extends OAuthGrantConnectorType> =
-  OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthRefreshArgs<
+  T extends AuthorizationGrantConnectorType,
+> = OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthRevokeArgs<T extends OAuthGrantConnectorType> =
-  OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthRevokeArgs<
+  T extends AuthorizationGrantConnectorType,
+> = OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
 export type ConnectorOAuthDeviceAuthStartArgs<
   T extends DeviceAuthGrantConnectorType,

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,7 +1,7 @@
 import type {
   CONNECTOR_TYPES,
   ConnectorOAuthClientConfig,
-  AuthorizationGrantConnectorType,
+  ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 
@@ -128,7 +128,7 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorOAuthClientFor<T extends AuthorizationGrantConnectorType> = {
+type ConnectorOAuthClientFor<T extends ConnectorAuthProviderType> = {
   [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
     readonly grant: {
       readonly kind: "auth-code" | "device-auth";
@@ -160,21 +160,17 @@ type TokenCredentialArgs<Client extends ConnectorOAuthClientConfig> =
       ? { readonly clientId: string }
       : NoClientCredentialArgs;
 
-export type ConnectorOAuthAuthorizeArgs<
-  T extends AuthorizationGrantConnectorType,
-> = OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthAuthorizeArgs<T extends ConnectorAuthProviderType> =
+  OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthExchangeArgs<
-  T extends AuthorizationGrantConnectorType,
-> = OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthExchangeArgs<T extends ConnectorAuthProviderType> =
+  OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthRefreshArgs<
-  T extends AuthorizationGrantConnectorType,
-> = OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthRefreshArgs<T extends ConnectorAuthProviderType> =
+  OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
-export type ConnectorOAuthRevokeArgs<
-  T extends AuthorizationGrantConnectorType,
-> = OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+export type ConnectorOAuthRevokeArgs<T extends ConnectorAuthProviderType> =
+  OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
 
 export type ConnectorOAuthDeviceAuthStartArgs<
   T extends DeviceAuthGrantConnectorType,

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,6 +1,6 @@
 import type {
   AuthCodeGrantConnectorType,
-  AuthorizationGrantConnectorType,
+  ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
 } from "../connectors";
 import type {
@@ -48,7 +48,7 @@ export interface NoneAccessProvider {
 }
 
 export interface RefreshTokenAccessProvider<
-  T extends AuthorizationGrantConnectorType,
+  T extends ConnectorAuthProviderType,
 > {
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
@@ -56,22 +56,22 @@ export interface RefreshTokenAccessProvider<
   refreshToken(args: ConnectorOAuthRefreshArgs<T>): Promise<OAuthRefreshResult>;
 }
 
-export type ConnectorAuthProviderAccess<
-  T extends AuthorizationGrantConnectorType,
-> = NoneAccessProvider | RefreshTokenAccessProvider<T>;
+export type ConnectorAuthProviderAccess<T extends ConnectorAuthProviderType> =
+  | NoneAccessProvider
+  | RefreshTokenAccessProvider<T>;
 
 interface NoneRevokeProvider {
   readonly kind: "none";
 }
 
-interface TokenRevokeProvider<T extends AuthorizationGrantConnectorType> {
+interface TokenRevokeProvider<T extends ConnectorAuthProviderType> {
   readonly kind: "token-revoke";
   revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
 }
 
-export type ConnectorAuthProviderRevoke<
-  T extends AuthorizationGrantConnectorType,
-> = NoneRevokeProvider | TokenRevokeProvider<T>;
+export type ConnectorAuthProviderRevoke<T extends ConnectorAuthProviderType> =
+  | NoneRevokeProvider
+  | TokenRevokeProvider<T>;
 
 export interface AuthProvider<TGrant, TAccess, TRevoke> {
   readonly grant: TGrant;

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,6 +1,6 @@
 import type {
   AuthCodeGrantConnectorType,
-  OAuthGrantConnectorType,
+  AuthorizationGrantConnectorType,
   DeviceAuthGrantConnectorType,
 } from "../connectors";
 import type {
@@ -47,29 +47,31 @@ export interface NoneAccessProvider {
   getAccessSecretName(): string;
 }
 
-export interface RefreshTokenAccessProvider<T extends OAuthGrantConnectorType> {
+export interface RefreshTokenAccessProvider<
+  T extends AuthorizationGrantConnectorType,
+> {
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
   getRefreshSecretName(): string;
   refreshToken(args: ConnectorOAuthRefreshArgs<T>): Promise<OAuthRefreshResult>;
 }
 
-export type OAuthConnectorAccessProvider<T extends OAuthGrantConnectorType> =
-  | NoneAccessProvider
-  | RefreshTokenAccessProvider<T>;
+export type ConnectorAuthProviderAccess<
+  T extends AuthorizationGrantConnectorType,
+> = NoneAccessProvider | RefreshTokenAccessProvider<T>;
 
 interface NoneRevokeProvider {
   readonly kind: "none";
 }
 
-interface TokenRevokeProvider<T extends OAuthGrantConnectorType> {
+interface TokenRevokeProvider<T extends AuthorizationGrantConnectorType> {
   readonly kind: "token-revoke";
   revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
 }
 
-export type OAuthConnectorRevokeProvider<T extends OAuthGrantConnectorType> =
-  | NoneRevokeProvider
-  | TokenRevokeProvider<T>;
+export type ConnectorAuthProviderRevoke<
+  T extends AuthorizationGrantConnectorType,
+> = NoneRevokeProvider | TokenRevokeProvider<T>;
 
 export interface AuthProvider<TGrant, TAccess, TRevoke> {
   readonly grant: TGrant;
@@ -81,16 +83,16 @@ export type AuthCodeConnectorAuthProvider<
   T extends AuthCodeGrantConnectorType,
 > = AuthProvider<
   AuthCodeGrantProvider<T>,
-  OAuthConnectorAccessProvider<T>,
-  OAuthConnectorRevokeProvider<T>
+  ConnectorAuthProviderAccess<T>,
+  ConnectorAuthProviderRevoke<T>
 >;
 
 export type DeviceAuthConnectorAuthProvider<
   T extends DeviceAuthGrantConnectorType,
 > = AuthProvider<
   DeviceAuthGrantProvider<T>,
-  OAuthConnectorAccessProvider<T>,
-  OAuthConnectorRevokeProvider<T>
+  ConnectorAuthProviderAccess<T>,
+  ConnectorAuthProviderRevoke<T>
 >;
 
 export type ModelProviderGrantProvider = NoneGrantProvider;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -13,7 +13,7 @@ import {
   type ConnectorOAuthClientConfig,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type OAuthGrantConnectorType,
+  type AuthorizationGrantConnectorType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
   type TokenRevokeConnectorType,
@@ -236,7 +236,7 @@ function isConnectorGrantConfigWithScopes(
 }
 
 function getConnectorOAuthGrantConfig(
-  type: OAuthGrantConnectorType,
+  type: AuthorizationGrantConnectorType,
 ): ConnectorGrantConfigWithScopes;
 function getConnectorOAuthGrantConfig(
   type: ConnectorType,
@@ -477,7 +477,7 @@ export function isStaticConfidentialConnectorOAuthClient(
 }
 
 function getConnectorOAuthClientConfig(
-  type: OAuthGrantConnectorType,
+  type: AuthorizationGrantConnectorType,
 ): ConnectorOAuthClientConfig;
 function getConnectorOAuthClientConfig(
   type: ConnectorType,

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -159,6 +159,52 @@ function connectorAccessEnvBindings(
   }
 }
 
+export type ConnectorAuthMethodAccessMetadata =
+  | {
+      readonly kind: "static";
+      readonly envBindings: ConnectorEnvBindings;
+    }
+  | {
+      readonly kind: "refresh-token";
+      readonly accessToken: string;
+      readonly refreshToken: string;
+      readonly envBindings: ConnectorEnvBindings;
+    }
+  | {
+      readonly kind: "none";
+      readonly envBindings: ConnectorEnvBindings;
+    };
+
+export function getConnectorAuthMethodAccessMetadata(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorAuthMethodAccessMetadata | undefined {
+  const method = getConnectorAuthMethod(type, authMethod);
+  if (!method) {
+    return undefined;
+  }
+
+  switch (method.access.kind) {
+    case "static":
+      return {
+        kind: "static",
+        envBindings: method.access.envBindings,
+      };
+    case "refresh-token":
+      return {
+        kind: "refresh-token",
+        accessToken: method.access.accessToken,
+        refreshToken: method.access.refreshToken,
+        envBindings: method.access.envBindings,
+      };
+    case "none":
+      return {
+        kind: "none",
+        envBindings: {},
+      };
+  }
+}
+
 function authMethodAccessPriority(method: ConnectorAuthMethodConfig): number {
   switch (method.grant.kind) {
     case "auth-code":

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -13,7 +13,7 @@ import {
   type ConnectorOAuthClientConfig,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type AuthorizationGrantConnectorType,
+  type ConnectorAuthProviderType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
   type TokenRevokeConnectorType,
@@ -236,7 +236,7 @@ function isConnectorGrantConfigWithScopes(
 }
 
 function getConnectorOAuthGrantConfig(
-  type: AuthorizationGrantConnectorType,
+  type: ConnectorAuthProviderType,
 ): ConnectorGrantConfigWithScopes;
 function getConnectorOAuthGrantConfig(
   type: ConnectorType,
@@ -477,7 +477,7 @@ export function isStaticConfidentialConnectorOAuthClient(
 }
 
 function getConnectorOAuthClientConfig(
-  type: AuthorizationGrantConnectorType,
+  type: ConnectorAuthProviderType,
 ): ConnectorOAuthClientConfig;
 function getConnectorOAuthClientConfig(
   type: ConnectorType,

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -940,7 +940,7 @@ export type ConnectorTypesByRevokeKind<Kind extends ConnectorRevokeKind> = {
   }[keyof ConnectorAuthMethodsOf<Type>];
 }[ConnectorType];
 
-export type AuthorizationGrantConnectorType = ConnectorTypesByGrantKind<
+export type ConnectorAuthProviderType = ConnectorTypesByGrantKind<
   "auth-code" | "device-auth"
 >;
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -940,7 +940,7 @@ export type ConnectorTypesByRevokeKind<Kind extends ConnectorRevokeKind> = {
   }[keyof ConnectorAuthMethodsOf<Type>];
 }[ConnectorType];
 
-export type OAuthGrantConnectorType = ConnectorTypesByGrantKind<
+export type AuthorizationGrantConnectorType = ConnectorTypesByGrantKind<
   "auth-code" | "device-auth"
 >;
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -29,7 +29,9 @@ export const gumroad = {
           ],
         },
         access: {
-          kind: "static",
+          kind: "refresh-token",
+          accessToken: "GUMROAD_ACCESS_TOKEN",
+          refreshToken: "GUMROAD_REFRESH_TOKEN",
           envBindings: {
             GUMROAD_TOKEN: "$secrets.GUMROAD_ACCESS_TOKEN",
           },

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -571,7 +571,7 @@ export {
   type TriggerSource,
   type LogsFilters,
   type ConnectorType,
-  type AuthorizationGrantConnectorType,
+  type ConnectorAuthProviderType,
   type ConnectorConfig,
   type ConnectorEnvBindings,
   type ConnectorAuthMethodConfig,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -571,7 +571,7 @@ export {
   type TriggerSource,
   type LogsFilters,
   type ConnectorType,
-  type OAuthGrantConnectorType,
+  type AuthorizationGrantConnectorType,
   type ConnectorConfig,
   type ConnectorEnvBindings,
   type ConnectorAuthMethodConfig,


### PR DESCRIPTION
## Summary

- derive connector runtime access metadata from the stored selected auth method instead of OAuth provider membership
- carry connector authMethod/accessKind metadata through runner execution context
- resolve firewall access/refresh from selected access metadata, with 424 only for ordinary missing config and 5xx for selected access resolution failures

Closes #15326

## Tests

- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts
- pnpm -F @vm0/api-contracts test
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/connectors test
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api check-types
- pnpm -F api lint
- cargo test --manifest-path crates/Cargo.toml -p runner types::tests::execution_context_all_optional_fields
- git diff --check
- pre-commit hook: knip, cargo fmt/clippy/doc, prettier, turbo check-types
