### PR TITLE
Support video embeds in blog markdown

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -26,6 +26,12 @@ interface PageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
+const VIDEO_SOURCE_REGEX = /\.(mp4|webm|mov)(?:[?#].*)?$/i;
+
+function isVideoSource(src: unknown): src is string {
+  return typeof src === "string" && VIDEO_SOURCE_REGEX.test(src);
+}
+
 export async function generateMetadata({
   params,
   searchParams,
@@ -260,6 +266,30 @@ export default async function BlogPostPage({
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeHighlight]}
+            components={{
+              img({ src, alt }) {
+                if (isVideoSource(src)) {
+                  return (
+                    <video
+                      className="blog-post-video"
+                      src={src}
+                      controls
+                      autoPlay
+                      muted
+                      loop
+                      playsInline
+                      preload="metadata"
+                      aria-label={alt || undefined}
+                    />
+                  );
+                }
+
+                return (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={src} alt={alt ?? ""} />
+                );
+              },
+            }}
           >
             {post.content}
           </ReactMarkdown>

--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -788,6 +788,17 @@
   margin: 32px 0;
 }
 
+/* Videos in content */
+.blog-post-content video {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 32px 0;
+  background: var(--code-input-bg);
+}
+
 /* Task lists (GFM support) */
 .blog-post-content input[type="checkbox"] {
   margin-right: 8px;


### PR DESCRIPTION
## Summary
- Render Markdown image nodes that point to MP4/WebM/MOV files as native video players in blog posts
- Add matching blog content video styles

## Verification
- pnpm -F web lint
- pnpm -F web check-types

## CMS
- Updated the Seedance 2.0 draft to use four MP4 URLs instead of GIF previews
- Added DE/JA/ES draft localizations
- Replaced the cover with a new Seedance 2.0 illustration and changed the author to Yuma