### PR TITLE
fix: classify codex session limits as usage limits

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -362,7 +362,9 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::InvalidApiKey);
     }
-    if matches!(framework, AgentFramework::Codex) && normalized.contains("usage limit") {
+    if matches!(framework, AgentFramework::Codex)
+        && (normalized.contains("usage limit") || normalized.contains("hit your session limit"))
+    {
         return Some(FailureReason::UsageLimit);
     }
     None
@@ -1019,6 +1021,16 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_classifies_codex_session_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            "You've hit your session limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits. Resets 12:50pm (Asia/Shanghai).",
+        );
+
+        assert_eq!(reason, Some(FailureReason::UsageLimit));
+    }
+
+    #[test]
     fn cli_failure_reason_classifies_codex_invalid_api_key_code() {
         let reason = classify_cli_failure_reason(
             AgentFramework::Codex,
@@ -1077,6 +1089,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "Claude usage limit reached. Visit https://claude.ai/settings/usage.",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_non_codex_session_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "You've hit your session limit. Visit https://chatgpt.com/codex/settings/usage.",
         );
 
         assert_eq!(reason, None);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -363,7 +363,7 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::InvalidApiKey);
     }
     if matches!(framework, AgentFramework::Codex)
-        && (normalized.contains("usage limit") || normalized.contains("hit your session limit"))
+        && (normalized.contains("usage limit") || normalized.contains("session limit"))
     {
         return Some(FailureReason::UsageLimit);
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1022,12 +1022,18 @@ mod tests {
 
     #[test]
     fn cli_failure_reason_classifies_codex_session_limit() {
-        let reason = classify_cli_failure_reason(
-            AgentFramework::Codex,
+        for message in [
             "You've hit your session limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits. Resets 12:50pm (Asia/Shanghai).",
-        );
+            "SESSION LIMIT reached. Please try again after the reset window.",
+        ] {
+            let reason = classify_cli_failure_reason(AgentFramework::Codex, message);
 
-        assert_eq!(reason, Some(FailureReason::UsageLimit));
+            assert_eq!(
+                reason,
+                Some(FailureReason::UsageLimit),
+                "message: {message}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classify Codex `You've hit your session limit` failures as `FailureReason::UsageLimit`
- Keep runner log-level routing on structured diagnostics instead of raw error strings
- Add Codex positive and non-Codex negative coverage for session-limit wording

Fixes #15360

## Tests

- `cargo test -p guest-agent cli_failure_reason`
- `cargo fmt --check`
- `git diff --check`

Note: the first post-format test rerun hit a local Cargo incremental target copy error while checks were run in parallel; rerunning the same focused test serially passed.