### PR TITLE
feat: add permission request realtime refresh

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
@@ -316,6 +316,34 @@ describe("POST /api/zero/permission-access-requests", () => {
     expect(response.body.createdAt).toStrictEqual(expect.any(String));
   });
 
+  it("publishes a permission request refresh when creating a request", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+        },
+      }),
+      [201],
+    );
+    await clearAllDetached();
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "permissionAccessRequestsChanged",
+      {
+        requestId: response.body.id,
+        status: "pending",
+      },
+    );
+  });
+
   it("deduplicates pending requests by updating the reason", async () => {
     const fixture = await track(
       store.set(seedPermissionAccessOrg$, {}, context.signal),
@@ -930,6 +958,14 @@ describe("PUT /api/zero/permission-access-requests", () => {
     await expect(readAgentPolicies(fixture.agentId)).resolves.toStrictEqual({
       github: { "issues:read": "allow" },
     });
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "permissionAccessRequestsChanged",
+      {
+        requestId: request.id,
+        status: "approved",
+      },
+    );
   });
 
   it("approves a deny request and stores a deny policy", async () => {

--- a/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
@@ -23,6 +23,7 @@ import {
   createSlackClient,
   postMessage,
 } from "../external/slack-message-client";
+import { publishUserSignal } from "../external/realtime";
 import { nowDate } from "../external/time";
 import { waitUntil } from "../context/wait-until";
 import { tapError } from "../utils";
@@ -34,6 +35,8 @@ type PermissionAccessRequestRow = typeof permissionAccessRequests.$inferSelect;
 type ForbiddenResponse = NonNullable<ReturnType<typeof requireAgentPermission>>;
 
 const log = logger("zero-permission-access-requests");
+const PERMISSION_ACCESS_REQUESTS_CHANGED_TOPIC =
+  "permissionAccessRequestsChanged";
 
 interface ListPermissionAccessRequestsArgs {
   readonly orgId: string;
@@ -272,6 +275,30 @@ async function notifyRequesterOfResolution(
   );
 }
 
+function publishPermissionAccessRequestsChanged(
+  userIds: readonly string[],
+  payload: { readonly requestId: string; readonly status: string },
+): void {
+  const uniqueUserIds = [...new Set(userIds)];
+  if (uniqueUserIds.length === 0) {
+    return;
+  }
+  waitUntil(
+    tapError(
+      publishUserSignal(
+        uniqueUserIds,
+        PERMISSION_ACCESS_REQUESTS_CHANGED_TOPIC,
+        payload,
+      ),
+      (error) => {
+        log.error("Failed to publish permission access request change", {
+          error,
+        });
+      },
+    ),
+  );
+}
+
 async function requesterNameMap(
   client: ReturnType<typeof clerk$.read>,
   userIds: readonly string[],
@@ -492,6 +519,10 @@ export const createPermissionAccessRequest$ = command(
         },
       ),
     );
+    publishPermissionAccessRequestsChanged([agent.owner], {
+      requestId: row.id,
+      status: row.status,
+    });
 
     return { kind: "ok", request: formatPermissionAccessRequest(row) };
   },
@@ -610,6 +641,13 @@ export const resolvePermissionAccessRequest$ = command(
           });
         },
       ),
+    );
+    publishPermissionAccessRequestsChanged(
+      [existing.requesterUserId, args.userId],
+      {
+        requestId: args.requestId,
+        status: updated.status,
+      },
     );
 
     return { kind: "ok", request: formatPermissionAccessRequest(updated) };

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -428,7 +428,7 @@ export const submitAccessRequest$ = command(
   },
 );
 
