### PR TITLE
fix: allow promo codes for credit checkouts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -43,6 +43,7 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
+import { mockStripeClient } from "../../external/stripe-client";
 import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
@@ -614,6 +615,9 @@ function mockStripeWebhookEnv(): void {
   mockOptionalEnv("STRIPE_WEBHOOK_SECRET", STRIPE_WEBHOOK_SECRET);
   mockEnv("ZERO_PRICE", STRIPE_PRICE_MAP);
   mockEnv("ZERO_ONE_TIME_CAMPAIGN", STRIPE_ONE_TIME_CAMPAIGN);
+  mockStripeClient(
+    context.mocks.stripe as unknown as Parameters<typeof mockStripeClient>[0],
+  );
 }
 
 function invoiceLinesWithSubscriptionPeriod(periodEnd: number): {
@@ -2269,7 +2273,46 @@ describe("POST /api/webhooks/stripe", () => {
       });
     });
 
-    it("grants custom credit purchase credits from the checkout total", async () => {
+    it("grants custom credit purchase credits from the checkout subtotal before discounts", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const creditsBefore = (await selectStripeBilling(fixture)).credits;
+      const sessionId = stripeId("cs");
+
+      const response = await postStripeWebhookEvent({
+        type: "checkout.session.completed",
+        dataObject: {
+          id: sessionId,
+          subscription: null,
+          customer: fixture.stripeCustomerId,
+          payment_status: "paid",
+          amount_subtotal: 10_000,
+          amount_total: 5000,
+          metadata: {
+            purpose: "credit_purchase",
+            orgId: fixture.orgId,
+            creditsAmountMode: "amount_subtotal",
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect((await selectStripeBilling(fixture)).credits).toBe(
+        creditsBefore + 100_000,
+      );
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        source: "auto_recharge",
+        stripeInvoiceId: sessionId,
+        amount: 100_000,
+        remaining: 100_000,
+      });
+    });
+
+    it("keeps processing older custom credit checkout sessions from the checkout total", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
@@ -2297,14 +2340,6 @@ describe("POST /api/webhooks/stripe", () => {
       expect((await selectStripeBilling(fixture)).credits).toBe(
         creditsBefore + 100_000,
       );
-      const records = await selectStripeCreditExpiresRecords(fixture);
-      expect(records).toHaveLength(1);
-      expect(records[0]).toMatchObject({
-        source: "auto_recharge",
-        stripeInvoiceId: sessionId,
-        amount: 100_000,
-        remaining: 100_000,
-      });
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -633,6 +633,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
             quantity: 1,
           },
         ],
+        allow_promotion_codes: true,
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,
@@ -698,10 +699,11 @@ describe("POST /api/zero/billing/credit-checkout", () => {
         mode: "payment",
         customer: customerId,
         line_items: [{ price: checkoutPriceId, quantity: 1 }],
+        allow_promotion_codes: true,
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,
-          creditsAmountMode: "amount_total",
+          creditsAmountMode: "amount_subtotal",
           requestedCreditsAmount: "150000",
         },
         payment_intent_data: {
@@ -710,7 +712,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
             type: "credit_purchase",
             purpose: "credit_purchase",
             orgId: fixture.orgId,
-            creditsAmountMode: "amount_total",
+            creditsAmountMode: "amount_subtotal",
             requestedCreditsAmount: "150000",
           },
         },

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -22,6 +22,7 @@ interface CheckoutSessionInput {
   readonly subscription: string | { readonly id: string } | null;
   readonly customer: string | { readonly id: string } | null;
   readonly metadata: Record<string, string> | null;
+  readonly amount_subtotal?: number | null;
   readonly amount_total?: number | null;
   readonly payment_status?: string | null;
 }
@@ -110,6 +111,13 @@ const CREDITS_PER_DOLLAR = 1000;
 
 function creditPurchaseAmount(session: CheckoutSessionInput): number {
   const metadata = session.metadata ?? {};
+  if (metadata.creditsAmountMode === "amount_subtotal") {
+    const amountSubtotal = session.amount_subtotal ?? session.amount_total;
+    if (amountSubtotal === undefined || amountSubtotal === null) {
+      return Number.NaN;
+    }
+    return Math.floor((amountSubtotal * CREDITS_PER_DOLLAR) / 100);
+  }
   if (metadata.creditsAmountMode === "amount_total") {
     const amountTotal = session.amount_total;
     if (amountTotal === undefined || amountTotal === null) {

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -256,7 +256,7 @@ export const createCreditCheckoutSession$ = command(
       signal.throwIfAborted();
       metadata = {
         ...baseMetadata,
-        creditsAmountMode: "amount_total",
+        creditsAmountMode: "amount_subtotal",
         requestedCreditsAmount: String(args.credits),
       };
       lineItems = [{ price: presetPriceId, quantity: 1 }];
@@ -279,6 +279,7 @@ export const createCreditCheckoutSession$ = command(
       mode: "payment",
       customer: customerId,
       line_items: lineItems,
+      allow_promotion_codes: true,
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
       payment_intent_data: {


### PR DESCRIPTION
## Summary
- Enable Stripe promotion codes on credit checkout sessions.
- Mark new custom credit checkouts to grant credits from `amount_subtotal` so coupon discounts do not reduce purchased credits.
- Keep webhook compatibility for older custom credit checkout sessions that used `amount_total`, and make focused Stripe webhook tests install the mock Stripe client directly.

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-third-party.test.ts -t "checkout.session.completed"`

Note: an earlier full `webhooks-third-party.test.ts` run was blocked by local DB schema drift after pulling main; the targeted Stripe checkout webhook tests pass.