### PR TITLE
fix: harden auto recharge setup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -196,6 +196,87 @@ describe("PUT /api/zero/billing/auto-recharge", () => {
     expect(row?.autoRechargeAmount).toBe(5000);
   });
 
+  it("triggers auto-recharge immediately when enabling below threshold", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(orgMetadata)
+      .set({
+        credits: 500,
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: null,
+      })
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_test" },
+    });
+    context.mocks.stripe.invoices.create.mockResolvedValue({
+      id: "in_auto_recharge_enable",
+    });
+    context.mocks.stripe.invoiceItems.create.mockResolvedValue({
+      id: "ii_auto_recharge_enable",
+    });
+    context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
+      id: "in_auto_recharge_enable",
+    });
+    context.mocks.stripe.invoices.pay.mockResolvedValue({
+      id: "in_auto_recharge_enable",
+      status: "paid",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      enabled: true,
+      threshold: 1000,
+      amount: 5000,
+    });
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: customerId,
+        auto_advance: false,
+        default_payment_method: "pm_test",
+        metadata: expect.objectContaining({
+          type: "auto_recharge",
+          orgId: fixture.orgId,
+          creditsAmount: "5000",
+        }),
+      }),
+    );
+    expect(context.mocks.stripe.invoiceItems.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice: "in_auto_recharge_enable",
+        customer: customerId,
+        amount: 500,
+        currency: "usd",
+      }),
+    );
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(
+      "in_auto_recharge_enable",
+    );
+
+    const [row] = await writeDb
+      .select({ pendingAt: orgMetadata.autoRechargePendingAt })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    expect(row?.pendingAt).toBeInstanceOf(Date);
+  });
+
   it("disables auto-recharge and clears pending state", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/routes/zero-billing-auto-recharge.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-auto-recharge.ts
@@ -9,6 +9,7 @@ import {
   autoRechargeConfig,
   updateAutoRechargeConfig$,
 } from "../services/billing.service";
+import { triggerAutoRecharge$ } from "../services/zero-credit-recharge.service";
 import type { RouteEntry } from "../route";
 
 const adminRequired = Object.freeze({
@@ -59,6 +60,11 @@ const updateAutoRechargeInner$ = command(
 
     if (!result.ok) {
       return badRequestMessage(result.error);
+    }
+
+    if (bodyResult.data.enabled) {
+      await set(triggerAutoRecharge$, auth.orgId, signal);
+      signal.throwIfAborted();
     }
 
     return { status: 200 as const, body: result.data };

--- a/turbo/apps/cli/src/commands/zero/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/credit.test.ts
@@ -89,4 +89,35 @@ describe("zero credit command", () => {
     });
     expect(output()).toContain("https://checkout.stripe.com/session/credit");
   });
+
+  it("rejects auto-recharge threshold without the auto-recharge flag", async () => {
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      return undefined as never;
+    });
+    const mockConsoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    server.use(stubMembers("admin"));
+
+    try {
+      await zeroCreditCommand.parseAsync([
+        "node",
+        "cli",
+        "20000",
+        "--auto-recharge-threshold",
+        "5000",
+        "--auto-recharge-amount",
+        "20000",
+      ]);
+
+      const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorOutput).toContain(
+        "--auto-recharge-threshold and --auto-recharge-amount require --auto-recharge",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    } finally {
+      mockConsoleError.mockRestore();
+      mockExit.mockRestore();
+    }
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/credit.ts
+++ b/turbo/apps/cli/src/commands/zero/credit.ts
@@ -53,26 +53,34 @@ export const zeroCreditCommand = new Command()
         const origin = await getPlatformOrigin();
         const successUrl = `${origin}/?settings=usage&credit=success`;
         const cancelUrl = `${origin}/?settings=usage&credit=canceled`;
-        const autoRecharge =
-          options.autoRecharge === undefined &&
-          options.autoRechargeThreshold === undefined &&
-          options.autoRechargeAmount === undefined
-            ? undefined
-            : {
-                enabled: options.autoRecharge === true,
-                threshold: options.autoRechargeThreshold,
-                amount: options.autoRechargeAmount,
-              };
+        if (
+          options.autoRecharge !== true &&
+          (options.autoRechargeThreshold !== undefined ||
+            options.autoRechargeAmount !== undefined)
+        ) {
+          throw new Error(
+            "--auto-recharge-threshold and --auto-recharge-amount require --auto-recharge",
+          );
+        }
 
         if (
-          autoRecharge?.enabled === true &&
-          (autoRecharge.threshold === undefined ||
-            autoRecharge.amount === undefined)
+          options.autoRecharge === true &&
+          (options.autoRechargeThreshold === undefined ||
+            options.autoRechargeAmount === undefined)
         ) {
           throw new Error(
             "--auto-recharge requires --auto-recharge-threshold and --auto-recharge-amount",
           );
         }
+
+        const autoRecharge =
+          options.autoRecharge === true
+            ? {
+                enabled: true,
+                threshold: options.autoRechargeThreshold,
+                amount: options.autoRechargeAmount,
+              }
+            : undefined;
 
         const result = await createZeroCreditCheckout({
           credits,


### PR DESCRIPTION
## Summary
- require `--auto-recharge` before accepting CLI auto-recharge threshold or amount flags
- trigger an immediate auto-recharge eligibility check after enabling org auto top-up settings
- add focused coverage for the CLI guard and settings-triggered auto-recharge path

## Tests
- `pnpm -F @vm0/cli test src/commands/zero/__tests__/credit.test.ts`
- `pnpm -F @vm0/cli check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `git diff --check`

## Not run
- `pnpm -F api test src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts` needs local Postgres; current environment reports `localhost:5432 - no response`.