-export const reloadPermissionAccessRequests$ = command(({ set }) => {
+const reloadPermissionAccessRequests$ = command(({ set }) => {
   set(internalRequestsReload$, (prev) => {
     return prev + 1;
   });

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -16,8 +16,12 @@ import {
 import { delay } from "signal-timers";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$, replaceSearchParams$ } from "../route.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
+
+const PERMISSION_ACCESS_REQUESTS_CHANGED_TOPIC =
+  "permissionAccessRequestsChanged";
 
 // ---------------------------------------------------------------------------
 // Route params
@@ -421,5 +425,30 @@ export const submitAccessRequest$ = command(
     const requestId = await set(createAccessRequest$, params, signal);
     set(internalReason$, "");
     set(updateRequestIdInUrl$, requestId);
+  },
+);
+
+export const reloadPermissionAccessRequests$ = command(({ set }) => {
+  set(internalRequestsReload$, (prev) => {
+    return prev + 1;
+  });
+  set(internalAgentReload$, (prev) => {
+    return prev + 1;
+  });
+  set(reloadAgentById$);
+});
+
+export const subscribePermissionAccessRequestsChanged$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const onChanged$ = command(({ set }) => {
+      set(reloadPermissionAccessRequests$);
+      return false;
+    });
+    await set(
+      setAblyLoop$,
+      PERMISSION_ACCESS_REQUESTS_CHANGED_TOPIC,
+      onChanged$,
+      signal,
+    );
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -360,6 +360,97 @@ describe("zero chat thread page display - permission action card", () => {
 
     expect(createCalled).toBeFalsy();
   });
+
+  it("refreshes a requested permission action when the Ably signal arrives", async () => {
+    let requestBody: unknown;
+    let agentPolicies: Record<
+      string,
+      { policies: Record<string, "allow" | "deny"> }
+    > = {
+      vercel: { policies: { "projects:write": "deny" } },
+    };
+    const pendingRequest = pendingPermissionRequest();
+
+    setMockOrg({ role: "member" });
+    setMockPermissionRequests([]);
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+          runId: "run-permission-request-refresh",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: agentPolicies,
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(
+        permissionAccessRequestsCreateContract.create,
+        ({ body, respond }) => {
+          requestBody = body;
+          setMockPermissionRequests([pendingRequest]);
+          return respond(201, pendingRequest);
+        },
+      ),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(hasSubscription("permissionAccessRequestsChanged")).toBeFalsy();
+    click(await within(card).findByText("Request approval"));
+
+    await waitFor(() => {
+      expect(requestBody).toMatchObject({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "vercel",
+        permission: "projects:write",
+        action: "allow",
+      });
+    });
+    await waitFor(() => {
+      expect(within(card).getByText("Request sent")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(hasSubscription("permissionAccessRequestsChanged")).toBeTruthy();
+    });
+
+    agentPolicies = {
+      vercel: { policies: { "projects:write": "allow" } },
+    };
+    setMockPermissionRequests([
+      pendingPermissionRequest({
+        id: pendingRequest.id,
+        status: "approved",
+        resolvedBy: "other-owner-id",
+        resolvedAt: "2026-03-10T00:01:00Z",
+      }),
+    ]);
+    triggerAblyEvent("permissionAccessRequestsChanged");
+
+    await waitFor(() => {
+      expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    });
+  });
 });
 
 // CHAT-D-036: Attachment image previews render in ChatMessageRow

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -162,6 +162,7 @@ import {
   extractPermissions,
   permissionExistingRequestByAction,
   saveAdminFocusedPolicy$,
+  subscribePermissionAccessRequestsChanged$,
   submitAccessRequest$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
@@ -2732,6 +2733,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const adminLoadable = useLoadable(isOrgAdmin$);
   const [saveLoadable, savePolicy] = useLoadableSet(saveAdminFocusedPolicy$);
   const [submitLoadable, submitRequest] = useLoadableSet(submitAccessRequest$);
+  const subscribeRequests = useSet(subscribePermissionAccessRequestsChanged$);
   const canManagePermissions =
     adminLoadable.state === "hasData" && adminLoadable.data;
   const existingRequestLoadable = useLoadable(
@@ -2807,6 +2809,11 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       return;
     }
 
+    detach(
+      subscribeRequests(pageSignal),
+      Reason.Daemon,
+      "permission access request realtime subscription",
+    );
     detach(
       submitRequest(
         {


### PR DESCRIPTION
## Summary
- Publish a user-level `permissionAccessRequestsChanged` Ably signal when permission access requests are created or resolved.
- In web chat, start the permission request Ably subscription only after the requester clicks `Request approval`, then reload permission request and agent permission data when approval arrives.
- Add API and platform coverage for the realtime refresh path.

## Tests
- `pnpm exec prettier --write apps/platform/src/views/main.tsx apps/platform/src/signals/permission-allow/permission-allow-signals.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts`