### PR TITLE
feat(web): add /presentation gallery page

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -91,6 +91,22 @@ describe("proxy middleware: public routes", () => {
     expect(clerkState.protectedPaths).toEqual([]);
   });
 
+  it("keeps locale-prefixed presentation gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/presentation");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("keeps locale-less presentation gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/presentation");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
   it("keeps locale-prefixed showcase public", async () => {
     const request = new NextRequest("https://www.vm0.ai/en/showcase");
 

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Image from "next/image";
-import { IconExternalLink, IconSparkles, IconX } from "@tabler/icons-react";
+import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
 import { getAppUrl } from "../../../src/lib/zero/url";
@@ -18,41 +17,41 @@ const PAGE_PADDING = 24;
 function PresentationCard({
   item,
   appUrl,
-  onOpen,
 }: {
   item: PresentationItem;
   appUrl: string;
-  onOpen: (item: PresentationItem) => void;
 }) {
   const remixHref = buildPresentationRemixHref(item, appUrl);
 
   return (
     <article
       id={item.slug}
-      className="flex flex-col overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)] transition-all duration-300 hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
+      className="overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)] transition-all duration-300 hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
     >
-      <button
-        type="button"
-        onClick={() => {
-          onOpen(item);
-        }}
-        aria-label={`Open ${item.title}`}
-        className="group relative block aspect-[1280/633] w-full overflow-hidden bg-[hsl(var(--gray-1))]"
+      <a
+        href={item.embedUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`View ${item.title} in a new tab`}
+        className="group block"
+        style={{ textDecoration: "none" }}
       >
-        <Image
-          src={item.previewImage}
-          alt={item.title}
-          fill
-          sizes="(min-width: 880px) 832px, calc(100vw - 48px)"
-          className="object-contain transition-transform duration-300 group-hover:scale-[1.03]"
-        />
-        <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
-          <div className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-2 text-[13px] font-medium text-[hsl(var(--foreground))] shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
-            <IconExternalLink size={16} stroke={2} />
-            Preview
+        <div className="relative aspect-[1280/633] overflow-hidden bg-[hsl(var(--gray-1))]">
+          <Image
+            src={item.previewImage}
+            alt={item.title}
+            fill
+            sizes="(min-width: 880px) 832px, calc(100vw - 48px)"
+            className="object-contain transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+          <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-2 text-[13px] font-medium text-[hsl(var(--foreground))] shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
+              <IconExternalLink size={16} stroke={2} />
+              View
+            </div>
           </div>
         </div>
-      </button>
+      </a>
       <div className="flex flex-col gap-3 px-4 py-3">
         <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
           {item.prompt}
@@ -69,100 +68,8 @@ function PresentationCard({
   );
 }
 
-function PresentationLightbox({
-  item,
-  appUrl,
-  onClose,
-}: {
-  item: PresentationItem;
-  appUrl: string;
-  onClose: () => void;
-}) {
-  const remixHref = buildPresentationRemixHref(item, appUrl);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [onClose]);
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={item.title}
-      onClick={onClose}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
-    >
-      <div
-        onClick={(event) => {
-          event.stopPropagation();
-        }}
-        className="flex max-h-[92vh] w-full max-w-[1100px] flex-col overflow-y-auto rounded-[16px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.35)]"
-      >
-        <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--gray-1))] px-4 py-3">
-          <h2 className="truncate text-[15px] font-medium text-[hsl(var(--foreground))]">
-            {item.title}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[hsl(var(--muted-foreground))] transition-colors hover:bg-[hsl(var(--gray-1))]"
-          >
-            <IconX size={18} stroke={2} />
-          </button>
-        </div>
-
-        <div className="relative aspect-[1280/633] w-full bg-[hsl(var(--gray-1))]">
-          <iframe
-            src={item.embedUrl}
-            title={item.title}
-            sandbox="allow-scripts allow-same-origin allow-popups"
-            className="absolute inset-0 h-full w-full border-0"
-          />
-        </div>
-
-        <div className="flex flex-col gap-3 border-t border-[hsl(var(--gray-1))] px-4 py-4">
-          <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
-            {item.prompt}
-          </pre>
-          <div className="flex items-center justify-between gap-3">
-            <a
-              href={item.embedUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-[hsl(var(--muted-foreground))] transition-colors hover:text-[hsl(var(--foreground))]"
-            >
-              <IconExternalLink size={15} stroke={2} />
-              Open full deck
-            </a>
-            <a
-              href={remixHref}
-              className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
-            >
-              <IconSparkles size={15} stroke={2} />
-              Prompt remix
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export function PresentationClient() {
   const appUrl = getAppUrl();
-  const [activeItem, setActiveItem] = useState<PresentationItem | null>(null);
 
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
@@ -178,8 +85,8 @@ export function PresentationClient() {
         >
           <h1 className="hero-title">Presentation</h1>
           <p className="hero-description">
-            Presentation decks you can preview, open, and remix into your own
-            Zero creation.
+            Get a polished deck from a single, short prompt. Focus on your
+            content and leave the design and creative work to VM0.
           </p>
         </div>
       </section>
@@ -195,28 +102,13 @@ export function PresentationClient() {
         >
           {PRESENTATION_ITEMS.map((item) => {
             return (
-              <PresentationCard
-                key={item.slug}
-                item={item}
-                appUrl={appUrl}
-                onOpen={setActiveItem}
-              />
+              <PresentationCard key={item.slug} item={item} appUrl={appUrl} />
             );
           })}
         </div>
       </section>
 
       <Footer />
-
-      {activeItem ? (
-        <PresentationLightbox
-          item={activeItem}
-          appUrl={appUrl}
-          onClose={() => {
-            setActiveItem(null);
-          }}
-        />
-      ) : null}
     </div>
   );
 }

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { IconExternalLink, IconSparkles, IconX } from "@tabler/icons-react";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
 import { getAppUrl } from "../../../src/lib/zero/url";
@@ -15,59 +17,137 @@ const PAGE_PADDING = 24;
 
 function PresentationCard({
   item,
-  appUrl,
+  onOpen,
 }: {
   item: PresentationItem;
-  appUrl: string;
+  onOpen: (item: PresentationItem) => void;
 }) {
-  const remixHref = buildPresentationRemixHref(item, appUrl);
-
   return (
     <article
       id={item.slug}
       className="flex flex-col overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)] transition-all duration-300 hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
     >
-      <div className="relative aspect-[16/10] overflow-hidden bg-[hsl(var(--gray-1))]">
-        <iframe
-          src={item.embedUrl}
-          title={item.title}
-          loading="lazy"
-          sandbox="allow-scripts allow-same-origin allow-popups"
-          className="absolute inset-0 h-full w-full border-0"
+      <button
+        type="button"
+        onClick={() => onOpen(item)}
+        aria-label={`Open ${item.title}`}
+        className="group relative block aspect-[16/10] w-full overflow-hidden bg-[hsl(var(--gray-1))]"
+      >
+        <Image
+          src={item.previewImage}
+          alt={item.title}
+          fill
+          sizes="(min-width: 1024px) 368px, (min-width: 640px) 50vw, 100vw"
+          className="object-cover object-top transition-transform duration-300 group-hover:scale-[1.03]"
         />
-        <a
-          href={item.embedUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={`Open ${item.title} in a new tab`}
-          className="absolute right-2.5 top-2.5 inline-flex items-center gap-1.5 rounded-full bg-white/90 px-3 py-1.5 text-[12px] font-medium text-[hsl(var(--foreground))] opacity-0 shadow-[0_8px_24px_rgba(0,0,0,0.18)] transition-opacity duration-200 hover:bg-white group-hover:opacity-100"
-        >
-          <IconExternalLink size={14} stroke={2} />
-          Open
-        </a>
-      </div>
-
-      <div className="flex flex-1 flex-col gap-3 px-4 py-3">
+        <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
+          <div className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-2 text-[13px] font-medium text-[hsl(var(--foreground))] shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
+            <IconExternalLink size={16} stroke={2} />
+            Preview
+          </div>
+        </div>
+      </button>
+      <div className="px-4 py-3">
         <h2 className="text-[14px] font-medium text-[hsl(var(--foreground))]">
           {item.title}
         </h2>
-        <pre className="max-h-[120px] flex-1 overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
-          {item.prompt}
-        </pre>
-        <a
-          href={remixHref}
-          className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
-        >
-          <IconSparkles size={15} stroke={2} />
-          Prompt remix
-        </a>
       </div>
     </article>
   );
 }
 
+function PresentationLightbox({
+  item,
+  appUrl,
+  onClose,
+}: {
+  item: PresentationItem;
+  appUrl: string;
+  onClose: () => void;
+}) {
+  const remixHref = buildPresentationRemixHref(item, appUrl);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={item.title}
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        className="flex max-h-[92vh] w-full max-w-[1100px] flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.35)]"
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--gray-1))] px-4 py-3">
+          <h2 className="truncate text-[15px] font-medium text-[hsl(var(--foreground))]">
+            {item.title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[hsl(var(--muted-foreground))] transition-colors hover:bg-[hsl(var(--gray-1))]"
+          >
+            <IconX size={18} stroke={2} />
+          </button>
+        </div>
+
+        <div className="relative min-h-[50vh] flex-1 bg-[hsl(var(--gray-1))]">
+          <iframe
+            src={item.embedUrl}
+            title={item.title}
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            className="absolute inset-0 h-full w-full border-0"
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-[hsl(var(--gray-1))] px-4 py-4">
+          <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
+            {item.prompt}
+          </pre>
+          <div className="flex items-center justify-between gap-3">
+            <a
+              href={item.embedUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-[hsl(var(--muted-foreground))] transition-colors hover:text-[hsl(var(--foreground))]"
+            >
+              <IconExternalLink size={15} stroke={2} />
+              Open full deck
+            </a>
+            <a
+              href={remixHref}
+              className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+            >
+              <IconSparkles size={15} stroke={2} />
+              Prompt remix
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function PresentationClient() {
   const appUrl = getAppUrl();
+  const [activeItem, setActiveItem] = useState<PresentationItem | null>(null);
 
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
@@ -83,7 +163,7 @@ export function PresentationClient() {
         >
           <h1 className="hero-title">Presentation</h1>
           <p className="hero-description">
-            Live presentation decks you can open, watch, and remix into your own
+            Presentation decks you can preview, open, and remix into your own
             Zero creation.
           </p>
         </div>
@@ -100,13 +180,25 @@ export function PresentationClient() {
         >
           {PRESENTATION_ITEMS.map((item) => {
             return (
-              <PresentationCard key={item.slug} item={item} appUrl={appUrl} />
+              <PresentationCard
+                key={item.slug}
+                item={item}
+                onOpen={setActiveItem}
+              />
             );
           })}
         </div>
       </section>
 
       <Footer />
+
+      {activeItem ? (
+        <PresentationLightbox
+          item={activeItem}
+          appUrl={appUrl}
+          onClose={() => setActiveItem(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -39,7 +39,7 @@ function PresentationCard({
           src={item.previewImage}
           alt={item.title}
           fill
-          sizes="(min-width: 1024px) 368px, (min-width: 640px) 50vw, 100vw"
+          sizes="(min-width: 640px) 50vw, 100vw"
           className="object-contain transition-transform duration-300 group-hover:scale-[1.03]"
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
@@ -49,11 +49,6 @@ function PresentationCard({
           </div>
         </div>
       </button>
-      <div className="px-4 py-3">
-        <h2 className="text-[14px] font-medium text-[hsl(var(--foreground))]">
-          {item.title}
-        </h2>
-      </div>
     </article>
   );
 }
@@ -180,7 +175,7 @@ export function PresentationClient() {
             margin: "0 auto",
             padding: `0 ${PAGE_PADDING}px`,
           }}
-          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+          className="grid grid-cols-1 gap-6 sm:grid-cols-2"
         >
           {PRESENTATION_ITEMS.map((item) => {
             return (

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -29,7 +29,9 @@ function PresentationCard({
     >
       <button
         type="button"
-        onClick={() => onOpen(item)}
+        onClick={() => {
+          onOpen(item);
+        }}
         aria-label={`Open ${item.title}`}
         className="group relative block aspect-[16/10] w-full overflow-hidden bg-[hsl(var(--gray-1))]"
       >
@@ -91,7 +93,9 @@ function PresentationLightbox({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
     >
       <div
-        onClick={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
         className="flex max-h-[92vh] w-full max-w-[1100px] flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.35)]"
       >
         <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--gray-1))] px-4 py-3">
@@ -196,7 +200,9 @@ export function PresentationClient() {
         <PresentationLightbox
           item={activeItem}
           appUrl={appUrl}
-          onClose={() => setActiveItem(null)}
+          onClose={() => {
+            setActiveItem(null);
+          }}
         />
       ) : null}
     </div>

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -12,16 +12,20 @@ import {
   type PresentationItem,
 } from "./data";
 
-const MAX_WIDTH = 1200;
+const MAX_WIDTH = 880;
 const PAGE_PADDING = 24;
 
 function PresentationCard({
   item,
+  appUrl,
   onOpen,
 }: {
   item: PresentationItem;
+  appUrl: string;
   onOpen: (item: PresentationItem) => void;
 }) {
+  const remixHref = buildPresentationRemixHref(item, appUrl);
+
   return (
     <article
       id={item.slug}
@@ -39,7 +43,7 @@ function PresentationCard({
           src={item.previewImage}
           alt={item.title}
           fill
-          sizes="(min-width: 640px) 50vw, 100vw"
+          sizes="(min-width: 880px) 832px, calc(100vw - 48px)"
           className="object-contain transition-transform duration-300 group-hover:scale-[1.03]"
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
@@ -49,6 +53,18 @@ function PresentationCard({
           </div>
         </div>
       </button>
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
+          {item.prompt}
+        </pre>
+        <a
+          href={remixHref}
+          className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+        >
+          <IconSparkles size={15} stroke={2} />
+          Prompt remix
+        </a>
+      </div>
     </article>
   );
 }
@@ -175,13 +191,14 @@ export function PresentationClient() {
             margin: "0 auto",
             padding: `0 ${PAGE_PADDING}px`,
           }}
-          className="grid grid-cols-1 gap-6 sm:grid-cols-2"
+          className="flex flex-col items-stretch gap-6"
         >
           {PRESENTATION_ITEMS.map((item) => {
             return (
               <PresentationCard
                 key={item.slug}
                 item={item}
+                appUrl={appUrl}
                 onOpen={setActiveItem}
               />
             );

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -33,14 +33,14 @@ function PresentationCard({
           onOpen(item);
         }}
         aria-label={`Open ${item.title}`}
-        className="group relative block aspect-[16/10] w-full overflow-hidden bg-[hsl(var(--gray-1))]"
+        className="group relative block aspect-[1280/633] w-full overflow-hidden bg-[hsl(var(--gray-1))]"
       >
         <Image
           src={item.previewImage}
           alt={item.title}
           fill
           sizes="(min-width: 1024px) 368px, (min-width: 640px) 50vw, 100vw"
-          className="object-cover object-top transition-transform duration-300 group-hover:scale-[1.03]"
+          className="object-contain transition-transform duration-300 group-hover:scale-[1.03]"
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
           <div className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-2 text-[13px] font-medium text-[hsl(var(--foreground))] shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
@@ -96,7 +96,7 @@ function PresentationLightbox({
         onClick={(event) => {
           event.stopPropagation();
         }}
-        className="flex max-h-[92vh] w-full max-w-[1100px] flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.35)]"
+        className="flex max-h-[92vh] w-full max-w-[1100px] flex-col overflow-y-auto rounded-[16px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.35)]"
       >
         <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--gray-1))] px-4 py-3">
           <h2 className="truncate text-[15px] font-medium text-[hsl(var(--foreground))]">
@@ -112,7 +112,7 @@ function PresentationLightbox({
           </button>
         </div>
 
-        <div className="relative min-h-[50vh] flex-1 bg-[hsl(var(--gray-1))]">
+        <div className="relative aspect-[1280/633] w-full bg-[hsl(var(--gray-1))]">
           <iframe
             src={item.embedUrl}
             title={item.title}

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
 import { getAppUrl } from "../../../src/lib/zero/url";
@@ -53,15 +54,13 @@ function PresentationCard({
         </div>
       </a>
       <div className="flex flex-col gap-3 px-4 py-3">
-        <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
-          {item.prompt}
-        </pre>
+        <CopyablePrompt prompt={item.prompt} />
         <a
           href={remixHref}
           className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
         >
           <IconSparkles size={15} stroke={2} />
-          Prompt remix
+          Try it
         </a>
       </div>
     </article>

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { Footer } from "../../components/Footer";
+import { Particles } from "../../components/Particles";
+import { getAppUrl } from "../../../src/lib/zero/url";
+import {
+  PRESENTATION_ITEMS,
+  buildPresentationRemixHref,
+  type PresentationItem,
+} from "./data";
+
+const MAX_WIDTH = 1200;
+const PAGE_PADDING = 24;
+
+function PresentationCard({
+  item,
+  appUrl,
+}: {
+  item: PresentationItem;
+  appUrl: string;
+}) {
+  const remixHref = buildPresentationRemixHref(item, appUrl);
+
+  return (
+    <article
+      id={item.slug}
+      className="flex flex-col overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)] transition-all duration-300 hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
+    >
+      <div className="relative aspect-[16/10] overflow-hidden bg-[hsl(var(--gray-1))]">
+        <iframe
+          src={item.embedUrl}
+          title={item.title}
+          loading="lazy"
+          sandbox="allow-scripts allow-same-origin allow-popups"
+          className="absolute inset-0 h-full w-full border-0"
+        />
+        <a
+          href={item.embedUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`Open ${item.title} in a new tab`}
+          className="absolute right-2.5 top-2.5 inline-flex items-center gap-1.5 rounded-full bg-white/90 px-3 py-1.5 text-[12px] font-medium text-[hsl(var(--foreground))] opacity-0 shadow-[0_8px_24px_rgba(0,0,0,0.18)] transition-opacity duration-200 hover:bg-white group-hover:opacity-100"
+        >
+          <IconExternalLink size={14} stroke={2} />
+          Open
+        </a>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 px-4 py-3">
+        <h2 className="text-[14px] font-medium text-[hsl(var(--foreground))]">
+          {item.title}
+        </h2>
+        <pre className="max-h-[120px] flex-1 overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
+          {item.prompt}
+        </pre>
+        <a
+          href={remixHref}
+          className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+        >
+          <IconSparkles size={15} stroke={2} />
+          Prompt remix
+        </a>
+      </div>
+    </article>
+  );
+}
+
+export function PresentationClient() {
+  const appUrl = getAppUrl();
+
+  return (
+    <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+      <Particles />
+
+      <section className="hero-section" style={{ paddingBottom: 32 }}>
+        <div
+          style={{
+            maxWidth: MAX_WIDTH,
+            margin: "0 auto",
+            padding: `0 ${PAGE_PADDING}px`,
+          }}
+        >
+          <h1 className="hero-title">Presentation</h1>
+          <p className="hero-description">
+            Live presentation decks you can open, watch, and remix into your own
+            Zero creation.
+          </p>
+        </div>
+      </section>
+
+      <section style={{ paddingBottom: 120 }}>
+        <div
+          style={{
+            maxWidth: MAX_WIDTH,
+            margin: "0 auto",
+            padding: `0 ${PAGE_PADDING}px`,
+          }}
+          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {PRESENTATION_ITEMS.map((item) => {
+            return (
+              <PresentationCard key={item.slug} item={item} appUrl={appUrl} />
+            );
+          })}
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/turbo/apps/web/app/[locale]/presentation/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation/data.ts
@@ -3,6 +3,7 @@ export interface PresentationItem {
   readonly title: string;
   readonly prompt: string;
   readonly embedUrl: string;
+  readonly previewImage: string;
 }
 
 export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
@@ -12,6 +13,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `spacex` and template `html-ppt-pitch-deck`, create a Starship V3 investor update deck. Cadence numbers, payload mass to LEO, Raptor 3 cost curve, lunar Starlink V3 architecture, and 18-month roadmap. Make it feel aerospace, technical, austere, bold.",
     embedUrl: "https://starship-v3-investor-update-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ca9ba36d-af12-4e01-8744-37b1d311c50c/01.jpg",
   },
   {
     slug: "vision-pro-studio-keynote",
@@ -19,6 +22,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `apple` and template `html-ppt-product-launch`, create a Vision Pro Studio Edition launch keynote. Hero reveal, R2 silicon specs, spatial workflows demo, pricing tiers, availability windows. Make it feel cinematic, minimal, premium.",
     embedUrl: "https://vision-pro-studio-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/69edbfb9-c17c-479a-a5b1-f40544bc4aad/02.jpg",
   },
   {
     slug: "tesla-q3-2026-shareholder-talk",
@@ -27,6 +32,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `tesla` and template `html-ppt-presenter-mode-reveal`, create a Q3 2026 vehicle delivery and FSD v14 shareholder talk. Production ramp, energy storage attach, FSD miles-per-intervention, Cybercab pilot cities, gigafactory map. Make it feel kinetic, sleek, confident.",
     embedUrl:
       "https://tesla-q3-2026-shareholder-talk-715f6d07-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e00269f7-b179-4fd6-b62f-e67a96808677/03.jpg",
   },
   {
     slug: "ferrari-sf90-xx-unveiling",
@@ -35,6 +42,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `ferrari` and template `html-ppt-zhangzara-bold-poster`, create an SF90 XX Stradale press unveiling. Powertrain reveal, aero numbers, track lap record, livery palette, owner-program tiers. Make it feel red-blooded, editorial, prestige.",
     embedUrl:
       "https://ferrari-sf90-xx-unveiling-715f6d07-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2bd7518a-7689-4145-8d69-896c8ed8a10b/04.jpg",
   },
   {
     slug: "air-max-day-2026-campaign",
@@ -42,6 +51,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `nike` and template `html-ppt-zhangzara-coral`, create an Air Max Day 2026 brand campaign deck. Story arc, athlete ambassadors, drop calendar, retail activations, social moments. Make it feel bold, kinetic, street.",
     embedUrl: "https://air-max-day-2026-campaign-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a7f2c881-2c92-4b26-8ad0-e347aa6ada14/05.jpg",
   },
   {
     slug: "crypto-liquidity-flow-research",
@@ -49,6 +60,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `binance` and template `html-ppt-graphify-dark-graph`, create a crypto liquidity flow research readout. Order book heatmap, market-maker graph, stablecoin corridors, MEV anomalies, settlement latency. Make it feel dark, quantitative, technical.",
     embedUrl: "https://crypto-liquidity-flow-research-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d1d0b732-27f3-41be-833d-c822f4c23797/06.jpg",
   },
   {
     slug: "bmw-neue-klasse-brand-book",
@@ -56,6 +69,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `bmw` and template `html-ppt-zhangzara-broadside`, create a Neue Klasse design language brand book unveil. Silhouette sketches, Hofmeister kink evolution, interior philosophy, color palette, model rollout. Make it feel precise, modernist, refined.",
     embedUrl: "https://bmw-neue-klasse-brand-book-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/eafc6916-cf43-45ab-a274-3455738a5ef5/07.jpg",
   },
   {
     slug: "bmw-m5-cs-touring-keynote",
@@ -63,6 +78,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `bmw-m` and template `html-ppt-product-launch`, create an M5 CS Touring launch keynote. Power numbers, Nurburgring time, chassis tech, livery options, customer track-day program. Make it feel motorsport, aggressive, premium.",
     embedUrl: "https://bmw-m5-cs-touring-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/da219e0c-35eb-4a3f-8d11-0ace6dcd32c4/08.jpg",
   },
   {
     slug: "bugatti-tourbillon-owners-briefing",
@@ -71,6 +88,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `bugatti` and template `html-ppt-zhangzara-monochrome`, create a Tourbillon hyper-GT owners briefing. Powertrain, atelier customization, Molsheim delivery experience, road-touring routes, heritage references. Make it feel luxury, hand-built, French-refined.",
     embedUrl:
       "https://bugatti-tourbillon-owners-briefing-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ed07e5e0-76f0-4dc2-8376-8aac6fafa254/09.jpg",
   },
   {
     slug: "lamborghini-revuelto-2027-lineup",
@@ -78,6 +97,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `lamborghini` and template `html-ppt-zhangzara-studio`, create a Revuelto color and trim 2027 lineup deck. Ad Personam palettes, carbon weave options, Y-shape design language, dealer rollout, owner events. Make it feel high-voltage, theatrical, exotic.",
     embedUrl: "https://lamborghini-revuelto-2027-lineup-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/9aa58691-6af0-41f9-a841-719a7134dfce/10.jpg",
   },
   {
     slug: "renault-5-etech-retro-launch",
@@ -85,6 +106,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `renault` and template `html-ppt-zhangzara-cartesian`, create a Renault 5 E-Tech retro-launch deck. Heritage timeline, battery options, charging network, color palette, French market positioning. Make it feel warm, design-forward, French.",
     embedUrl: "https://renault-5-etech-retro-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/01f92cd9-6b11-47ea-8d82-12c9e3be1d11/11.jpg",
   },
   {
     slug: "openai-gpt-6-conf-talk",
@@ -92,6 +115,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `openai` and template `html-ppt-tech-sharing`, create a GPT-6 capability and safety conference talk. Reasoning benchmarks, training compute, alignment evals, deployment policy, partner ecosystem. Make it feel research, candid, technical.",
     embedUrl: "https://openai-gpt-6-conf-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/18a5d6d2-17d5-4cd7-92d8-788ae2bf475e/12.jpg",
   },
   {
     slug: "claude-5-model-deep-dive",
@@ -99,6 +124,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `claude` and template `html-ppt-obsidian-claude-gradient`, create a Claude 5 model card and product deep-dive. Eval suite, constitutional AI updates, context window, agent harness, customer wins. Make it feel thoughtful, deliberate, gradient-elegant.",
     embedUrl: "https://claude-5-model-deep-dive-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/51044e26-0fb2-48eb-952e-c46a06602df8/13.jpg",
   },
   {
     slug: "cohere-enterprise-rag-arch",
@@ -106,6 +133,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `cohere` and template `html-ppt-knowledge-arch-blueprint`, create an enterprise RAG reference architecture session. Embedding pipeline, retrieval graph, reranker stack, eval harness, deployment topology. Make it feel architectural, enterprise, blueprint-clean.",
     embedUrl: "https://cohere-enterprise-rag-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/16e50264-9ef9-49d2-986a-602f0ebc0647/14.jpg",
   },
   {
     slug: "mixtral-next-moe-research",
@@ -113,6 +142,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `mistral-ai` and template `html-ppt-tech-sharing`, create a Mixtral-Next mixture-of-experts research talk. Routing math, expert utilization charts, throughput benchmarks, open-weight policy, partner programs. Make it feel European, research, candid.",
     embedUrl: "https://mixtral-next-moe-research-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/142b780d-f808-487c-adf3-8985da1370b5/15.jpg",
   },
   {
     slug: "huggingface-state-of-the-hub",
@@ -120,6 +151,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `huggingface` and template `html-ppt-creative-mode`, create an open model community state-of-the-hub annual recap. Downloads dashboard, top contributors, dataset spotlights, hub partnerships, roadmap. Make it feel warm, community, playful.",
     embedUrl: "https://huggingface-state-of-the-hub-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/94299487-0db8-422c-8072-6496caa17c6e/16.jpg",
   },
   {
     slug: "grok-4-infra-disclosure",
@@ -127,6 +160,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `x-ai` and template `html-ppt-hermes-cyber-terminal`, create a Grok 4 capability and infra disclosure. Training cluster, Colossus topology, tool use evals, deployment guardrails, public usage stats. Make it feel cyberpunk, terminal, bold.",
     embedUrl: "https://grok-4-infra-disclosure-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e3554d44-46c7-435e-a443-cc6104c0bf6a/17.jpg",
   },
   {
     slug: "minimax-m2-product-launch",
@@ -134,6 +169,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `minimax` and template `html-ppt-xhs-white-editorial`, create a MiniMax M2 product launch deck. Multimodal samples, agent benchmarks, partner integrations, China-market rollout, pricing tiers. Make it feel pastel, modern, friendly.",
     embedUrl: "https://minimax-m2-product-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8621506b-3c2d-4348-b17e-9437dbe1076e/18.jpg",
   },
   {
     slug: "nvidia-blackwell-ultra-arch",
@@ -141,6 +178,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `nvidia` and template `html-ppt-knowledge-arch-blueprint`, create a Blackwell Ultra reference data-center architecture briefing. NVLink fabric, rack power profile, liquid cooling, cluster topology, MLPerf numbers. Make it feel architectural, high-performance, technical.",
     embedUrl: "https://nvidia-blackwell-ultra-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/5f97e72e-4065-4fa6-aa12-23f73f2d8eff/19.jpg",
   },
   {
     slug: "ibm-consulting-hybrid-cloud-qbr",
@@ -148,6 +187,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `ibm` and template `html-ppt-weekly-report`, create an IBM Consulting hybrid-cloud QBR for a Fortune 100 client. Engagement KPIs, workload migration progress, FinOps savings, risk register, next-quarter roadmap. Make it feel corporate, measured, enterprise.",
     embedUrl: "https://ibm-consulting-hybrid-cloud-qbr-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3ec5a6ba-07b7-4c09-9ed1-bc677a37d5ec/20.jpg",
   },
   {
     slug: "cisco-netops-weekly-status",
@@ -155,6 +196,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `cisco` and template `html-ppt-weekly-report`, create a global NetOps weekly status report. SLA dashboards, incident summary, capacity headroom, security posture, change calendar. Make it feel corporate, operational, clear.",
     embedUrl: "https://cisco-netops-weekly-status-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/80e3e6d7-62a6-497e-aca5-cac3d8bd451e/21.jpg",
   },
   {
     slug: "meta-rayban-display-keynote",
@@ -162,6 +205,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `meta` and template `html-ppt-product-launch`, create a Ray-Ban Display launch keynote. Hardware specs, AI assistant demos, social capture stories, pricing tiers, retail rollout. Make it feel cinematic, social, premium.",
     embedUrl: "https://meta-rayban-display-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/095dfe2e-7506-4599-b154-e2ccdee3be88/22.jpg",
   },
   {
     slug: "discord-community-summit-2026",
@@ -169,6 +214,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `discord` and template `html-ppt-zhangzara-block-frame`, create a Discord platform 2026 community summit deck. New voice features, Activities SDK, creator monetization, moderator tools, partner spotlights. Make it feel playful, pastel-pop, community.",
     embedUrl: "https://discord-community-summit-2026-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/011e5901-06ef-4e90-a5ba-a63a595a032f/23.jpg",
   },
   {
     slug: "slack-enterprise-success-qbr",
@@ -176,6 +223,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `slack` and template `html-ppt-weekly-report`, create an enterprise customer success QBR for a 30k-seat account. Adoption metrics, channel health, integrations attached, automation hours saved, renewal motion. Make it feel corporate, friendly, structured.",
     embedUrl: "https://slack-enterprise-success-qbr-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a8945365-9f26-4516-aa2c-b53c552323ba/24.jpg",
   },
   {
     slug: "notion-ai-pm-training-module",
@@ -183,6 +232,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `notion` and template `html-ppt-course-module`, create a Notion AI for product managers self-paced training module. Lesson outline, exercises, AI prompt library, project rubric, completion checklist. Make it feel warm, editorial, instructional.",
     embedUrl: "https://notion-ai-pm-training-module-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/bc724eed-2d1a-4932-ad25-2cee58baf1d8/25.jpg",
   },
   {
     slug: "airbnb-icons-2027-host-pitch",
@@ -190,6 +241,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `airbnb` and template `html-ppt-zhangzara-soft-editorial`, create an Airbnb Icons 2027 host pitch deck. Story collections, guest personas, photography moodboard, host requirements, payout economics. Make it feel warm, editorial, hospitable.",
     embedUrl: "https://airbnb-icons-2027-host-pitch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/1c2348e1-de43-4acd-9802-7b8b5760bcd1/26.jpg",
   },
   {
     slug: "airtable-cobuilder-arch",
@@ -197,6 +250,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `airtable` and template `html-ppt-knowledge-arch-blueprint`, create an Airtable Cobuilder reference architecture briefing for enterprise IT. Data model, sync graph, automation engine, governance layer, rollout plan. Make it feel architectural, enterprise, blueprint-clean.",
     embedUrl: "https://airtable-cobuilder-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/35e83506-7f68-406c-a662-1ef451d46449/27.jpg",
   },
   {
     slug: "ant-design-v6-governance-review",
@@ -204,6 +259,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `ant` and template `html-ppt-weekly-report`, create an Ant Design System v6 internal governance review. Component adoption, theming changes, accessibility scores, release calendar, open issues. Make it feel structured, corporate, clear.",
     embedUrl: "https://ant-design-v6-governance-review-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/fa851b6d-3550-4cc4-a34b-1b399385d281/28.jpg",
   },
   {
     slug: "cal-com-routing-forms-v2-launch",
@@ -211,6 +268,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `cal` and template `html-ppt-product-launch`, create a Cal.com Routing Forms v2 launch deck. New form builder, workflow webhooks, embed SDK, pricing tiers, customer wins. Make it feel friendly, modern, developer.",
     embedUrl: "https://cal-com-routing-forms-v2-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e62c0908-a068-4451-8894-e7bdc6bdb05d/29.jpg",
   },
   {
     slug: "canva-design-ai-allhands",
@@ -218,6 +277,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `canva` and template `html-ppt-zhangzara-creative-mode`, create a Canva Design AI for marketers all-hands deck. New magic features, brand kits, education program, case studies, roadmap. Make it feel colorful, friendly, energetic.",
     embedUrl: "https://canva-design-ai-allhands-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/92ef7561-884e-438b-8f90-74c3b035e356/30.jpg",
   },
   {
     slug: "clickhouse-query-performance-talk",
@@ -225,6 +286,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `clickhouse` and template `html-ppt-tech-sharing`, create a ClickHouse Cloud query-performance deep-dive conference talk. JOIN reordering, parallel replicas, S3 cold tier, benchmark vs Snowflake, optimization recipes. Make it feel technical, candid, performance.",
     embedUrl: "https://clickhouse-query-performance-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b126c3a6-5f8b-4731-af1c-5d89b18498de/31.jpg",
   },
   {
     slug: "coinbase-institutional-prime-deck",
@@ -232,6 +295,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `coinbase` and template `html-ppt-pitch-deck`, create a Coinbase Institutional prime-brokerage sales deck. AUC scale, custody architecture, OTC desk, derivatives roadmap, regulatory posture. Make it feel institutional, sleek, blue-chip.",
     embedUrl: "https://coinbase-institutional-prime-deck-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/532a8473-5a1d-4656-95fb-17e909cf754b/32.jpg",
   },
   {
     slug: "composio-agent-tooling-arch",
@@ -239,6 +304,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `composio` and template `html-ppt-knowledge-arch-blueprint`, create a Composio agent-tooling reference architecture for an enterprise prospect. Tool registry, auth proxy, sandboxing layer, observability, integration matrix. Make it feel architectural, technical, clean.",
     embedUrl: "https://composio-agent-tooling-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b549413b-061d-4730-88c7-c766c27fba2e/33.jpg",
   },
   {
     slug: "cursor-1-0-developer-conf",
@@ -246,6 +313,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `cursor` and template `html-ppt-tech-sharing`, create a Cursor 1.0 developer conference talk. Agent mode demo, codebase indexing, MCP support, enterprise SSO, pricing. Make it feel developer, sleek, confident.",
     embedUrl: "https://cursor-1-0-developer-conf-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b3f72a45-54c6-4fa7-a837-3f9ce0133a8a/34.jpg",
   },
   {
     slug: "duolingo-math-parents-launch",
@@ -253,6 +322,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `duolingo` and template `html-ppt-zhangzara-daisy-days`, create a Duolingo Math launch deck for parents and educators. Curriculum scope, gamification mechanics, parent dashboard, school program, pricing. Make it feel cheerful, friendly, family.",
     embedUrl: "https://duolingo-math-parents-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/61647e04-a82f-47f3-8f86-a995395b2195/35.jpg",
   },
   {
     slug: "elevenlabs-voice-3-keynote",
@@ -260,6 +331,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `elevenlabs` and template `html-ppt-product-launch`, create an ElevenLabs Voice 3 model launch keynote. Sample reel, latency benchmarks, voice cloning policy, agent voices, pricing tiers. Make it feel premium, voice-forward, sleek.",
     embedUrl: "https://elevenlabs-voice-3-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/72d4b7c9-a05a-4cb7-9f52-abe46a768abe/36.jpg",
   },
   {
     slug: "expo-router-v5-conf-talk",
@@ -267,6 +340,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `expo` and template `html-ppt-tech-sharing`, create an Expo Router v5 conference talk. New routing primitives, server components, EAS updates, performance wins, migration guide. Make it feel developer, friendly, technical.",
     embedUrl: "https://expo-router-v5-conf-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0ff00890-6c31-4649-8103-7e96e3a60908/37.jpg",
   },
   {
     slug: "figma-sites-ga-keynote",
@@ -274,6 +349,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `figma` and template `html-ppt-product-launch`, create a Figma Sites GA launch keynote. New site editor, CMS panel, publishing pipeline, pricing, customer stories. Make it feel design, premium, modern.",
     embedUrl: "https://figma-sites-ga-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e990a33a-9aad-4da1-99b1-f2383257fdee/38.jpg",
   },
   {
     slug: "framer-ai-sites-2026-launch",
@@ -281,6 +358,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `framer` and template `html-ppt-product-launch`, create a Framer AI Sites 2026 launch deck. Prompt-to-site demo, CMS, SEO panel, e-commerce add-on, pricing. Make it feel design, friendly, fast.",
     embedUrl: "https://framer-ai-sites-2026-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/945ff862-f11f-4055-bfc7-220d007897fe/39.jpg",
   },
   {
     slug: "github-universe-copilot-keynote",
@@ -288,6 +367,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `github` and template `html-ppt-tech-sharing`, create a GitHub Universe Copilot Workspace keynote. Issue-to-PR flow, plan-edit-test loop, enterprise rollout, security posture, customer wins. Make it feel developer, candid, confident.",
     embedUrl: "https://github-universe-copilot-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d176742c-6d72-4e5d-8bce-ebe01e548a2f/40.jpg",
   },
   {
     slug: "terraform-stacks-bank-arch",
@@ -295,6 +376,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `hashicorp` and template `html-ppt-knowledge-arch-blueprint`, create a Terraform Stacks reference deployment architecture for a bank. Stack topology, state isolation, policy guardrails, CI/CD pipeline, migration plan. Make it feel architectural, enterprise, precise.",
     embedUrl: "https://terraform-stacks-bank-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/557b3c8a-75d6-48af-b3d1-c7952f7d77cd/41.jpg",
   },
   {
     slug: "intercom-fin-ai-agent-sales",
@@ -302,6 +385,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `intercom` and template `html-ppt-pitch-deck`, create an Intercom Fin AI Agent enterprise sales deck. Deflection rate proof, integrations, governance controls, pricing model, customer wins. Make it feel modern, friendly, sales.",
     embedUrl: "https://intercom-fin-ai-agent-sales-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4da7c33a-ae2b-4230-9dd8-c7066ae40b7d/42.jpg",
   },
   {
     slug: "kraken-pro-flash-crash-postmortem",
@@ -309,6 +394,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `kraken` and template `html-ppt-hermes-cyber-terminal`, create a Kraken Pro trading platform internal post-mortem on a flash-crash incident. Timeline, order book state, throttle decisions, customer comms, remediation. Make it feel terminal, candid, technical.",
     embedUrl: "https://kraken-pro-flash-crash-postmortem-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/54d22103-67e7-4b63-a3ec-42cb6a3bb04d/43.jpg",
   },
   {
     slug: "levels-metabolic-q-report",
@@ -316,6 +403,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `levels` and template `html-ppt-xhs-pastel-card`, create a Levels metabolic health quarterly member report. Glucose variability trends, food correlations, sleep impact, exercise wins, next-quarter goals. Make it feel calm, pastel, member-friendly.",
     embedUrl: "https://levels-metabolic-q-report-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/46c8082b-e29b-4680-8144-9fcdd0e961de/44.jpg",
   },
   {
     slug: "linear-product-intelligence-keynote",
@@ -324,6 +413,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `linear-app` and template `html-ppt-presenter-mode-reveal`, create a Linear Product Intelligence launch keynote. New insights view, AI triage, roadmap canvas, customer wins, pricing tiers. Make it feel modern, sleek, confident.",
     embedUrl:
       "https://linear-product-intelligence-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/05efce44-a920-46e9-a47e-d759e727b4dc/45.jpg",
   },
   {
     slug: "lingo-localization-ops-training",
@@ -331,6 +422,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `lingo` and template `html-ppt-course-module`, create a Lingo localization-ops onboarding training module for translators. Workflow walkthrough, glossary, QA checks, payout calendar, certification path. Make it feel warm, instructional, friendly.",
     embedUrl: "https://lingo-localization-ops-training-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ee5bff80-0546-4dad-8a18-4d8c909e64a1/46.jpg",
   },
   {
     slug: "loom-ai-workflows-launch",
@@ -338,6 +431,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `loom` and template `html-ppt-product-launch`, create a Loom AI Workflows launch deck. Auto-summary, action items, integrations, enterprise SSO, pricing. Make it feel friendly, modern, video-first.",
     embedUrl: "https://loom-ai-workflows-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ce0a6d49-6ccb-4d4a-b4ad-01812bfd5228/47.jpg",
   },
   {
     slug: "lovable-v3-community-launch",
@@ -345,6 +440,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `lovable` and template `html-ppt-zhangzara-playful`, create a Lovable v3 community launch deck. Prompt-to-app demo, project gallery, builder economics, partner ecosystem, roadmap. Make it feel playful, friendly, indie.",
     embedUrl: "https://lovable-v3-community-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/acaba5da-dde7-4e6e-badf-f8f74d198886/48.jpg",
   },
   {
     slug: "mastercard-fraud-risk-council",
@@ -352,6 +449,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `mastercard` and template `html-ppt-weekly-report`, create a Mastercard fraud-risk weekly council report. Authorization-decline trends, model performance, geo heatmap, issuer alerts, control changes. Make it feel corporate, structured, financial.",
     embedUrl: "https://mastercard-fraud-risk-council-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/bcf655e2-83a9-4f84-ab41-8882a8b7d86b/49.jpg",
   },
   {
     slug: "mintlify-docs-writing-workshop",
@@ -359,6 +458,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `mintlify` and template `html-ppt-course-module`, create a Mintlify docs-writing workshop deck for new technical writers. Module outline, examples, exercise prompts, peer review, certification. Make it feel warm, editorial, instructional.",
     embedUrl: "https://mintlify-docs-writing-workshop-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/affc2cb8-e29c-406b-859a-ed5ada07808e/50.jpg",
   },
   {
     slug: "miro-innovation-workshop",
@@ -366,6 +467,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `miro` and template `html-ppt-zhangzara-scatterbrain`, create a Miro Innovation Workspace customer co-creation workshop deck. Discovery board, opportunity map, prototype sticky notes, voting matrix, next steps. Make it feel post-it, playful, workshop.",
     embedUrl: "https://miro-innovation-workshop-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b1894363-094a-49b8-bb2c-06f8c08ff4e4/51.jpg",
   },
   {
     slug: "mongodb-atlas-vector-search-talk",
@@ -373,6 +476,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `mongodb` and template `html-ppt-tech-sharing`, create a MongoDB Atlas Vector Search conference talk. Index internals, hybrid search, embedding refresh, benchmark numbers, customer wins. Make it feel technical, candid, database.",
     embedUrl: "https://mongodb-atlas-vector-search-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a72acc89-65c2-4dad-b423-fa7efa511b8c/52.jpg",
   },
   {
     slug: "ollama-on-device-community-talk",
@@ -380,6 +485,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `ollama` and template `html-ppt-hermes-cyber-terminal`, create an Ollama on-device deployment community talk. Model zoo, GPU profile guide, quantization tradeoffs, MCP integration, roadmap. Make it feel terminal, indie, technical.",
     embedUrl: "https://ollama-on-device-community-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/7722d6a7-af35-428d-a10d-09204f717049/53.jpg",
   },
   {
     slug: "perplexity-pages-comet-keynote",
@@ -387,6 +494,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `perplexity` and template `html-ppt-product-launch`, create a Perplexity Pages and Comet browser launch keynote. New page editor, agent browsing, pricing tiers, partner publishers, growth. Make it feel sleek, modern, research.",
     embedUrl: "https://perplexity-pages-comet-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/cf11f784-c3b5-44b0-8f8c-aac37fc64b94/54.jpg",
   },
   {
     slug: "pinterest-predicts-2027",
@@ -394,6 +503,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `pinterest` and template `html-ppt-xhs-post`, create a Pinterest Predicts 2027 trend release. Trend cards, search-volume charts, brand opportunity callouts, creator quotes, campaign ideas. Make it feel editorial, pastel, lifestyle.",
     embedUrl: "https://pinterest-predicts-2027-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/09712cfb-d33f-4a74-8fbf-215ce6bce975/55.jpg",
   },
   {
     slug: "posthog-product-eng-metrics-talk",
@@ -401,6 +512,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `posthog` and template `html-ppt-tech-sharing`, create a PostHog product-engineering metrics conference talk. North-star tree, experiments velocity, retention curves, error budgets, recipes. Make it feel candid, technical, indie.",
     embedUrl: "https://posthog-product-eng-metrics-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d902c52c-0f07-4bd3-b04e-b5466270b303/56.jpg",
   },
   {
     slug: "raycast-for-teams-keynote",
@@ -408,6 +521,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `raycast` and template `html-ppt-product-launch`, create a Raycast for Teams launch keynote. Shared snippets, AI commands, team analytics, pricing tiers, enterprise readiness. Make it feel sleek, premium, developer.",
     embedUrl: "https://raycast-for-teams-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d1ddd039-157b-4d43-b706-b41b5687b652/57.jpg",
   },
   {
     slug: "replicate-model-serving-infra-talk",
@@ -416,6 +531,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `replicate` and template `html-ppt-tech-sharing`, create a Replicate model-serving infra deep-dive talk. Cold-start architecture, scheduler, GPU bin packing, cost economics, roadmap. Make it feel technical, candid, infra.",
     embedUrl:
       "https://replicate-model-serving-infra-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/84acedce-ae03-4477-8380-e89366d3b4eb/58.jpg",
   },
   {
     slug: "resend-broadcasts-2-launch",
@@ -423,6 +540,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `resend` and template `html-ppt-product-launch`, create a Resend Broadcasts 2.0 launch deck. New editor, segmentation, deliverability dashboard, pricing, customer wins. Make it feel modern, friendly, developer.",
     embedUrl: "https://resend-broadcasts-2-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/be7d2295-742d-408b-80dc-21fe731cce40/59.jpg",
   },
   {
     slug: "revolut-business-latam-update",
@@ -430,6 +549,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `revolut` and template `html-ppt-pitch-deck`, create a Revolut Business expansion-to-LATAM investor update. Market sizing, regulatory path, product wedge, unit economics, hiring plan. Make it feel sleek, fintech, confident.",
     embedUrl: "https://revolut-business-latam-update-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e1d12fd2-f2c9-445c-b2e2-d9ac9bc0e323/60.jpg",
   },
   {
     slug: "runway-gen-4-film-tools",
@@ -437,6 +558,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `runwayml` and template `html-ppt-zhangzara-bold-poster`, create a Runway Gen-4 film-tools launch deck for studios. Pipeline integration, look-dev examples, talent quotes, festival placements, pricing. Make it feel cinematic, bold, editorial.",
     embedUrl: "https://runway-gen-4-film-tools-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8c4091b9-91cc-4a26-b91d-5c73616a9498/61.jpg",
   },
   {
     slug: "sanity-content-platform-arch",
@@ -444,6 +567,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `sanity` and template `html-ppt-knowledge-arch-blueprint`, create a Sanity content-platform reference architecture for a media company. Content graph, GROQ queries, syndication pipeline, governance, migration plan. Make it feel architectural, editorial, clean.",
     embedUrl: "https://sanity-content-platform-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/835c0f27-0ed0-4feb-9192-63738ebbdd8b/62.jpg",
   },
   {
     slug: "sentry-prod-outage-postmortem",
@@ -451,6 +576,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `sentry` and template `html-ppt-testing-safety-alert`, create a production incident post-mortem deck for a major customer outage. Incident timeline, blast radius, contributing factors, remediation, follow-ups. Make it feel alert, accountable, structured.",
     embedUrl: "https://sentry-prod-outage-postmortem-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0402048e-e931-4fc4-a372-100d1459517f/63.jpg",
   },
   {
     slug: "shopify-magic-merchants-launch",
@@ -458,6 +585,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `shopify` and template `html-ppt-product-launch`, create a Shopify Magic for Merchants summer edition launch deck. AI tools demo, store templates, payment updates, merchant case studies, pricing. Make it feel friendly, modern, commerce.",
     embedUrl: "https://shopify-magic-merchants-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d6dd24ec-c19f-444e-b9a6-86d7ced2b867/64.jpg",
   },
   {
     slug: "spotify-wrapped-2027",
@@ -465,6 +594,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `spotify` and template `html-ppt-product-launch`, create a Spotify Wrapped 2027 product launch deck. Personalization features, creator stories, advertiser opportunities, partner spotlights, rollout calendar. Make it feel kinetic, expressive, music-first.",
     embedUrl: "https://spotify-wrapped-2027-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3b9e552d-877a-485e-a5c1-390236a2cbc7/65.jpg",
   },
   {
     slug: "starbucks-reserve-brand-book",
@@ -472,6 +603,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `starbucks` and template `html-ppt-zhangzara-mat`, create a Starbucks Reserve global brand book unveil. Bean story, store design language, beverage rituals, art collaborations, market rollout. Make it feel warm, refined, cafe.",
     embedUrl: "https://starbucks-reserve-brand-book-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/39b10cfa-0b55-4bf5-a724-f06bd2532c96/66.jpg",
   },
   {
     slug: "stripe-marketplace-arch",
@@ -479,6 +612,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `stripe` and template `html-ppt-knowledge-arch-blueprint`, create a Stripe platform reference architecture for a marketplace. Account model, Connect flows, Tax engine, Radar, settlement timeline. Make it feel architectural, fintech, precise.",
     embedUrl: "https://stripe-marketplace-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c01c5814-b72b-43cc-92b6-2adc339208e1/67.jpg",
   },
   {
     slug: "supabase-postgres-17-talk",
@@ -486,6 +621,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `supabase` and template `html-ppt-tech-sharing`, create a Supabase Postgres 17 features conference talk. Foreign data wrappers, vector index, realtime improvements, edge functions, customer wins. Make it feel developer, candid, open-source.",
     embedUrl: "https://supabase-postgres-17-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/07108888-9c2b-4891-a43e-dd2b3f228601/68.jpg",
   },
   {
     slug: "superhuman-ai-inbox-launch",
@@ -493,6 +630,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `superhuman` and template `html-ppt-product-launch`, create a Superhuman AI Inbox launch deck. New triage flow, command palette, calendar integration, pricing tiers, testimonials. Make it feel premium, sleek, productivity.",
     embedUrl: "https://superhuman-ai-inbox-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3e7493d6-a916-4487-a54f-a6c34bda9e4b/69.jpg",
   },
   {
     slug: "together-inference-engine-talk",
@@ -500,6 +639,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `together-ai` and template `html-ppt-tech-sharing`, create a Together Inference Engine performance research talk. Speculative decoding, KV cache reuse, MLPerf benchmarks, partner stories, roadmap. Make it feel research, technical, candid.",
     embedUrl: "https://together-inference-engine-talk-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d95e2199-9581-4a6d-a4bc-755958ed049e/70.jpg",
   },
   {
     slug: "uber-eats-marketplace-wbr",
@@ -507,6 +648,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `uber` and template `html-ppt-weekly-report`, create an Uber Eats marketplace weekly business review. Cohort GMV, courier supply, restaurant churn, ad revenue, growth experiments. Make it feel corporate, marketplace, data-driven.",
     embedUrl: "https://uber-eats-marketplace-wbr-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8e92078e-a3c2-4db7-9cb4-2c875a622a4e/71.jpg",
   },
   {
     slug: "vercel-v0-ga-enterprise-launch",
@@ -514,6 +657,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `vercel` and template `html-ppt-product-launch`, create a Vercel v0 GA enterprise launch deck. New site builder, AI workflow, design partner stories, pricing, enterprise controls. Make it feel sleek, modern, developer.",
     embedUrl: "https://vercel-v0-ga-enterprise-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/39a7aaf1-6451-4de4-bc45-10946e335ed8/72.jpg",
   },
   {
     slug: "vodafone-enterprise-services-qbr",
@@ -521,6 +666,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `vodafone` and template `html-ppt-weekly-report`, create a Vodafone enterprise-services QBR for a multinational client. SLA scorecards, network performance, security posture, change calendar, roadmap. Make it feel corporate, telco, structured.",
     embedUrl: "https://vodafone-enterprise-services-qbr-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/92f37d04-443d-4639-83a9-33c0328634ee/73.jpg",
   },
   {
     slug: "webex-contact-center-qbr",
@@ -528,6 +675,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `webex` and template `html-ppt-weekly-report`, create a Webex Contact Center QBR for a Fortune 500 client. Adoption stats, AI agent attach, queue performance, NPS, renewal plan. Make it feel corporate, professional, clear.",
     embedUrl: "https://webex-contact-center-qbr-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8e6b8007-f214-44b1-b91e-e127154ee0df/74.jpg",
   },
   {
     slug: "webflow-conf-2026-keynote",
@@ -535,6 +684,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `webflow` and template `html-ppt-zhangzara-creative-mode`, create a Webflow Conf 2026 keynote deck. Designer 2 release, AI site builder, CMS upgrades, partner showcase, ecosystem stats. Make it feel colorful, design, energetic.",
     embedUrl: "https://webflow-conf-2026-keynote-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e3015970-2511-4431-8aa4-864c1248b91f/75.jpg",
   },
   {
     slug: "wechat-miniprogram-2027",
@@ -542,6 +693,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `wechat` and template `guizang-ppt`, create a 微信小程序 2027 生态年度大会主题演讲. 小程序数量、视频号联动、AI 能力开放、商家案例、商业化路径. Make it feel 电子杂志, 中式, 优雅.",
     embedUrl: "https://wechat-miniprogram-2027-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3ab7c2cf-46ce-4ff6-8d97-927bcdd6d15a/76.jpg",
   },
   {
     slug: "wise-treasury-weekly-ops",
@@ -549,6 +702,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `wise` and template `html-ppt-weekly-report`, create a Wise treasury weekly ops review. FX exposure, corridor volumes, settlement breakage, compliance flags, runway. Make it feel corporate, fintech, structured.",
     embedUrl: "https://wise-treasury-weekly-ops-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/aedd6ccf-045e-419c-b396-92258eabd1f6/77.jpg",
   },
   {
     slug: "xhs-2027-spring-summer-trends",
@@ -556,6 +711,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `xiaohongshu` and template `html-ppt-xhs-post`, create a 小红书 2027 春夏种草趋势报告. 趋势卡片、爆款笔记拆解、博主合作建议、品牌进入策略、案例集. Make it feel 马卡龙, 生活方式, 中文.",
     embedUrl: "https://xhs-2027-spring-summer-trends-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/143681e9-ba38-4385-8fc9-0f0070d0292d/78.jpg",
   },
   {
     slug: "xhs-creator-annual-review",
@@ -563,6 +720,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `xiaohongshu` and template `html-ppt-xhs-pastel-card`, create a 小红书博主个人成长年报. 内容选题复盘、粉丝画像、合作品牌清单、明年计划、感谢清单. Make it feel 柔和, 慢生活, 治愈.",
     embedUrl: "https://xhs-creator-annual-review-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4be2fc56-0fd7-48ce-9b69-16c0cf1142bd/79.jpg",
   },
   {
     slug: "zapier-central-orchestration-arch",
@@ -570,6 +729,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `zapier` and template `html-ppt-knowledge-arch-blueprint`, create a Zapier Central agent-orchestration reference architecture for ops teams. Trigger graph, agent skills, data store, governance, rollout plan. Make it feel architectural, friendly, automation.",
     embedUrl: "https://zapier-central-orchestration-arch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ae6425a3-0878-424d-a2b0-0e32813e4154/80.jpg",
   },
   {
     slug: "saas-revops-weekly-metrics",
@@ -577,6 +738,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `dashboard` and template `html-ppt-weekly-report`, create a SaaS revops weekly metrics review. ARR waterfall, pipeline coverage, win rate by segment, churn cohort, forecast call. Make it feel corporate, data-dense, clear.",
     embedUrl: "https://saas-revops-weekly-metrics-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/2bfd342f-d627-4164-9550-1f3e7a927ade/81.jpg",
   },
   {
     slug: "prop-desk-daily-pnl",
@@ -584,6 +747,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `trading-terminal` and template `html-ppt-hermes-cyber-terminal`, create a prop-trading desk daily P&L recap. Greeks dashboard, vol surface, top winners/losers, risk limits, overnight watchlist. Make it feel terminal, dense, technical.",
     embedUrl: "https://prop-desk-daily-pnl-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/625e1323-3d8d-483e-821d-6bcd9d00877b/82.jpg",
   },
   {
     slug: "craft-coffee-feature-pitch",
@@ -591,6 +756,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `warm-editorial` and template `html-ppt-taste-editorial`, create a long-form magazine feature pitch on the future of craft coffee. Story arc, photography moodboard, sources, columnist quotes, publishing schedule. Make it feel warm, editorial, hairline.",
     embedUrl: "https://craft-coffee-feature-pitch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/c21b42c5-95b0-42bc-80da-33a4f6b5089f/83.jpg",
   },
   {
     slug: "nym-year-in-review",
@@ -598,6 +765,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `editorial` and template `html-ppt-taste-editorial`, create a New York Magazine year-in-review staff readout. Hero stories, traffic anatomy, subscriber growth, editorial wins, 2027 commissions. Make it feel editorial, considered, refined.",
     embedUrl: "https://nym-year-in-review-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/175b83e6-802c-4eed-8571-edc5591e246c/84.jpg",
   },
   {
     slug: "indie-author-book-launch",
@@ -605,6 +774,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `mono` and template `html-ppt-zhangzara-monochrome`, create an indie author book launch deck. Synopsis, character map, reader personas, tour cities, press kit. Make it feel monochrome, literary, considered.",
     embedUrl: "https://indie-author-book-launch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/01a16f1d-66d9-4bf3-acb3-6fa2850adae9/85.jpg",
   },
   {
     slug: "agent-system-architecture-readout",
@@ -612,6 +783,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `agentic` and template `html-ppt-graphify-dark-graph`, create an internal agent-system architecture readout for an enterprise platform team. Agent graph, tool registry, eval harness, observability, rollout plan. Make it feel dark, graph-driven, technical.",
     embedUrl: "https://agent-system-architecture-readout-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6e016ec1-f6f7-4b5f-90f5-245139741ec5/86.jpg",
   },
   {
     slug: "creative-portfolio-capsule-pitch",
@@ -619,6 +792,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `bento` and template `html-ppt-zhangzara-capsule`, create a personal portfolio pitch for a multi-disciplinary creative. Project capsules, skills grid, client logos, testimonial pulls, contact card. Make it feel capsule, lifestyle, friendly.",
     embedUrl: "https://creative-portfolio-capsule-pitch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/7e546395-0103-499b-ba2a-5e565e8411f0/87.jpg",
   },
   {
     slug: "protest-poster-history-capstone",
@@ -626,6 +801,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `brutalism` and template `html-ppt-zhangzara-raw-grid`, create a graphic-design-school capstone presentation on protest poster history. Era timeline, case studies, typography study, field photography, final thesis. Make it feel raw-grid, brutalist, academic.",
     embedUrl: "https://protest-poster-history-capstone-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0a7fe625-5627-4bc7-8e5c-3393933beae7/88.jpg",
   },
   {
     slug: "wellness-app-annual-story",
@@ -633,6 +810,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `claymorphism` and template `html-ppt-xhs-pastel-card`, create a wellness-app subscriber annual story. Habit streaks, sleep gains, mindful minutes, community moments, next-year ritual. Make it feel pastel, soft, calming.",
     embedUrl: "https://wellness-app-annual-story-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/d988d8e6-f736-4257-bec6-6e52f83ce978/89.jpg",
   },
   {
     slug: "kindergarten-family-yearbook",
@@ -640,6 +819,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `clay` and template `html-ppt-zhangzara-daisy-days`, create a kindergarten family-yearbook reveal for parents. Class moments, art highlights, milestone chart, teacher notes, summer plans. Make it feel cheerful, friendly, family.",
     embedUrl: "https://kindergarten-family-yearbook-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4bdd62fa-5919-46ae-9a62-9f8a146f0b22/90.jpg",
   },
   {
     slug: "indie-pixel-game-press-deck",
@@ -647,6 +828,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `cosmic` and template `html-ppt-zhangzara-8-bit-orbit`, create an indie video game pre-launch press deck. Story pitch, gameplay loop, art direction, soundtrack samples, release window. Make it feel pixel, neon, gaming.",
     embedUrl: "https://indie-pixel-game-press-deck-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/aab12986-5c0e-4cd8-aa2e-7609b6534f05/91.jpg",
   },
   {
     slug: "indie-zine-release-party",
@@ -654,6 +837,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `dithered` and template `html-ppt-zhangzara-retro-zine`, create an indie zine release-party deck for a local arts collective. Zine spreads, contributor bios, print run, distribution plan, launch night flow. Make it feel zine, tactile, retro.",
     embedUrl: "https://indie-zine-release-party-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/f9f431e4-2af6-4c1c-a9ba-d79e393fd7c0/92.jpg",
   },
   {
     slug: "fashion-house-autumn-lookbook",
@@ -661,6 +846,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `dramatic` and template `html-ppt-zhangzara-pink-script`, create a fashion house autumn collection lookbook reveal. Mood manifesto, silhouette stories, fabric swatches, runway lineup, retail drop. Make it feel late-night, expressive, editorial.",
     embedUrl: "https://fashion-house-autumn-lookbook-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b12034b5-4a8c-4397-b77e-b1d4a464034f/93.jpg",
   },
   {
     slug: "art-biennale-curator-pitch",
@@ -668,6 +855,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `expressive` and template `html-ppt-zhangzara-bold-poster`, create an art biennale curator concept pitch deck. Curatorial statement, artist lineup, venue map, public program, funding ask. Make it feel poster, editorial, bold.",
     embedUrl: "https://art-biennale-curator-pitch-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/868105dc-90ae-4e99-a045-0f22e7733a70/94.jpg",
   },
   {
     slug: "grove-restoration-annual-report",
@@ -675,6 +864,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `fantasy` and template `html-ppt-zhangzara-grove`, create a sustainability nonprofit grove-restoration annual report. Hectares restored, species returned, community stories, donor wall, next-year goals. Make it feel forest, hopeful, refined.",
     embedUrl: "https://grove-restoration-annual-report-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/78e6570a-5936-4f93-a038-c83f885c6f33/95.jpg",
   },
   {
     slug: "antique-paper-restoration-catalogue",
@@ -683,6 +874,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `kami` and template `kami-deck`, create an antique paper restoration studio exhibit catalogue. Featured works, technique notes, restorer profiles, sponsor wall, event calendar. Make it feel parchment, considered, craft.",
     embedUrl:
       "https://antique-paper-restoration-catalogue-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/245ae8d0-d9b5-4d50-b2d5-6f88220d0ce2/96.jpg",
   },
   {
     slug: "vm0-atelier-zero-v2-unveil",
@@ -690,6 +883,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `atelier-zero` and template `open-design-landing-deck`, create a vm0 design-system v2 internal unveil for the team. New tokens, component refactors, motion language, doc rewrite, rollout plan. Make it feel italic-serif, coral, atelier.",
     embedUrl: "https://vm0-atelier-zero-v2-unveil-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/997998fb-d8ec-485a-b8ef-6eb672b1eefb/97.jpg",
   },
   {
     slug: "community-zine-workshop-facilitator",
@@ -698,6 +893,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `paper` and template `html-ppt-zhangzara-pin-and-paper`, create a community zine workshop facilitator deck. Workshop arc, supply list, sample spreads, peer feedback flow, takeaway zine. Make it feel handwritten, friendly, paper.",
     embedUrl:
       "https://community-zine-workshop-facilitator-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b6992a13-7ff4-4a7a-97ec-438fe51e958a/98.jpg",
   },
   {
     slug: "90s-tech-nostalgia-lightning",
@@ -705,6 +902,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `retro` and template `html-ppt-zhangzara-retro-windows`, create a 90s tech-nostalgia conference lightning talk. Boot-screen tour, software archaeology, AOL anecdotes, demo screenshots, audience Q&A. Make it feel pixel, retro, playful.",
     embedUrl: "https://90s-tech-nostalgia-lightning-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/67585023-4897-43e6-90c4-690c42cbc309/99.jpg",
   },
   {
     slug: "ps6-dev-summit-roadmap",
@@ -712,6 +911,8 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
     prompt:
       "/gen presentation with design system `playstation` and template `html-ppt-zhangzara-8-bit-orbit`, create a PS6 dev-summit roadmap deck for studio partners. Console specs, dev-kit timeline, marquee titles, store policy updates, partner programs. Make it feel arcade, neon, gaming.",
     embedUrl: "https://ps6-dev-summit-roadmap-715f6d07.sites.vm0.io",
+    previewImage:
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0f330fa2-02ad-471a-80e0-8e7fefba92b2/100.jpg",
   },
 ];
 

--- a/turbo/apps/web/app/[locale]/presentation/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation/data.ts
@@ -52,7 +52,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `nike` and template `html-ppt-zhangzara-coral`, create an Air Max Day 2026 brand campaign deck. Story arc, athlete ambassadors, drop calendar, retail activations, social moments. Make it feel bold, kinetic, street.",
     embedUrl: "https://air-max-day-2026-campaign-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a7f2c881-2c92-4b26-8ad0-e347aa6ada14/05.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/9b0ccacc-9e9a-4c9d-bd01-fab56b24f5a5/05.jpg",
   },
   {
     slug: "crypto-liquidity-flow-research",
@@ -107,7 +107,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `renault` and template `html-ppt-zhangzara-cartesian`, create a Renault 5 E-Tech retro-launch deck. Heritage timeline, battery options, charging network, color palette, French market positioning. Make it feel warm, design-forward, French.",
     embedUrl: "https://renault-5-etech-retro-launch-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/01f92cd9-6b11-47ea-8d82-12c9e3be1d11/11.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/67056cf8-b935-4eab-bbf9-d63f906aace2/11.jpg",
   },
   {
     slug: "openai-gpt-6-conf-talk",
@@ -242,7 +242,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `airbnb` and template `html-ppt-zhangzara-soft-editorial`, create an Airbnb Icons 2027 host pitch deck. Story collections, guest personas, photography moodboard, host requirements, payout economics. Make it feel warm, editorial, hospitable.",
     embedUrl: "https://airbnb-icons-2027-host-pitch-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/1c2348e1-de43-4acd-9802-7b8b5760bcd1/26.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/90cfa844-955d-4759-9a19-285bb0f13bd3/26.jpg",
   },
   {
     slug: "airtable-cobuilder-arch",
@@ -305,7 +305,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `composio` and template `html-ppt-knowledge-arch-blueprint`, create a Composio agent-tooling reference architecture for an enterprise prospect. Tool registry, auth proxy, sandboxing layer, observability, integration matrix. Make it feel architectural, technical, clean.",
     embedUrl: "https://composio-agent-tooling-arch-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/b549413b-061d-4730-88c7-c766c27fba2e/33.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0062e788-a1d0-4c71-9f30-d20f1a3c05a3/33.jpg",
   },
   {
     slug: "cursor-1-0-developer-conf",
@@ -395,7 +395,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `kraken` and template `html-ppt-hermes-cyber-terminal`, create a Kraken Pro trading platform internal post-mortem on a flash-crash incident. Timeline, order book state, throttle decisions, customer comms, remediation. Make it feel terminal, candid, technical.",
     embedUrl: "https://kraken-pro-flash-crash-postmortem-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/54d22103-67e7-4b63-a3ec-42cb6a3bb04d/43.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/a1e56c73-d52c-42e2-925b-6d402cc170b2/43.jpg",
   },
   {
     slug: "levels-metabolic-q-report",
@@ -423,7 +423,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `lingo` and template `html-ppt-course-module`, create a Lingo localization-ops onboarding training module for translators. Workflow walkthrough, glossary, QA checks, payout calendar, certification path. Make it feel warm, instructional, friendly.",
     embedUrl: "https://lingo-localization-ops-training-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ee5bff80-0546-4dad-8a18-4d8c909e64a1/46.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/8a0ae449-2f40-40dd-b449-9a4abd2f9037/46.jpg",
   },
   {
     slug: "loom-ai-workflows-launch",
@@ -459,7 +459,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `mintlify` and template `html-ppt-course-module`, create a Mintlify docs-writing workshop deck for new technical writers. Module outline, examples, exercise prompts, peer review, certification. Make it feel warm, editorial, instructional.",
     embedUrl: "https://mintlify-docs-writing-workshop-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/affc2cb8-e29c-406b-859a-ed5ada07808e/50.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/50c6bf39-0fe5-4419-87bc-a146fefab1f2/50.jpg",
   },
   {
     slug: "miro-innovation-workshop",
@@ -495,7 +495,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `perplexity` and template `html-ppt-product-launch`, create a Perplexity Pages and Comet browser launch keynote. New page editor, agent browsing, pricing tiers, partner publishers, growth. Make it feel sleek, modern, research.",
     embedUrl: "https://perplexity-pages-comet-keynote-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/cf11f784-c3b5-44b0-8f8c-aac37fc64b94/54.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/cdfe86fd-b14a-4571-a763-25d7ab97211f/54.jpg",
   },
   {
     slug: "pinterest-predicts-2027",
@@ -685,7 +685,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `webflow` and template `html-ppt-zhangzara-creative-mode`, create a Webflow Conf 2026 keynote deck. Designer 2 release, AI site builder, CMS upgrades, partner showcase, ecosystem stats. Make it feel colorful, design, energetic.",
     embedUrl: "https://webflow-conf-2026-keynote-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e3015970-2511-4431-8aa4-864c1248b91f/75.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/82705e3b-4ca9-4353-9628-78ef9a566ab2/75.jpg",
   },
   {
     slug: "wechat-miniprogram-2027",
@@ -712,7 +712,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `xiaohongshu` and template `html-ppt-xhs-post`, create a 小红书 2027 春夏种草趋势报告. 趋势卡片、爆款笔记拆解、博主合作建议、品牌进入策略、案例集. Make it feel 马卡龙, 生活方式, 中文.",
     embedUrl: "https://xhs-2027-spring-summer-trends-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/143681e9-ba38-4385-8fc9-0f0070d0292d/78.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/681c6b00-6191-4945-9724-e39caef0e8e1/78.jpg",
   },
   {
     slug: "xhs-creator-annual-review",
@@ -721,7 +721,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `xiaohongshu` and template `html-ppt-xhs-pastel-card`, create a 小红书博主个人成长年报. 内容选题复盘、粉丝画像、合作品牌清单、明年计划、感谢清单. Make it feel 柔和, 慢生活, 治愈.",
     embedUrl: "https://xhs-creator-annual-review-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4be2fc56-0fd7-48ce-9b69-16c0cf1142bd/79.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/02a8b28b-f905-4cff-9d5b-3b37f21fd23d/79.jpg",
   },
   {
     slug: "zapier-central-orchestration-arch",
@@ -730,7 +730,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `zapier` and template `html-ppt-knowledge-arch-blueprint`, create a Zapier Central agent-orchestration reference architecture for ops teams. Trigger graph, agent skills, data store, governance, rollout plan. Make it feel architectural, friendly, automation.",
     embedUrl: "https://zapier-central-orchestration-arch-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/ae6425a3-0878-424d-a2b0-0e32813e4154/80.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/3e3cd579-f1f0-47e7-b5a4-4daf68981039/80.jpg",
   },
   {
     slug: "saas-revops-weekly-metrics",
@@ -766,7 +766,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `editorial` and template `html-ppt-taste-editorial`, create a New York Magazine year-in-review staff readout. Hero stories, traffic anatomy, subscriber growth, editorial wins, 2027 commissions. Make it feel editorial, considered, refined.",
     embedUrl: "https://nym-year-in-review-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/175b83e6-802c-4eed-8571-edc5591e246c/84.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/4152c201-0a30-40e8-9106-5f6238386dfc/84.jpg",
   },
   {
     slug: "indie-author-book-launch",
@@ -784,7 +784,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `agentic` and template `html-ppt-graphify-dark-graph`, create an internal agent-system architecture readout for an enterprise platform team. Agent graph, tool registry, eval harness, observability, rollout plan. Make it feel dark, graph-driven, technical.",
     embedUrl: "https://agent-system-architecture-readout-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6e016ec1-f6f7-4b5f-90f5-245139741ec5/86.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/6cd9a0f3-44bb-42ca-8ce1-2704dc924f57/86.jpg",
   },
   {
     slug: "creative-portfolio-capsule-pitch",
@@ -912,7 +912,7 @@ export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
       "/gen presentation with design system `playstation` and template `html-ppt-zhangzara-8-bit-orbit`, create a PS6 dev-summit roadmap deck for studio partners. Console specs, dev-kit timeline, marquee titles, store policy updates, partner programs. Make it feel arcade, neon, gaming.",
     embedUrl: "https://ps6-dev-summit-roadmap-715f6d07.sites.vm0.io",
     previewImage:
-      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/0f330fa2-02ad-471a-80e0-8e7fefba92b2/100.jpg",
+      "https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/caabca48-9d75-4865-a071-67d1cea65fc0/100.jpg",
   },
 ];
 

--- a/turbo/apps/web/app/[locale]/presentation/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation/data.ts
@@ -1,0 +1,726 @@
+export interface PresentationItem {
+  readonly slug: string;
+  readonly title: string;
+  readonly prompt: string;
+  readonly embedUrl: string;
+}
+
+export const PRESENTATION_ITEMS: readonly PresentationItem[] = [
+  {
+    slug: "starship-v3-investor-update",
+    title: "Starship V3 Investor Update",
+    prompt:
+      "/gen presentation with design system `spacex` and template `html-ppt-pitch-deck`, create a Starship V3 investor update deck. Cadence numbers, payload mass to LEO, Raptor 3 cost curve, lunar Starlink V3 architecture, and 18-month roadmap. Make it feel aerospace, technical, austere, bold.",
+    embedUrl: "https://starship-v3-investor-update-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "vision-pro-studio-keynote",
+    title: "Vision Pro Studio Keynote",
+    prompt:
+      "/gen presentation with design system `apple` and template `html-ppt-product-launch`, create a Vision Pro Studio Edition launch keynote. Hero reveal, R2 silicon specs, spatial workflows demo, pricing tiers, availability windows. Make it feel cinematic, minimal, premium.",
+    embedUrl: "https://vision-pro-studio-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "tesla-q3-2026-shareholder-talk",
+    title: "Tesla Q3 2026 Shareholder Talk",
+    prompt:
+      "/gen presentation with design system `tesla` and template `html-ppt-presenter-mode-reveal`, create a Q3 2026 vehicle delivery and FSD v14 shareholder talk. Production ramp, energy storage attach, FSD miles-per-intervention, Cybercab pilot cities, gigafactory map. Make it feel kinetic, sleek, confident.",
+    embedUrl:
+      "https://tesla-q3-2026-shareholder-talk-715f6d07-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "ferrari-sf90-xx-unveiling",
+    title: "Ferrari SF90 Xx Unveiling",
+    prompt:
+      "/gen presentation with design system `ferrari` and template `html-ppt-zhangzara-bold-poster`, create an SF90 XX Stradale press unveiling. Powertrain reveal, aero numbers, track lap record, livery palette, owner-program tiers. Make it feel red-blooded, editorial, prestige.",
+    embedUrl:
+      "https://ferrari-sf90-xx-unveiling-715f6d07-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "air-max-day-2026-campaign",
+    title: "Air Max Day 2026 Campaign",
+    prompt:
+      "/gen presentation with design system `nike` and template `html-ppt-zhangzara-coral`, create an Air Max Day 2026 brand campaign deck. Story arc, athlete ambassadors, drop calendar, retail activations, social moments. Make it feel bold, kinetic, street.",
+    embedUrl: "https://air-max-day-2026-campaign-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "crypto-liquidity-flow-research",
+    title: "Crypto Liquidity Flow Research",
+    prompt:
+      "/gen presentation with design system `binance` and template `html-ppt-graphify-dark-graph`, create a crypto liquidity flow research readout. Order book heatmap, market-maker graph, stablecoin corridors, MEV anomalies, settlement latency. Make it feel dark, quantitative, technical.",
+    embedUrl: "https://crypto-liquidity-flow-research-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "bmw-neue-klasse-brand-book",
+    title: "Bmw Neue Klasse Brand Book",
+    prompt:
+      "/gen presentation with design system `bmw` and template `html-ppt-zhangzara-broadside`, create a Neue Klasse design language brand book unveil. Silhouette sketches, Hofmeister kink evolution, interior philosophy, color palette, model rollout. Make it feel precise, modernist, refined.",
+    embedUrl: "https://bmw-neue-klasse-brand-book-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "bmw-m5-cs-touring-keynote",
+    title: "Bmw M5 CS Touring Keynote",
+    prompt:
+      "/gen presentation with design system `bmw-m` and template `html-ppt-product-launch`, create an M5 CS Touring launch keynote. Power numbers, Nurburgring time, chassis tech, livery options, customer track-day program. Make it feel motorsport, aggressive, premium.",
+    embedUrl: "https://bmw-m5-cs-touring-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "bugatti-tourbillon-owners-briefing",
+    title: "Bugatti Tourbillon Owners Briefing",
+    prompt:
+      "/gen presentation with design system `bugatti` and template `html-ppt-zhangzara-monochrome`, create a Tourbillon hyper-GT owners briefing. Powertrain, atelier customization, Molsheim delivery experience, road-touring routes, heritage references. Make it feel luxury, hand-built, French-refined.",
+    embedUrl:
+      "https://bugatti-tourbillon-owners-briefing-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "lamborghini-revuelto-2027-lineup",
+    title: "Lamborghini Revuelto 2027 Lineup",
+    prompt:
+      "/gen presentation with design system `lamborghini` and template `html-ppt-zhangzara-studio`, create a Revuelto color and trim 2027 lineup deck. Ad Personam palettes, carbon weave options, Y-shape design language, dealer rollout, owner events. Make it feel high-voltage, theatrical, exotic.",
+    embedUrl: "https://lamborghini-revuelto-2027-lineup-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "renault-5-etech-retro-launch",
+    title: "Renault 5 Etech Retro Launch",
+    prompt:
+      "/gen presentation with design system `renault` and template `html-ppt-zhangzara-cartesian`, create a Renault 5 E-Tech retro-launch deck. Heritage timeline, battery options, charging network, color palette, French market positioning. Make it feel warm, design-forward, French.",
+    embedUrl: "https://renault-5-etech-retro-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "openai-gpt-6-conf-talk",
+    title: "Openai GPT 6 Conf Talk",
+    prompt:
+      "/gen presentation with design system `openai` and template `html-ppt-tech-sharing`, create a GPT-6 capability and safety conference talk. Reasoning benchmarks, training compute, alignment evals, deployment policy, partner ecosystem. Make it feel research, candid, technical.",
+    embedUrl: "https://openai-gpt-6-conf-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "claude-5-model-deep-dive",
+    title: "Claude 5 Model Deep Dive",
+    prompt:
+      "/gen presentation with design system `claude` and template `html-ppt-obsidian-claude-gradient`, create a Claude 5 model card and product deep-dive. Eval suite, constitutional AI updates, context window, agent harness, customer wins. Make it feel thoughtful, deliberate, gradient-elegant.",
+    embedUrl: "https://claude-5-model-deep-dive-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "cohere-enterprise-rag-arch",
+    title: "Cohere Enterprise RAG Arch",
+    prompt:
+      "/gen presentation with design system `cohere` and template `html-ppt-knowledge-arch-blueprint`, create an enterprise RAG reference architecture session. Embedding pipeline, retrieval graph, reranker stack, eval harness, deployment topology. Make it feel architectural, enterprise, blueprint-clean.",
+    embedUrl: "https://cohere-enterprise-rag-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "mixtral-next-moe-research",
+    title: "Mixtral Next Moe Research",
+    prompt:
+      "/gen presentation with design system `mistral-ai` and template `html-ppt-tech-sharing`, create a Mixtral-Next mixture-of-experts research talk. Routing math, expert utilization charts, throughput benchmarks, open-weight policy, partner programs. Make it feel European, research, candid.",
+    embedUrl: "https://mixtral-next-moe-research-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "huggingface-state-of-the-hub",
+    title: "Huggingface State Of The Hub",
+    prompt:
+      "/gen presentation with design system `huggingface` and template `html-ppt-creative-mode`, create an open model community state-of-the-hub annual recap. Downloads dashboard, top contributors, dataset spotlights, hub partnerships, roadmap. Make it feel warm, community, playful.",
+    embedUrl: "https://huggingface-state-of-the-hub-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "grok-4-infra-disclosure",
+    title: "Grok 4 Infra Disclosure",
+    prompt:
+      "/gen presentation with design system `x-ai` and template `html-ppt-hermes-cyber-terminal`, create a Grok 4 capability and infra disclosure. Training cluster, Colossus topology, tool use evals, deployment guardrails, public usage stats. Make it feel cyberpunk, terminal, bold.",
+    embedUrl: "https://grok-4-infra-disclosure-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "minimax-m2-product-launch",
+    title: "Minimax M2 Product Launch",
+    prompt:
+      "/gen presentation with design system `minimax` and template `html-ppt-xhs-white-editorial`, create a MiniMax M2 product launch deck. Multimodal samples, agent benchmarks, partner integrations, China-market rollout, pricing tiers. Make it feel pastel, modern, friendly.",
+    embedUrl: "https://minimax-m2-product-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "nvidia-blackwell-ultra-arch",
+    title: "NVIDIA Blackwell Ultra Arch",
+    prompt:
+      "/gen presentation with design system `nvidia` and template `html-ppt-knowledge-arch-blueprint`, create a Blackwell Ultra reference data-center architecture briefing. NVLink fabric, rack power profile, liquid cooling, cluster topology, MLPerf numbers. Make it feel architectural, high-performance, technical.",
+    embedUrl: "https://nvidia-blackwell-ultra-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "ibm-consulting-hybrid-cloud-qbr",
+    title: "IBM Consulting Hybrid Cloud QBR",
+    prompt:
+      "/gen presentation with design system `ibm` and template `html-ppt-weekly-report`, create an IBM Consulting hybrid-cloud QBR for a Fortune 100 client. Engagement KPIs, workload migration progress, FinOps savings, risk register, next-quarter roadmap. Make it feel corporate, measured, enterprise.",
+    embedUrl: "https://ibm-consulting-hybrid-cloud-qbr-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "cisco-netops-weekly-status",
+    title: "Cisco Netops Weekly Status",
+    prompt:
+      "/gen presentation with design system `cisco` and template `html-ppt-weekly-report`, create a global NetOps weekly status report. SLA dashboards, incident summary, capacity headroom, security posture, change calendar. Make it feel corporate, operational, clear.",
+    embedUrl: "https://cisco-netops-weekly-status-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "meta-rayban-display-keynote",
+    title: "Meta Rayban Display Keynote",
+    prompt:
+      "/gen presentation with design system `meta` and template `html-ppt-product-launch`, create a Ray-Ban Display launch keynote. Hardware specs, AI assistant demos, social capture stories, pricing tiers, retail rollout. Make it feel cinematic, social, premium.",
+    embedUrl: "https://meta-rayban-display-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "discord-community-summit-2026",
+    title: "Discord Community Summit 2026",
+    prompt:
+      "/gen presentation with design system `discord` and template `html-ppt-zhangzara-block-frame`, create a Discord platform 2026 community summit deck. New voice features, Activities SDK, creator monetization, moderator tools, partner spotlights. Make it feel playful, pastel-pop, community.",
+    embedUrl: "https://discord-community-summit-2026-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "slack-enterprise-success-qbr",
+    title: "Slack Enterprise Success QBR",
+    prompt:
+      "/gen presentation with design system `slack` and template `html-ppt-weekly-report`, create an enterprise customer success QBR for a 30k-seat account. Adoption metrics, channel health, integrations attached, automation hours saved, renewal motion. Make it feel corporate, friendly, structured.",
+    embedUrl: "https://slack-enterprise-success-qbr-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "notion-ai-pm-training-module",
+    title: "Notion AI PM Training Module",
+    prompt:
+      "/gen presentation with design system `notion` and template `html-ppt-course-module`, create a Notion AI for product managers self-paced training module. Lesson outline, exercises, AI prompt library, project rubric, completion checklist. Make it feel warm, editorial, instructional.",
+    embedUrl: "https://notion-ai-pm-training-module-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "airbnb-icons-2027-host-pitch",
+    title: "Airbnb Icons 2027 Host Pitch",
+    prompt:
+      "/gen presentation with design system `airbnb` and template `html-ppt-zhangzara-soft-editorial`, create an Airbnb Icons 2027 host pitch deck. Story collections, guest personas, photography moodboard, host requirements, payout economics. Make it feel warm, editorial, hospitable.",
+    embedUrl: "https://airbnb-icons-2027-host-pitch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "airtable-cobuilder-arch",
+    title: "Airtable Cobuilder Arch",
+    prompt:
+      "/gen presentation with design system `airtable` and template `html-ppt-knowledge-arch-blueprint`, create an Airtable Cobuilder reference architecture briefing for enterprise IT. Data model, sync graph, automation engine, governance layer, rollout plan. Make it feel architectural, enterprise, blueprint-clean.",
+    embedUrl: "https://airtable-cobuilder-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "ant-design-v6-governance-review",
+    title: "Ant Design V6 Governance Review",
+    prompt:
+      "/gen presentation with design system `ant` and template `html-ppt-weekly-report`, create an Ant Design System v6 internal governance review. Component adoption, theming changes, accessibility scores, release calendar, open issues. Make it feel structured, corporate, clear.",
+    embedUrl: "https://ant-design-v6-governance-review-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "cal-com-routing-forms-v2-launch",
+    title: "Cal Com Routing Forms V2 Launch",
+    prompt:
+      "/gen presentation with design system `cal` and template `html-ppt-product-launch`, create a Cal.com Routing Forms v2 launch deck. New form builder, workflow webhooks, embed SDK, pricing tiers, customer wins. Make it feel friendly, modern, developer.",
+    embedUrl: "https://cal-com-routing-forms-v2-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "canva-design-ai-allhands",
+    title: "Canva Design AI Allhands",
+    prompt:
+      "/gen presentation with design system `canva` and template `html-ppt-zhangzara-creative-mode`, create a Canva Design AI for marketers all-hands deck. New magic features, brand kits, education program, case studies, roadmap. Make it feel colorful, friendly, energetic.",
+    embedUrl: "https://canva-design-ai-allhands-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "clickhouse-query-performance-talk",
+    title: "Clickhouse Query Performance Talk",
+    prompt:
+      "/gen presentation with design system `clickhouse` and template `html-ppt-tech-sharing`, create a ClickHouse Cloud query-performance deep-dive conference talk. JOIN reordering, parallel replicas, S3 cold tier, benchmark vs Snowflake, optimization recipes. Make it feel technical, candid, performance.",
+    embedUrl: "https://clickhouse-query-performance-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "coinbase-institutional-prime-deck",
+    title: "Coinbase Institutional Prime Deck",
+    prompt:
+      "/gen presentation with design system `coinbase` and template `html-ppt-pitch-deck`, create a Coinbase Institutional prime-brokerage sales deck. AUC scale, custody architecture, OTC desk, derivatives roadmap, regulatory posture. Make it feel institutional, sleek, blue-chip.",
+    embedUrl: "https://coinbase-institutional-prime-deck-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "composio-agent-tooling-arch",
+    title: "Composio Agent Tooling Arch",
+    prompt:
+      "/gen presentation with design system `composio` and template `html-ppt-knowledge-arch-blueprint`, create a Composio agent-tooling reference architecture for an enterprise prospect. Tool registry, auth proxy, sandboxing layer, observability, integration matrix. Make it feel architectural, technical, clean.",
+    embedUrl: "https://composio-agent-tooling-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "cursor-1-0-developer-conf",
+    title: "Cursor 1 0 Developer Conf",
+    prompt:
+      "/gen presentation with design system `cursor` and template `html-ppt-tech-sharing`, create a Cursor 1.0 developer conference talk. Agent mode demo, codebase indexing, MCP support, enterprise SSO, pricing. Make it feel developer, sleek, confident.",
+    embedUrl: "https://cursor-1-0-developer-conf-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "duolingo-math-parents-launch",
+    title: "Duolingo Math Parents Launch",
+    prompt:
+      "/gen presentation with design system `duolingo` and template `html-ppt-zhangzara-daisy-days`, create a Duolingo Math launch deck for parents and educators. Curriculum scope, gamification mechanics, parent dashboard, school program, pricing. Make it feel cheerful, friendly, family.",
+    embedUrl: "https://duolingo-math-parents-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "elevenlabs-voice-3-keynote",
+    title: "Elevenlabs Voice 3 Keynote",
+    prompt:
+      "/gen presentation with design system `elevenlabs` and template `html-ppt-product-launch`, create an ElevenLabs Voice 3 model launch keynote. Sample reel, latency benchmarks, voice cloning policy, agent voices, pricing tiers. Make it feel premium, voice-forward, sleek.",
+    embedUrl: "https://elevenlabs-voice-3-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "expo-router-v5-conf-talk",
+    title: "Expo Router V5 Conf Talk",
+    prompt:
+      "/gen presentation with design system `expo` and template `html-ppt-tech-sharing`, create an Expo Router v5 conference talk. New routing primitives, server components, EAS updates, performance wins, migration guide. Make it feel developer, friendly, technical.",
+    embedUrl: "https://expo-router-v5-conf-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "figma-sites-ga-keynote",
+    title: "Figma Sites GA Keynote",
+    prompt:
+      "/gen presentation with design system `figma` and template `html-ppt-product-launch`, create a Figma Sites GA launch keynote. New site editor, CMS panel, publishing pipeline, pricing, customer stories. Make it feel design, premium, modern.",
+    embedUrl: "https://figma-sites-ga-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "framer-ai-sites-2026-launch",
+    title: "Framer AI Sites 2026 Launch",
+    prompt:
+      "/gen presentation with design system `framer` and template `html-ppt-product-launch`, create a Framer AI Sites 2026 launch deck. Prompt-to-site demo, CMS, SEO panel, e-commerce add-on, pricing. Make it feel design, friendly, fast.",
+    embedUrl: "https://framer-ai-sites-2026-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "github-universe-copilot-keynote",
+    title: "Github Universe Copilot Keynote",
+    prompt:
+      "/gen presentation with design system `github` and template `html-ppt-tech-sharing`, create a GitHub Universe Copilot Workspace keynote. Issue-to-PR flow, plan-edit-test loop, enterprise rollout, security posture, customer wins. Make it feel developer, candid, confident.",
+    embedUrl: "https://github-universe-copilot-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "terraform-stacks-bank-arch",
+    title: "Terraform Stacks Bank Arch",
+    prompt:
+      "/gen presentation with design system `hashicorp` and template `html-ppt-knowledge-arch-blueprint`, create a Terraform Stacks reference deployment architecture for a bank. Stack topology, state isolation, policy guardrails, CI/CD pipeline, migration plan. Make it feel architectural, enterprise, precise.",
+    embedUrl: "https://terraform-stacks-bank-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "intercom-fin-ai-agent-sales",
+    title: "Intercom Fin AI Agent Sales",
+    prompt:
+      "/gen presentation with design system `intercom` and template `html-ppt-pitch-deck`, create an Intercom Fin AI Agent enterprise sales deck. Deflection rate proof, integrations, governance controls, pricing model, customer wins. Make it feel modern, friendly, sales.",
+    embedUrl: "https://intercom-fin-ai-agent-sales-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "kraken-pro-flash-crash-postmortem",
+    title: "Kraken Pro Flash Crash Postmortem",
+    prompt:
+      "/gen presentation with design system `kraken` and template `html-ppt-hermes-cyber-terminal`, create a Kraken Pro trading platform internal post-mortem on a flash-crash incident. Timeline, order book state, throttle decisions, customer comms, remediation. Make it feel terminal, candid, technical.",
+    embedUrl: "https://kraken-pro-flash-crash-postmortem-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "levels-metabolic-q-report",
+    title: "Levels Metabolic Q Report",
+    prompt:
+      "/gen presentation with design system `levels` and template `html-ppt-xhs-pastel-card`, create a Levels metabolic health quarterly member report. Glucose variability trends, food correlations, sleep impact, exercise wins, next-quarter goals. Make it feel calm, pastel, member-friendly.",
+    embedUrl: "https://levels-metabolic-q-report-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "linear-product-intelligence-keynote",
+    title: "Linear Product Intelligence Keynote",
+    prompt:
+      "/gen presentation with design system `linear-app` and template `html-ppt-presenter-mode-reveal`, create a Linear Product Intelligence launch keynote. New insights view, AI triage, roadmap canvas, customer wins, pricing tiers. Make it feel modern, sleek, confident.",
+    embedUrl:
+      "https://linear-product-intelligence-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "lingo-localization-ops-training",
+    title: "Lingo Localization Ops Training",
+    prompt:
+      "/gen presentation with design system `lingo` and template `html-ppt-course-module`, create a Lingo localization-ops onboarding training module for translators. Workflow walkthrough, glossary, QA checks, payout calendar, certification path. Make it feel warm, instructional, friendly.",
+    embedUrl: "https://lingo-localization-ops-training-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "loom-ai-workflows-launch",
+    title: "Loom AI Workflows Launch",
+    prompt:
+      "/gen presentation with design system `loom` and template `html-ppt-product-launch`, create a Loom AI Workflows launch deck. Auto-summary, action items, integrations, enterprise SSO, pricing. Make it feel friendly, modern, video-first.",
+    embedUrl: "https://loom-ai-workflows-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "lovable-v3-community-launch",
+    title: "Lovable V3 Community Launch",
+    prompt:
+      "/gen presentation with design system `lovable` and template `html-ppt-zhangzara-playful`, create a Lovable v3 community launch deck. Prompt-to-app demo, project gallery, builder economics, partner ecosystem, roadmap. Make it feel playful, friendly, indie.",
+    embedUrl: "https://lovable-v3-community-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "mastercard-fraud-risk-council",
+    title: "Mastercard Fraud Risk Council",
+    prompt:
+      "/gen presentation with design system `mastercard` and template `html-ppt-weekly-report`, create a Mastercard fraud-risk weekly council report. Authorization-decline trends, model performance, geo heatmap, issuer alerts, control changes. Make it feel corporate, structured, financial.",
+    embedUrl: "https://mastercard-fraud-risk-council-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "mintlify-docs-writing-workshop",
+    title: "Mintlify Docs Writing Workshop",
+    prompt:
+      "/gen presentation with design system `mintlify` and template `html-ppt-course-module`, create a Mintlify docs-writing workshop deck for new technical writers. Module outline, examples, exercise prompts, peer review, certification. Make it feel warm, editorial, instructional.",
+    embedUrl: "https://mintlify-docs-writing-workshop-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "miro-innovation-workshop",
+    title: "Miro Innovation Workshop",
+    prompt:
+      "/gen presentation with design system `miro` and template `html-ppt-zhangzara-scatterbrain`, create a Miro Innovation Workspace customer co-creation workshop deck. Discovery board, opportunity map, prototype sticky notes, voting matrix, next steps. Make it feel post-it, playful, workshop.",
+    embedUrl: "https://miro-innovation-workshop-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "mongodb-atlas-vector-search-talk",
+    title: "Mongodb Atlas Vector Search Talk",
+    prompt:
+      "/gen presentation with design system `mongodb` and template `html-ppt-tech-sharing`, create a MongoDB Atlas Vector Search conference talk. Index internals, hybrid search, embedding refresh, benchmark numbers, customer wins. Make it feel technical, candid, database.",
+    embedUrl: "https://mongodb-atlas-vector-search-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "ollama-on-device-community-talk",
+    title: "Ollama On Device Community Talk",
+    prompt:
+      "/gen presentation with design system `ollama` and template `html-ppt-hermes-cyber-terminal`, create an Ollama on-device deployment community talk. Model zoo, GPU profile guide, quantization tradeoffs, MCP integration, roadmap. Make it feel terminal, indie, technical.",
+    embedUrl: "https://ollama-on-device-community-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "perplexity-pages-comet-keynote",
+    title: "Perplexity Pages Comet Keynote",
+    prompt:
+      "/gen presentation with design system `perplexity` and template `html-ppt-product-launch`, create a Perplexity Pages and Comet browser launch keynote. New page editor, agent browsing, pricing tiers, partner publishers, growth. Make it feel sleek, modern, research.",
+    embedUrl: "https://perplexity-pages-comet-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "pinterest-predicts-2027",
+    title: "Pinterest Predicts 2027",
+    prompt:
+      "/gen presentation with design system `pinterest` and template `html-ppt-xhs-post`, create a Pinterest Predicts 2027 trend release. Trend cards, search-volume charts, brand opportunity callouts, creator quotes, campaign ideas. Make it feel editorial, pastel, lifestyle.",
+    embedUrl: "https://pinterest-predicts-2027-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "posthog-product-eng-metrics-talk",
+    title: "Posthog Product Eng Metrics Talk",
+    prompt:
+      "/gen presentation with design system `posthog` and template `html-ppt-tech-sharing`, create a PostHog product-engineering metrics conference talk. North-star tree, experiments velocity, retention curves, error budgets, recipes. Make it feel candid, technical, indie.",
+    embedUrl: "https://posthog-product-eng-metrics-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "raycast-for-teams-keynote",
+    title: "Raycast For Teams Keynote",
+    prompt:
+      "/gen presentation with design system `raycast` and template `html-ppt-product-launch`, create a Raycast for Teams launch keynote. Shared snippets, AI commands, team analytics, pricing tiers, enterprise readiness. Make it feel sleek, premium, developer.",
+    embedUrl: "https://raycast-for-teams-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "replicate-model-serving-infra-talk",
+    title: "Replicate Model Serving Infra Talk",
+    prompt:
+      "/gen presentation with design system `replicate` and template `html-ppt-tech-sharing`, create a Replicate model-serving infra deep-dive talk. Cold-start architecture, scheduler, GPU bin packing, cost economics, roadmap. Make it feel technical, candid, infra.",
+    embedUrl:
+      "https://replicate-model-serving-infra-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "resend-broadcasts-2-launch",
+    title: "Resend Broadcasts 2 Launch",
+    prompt:
+      "/gen presentation with design system `resend` and template `html-ppt-product-launch`, create a Resend Broadcasts 2.0 launch deck. New editor, segmentation, deliverability dashboard, pricing, customer wins. Make it feel modern, friendly, developer.",
+    embedUrl: "https://resend-broadcasts-2-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "revolut-business-latam-update",
+    title: "Revolut Business Latam Update",
+    prompt:
+      "/gen presentation with design system `revolut` and template `html-ppt-pitch-deck`, create a Revolut Business expansion-to-LATAM investor update. Market sizing, regulatory path, product wedge, unit economics, hiring plan. Make it feel sleek, fintech, confident.",
+    embedUrl: "https://revolut-business-latam-update-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "runway-gen-4-film-tools",
+    title: "Runway Gen 4 Film Tools",
+    prompt:
+      "/gen presentation with design system `runwayml` and template `html-ppt-zhangzara-bold-poster`, create a Runway Gen-4 film-tools launch deck for studios. Pipeline integration, look-dev examples, talent quotes, festival placements, pricing. Make it feel cinematic, bold, editorial.",
+    embedUrl: "https://runway-gen-4-film-tools-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "sanity-content-platform-arch",
+    title: "Sanity Content Platform Arch",
+    prompt:
+      "/gen presentation with design system `sanity` and template `html-ppt-knowledge-arch-blueprint`, create a Sanity content-platform reference architecture for a media company. Content graph, GROQ queries, syndication pipeline, governance, migration plan. Make it feel architectural, editorial, clean.",
+    embedUrl: "https://sanity-content-platform-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "sentry-prod-outage-postmortem",
+    title: "Sentry Prod Outage Postmortem",
+    prompt:
+      "/gen presentation with design system `sentry` and template `html-ppt-testing-safety-alert`, create a production incident post-mortem deck for a major customer outage. Incident timeline, blast radius, contributing factors, remediation, follow-ups. Make it feel alert, accountable, structured.",
+    embedUrl: "https://sentry-prod-outage-postmortem-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "shopify-magic-merchants-launch",
+    title: "Shopify Magic Merchants Launch",
+    prompt:
+      "/gen presentation with design system `shopify` and template `html-ppt-product-launch`, create a Shopify Magic for Merchants summer edition launch deck. AI tools demo, store templates, payment updates, merchant case studies, pricing. Make it feel friendly, modern, commerce.",
+    embedUrl: "https://shopify-magic-merchants-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "spotify-wrapped-2027",
+    title: "Spotify Wrapped 2027",
+    prompt:
+      "/gen presentation with design system `spotify` and template `html-ppt-product-launch`, create a Spotify Wrapped 2027 product launch deck. Personalization features, creator stories, advertiser opportunities, partner spotlights, rollout calendar. Make it feel kinetic, expressive, music-first.",
+    embedUrl: "https://spotify-wrapped-2027-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "starbucks-reserve-brand-book",
+    title: "Starbucks Reserve Brand Book",
+    prompt:
+      "/gen presentation with design system `starbucks` and template `html-ppt-zhangzara-mat`, create a Starbucks Reserve global brand book unveil. Bean story, store design language, beverage rituals, art collaborations, market rollout. Make it feel warm, refined, cafe.",
+    embedUrl: "https://starbucks-reserve-brand-book-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "stripe-marketplace-arch",
+    title: "Stripe Marketplace Arch",
+    prompt:
+      "/gen presentation with design system `stripe` and template `html-ppt-knowledge-arch-blueprint`, create a Stripe platform reference architecture for a marketplace. Account model, Connect flows, Tax engine, Radar, settlement timeline. Make it feel architectural, fintech, precise.",
+    embedUrl: "https://stripe-marketplace-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "supabase-postgres-17-talk",
+    title: "Supabase Postgres 17 Talk",
+    prompt:
+      "/gen presentation with design system `supabase` and template `html-ppt-tech-sharing`, create a Supabase Postgres 17 features conference talk. Foreign data wrappers, vector index, realtime improvements, edge functions, customer wins. Make it feel developer, candid, open-source.",
+    embedUrl: "https://supabase-postgres-17-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "superhuman-ai-inbox-launch",
+    title: "Superhuman AI Inbox Launch",
+    prompt:
+      "/gen presentation with design system `superhuman` and template `html-ppt-product-launch`, create a Superhuman AI Inbox launch deck. New triage flow, command palette, calendar integration, pricing tiers, testimonials. Make it feel premium, sleek, productivity.",
+    embedUrl: "https://superhuman-ai-inbox-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "together-inference-engine-talk",
+    title: "Together Inference Engine Talk",
+    prompt:
+      "/gen presentation with design system `together-ai` and template `html-ppt-tech-sharing`, create a Together Inference Engine performance research talk. Speculative decoding, KV cache reuse, MLPerf benchmarks, partner stories, roadmap. Make it feel research, technical, candid.",
+    embedUrl: "https://together-inference-engine-talk-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "uber-eats-marketplace-wbr",
+    title: "Uber Eats Marketplace WBR",
+    prompt:
+      "/gen presentation with design system `uber` and template `html-ppt-weekly-report`, create an Uber Eats marketplace weekly business review. Cohort GMV, courier supply, restaurant churn, ad revenue, growth experiments. Make it feel corporate, marketplace, data-driven.",
+    embedUrl: "https://uber-eats-marketplace-wbr-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "vercel-v0-ga-enterprise-launch",
+    title: "Vercel V0 GA Enterprise Launch",
+    prompt:
+      "/gen presentation with design system `vercel` and template `html-ppt-product-launch`, create a Vercel v0 GA enterprise launch deck. New site builder, AI workflow, design partner stories, pricing, enterprise controls. Make it feel sleek, modern, developer.",
+    embedUrl: "https://vercel-v0-ga-enterprise-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "vodafone-enterprise-services-qbr",
+    title: "Vodafone Enterprise Services QBR",
+    prompt:
+      "/gen presentation with design system `vodafone` and template `html-ppt-weekly-report`, create a Vodafone enterprise-services QBR for a multinational client. SLA scorecards, network performance, security posture, change calendar, roadmap. Make it feel corporate, telco, structured.",
+    embedUrl: "https://vodafone-enterprise-services-qbr-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "webex-contact-center-qbr",
+    title: "Webex Contact Center QBR",
+    prompt:
+      "/gen presentation with design system `webex` and template `html-ppt-weekly-report`, create a Webex Contact Center QBR for a Fortune 500 client. Adoption stats, AI agent attach, queue performance, NPS, renewal plan. Make it feel corporate, professional, clear.",
+    embedUrl: "https://webex-contact-center-qbr-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "webflow-conf-2026-keynote",
+    title: "Webflow Conf 2026 Keynote",
+    prompt:
+      "/gen presentation with design system `webflow` and template `html-ppt-zhangzara-creative-mode`, create a Webflow Conf 2026 keynote deck. Designer 2 release, AI site builder, CMS upgrades, partner showcase, ecosystem stats. Make it feel colorful, design, energetic.",
+    embedUrl: "https://webflow-conf-2026-keynote-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "wechat-miniprogram-2027",
+    title: "Wechat Miniprogram 2027",
+    prompt:
+      "/gen presentation with design system `wechat` and template `guizang-ppt`, create a 微信小程序 2027 生态年度大会主题演讲. 小程序数量、视频号联动、AI 能力开放、商家案例、商业化路径. Make it feel 电子杂志, 中式, 优雅.",
+    embedUrl: "https://wechat-miniprogram-2027-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "wise-treasury-weekly-ops",
+    title: "Wise Treasury Weekly Ops",
+    prompt:
+      "/gen presentation with design system `wise` and template `html-ppt-weekly-report`, create a Wise treasury weekly ops review. FX exposure, corridor volumes, settlement breakage, compliance flags, runway. Make it feel corporate, fintech, structured.",
+    embedUrl: "https://wise-treasury-weekly-ops-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "xhs-2027-spring-summer-trends",
+    title: "Xhs 2027 Spring Summer Trends",
+    prompt:
+      "/gen presentation with design system `xiaohongshu` and template `html-ppt-xhs-post`, create a 小红书 2027 春夏种草趋势报告. 趋势卡片、爆款笔记拆解、博主合作建议、品牌进入策略、案例集. Make it feel 马卡龙, 生活方式, 中文.",
+    embedUrl: "https://xhs-2027-spring-summer-trends-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "xhs-creator-annual-review",
+    title: "Xhs Creator Annual Review",
+    prompt:
+      "/gen presentation with design system `xiaohongshu` and template `html-ppt-xhs-pastel-card`, create a 小红书博主个人成长年报. 内容选题复盘、粉丝画像、合作品牌清单、明年计划、感谢清单. Make it feel 柔和, 慢生活, 治愈.",
+    embedUrl: "https://xhs-creator-annual-review-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "zapier-central-orchestration-arch",
+    title: "Zapier Central Orchestration Arch",
+    prompt:
+      "/gen presentation with design system `zapier` and template `html-ppt-knowledge-arch-blueprint`, create a Zapier Central agent-orchestration reference architecture for ops teams. Trigger graph, agent skills, data store, governance, rollout plan. Make it feel architectural, friendly, automation.",
+    embedUrl: "https://zapier-central-orchestration-arch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "saas-revops-weekly-metrics",
+    title: "Saas Revops Weekly Metrics",
+    prompt:
+      "/gen presentation with design system `dashboard` and template `html-ppt-weekly-report`, create a SaaS revops weekly metrics review. ARR waterfall, pipeline coverage, win rate by segment, churn cohort, forecast call. Make it feel corporate, data-dense, clear.",
+    embedUrl: "https://saas-revops-weekly-metrics-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "prop-desk-daily-pnl",
+    title: "Prop Desk Daily Pnl",
+    prompt:
+      "/gen presentation with design system `trading-terminal` and template `html-ppt-hermes-cyber-terminal`, create a prop-trading desk daily P&L recap. Greeks dashboard, vol surface, top winners/losers, risk limits, overnight watchlist. Make it feel terminal, dense, technical.",
+    embedUrl: "https://prop-desk-daily-pnl-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "craft-coffee-feature-pitch",
+    title: "Craft Coffee Feature Pitch",
+    prompt:
+      "/gen presentation with design system `warm-editorial` and template `html-ppt-taste-editorial`, create a long-form magazine feature pitch on the future of craft coffee. Story arc, photography moodboard, sources, columnist quotes, publishing schedule. Make it feel warm, editorial, hairline.",
+    embedUrl: "https://craft-coffee-feature-pitch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "nym-year-in-review",
+    title: "NYM Year In Review",
+    prompt:
+      "/gen presentation with design system `editorial` and template `html-ppt-taste-editorial`, create a New York Magazine year-in-review staff readout. Hero stories, traffic anatomy, subscriber growth, editorial wins, 2027 commissions. Make it feel editorial, considered, refined.",
+    embedUrl: "https://nym-year-in-review-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "indie-author-book-launch",
+    title: "Indie Author Book Launch",
+    prompt:
+      "/gen presentation with design system `mono` and template `html-ppt-zhangzara-monochrome`, create an indie author book launch deck. Synopsis, character map, reader personas, tour cities, press kit. Make it feel monochrome, literary, considered.",
+    embedUrl: "https://indie-author-book-launch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "agent-system-architecture-readout",
+    title: "Agent System Architecture Readout",
+    prompt:
+      "/gen presentation with design system `agentic` and template `html-ppt-graphify-dark-graph`, create an internal agent-system architecture readout for an enterprise platform team. Agent graph, tool registry, eval harness, observability, rollout plan. Make it feel dark, graph-driven, technical.",
+    embedUrl: "https://agent-system-architecture-readout-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "creative-portfolio-capsule-pitch",
+    title: "Creative Portfolio Capsule Pitch",
+    prompt:
+      "/gen presentation with design system `bento` and template `html-ppt-zhangzara-capsule`, create a personal portfolio pitch for a multi-disciplinary creative. Project capsules, skills grid, client logos, testimonial pulls, contact card. Make it feel capsule, lifestyle, friendly.",
+    embedUrl: "https://creative-portfolio-capsule-pitch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "protest-poster-history-capstone",
+    title: "Protest Poster History Capstone",
+    prompt:
+      "/gen presentation with design system `brutalism` and template `html-ppt-zhangzara-raw-grid`, create a graphic-design-school capstone presentation on protest poster history. Era timeline, case studies, typography study, field photography, final thesis. Make it feel raw-grid, brutalist, academic.",
+    embedUrl: "https://protest-poster-history-capstone-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "wellness-app-annual-story",
+    title: "Wellness App Annual Story",
+    prompt:
+      "/gen presentation with design system `claymorphism` and template `html-ppt-xhs-pastel-card`, create a wellness-app subscriber annual story. Habit streaks, sleep gains, mindful minutes, community moments, next-year ritual. Make it feel pastel, soft, calming.",
+    embedUrl: "https://wellness-app-annual-story-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "kindergarten-family-yearbook",
+    title: "Kindergarten Family Yearbook",
+    prompt:
+      "/gen presentation with design system `clay` and template `html-ppt-zhangzara-daisy-days`, create a kindergarten family-yearbook reveal for parents. Class moments, art highlights, milestone chart, teacher notes, summer plans. Make it feel cheerful, friendly, family.",
+    embedUrl: "https://kindergarten-family-yearbook-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "indie-pixel-game-press-deck",
+    title: "Indie Pixel Game Press Deck",
+    prompt:
+      "/gen presentation with design system `cosmic` and template `html-ppt-zhangzara-8-bit-orbit`, create an indie video game pre-launch press deck. Story pitch, gameplay loop, art direction, soundtrack samples, release window. Make it feel pixel, neon, gaming.",
+    embedUrl: "https://indie-pixel-game-press-deck-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "indie-zine-release-party",
+    title: "Indie Zine Release Party",
+    prompt:
+      "/gen presentation with design system `dithered` and template `html-ppt-zhangzara-retro-zine`, create an indie zine release-party deck for a local arts collective. Zine spreads, contributor bios, print run, distribution plan, launch night flow. Make it feel zine, tactile, retro.",
+    embedUrl: "https://indie-zine-release-party-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "fashion-house-autumn-lookbook",
+    title: "Fashion House Autumn Lookbook",
+    prompt:
+      "/gen presentation with design system `dramatic` and template `html-ppt-zhangzara-pink-script`, create a fashion house autumn collection lookbook reveal. Mood manifesto, silhouette stories, fabric swatches, runway lineup, retail drop. Make it feel late-night, expressive, editorial.",
+    embedUrl: "https://fashion-house-autumn-lookbook-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "art-biennale-curator-pitch",
+    title: "Art Biennale Curator Pitch",
+    prompt:
+      "/gen presentation with design system `expressive` and template `html-ppt-zhangzara-bold-poster`, create an art biennale curator concept pitch deck. Curatorial statement, artist lineup, venue map, public program, funding ask. Make it feel poster, editorial, bold.",
+    embedUrl: "https://art-biennale-curator-pitch-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "grove-restoration-annual-report",
+    title: "Grove Restoration Annual Report",
+    prompt:
+      "/gen presentation with design system `fantasy` and template `html-ppt-zhangzara-grove`, create a sustainability nonprofit grove-restoration annual report. Hectares restored, species returned, community stories, donor wall, next-year goals. Make it feel forest, hopeful, refined.",
+    embedUrl: "https://grove-restoration-annual-report-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "antique-paper-restoration-catalogue",
+    title: "Antique Paper Restoration Catalogue",
+    prompt:
+      "/gen presentation with design system `kami` and template `kami-deck`, create an antique paper restoration studio exhibit catalogue. Featured works, technique notes, restorer profiles, sponsor wall, event calendar. Make it feel parchment, considered, craft.",
+    embedUrl:
+      "https://antique-paper-restoration-catalogue-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "vm0-atelier-zero-v2-unveil",
+    title: "Vm0 Atelier Zero V2 Unveil",
+    prompt:
+      "/gen presentation with design system `atelier-zero` and template `open-design-landing-deck`, create a vm0 design-system v2 internal unveil for the team. New tokens, component refactors, motion language, doc rewrite, rollout plan. Make it feel italic-serif, coral, atelier.",
+    embedUrl: "https://vm0-atelier-zero-v2-unveil-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "community-zine-workshop-facilitator",
+    title: "Community Zine Workshop Facilitator",
+    prompt:
+      "/gen presentation with design system `paper` and template `html-ppt-zhangzara-pin-and-paper`, create a community zine workshop facilitator deck. Workshop arc, supply list, sample spreads, peer feedback flow, takeaway zine. Make it feel handwritten, friendly, paper.",
+    embedUrl:
+      "https://community-zine-workshop-facilitator-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "90s-tech-nostalgia-lightning",
+    title: "90S Tech Nostalgia Lightning",
+    prompt:
+      "/gen presentation with design system `retro` and template `html-ppt-zhangzara-retro-windows`, create a 90s tech-nostalgia conference lightning talk. Boot-screen tour, software archaeology, AOL anecdotes, demo screenshots, audience Q&A. Make it feel pixel, retro, playful.",
+    embedUrl: "https://90s-tech-nostalgia-lightning-715f6d07.sites.vm0.io",
+  },
+  {
+    slug: "ps6-dev-summit-roadmap",
+    title: "PS6 Dev Summit Roadmap",
+    prompt:
+      "/gen presentation with design system `playstation` and template `html-ppt-zhangzara-8-bit-orbit`, create a PS6 dev-summit roadmap deck for studio partners. Console specs, dev-kit timeline, marquee titles, store policy updates, partner programs. Make it feel arcade, neon, gaming.",
+    embedUrl: "https://ps6-dev-summit-roadmap-715f6d07.sites.vm0.io",
+  },
+];
+
+export function buildPresentationRemixHref(
+  item: PresentationItem,
+  appUrl: string,
+): string {
+  const url = new URL("/onboarding", appUrl);
+  url.searchParams.set("prompt", item.prompt);
+  url.searchParams.set("showcase", item.embedUrl);
+  return url.toString();
+}

--- a/turbo/apps/web/app/[locale]/presentation/page.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import type { Locale } from "../../../i18n";
+import { buildLocaleAlternates } from "../../lib/seo/alternates";
+import { PresentationClient } from "./PresentationClient";
+import { PRESENTATION_ITEMS } from "./data";
+
+const BASE_URL = "https://www.vm0.ai";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const url = `${BASE_URL}/${locale}/presentation`;
+
+  return {
+    title: "Presentation Gallery - Remix Zero Prompts",
+    description:
+      "Hidden gallery of presentation deck examples for remixing Zero presentation generation.",
+    alternates: buildLocaleAlternates("/presentation", locale as Locale),
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title: "VM0 Presentation Gallery",
+      description: "Presentation deck examples for remixing Zero generation.",
+      url,
+      type: "website",
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "VM0 Presentation Gallery",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "VM0 Presentation Gallery",
+      description: "Presentation deck examples for remixing Zero generation.",
+      images: ["/og-image.png"],
+      creator: "@vm0_ai",
+      site: "@vm0_ai",
+    },
+  };
+}
+
+export default async function PresentationGalleryPage({ params }: PageProps) {
+  const { locale } = await params;
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "VM0 Presentation Gallery",
+    description: "Presentation deck examples for remixing Zero generation.",
+    itemListElement: PRESENTATION_ITEMS.map((item, i) => {
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${BASE_URL}/${locale}/presentation#${item.slug}`,
+        name: item.title,
+      };
+    }),
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(itemListJsonLd)}
+      </script>
+      <PresentationClient />
+    </>
+  );
+}

--- a/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
@@ -45,13 +45,13 @@ function GalleryCard({ item, appUrl }: { item: GalleryItem; appUrl: string }) {
           </div>
         </div>
       </a>
-      <div className="flex items-center justify-between gap-3 px-4 py-3">
-        <h2 className="text-[14px] font-medium text-[hsl(var(--foreground))]">
-          {item.title}
-        </h2>
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
+          {item.prompt}
+        </pre>
         <a
           href={remixHref}
-          className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+          className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
         >
           <IconSparkles size={15} stroke={2} />
           Prompt remix

--- a/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
@@ -78,8 +78,8 @@ export function WebDesignClient() {
         >
           <h1 className="hero-title">Website Design</h1>
           <p className="hero-description">
-            Image-led website examples you can open, inspect, and remix into
-            your own Zero creation.
+            Get your creative website from a single, short prompt. We promise it
+            works with no extra setup.
           </p>
         </div>
       </section>

--- a/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
 import { getAppUrl } from "../../../src/lib/zero/url";
@@ -46,15 +47,13 @@ function GalleryCard({ item, appUrl }: { item: GalleryItem; appUrl: string }) {
         </div>
       </a>
       <div className="flex flex-col gap-3 px-4 py-3">
-        <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
-          {item.prompt}
-        </pre>
+        <CopyablePrompt prompt={item.prompt} />
         <a
           href={remixHref}
           className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
         >
           <IconSparkles size={15} stroke={2} />
-          Prompt remix
+          Try it
         </a>
       </div>
     </article>

--- a/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
@@ -79,7 +79,7 @@ export function WebDesignClient() {
           <h1 className="hero-title">Website Design</h1>
           <p className="hero-description">
             Get your creative website from a single, short prompt. We promise it
-            works with no extra setup.
+            works with no extra setup in VM0.
           </p>
         </div>
       </section>

--- a/turbo/apps/web/app/components/CopyablePrompt.tsx
+++ b/turbo/apps/web/app/components/CopyablePrompt.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { IconCheck, IconCopy } from "@tabler/icons-react";
+
+export function CopyablePrompt({ prompt }: { prompt: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    window.setTimeout(() => {
+      setCopied(false);
+    }, 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label="Copy prompt"
+      className="group/copy relative block w-full cursor-pointer text-left"
+    >
+      <pre className="max-h-[120px] overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-[hsl(var(--gray-1))] px-3 py-2.5 pr-16 font-mono text-[12px] leading-[1.5] text-[hsl(var(--muted-foreground))]">
+        {prompt}
+      </pre>
+      <span
+        className={`absolute right-2 top-2 inline-flex items-center gap-1 rounded-[6px] bg-[hsl(var(--foreground))] px-2 py-1 text-[11px] font-medium text-white transition-opacity duration-150 group-hover/copy:opacity-100 ${
+          copied ? "opacity-100" : "opacity-0"
+        }`}
+      >
+        {copied ? (
+          <>
+            <IconCheck size={12} stroke={2.5} />
+            Copied
+          </>
+        ) : (
+          <>
+            <IconCopy size={12} stroke={2} />
+            Copy
+          </>
+        )}
+      </span>
+    </button>
+  );
+}

--- a/turbo/apps/web/app/components/CopyablePrompt.tsx
+++ b/turbo/apps/web/app/components/CopyablePrompt.tsx
@@ -7,11 +7,18 @@ export function CopyablePrompt({ prompt }: { prompt: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(prompt);
-    setCopied(true);
-    window.setTimeout(() => {
-      setCopied(false);
-    }, 1500);
+    navigator.clipboard
+      .writeText(prompt)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => {
+          setCopied(false);
+        }, 1500);
+      })
+      .catch((error: unknown) => {
+        // Log error when clipboard API is unavailable (e.g., insecure context)
+        console.warn("Failed to copy to clipboard:", error);
+      });
   };
 
   return (

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -41,6 +41,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/showcase",
   "/web-design",
   "/:locale/web-design",
+  "/presentation",
+  "/:locale/presentation",
   "/terms-of-use",
   "/privacy-policy",
   "/support",


### PR DESCRIPTION
## Summary
- Adds a hidden `/[locale]/presentation` gallery, modeled on the existing `/[locale]/web-design` page (public, `robots: noindex`).
- Renders all 100 generated presentation decks in a **3-up responsive grid** (`1 / 2 / 3` columns).
- Each item is a **live `<iframe>`** embedding the hosted deck (lazy-loaded, sandboxed), with the original **`/gen presentation ...` prompt** shown below it and a **"Prompt remix" CTA** that deep-links into `/onboarding?prompt=...&showcase=...` — same remix pattern as the web-design gallery.

## Files
- `app/[locale]/presentation/page.tsx` — metadata + JSON-LD `ItemList`, renders the client.
- `app/[locale]/presentation/PresentationClient.tsx` — hero + 3-column grid of iframe cards.
- `app/[locale]/presentation/data.ts` — `PRESENTATION_ITEMS` (100 entries: slug, title, prompt, embedUrl) + `buildPresentationRemixHref`.

## Notes
- Decks are served from `*-715f6d07.sites.vm0.io`; iframes use `sandbox="allow-scripts allow-same-origin allow-popups"` and `loading="lazy"`.
- Interpreted "每页给 3 个" as 3 cards per row.
- Prettier 3.6.2 clean; tokens reuse existing `--gray-0/1`, `--foreground`, `--muted-foreground`.

## Test plan
- [ ] `pnpm --filter web dev`, open `/en/presentation` (no login) and confirm the 3-up grid renders.
- [ ] Each iframe loads its deck cover slide; "Open" launches the full deck in a new tab.
- [ ] "Prompt remix" navigates to `/onboarding` with the prompt prefilled and the deck as showcase.
- [ ] Responsive: 1 col mobile, 2 col tablet, 3 col desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)