### PR TITLE
fix: unify credit checkout pricing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -601,6 +601,22 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     return fixture;
   }
 
+  function mockCustomCreditCheckoutPrice(checkoutPriceId: string): void {
+    context.mocks.stripe.prices.retrieve.mockResolvedValue({
+      id: TEST_PRICE_CUSTOM_CREDITS,
+      currency: "usd",
+      product: "prod_test_custom_credits",
+      custom_unit_amount: {
+        minimum: 100,
+        maximum: 1_000_000,
+        preset: 10_000,
+      },
+    });
+    context.mocks.stripe.prices.create.mockResolvedValue({
+      id: checkoutPriceId,
+    });
+  }
+
   it("returns 403 for non-admin org member", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
@@ -659,7 +675,9 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const checkoutPriceId = "price_test_credit_checkout";
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    mockCustomCreditCheckoutPrice(checkoutPriceId);
     context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
       url: "https://checkout.stripe.com/session/credit",
     });
@@ -681,25 +699,30 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     expect(response.body).toStrictEqual({
       url: "https://checkout.stripe.com/session/credit",
     });
+    expect(context.mocks.stripe.prices.retrieve).toHaveBeenCalledWith(
+      TEST_PRICE_CUSTOM_CREDITS,
+    );
+    expect(context.mocks.stripe.prices.create).toHaveBeenCalledWith({
+      currency: "usd",
+      product: "prod_test_custom_credits",
+      custom_unit_amount: {
+        enabled: true,
+        minimum: 100,
+        maximum: 1_000_000,
+        preset: 2000,
+      },
+    });
     expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: "payment",
         customer: customerId,
-        line_items: [
-          {
-            price_data: {
-              currency: "usd",
-              unit_amount: 2000,
-              product_data: { name: "20,000 Zero credits" },
-            },
-            quantity: 1,
-          },
-        ],
+        line_items: [{ price: checkoutPriceId, quantity: 1 }],
         allow_promotion_codes: true,
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,
-          creditsAmount: "20000",
+          creditsAmountMode: "amount_subtotal",
+          requestedCreditsAmount: "20000",
         },
       }),
     );
@@ -715,6 +738,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    mockCustomCreditCheckoutPrice("price_test_zero_credit_checkout");
     context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
       url: "https://checkout.stripe.com/session/zero-credit",
     });
@@ -756,15 +780,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const checkoutPriceId = "price_test_custom_checkout";
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
-    context.mocks.stripe.prices.retrieve.mockResolvedValue({
-      id: TEST_PRICE_CUSTOM_CREDITS,
-      currency: "usd",
-      product: "prod_test_custom_credits",
-      custom_unit_amount: { minimum: 100, maximum: 1_000_000, preset: 10_000 },
-    });
-    context.mocks.stripe.prices.create.mockResolvedValue({
-      id: checkoutPriceId,
-    });
+    mockCustomCreditCheckoutPrice(checkoutPriceId);
     context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
       url: "https://checkout.stripe.com/session/custom-credit",
     });
@@ -826,7 +842,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     );
   });
 
