### PR TITLE
feat(platform): add buy credits section to billing settings

### DIFF
--- a/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
@@ -4,9 +4,9 @@ import type { Setter } from "ccstate";
 import { env } from "../../lib/env";
 import { getMemberRoleAndUpdateCache$ } from "./auth.service";
 
-function comparePlansUrl(): string {
+function addCreditsUrl(): string {
   const appUrl = env("APP_URL").replace(/\/$/, "");
-  return `${appUrl}/?settings=billing&billingView=plans`;
+  return `${appUrl}/?settings=billing&billingView=credits`;
 }
 
 export async function formatIntegrationRunError(args: {
@@ -37,7 +37,7 @@ export async function formatIntegrationRunError(args: {
     message: args.message,
     insufficientCredits: {
       canManageBilling: membership?.role === "admin",
-      comparePlansUrl: comparePlansUrl(),
+      addCreditsUrl: addCreditsUrl(),
     },
   });
 }

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -408,16 +408,12 @@ export type BuyCreditsSelection = 10 | 20 | 50 | "custom";
 
 const internalBuyCreditsSelection$ = state<BuyCreditsSelection>(20);
 const internalBuyCreditsCustomDollars$ = state("");
-const internalBuyCreditsCoupon$ = state("");
 
 export const buyCreditsSelection$ = computed((get) => {
   return get(internalBuyCreditsSelection$);
 });
 export const buyCreditsCustomDollars$ = computed((get) => {
   return get(internalBuyCreditsCustomDollars$);
-});
-export const buyCreditsCoupon$ = computed((get) => {
-  return get(internalBuyCreditsCoupon$);
 });
 
 export const setBuyCreditsSelection$ = command(
@@ -427,7 +423,4 @@ export const setBuyCreditsSelection$ = command(
 );
 export const setBuyCreditsCustomDollars$ = command(({ set }, value: string) => {
   set(internalBuyCreditsCustomDollars$, value);
-});
-export const setBuyCreditsCoupon$ = command(({ set }, value: string) => {
-  set(internalBuyCreditsCoupon$, value);
 });

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -399,3 +399,35 @@ export const invoicesAsync$ = computed(async (get) => {
   const result = await accept(client.get(), [200]);
   return result.body;
 });
+
+// ---------------------------------------------------------------------------
+// Buy credits form state (Billing page > Buy credits section)
+// ---------------------------------------------------------------------------
+
+export type BuyCreditsSelection = 10 | 20 | 50 | "custom";
+
+const internalBuyCreditsSelection$ = state<BuyCreditsSelection>(20);
+const internalBuyCreditsCustomDollars$ = state("");
+const internalBuyCreditsCoupon$ = state("");
+
+export const buyCreditsSelection$ = computed((get) => {
+  return get(internalBuyCreditsSelection$);
+});
+export const buyCreditsCustomDollars$ = computed((get) => {
+  return get(internalBuyCreditsCustomDollars$);
+});
+export const buyCreditsCoupon$ = computed((get) => {
+  return get(internalBuyCreditsCoupon$);
+});
+
+export const setBuyCreditsSelection$ = command(
+  ({ set }, value: BuyCreditsSelection) => {
+    set(internalBuyCreditsSelection$, value);
+  },
+);
+export const setBuyCreditsCustomDollars$ = command(({ set }, value: string) => {
+  set(internalBuyCreditsCustomDollars$, value);
+});
+export const setBuyCreditsCoupon$ = command(({ set }, value: string) => {
+  set(internalBuyCreditsCoupon$, value);
+});

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -408,12 +408,16 @@ export type BuyCreditsSelection = 10 | 20 | 50 | "custom";
 
 const internalBuyCreditsSelection$ = state<BuyCreditsSelection>(20);
 const internalBuyCreditsCustomDollars$ = state("");
+const internalBuyCreditsCouponCode$ = state("");
 
 export const buyCreditsSelection$ = computed((get) => {
   return get(internalBuyCreditsSelection$);
 });
 export const buyCreditsCustomDollars$ = computed((get) => {
   return get(internalBuyCreditsCustomDollars$);
+});
+export const buyCreditsCouponCode$ = computed((get) => {
+  return get(internalBuyCreditsCouponCode$);
 });
 
 export const setBuyCreditsSelection$ = command(
@@ -423,4 +427,7 @@ export const setBuyCreditsSelection$ = command(
 );
 export const setBuyCreditsCustomDollars$ = command(({ set }, value: string) => {
   set(internalBuyCreditsCustomDollars$, value);
+});
+export const setBuyCreditsCouponCode$ = command(({ set }, value: string) => {
+  set(internalBuyCreditsCouponCode$, value);
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
@@ -10,7 +10,10 @@ import {
   settingsActiveSection$,
   settingsDialogOpen$,
 } from "../settings-dialog.ts";
-import { billingSubPage$ } from "../org-manage-tabs-state.ts";
+import {
+  billingScrollTarget$,
+  billingSubPage$,
+} from "../org-manage-tabs-state.ts";
 import { searchParams$ } from "../../../route.ts";
 import {
   resetMockOrg,
@@ -65,6 +68,25 @@ describe("checkUnifiedSettingsParam$", () => {
     expect(store.get(searchParams$).has("billingView")).toBeFalsy();
   });
 
+  it("opens billing on Buy credits when ?settings=billing&billingView=credits", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    createPushStateMock(signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=billing&billingView=credits" },
+      signal,
+    );
+
+    await store.set(checkUnifiedSettingsParam$, signal);
+
+    expect(store.get(settingsDialogOpen$)).toBeTruthy();
+    expect(store.get(settingsActiveSection$)).toBe("billing");
+    expect(store.get(billingSubPage$)).toBeFalsy();
+    expect(store.get(billingScrollTarget$)).toBe("buy-credits");
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
+  });
+
   it("keeps non-admins on the home page when opening Compare plans link", async () => {
     const { store, signal } = context;
     setupAuth(signal);
@@ -79,6 +101,25 @@ describe("checkUnifiedSettingsParam$", () => {
 
     expect(store.get(settingsDialogOpen$)).toBeFalsy();
     expect(store.get(billingSubPage$)).toBeFalsy();
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
+  });
+
+  it("keeps non-admins on the home page when opening Buy credits link", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    setMockOrg({ role: "member" });
+    createPushStateMock(signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=billing&billingView=credits" },
+      signal,
+    );
+
+    await store.set(checkUnifiedSettingsParam$, signal);
+
+    expect(store.get(settingsDialogOpen$)).toBeFalsy();
+    expect(store.get(billingSubPage$)).toBeFalsy();
+    expect(store.get(billingScrollTarget$)).toBeNull();
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
     expect(store.get(searchParams$).has("billingView")).toBeFalsy();
   });

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -26,14 +26,25 @@ export type OrgManageTab =
   | "invoices";
 
 const internalActiveTab$ = state<OrgManageTab>("general");
+const internalBillingScrollTarget$ = state<"buy-credits" | null>(null);
 
 export const orgManageTab$ = computed((get) => {
   return get(internalActiveTab$);
 });
 
+export const billingScrollTarget$ = computed((get) => {
+  return get(internalBillingScrollTarget$);
+});
+
 export const setActiveOrgManageTab$ = command(({ set }, tab: OrgManageTab) => {
   set(internalActiveTab$, tab);
 });
+
+export const setBillingScrollTarget$ = command(
+  ({ set }, target: "buy-credits" | null) => {
+    set(internalBillingScrollTarget$, target);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // org-general-tab: ProfileSection

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -4,6 +4,7 @@ import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import {
   initProfileName$,
+  setBillingScrollTarget$,
   setBillingSubPage$,
 } from "./org-manage-tabs-state.ts";
 
@@ -125,10 +126,13 @@ export const checkUnifiedSettingsParam$ = command(
       const section = value;
       const opensBillingPlans =
         section === "billing" && billingView === "plans";
+      const opensBuyCredits =
+        section === "billing" && billingView === "credits";
       const isAdmin = await get(isOrgAdmin$);
       signal.throwIfAborted();
-      if (!isAdmin && opensBillingPlans) {
+      if (!isAdmin && (opensBillingPlans || opensBuyCredits)) {
         set(setBillingSubPage$, false);
+        set(setBillingScrollTarget$, null);
       } else {
         const resolved =
           !isAdmin && isAdminOnlySettingsSection(section)
@@ -136,6 +140,10 @@ export const checkUnifiedSettingsParam$ = command(
             : section;
         set(internalActiveSection$, resolved);
         set(setBillingSubPage$, opensBillingPlans && resolved === "billing");
+        set(
+          setBillingScrollTarget$,
+          opensBuyCredits && resolved === "billing" ? "buy-credits" : null,
+        );
         await set(setSettingsDialogOpen$, true, signal);
       }
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
@@ -10,6 +11,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
 import { reloadBillingStatus$ } from "../../../signals/zero-page/billing.ts";
+import { pathname$ } from "../../../signals/route.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
   zeroBillingStatusContract,
@@ -282,6 +284,75 @@ describe("org billing tab - buy credits section", () => {
       successUrl: expect.stringContaining(
         "credit_checkout_session_id={CHECKOUT_SESSION_ID}",
       ),
+    });
+  });
+
+  it("shows range toast without starting checkout for invalid custom amounts", async () => {
+    const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+      return "" as ReturnType<typeof toast.error>;
+    });
+    let capturedBody: unknown = null;
+    server.use(
+      mockApi(zeroBillingCreditCheckoutContract.create, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
+          url: "https://checkout.stripe.com/test?credits=invalid",
+        });
+      }),
+    );
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Custom"));
+    await fill(screen.getByLabelText("Custom dollar amount"), "10001");
+
+    const buyButton = queryAllByRoleFast("button").find((el) => {
+      return el.textContent?.trim() === "Quick buy";
+    });
+    expect(buyButton).toBeDefined();
+    expect(buyButton!).toHaveAttribute("aria-disabled", "true");
+    click(buyButton!);
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith("Enter between $1 and $10,000");
+    });
+    expect(capturedBody).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("navigates coupon codes to the redeem campaign route", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    await fill(screen.getByLabelText("Coupon code"), "ZERO100");
+    const redeemButton = queryAllByRoleFast("button").find((el) => {
+      return el.textContent?.trim() === "Redeem";
+    });
+    expect(redeemButton).toBeDefined();
+    click(redeemButton!);
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/redeem/ZERO100");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -220,6 +220,26 @@ describe("org billing tab - buy credits section", () => {
     expect(screen.getByText("Quick buy $20.00")).toBeInTheDocument();
   });
 
+  it("hides buy credits for suspended workspaces", async () => {
+    setMockBillingStatus({
+      tier: "pro-suspend",
+      credits: 0,
+      subscriptionStatus: null,
+      hasSubscription: false,
+      cancelAtPeriodEnd: false,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("No active plan")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Buy credits")).not.toBeInTheDocument();
+    expect(screen.queryByText("Quick buy $20.00")).not.toBeInTheDocument();
+  });
+
   it("starts custom amount credit checkout", async () => {
     let capturedBody: unknown = null;
     server.use(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -15,6 +15,7 @@ import {
   zeroBillingStatusContract,
   zeroBillingAutoRechargeContract,
   zeroBillingCheckoutContract,
+  zeroBillingCreditCheckoutContract,
   zeroBillingPortalContract,
   zeroBillingDowngradeContract,
 } from "@vm0/api-contracts/contracts/zero-billing";
@@ -196,6 +197,72 @@ describe("org billing tab - pricing sub-page navigation", () => {
     for (const btn of currentPlanButtons) {
       expect(btn).toBeDisabled();
     }
+  });
+});
+
+describe("org billing tab - buy credits section", () => {
+  afterEach(() => {
+    if (!window.location.href.startsWith("http://localhost")) {
+      window.location.href = "http://localhost/";
+    }
+  });
+
+  it("shows buy credits for free workspaces", async () => {
+    setMockBillingStatus({ tier: "free", credits: 0 });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Free plan")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Buy credits")).toBeInTheDocument();
+    expect(screen.getByText("Quick buy $20.00")).toBeInTheDocument();
+  });
+
+  it("starts custom amount credit checkout", async () => {
+    let capturedBody: unknown = null;
+    server.use(
+      mockApi(zeroBillingCreditCheckoutContract.create, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
+          url: "https://checkout.stripe.com/test?credits=custom",
+        });
+      }),
+    );
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Custom"));
+    await fill(screen.getByLabelText("Custom dollar amount"), "123");
+
+    const buyButton = queryAllByRoleFast("button").find((el) => {
+      return el.textContent?.trim() === "Quick buy $123.00";
+    });
+    expect(buyButton).toBeDefined();
+    click(buyButton!);
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        credits: 123_000,
+        customAmount: true,
+      });
+    });
+    expect(capturedBody).toMatchObject({
+      successUrl: expect.stringContaining(
+        "credit_checkout_session_id={CHECKOUT_SESSION_ID}",
+      ),
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
@@ -10,7 +10,6 @@ import {
   setBuyCreditsCustomDollars$,
   setBuyCreditsSelection$,
   startCreditCheckout$,
-  type BillingTier,
   type BuyCreditsSelection,
   type CreditCheckoutSelection,
 } from "../../../../signals/zero-page/billing.ts";
@@ -179,21 +178,13 @@ function resolveBuyDollars(
   return valid ? value : null;
 }
 
-export function BuyCreditsSection({
-  currentTier,
-}: {
-  currentTier: BillingTier;
-}) {
+export function BuyCreditsSection() {
   const pageSignal = useGet(pageSignal$);
   const [checkoutLoadable, checkout] = useLoadableSet(startCreditCheckout$);
   const selection = useGet(buyCreditsSelection$);
   const customDollars = useGet(buyCreditsCustomDollars$);
   const setSelection = useSet(setBuyCreditsSelection$);
   const setCustomDollars = useSet(setBuyCreditsCustomDollars$);
-
-  if (currentTier === "free" || currentTier === "pro-suspend") {
-    return null;
-  }
 
   const redirecting = checkoutLoadable.state === "loading";
   const buyDollars = resolveBuyDollars(selection, customDollars);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
@@ -4,13 +4,9 @@ import { Button, Input } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
-import { detachedNavigateTo$ } from "../../../../signals/route.ts";
-import { ROUTES } from "../../../../signals/route-paths.ts";
 import {
-  buyCreditsCoupon$,
   buyCreditsCustomDollars$,
   buyCreditsSelection$,
-  setBuyCreditsCoupon$,
   setBuyCreditsCustomDollars$,
   setBuyCreditsSelection$,
   startCreditCheckout$,
@@ -48,7 +44,7 @@ const tileBaseClass =
 
 function tileBorderClass(selected: boolean): string {
   return selected
-    ? "border border-foreground ring-1 ring-foreground"
+    ? "border border-primary ring-2 ring-primary/20"
     : "zero-border hover:border-muted-foreground/30";
 }
 
@@ -167,58 +163,6 @@ function TileGrid({
   );
 }
 
-function ActionsRow({
-  coupon,
-  onCouponChange,
-  onRedeem,
-  redeemDisabled,
-  buyLabel,
-  buyDisabled,
-  onBuy,
-}: {
-  coupon: string;
-  onCouponChange: (next: string) => void;
-  onRedeem: () => void;
-  redeemDisabled: boolean;
-  buyLabel: string;
-  buyDisabled: boolean;
-  onBuy: (e: React.MouseEvent<HTMLButtonElement>) => void;
-}) {
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
-      <div className="flex items-center gap-2">
-        <Input
-          type="text"
-          value={coupon}
-          onChange={(e) => {
-            onCouponChange(e.target.value);
-          }}
-          placeholder="Enter coupon code"
-          className="h-9 w-[200px]"
-          aria-label="Coupon code"
-        />
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-9 px-4 text-sm"
-          disabled={redeemDisabled}
-          onClick={onRedeem}
-        >
-          Redeem
-        </Button>
-      </div>
-      <Button
-        size="sm"
-        className="h-9 px-4 text-sm font-medium"
-        disabled={buyDisabled}
-        onClick={onBuy}
-      >
-        {buyLabel}
-      </Button>
-    </div>
-  );
-}
-
 function resolveBuyDollars(
   selection: BuyCreditsSelection,
   customDollars: string,
@@ -242,13 +186,10 @@ export function BuyCreditsSection({
 }) {
   const pageSignal = useGet(pageSignal$);
   const [checkoutLoadable, checkout] = useLoadableSet(startCreditCheckout$);
-  const navigateTo = useSet(detachedNavigateTo$);
   const selection = useGet(buyCreditsSelection$);
   const customDollars = useGet(buyCreditsCustomDollars$);
-  const coupon = useGet(buyCreditsCoupon$);
   const setSelection = useSet(setBuyCreditsSelection$);
   const setCustomDollars = useSet(setBuyCreditsCustomDollars$);
-  const setCoupon = useSet(setBuyCreditsCoupon$);
 
   if (currentTier === "free" || currentTier === "pro-suspend") {
     return null;
@@ -275,16 +216,6 @@ export function BuyCreditsSection({
     detach(checkout(payload, newTab, pageSignal), Reason.DomCallback);
   };
 
-  const trimmedCoupon = coupon.trim();
-  const handleRedeem = () => {
-    if (trimmedCoupon === "") {
-      return;
-    }
-    navigateTo(ROUTES.redeemCampaign, {
-      pathParams: { campaign: trimmedCoupon },
-    });
-  };
-
   return (
     <section className="flex flex-col gap-3">
       <h3 className="text-sm font-medium text-foreground">Buy credits</h3>
@@ -307,15 +238,16 @@ export function BuyCreditsSection({
           />
         </div>
         <div className="h-0 zero-border-t mx-5" />
-        <ActionsRow
-          coupon={coupon}
-          onCouponChange={setCoupon}
-          onRedeem={handleRedeem}
-          redeemDisabled={trimmedCoupon === ""}
-          buyLabel={buyLabel}
-          buyDisabled={buyDisabled}
-          onBuy={handleBuy}
-        />
+        <div className="flex items-center justify-end px-5 py-4">
+          <Button
+            size="sm"
+            className="h-9 px-4 text-sm font-medium"
+            disabled={buyDisabled}
+            onClick={handleBuy}
+          >
+            {buyLabel}
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
@@ -3,10 +3,14 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { Button, Input } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detachedNavigateTo$ } from "../../../../signals/route.ts";
+import { ROUTES } from "../../../../signals/route-paths.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import {
+  buyCreditsCouponCode$,
   buyCreditsCustomDollars$,
   buyCreditsSelection$,
+  setBuyCreditsCouponCode$,
   setBuyCreditsCustomDollars$,
   setBuyCreditsSelection$,
   startCreditCheckout$,
@@ -183,12 +187,16 @@ export function BuyCreditsSection() {
   const [checkoutLoadable, checkout] = useLoadableSet(startCreditCheckout$);
   const selection = useGet(buyCreditsSelection$);
   const customDollars = useGet(buyCreditsCustomDollars$);
+  const couponCode = useGet(buyCreditsCouponCode$);
   const setSelection = useSet(setBuyCreditsSelection$);
   const setCustomDollars = useSet(setBuyCreditsCustomDollars$);
+  const setCouponCode = useSet(setBuyCreditsCouponCode$);
+  const navigate = useSet(detachedNavigateTo$);
 
   const redirecting = checkoutLoadable.state === "loading";
   const buyDollars = resolveBuyDollars(selection, customDollars);
-  const buyDisabled = redirecting || buyDollars === null;
+  const buyInvalid = buyDollars === null;
+  const trimmedCouponCode = couponCode.trim();
   const buyLabel = redirecting
     ? "Redirecting..."
     : buyDollars === null
@@ -197,7 +205,11 @@ export function BuyCreditsSection() {
 
   const handleBuy = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (buyDollars === null) {
-      toast.error(`Enter between $${MIN_CUSTOM_USD} and $${MAX_CUSTOM_USD}`);
+      toast.error(
+        `Enter between $${MIN_CUSTOM_USD} and $${MAX_CUSTOM_USD.toLocaleString(
+          "en-US",
+        )}`,
+      );
       return;
     }
     const credits = buyDollars * CREDITS_PER_DOLLAR;
@@ -205,6 +217,14 @@ export function BuyCreditsSection() {
       selection === "custom" ? { credits, customAmount: true } : { credits };
     const newTab = e.metaKey || e.ctrlKey;
     detach(checkout(payload, newTab, pageSignal), Reason.DomCallback);
+  };
+  const handleRedeem = () => {
+    if (trimmedCouponCode === "") {
+      return;
+    }
+    navigate(ROUTES.redeemCampaign, {
+      pathParams: { campaign: trimmedCouponCode },
+    });
   };
 
   return (
@@ -229,11 +249,37 @@ export function BuyCreditsSection() {
           />
         </div>
         <div className="h-0 zero-border-t mx-5" />
-        <div className="flex items-center justify-end px-5 py-4">
+        <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
+            <Input
+              type="text"
+              value={couponCode}
+              onChange={(e) => {
+                setCouponCode(e.target.value);
+              }}
+              placeholder="Enter coupon code"
+              aria-label="Coupon code"
+              className="h-9 w-full sm:w-[220px]"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-9 px-4 text-sm font-medium"
+              disabled={trimmedCouponCode === ""}
+              onClick={handleRedeem}
+            >
+              Redeem
+            </Button>
+          </div>
           <Button
+            type="button"
             size="sm"
-            className="h-9 px-4 text-sm font-medium"
-            disabled={buyDisabled}
+            className={`h-9 px-4 text-sm font-medium ${
+              buyInvalid ? "opacity-60" : ""
+            }`}
+            disabled={redirecting}
+            aria-disabled={buyInvalid}
             onClick={handleBuy}
           >
             {buyLabel}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
@@ -1,0 +1,322 @@
+import { useGet, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Button, Input } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+import { detachedNavigateTo$ } from "../../../../signals/route.ts";
+import { ROUTES } from "../../../../signals/route-paths.ts";
+import {
+  buyCreditsCoupon$,
+  buyCreditsCustomDollars$,
+  buyCreditsSelection$,
+  setBuyCreditsCoupon$,
+  setBuyCreditsCustomDollars$,
+  setBuyCreditsSelection$,
+  startCreditCheckout$,
+  type BillingTier,
+  type BuyCreditsSelection,
+  type CreditCheckoutSelection,
+} from "../../../../signals/zero-page/billing.ts";
+
+const CREDITS_PER_DOLLAR = 1000;
+const PRESETS = [10, 20, 50] as const;
+const MIN_CUSTOM_USD = 1;
+const MAX_CUSTOM_USD = 10_000;
+
+type Preset = (typeof PRESETS)[number];
+
+const settingsCardBorder = {
+  border: "0.7px solid hsl(var(--gray-400))",
+} as const;
+
+function formatUsd(dollars: number): string {
+  return dollars.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatCredits(dollars: number): string {
+  return `${(dollars * CREDITS_PER_DOLLAR).toLocaleString("en-US")} credits`;
+}
+
+const tileBaseClass =
+  "flex flex-col rounded-xl bg-background px-4 py-3 text-left transition-colors";
+
+function tileBorderClass(selected: boolean): string {
+  return selected
+    ? "border border-foreground ring-1 ring-foreground"
+    : "zero-border hover:border-muted-foreground/30";
+}
+
+function PresetTile({
+  dollars,
+  selected,
+  onSelect,
+}: {
+  dollars: Preset;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`${tileBaseClass} ${tileBorderClass(selected)}`}
+    >
+      <span className="text-sm font-semibold text-foreground">${dollars}</span>
+      <span className="mt-1 text-[13px] text-muted-foreground">
+        {formatCredits(dollars)}
+      </span>
+    </button>
+  );
+}
+
+function CustomTile({
+  selected,
+  value,
+  onSelect,
+  onChange,
+}: {
+  selected: boolean;
+  value: string;
+  onSelect: () => void;
+  onChange: (next: string) => void;
+}) {
+  if (!selected) {
+    return (
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-pressed={false}
+        className={`${tileBaseClass} ${tileBorderClass(false)}`}
+      >
+        <span className="text-sm font-semibold text-foreground">Custom</span>
+        <span className="mt-1 text-[13px] text-muted-foreground">
+          Any amount
+        </span>
+      </button>
+    );
+  }
+  return (
+    <div className={`${tileBaseClass} ${tileBorderClass(true)}`}>
+      <div className="flex items-baseline gap-1">
+        <span className="text-sm font-semibold text-foreground">$</span>
+        <Input
+          type="text"
+          inputMode="numeric"
+          value={value}
+          autoFocus
+          onChange={(e) => {
+            const next = e.target.value;
+            if (next !== "" && !/^\d+$/.test(next)) {
+              return;
+            }
+            onChange(next);
+          }}
+          placeholder="100"
+          className="h-6 w-full border-0 bg-transparent p-0 text-sm font-semibold shadow-none focus-visible:ring-0"
+          aria-label="Custom dollar amount"
+        />
+      </div>
+      <span className="mt-1 text-[13px] text-muted-foreground">
+        {value === "" ? "Any amount" : formatCredits(Number(value))}
+      </span>
+    </div>
+  );
+}
+
+function TileGrid({
+  selection,
+  customDollars,
+  onSelect,
+  onCustomChange,
+}: {
+  selection: BuyCreditsSelection;
+  customDollars: string;
+  onSelect: (next: BuyCreditsSelection) => void;
+  onCustomChange: (next: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+      {PRESETS.map((dollars) => {
+        return (
+          <PresetTile
+            key={dollars}
+            dollars={dollars}
+            selected={selection === dollars}
+            onSelect={() => {
+              onSelect(dollars);
+            }}
+          />
+        );
+      })}
+      <CustomTile
+        selected={selection === "custom"}
+        value={customDollars}
+        onSelect={() => {
+          onSelect("custom");
+        }}
+        onChange={onCustomChange}
+      />
+    </div>
+  );
+}
+
+function ActionsRow({
+  coupon,
+  onCouponChange,
+  onRedeem,
+  redeemDisabled,
+  buyLabel,
+  buyDisabled,
+  onBuy,
+}: {
+  coupon: string;
+  onCouponChange: (next: string) => void;
+  onRedeem: () => void;
+  redeemDisabled: boolean;
+  buyLabel: string;
+  buyDisabled: boolean;
+  onBuy: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
+      <div className="flex items-center gap-2">
+        <Input
+          type="text"
+          value={coupon}
+          onChange={(e) => {
+            onCouponChange(e.target.value);
+          }}
+          placeholder="Enter coupon code"
+          className="h-9 w-[200px]"
+          aria-label="Coupon code"
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9 px-4 text-sm"
+          disabled={redeemDisabled}
+          onClick={onRedeem}
+        >
+          Redeem
+        </Button>
+      </div>
+      <Button
+        size="sm"
+        className="h-9 px-4 text-sm font-medium"
+        disabled={buyDisabled}
+        onClick={onBuy}
+      >
+        {buyLabel}
+      </Button>
+    </div>
+  );
+}
+
+function resolveBuyDollars(
+  selection: BuyCreditsSelection,
+  customDollars: string,
+): number | null {
+  if (selection !== "custom") {
+    return selection;
+  }
+  const value = Number(customDollars);
+  const valid =
+    customDollars !== "" &&
+    Number.isInteger(value) &&
+    value >= MIN_CUSTOM_USD &&
+    value <= MAX_CUSTOM_USD;
+  return valid ? value : null;
+}
+
+export function BuyCreditsSection({
+  currentTier,
+}: {
+  currentTier: BillingTier;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [checkoutLoadable, checkout] = useLoadableSet(startCreditCheckout$);
+  const navigateTo = useSet(detachedNavigateTo$);
+  const selection = useGet(buyCreditsSelection$);
+  const customDollars = useGet(buyCreditsCustomDollars$);
+  const coupon = useGet(buyCreditsCoupon$);
+  const setSelection = useSet(setBuyCreditsSelection$);
+  const setCustomDollars = useSet(setBuyCreditsCustomDollars$);
+  const setCoupon = useSet(setBuyCreditsCoupon$);
+
+  if (currentTier === "free" || currentTier === "pro-suspend") {
+    return null;
+  }
+
+  const redirecting = checkoutLoadable.state === "loading";
+  const buyDollars = resolveBuyDollars(selection, customDollars);
+  const buyDisabled = redirecting || buyDollars === null;
+  const buyLabel = redirecting
+    ? "Redirecting..."
+    : buyDollars === null
+      ? "Quick buy"
+      : `Quick buy ${formatUsd(buyDollars)}`;
+
+  const handleBuy = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (buyDollars === null) {
+      toast.error(`Enter between $${MIN_CUSTOM_USD} and $${MAX_CUSTOM_USD}`);
+      return;
+    }
+    const credits = buyDollars * CREDITS_PER_DOLLAR;
+    const payload: CreditCheckoutSelection =
+      selection === "custom" ? { credits, customAmount: true } : { credits };
+    const newTab = e.metaKey || e.ctrlKey;
+    detach(checkout(payload, newTab, pageSignal), Reason.DomCallback);
+  };
+
+  const trimmedCoupon = coupon.trim();
+  const handleRedeem = () => {
+    if (trimmedCoupon === "") {
+      return;
+    }
+    navigateTo(ROUTES.redeemCampaign, {
+      pathParams: { campaign: trimmedCoupon },
+    });
+  };
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h3 className="text-sm font-medium text-foreground">Buy credits</h3>
+      <div
+        className="overflow-hidden rounded-xl bg-card"
+        style={settingsCardBorder}
+      >
+        <div className="flex flex-col gap-3 px-5 py-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">Amount</p>
+            <p className="mt-0.5 text-[13px] text-muted-foreground">
+              Credits never expire. 1 USD = 1,000 credits.
+            </p>
+          </div>
+          <TileGrid
+            selection={selection}
+            customDollars={customDollars}
+            onSelect={setSelection}
+            onCustomChange={setCustomDollars}
+          />
+        </div>
+        <div className="h-0 zero-border-t mx-5" />
+        <ActionsRow
+          coupon={coupon}
+          onCouponChange={setCoupon}
+          onRedeem={handleRedeem}
+          redeemDisabled={trimmedCoupon === ""}
+          buyLabel={buyLabel}
+          buyDisabled={buyDisabled}
+          onBuy={handleBuy}
+        />
+      </div>
+    </section>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -511,6 +511,13 @@ function PlanActionButtons({
   );
 }
 
+function shouldShowBuyCreditsSection(
+  hasBillingStatus: boolean,
+  currentTier: BillingTier,
+): boolean {
+  return hasBillingStatus && currentTier !== "pro-suspend";
+}
+
 export function OrgBillingTab() {
   const pricingOpen = useGet(billingSubPage$);
   const billingScrollTarget = useGet(billingScrollTarget$);
@@ -549,6 +556,10 @@ export function OrgBillingTab() {
     currentTier === "pro-suspend"
       ? "No active plan"
       : `${formatTierLabel(currentTier)} plan`;
+  const showBuyCredits = shouldShowBuyCreditsSection(
+    status !== null,
+    currentTier,
+  );
 
   if (pricingOpen) {
     return (
@@ -680,7 +691,7 @@ export function OrgBillingTab() {
         </div>
       </section>
 
-      {status && (
+      {showBuyCredits && (
         <div
           ref={(el) => {
             if (el && billingScrollTarget === "buy-credits") {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -41,6 +41,7 @@ import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { AutoRechargeSection } from "../../billing-dialog.tsx";
+import { BuyCreditsSection } from "./buy-credits-section.tsx";
 import {
   billingSubPage$,
   setBillingSubPage$,
@@ -674,6 +675,8 @@ export function OrgBillingTab() {
           )}
         </div>
       </section>
+
+      {status && <BuyCreditsSection currentTier={currentTier} />}
 
       {status && (
         <AutoRechargeSection

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -43,7 +43,9 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 import { AutoRechargeSection } from "../../billing-dialog.tsx";
 import { BuyCreditsSection } from "./buy-credits-section.tsx";
 import {
+  billingScrollTarget$,
   billingSubPage$,
+  setBillingScrollTarget$,
   setBillingSubPage$,
   selectedTarget$,
   setSelectedTarget$,
@@ -511,7 +513,9 @@ function PlanActionButtons({
 
 export function OrgBillingTab() {
   const pricingOpen = useGet(billingSubPage$);
+  const billingScrollTarget = useGet(billingScrollTarget$);
   const setBillingSubPage = useSet(setBillingSubPage$);
+  const setBillingScrollTarget = useSet(setBillingScrollTarget$);
   const setPricingOpen = (v: boolean) => {
     return setBillingSubPage(v);
   };
@@ -676,7 +680,20 @@ export function OrgBillingTab() {
         </div>
       </section>
 
-      {status && <BuyCreditsSection currentTier={currentTier} />}
+      {status && (
+        <div
+          ref={(el) => {
+            if (el && billingScrollTarget === "buy-credits") {
+              window.setTimeout(() => {
+                el.scrollIntoView({ block: "start", behavior: "smooth" });
+                setBillingScrollTarget(null);
+              }, 0);
+            }
+          }}
+        >
+          <BuyCreditsSection />
+        </div>
+      )}
 
       {status && (
         <AutoRechargeSection

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -24,19 +24,19 @@ describe("formatRunErrorForExternalSurface", () => {
     ).toBe("Cannot continue session with this provider");
   });
 
-  it("appends Compare plans link for admins on insufficient credits", () => {
+  it("appends Add credits link for admins on insufficient credits", () => {
     expect(
       formatRunErrorForExternalSurface({
         code: "INSUFFICIENT_CREDITS",
         message: "Insufficient credits. Please add credits to continue.",
         insufficientCredits: {
           canManageBilling: true,
-          comparePlansUrl:
-            "https://app.example.test/?settings=billing&billingView=plans",
+          addCreditsUrl:
+            "https://app.example.test/?settings=billing&billingView=credits",
         },
       }),
     ).toBe(
-      "Insufficient credits. Please add credits to continue.\n\nCompare plans: https://app.example.test/?settings=billing&billingView=plans",
+      "Insufficient credits. Please add credits to continue.\n\nAdd credits: https://app.example.test/?settings=billing&billingView=credits",
     );
   });
 
@@ -47,8 +47,8 @@ describe("formatRunErrorForExternalSurface", () => {
         message: "Insufficient credits. Please add credits to continue.",
         insufficientCredits: {
           canManageBilling: false,
-          comparePlansUrl:
-            "https://app.example.test/?settings=billing&billingView=plans",
+          addCreditsUrl:
+            "https://app.example.test/?settings=billing&billingView=credits",
         },
       }),
     ).toBe(INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE);

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -158,10 +158,17 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
 export function formatRunErrorForExternalSurface(params: {
   readonly code: string;
   readonly message: string;
-  readonly insufficientCredits?: {
-    readonly canManageBilling: boolean;
-    readonly comparePlansUrl: string;
-  };
+  readonly insufficientCredits?:
+    | {
+        readonly canManageBilling: boolean;
+        readonly addCreditsUrl: string;
+        readonly comparePlansUrl?: string;
+      }
+    | {
+        readonly canManageBilling: boolean;
+        readonly comparePlansUrl: string;
+        readonly addCreditsUrl?: string;
+      };
 }): string {
   const errorMessage = params.message.trim() || "Run failed";
   const chatgptCodexUsageLimitMessage =
@@ -177,7 +184,10 @@ export function formatRunErrorForExternalSurface(params: {
     if (!params.insufficientCredits.canManageBilling) {
       return INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE;
     }
-    return `${errorMessage}\n\nCompare plans: ${params.insufficientCredits.comparePlansUrl}`;
+    const addCreditsUrl =
+      params.insufficientCredits.addCreditsUrl ??
+      params.insufficientCredits.comparePlansUrl;
+    return `${errorMessage}\n\nAdd credits: ${addCreditsUrl}`;
   }
 
   return isGenericRunErrorForDisplay(errorMessage)


### PR DESCRIPTION
## Summary
- New **Buy credits** card on the Billing settings page (between Plan and Auto-recharge), modeled after fal.ai's recharge UI per Ming's pick.
- Wired to the existing `startCreditCheckout$` Stripe flow for the **Quick buy** CTA and to `/redeem/:campaign` for the **Redeem** action — no new endpoints.
- Local form state (selection, custom amount, coupon) lives in ccstate signals alongside the rest of the billing module.

## Design
Matches Ming's selected mockup:
- Section header **Buy credits** + card
- Top region: `Amount` sub-label, helper "Credits never expire. 1 USD = 1,000 credits.", and a 4-column tile grid (`$10` / `$20` / `$50` / `Custom`)
- `Custom` tile reveals an inline `$` input on select; out-of-range values disable the CTA and toast on click
- Divider (`zero-border-t mx-5`)
- Bottom row: `Enter coupon code` input + `Redeem` outline button on the left, `Quick buy \$XX.XX` neutral-dark page primary on the right

Variant gallery (for reference): https://billing-buy-credits-mockups-715f6d07.sites.vm0.io

## vm0 rules applied
- Sentence case throughout (`Buy credits`, `Quick buy`, `Redeem`)
- Reuses `Button` / `Input` from `@vm0/ui`; no new primitives
- Card border + radius match `AutoRechargeSection` (`overflow-hidden rounded-xl bg-card` + `settingsCardBorder`)
- Page primary uses default `<Button>` (neutral-dark, "Add schedule" style), not brand color
- ccstate signals for form state (no `useState`)
- Section is hidden for `free` / `pro-suspend` tiers, matching `AutoRechargeSection` gating

## Test plan
- [ ] On a Pro/Team workspace: open **Billing**, confirm the new section appears between **Plan** and **Auto-recharge**
- [ ] Click `\$10` / `\$20` / `\$50` — the CTA updates to `Quick buy \$10.00` / `\$20.00` / `\$50.00`
- [ ] Click **Custom**, type a value, confirm the credits hint updates and the CTA shows `Quick buy \$X.00`
- [ ] Custom value outside [\$1, \$10,000] disables the CTA; clicking it toasts the range
- [ ] Clicking **Quick buy** redirects to Stripe Checkout; on return, credits are reflected (existing flow)
- [ ] Type a coupon code, click **Redeem**, confirm navigation to `/redeem/<code>`
- [ ] Section is hidden on a `free` or `pro-suspend` workspace