### PR TITLE
feat: add echo jsonl mode to mock claude

### DIFF
--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -29,6 +29,8 @@
 //!   @exit-after-result        - Emit result event, exit(0) immediately;
 //!                               tests that reap stays no-op on the
 //!                               happy path
+//!   @ECHO@                    - First-line marker. Validate remaining non-empty
+//!                               lines as JSONL and emit them unchanged.
 
 use serde_json::{Value, json};
 use std::io::Write;
@@ -36,6 +38,7 @@ use std::process::{Command, ExitCode, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
+const ECHO_MARKER: &str = "@ECHO@";
 
 /// Parsed command-line arguments.
 struct ParsedArgs {
@@ -45,6 +48,7 @@ struct ParsedArgs {
 
 #[derive(Debug, Eq, PartialEq)]
 enum MockScenario<'a> {
+    EchoJsonl(&'a str),
     FailNoNewline(&'a str),
     FailInvalidUtf8,
     FailInvalidUtf8Long,
@@ -58,6 +62,9 @@ enum MockScenario<'a> {
 
 impl<'a> MockScenario<'a> {
     fn from_prompt(prompt: &'a str) -> Self {
+        if let Some(payload) = echo_jsonl_payload(prompt) {
+            return Self::EchoJsonl(payload);
+        }
         if let Some(msg) = prompt.strip_prefix("@fail-no-newline:") {
             return Self::FailNoNewline(msg);
         }
@@ -102,6 +109,77 @@ impl<'a> MockScenario<'a> {
         }
         Self::Shell
     }
+}
+
+fn echo_jsonl_payload(prompt: &str) -> Option<&str> {
+    let (first_line, payload) = prompt.split_once('\n').unwrap_or((prompt, ""));
+    if first_line.trim_end_matches('\r') == ECHO_MARKER {
+        return Some(payload);
+    }
+    None
+}
+
+fn parse_echo_jsonl(payload: &str) -> Result<Vec<(String, Value)>, String> {
+    let mut events = Vec::new();
+    for (index, line) in payload.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str::<Value>(line)
+            .map_err(|e| format!("invalid @ECHO@ JSONL line {}: {e}", index + 2))?;
+        events.push((line.to_string(), event));
+    }
+
+    if events.is_empty() {
+        return Err("@ECHO@ payload must contain at least one JSONL event".to_string());
+    }
+
+    Ok(events)
+}
+
+fn echo_session_id(events: &[(String, Value)]) -> Option<&str> {
+    events.iter().find_map(|(_, event)| {
+        let event_type = event.get("type").and_then(Value::as_str)?;
+        let subtype = event.get("subtype").and_then(Value::as_str)?;
+        if event_type != "system" || subtype != "init" {
+            return None;
+        }
+        event.get("session_id").and_then(Value::as_str)
+    })
+}
+
+fn write_echo_session_history(events: &[(String, Value)]) {
+    let Some(session_id) = echo_session_id(events) else {
+        return;
+    };
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "/".to_string());
+
+    if let Some(path) = create_session_history(session_id, &cwd)
+        && let Ok(mut file) = std::fs::File::create(&path)
+    {
+        for (line, _) in events {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+}
+
+fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
+    let events = match parse_echo_jsonl(payload) {
+        Ok(events) => events,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(1);
+        }
+    };
+
+    for (line, _) in &events {
+        println!("{line}");
+    }
+    write_echo_session_history(&events);
+    let _ = std::io::stdout().flush();
+    ExitCode::SUCCESS
 }
 
 fn skip_flag_value(args: &[String], i: &mut usize) {
@@ -480,6 +558,7 @@ fn main() -> ExitCode {
     let parsed = parse_args(&args);
 
     match MockScenario::from_prompt(&parsed.prompt) {
+        MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload),
         MockScenario::FailNoNewline(msg) => {
             eprint!("{msg}");
             let _ = std::io::stderr().flush();
@@ -840,5 +919,50 @@ mod tests {
     #[test]
     fn classifies_ordinary_prompt_as_shell() {
         assert_eq!(MockScenario::from_prompt("echo hello"), MockScenario::Shell);
+    }
+
+    #[test]
+    fn classifies_echo_jsonl_when_first_line_is_marker() {
+        assert_eq!(
+            MockScenario::from_prompt("@ECHO@\n{\"type\":\"result\"}"),
+            MockScenario::EchoJsonl("{\"type\":\"result\"}")
+        );
+    }
+
+    #[test]
+    fn classifies_echo_jsonl_with_crlf_marker() {
+        assert_eq!(
+            MockScenario::from_prompt("@ECHO@\r\n{\"type\":\"result\"}"),
+            MockScenario::EchoJsonl("{\"type\":\"result\"}")
+        );
+    }
+
+    #[test]
+    fn does_not_classify_marker_with_extra_text_as_echo_jsonl() {
+        assert_eq!(
+            MockScenario::from_prompt("@ECHO@ please\n{\"type\":\"result\"}"),
+            MockScenario::Shell
+        );
+    }
+
+    #[test]
+    fn parses_echo_jsonl_non_empty_lines() {
+        let events =
+            parse_echo_jsonl(r#"{"type":"system","subtype":"init","session_id":"preview-1"}"#)
+                .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].1["type"], "system");
+    }
+
+    #[test]
+    fn rejects_invalid_echo_jsonl() {
+        let err = parse_echo_jsonl(r#"{"type":"system""#).unwrap_err();
+        assert!(err.contains("invalid @ECHO@ JSONL line 2"));
+    }
+
+    #[test]
+    fn rejects_empty_echo_jsonl_payload() {
+        let err = parse_echo_jsonl("\n\n").unwrap_err();
+        assert_eq!(err, "@ECHO@ payload must contain at least one JSONL event");
     }
 }

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::process::Command;
+
+fn mock_claude() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_guest-mock-claude"))
+}
+
+fn expected_history_path(
+    home: &std::path::Path,
+    session_id: &str,
+) -> Result<std::path::PathBuf, std::io::Error> {
+    let cwd = std::env::current_dir()?.to_string_lossy().into_owned();
+    let project_name = cwd.trim_start_matches('/').replace('/', "-");
+    Ok(home
+        .join(".claude")
+        .join("projects")
+        .join(format!("-{project_name}"))
+        .join(format!("{session_id}.jsonl")))
+}
+
+#[test]
+fn echo_jsonl_outputs_valid_payload_unchanged() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let payload = [
+        r#"{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"preview-1","tools":["Bash"],"model":"mock-claude"}"#,
+        r#"{"type":"assistant","session_id":"preview-1","message":{"role":"assistant","content":[{"type":"text","text":"fixture response"}]}}"#,
+        r#"{"type":"result","subtype":"success","session_id":"preview-1","is_error":false,"duration_ms":100,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}"#,
+    ]
+    .join("\n");
+    let prompt = format!("@ECHO@\n{payload}\n");
+
+    let output = mock_claude()
+        .env("HOME", home.path())
+        .args(["--output-format", "stream-json", "--", &prompt])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("{payload}\n")
+    );
+    assert!(output.stderr.is_empty());
+
+    let history = fs::read_to_string(expected_history_path(home.path(), "preview-1")?)?;
+    assert_eq!(history, format!("{payload}\n"));
+    Ok(())
+}
+
+#[test]
+fn echo_jsonl_rejects_invalid_json_line() -> Result<(), Box<dyn std::error::Error>> {
+    let output = mock_claude()
+        .args(["--output-format", "stream-json", "--", "@ECHO@\n{\"type\""])
+        .output()?;
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid @ECHO@ JSONL line 2"));
+    Ok(())
+}
+
+#[test]
+fn echo_jsonl_rejects_empty_payload() -> Result<(), Box<dyn std::error::Error>> {
+    let output = mock_claude()
+        .args(["--output-format", "stream-json", "--", "@ECHO@\n\n"])
+        .output()?;
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("@ECHO@ payload must contain at least one JSONL event")
+    );
+    Ok(())
+}

--- a/e2e/tests/03-runner/t58-mock-claude-echo-jsonl.bats
+++ b/e2e/tests/03-runner/t58-mock-claude-echo-jsonl.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+# Test mock-claude @ECHO@ JSONL fixture mode end-to-end.
+# Verifies the CLI -> API -> runner -> sandbox pipeline can replay a supplied
+# Claude-compatible JSONL stream without invoking the real Claude CLI.
+
+load '../../helpers/setup'
+
+setup_file() {
+    export AGENT_NAME="e2e-t58-$(date +%s%3N)-$RANDOM"
+    export TEST_DIR="$(mktemp -d)"
+
+    create_test_volume "e2e-vol-t58"
+    export SHARED_VOLUME_NAME="$VOLUME_NAME"
+    export SHARED_VOLUME_DIR="$TEST_VOLUME_DIR"
+
+    export TEST_CONFIG="$TEST_DIR/vm0.yaml"
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "E2E test agent for mock Claude echo JSONL"
+    framework: claude-code
+    volumes:
+      - claude-files:/home/user/.claude
+    working_dir: /home/user/workspace
+volumes:
+  claude-files:
+    name: $SHARED_VOLUME_NAME
+    version: latest
+EOF
+    $VM0_CLI compose "$TEST_CONFIG" >/dev/null
+}
+
+teardown_file() {
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+    if [ -n "$SHARED_VOLUME_DIR" ] && [ -d "$SHARED_VOLUME_DIR" ]; then
+        rm -rf "$SHARED_VOLUME_DIR"
+    fi
+}
+
+@test "t58-1: mock Claude echoes supplied JSONL stream" {
+    local session_id="echo-jsonl-$(date +%s%3N)-$RANDOM"
+    local prompt
+    prompt=$(cat <<EOF
+@ECHO@
+{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"$session_id","tools":["Bash"],"model":"mock-claude"}
+{"type":"assistant","session_id":"$session_id","message":{"role":"assistant","content":[{"type":"text","text":"echo-jsonl fixture response"}]}}
+{"type":"result","subtype":"success","session_id":"$session_id","is_error":false,"duration_ms":100,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}
+EOF
+)
+
+    run $VM0_CLI run "$AGENT_NAME" --verbose "$prompt"
+
+    assert_success
+    assert_output --partial "▷ Claude Code Started"
+    assert_output --partial "echo-jsonl fixture response"
+    assert_output --partial "◆ Claude Code Completed"
+    assert_output --partial "Checkpoint:"
+    assert_output --partial "Session:"
+}


### PR DESCRIPTION
## Summary
- add an `@ECHO@` first-line scenario to `guest-mock-claude`
- validate the remaining prompt payload as JSONL, emit it unchanged, and write matching session history when a `system/init` session id is present
- add binary-level tests for successful echo, invalid JSON, and empty payloads
- add a runner E2E that sends an `@ECHO@` JSONL prompt through `vm0 run` and verifies the replayed assistant text plus completion/checkpoint output

## Tests
- `cargo fmt -p guest-mock-claude -- --check`
- `cargo clippy -p guest-mock-claude --all-targets -- -D warnings`
- `cargo test -p guest-mock-claude`
- `git diff --cached --check` for the E2E addition before commit

Note: I did not run the BATS E2E locally because the local runtime does not have the E2E runner stack/BATS command available; CI should run it.