### PR TITLE
refactor: group runner start state by lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -27,7 +27,7 @@
 //! - the first heartbeat and idle-cleanup ticks are deferred;
 //! - teardown drops discovery before provider shutdown.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -488,79 +488,144 @@ pub async fn run_start(
     });
 
     let config = RunConfig {
-        id: runner_id,
-        name,
-        group: group_name,
-        profiles: runner_config.profiles,
-        runtime,
-        home,
-        budget,
-        device_rate_limits,
-        idle_pool,
-        parking_gate,
-        status,
-        mitm,
-        mitm_crash_rx,
-        provider,
-        cancel_tokens,
-        cancel,
+        runner: RunnerInfo {
+            id: runner_id,
+            name,
+            group: group_name,
+            profiles: runner_config.profiles,
+        },
+        paths: RunPaths {
+            home,
+            base_dir: runner_config.base_dir,
+        },
+        sandbox_runtime: SandboxRuntimeConfig {
+            runtime,
+            firecracker: runner_config.firecracker,
+        },
+        capacity: CapacityPolicy {
+            budget,
+            min_vcpu,
+            min_memory_mb,
+            device_rate_limits,
+        },
+        shared: RunnerSharedState {
+            idle_pool,
+            parking_gate,
+            status,
+        },
+        provider: ProviderState {
+            provider,
+            cancel_tokens,
+            cancel,
+        },
+        proxy: ProxyState {
+            mitm,
+            mitm_crash_rx,
+        },
         exec_config,
-        firecracker: runner_config.firecracker,
-        base_dir: runner_config.base_dir,
-        min_vcpu,
-        min_memory_mb,
-        kmsg_handle,
-        dns_handle,
-        memory_prefetch,
-        signal_source: SignalSource::Real(signals),
-        orphan_reap_process_discovery: None,
+        shutdown: ShutdownHandles {
+            kmsg_handle,
+            dns_handle,
+            memory_prefetch,
+        },
+        signals: SignalState {
+            signal_source: SignalSource::Real(signals),
+        },
+        orphan_reap: OrphanReapState {
+            process_discovery: None,
+        },
         #[cfg(test)]
-        outer_job_panic: None,
-        #[cfg(test)]
-        test_observer: StartLoopTestObserver::default(),
+        test_hooks: RunTestHooks {
+            outer_job_panic: None,
+            test_observer: StartLoopTestObserver::default(),
+        },
     };
 
     run(config).await
 }
 
 struct RunConfig {
+    runner: RunnerInfo,
+    paths: RunPaths,
+    sandbox_runtime: SandboxRuntimeConfig,
+    capacity: CapacityPolicy,
+    shared: RunnerSharedState,
+    provider: ProviderState,
+    proxy: ProxyState,
+    exec_config: Arc<ExecutorConfig>,
+    shutdown: ShutdownHandles,
+    signals: SignalState,
+    orphan_reap: OrphanReapState,
+    #[cfg(test)]
+    test_hooks: RunTestHooks,
+}
+
+struct RunnerInfo {
     id: String,
     name: String,
     group: String,
-    profiles: std::collections::BTreeMap<String, ProfileConfig>,
-    runtime: Box<dyn SandboxRuntime>,
+    profiles: BTreeMap<String, ProfileConfig>,
+}
+
+struct RunPaths {
     home: HomePaths,
+    base_dir: PathBuf,
+}
+
+struct SandboxRuntimeConfig {
+    runtime: Box<dyn SandboxRuntime>,
+    firecracker: config::FirecrackerConfig,
+}
+
+struct CapacityPolicy {
     budget: Arc<ResourceBudget>,
+    min_vcpu: u32,
+    min_memory_mb: u32,
     device_rate_limits: Option<sandbox::DeviceRateLimits>,
+}
+
+struct RunnerSharedState {
     idle_pool: SharedIdlePool,
     parking_gate: ParkingGate,
     status: Arc<StatusTracker>,
-    mitm: proxy::MitmProxy,
-    mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
+}
+
+struct ProviderState {
     provider: Arc<dyn JobProvider>,
     /// Per-job cancel tokens shared with the provider for cancel events
     /// (Ably for ApiProvider, `.cancel` files for LocalProvider).
     cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     cancel: CancellationToken,
-    exec_config: Arc<ExecutorConfig>,
-    firecracker: config::FirecrackerConfig,
-    base_dir: std::path::PathBuf,
-    min_vcpu: u32,
-    min_memory_mb: u32,
+}
+
+struct ProxyState {
+    mitm: proxy::MitmProxy,
+    mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
+}
+
+struct ShutdownHandles {
     kmsg_handle: kmsg_log::KmsgHandle,
     dns_handle: dns::DnsProxy,
     memory_prefetch: prefetch::MemoryPrefetchTasks,
-    /// Deterministic process snapshot for orphan-reaper tests. Production leaves
-    /// this unset and scans `/proc`.
-    orphan_reap_process_discovery: Option<OrphanReapProcessDiscovery>,
+}
+
+struct SignalState {
     /// How the run's mode channel is driven. Production supplies the signal
     /// streams registered at the top of `run_start`; tests supply a
     /// pre-built `SignalController` so they can drive mode transitions
     /// through the lifecycle controller.
     signal_source: SignalSource,
-    #[cfg(test)]
+}
+
+struct OrphanReapState {
+    /// Deterministic process snapshot for orphan-reaper tests. Production leaves
+    /// this unset and scans `/proc`.
+    process_discovery: Option<OrphanReapProcessDiscovery>,
+}
+
+#[cfg(test)]
+struct RunTestHooks {
     outer_job_panic: Option<OuterJobPanicPoint>,
-    #[cfg(test)]
     test_observer: StartLoopTestObserver,
 }
 
