### PR TITLE
chore: remove GA feature switches

### DIFF
--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -24,8 +24,6 @@ const PAT_TOKEN_PREFIX = "vm0_pat_";
 
 const CONDITIONAL_CAPABILITIES = [
   ["computer-use:write", FeatureSwitchKey.ComputerUse],
-  ["host:read", FeatureSwitchKey.HostedSites],
-  ["host:write", FeatureSwitchKey.HostedSites],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
 const AGENT_EXCLUDED_CAPABILITIES = [

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -785,7 +785,7 @@ describe("POST /api/zero/chat/messages", () => {
     });
   });
 
-  it("passes user feature switch overrides into generated ZERO_TOKEN capabilities", async () => {
+  it("passes enabled feature switch overrides into generated ZERO_TOKEN capabilities", async () => {
     const fixture = await track(seedFixture());
     await store
       .set(writeDb$)
@@ -795,7 +795,6 @@ describe("POST /api/zero/chat/messages", () => {
         userId: fixture.userId,
         switches: {
           [FeatureSwitchKey.ComputerUse]: true,
-          [FeatureSwitchKey.HostedSites]: true,
         },
         updatedAt: nowDate(),
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -2,13 +2,11 @@ import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { describe, expect, it } from "vitest";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { hostedDeployments, hostedSites } from "@vm0/db/schema/hosted-site";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
@@ -37,26 +35,12 @@ const track = createFixtureTracker<HostedSiteFixture>(async (fixture) => {
     .delete(hostedDeployments)
     .where(eq(hostedDeployments.orgId, fixture.orgId));
   await writeDb.delete(hostedSites).where(eq(hostedSites.orgId, fixture.orgId));
-  await writeDb
-    .delete(userFeatureSwitches)
-    .where(
-      and(
-        eq(userFeatureSwitches.orgId, fixture.orgId),
-        eq(userFeatureSwitches.userId, fixture.userId),
-      ),
-    );
   await store.set(deleteUsageInsightFixture$, fixture, context.signal);
 });
 
-async function seedHostedSitesEnabled(): Promise<HostedSiteFixture> {
+function seedHostedSiteFixture(): Promise<HostedSiteFixture> {
   const orgId = `org_${randomUUID()}`;
   const userId = `user_${randomUUID()}`;
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(userFeatureSwitches).values({
-    orgId,
-    userId,
-    switches: { [FeatureSwitchKey.HostedSites]: true },
-  });
   return track(Promise.resolve({ orgId, userId }));
 }
 
@@ -123,31 +107,8 @@ describe("POST /api/zero/host/deployments/prepare", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("returns 403 when hosted sites are disabled", async () => {
-    const orgId = `org_${randomUUID()}`;
-    const userId = `user_${randomUUID()}`;
-    const writeDb = store.set(writeDb$);
-    await writeDb.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.HostedSites]: false },
-    });
-    mocks.clerk.session(userId, orgId);
-
-    const client = setupApp({ context })(zeroHostContract);
-    const response = await accept(
-      client.prepare({
-        headers: { authorization: "Bearer clerk-session" },
-        body: { site: "demo-site", spaFallback: true, files: validFiles() },
-      }),
-      [403],
-    );
-    expect(response.body.error.message).toBe("Hosted sites are not enabled");
-    await track(Promise.resolve({ orgId, userId }));
-  });
-
   it("creates a deployment and returns per-file upload URLs", async () => {
-    const fixture = await seedHostedSitesEnabled();
+    const fixture = await seedHostedSiteFixture();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroHostContract);
@@ -193,7 +154,7 @@ describe("POST /api/zero/host/deployments/prepare", () => {
   });
 
   it("rejects deployments missing index.html", async () => {
-    const fixture = await seedHostedSitesEnabled();
+    const fixture = await seedHostedSiteFixture();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroHostContract);
@@ -214,7 +175,7 @@ describe("POST /api/zero/host/deployments/prepare", () => {
 
 describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
   it("marks a deployment ready and writes manifest plus active pointer", async () => {
-    const fixture = await seedHostedSitesEnabled();
+    const fixture = await seedHostedSiteFixture();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroHostContract);
@@ -262,7 +223,7 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
   });
 
   it("records a run artifact that points at the hosted site URL", async () => {
-    const fixture = await seedHostedSitesEnabled();
+    const fixture = await seedHostedSiteFixture();
     const { composeId } = await store.set(
       seedCompose$,
       { orgId: fixture.orgId, userId: fixture.userId },

--- a/turbo/apps/api/src/signals/routes/zero-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-host.ts
@@ -1,28 +1,15 @@
-import { command, type Computed } from "ccstate";
+import { command } from "ccstate";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   completeHostedSiteDeployment$,
   prepareHostedSiteDeployment$,
 } from "../services/zero-host.service";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
-
-const hostedSitesDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Hosted sites are not enabled",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
 
 function internalError(message: string) {
   return {
@@ -33,28 +20,9 @@ function internalError(message: string) {
   };
 }
 
-async function hostedSitesEnabled(
-  get: <T>(computed: Computed<T>) => T,
-  auth: { readonly orgId: string; readonly userId: string },
-): Promise<boolean> {
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  return isFeatureEnabled(FeatureSwitchKey.HostedSites, {
-    orgId: auth.orgId,
-    userId: auth.userId,
-    overrides,
-  });
-}
-
 const prepareBody$ = bodyResultOf(zeroHostContract.prepare);
 const prepareInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  const enabled = await hostedSitesEnabled(get, auth);
-  signal.throwIfAborted();
-  if (!enabled) {
-    return hostedSitesDisabled;
-  }
 
   const bodyResult = await get(prepareBody$);
   signal.throwIfAborted();
@@ -90,11 +58,6 @@ const prepareInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const completeParams$ = pathParamsOf(zeroHostContract.complete);
 const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  const enabled = await hostedSitesEnabled(get, auth);
-  signal.throwIfAborted();
-  if (!enabled) {
-    return hostedSitesDisabled;
-  }
 
   const params = get(completeParams$);
   const result = await set(

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Command, Help } from "commander";
 import { buildZeroHelpText, registerZeroCommands } from "../zero";
 import { decodeZeroTokenPayload } from "../lib/api/zero-token";
@@ -362,28 +361,10 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toContain("whoami");
   });
 
-  it("should hide generate when only host:write is present and hostedSites is disabled", () => {
+  it("should show generate when file capabilities are missing", () => {
     const token = buildZeroToken({
-      userId: "user-non-staff",
-      orgId: "org-non-staff",
-      scope: "zero",
-      capabilities: ["host:write"],
-      featureSwitches: { [FeatureSwitchKey.HostedSites]: false },
-    });
-    vi.stubEnv("ZERO_TOKEN", token);
-
-    const prog = buildProgram();
-
-    expect(hiddenCommandNames(prog)).toContain("generate");
-  });
-
-  it("should show generate when hostedSites is enabled", () => {
-    const token = buildZeroToken({
-      userId: "user-enabled",
-      orgId: "org-non-staff",
       scope: "zero",
       capabilities: [],
-      featureSwitches: { [FeatureSwitchKey.HostedSites]: true },
     });
     vi.stubEnv("ZERO_TOKEN", token);
 
@@ -498,27 +479,10 @@ describe("registerZeroCommands", () => {
     );
   });
 
-  it("should hide the website help example when hostedSites is disabled", () => {
+  it("should show the website help example", () => {
     const token = buildZeroToken({
-      userId: "user-non-staff",
-      orgId: "org-non-staff",
-      scope: "zero",
-      capabilities: ["host:write"],
-      featureSwitches: { [FeatureSwitchKey.HostedSites]: false },
-    });
-
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
-      "Generate website?",
-    );
-  });
-
-  it("should show the website help example when hostedSites is enabled", () => {
-    const token = buildZeroToken({
-      userId: "user-enabled",
-      orgId: "org-non-staff",
       scope: "zero",
       capabilities: [],
-      featureSwitches: { [FeatureSwitchKey.HostedSites]: true },
     });
 
     expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
@@ -672,7 +636,7 @@ describe("registerZeroCommands", () => {
   });
 });
 
-describe("zero generate feature switch visibility", () => {
+describe("zero generate command visibility", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
@@ -685,27 +649,10 @@ describe("zero generate feature switch visibility", () => {
     return generateCommand as Command;
   }
 
-  it("should hide website generation when hostedSites is disabled", async () => {
+  it("should show website generation", async () => {
     const token = buildZeroToken({
-      userId: "user-non-staff",
-      orgId: "org-non-staff",
-      scope: "zero",
-      capabilities: ["host:write"],
-      featureSwitches: { [FeatureSwitchKey.HostedSites]: false },
-    });
-
-    const generateCommand = await importGenerateCommand(token);
-
-    expect(visibleCommandNames(generateCommand)).not.toContain("website");
-  });
-
-  it("should show website generation when hostedSites is enabled", async () => {
-    const token = buildZeroToken({
-      userId: "user-enabled",
-      orgId: "org-non-staff",
       scope: "zero",
       capabilities: [],
-      featureSwitches: { [FeatureSwitchKey.HostedSites]: true },
     });
 
     const generateCommand = await importGenerateCommand(token);

--- a/turbo/apps/cli/src/commands/zero/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/index.ts
@@ -1,6 +1,4 @@
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Command } from "commander";
-import { zeroTokenAllowsFeatureSwitch } from "../../../lib/api/zero-token";
 import { imageCommand } from "./image";
 import {
   dashboardDesignCommand,
@@ -47,11 +45,7 @@ function buildGenerateHelpText(): string {
     '  Generate report:       zero generate report --prompt "A Q2 usage report"',
     '  Generate docs:         zero generate docs-design --prompt "A setup guide"',
     '  Generate video:        zero generate video --prompt "A cinematic city shot"',
-    ...(zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.HostedSites)
-      ? [
-          '  Generate site:         zero generate website --prompt "A launch site"',
-        ]
-      : []),
+    '  Generate site:         zero generate website --prompt "A launch site"',
     '  Generate speech:       zero generate voice --prompt "Hello"',
     "",
     "  List image providers:  zero generate image",
@@ -75,12 +69,7 @@ export const generateCommand = new Command()
   .addCommand(dashboardDesignCommand)
   .addCommand(mobileAppDesignCommand)
   .addCommand(videoCommand)
-  .addCommand(
-    websiteCommand,
-    zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.HostedSites)
-      ? {}
-      : { hidden: true },
-  )
+  .addCommand(websiteCommand)
   .addCommand(voiceCommand)
   .addCommand(audioCommand)
   .addCommand(textCommand)

--- a/turbo/apps/cli/src/lib/api/zero-token.ts
+++ b/turbo/apps/cli/src/lib/api/zero-token.ts
@@ -1,13 +1,9 @@
-import type { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-
 export interface ZeroTokenPayload {
   userId: string;
   runId: string;
   orgId: string;
   scope: string;
   capabilities: string[];
-  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
   iat: number;
   exp: number;
 }
@@ -42,18 +38,4 @@ export function decodeZeroTokenPayload(
     // Malformed token — fall through
   }
   return undefined;
-}
-
-export function zeroTokenAllowsFeatureSwitch(
-  key: FeatureSwitchKey,
-  payload: ZeroTokenPayload | undefined = decodeZeroTokenPayload(),
-): boolean {
-  if (!payload) return true;
-  const tokenValue = payload.featureSwitches?.[key];
-  if (typeof tokenValue === "boolean") return tokenValue;
-
-  return isFeatureEnabled(key, {
-    userId: payload.userId,
-    orgId: payload.orgId,
-  });
 }

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -1,7 +1,6 @@
 // Zero CLI entry point - standalone binary for zero platform commands
 // Sentry must be initialized before any other imports
 import "./instrument.js";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Command } from "commander";
 import { configureGlobalProxyFromEnv } from "./lib/network/proxy.js";
 import { zeroOrgCommand } from "./commands/zero/org";
@@ -33,7 +32,6 @@ import { zeroModelCommand } from "./commands/zero/model";
 import { zeroModelProviderCommand } from "./commands/zero/model-provider";
 import {
   decodeZeroTokenPayload,
-  zeroTokenAllowsFeatureSwitch,
   type ZeroTokenPayload,
 } from "./lib/api/zero-token.js";
 
@@ -67,7 +65,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   whoami: null,
   "developer-support": null,
   "computer-use": "computer-use:write",
-  generate: "file:write",
+  generate: null,
   web: null,
   host: "host:write",
   maps: "maps:read",
@@ -108,12 +106,6 @@ function shouldHideCommand(
   payload: ZeroTokenPayload | undefined,
 ): boolean {
   if (!payload) return false;
-  if (name === "generate") {
-    return (
-      !payload.capabilities.includes("file:write") &&
-      !zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.HostedSites, payload)
-    );
-  }
   const requiredCap = COMMAND_CAPABILITY_MAP[name];
   if (requiredCap === undefined) return true;
   if (requiredCap === null) return false;
@@ -153,9 +145,7 @@ export function buildZeroHelpText(
     "  Manage custom skills?  zero skill --help",
     "  List generators?       zero generate --help",
     '  Generate image?        zero generate image --prompt "..."',
-    ...(zeroTokenAllowsFeatureSwitch(FeatureSwitchKey.HostedSites, payload)
-      ? ['  Generate website?      zero generate website --prompt "..."']
-      : []),
+    '  Generate website?      zero generate website --prompt "..."',
     '  Generate voice?        zero generate voice --prompt "..."',
     ...(shouldHideCommand("host", payload)
       ? []

--- a/turbo/apps/platform/src/lib/__tests__/push-notifications.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/push-notifications.test.ts
@@ -1,34 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createStore } from "ccstate";
-
-const { setEnabled, getEnabled } = vi.hoisted(() => {
-  let enabled = false;
-  return {
-    setEnabled: (v: boolean) => {
-      enabled = v;
-    },
-    getEnabled: () => {
-      return enabled;
-    },
-  };
-});
-
-vi.mock("../../signals/external/feature-switch.ts", async () => {
-  const { computed } = await import("ccstate");
-  return {
-    pwaOfflineCacheEnabled$: computed(() => {
-      return getEnabled();
-    }),
-  };
-});
 
 const { registerServiceWorker$ } = await import("../push-notifications");
 
 describe("registerServiceWorker$", () => {
-  beforeEach(() => {
-    setEnabled(false);
-  });
-
   function setupServiceWorkerMocks() {
     const mockRegister = vi.fn().mockResolvedValue({});
     vi.stubGlobal("navigator", { serviceWorker: { register: mockRegister } });
@@ -36,8 +11,7 @@ describe("registerServiceWorker$", () => {
     return { mockRegister };
   }
 
-  it("passes updateViaCache: none when PwaOfflineCache is enabled", async () => {
-    setEnabled(true);
+  it("passes updateViaCache: none when registering the service worker", async () => {
     const { mockRegister } = setupServiceWorkerMocks();
 
     const store = createStore();
@@ -46,15 +20,5 @@ describe("registerServiceWorker$", () => {
     expect(mockRegister).toHaveBeenCalledWith("/sw.js", {
       updateViaCache: "none",
     });
-  });
-
-  it("omits updateViaCache: none when PwaOfflineCache is disabled", async () => {
-    setEnabled(false);
-    const { mockRegister } = setupServiceWorkerMocks();
-
-    const store = createStore();
-    await store.set(registerServiceWorker$, AbortSignal.timeout(5000));
-
-    expect(mockRegister).toHaveBeenCalledWith("/sw.js", undefined);
   });
 });

--- a/turbo/apps/platform/src/lib/push-notifications.ts
+++ b/turbo/apps/platform/src/lib/push-notifications.ts
@@ -6,7 +6,6 @@
  */
 
 import { command, state } from "ccstate";
-import { pwaOfflineCacheEnabled$ } from "../signals/external/feature-switch.ts";
 import { clerk$ } from "../signals/auth.ts";
 import { apiBase$ } from "../signals/fetch.ts";
 import { bestEffort } from "../signals/utils.ts";
@@ -19,20 +18,18 @@ const subscribing$ = state(false);
  * No-ops if push is not supported in this browser.
  */
 export const registerServiceWorker$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
       return;
     }
 
-    const pwaOfflineEnabled = get(pwaOfflineCacheEnabled$);
     signal.throwIfAborted();
 
     await bestEffort(
       (async () => {
-        const registration = await navigator.serviceWorker.register(
-          "/sw.js",
-          pwaOfflineEnabled ? { updateViaCache: "none" } : undefined,
-        );
+        const registration = await navigator.serviceWorker.register("/sw.js", {
+          updateViaCache: "none",
+        });
 
         signal.throwIfAborted();
         set(swRegistration$, registration);

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -113,7 +113,3 @@ export const resetFeatureSwitches$ = command(
     await set(reloadFeatureSwitch$, signal);
   },
 );
-
-export const pwaOfflineCacheEnabled$ = computed((get) => {
-  return get(featureSwitch$)[FeatureSwitchKey.PwaOfflineCache] ?? false;
-});

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -24,7 +24,6 @@ export enum FeatureSwitchKey {
   MetaAdsConnector = "metaAdsConnector",
   StripeConnector = "stripeConnector",
   PosthogConnector = "posthogConnector",
-  PwaOfflineCache = "pwaOfflineCache",
   MailchimpConnector = "mailchimpConnector",
   ResendConnector = "resendConnector",
   DataExport = "dataExport",
@@ -49,7 +48,6 @@ export enum FeatureSwitchKey {
   ApiBackend = "apiBackend",
 
   ZapierConnector = "zapierConnector",
-  HostedSites = "hostedSites",
   SandboxIoLimiters = "sandboxIoLimiters",
   ChatArtifactSidebar = "chatArtifactSidebar",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -90,8 +90,6 @@ describe("getAllFeatureStates", () => {
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.HostedSites]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatHeaderNewButton]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatMessageStartButton]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadRename]).toBe(false);
@@ -100,8 +98,6 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(true);
-    expect(otherOrgStates[FeatureSwitchKey.HostedSites]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -134,12 +134,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the PostHog analytics connector",
     enabled: false,
   },
-  [FeatureSwitchKey.PwaOfflineCache]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Enable PWA offline caching (static asset cache-first, offline fallback page, and service worker updateViaCache: none)",
-    enabled: true,
-  },
   [FeatureSwitchKey.MailchimpConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Mailchimp email marketing connector",
@@ -264,11 +258,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable the Zapier connector. When disabled, Zapier is hidden from the connectors list and cannot be connected.",
     enabled: false,
-  },
-  [FeatureSwitchKey.HostedSites]: {
-    maintainer: "lancy@vm0.ai",
-    description: "Enable static hosted-site deployments from zero host.",
-    enabled: true,
   },
   [FeatureSwitchKey.SandboxIoLimiters]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary
- remove PwaOfflineCache and HostedSites from the feature switch enum/registry
- make PWA service worker offline-cache registration path unconditional
- make hosted-sites Zero token capabilities, route access, and CLI generate website visibility unconditional
- delete obsolete disabled-path tests

## Tests
- pnpm format
- pnpm -F @vm0/core run lint
- pnpm -F @vm0/connectors run lint
- pnpm -F @vm0/cli run lint
- pnpm -F api run lint
- pnpm -F @vm0/app run lint
- pnpm -F @vm0/core run check-types
- pnpm -F @vm0/connectors run check-types
- pnpm -F @vm0/cli run check-types
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app run check-types
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api run check-types
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app exec vitest run src/lib/__tests__/push-notifications.test.ts
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/auth/__tests__/tokens.test.ts src/signals/routes/__tests__/zero-host.test.ts src/signals/routes/__tests__/zero-chat-messages.test.ts
- pnpm -F @vm0/cli exec vitest run src/__tests__/zero-capability-visibility.test.ts