### PR TITLE
fix: show negative org credit balances

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -108,6 +108,22 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.body.currentPeriodEnd).toBeNull();
   });
 
+  it("preserves negative org credit balances", async () => {
+    const fixture = await track(
+      store.set(seedBillingStatusOrg$, { credits: -1234 }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.credits).toBe(-1234);
+  });
+
   it("returns billing status for zero tokens with billing read capability", async () => {
     const fixture = await track(
       store.set(seedBillingStatusOrg$, { credits: 100_000 }, context.signal),

--- a/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
@@ -260,7 +260,7 @@ function billingStatusResponse(args: {
   activeRecords: readonly ActiveCreditRecord[];
 }): BillingStatusResponse {
   const org = args.org ?? DEFAULT_BILLING_ORG;
-  const displayedCredits = Math.max(org.credits - args.unsettledExpired, 0);
+  const displayedCredits = org.credits - args.unsettledExpired;
 
   return {
     tier: org.tier,


### PR DESCRIPTION
## Summary
- preserve negative spendable org credits in `GET /api/zero/billing/status` instead of clamping to 0
- add a billing status regression test for negative org balances

Closes #15378

## Verification
- `pnpm exec prettier --check apps/api/src/signals/services/zero-billing-status.service.ts apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
- `pnpm exec vitest run src/signals/routes/__tests__/zero-billing-status.test.ts -c vitest.config.ts --bail=1 --maxWorkers=1` *(blocked locally: no Postgres listening at `localhost:5432` for `vm0_test`)*