-  it("returns 400 when custom credit price is not configured", async () => {
+  it("returns 400 when credit price is not configured", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     mockEnv(
@@ -843,7 +859,6 @@ describe("POST /api/zero/billing/credit-checkout", () => {
       client.create({
         body: {
           credits: 100_000,
-          customAmount: true,
           successUrl: `${APP_ORIGIN}/billing?credit=success`,
           cancelUrl: `${APP_ORIGIN}/billing?credit=canceled`,
         },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -717,13 +717,17 @@ describe("POST /api/zero/billing/credit-checkout", () => {
         mode: "payment",
         customer: customerId,
         line_items: [{ price: checkoutPriceId, quantity: 1 }],
-        allow_promotion_codes: true,
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,
           creditsAmountMode: "amount_subtotal",
           requestedCreditsAmount: "20000",
         },
+      }),
+    );
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        allow_promotion_codes: true,
       }),
     );
   });
@@ -821,7 +825,6 @@ describe("POST /api/zero/billing/credit-checkout", () => {
         mode: "payment",
         customer: customerId,
         line_items: [{ price: checkoutPriceId, quantity: 1 }],
-        allow_promotion_codes: true,
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,

--- a/turbo/apps/api/src/signals/routes/zero-billing-credit-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-credit-checkout.ts
@@ -42,7 +42,6 @@ const creditCheckoutAuthed$ = command(
       return bodyResult.response;
     }
     const { credits, successUrl, cancelUrl, autoRecharge } = bodyResult.data;
-    const customAmount = bodyResult.data.customAmount === true;
 
     const appOrigin = new URL(env("APP_URL")).origin;
     if (
@@ -54,7 +53,7 @@ const creditCheckoutAuthed$ = command(
       );
     }
 
-    if (customAmount && !activeCustomCreditPriceId()) {
+    if (!activeCustomCreditPriceId()) {
       return badRequestMessage("Custom credit price not configured");
     }
 
@@ -93,7 +92,6 @@ const creditCheckoutAuthed$ = command(
       {
         orgId: auth.orgId,
         credits,
-        customAmount,
         successUrl,
         cancelUrl,
       },

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -259,7 +259,6 @@ export const createCreditCheckoutSession$ = command(
       mode: "payment",
       customer: customerId,
       line_items: [{ price: presetPriceId, quantity: 1 }],
-      allow_promotion_codes: true,
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
       payment_intent_data: {

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -31,7 +31,6 @@ type CheckoutCompletionResult =
 interface CreateCreditCheckoutSessionArgs {
   readonly orgId: string;
   readonly credits: number;
-  readonly customAmount?: boolean;
   readonly successUrl: string;
   readonly cancelUrl: string;
 }
@@ -239,46 +238,27 @@ export const createCreditCheckoutSession$ = command(
       purpose: "credit_purchase",
       orgId: args.orgId,
     };
-    let metadata: Stripe.MetadataParam;
-    let lineItems: Stripe.Checkout.SessionCreateParams.LineItem[];
-    if (args.customAmount === true) {
-      const customCreditPriceId = activeCustomCreditPriceId();
-      if (!customCreditPriceId) {
-        throw new Error("Custom credit price not configured");
-      }
-      const presetAmountCents =
-        Math.ceil(args.credits / CREDITS_PER_DOLLAR) * 100;
-      const presetPriceId = await createPresetCustomCreditPrice(
-        stripe,
-        customCreditPriceId,
-        presetAmountCents,
-      );
-      signal.throwIfAborted();
-      metadata = {
-        ...baseMetadata,
-        creditsAmountMode: "amount_subtotal",
-        requestedCreditsAmount: String(args.credits),
-      };
-      lineItems = [{ price: presetPriceId, quantity: 1 }];
-    } else {
-      metadata = { ...baseMetadata, creditsAmount: String(args.credits) };
-      lineItems = [
-        {
-          price_data: {
-            currency: "usd",
-            unit_amount: Math.ceil(args.credits / CREDITS_PER_DOLLAR) * 100,
-            product_data: {
-              name: `${args.credits.toLocaleString()} Zero credits`,
-            },
-          },
-          quantity: 1,
-        },
-      ];
+    const customCreditPriceId = activeCustomCreditPriceId();
+    if (!customCreditPriceId) {
+      throw new Error("Custom credit price not configured");
     }
+    const presetAmountCents =
+      Math.ceil(args.credits / CREDITS_PER_DOLLAR) * 100;
+    const presetPriceId = await createPresetCustomCreditPrice(
+      stripe,
+      customCreditPriceId,
+      presetAmountCents,
+    );
+    signal.throwIfAborted();
+    const metadata: Stripe.MetadataParam = {
+      ...baseMetadata,
+      creditsAmountMode: "amount_subtotal",
+      requestedCreditsAmount: String(args.credits),
+    };
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
       customer: customerId,
-      line_items: lineItems,
+      line_items: [{ price: presetPriceId, quantity: 1 }],
       allow_promotion_codes: true,
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -408,16 +408,12 @@ export type BuyCreditsSelection = 10 | 20 | 50 | "custom";
 
 const internalBuyCreditsSelection$ = state<BuyCreditsSelection>(20);
 const internalBuyCreditsCustomDollars$ = state("");
-const internalBuyCreditsCouponCode$ = state("");
 
 export const buyCreditsSelection$ = computed((get) => {
   return get(internalBuyCreditsSelection$);
 });
 export const buyCreditsCustomDollars$ = computed((get) => {
   return get(internalBuyCreditsCustomDollars$);
-});
-export const buyCreditsCouponCode$ = computed((get) => {
-  return get(internalBuyCreditsCouponCode$);
 });
 
 export const setBuyCreditsSelection$ = command(
@@ -427,7 +423,4 @@ export const setBuyCreditsSelection$ = command(
 );
 export const setBuyCreditsCustomDollars$ = command(({ set }, value: string) => {
   set(internalBuyCreditsCustomDollars$, value);
-});
-export const setBuyCreditsCouponCode$ = command(({ set }, value: string) => {
-  set(internalBuyCreditsCouponCode$, value);
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
 import { reloadBillingStatus$ } from "../../../signals/zero-page/billing.ts";
-import { pathname$ } from "../../../signals/route.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
   zeroBillingStatusContract,
@@ -328,32 +327,6 @@ describe("org billing tab - buy credits section", () => {
     });
     expect(capturedBody).toBeNull();
     errorSpy.mockRestore();
-  });
-
-  it("navigates coupon codes to the redeem campaign route", async () => {
-    setMockBillingStatus({
-      tier: "pro",
-      credits: 20_000,
-      subscriptionStatus: "active",
-      hasSubscription: true,
-    });
-
-    await openBillingTab();
-
-    await waitFor(() => {
-      expect(screen.getByText("Pro plan")).toBeInTheDocument();
-    });
-
-    await fill(screen.getByLabelText("Coupon code"), "ZERO100");
-    const redeemButton = queryAllByRoleFast("button").find((el) => {
-      return el.textContent?.trim() === "Redeem";
-    });
-    expect(redeemButton).toBeDefined();
-    click(redeemButton!);
-
-    await waitFor(() => {
-      expect(context.store.get(pathname$)).toBe("/redeem/ZERO100");
-    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
@@ -3,14 +3,10 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { Button, Input } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { detachedNavigateTo$ } from "../../../../signals/route.ts";
-import { ROUTES } from "../../../../signals/route-paths.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import {
-  buyCreditsCouponCode$,
   buyCreditsCustomDollars$,
   buyCreditsSelection$,
-  setBuyCreditsCouponCode$,
   setBuyCreditsCustomDollars$,
   setBuyCreditsSelection$,
   startCreditCheckout$,
@@ -187,16 +183,12 @@ export function BuyCreditsSection() {
   const [checkoutLoadable, checkout] = useLoadableSet(startCreditCheckout$);
   const selection = useGet(buyCreditsSelection$);
   const customDollars = useGet(buyCreditsCustomDollars$);
-  const couponCode = useGet(buyCreditsCouponCode$);
   const setSelection = useSet(setBuyCreditsSelection$);
   const setCustomDollars = useSet(setBuyCreditsCustomDollars$);
-  const setCouponCode = useSet(setBuyCreditsCouponCode$);
-  const navigate = useSet(detachedNavigateTo$);
 
   const redirecting = checkoutLoadable.state === "loading";
   const buyDollars = resolveBuyDollars(selection, customDollars);
   const buyInvalid = buyDollars === null;
-  const trimmedCouponCode = couponCode.trim();
   const buyLabel = redirecting
     ? "Redirecting..."
     : buyDollars === null
@@ -217,14 +209,6 @@ export function BuyCreditsSection() {
       selection === "custom" ? { credits, customAmount: true } : { credits };
     const newTab = e.metaKey || e.ctrlKey;
     detach(checkout(payload, newTab, pageSignal), Reason.DomCallback);
-  };
-  const handleRedeem = () => {
-    if (trimmedCouponCode === "") {
-      return;
-    }
-    navigate(ROUTES.redeemCampaign, {
-      pathParams: { campaign: trimmedCouponCode },
-    });
   };
 
   return (
@@ -249,29 +233,7 @@ export function BuyCreditsSection() {
           />
         </div>
         <div className="h-0 zero-border-t mx-5" />
-        <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
-            <Input
-              type="text"
-              value={couponCode}
-              onChange={(e) => {
-                setCouponCode(e.target.value);
-              }}
-              placeholder="Enter coupon code"
-              aria-label="Coupon code"
-              className="h-9 w-full sm:w-[220px]"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-9 px-4 text-sm font-medium"
-              disabled={trimmedCouponCode === ""}
-              onClick={handleRedeem}
-            >
-              Redeem
-            </Button>
-          </div>
+        <div className="flex justify-end px-5 py-4">
           <Button
             type="button"
             size="sm"


### PR DESCRIPTION
## Summary
- Route every credit checkout through the configured `ZERO_PRICE.customCredits[0]` template price.
- Remove the inline `price_data` branch so org billing and chat-thread credit cards use the same Stripe custom credits pricing path.
- Require the custom credits price configuration for all credit checkout requests and update checkout tests for fixed/custom amounts.
- Remove the Buy credits coupon-code entry UI and its local form state.
- Disable Stripe promotion codes for custom credit checkout because Stripe rejects `allow_promotion_codes` with `custom_unit_amount` prices.

## Testing
- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx -t "credit checkout"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx -t "buy credits"`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`