### PR TITLE
fix(cli): clean up generate artifact flags

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -62,12 +62,10 @@ describe("zero generate source-backed artifact commands", () => {
         command,
         "--prompt",
         prompt,
-        "--site",
+        "--site-slug",
         `${command}-demo`,
         "--title",
         `${command} demo`,
-        "--audience",
-        "internal product team",
       ]);
 
       const stdout = output();
@@ -96,7 +94,7 @@ describe("zero generate source-backed artifact commands", () => {
       "mobile-app-design",
       "--prompt",
       "A mobile review screen",
-      "--site",
+      "--site-slug",
       "mobile-review",
       "--json",
     ]);
@@ -157,6 +155,41 @@ describe("zero generate source-backed artifact commands", () => {
     );
   });
 
+  it("filters template candidates by target when requested", () => {
+    const websiteSelection = selectResourceCandidates("website");
+    const presentationSelection = selectResourceCandidates("presentation");
+
+    expect(websiteSelection.candidates.templates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "template:saas-landing",
+          description: expect.stringContaining("Single-page SaaS landing"),
+        }),
+      ]),
+    );
+    expect(websiteSelection.candidates.templates).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "template:html-ppt-pitch-deck" }),
+      ]),
+    );
+    expect(presentationSelection.candidates.templates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "template:html-ppt-pitch-deck",
+          description: expect.stringContaining("Investor-ready"),
+        }),
+      ]),
+    );
+    expect(presentationSelection.candidates.designSystems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "design-system:shopify",
+          description: expect.stringContaining("E-commerce platform"),
+        }),
+      ]),
+    );
+  });
+
   it("attributes every vm0 image style to the vm0-skills repo", () => {
     const selection = selectResourceCandidates();
     const vm0ImageStyles = selection.candidates.imageStyles.filter((entry) => {
@@ -191,7 +224,7 @@ describe("zero generate source-backed artifact commands", () => {
       "report",
       "--prompt",
       "Q2 finance report",
-      "--site",
+      "--site-slug",
       "q2-finance-demo",
       "--design-system",
       "apple",

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -41,18 +41,12 @@ describe("zero generate presentation command", () => {
       "presentation",
       "--prompt",
       "API migration plan",
-      "--style",
-      "swiss",
       "--slides",
       "10",
       "--images",
       "8",
       "--image-model",
       "gpt-image-1.5",
-      "--theme",
-      "ikb",
-      "--audience",
-      "engineering leadership",
       "--title",
       "API Migration Plan",
     ]);
@@ -65,16 +59,14 @@ describe("zero generate presentation command", () => {
     expect(stdout).toContain("API migration plan");
     expect(stdout).toContain("skill:article-magazine");
     expect(stdout).toContain("template:html-ppt-graphify-dark-graph");
+    expect(stdout).not.toContain("template:saas-landing");
     expect(stdout).toContain(
       "Write the artifact under `./generated/mockups/api-migration-plan/`.",
     );
     expect(stdout).toContain(
       "zero host ./generated/mockups/api-migration-plan --site api-migration-plan",
     );
-    expect(stdout).toContain("Style: swiss");
     expect(stdout).toContain("Slide count: 10");
-    expect(stdout).toContain("Theme: ikb");
-    expect(stdout).toContain("Audience: engineering leadership");
     expect(stdout).toContain("Use a fixed 1920x1080 slide canvas");
   });
 
@@ -85,8 +77,8 @@ describe("zero generate presentation command", () => {
       "presentation",
       "--prompt",
       "JSON please",
-      "--title",
-      "API Migration Plan",
+      "--site-slug",
+      "api-migration-plan",
       "--json",
     ]);
 
@@ -130,6 +122,8 @@ describe("zero generate presentation command", () => {
 
     expect(helpOutput).toContain("Image model for generated visuals (default:");
     expect(helpOutput).toContain("gpt-image-1): gpt-image-2");
+    expect(helpOutput).not.toContain("--style");
+    expect(helpOutput).not.toContain("--theme");
   });
 
   it("should list presentation templates and design systems in help", () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -40,13 +40,9 @@ describe("zero generate website command", () => {
       "website",
       "--prompt",
       "observability launch site",
-      "--template-direction",
-      "launch",
       "--title",
       "Clearpath",
-      "--audience",
-      "small engineering teams",
-      "--site",
+      "--site-slug",
       "clearpath-demo",
     ]);
 
@@ -57,14 +53,13 @@ describe("zero generate website command", () => {
     expect(stdout).toContain("## Candidate Registry Slice");
     expect(stdout).toContain("observability launch site");
     expect(stdout).toContain("template:web-prototype-taste-editorial");
+    expect(stdout).not.toContain("template:html-ppt-pitch-deck");
     expect(stdout).toContain(
       "Write the artifact under `./generated/mockups/clearpath-demo/`.",
     );
     expect(stdout).toContain(
       "zero host ./generated/mockups/clearpath-demo --site clearpath-demo --spa",
     );
-    expect(stdout).toContain("Template direction: launch");
-    expect(stdout).toContain("Audience: small engineering teams");
   });
 
   it("should accept --template and --design-system from the registry", async () => {
@@ -78,7 +73,7 @@ describe("zero generate website command", () => {
       "saas-landing",
       "--design-system",
       "stripe",
-      "--site",
+      "--site-slug",
       "saas-pricing-demo",
     ]);
 
@@ -132,7 +127,7 @@ describe("zero generate website command", () => {
       "website",
       "--prompt",
       "observability launch site",
-      "--site",
+      "--site-slug",
       "clearpath-demo",
       "--json",
     ]);

--- a/turbo/apps/cli/src/commands/zero/generate/artifacts.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/artifacts.ts
@@ -1,11 +1,10 @@
 import { createArtifactGenerateCommand } from "../shared/artifact-generate";
 
 function standardDetails(kind: string) {
-  return (options: { title?: string; audience?: string }) => {
+  return (options: { title?: string }) => {
     return [
       `Artifact kind: ${kind}`,
       `Requested title/name: ${options.title ?? "not specified"}`,
-      `Audience: ${options.audience ?? "not specified"}`,
     ];
   };
 }
@@ -17,7 +16,7 @@ export const reportCommand = createArtifactGenerateCommand({
   description: "Generate an HTML report from a prompt",
   usageCommand: "zero generate report",
   examples: `  Generate report:      zero generate report --prompt "A Q2 usage report for the API team"
-  Stable hosted slug:    zero generate report --site api-usage-q2 --prompt "A Q2 usage report"
+  Stable hosted slug:    zero generate report --site-slug api-usage-q2 --prompt "A Q2 usage report"
   List providers:        zero generate report`,
   details: standardDetails("report"),
   artifactRules: [
@@ -35,7 +34,7 @@ export const docsDesignCommand = createArtifactGenerateCommand({
   description: "Generate a documentation design from a prompt",
   usageCommand: "zero generate docs-design",
   examples: `  Generate docs design: zero generate docs-design --prompt "Docs for adding artifact targets"
-  Stable hosted slug:    zero generate docs-design --site artifact-target-docs --prompt "Artifact target docs"
+  Stable hosted slug:    zero generate docs-design --site-slug artifact-target-docs --prompt "Artifact target docs"
   List providers:        zero generate docs-design`,
   details: standardDetails("docs-design"),
   artifactRules: [
@@ -53,7 +52,7 @@ export const posterCommand = createArtifactGenerateCommand({
   description: "Generate an HTML poster from a prompt",
   usageCommand: "zero generate poster",
   examples: `  Generate poster:      zero generate poster --prompt "A launch poster for artifact targets"
-  Stable hosted slug:    zero generate poster --site artifact-poster --prompt "A launch poster"
+  Stable hosted slug:    zero generate poster --site-slug artifact-poster --prompt "A launch poster"
   List providers:        zero generate poster`,
   details: standardDetails("poster"),
   artifactRules: [
@@ -71,7 +70,7 @@ export const dashboardDesignCommand = createArtifactGenerateCommand({
   description: "Generate a dashboard design from a prompt",
   usageCommand: "zero generate dashboard-design",
   examples: `  Generate dash design: zero generate dashboard-design --prompt "An ops dashboard for generation runs"
-  Stable hosted slug:    zero generate dashboard-design --site generation-ops --prompt "A generation ops dashboard"
+  Stable hosted slug:    zero generate dashboard-design --site-slug generation-ops --prompt "A generation ops dashboard"
   List providers:        zero generate dashboard-design`,
   details: standardDetails("dashboard-design"),
   artifactRules: [
@@ -89,7 +88,7 @@ export const mobileAppDesignCommand = createArtifactGenerateCommand({
   description: "Generate a mobile app design prototype from a prompt",
   usageCommand: "zero generate mobile-app-design",
   examples: `  Generate mobile UI:   zero generate mobile-app-design --prompt "A mobile review screen for generation artifacts"
-  Stable hosted slug:    zero generate mobile-app-design --site generation-mobile-review --prompt "A mobile review screen"
+  Stable hosted slug:    zero generate mobile-app-design --site-slug generation-mobile-review --prompt "A mobile review screen"
   List providers:        zero generate mobile-app-design`,
   details: standardDetails("mobile-app-design"),
   artifactRules: [

--- a/turbo/apps/cli/src/commands/zero/generate/presentation.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/presentation.ts
@@ -6,7 +6,7 @@ export const presentationCommand = createPresentationGenerateCommand({
   usageCommand: "zero generate presentation",
   examples: `  Generate deck:         zero generate presentation --prompt "A strategy deck for reducing support volume"
   Pipe prompt:           cat brief.txt | zero generate presentation
-  Swiss style:           zero generate presentation --style swiss --theme ikb --slides 10 --images 8 --image-model gpt-image-1.5 --prompt "A product launch narrative"
-  Audience context:      zero generate presentation --audience "engineering leadership" --prompt "API migration plan"
+  Generated visuals:     zero generate presentation --slides 10 --images 8 --image-model gpt-image-1.5 --prompt "A product launch narrative"
+  Stable hosted slug:    zero generate presentation --site-slug api-migration-plan --prompt "API migration plan"
   List providers:        zero generate presentation`,
 });

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -13,7 +13,6 @@ import {
 } from "../shared/resource-listing";
 import { dispatchGenerate } from "./lib/dispatch";
 
-const WEBSITE_TEMPLATE_DIRECTIONS = ["auto", "launch", "profile"] as const;
 const WEBSITE_MAX_IMAGES = 3;
 const WEBSITE_TARGET = "website";
 const WEBSITE_USAGE_COMMAND = "zero generate website";
@@ -21,29 +20,14 @@ const WEBSITE_USAGE_COMMAND = "zero generate website";
 interface WebsiteOptions {
   readonly prompt?: string;
   readonly provider?: string;
-  readonly templateDirection: string;
   readonly template?: string;
   readonly designSystem?: string;
   readonly images: number;
   readonly imageModel?: string;
-  readonly site?: string;
+  readonly siteSlug?: string;
   readonly title?: string;
-  readonly audience?: string;
   readonly all?: boolean;
   readonly json?: boolean;
-}
-
-function parseTemplateDirection(value: string): string {
-  if (
-    WEBSITE_TEMPLATE_DIRECTIONS.some((direction) => {
-      return direction === value;
-    })
-  ) {
-    return value;
-  }
-  throw new InvalidArgumentError(
-    "template-direction must be auto, launch, or profile",
-  );
 }
 
 function parseImageCount(value: string): number {
@@ -108,12 +92,6 @@ export const websiteCommand = new Command()
     "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
   )
   .option(
-    "--template-direction <direction>",
-    "High-level website direction: auto, launch, or profile",
-    parseTemplateDirection,
-    "auto",
-  )
-  .option(
     "--template <id>",
     "Template id from the registry, scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
   )
@@ -131,9 +109,8 @@ export const websiteCommand = new Command()
     "--image-model <model>",
     "Image model for generated visuals (default: gpt-image-1): gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
   )
-  .option("--site <slug>", "Hosted site slug; defaults to the generated name")
+  .option("--site-slug <slug>", "Hosted site slug override")
   .option("--title <text>", "Requested site title or name")
-  .option("--audience <text>", "Audience context")
   .option("--json", "Print metadata as JSON")
   .addHelpText("after", () => {
     const designSystems = listDesignSystems();
@@ -141,10 +118,9 @@ export const websiteCommand = new Command()
     return `
 Examples:
   Generate site:         zero generate website --prompt "A launch site for a developer observability tool"
-  Pick direction:        zero generate website --template-direction profile --images 2 --image-model gpt-image-1.5 --prompt "Portfolio for a robotics photographer"
   Pick template:         zero generate website --template saas-landing --prompt "Launch site for a billing API"
   Pick design system:    zero generate website --design-system stripe --prompt "Pricing page for a SaaS"
-  Stable hosted slug:    zero generate website --site api-migration-demo --prompt "An internal migration microsite"
+  Stable hosted slug:    zero generate website --site-slug api-migration-demo --prompt "An internal migration microsite"
   Pipe prompt:           cat brief.txt | zero generate website
   List providers:        zero generate website
 
@@ -201,15 +177,13 @@ ${formatRegistryListing(templates, "website templates")}`;
         kind: "website",
         prompt,
         slugSource: options.title,
-        site: options.site,
+        siteSlug: options.siteSlug,
         details: [
-          `Template direction: ${options.templateDirection}`,
           `Suggested generated visual count: ${options.images}`,
           `Image model preference if visuals are generated separately: ${
             options.imageModel ?? "default"
           }`,
           `Requested title/site name: ${options.title ?? "not specified"}`,
-          `Audience: ${options.audience ?? "not specified"}`,
           `Selected design system: ${
             resolvedDesignSystem
               ? `${resolvedDesignSystem.id} (${resolvedDesignSystem.name})`

--- a/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
@@ -19,9 +19,8 @@ import type { GenerationType } from "../generate/lib/lister";
 interface ArtifactOptions {
   prompt?: string;
   provider?: string;
-  site?: string;
+  siteSlug?: string;
   title?: string;
-  audience?: string;
   designSystem?: string;
   template?: string;
   all?: boolean;
@@ -90,9 +89,8 @@ export function createArtifactGenerateCommand(
       "--all",
       "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
     )
-    .option("--site <slug>", "Hosted site slug; defaults to generated name")
+    .option("--site-slug <slug>", "Hosted site slug override")
     .option("--title <text>", "Requested artifact title or name")
-    .option("--audience <text>", "Audience context")
     .option(
       "--design-system <id>",
       "Design system id from the registry (see Design Systems below). Accepts either 'apple' or 'design-system:apple'.",
@@ -185,7 +183,7 @@ ${formatRegistryListing(templates, `${config.target} templates`)}`;
           kind: toGenerationTarget(config.target),
           prompt,
           slugSource: options.title,
-          site: options.site,
+          siteSlug: options.siteSlug,
           details: [...config.details(options), ...extraDetails],
           artifactRules: config.artifactRules,
         });

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -11,7 +11,7 @@ interface HtmlArtifactAuthoringOptions {
   readonly kind: HtmlArtifactKind;
   readonly prompt: string;
   readonly slugSource?: string;
-  readonly site?: string;
+  readonly siteSlug?: string;
   readonly details: readonly string[];
   readonly artifactRules: readonly string[];
 }
@@ -92,13 +92,14 @@ function outputDirForSite(site: string): string {
 export function createHtmlArtifactAuthoringPacket(
   options: HtmlArtifactAuthoringOptions,
 ): HtmlArtifactAuthoringPacket {
-  const site = options.site ?? slugify(options.slugSource ?? options.prompt);
+  const site =
+    options.siteSlug ?? slugify(options.slugSource ?? options.prompt);
   const outputDir = outputDirForSite(site);
   const hostCommand = `zero host ${outputDir} --site ${site}${
     options.kind === "website" ? " --spa" : ""
   }`;
   const title = titleForKind(options.kind);
-  const candidateSlice = selectResourceCandidates();
+  const candidateSlice = selectResourceCandidates(options.kind);
   const selectionSchema = {
     skills: "string[]",
     template: "string",

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -20,13 +20,11 @@ const PRESENTATION_TARGET = "presentation";
 interface PresentationOptions {
   prompt?: string;
   provider?: string;
-  style: string;
   slides: number;
   images: number;
   imageModel?: string;
-  theme?: string;
-  audience?: string;
   title?: string;
+  siteSlug?: string;
   designSystem?: string;
   template?: string;
   all?: boolean;
@@ -119,7 +117,6 @@ export function createPresentationGenerateCommand(
       "--all",
       "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
     )
-    .option("--style <style>", "Style: editorial or swiss", "editorial")
     .option("--slides <count>", "Slide count: 4-20", parseSlideCount, 8)
     .option(
       "--images <count>",
@@ -131,12 +128,8 @@ export function createPresentationGenerateCommand(
       "--image-model <model>",
       "Image model for generated visuals (default: gpt-image-1): gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
     )
-    .option(
-      "--theme <theme>",
-      "Theme: editorial supports ink, coral, forest; swiss supports ikb, lemon, lime, mono",
-    )
-    .option("--audience <text>", "Audience context")
     .option("--title <text>", "Requested deck title")
+    .option("--site-slug <slug>", "Hosted site slug override")
     .option(
       "--design-system <id>",
       "Design system id from the registry (see Design Systems below). Accepts either 'apple' or 'design-system:apple'.",
@@ -215,15 +208,13 @@ ${formatRegistryListing(templates, "presentation templates")}`;
           kind: "presentation",
           prompt,
           slugSource: options.title,
+          siteSlug: options.siteSlug,
           details: [
-            `Style: ${options.style}`,
             `Slide count: ${options.slides}`,
             `Suggested generated visual count: ${options.images}`,
             `Image model preference if visuals are generated separately: ${
               options.imageModel ?? "default"
             }`,
-            `Theme: ${options.theme ?? "agent decides from style"}`,
-            `Audience: ${options.audience ?? "not specified"}`,
             `Requested deck title: ${options.title ?? "not specified"}`,
             `Selected design system: ${
               resolvedDesignSystem

--- a/turbo/apps/cli/src/commands/zero/shared/resource-registry.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/resource-registry.ts
@@ -3364,7 +3364,9 @@ export function toGenerationTarget(value: string): GenerationTarget {
   return value as GenerationTarget;
 }
 
-export function selectResourceCandidates(): ResourceCandidateSlice {
+export function selectResourceCandidates(
+  target?: GenerationTarget,
+): ResourceCandidateSlice {
   return {
     registryVersion: RESOURCE_REGISTRY_VERSION,
     source: {
@@ -3383,7 +3385,7 @@ export function selectResourceCandidates(): ResourceCandidateSlice {
     ],
     candidates: {
       skills: filterByKind("skill"),
-      templates: filterByKind("template"),
+      templates: listTemplates(target),
       designSystems: filterByKind("design-system"),
       imageStyles: filterByKind("image-style"),
       audioStyles: filterByKind("audio-style"),


### PR DESCRIPTION
## Summary
- remove legacy presentation `--style` and `--theme` flags
- remove low-value `--audience` and website `--template-direction` generation hints
- rename generate artifact slug override from `--site` to `--site-slug` while keeping hosted output commands unchanged
- make website, report, docs-design, poster, dashboard-design, and mobile-app-design share the same HTML artifact params: `--prompt`, `--site-slug`, `--title`, `--design-system`, `--template`
- make presentation use the same base params plus only `--slides`
- remove HTML artifact `--provider`, `--all`, `--images`, and `--image-model` flags
- make no-prompt HTML artifact choices use built-in command output with target-filtered templates and design-system descriptions

## Verification
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/presentation.test.ts src/commands/zero/generate/__tests__/website.test.ts src/commands/zero/generate/__tests__/artifacts.test.ts src/commands/zero/generate/__tests__/lister.test.ts`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/cli build`

## Report
- https://generate-parameter-distribution-715f6d07.sites.vm0.io