@@ -842,40 +907,37 @@ fn maybe_panic_outer_job(
 
 async fn run(config: RunConfig) -> RunnerResult<()> {
     let RunConfig {
-        id: runner_id,
-        name,
-        group,
-        profiles,
+        runner,
+        paths,
+        sandbox_runtime,
+        capacity,
+        shared,
+        provider: provider_state,
+        proxy,
+        exec_config,
+        shutdown,
+        signals,
+        orphan_reap,
+        #[cfg(test)]
+        test_hooks,
+    } = config;
+    let SandboxRuntimeConfig {
         mut runtime,
-        home,
-        budget,
-        device_rate_limits,
-        idle_pool,
-        parking_gate,
-        status,
+        firecracker,
+    } = sandbox_runtime;
+    let ProxyState {
         mut mitm,
         mut mitm_crash_rx,
-        provider,
-        cancel_tokens,
-        cancel,
-        exec_config,
-        firecracker,
-        base_dir,
-        min_vcpu,
-        min_memory_mb,
-        kmsg_handle,
-        dns_handle,
-        mut memory_prefetch,
-        orphan_reap_process_discovery,
-        signal_source,
-        #[cfg(test)]
-        outer_job_panic,
-        #[cfg(test)]
-        test_observer,
-    } = config;
+    } = proxy;
 
-    let mut factories =
-        start_factories(&profiles, &firecracker, &base_dir, &home, runtime.as_mut()).await?;
+    let mut factories = start_factories(
+        &runner.profiles,
+        &firecracker,
+        &paths.base_dir,
+        &paths.home,
+        runtime.as_mut(),
+    )
+    .await?;
 
     let mut jobs: JoinSet<Option<RunId>> = JoinSet::new();
     // Tracked destroy tasks — JoinSet ensures we can await all in-flight
@@ -883,13 +945,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // "factory still referenced" warnings from Arc::try_unwrap.
     let mut destroy_tasks: JoinSet<()> = JoinSet::new();
 
-    status.write_initial().await;
+    shared.status.write_initial().await;
     info!(
-        name = %name,
-        group = %group,
-        effective_vcpu = budget.effective_vcpu(),
-        effective_memory_mb = budget.effective_memory_mb(),
-        max_concurrent = budget.max_concurrent(),
+        name = %runner.name,
+        group = %runner.group,
+        effective_vcpu = capacity.budget.effective_vcpu(),
+        effective_memory_mb = capacity.budget.effective_memory_mb(),
+        max_concurrent = capacity.budget.max_concurrent(),
         "runner started"
     );
 
@@ -905,12 +967,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     // Signal handling / mode channel
     // -----------------------------------------------------------------------
-    let signal = match signal_source {
+    let signal = match signals.signal_source {
         SignalSource::Real(signals) => SignalController::spawn(
-            cancel.clone(),
-            Arc::clone(&cancel_tokens),
+            provider_state.cancel.clone(),
+            Arc::clone(&provider_state.cancel_tokens),
             signals,
-            parking_gate.clone(),
+            shared.parking_gate.clone(),
         ),
         SignalSource::Override(controller) => controller,
     };
@@ -963,38 +1025,44 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     orphan_reap_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let hb_ctx = HeartbeatContext::new(
-        &idle_pool, &runner_id, &name, &group, &profiles, &budget, &*provider,
+        &shared.idle_pool,
+        &runner.id,
+        &runner.name,
+        &runner.group,
+        &runner.profiles,
+        &capacity.budget,
+        &*provider_state.provider,
     );
 
     // Pin the discover future so it survives cancellation by other select!
     // branches (heartbeat, idle cleanup, etc.). Without pinning, heartbeat
     // (10s) cancels discover() on every tick, restarting its internal poll
     // sleep (30s) from scratch — so poll never fires. See #8747.
-    let mut discover_fut = Box::pin(provider.discover());
+    let mut discover_fut = Box::pin(provider_state.provider.discover());
 
     let mut current_mode = RunnerMode::Running;
     let spawn_ctx = SpawnContext {
-        provider: Arc::clone(&provider),
+        provider: Arc::clone(&provider_state.provider),
         exec_config: Arc::clone(&exec_config),
-        idle_pool: Arc::clone(&idle_pool),
-        status: Arc::clone(&status),
-        cancel_tokens: Arc::clone(&cancel_tokens),
+        idle_pool: Arc::clone(&shared.idle_pool),
+        status: Arc::clone(&shared.status),
+        cancel_tokens: Arc::clone(&provider_state.cancel_tokens),
         orphaned_active_runs: orphaned_active_runs.clone(),
-        parking_gate: parking_gate.clone(),
+        parking_gate: shared.parking_gate.clone(),
         park_notify: Arc::clone(&park_notify),
         usage_flush_tx,
-        device_rate_limits: device_rate_limits.clone(),
+        device_rate_limits: capacity.device_rate_limits.clone(),
         #[cfg(test)]
-        outer_job_panic,
+        outer_job_panic: test_hooks.outer_job_panic,
         #[cfg(test)]
-        test_observer: test_observer.clone(),
+        test_observer: test_hooks.test_observer.clone(),
     };
     let mut draining_idle_pool_drained = false;
     loop {
         let mode = *mode_rx.borrow_and_update();
         if mode != current_mode {
             current_mode = mode;
-            status.set_mode(mode).await;
+            shared.status.set_mode(mode).await;
         }
         match mode {
             // Stopped should not normally reach here — teardown sets it and
@@ -1008,7 +1076,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     // Soft drain entry. Destroy the idle pool once (releases
                     // budget — matches pre-split teardown behavior), then keep
                     // servicing the shared reactor while jobs finish.
-                    drain_idle_pool(&idle_pool, &status, "draining").await;
+                    drain_idle_pool(&shared.idle_pool, &shared.status, "draining").await;
                     draining_idle_pool_drained = true;
                 }
                 if jobs.is_empty() {
@@ -1035,8 +1103,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
 
         let can_discover = if matches!(mode, RunnerMode::Running) {
-            if !budget.can_afford(min_vcpu, min_memory_mb) {
-                let expired = evict_expired_idle_entries(&idle_pool, &status).await;
+            if !capacity
+                .budget
+                .can_afford(capacity.min_vcpu, capacity.min_memory_mb)
+            {
+                let expired = evict_expired_idle_entries(&shared.idle_pool, &shared.status).await;
                 if !expired.is_empty() {
                     info!(
                         count = expired.len(),
@@ -1050,7 +1121,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 // parking discovery. NOTE: evict_oldest is session-blind — it
                 // may destroy the VM the next job wants to reuse. A proper fix
                 // requires knowing session_id before claim, tracked separately.
-                if let Some(evicted) = evict_oldest_idle_entry(&idle_pool, &status).await {
+                if let Some(evicted) =
+                    evict_oldest_idle_entry(&shared.idle_pool, &shared.status).await
+                {
                     info!(
                         session_id = %evicted.session_id(),
                         profile = %evicted.profile_name(),
@@ -1064,13 +1137,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     continue;
                 }
             }
-            budget.can_afford(min_vcpu, min_memory_mb)
+            capacity
+                .budget
+                .can_afford(capacity.min_vcpu, capacity.min_memory_mb)
         } else {
             false
         };
         #[cfg(test)]
         if matches!(mode, RunnerMode::Running) && !can_discover {
-            test_observer.notify_budget_exhausted_reactor();
+            test_hooks.test_observer.notify_budget_exhausted_reactor();
         }
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
@@ -1079,17 +1154,17 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             discovered = &mut discover_fut, if can_discover => {
                 let Some(candidate) = discovered else { break };
                 // Future completed — create a new one for the next discovery.
-                discover_fut = Box::pin(provider.discover());
+                discover_fut = Box::pin(provider_state.provider.discover());
                 handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {
-                        profiles: &profiles,
+                        profiles: &runner.profiles,
                         factories: &factories,
-                        budget: &budget,
-                        idle_pool: &idle_pool,
-                        status: &status,
+                        budget: &capacity.budget,
+                        idle_pool: &shared.idle_pool,
+                        status: &shared.status,
                         mode_rx: &mode_rx,
-                        cancel_tokens: &cancel_tokens,
+                        cancel_tokens: &provider_state.cancel_tokens,
                         spawn_ctx: &spawn_ctx,
                         destroy_tasks: &mut destroy_tasks,
                         jobs: &mut jobs,
@@ -1108,8 +1183,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 }
                 handle_stopping_signal(
                     "signal-handler-task",
-                    &cancel,
-                    &cancel_tokens,
+                    &provider_state.cancel,
+                    &provider_state.cancel_tokens,
                     &lifecycle,
                 ).await;
             }
@@ -1117,30 +1192,30 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // normal Running mode can retain completed JoinSet entries and
             // stale cancel tokens until drain, budget exhaustion, or shutdown.
             result = jobs.join_next(), if !jobs.is_empty() => {
-                handle_job_result(result, &cancel_tokens).await;
+                handle_job_result(result, &provider_state.cancel_tokens).await;
                 if !orphaned_active_runs.is_empty() {
                     reap_orphaned_active_runs(
                         &orphaned_active_runs,
-                        &idle_pool,
-                        &status,
+                        &shared.idle_pool,
+                        &shared.status,
                         OrphanReapMode::Immediate,
-                        orphan_reap_process_discovery.as_ref(),
+                        orphan_reap.process_discovery.as_ref(),
                     ).await;
                 }
             }
             Some(()) = usage_flush_rx.recv() => {
                 #[cfg(test)]
-                test_observer.notify_usage_flush_requested();
+                test_hooks.test_observer.notify_usage_flush_requested();
                 mitm.request_usage_flush();
             }
             // Reconcile active runs left visible after an outer job-task panic.
             _ = orphan_reap_tick.tick(), if !orphaned_active_runs.is_empty() => {
                 reap_orphaned_active_runs(
                     &orphaned_active_runs,
-                    &idle_pool,
-                    &status,
+                    &shared.idle_pool,
+                    &shared.status,
                     OrphanReapMode::ConfirmAbsent,
-                    orphan_reap_process_discovery.as_ref(),
+                    orphan_reap.process_discovery.as_ref(),
                 ).await;
             }
             // Reap completed destroy tasks
@@ -1162,14 +1237,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             () = sleep_until_retry(&mitm_retry.restart_at) => {}
             // Idle pool cleanup: evict expired VMs and update status
             _ = idle_cleanup.tick(), if can_discover => {
-                let expired = cleanup_expired_idle_entries(&idle_pool, &status).await;
+                let expired = cleanup_expired_idle_entries(&shared.idle_pool, &shared.status).await;
                 #[cfg(test)]
                 let expired_count = expired.len();
                 for entry in expired {
                     spawn_idle_destroy_job(&mut destroy_tasks, entry, "idle_expired");
                 }
                 #[cfg(test)]
-                test_observer.record(StartLoopEvent::IdleCleanupProcessed { expired_count });
+                test_hooks
+                    .test_observer
+                    .record(StartLoopEvent::IdleCleanupProcessed { expired_count });
             }
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {
@@ -1188,6 +1265,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
+    let ShutdownHandles {
+        kmsg_handle,
+        dns_handle,
+        mut memory_prefetch,
+    } = shutdown;
     let teardown = TeardownTimer::start();
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");
@@ -1203,29 +1285,29 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // consistent with the empty pool.
     lifecycle.close_parking();
     let phase = teardown.phase_start("drain_idle_pool");
-    drain_idle_pool(&idle_pool, &status, "shutdown").await;
+    drain_idle_pool(&shared.idle_pool, &shared.status, "shutdown").await;
     teardown.phase_complete("drain_idle_pool", phase);
 
     let phase = teardown.phase_start("provider_shutdown");
-    provider.shutdown().await;
+    provider_state.provider.shutdown().await;
     teardown.phase_complete("provider_shutdown", phase);
 
     // Send final heartbeat with Stopping so the server stops routing jobs
     // to this runner immediately, without waiting for TTL expiry.
     let phase = teardown.phase_start("final_heartbeat");
     {
-        let pool = idle_pool.lock().await;
+        let pool = shared.idle_pool.lock().await;
         let state = collect_heartbeat_state(
-            &runner_id,
-            &name,
-            &group,
-            &profiles,
-            &budget,
+            &runner.id,
+            &runner.name,
+            &runner.group,
+            &runner.profiles,
+            &capacity.budget,
             &pool,
             RunnerMode::Stopping,
         );
         drop(pool);
-        provider.heartbeat(&state).await;
+        provider_state.provider.heartbeat(&state).await;
     }
     teardown.phase_complete("final_heartbeat", phase);
 
@@ -1238,20 +1320,20 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
             tokio::select! {
                 result = jobs.join_next() => {
-                    handle_job_result(result, &cancel_tokens).await;
+                    handle_job_result(result, &provider_state.cancel_tokens).await;
                     if !orphaned_active_runs.is_empty() {
                         reap_orphaned_active_runs(
                             &orphaned_active_runs,
-                            &idle_pool,
-                            &status,
+                            &shared.idle_pool,
+                            &shared.status,
                             OrphanReapMode::Immediate,
-                            orphan_reap_process_discovery.as_ref(),
+                            orphan_reap.process_discovery.as_ref(),
                         ).await;
                     }
                 }
                 Some(()) = usage_flush_rx.recv() => {
                     #[cfg(test)]
-                    test_observer.notify_usage_flush_requested();
+                    test_hooks.test_observer.notify_usage_flush_requested();
                     mitm.request_usage_flush();
                 }
                 Some(result) = destroy_tasks.join_next() => {
@@ -1275,10 +1357,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let phase = teardown.phase_start("orphan_reap_shutdown_final");
         reap_orphaned_active_runs(
             &orphaned_active_runs,
-            &idle_pool,
-            &status,
+            &shared.idle_pool,
+            &shared.status,
             OrphanReapMode::ShutdownFinal,
-            orphan_reap_process_discovery.as_ref(),
+            orphan_reap.process_discovery.as_ref(),
         )
         .await;
         teardown.phase_complete("orphan_reap_shutdown_final", phase);
@@ -1321,7 +1403,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // remains bounded best-effort, and timeout is the abnormal data-loss path.
     let phase = teardown.phase_start("wait_usage_flush");
     if let Some(usage_flush_target) = mitm.usage_flush_target() {
-        let addon_dir = base_dir.join("mitm-addon");
+        let addon_dir = paths.base_dir.join("mitm-addon");
         match proxy::write_usage_flush_request(&addon_dir, &usage_flush_target).await {
             Ok(usage_flush_request) => {
                 info!("requesting proxy usage flush");
@@ -1373,7 +1455,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     teardown.phase_complete("memory_prefetch_drain", phase);
 
     let phase = teardown.phase_start("status_stopped");
-    status.set_mode(RunnerMode::Stopped).await;
+    shared.status.set_mode(RunnerMode::Stopped).await;
     teardown.phase_complete("status_stopped", phase);
     info!(total_teardown_ms = teardown.elapsed_ms(), "runner stopped");
 

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -24,7 +24,7 @@ async fn budget_full_skips_then_resumes() {
     ));
     // Budget for exactly 1 job (2 vcpu, 4096 MB).
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     // First job: claims the entire budget.
@@ -73,7 +73,7 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
@@ -133,8 +133,8 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
 #[tokio::test(start_paused = true)]
 async fn cleanup_tick_evicts_expired_entries() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     // Pre-seed: park an entry that is already expired (400s old, 300s timeout).
     seed_idle_pool_expired(&idle_pool, &budget, "sess-exp", "vm0/default", 2, 4096).await;
@@ -173,8 +173,8 @@ async fn cleanup_tick_evicts_expired_entries() {
 async fn budget_exhausted_evicts_idle_and_admits_job() {
     // Budget: exactly 1 default job (2 vcpu, 4096 MB).
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     // Pre-seed: idle VM fills the entire budget.
     seed_idle_pool(&idle_pool, &budget, "sess-evict", "vm0/default", 2, 4096).await;
@@ -205,8 +205,8 @@ async fn budget_exhausted_evicts_idle_and_admits_job() {
 #[tokio::test(start_paused = true)]
 async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
     let (config, env) = mock_run_config(two_profiles(), 6, 12288, 3);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let status_path = env._temp_dir.path().join("status.json");
     let now = std::time::Instant::now();
 
@@ -276,8 +276,8 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
 #[tokio::test(start_paused = true)]
 async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
     let (config, env) = mock_run_config(two_profiles(), 7, 13312, 3);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let status_path = env._temp_dir.path().join("status.json");
     let now = std::time::Instant::now();
 
@@ -364,8 +364,8 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
 #[tokio::test(start_paused = true)]
 async fn budget_pressure_eviction_clears_status_json_idle_vms() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -10,7 +10,7 @@ async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.push_destroy_panic("simulated destroy panic");
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -41,8 +41,8 @@ async fn failed_job_with_session_not_parked() {
         1,
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -79,9 +79,9 @@ async fn cancelled_job_not_parked() {
         gate,
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -124,9 +124,9 @@ async fn create_failure_completes_and_cleans_run_state() {
         message: "create failed".into(),
     }));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
@@ -17,9 +17,9 @@ async fn outer_job_panic_after_idle_pool_owned_cleans_token_and_active_status() 
         4,
         Arc::new(sandbox_mock::MockSandboxOverrides::new()),
     );
-    config.outer_job_panic = Some(OuterJobPanicPoint::IdlePoolOwned);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::IdlePoolOwned);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
@@ -58,12 +58,12 @@ async fn outer_job_panic_active_unknown_reconciles_on_shutdown_final_scan() {
         4,
         Arc::new(sandbox_mock::MockSandboxOverrides::new()),
     );
-    config.outer_job_panic = Some(OuterJobPanicPoint::ActiveOrUnknown);
-    config.orphan_reap_process_discovery = Some(OrphanReapProcessDiscovery {
+    config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::ActiveOrUnknown);
+    config.orphan_reap.process_discovery = Some(OrphanReapProcessDiscovery {
         firecrackers: Arc::new(Vec::new()),
         incomplete_for_current_runner: false,
     });
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
@@ -95,8 +95,8 @@ async fn outer_job_panic_after_destroy_completed_cleans_token_and_active_status(
     overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
 
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    config.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -19,8 +19,8 @@ async fn park_failure_destroys_sandbox_and_skips_pool() {
     }));
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -60,8 +60,8 @@ async fn park_panic_destroys_sandbox_reports_completion_and_releases_budget() {
     overrides.push_park_panic("simulated park panic");
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -94,8 +94,8 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     {
         let mut pool = idle_pool.lock().await;
         *pool = IdlePool::new(IdlePoolConfig {
@@ -166,8 +166,8 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -244,9 +244,9 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -322,9 +322,9 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let cancel_tokens = Arc::clone(&config.cancel_tokens);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -23,8 +23,8 @@ async fn unpark_failure_destroys_idle_entry_and_falls_through() {
         message: "simulated unpark failure".into(),
     }));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
 
     // Pre-seed via the factory so the seeded MockSandbox shares the
     // override set (and consumes the queued unpark error).
@@ -101,9 +101,9 @@ async fn unpark_failure_status_switches_from_idle_to_active_while_job_runs() {
         message: "simulated unpark failure".into(),
     }));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let status = Arc::clone(&config.status);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let status = Arc::clone(&config.shared.status);
     let status_path = env._temp_dir.path().join("status.json");
 
     seed_idle_pool_with_overrides(
@@ -155,8 +155,8 @@ async fn unpark_panic_destroys_idle_entry_and_falls_through() {
     let counter = Arc::clone(&overrides);
     overrides.push_unpark_panic("simulated unpark panic");
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
 
     seed_idle_pool_with_overrides(
         &idle_pool,

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -122,8 +122,8 @@ async fn job_without_session_does_not_park() {
 #[tokio::test(start_paused = true)]
 async fn successful_job_parks_in_idle_pool() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -164,8 +164,8 @@ async fn successful_job_parks_in_idle_pool() {
 #[tokio::test(start_paused = true)]
 async fn job_without_session_destroys_sandbox() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -235,8 +235,8 @@ async fn park_triggers_immediate_heartbeat() {
 #[tokio::test(start_paused = true)]
 async fn session_affinity_reuses_idle_vm() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     // Pre-seed: park a VM for session "sess-reuse" with matching profile.
     let seeded_sandbox_id =
@@ -290,8 +290,8 @@ async fn session_affinity_reuses_idle_vm() {
 #[tokio::test(start_paused = true)]
 async fn reuse_take_refreshes_provider_held_session_states() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     seed_idle_pool(&idle_pool, &budget, "sess-refresh", "vm0/default", 2, 4096).await;
 
@@ -326,7 +326,7 @@ async fn disabled_io_limiter_feature_omits_limits_on_fresh_create() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    config.device_rate_limits = Some(device_rate_limits());
+    config.capacity.device_rate_limits = Some(device_rate_limits());
 
     let run_handle = tokio::spawn(run(config));
     let run_id = RunId::new_v4();
@@ -360,9 +360,9 @@ async fn disabled_io_limiter_feature_reuses_unlimited_idle_vm() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
-    config.device_rate_limits = Some(device_rate_limits());
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    config.capacity.device_rate_limits = Some(device_rate_limits());
 
     let seeded_sandbox_id = seed_idle_pool_with_overrides(
         &idle_pool,
@@ -411,9 +411,9 @@ async fn missing_io_limiter_feature_reuses_unlimited_idle_vm() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
-    config.device_rate_limits = Some(device_rate_limits());
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    config.capacity.device_rate_limits = Some(device_rate_limits());
 
     let seeded_sandbox_id = seed_idle_pool_with_overrides(
         &idle_pool,
@@ -458,8 +458,8 @@ async fn enabled_io_limiter_feature_without_host_capacity_reuses_unlimited_idle_
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     let seeded_sandbox_id = seed_idle_pool_with_overrides(
         &idle_pool,
@@ -507,10 +507,10 @@ async fn device_limit_mismatch_destroys_idle_vm_and_fresh_creates() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let limits = device_rate_limits();
-    config.device_rate_limits = Some(limits.clone());
+    config.capacity.device_rate_limits = Some(limits.clone());
 
     let seeded_sandbox_id = seed_idle_pool_with_overrides(
         &idle_pool,
@@ -567,9 +567,9 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
     ));
     let (config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
-    let status = Arc::clone(&config.status);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let status = Arc::clone(&config.shared.status);
     let status_path = env._temp_dir.path().join("status.json");
 
     let _seeded_sandbox_id = seed_idle_pool_with_overrides(
@@ -660,8 +660,8 @@ async fn job_without_session_reports_no_session_id() {
 #[tokio::test(start_paused = true)]
 async fn profile_mismatch_destroys_stale_vm() {
     let (config, env) = mock_run_config(two_profiles(), 16, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     // Pre-seed: park a "vm0/default" (2vcpu) VM for session "sess-mm".
     seed_idle_pool(&idle_pool, &budget, "sess-mm", "vm0/default", 2, 4096).await;
@@ -718,9 +718,9 @@ async fn profile_mismatch_status_switches_from_idle_to_active_while_job_runs() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(two_profiles(), 16, 32768, 4, overrides);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
-    let status = Arc::clone(&config.status);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let status = Arc::clone(&config.shared.status);
     let status_path = env._temp_dir.path().join("status.json");
 
     seed_idle_pool(
@@ -772,8 +772,8 @@ async fn profile_mismatch_status_switches_from_idle_to_active_while_job_runs() {
 #[tokio::test(start_paused = true)]
 async fn shutdown_drains_idle_pool() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
 
     // Pre-seed: two idle entries holding budget.
     seed_idle_pool(&idle_pool, &budget, "sess-drain-1", "vm0/default", 2, 4096).await;
@@ -802,8 +802,8 @@ async fn job_completing_during_active_draining_is_not_parked() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     // Claim a gated job with a reusable session while Running.
@@ -879,8 +879,8 @@ async fn soft_drain_resume_opens_parking_before_running_ack() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -946,7 +946,7 @@ async fn soft_drain_resume_opens_parking_before_running_ack() {
 async fn shutdown_clears_idle_vms_in_status_json() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let status_path = env._temp_dir.path().join("status.json");
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     // Park a VM via a normal job → status.json records the idle VM.
@@ -1017,8 +1017,8 @@ async fn shutdown_clears_idle_vms_in_status_json() {
 #[tokio::test(start_paused = true)]
 async fn sequential_same_session_reuse_cycle() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     // Job 1: parks VM for session "sess-seq".
@@ -1083,8 +1083,8 @@ async fn park_evicts_via_guest_session_id() {
         stderr: Vec::new(),
     });
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let budget = Arc::clone(&config.budget);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
 
     // Pre-seed idle pool with session "sess-evict".
     seed_idle_pool(&idle_pool, &budget, "sess-evict", "vm0/default", 2, 4096).await;
@@ -1133,7 +1133,7 @@ async fn reuse_cycle_invokes_park_and_unpark_symmetrically() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     // Job 1: fresh create → run → park.
@@ -1190,7 +1190,7 @@ async fn park_called_when_vm_enters_idle_pool() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -1231,7 +1231,7 @@ async fn park_called_when_vm_enters_idle_pool() {
 #[tokio::test(start_paused = true)]
 async fn reuse_enabled_empty_pool_reports_pool_miss() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let idle_pool = Arc::clone(&config.idle_pool);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
 
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -49,7 +49,7 @@ async fn install_usage_flush_child(config: &mut RunConfig) {
     use std::os::unix::fs::PermissionsExt;
     use tokio::io::AsyncBufReadExt;
 
-    let script = config.base_dir.join("usage-flush-child.sh");
+    let script = config.paths.base_dir.join("usage-flush-child.sh");
     std::fs::write(
         &script,
         r#"#!/usr/bin/env bash
@@ -91,7 +91,7 @@ while true; do read -r _ <&3 || true; done
         .unwrap()
         .expect("usage flush child stdout closed before ready");
     assert_eq!(ready, "ready");
-    config.mitm.set_child_for_test(child);
+    config.proxy.mitm.set_child_for_test(child);
 }
 
 // -----------------------------------------------------------------------
@@ -122,9 +122,9 @@ async fn main_loop_discover_claim_execute_complete() {
 async fn job_completion_requests_proxy_usage_flush_without_waiting() {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     install_usage_flush_child(&mut config).await;
-    let usage_state_id = config.mitm.usage_state_id_for_test().to_string();
-    write_usage_pending_state(&config.base_dir, &usage_state_id, 0, 0, 1);
-    let base_dir = config.base_dir.clone();
+    let usage_state_id = config.proxy.mitm.usage_state_id_for_test().to_string();
+    write_usage_pending_state(&config.paths.base_dir, &usage_state_id, 0, 0, 1);
+    let base_dir = config.paths.base_dir.clone();
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -388,7 +388,7 @@ async fn shutdown_drains_memory_prefetch_before_stopped() {
         let _ = cancelled_tx.send(());
         let _ = release_rx.await;
     });
-    config.memory_prefetch =
+    config.shutdown.memory_prefetch =
         crate::prefetch::MemoryPrefetchTasks::from_test_handle(prefetch_cancel, handle);
     let run_handle = tokio::spawn(run(config));
 
@@ -498,8 +498,8 @@ async fn drain_resume_then_second_drain_drains_idle_pool() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    let idle_pool = Arc::clone(&config.idle_pool);
-    let budget = Arc::clone(&config.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -620,7 +620,7 @@ async fn heartbeat_fires_while_budget_exhausted() {
     ));
     // Budget sized for exactly one `test_profiles()` slot (vcpu=2, mem=4096).
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -794,7 +794,7 @@ async fn graceful_shutdown_aborts_signal_handler_task() {
         .expect("signal handler test task should start");
 
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    config.signal_source = SignalSource::Override(SignalController {
+    config.signals.signal_source = SignalSource::Override(SignalController {
         mode_rx: env.mode_tx.subscribe(),
         lifecycle: env.lifecycle.clone(),
         handler_task: Some(SignalHandlerTask::new(handler_task)),
@@ -818,7 +818,7 @@ async fn assert_signal_handler_task_end_cancels_active_jobs(
         gate,
     ));
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    config.signal_source = SignalSource::Override(SignalController {
+    config.signals.signal_source = SignalSource::Override(SignalController {
         mode_rx: env.mode_tx.subscribe(),
         lifecycle: env.lifecycle.clone(),
         handler_task: Some(SignalHandlerTask::new(handler_task)),
@@ -1146,7 +1146,7 @@ async fn draining_auto_stop_preserves_concurrent_resume() {
 async fn claim_failure_rolls_back_budget() {
     // Budget for exactly 1 job (2 vcpu, 4096 MB matches the test profile).
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -1184,7 +1184,7 @@ async fn claim_failure_rolls_back_budget() {
 async fn claim_run_id_mismatch_rolls_back_local_state() {
     // Budget for exactly 1 job, so a leaked lease would block the follow-up job.
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -1316,7 +1316,7 @@ async fn duplicate_discovery_deduplicated() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
-    let budget = Arc::clone(&config.budget);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -173,32 +173,53 @@ fn build_mock_run_config_with_runtime(
         )));
 
     let config = RunConfig {
-        id: "test-runner".into(),
-        name: "test".into(),
-        group: "test-group".into(),
-        profiles,
-        runtime,
-        home: home.clone(),
-        budget: Arc::new(ResourceBudget::new(
-            budget_vcpu,
-            budget_memory_mb,
-            1.0,
-            max_concurrent,
-        )),
-        device_rate_limits: None,
-        idle_pool: Arc::clone(&idle_pool),
-        parking_gate: parking_gate.clone(),
-        status: Arc::new(StatusTracker::new(
-            temp_dir.path().join("status.json"),
-            max_concurrent,
-            None,
-            None,
-        )),
-        mitm,
-        mitm_crash_rx,
-        provider,
-        cancel_tokens: Arc::clone(&cancel_tokens),
-        cancel: cancel.clone(),
+        runner: RunnerInfo {
+            id: "test-runner".into(),
+            name: "test".into(),
+            group: "test-group".into(),
+            profiles,
+        },
+        paths: RunPaths {
+            home: home.clone(),
+            base_dir: temp_dir.path().to_path_buf(),
+        },
+        sandbox_runtime: SandboxRuntimeConfig {
+            runtime,
+            firecracker: config::FirecrackerConfig {
+                binary: PathBuf::new(),
+                kernel: PathBuf::new(),
+            },
+        },
+        capacity: CapacityPolicy {
+            budget: Arc::new(ResourceBudget::new(
+                budget_vcpu,
+                budget_memory_mb,
+                1.0,
+                max_concurrent,
+            )),
+            min_vcpu,
+            min_memory_mb,
+            device_rate_limits: None,
+        },
+        shared: RunnerSharedState {
+            idle_pool: Arc::clone(&idle_pool),
+            parking_gate: parking_gate.clone(),
+            status: Arc::new(StatusTracker::new(
+                temp_dir.path().join("status.json"),
+                max_concurrent,
+                None,
+                None,
+            )),
+        },
+        provider: ProviderState {
+            provider,
+            cancel_tokens: Arc::clone(&cancel_tokens),
+            cancel: cancel.clone(),
+        },
+        proxy: ProxyState {
+            mitm,
+            mitm_crash_rx,
+        },
         exec_config: Arc::new(executor::ExecutorConfig {
             api_url: api_url.to_string(),
             registry,
@@ -212,24 +233,25 @@ fn build_mock_run_config_with_runtime(
             network_log_drain: NetworkLogDrainCoordinator::noop(),
             home,
         }),
-        firecracker: config::FirecrackerConfig {
-            binary: PathBuf::new(),
-            kernel: PathBuf::new(),
+        shutdown: ShutdownHandles {
+            kmsg_handle: kmsg_log::KmsgHandle::noop(),
+            dns_handle: crate::dns::DnsProxy::noop(),
+            memory_prefetch: prefetch::MemoryPrefetchTasks::empty(),
         },
-        base_dir: temp_dir.path().to_path_buf(),
-        min_vcpu,
-        min_memory_mb,
-        kmsg_handle: kmsg_log::KmsgHandle::noop(),
-        dns_handle: crate::dns::DnsProxy::noop(),
-        memory_prefetch: prefetch::MemoryPrefetchTasks::empty(),
-        orphan_reap_process_discovery: None,
-        signal_source: SignalSource::Override(SignalController {
-            mode_rx,
-            lifecycle: lifecycle.clone(),
-            handler_task: None,
-        }),
-        outer_job_panic: None,
-        test_observer: start_observer.clone(),
+        signals: SignalState {
+            signal_source: SignalSource::Override(SignalController {
+                mode_rx,
+                lifecycle: lifecycle.clone(),
+                handler_task: None,
+            }),
+        },
+        orphan_reap: OrphanReapState {
+            process_discovery: None,
+        },
+        test_hooks: RunTestHooks {
+            outer_job_panic: None,
+            test_observer: start_observer.clone(),
+        },
     };
 
     let env = MockRunEnv {


### PR DESCRIPTION
## Summary

- Group runner start `RunConfig` fields by lifecycle ownership instead of keeping one flat field list.
- Keep the `run()` reactor procedural while reading grouped state near the phases that consume it.
- Update runner start test support and direct config references for the grouped shape.

Fixes #15344.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
