### PR TITLE
ci: load web api oauth config from doppler

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -68,11 +68,15 @@ runs:
 
         vars_json="${REPO_VARS_JSON:-}"
         secrets_json="${REPO_SECRETS_JSON:-}"
+        doppler_secrets_json="${DOPPLER_SECRETS_JSON:-}"
         if [[ -z "$vars_json" ]]; then
           vars_json="{}"
         fi
         if [[ -z "$secrets_json" ]]; then
           secrets_json="{}"
+        fi
+        if [[ -z "$doppler_secrets_json" ]]; then
+          doppler_secrets_json="{}"
         fi
         env_file="${RUNNER_TEMP}/web-api-${INPUT_APP}-${INPUT_ENVIRONMENT}.env"
         : > "$env_file"
@@ -89,6 +93,10 @@ runs:
 
         repo_secret() {
           json_get "$secrets_json" "$1"
+        }
+
+        doppler_secret() {
+          json_get "$doppler_secrets_json" "$1"
         }
 
         first_non_empty() {
@@ -113,6 +121,23 @@ runs:
 
         add_secret() {
           add_env "$1" "$(repo_secret "$2")"
+        }
+
+        add_oauth_client_config_key() {
+          local key="$1"
+          local value
+          value="$(doppler_secret "$key")"
+          if [[ -z "$value" ]]; then
+            echo "::error::${key} is missing from Doppler OAuth config"
+            exit 1
+          fi
+          add_env "$key" "$value"
+        }
+
+        add_oauth_client_config() {
+          local prefix="$1"
+          add_oauth_client_config_key "${prefix}_OAUTH_CLIENT_ID"
+          add_oauth_client_config_key "${prefix}_OAUTH_CLIENT_SECRET"
         }
 
         if [[ -n "$INPUT_DATABASE_URL" ]]; then
@@ -211,8 +236,6 @@ runs:
           add_env VM0_DEBUG "*"
         fi
         add_var CLAUDE_CODE_VERSION_URL CLAUDE_CODE_VERSION_URL
-        add_var SLACK_OAUTH_CLIENT_ID SLACK_OAUTH_CLIENT_ID
-        add_secret SLACK_OAUTH_CLIENT_SECRET SLACK_OAUTH_CLIENT_SECRET
         add_secret SLACK_SIGNING_SECRET SLACK_SIGNING_SECRET
         add_secret TELEGRAM_OFFICIAL_BOT_TOKEN TELEGRAM_OFFICIAL_BOT_TOKEN
         add_var TELEGRAM_OFFICIAL_BOT_USERNAME TELEGRAM_OFFICIAL_BOT_USERNAME
@@ -235,77 +258,51 @@ runs:
         add_secret SENTRY_AUTH_TOKEN SENTRY_AUTH_TOKEN
         add_var SENTRY_ORG SENTRY_ORG
 
-        add_var GH_OAUTH_CLIENT_ID GH_OAUTH_CLIENT_ID
-        add_secret GH_OAUTH_CLIENT_SECRET GH_OAUTH_CLIENT_SECRET
-        add_var NOTION_OAUTH_CLIENT_ID NOTION_OAUTH_CLIENT_ID
-        add_secret NOTION_OAUTH_CLIENT_SECRET NOTION_OAUTH_CLIENT_SECRET
-        add_var GOOGLE_OAUTH_CLIENT_ID GOOGLE_OAUTH_CLIENT_ID
-        add_secret GOOGLE_OAUTH_CLIENT_SECRET GOOGLE_OAUTH_CLIENT_SECRET
+        oauth_client_config_prefixes=(
+          GH
+          SLACK
+          NOTION
+          GOOGLE
+          MICROSOFT
+          LINEAR
+          FIGMA
+          DEEL
+          DOCUSIGN
+          DROPBOX
+          NEON
+          REDDIT
+          STRAVA
+          X
+          VERCEL
+          SENTRY
+          INTERVALS_ICU
+          SUPABASE
+          XERO
+          MONDAY
+          WEBFLOW
+          CANVA
+          HUBSPOT
+          CLOSE
+          META_ADS
+          AHREFS
+          AIRTABLE
+          TODOIST
+          ASANA
+          POSTHOG
+          GUMROAD
+          MERCURY
+          SPOTIFY
+          STRIPE
+        )
+        for prefix in "${oauth_client_config_prefixes[@]}"; do
+          add_oauth_client_config "$prefix"
+        done
+
         add_secret GOOGLE_ADS_DEVELOPER_TOKEN GOOGLE_ADS_DEVELOPER_TOKEN
         add_secret GOOGLE_ADS_LOGIN_CUSTOMER_ID GOOGLE_ADS_LOGIN_CUSTOMER_ID
         add_secret ZERO_MAPS_GOOGLE_MAPS_TOKEN ZERO_MAPS_GOOGLE_MAPS_TOKEN
-        add_var MICROSOFT_OAUTH_CLIENT_ID MICROSOFT_OAUTH_CLIENT_ID
-        add_secret MICROSOFT_OAUTH_CLIENT_SECRET MICROSOFT_OAUTH_CLIENT_SECRET
-        add_var LINEAR_OAUTH_CLIENT_ID LINEAR_OAUTH_CLIENT_ID
-        add_secret LINEAR_OAUTH_CLIENT_SECRET LINEAR_OAUTH_CLIENT_SECRET
-        add_var FIGMA_OAUTH_CLIENT_ID FIGMA_OAUTH_CLIENT_ID
-        add_secret FIGMA_OAUTH_CLIENT_SECRET FIGMA_OAUTH_CLIENT_SECRET
-        add_var DEEL_OAUTH_CLIENT_ID DEEL_OAUTH_CLIENT_ID
-        add_secret DEEL_OAUTH_CLIENT_SECRET DEEL_OAUTH_CLIENT_SECRET
-        add_var DOCUSIGN_OAUTH_CLIENT_ID DOCUSIGN_OAUTH_CLIENT_ID
-        add_secret DOCUSIGN_OAUTH_CLIENT_SECRET DOCUSIGN_OAUTH_CLIENT_SECRET
-        add_var DROPBOX_OAUTH_CLIENT_ID DROPBOX_OAUTH_CLIENT_ID
-        add_secret DROPBOX_OAUTH_CLIENT_SECRET DROPBOX_OAUTH_CLIENT_SECRET
-        add_var NEON_OAUTH_CLIENT_ID NEON_OAUTH_CLIENT_ID
-        add_secret NEON_OAUTH_CLIENT_SECRET NEON_OAUTH_CLIENT_SECRET
-        add_var REDDIT_OAUTH_CLIENT_ID REDDIT_OAUTH_CLIENT_ID
-        add_secret REDDIT_OAUTH_CLIENT_SECRET REDDIT_OAUTH_CLIENT_SECRET
-        add_var STRAVA_OAUTH_CLIENT_ID STRAVA_OAUTH_CLIENT_ID
-        add_secret STRAVA_OAUTH_CLIENT_SECRET STRAVA_OAUTH_CLIENT_SECRET
-        add_var X_OAUTH_CLIENT_ID X_OAUTH_CLIENT_ID
-        add_secret X_OAUTH_CLIENT_SECRET X_OAUTH_CLIENT_SECRET
-        add_var VERCEL_OAUTH_CLIENT_ID VERCEL_OAUTH_CLIENT_ID
-        add_secret VERCEL_OAUTH_CLIENT_SECRET VERCEL_OAUTH_CLIENT_SECRET
         add_var VERCEL_INTEGRATION_SLUG VERCEL_INTEGRATION_SLUG
-        add_var SENTRY_OAUTH_CLIENT_ID SENTRY_OAUTH_CLIENT_ID
-        add_secret SENTRY_OAUTH_CLIENT_SECRET SENTRY_OAUTH_CLIENT_SECRET
-        add_var INTERVALS_ICU_OAUTH_CLIENT_ID INTERVALS_ICU_OAUTH_CLIENT_ID
-        add_secret INTERVALS_ICU_OAUTH_CLIENT_SECRET INTERVALS_ICU_OAUTH_CLIENT_SECRET
-        add_var SUPABASE_OAUTH_CLIENT_ID SUPABASE_OAUTH_CLIENT_ID
-        add_secret SUPABASE_OAUTH_CLIENT_SECRET SUPABASE_OAUTH_CLIENT_SECRET
-        add_var XERO_OAUTH_CLIENT_ID XERO_OAUTH_CLIENT_ID
-        add_secret XERO_OAUTH_CLIENT_SECRET XERO_OAUTH_CLIENT_SECRET
-        add_var MONDAY_OAUTH_CLIENT_ID MONDAY_OAUTH_CLIENT_ID
-        add_secret MONDAY_OAUTH_CLIENT_SECRET MONDAY_OAUTH_CLIENT_SECRET
         add_var MONDAY_OAUTH_APP_ID MONDAY_OAUTH_APP_ID
-        add_var WEBFLOW_OAUTH_CLIENT_ID WEBFLOW_OAUTH_CLIENT_ID
-        add_secret WEBFLOW_OAUTH_CLIENT_SECRET WEBFLOW_OAUTH_CLIENT_SECRET
-        add_var CANVA_OAUTH_CLIENT_ID CANVA_OAUTH_CLIENT_ID
-        add_secret CANVA_OAUTH_CLIENT_SECRET CANVA_OAUTH_CLIENT_SECRET
-        add_var HUBSPOT_OAUTH_CLIENT_ID HUBSPOT_OAUTH_CLIENT_ID
-        add_secret HUBSPOT_OAUTH_CLIENT_SECRET HUBSPOT_OAUTH_CLIENT_SECRET
-        add_var CLOSE_OAUTH_CLIENT_ID CLOSE_OAUTH_CLIENT_ID
-        add_secret CLOSE_OAUTH_CLIENT_SECRET CLOSE_OAUTH_CLIENT_SECRET
-        add_var META_ADS_OAUTH_CLIENT_ID META_ADS_OAUTH_CLIENT_ID
-        add_secret META_ADS_OAUTH_CLIENT_SECRET META_ADS_OAUTH_CLIENT_SECRET
-        add_var AHREFS_OAUTH_CLIENT_ID AHREFS_OAUTH_CLIENT_ID
-        add_secret AHREFS_OAUTH_CLIENT_SECRET AHREFS_OAUTH_CLIENT_SECRET
-        add_var AIRTABLE_OAUTH_CLIENT_ID AIRTABLE_OAUTH_CLIENT_ID
-        add_secret AIRTABLE_OAUTH_CLIENT_SECRET AIRTABLE_OAUTH_CLIENT_SECRET
-        add_var TODOIST_OAUTH_CLIENT_ID TODOIST_OAUTH_CLIENT_ID
-        add_secret TODOIST_OAUTH_CLIENT_SECRET TODOIST_OAUTH_CLIENT_SECRET
-        add_var ASANA_OAUTH_CLIENT_ID ASANA_OAUTH_CLIENT_ID
-        add_secret ASANA_OAUTH_CLIENT_SECRET ASANA_OAUTH_CLIENT_SECRET
-        add_var POSTHOG_OAUTH_CLIENT_ID POSTHOG_OAUTH_CLIENT_ID
-        add_secret POSTHOG_OAUTH_CLIENT_SECRET POSTHOG_OAUTH_CLIENT_SECRET
-        add_var GUMROAD_OAUTH_CLIENT_ID GUMROAD_OAUTH_CLIENT_ID
-        add_secret GUMROAD_OAUTH_CLIENT_SECRET GUMROAD_OAUTH_CLIENT_SECRET
-        add_var MERCURY_OAUTH_CLIENT_ID MERCURY_OAUTH_CLIENT_ID
-        add_secret MERCURY_OAUTH_CLIENT_SECRET MERCURY_OAUTH_CLIENT_SECRET
-        add_var SPOTIFY_OAUTH_CLIENT_ID SPOTIFY_OAUTH_CLIENT_ID
-        add_secret SPOTIFY_OAUTH_CLIENT_SECRET SPOTIFY_OAUTH_CLIENT_SECRET
-        add_var STRIPE_OAUTH_CLIENT_ID STRIPE_OAUTH_CLIENT_ID
-        add_secret STRIPE_OAUTH_CLIENT_SECRET STRIPE_OAUTH_CLIENT_SECRET
         add_secret STRIPE_SECRET_KEY STRIPE_SECRET_KEY
         add_secret STRIPE_WEBHOOK_SECRET STRIPE_WEBHOOK_SECRET
         add_secret CLERK_WEBHOOK_SIGNING_SECRET CLERK_WEBHOOK_SIGNING_SECRET

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ACTION="${REPO_ROOT}/.github/actions/web-api-env/action.yml"
+TEMP_DIRS=()
+
+cleanup() {
+  if [[ "${#TEMP_DIRS[@]}" -gt 0 ]]; then
+    rm -rf "${TEMP_DIRS[@]}"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+  if [[ "$output" != *"$expected"* ]]; then
+    fail "expected output to contain: ${expected}"
+  fi
+}
+
+assert_env_value() {
+  local env_file="$1"
+  local key="$2"
+  local expected="$3"
+  local value
+  value="$(awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; found = 1 } END { if (!found) exit 1 }' "$env_file")" ||
+    fail "expected ${key} in ${env_file}"
+  if [[ "$value" != "$expected" ]]; then
+    fail "expected ${key}=${expected}, got ${value}"
+  fi
+}
+
+assert_env_absent_value() {
+  local env_file="$1"
+  local unexpected="$2"
+  if grep -Fq "$unexpected" "$env_file"; then
+    fail "did not expect rendered env to contain ${unexpected}"
+  fi
+}
+
+extract_action_script() {
+  awk '
+    /^      run: \|$/ {
+      in_run = 1
+      next
+    }
+    in_run && /^        / {
+      sub(/^        /, "")
+      print
+      next
+    }
+    in_run && /^$/ {
+      print
+      next
+    }
+    in_run {
+      exit
+    }
+  ' "$ACTION"
+}
+
+oauth_client_config_prefixes() {
+  awk '
+    /^        oauth_client_config_prefixes=\($/ {
+      in_list = 1
+      next
+    }
+    in_list && /^        \)$/ {
+      exit
+    }
+    in_list {
+      sub(/^        /, "")
+      gsub(/[[:space:]]/, "")
+      if ($0 != "") {
+        print
+      }
+    }
+  ' "$ACTION"
+}
+
+oauth_client_config_keys() {
+  local prefix
+  while IFS= read -r prefix; do
+    printf '%s_OAUTH_CLIENT_ID\n' "$prefix"
+    printf '%s_OAUTH_CLIENT_SECRET\n' "$prefix"
+  done < <(oauth_client_config_prefixes)
+}
+
+verify_workflow_oauth_client_config_keys() {
+  awk '
+    /^          EXPECTED_KEYS: \|$/ {
+      in_list = 1
+      next
+    }
+    in_list && /^            [A-Z0-9_]+_OAUTH_CLIENT_(ID|SECRET)$/ {
+      sub(/^            /, "")
+      print
+      next
+    }
+    in_list && /^        run:/ {
+      in_list = 0
+    }
+  ' "${REPO_ROOT}/.github/workflows/verify-doppler-oauth-config.yml" | sort -u
+}
+
+build_doppler_secrets_json() {
+  local omit_key="${1:-}"
+  local json="{}"
+  local key
+  while IFS= read -r key; do
+    if [[ "$key" == "$omit_key" ]]; then
+      continue
+    fi
+    json="$(jq -c --arg key "$key" --arg value "doppler-${key}" '. + {($key): $value}' <<< "$json")"
+  done < <(oauth_client_config_keys)
+  printf '%s' "$json"
+}
+
+run_action() {
+  local doppler_secrets_json="$1"
+  local test_dir="$2"
+  local action_script="${test_dir}/web-api-env-action.sh"
+  local github_output="${test_dir}/github-output"
+
+  extract_action_script > "$action_script"
+
+  env \
+    RUNNER_TEMP="$test_dir" \
+    GITHUB_OUTPUT="$github_output" \
+    GITHUB_SHA="test-sha" \
+    INPUT_APP="api" \
+    INPUT_ENVIRONMENT="preview" \
+    INPUT_DATABASE_URL="postgres://preview-db" \
+    INPUT_JOB_REF="pr-123" \
+    INPUT_WEB_URL="https://pr-123-www.vm0.test" \
+    INPUT_APP_URL="https://pr-123-app.vm0.test" \
+    INPUT_API_URL="https://pr-123-api.vm0.test" \
+    INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
+    REPO_VARS_JSON='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var"}' \
+    REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret"}' \
+    DOPPLER_SECRETS_JSON="$doppler_secrets_json" \
+    bash "$action_script"
+}
+
+if grep -En 'add_(var|secret) [A-Z0-9_]+_OAUTH_CLIENT_(ID|SECRET)' "$ACTION"; then
+  fail "OAuth client id/secret entries must come from Doppler, not GitHub vars or secrets"
+fi
+
+if ! oauth_client_config_prefixes | grep -qx SLACK; then
+  fail "expected Slack OAuth client config to come from Doppler"
+fi
+
+if ! diff -u <(oauth_client_config_keys | sort -u) <(verify_workflow_oauth_client_config_keys); then
+  fail "web-api-env OAuth client config keys must match verify-doppler-oauth-config expected keys"
+fi
+
+success_dir="$(mktemp -d)"
+TEMP_DIRS+=("$success_dir")
+success_output="$(run_action "$(build_doppler_secrets_json)" "$success_dir")"
+success_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${success_dir}/github-output")"
+assert_contains "$success_output" "Rendered"
+assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT_ID"
+assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
+assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
+assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_SECRET "doppler-SLACK_OAUTH_CLIENT_SECRET"
+assert_env_value "$success_env_file" GOOGLE_ADS_DEVELOPER_TOKEN "github-google-ads-secret"
+assert_env_absent_value "$success_env_file" "github-gh-client-id"
+assert_env_absent_value "$success_env_file" "github-gh-client-secret"
+assert_env_absent_value "$success_env_file" "github-slack-client-id"
+assert_env_absent_value "$success_env_file" "github-slack-client-secret"
+
+missing_dir="$(mktemp -d)"
+TEMP_DIRS+=("$missing_dir")
+status=0
+missing_output="$(run_action "$(build_doppler_secrets_json GH_OAUTH_CLIENT_SECRET)" "$missing_dir" 2>&1)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected missing Doppler OAuth client config to fail"
+fi
+assert_contains "$missing_output" "::error::GH_OAUTH_CLIENT_SECRET is missing from Doppler OAuth config"
+
+echo "web-api-env-action-test: ok"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -285,6 +285,7 @@ jobs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
       contents: read
+      id-token: write
     environment: production
     steps:
       - uses: actions/checkout@v6
@@ -322,6 +323,15 @@ jobs:
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 
+      - name: Fetch production Doppler OAuth config
+        id: doppler-oauth
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: vm0
+          doppler-config: prd
+
       - name: Resolve Web production environment
         id: web-production-env
         uses: ./.github/actions/web-api-env
@@ -335,6 +345,7 @@ jobs:
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
+          DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
       - name: Build Web Staged Production Deployment
         id: deploy
@@ -405,6 +416,7 @@ jobs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
       contents: read
+      id-token: write
     environment: production
     steps:
       - uses: actions/checkout@v6
@@ -441,6 +453,15 @@ jobs:
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 
+      - name: Fetch production Doppler OAuth config
+        id: doppler-oauth
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: vm0
+          doppler-config: prd
+
       - name: Resolve API production environment
         id: api-production-env
         uses: ./.github/actions/web-api-env
@@ -454,6 +475,7 @@ jobs:
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
+          DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
       - name: Build API Staged Production Deployment
         id: deploy

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -769,6 +769,7 @@ jobs:
       pull-requests: write
       issues: write
       deployments: write
+      id-token: write
     defaults:
       run:
         shell: bash
@@ -784,6 +785,15 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_WEB }}
 
+      - name: Fetch development Doppler OAuth config
+        id: doppler-oauth
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: vm0
+          doppler-config: dev
+
       - name: Resolve Web build environment
         id: web-build-env
         uses: ./.github/actions/web-api-env
@@ -798,6 +808,7 @@ jobs:
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
+          DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
       # Step 2: Create Neon branch
       - name: Create Neon Branch
@@ -883,6 +894,7 @@ jobs:
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
+          DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
       # Step 4: Deploy prebuilt artifacts with database URL
       - name: Start deployment
@@ -986,6 +998,7 @@ jobs:
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
+          DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
       - name: Deploy API to Vercel
         id: api-deploy


### PR DESCRIPTION
## Summary
- load Web/API OAuth client IDs and secrets from Doppler output in `web-api-env`
- fetch Doppler OAuth config for preview deploys and production release builds
- add a shell regression test for Doppler OAuth rendering and verify-workflow key drift

## Testing
- `.github/scripts/tests/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color`
- `git diff --check`

## Notes
- The existing `verify-doppler-oauth-config` workflow is kept in place.
- Doppler OIDC requires `id-token: write`; the Doppler identity policy should remain restricted to trusted subjects.