### PR TITLE
refactor: resolve connector auth clients by method

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type {
   AuthCodeGrantConnectorType,
-  ConnectorOAuthClientConfig,
+  ConnectorAuthClientConfig,
 } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
@@ -201,7 +201,7 @@ function mockOAuthEnv(): void {
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
-} as const satisfies ConnectorOAuthClientConfig;
+} as const satisfies ConnectorAuthClientConfig;
 
 type CapturedOAuthExchange = {
   readonly clientId: string | undefined;
@@ -228,17 +228,17 @@ function useDynamicTestOAuthExchange(): {
 function configureDynamicTestOAuthExchange(
   exchanges: CapturedOAuthExchange[],
 ): () => void {
-  const grant = getConnectorAuthMethod("test-oauth", "oauth")?.grant;
-  if (grant?.kind !== "auth-code") {
+  const method = getConnectorAuthMethod("test-oauth", "oauth");
+  if (method?.grant.kind !== "auth-code") {
     throw new Error("test-oauth OAuth config is missing");
   }
 
-  const mutableGrant = grant as { client: ConnectorOAuthClientConfig };
-  const originalClient = grant.client;
+  const mutableMethod = method as { client: ConnectorAuthClientConfig };
+  const originalClient = mutableMethod.client;
   const provider = testOauthProvider;
   const originalExchangeCode = provider.grant.exchangeCode;
 
-  mutableGrant.client = dynamicPublicClient;
+  mutableMethod.client = dynamicPublicClient;
   provider.grant.exchangeCode = (args) => {
     exchanges.push({
       clientId: args.clientId,
@@ -263,7 +263,7 @@ function configureDynamicTestOAuthExchange(
   };
 
   return () => {
-    mutableGrant.client = originalClient;
+    mutableMethod.client = originalClient;
     provider.grant.exchangeCode = originalExchangeCode;
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -7,7 +7,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { webhookFirewallAuthContract } from "@vm0/api-contracts/contracts/webhooks";
-import type { ConnectorOAuthClientConfig } from "@vm0/connectors/connectors";
+import type { ConnectorAuthClientConfig } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { testOauthProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import { connectors } from "@vm0/db/schema/connector";
@@ -356,7 +356,7 @@ async function seedGithubOAuthStaticAccessConnector(
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
-} as const satisfies ConnectorOAuthClientConfig;
+} as const satisfies ConnectorAuthClientConfig;
 
 type CapturedOAuthRefresh = {
   readonly clientId: string | undefined;
@@ -378,20 +378,20 @@ function useDynamicTestOAuthRefresh(): {
 function configureDynamicTestOAuthRefresh(
   refreshes: CapturedOAuthRefresh[],
 ): () => void {
-  const grant = getConnectorAuthMethod("test-oauth", "oauth")?.grant;
-  if (grant?.kind !== "auth-code") {
+  const method = getConnectorAuthMethod("test-oauth", "oauth");
+  if (method?.grant.kind !== "auth-code") {
     throw new Error("test-oauth OAuth config is missing");
   }
 
-  const mutableGrant = grant as { client: ConnectorOAuthClientConfig };
-  const originalClient = grant.client;
+  const mutableMethod = method as { client: ConnectorAuthClientConfig };
+  const originalClient = mutableMethod.client;
   const access = testOauthProvider.access;
   if (access.kind !== "refresh-token") {
     throw new Error("test-oauth provider should support refresh");
   }
   const originalRefreshToken = access.refreshToken;
 
-  mutableGrant.client = dynamicPublicClient;
+  mutableMethod.client = dynamicPublicClient;
   access.refreshToken = (args) => {
     refreshes.push({
       clientId: args.clientId,
@@ -406,7 +406,7 @@ function configureDynamicTestOAuthRefresh(
   };
 
   return () => {
-    mutableGrant.client = originalClient;
+    mutableMethod.client = originalClient;
     access.refreshToken = originalRefreshToken;
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { ConnectorOAuthClientConfig } from "@vm0/connectors/connectors";
+import type { ConnectorAuthClientConfig } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { testOauthProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
@@ -88,7 +88,7 @@ function mockOAuthEnv(): void {
 const dynamicPublicClient = {
   clientRegistration: "dynamic",
   clientType: "public",
-} as const satisfies ConnectorOAuthClientConfig;
+} as const satisfies ConnectorAuthClientConfig;
 
 async function enableConnectorFeature(
   userId: string,
@@ -104,17 +104,17 @@ async function enableConnectorFeature(
 }
 
 function useDynamicTestOAuthAuthorize(): () => void {
-  const grant = getConnectorAuthMethod("test-oauth", "oauth")?.grant;
-  if (grant?.kind !== "auth-code") {
+  const method = getConnectorAuthMethod("test-oauth", "oauth");
+  if (method?.grant.kind !== "auth-code") {
     throw new Error("test-oauth OAuth config is missing");
   }
 
-  const mutableGrant = grant as { client: ConnectorOAuthClientConfig };
-  const originalClient = grant.client;
+  const mutableMethod = method as { client: ConnectorAuthClientConfig };
+  const originalClient = mutableMethod.client;
   const provider = testOauthProvider;
   const originalBuildAuthUrl = provider.grant.buildAuthUrl;
 
-  mutableGrant.client = dynamicPublicClient;
+  mutableMethod.client = dynamicPublicClient;
   provider.grant.buildAuthUrl = (args) => {
     expect(args.clientId).toBeUndefined();
     return {
@@ -124,7 +124,7 @@ function useDynamicTestOAuthAuthorize(): () => void {
   };
 
   return () => {
-    mutableGrant.client = originalClient;
+    mutableMethod.client = originalClient;
     provider.grant.buildAuthUrl = originalBuildAuthUrl;
   };
 }

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -13,6 +13,7 @@ import {
 } from "@vm0/connectors/connectors";
 import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
 import {
+  getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
@@ -219,15 +220,25 @@ const createTestConnector$ = command(
     let grantConnectorType:
       | AuthCodeGrantConnectorType
       | DeviceAuthGrantConnectorType;
+    let authMethodGrantKind: "auth-code" | "device-auth";
     if (hasConnectorAuthCodeGrant(connectorType)) {
       grantConnectorType = connectorType;
+      authMethodGrantKind = "auth-code";
     } else if (hasConnectorDeviceAuthGrant(connectorType)) {
       grantConnectorType = connectorType;
+      authMethodGrantKind = "device-auth";
     } else {
       return stringError(
         400,
         `${connectorType} connector does not use an auth-code or device-auth grant`,
       );
+    }
+    const authMethod = getConnectorAuthMethodIdForGrantKind(
+      grantConnectorType,
+      authMethodGrantKind,
+    );
+    if (!authMethod) {
+      throw new Error(`${grantConnectorType} connector has no auth method`);
     }
     const secretMetadata = getConnectorOAuthSecretMetadata(grantConnectorType);
     const refreshSecretName = secretMetadata.isRefreshable
@@ -239,6 +250,7 @@ const createTestConnector$ = command(
         orgId,
         userId,
         type: grantConnectorType,
+        authMethod,
         accessToken: bodyResult.data.accessToken,
         userInfo: {
           id: `e2e-test-${grantConnectorType}`,

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -1,5 +1,5 @@
 import {
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
   type ConnectorAuthClient,
@@ -69,7 +69,7 @@ export function prepareResolvedConnectorAuthCodeStart(args: {
 }): PrepareResolvedConnectorAuthCodeStartResult {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     args.type,
     args.authMethod,
     args.readEnv,

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -1,9 +1,9 @@
 import {
+  getConnectorAuthMethodClient,
   getConnectorAuthMethodIdForGrantKind,
-  getConnectorOAuthClient,
   hasConnectorAuthCodeGrant,
+  type ConnectorAuthClient,
   type ConnectorEnvReader,
-  type ConnectorOAuthClient,
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeGrantConnectorType,
@@ -22,7 +22,7 @@ type PrepareResolvedConnectorAuthCodeStartResult =
       readonly ok: true;
       readonly state: string;
       readonly redirectUri: string;
-      readonly oauthClient: ConnectorOAuthClient;
+      readonly authClient: ConnectorAuthClient;
     }
   | {
       readonly ok: false;
@@ -63,13 +63,18 @@ export function resolveConnectorAuthCodeStartType(
 // normal async commit point.
 export function prepareResolvedConnectorAuthCodeStart(args: {
   readonly type: AuthCodeGrantConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareResolvedConnectorAuthCodeStartResult {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
-  const oauthClient = getConnectorOAuthClient(args.type, args.readEnv);
-  if (!oauthClient) {
+  const authClient = getConnectorAuthMethodClient(
+    args.type,
+    args.authMethod,
+    args.readEnv,
+  );
+  if (!authClient) {
     return { ok: false, reason: "oauth_not_configured" };
   }
 
@@ -77,20 +82,20 @@ export function prepareResolvedConnectorAuthCodeStart(args: {
     ok: true,
     state,
     redirectUri,
-    oauthClient,
+    authClient,
   };
 }
 
 export async function buildResolvedConnectorAuthCodeAuthUrl(args: {
   readonly type: AuthCodeGrantConnectorType;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<AuthUrlResult> {
   return normalizeAuthUrlResult(
     await buildConnectorOAuthAuthUrl({
       type: args.type,
-      oauthClient: args.oauthClient,
+      authClient: args.authClient,
       redirectUri: args.redirectUri,
       state: args.state,
     }),

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -3,13 +3,15 @@ import { unescape as decodeCookieComponent } from "node:querystring";
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
+  getConnectorAuthMethodClient,
+  getConnectorAuthMethodGrantScopes,
+  getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
-  getConnectorOAuthClient,
-  getConnectorAuthCodeGrantConfig,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
   type AuthCodeGrantConnectorType,
+  type ConnectorAuthMethodId,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorOAuthCode,
@@ -58,6 +60,7 @@ type CallbackIdentity = {
 
 type CompleteOAuthCallbackInput = {
   readonly connectorType: AuthCodeGrantConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -108,6 +111,7 @@ type ResolvedOAuthConnectorType =
   | {
       readonly ok: true;
       readonly connectorType: AuthCodeGrantConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
     }
   | {
       readonly ok: false;
@@ -170,20 +174,25 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
 
 async function exchangeTokenForConnector(args: {
   readonly connectorType: AuthCodeGrantConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  const oauthClient = getConnectorOAuthClient(args.connectorType, optionalEnv);
-  if (!oauthClient) {
+  const authClient = getConnectorAuthMethodClient(
+    args.connectorType,
+    args.authMethod,
+    optionalEnv,
+  );
+  if (!authClient) {
     throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
   return await exchangeConnectorOAuthCode({
     type: args.connectorType,
-    oauthClient,
+    authClient,
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,
@@ -194,8 +203,9 @@ async function exchangeTokenForConnector(args: {
 
 function getRequestedScopes(
   connectorType: AuthCodeGrantConnectorType,
+  authMethod: ConnectorAuthMethodId,
 ): readonly string[] {
-  return getConnectorAuthCodeGrantConfig(connectorType).scopes;
+  return getConnectorAuthMethodGrantScopes(connectorType, authMethod);
 }
 
 function resolveOAuthConnectorType(
@@ -222,7 +232,15 @@ function resolveOAuthConnectorType(
     };
   }
 
-  return { ok: true, connectorType };
+  const authMethod = getConnectorAuthMethodIdForGrantKind(
+    connectorType,
+    "auth-code",
+  );
+  if (!authMethod) {
+    throw new Error(`${connectorType} connector has no auth-code auth method`);
+  }
+
+  return { ok: true, connectorType, authMethod };
 }
 
 async function claimStoredOAuthStateForCallback(args: {
@@ -371,6 +389,7 @@ const completeOAuthCallback$ = command(
   ): Promise<Response> => {
     const token = await exchangeTokenForConnector({
       connectorType: args.connectorType,
+      authMethod: args.authMethod,
       code: args.code,
       redirectUri: args.redirectUri,
       state: args.state,
@@ -386,9 +405,10 @@ const completeOAuthCallback$ = command(
         orgId: args.identity.orgId,
         userId: args.identity.userId,
         type: args.connectorType,
+        authMethod: args.authMethod,
         accessToken: token.accessToken,
         userInfo: token.userInfo,
-        oauthScopes: getRequestedScopes(args.connectorType),
+        oauthScopes: getRequestedScopes(args.connectorType, args.authMethod),
         refreshToken: token.refreshToken,
         refreshSecretName: secretMetadata.isRefreshable
           ? secretMetadata.refreshSecretName
@@ -504,7 +524,7 @@ const callbackConnectorInner$ = command(
     if (!connectorTypeResult.ok) {
       return connectorTypeResult.response;
     }
-    const { connectorType } = connectorTypeResult;
+    const { connectorType, authMethod } = connectorTypeResult;
 
     const writeDb = set(writeDb$);
     const savedState = getCookie(request, CONNECTOR_OAUTH_STATE_COOKIE_NAME);
@@ -595,6 +615,7 @@ const callbackConnectorInner$ = command(
         completeOAuthCallback$,
         {
           connectorType,
+          authMethod,
           code,
           redirectUri: resolvedState.redirectUri,
           state,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -3,7 +3,7 @@ import { unescape as decodeCookieComponent } from "node:querystring";
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodGrantScopes,
   getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
@@ -181,7 +181,7 @@ async function exchangeTokenForConnector(args: {
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     args.connectorType,
     args.authMethod,
     optionalEnv,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -5,10 +5,10 @@ import {
 } from "@vm0/api-contracts/contracts/github-oauth";
 import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import {
-  getConnectorOAuthClient,
+  getConnectorAuthMethodClient,
   getConnectorOAuthScopes,
-  isStaticConfidentialConnectorOAuthClient,
-  type StaticConfidentialConnectorOAuthClient,
+  isStaticConfidentialConnectorAuthClient,
+  type StaticConfidentialConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import { exchangeConnectorOAuthCode } from "@vm0/connectors/auth-providers";
 import {
@@ -86,16 +86,20 @@ function githubAppSetupCallbackRedirectUri(origin: string): string {
 }
 
 function githubUserOauthClient():
-  | StaticConfidentialConnectorOAuthClient
+  | StaticConfidentialConnectorAuthClient
   | undefined {
-  const oauthClient = getConnectorOAuthClient("github", optionalEnv);
-  if (!oauthClient) {
+  const authClient = getConnectorAuthMethodClient(
+    "github",
+    "oauth",
+    optionalEnv,
+  );
+  if (!authClient) {
     return undefined;
   }
-  if (!isStaticConfidentialConnectorOAuthClient(oauthClient)) {
+  if (!isStaticConfidentialConnectorAuthClient(authClient)) {
     return undefined;
   }
-  return oauthClient;
+  return authClient;
 }
 
 function githubAppUserOauthCredentials():
@@ -381,6 +385,7 @@ const connectGithubUserAfterSetup$ = command(
           orgId: args.orgId,
           userId: vm0UserId,
           type: "github",
+          authMethod: "oauth",
           accessToken,
           userInfo,
           oauthScopes:
@@ -726,8 +731,8 @@ const callbackGithubUserOauth$ = command(
       );
     }
 
-    const oauthClient = githubUserOauthClient();
-    if (!oauthClient) {
+    const authClient = githubUserOauthClient();
+    if (!authClient) {
       return worksErrorRedirect("GitHub OAuth is not configured");
     }
 
@@ -735,7 +740,7 @@ const callbackGithubUserOauth$ = command(
     const redirectUri = githubUserConnectCallbackRedirectUri(origin);
     const token = await exchangeConnectorOAuthCode({
       type: "github",
-      oauthClient,
+      authClient,
       code: query.code,
       redirectUri,
       state: query.state,
@@ -760,6 +765,7 @@ const callbackGithubUserOauth$ = command(
         orgId: state.orgId,
         userId: state.vm0UserId,
         type: "github",
+        authMethod: "oauth",
         accessToken: token.accessToken,
         userInfo: token.userInfo,
         oauthScopes: getConnectorOAuthScopes(GITHUB_CONNECTOR_TYPE),

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -5,7 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/github-oauth";
 import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import {
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorOAuthScopes,
   isStaticConfidentialConnectorAuthClient,
   type StaticConfidentialConnectorAuthClient,
@@ -88,7 +88,7 @@ function githubAppSetupCallbackRedirectUri(origin: string): string {
 function githubUserOauthClient():
   | StaticConfidentialConnectorAuthClient
   | undefined {
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     "github",
     "oauth",
     optionalEnv,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -384,6 +384,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const prepared = prepareResolvedConnectorAuthCodeStart({
       type: authCodeStartType.type,
+      authMethod: authCodeStartType.authMethod,
       origin,
       readEnv: optionalEnv,
     });
@@ -392,7 +393,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
-      oauthClient: prepared.oauthClient,
+      authClient: prepared.authClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
     });
@@ -455,6 +456,7 @@ const startConnectorOauthInner$ = command(
     const origin = getConnectorOAuthOrigin(request);
     const prepared = prepareResolvedConnectorAuthCodeStart({
       type: authCodeStartType.type,
+      authMethod: authCodeStartType.authMethod,
       origin,
       readEnv: optionalEnv,
     });
@@ -463,7 +465,7 @@ const startConnectorOauthInner$ = command(
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
-      oauthClient: prepared.oauthClient,
+      authClient: prepared.authClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
     });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -6,7 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
-  getConnectorOAuthClient,
+  getConnectorAuthMethodClient,
   getConnectorAuthMethodAccessMetadata,
   type ConnectorAuthMethodAccessMetadata,
 } from "@vm0/connectors/connector-utils";
@@ -330,6 +330,7 @@ interface RefreshBatchContext {
 }
 
 interface ConnectorAccessState {
+  readonly authMethod: string;
   readonly accessMetadata: ConnectorAuthMethodAccessMetadata;
   readonly tokenExpiresAt: number | null;
 }
@@ -620,6 +621,7 @@ async function loadConnectorAccessStates(
       continue;
     }
     result.set(row.type, {
+      authMethod: row.authMethod,
       accessMetadata,
       tokenExpiresAt: row.tokenExpiresAt
         ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
@@ -791,15 +793,14 @@ function prepareRefreshTokenContext(
     };
   }
 
-  const accessMetadata = args.connectorAccessByType.get(
-    args.connectorType,
-  )?.accessMetadata;
-  if (accessMetadata?.kind !== "refresh-token") {
+  const connectorAccess = args.connectorAccessByType.get(args.connectorType);
+  if (connectorAccess?.accessMetadata.kind !== "refresh-token") {
     L.debug(
       `${args.connectorType} does not use refresh-token access, skipping`,
     );
     return { ok: false, reason: "not-refreshable" };
   }
+  const accessMetadata = connectorAccess.accessMetadata;
   const parsedConnectorType = connectorTypeSchema.safeParse(args.connectorType);
   if (!parsedConnectorType.success) {
     return { ok: false, reason: "not-refreshable" };
@@ -807,13 +808,14 @@ function prepareRefreshTokenContext(
   if (!hasConnectorAuthProvider(parsedConnectorType.data)) {
     return { ok: false, reason: "not-refreshable" };
   }
-  const oauthClient = getConnectorOAuthClient(
+  const authClient = getConnectorAuthMethodClient(
     parsedConnectorType.data,
+    connectorAccess.authMethod,
     (name) => {
       return optionalEnv(name);
     },
   );
-  if (!oauthClient) {
+  if (!authClient) {
     L.debug(
       `${args.connectorType} connector client not configured, skipping token refresh`,
     );
@@ -843,7 +845,7 @@ function prepareRefreshTokenContext(
     prepared: {
       sourceType: "connector",
       connectorType: parsedConnectorType.data,
-      clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
+      clientArgs: getConnectorAuthProviderClientArgs(authClient),
       context,
     },
   };

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -6,7 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodAccessMetadata,
   type ConnectorAuthMethodAccessMetadata,
 } from "@vm0/connectors/connector-utils";
@@ -808,7 +808,7 @@ function prepareRefreshTokenContext(
   if (!hasConnectorAuthProvider(parsedConnectorType.data)) {
     return { ok: false, reason: "not-refreshable" };
   }
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     parsedConnectorType.data,
     connectorAccess.authMethod,
     (name) => {

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -11,11 +11,11 @@ import type {
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  getConnectorAuthMethodClient,
   getConnectorAuthMethodIdForGrantKind,
-  getConnectorOAuthClient,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
-  type ConnectorOAuthClient,
+  type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   getConnectorOAuthSecretMetadata,
@@ -87,7 +87,7 @@ type PollClaimedSessionArgs = {
   readonly orgId: string;
   readonly userId: string;
   readonly type: DeviceAuthGrantConnectorType;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly signal: AbortSignal;
@@ -205,14 +205,19 @@ function resolveDeviceAuthType(
   return { type, authMethod };
 }
 
-function resolveRequiredOAuthClient(
+function resolveRequiredAuthClient(
   type: DeviceAuthGrantConnectorType,
-): ConnectorOAuthClient | ReturnType<typeof internalServerError> {
-  const oauthClient = getConnectorOAuthClient(type, optionalEnv);
-  if (!oauthClient) {
+  authMethod: ConnectorAuthMethodId,
+): ConnectorAuthClient | ReturnType<typeof internalServerError> {
+  const authClient = getConnectorAuthMethodClient(
+    type,
+    authMethod,
+    optionalEnv,
+  );
+  if (!authClient) {
     return internalServerError(`${type} OAuth is not configured`);
   }
-  return oauthClient;
+  return authClient;
 }
 
 async function lockDeviceAuthSessionOwner(args: {
@@ -600,7 +605,7 @@ async function runClaimedSession(
   });
   const pollResult = await pollConnectorOAuthDeviceAuth({
     type: args.type,
-    oauthClient: args.oauthClient,
+    authClient: args.authClient,
     deviceCode: providerState.deviceCode,
   });
   args.signal.throwIfAborted();
@@ -707,14 +712,17 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const oauthClient = resolveRequiredOAuthClient(resolvedType.type);
-    if ("status" in oauthClient) {
-      return oauthClient;
+    const authClient = resolveRequiredAuthClient(
+      resolvedType.type,
+      resolvedType.authMethod,
+    );
+    if ("status" in authClient) {
+      return authClient;
     }
 
     const startResult = await startConnectorOAuthDeviceAuth({
       type: resolvedType.type,
-      oauthClient,
+      authClient,
     });
     signal.throwIfAborted();
 
@@ -822,9 +830,12 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const oauthClient = resolveRequiredOAuthClient(resolvedType.type);
-    if ("status" in oauthClient) {
-      return oauthClient;
+    const authClient = resolveRequiredAuthClient(
+      resolvedType.type,
+      resolvedType.authMethod,
+    );
+    if ("status" in authClient) {
+      return authClient;
     }
 
     const writeDb = set(writeDb$);
@@ -894,7 +905,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       orgId: args.orgId,
       userId: args.userId,
       type: resolvedType.type,
-      oauthClient,
+      authClient,
       session: claimedSession,
       claimStartedAt,
       signal,
@@ -908,6 +919,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
             orgId: args.orgId,
             userId: args.userId,
             type: resolvedType.type,
+            authMethod: resolvedType.authMethod,
             accessToken: result.token.accessToken,
             userInfo: result.token.userInfo,
             oauthScopes: result.token.scopes,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -11,7 +11,7 @@ import type {
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
@@ -209,7 +209,7 @@ function resolveRequiredAuthClient(
   type: DeviceAuthGrantConnectorType,
   authMethod: ConnectorAuthMethodId,
 ): ConnectorAuthClient | ReturnType<typeof internalServerError> {
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     type,
     authMethod,
     optionalEnv,

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -12,7 +12,7 @@ import {
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 import {
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   isStaticConfidentialConnectorAuthClient,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
@@ -370,7 +370,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   readonly readEnv: ConnectorEnvReader;
   readonly signal: AbortSignal;
 }): Promise<string | null> {
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     "github",
     "oauth",
     args.readEnv,

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -12,8 +12,8 @@ import {
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 import {
-  getConnectorOAuthClient,
-  isStaticConfidentialConnectorOAuthClient,
+  getConnectorAuthMethodClient,
+  isStaticConfidentialConnectorAuthClient,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
@@ -370,8 +370,12 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   readonly readEnv: ConnectorEnvReader;
   readonly signal: AbortSignal;
 }): Promise<string | null> {
-  const oauthClient = getConnectorOAuthClient("github", args.readEnv);
-  if (!oauthClient || !isStaticConfidentialConnectorOAuthClient(oauthClient)) {
+  const authClient = getConnectorAuthMethodClient(
+    "github",
+    "oauth",
+    args.readEnv,
+  );
+  if (!authClient || !isStaticConfidentialConnectorAuthClient(authClient)) {
     return null;
   }
 
@@ -380,7 +384,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   const authResult = normalizeAuthUrlResult(
     await buildConnectorOAuthAuthUrl({
       type: "github",
-      oauthClient,
+      authClient,
       redirectUri,
       state,
     }),

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1182,8 +1182,9 @@ function connectorTokenExpiresAt(args: {
 
 function allowedOAuthConnectorSecretNames(
   type: ConnectorAuthProviderType,
+  authMethod: ConnectorAuthMethodId,
 ): Set<string> {
-  return new Set(getConnectorSecretNames(type, "oauth"));
+  return new Set(getConnectorSecretNames(type, authMethod));
 }
 
 function isOAuthPrimaryTokenSecret(args: {
@@ -1198,6 +1199,7 @@ function isOAuthPrimaryTokenSecret(args: {
 
 function validateExtraOAuthConnectorSecrets(args: {
   readonly type: ConnectorAuthProviderType;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
   readonly accessSecretName: string;
   readonly refreshSecretName: string | undefined;
@@ -1207,7 +1209,10 @@ function validateExtraOAuthConnectorSecrets(args: {
     return [];
   }
 
-  const allowedSecretNames = allowedOAuthConnectorSecretNames(args.type);
+  const allowedSecretNames = allowedOAuthConnectorSecretNames(
+    args.type,
+    args.authMethod,
+  );
   for (const [name] of extraSecrets) {
     if (
       isOAuthPrimaryTokenSecret({
@@ -1477,6 +1482,7 @@ export const upsertOAuthConnector$ = command(
     });
     const extraSecrets = validateExtraOAuthConnectorSecrets({
       type: args.type,
+      authMethod: args.authMethod,
       extraConnectorSecrets: args.extraConnectorSecrets,
       accessSecretName: secretMetadata.accessSecretName,
       refreshSecretName: secretMetadata.isRefreshable

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -8,11 +8,11 @@ import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zer
 import {
   connectorAuthMethodSupportsTokenRevoke,
   getAvailableConnectorAuthMethods,
+  getConnectorAuthMethodClient,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNames,
-  getConnectorOAuthClient,
   getConnectorSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
@@ -26,6 +26,7 @@ import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
+  type ConnectorAuthMethodId,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type ConnectorAuthProviderType,
@@ -120,6 +121,7 @@ interface EncryptedOAuthConnectorSecret {
 
 interface PendingConnectorTokenRevoke {
   readonly type: TokenRevokeConnectorType;
+  readonly authMethod: string;
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
@@ -508,6 +510,7 @@ async function loadPendingConnectorTokenRevoke(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly type: TokenRevokeConnectorType;
+  readonly authMethod: string;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingConnectorTokenRevoke | null> {
@@ -535,6 +538,7 @@ async function loadPendingConnectorTokenRevoke(args: {
 
   return {
     type: connectorType,
+    authMethod: args.authMethod,
     encryptedAccessToken: accessTokenSecret.encryptedValue,
     featureSwitchContext: args.featureSwitchContext,
   };
@@ -543,8 +547,12 @@ async function loadPendingConnectorTokenRevoke(args: {
 async function revokePendingConnectorToken(args: {
   readonly pending: PendingConnectorTokenRevoke;
 }): Promise<void> {
-  const oauthClient = getConnectorOAuthClient(args.pending.type, optionalEnv);
-  if (!oauthClient) {
+  const authClient = getConnectorAuthMethodClient(
+    args.pending.type,
+    args.pending.authMethod,
+    optionalEnv,
+  );
+  if (!authClient) {
     return;
   }
 
@@ -552,7 +560,7 @@ async function revokePendingConnectorToken(args: {
   await bestEffort(
     revokeConnectorOAuthToken({
       type: args.pending.type,
-      oauthClient,
+      authClient,
       loadAccessToken: () => {
         return decryptStoredSecretValue(
           args.pending.encryptedAccessToken,
@@ -667,6 +675,7 @@ export const deleteZeroConnectorLocalState$ = command(
           orgId: args.orgId,
           userId: args.userId,
           type: args.type,
+          authMethod: existing.authMethod,
           featureSwitchContext,
           signal,
         });
@@ -962,6 +971,7 @@ async function cleanupExistingStoredConnectorForApiTokenConnect(
       orgId: args.orgId,
       userId: args.userId,
       type: args.type,
+      authMethod: existing.authMethod,
       featureSwitchContext: args.featureSwitchContext,
       signal: args.signal,
     });
@@ -1337,6 +1347,7 @@ async function upsertOAuthConnectorRow(
     readonly orgId: string;
     readonly userId: string;
     readonly type: ConnectorAuthProviderType;
+    readonly authMethod: ConnectorAuthMethodId;
     readonly userInfo: ExternalUserInfo;
     readonly oauthScopes: readonly string[];
     readonly tokenExpiresAt: Date | null;
@@ -1348,7 +1359,7 @@ async function upsertOAuthConnectorRow(
     .values({
       userId: args.userId,
       type: args.type,
-      authMethod: "oauth",
+      authMethod: args.authMethod,
       externalId: args.userInfo.id,
       externalUsername: args.userInfo.username,
       externalEmail: args.userInfo.email,
@@ -1360,7 +1371,7 @@ async function upsertOAuthConnectorRow(
     .onConflictDoUpdate({
       target: [connectors.orgId, connectors.userId, connectors.type],
       set: {
-        authMethod: "oauth",
+        authMethod: args.authMethod,
         externalId: args.userInfo.id,
         externalUsername: args.userInfo.username,
         externalEmail: args.userInfo.email,
@@ -1396,29 +1407,32 @@ async function deleteObsoleteConnectorScopedStateForOAuthConnect(
     readonly orgId: string;
     readonly userId: string;
     readonly type: ConnectorAuthProviderType;
+    readonly authMethod: ConnectorAuthMethodId;
     readonly existingAuthMethod: string | null;
     readonly signal: AbortSignal;
   },
 ): Promise<void> {
-  if (!args.existingAuthMethod || args.existingAuthMethod === "oauth") {
+  if (!args.existingAuthMethod || args.existingAuthMethod === args.authMethod) {
     return;
   }
 
-  const oauthSecretNames = new Set(getConnectorSecretNames(args.type, "oauth"));
+  const targetSecretNames = new Set(
+    getConnectorSecretNames(args.type, args.authMethod),
+  );
   const obsoleteSecretNames = getConnectorSecretNames(
     args.type,
     args.existingAuthMethod,
   ).filter((name) => {
-    return !oauthSecretNames.has(name);
+    return !targetSecretNames.has(name);
   });
-  const oauthVariableNames = new Set(
-    getConnectorVariableNames(args.type, "oauth"),
+  const targetVariableNames = new Set(
+    getConnectorVariableNames(args.type, args.authMethod),
   );
   const obsoleteVariableNames = getConnectorVariableNames(
     args.type,
     args.existingAuthMethod,
   ).filter((name) => {
-    return !oauthVariableNames.has(name);
+    return !targetVariableNames.has(name);
   });
   await deleteConnectorScopedSecretNames(db, {
     orgId: args.orgId,
@@ -1441,6 +1455,7 @@ export const upsertOAuthConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly type: ConnectorAuthProviderType;
+      readonly authMethod: ConnectorAuthMethodId;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];
@@ -1515,6 +1530,7 @@ export const upsertOAuthConnector$ = command(
         orgId: args.orgId,
         userId: args.userId,
         type: args.type,
+        authMethod: args.authMethod,
         userInfo: args.userInfo,
         oauthScopes: args.oauthScopes,
         tokenExpiresAt,
@@ -1525,6 +1541,7 @@ export const upsertOAuthConnector$ = command(
         orgId: args.orgId,
         userId: args.userId,
         type: args.type,
+        authMethod: args.authMethod,
         existingAuthMethod,
         signal,
       });

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -8,7 +8,7 @@ import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zer
 import {
   connectorAuthMethodSupportsTokenRevoke,
   getAvailableConnectorAuthMethods,
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
@@ -547,7 +547,7 @@ async function loadPendingConnectorTokenRevoke(args: {
 async function revokePendingConnectorToken(args: {
   readonly pending: PendingConnectorTokenRevoke;
 }): Promise<void> {
-  const authClient = getConnectorAuthMethodClient(
+  const authClient = resolveConnectorAuthClientForMethod(
     args.pending.type,
     args.pending.authMethod,
     optionalEnv,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -36,7 +36,7 @@ import {
   hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthCodeGrantConfig,
   getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodClient,
+  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorDeviceAuthGrantConfig,
@@ -88,7 +88,7 @@ const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
 
 function getOauthAuthClient(type: ConnectorType, readEnv: ConnectorEnvReader) {
-  return getConnectorAuthMethodClient(type, "oauth", readEnv);
+  return resolveConnectorAuthClientForMethod(type, "oauth", readEnv);
 }
 
 beforeAll(() => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -36,12 +36,12 @@ import {
   hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthCodeGrantConfig,
   getConnectorAuthMethodAccessMetadata,
+  getConnectorAuthMethodClient,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorDeviceAuthGrantConfig,
   getConnectorTypeForSecretName,
   getConnectorEnvBindings,
-  getConnectorOAuthClient,
   getConnectorOAuthScopes,
   getConnectorManualGrantFieldNames,
   getRuntimeAvailableConnectorTypes,
@@ -49,9 +49,10 @@ import {
   getConnectorVariableNames,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
-  isStaticConfidentialConnectorOAuthClient,
-  isStaticConnectorOAuthClient,
+  isStaticConfidentialConnectorAuthClient,
+  isStaticConnectorAuthClient,
   isGoogleOAuthConnector,
+  type ConnectorEnvReader,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
@@ -85,6 +86,10 @@ function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
 
 const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
+
+function getOauthAuthClient(type: ConnectorType, readEnv: ConnectorEnvReader) {
+  return getConnectorAuthMethodClient(type, "oauth", readEnv);
+}
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
@@ -464,7 +469,7 @@ describe("connector grant provider capability checks", () => {
   });
 
   it("rejects refresh for OAuth connectors without refresh-token access", async () => {
-    const oauthClient = getConnectorOAuthClient("github", (name) => {
+    const oauthClient = getOauthAuthClient("github", (name) => {
       if (name === "GH_OAUTH_CLIENT_ID") {
         return "test-github-client";
       }
@@ -489,7 +494,7 @@ describe("connector grant provider capability checks", () => {
   });
 
   it("revokes OAuth tokens through the provider registry", async () => {
-    const oauthClient = getConnectorOAuthClient("github", (name) => {
+    const oauthClient = getOauthAuthClient("github", (name) => {
       if (name === "GH_OAUTH_CLIENT_ID") {
         return "test-github-client";
       }
@@ -520,7 +525,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       revokeConnectorOAuthToken({
         type: "github",
-        oauthClient,
+        authClient: oauthClient,
         loadAccessToken: () => {
           return "gh-access-token";
         },
@@ -533,7 +538,7 @@ describe("connector grant provider capability checks", () => {
   });
 
   it("returns unsupported for OAuth connectors without revoke support", async () => {
-    const oauthClient = getConnectorOAuthClient("notion", (name) => {
+    const oauthClient = getOauthAuthClient("notion", (name) => {
       if (name === "NOTION_OAUTH_CLIENT_ID") {
         return "test-notion-client";
       }
@@ -553,7 +558,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       revokeConnectorOAuthToken({
         type: "notion",
-        oauthClient,
+        authClient: oauthClient,
         loadAccessToken: () => {
           loadedAccessToken = true;
           return "notion-access-token";
@@ -578,7 +583,7 @@ describe("connector grant provider capability checks", () => {
       );
 
       for (const type of providerTypes) {
-        const oauthClient = getConnectorOAuthClient(type, () => {
+        const oauthClient = getOauthAuthClient(type, () => {
           return "test-client-credential";
         });
         expect(oauthClient, `${type}: OAuth client`).toBeDefined();
@@ -587,7 +592,7 @@ describe("connector grant provider capability checks", () => {
         }
         const authResult = await buildConnectorOAuthAuthUrl({
           type,
-          oauthClient,
+          authClient: oauthClient,
           redirectUri: "https://app.test/callback",
           state: "state-123",
         });
@@ -678,7 +683,7 @@ describe("connector grant provider capability checks", () => {
       }),
     );
 
-    const oauthClient = getConnectorOAuthClient("test-oauth-device", () => {
+    const oauthClient = getOauthAuthClient("test-oauth-device", () => {
       return undefined;
     });
     expect(oauthClient).toBeDefined();
@@ -689,7 +694,7 @@ describe("connector grant provider capability checks", () => {
 
     const startResult = await startConnectorOAuthDeviceAuth({
       type: "test-oauth-device",
-      oauthClient,
+      authClient: oauthClient,
     });
     expect(startResult).toStrictEqual({
       deviceCode: "test-device:test-oauth-device-client:read",
@@ -704,21 +709,21 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "slow-down",
       }),
     ).resolves.toStrictEqual({ status: "slow_down" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "denied",
       }),
     ).resolves.toStrictEqual({
@@ -729,7 +734,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "expired",
       }),
     ).resolves.toStrictEqual({
@@ -740,7 +745,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "error",
       }),
     ).resolves.toStrictEqual({
@@ -751,7 +756,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "invalid-grant",
       }),
     ).resolves.toStrictEqual({
@@ -762,7 +767,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "test-oauth-device",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: startResult.deviceCode,
       }),
     ).resolves.toStrictEqual({
@@ -881,7 +886,7 @@ describe("connector grant provider capability checks", () => {
       }),
     );
 
-    const oauthClient = getConnectorOAuthClient("base44", () => {
+    const oauthClient = getOauthAuthClient("base44", () => {
       return undefined;
     });
     expect(oauthClient).toBeDefined();
@@ -893,7 +898,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       startConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
       }),
     ).resolves.toStrictEqual({
       deviceCode: "base44-device-code",
@@ -908,21 +913,21 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "slow-down",
       }),
     ).resolves.toStrictEqual({ status: "slow_down" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "denied",
       }),
     ).resolves.toStrictEqual({
@@ -933,7 +938,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "expired",
       }),
     ).resolves.toStrictEqual({
@@ -944,7 +949,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "temporarily-unavailable",
       }),
     ).resolves.toStrictEqual({
@@ -955,7 +960,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "base44",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "base44-device-code",
       }),
     ).resolves.toStrictEqual({
@@ -1161,7 +1166,7 @@ describe("connector grant provider capability checks", () => {
       ),
     );
 
-    const oauthClient = getConnectorOAuthClient("slock", () => {
+    const oauthClient = getOauthAuthClient("slock", () => {
       return undefined;
     });
     expect(oauthClient).toBeDefined();
@@ -1173,7 +1178,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       startConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
       }),
     ).resolves.toStrictEqual({
       deviceCode: "slock-device-code",
@@ -1187,14 +1192,14 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "denied",
       }),
     ).resolves.toStrictEqual({
@@ -1205,7 +1210,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "expired",
       }),
     ).resolves.toStrictEqual({
@@ -1216,7 +1221,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "no-servers",
       }),
     ).resolves.toStrictEqual({
@@ -1227,7 +1232,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "missing-refresh",
       }),
     ).resolves.toMatchObject({
@@ -1237,7 +1242,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "server-error",
       }),
     ).resolves.toStrictEqual({
@@ -1249,7 +1254,7 @@ describe("connector grant provider capability checks", () => {
     await expect(
       pollConnectorOAuthDeviceAuth({
         type: "slock",
-        oauthClient,
+        authClient: oauthClient,
         deviceCode: "userinfo-error",
       }),
     ).resolves.toStrictEqual({
@@ -1260,7 +1265,7 @@ describe("connector grant provider capability checks", () => {
     });
     const completeResult = await pollConnectorOAuthDeviceAuth({
       type: "slock",
-      oauthClient,
+      authClient: oauthClient,
       deviceCode: "slock-device-code",
     });
     expect(completeResult).toMatchObject({
@@ -1294,7 +1299,7 @@ describe("connector grant provider capability checks", () => {
 
     const malformedCompleteResult = await pollConnectorOAuthDeviceAuth({
       type: "slock",
-      oauthClient,
+      authClient: oauthClient,
       deviceCode: "malformed-token",
     });
     expect(malformedCompleteResult).toMatchObject({
@@ -1757,7 +1762,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("derives static confidential OAuth client from connector config", () => {
-    const oauthClient = getConnectorOAuthClient("github", (name) => {
+    const oauthClient = getOauthAuthClient("github", (name) => {
       return (
         {
           GH_OAUTH_CLIENT_ID: "github-client-id",
@@ -1775,7 +1780,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("does not configure static confidential OAuth when the secret is missing", () => {
-    const oauthClient = getConnectorOAuthClient("github", (name) => {
+    const oauthClient = getOauthAuthClient("github", (name) => {
       return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
     });
 
@@ -1783,7 +1788,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("supports literal static OAuth clients without runtime OAuth client env", () => {
-    const oauthClient = getConnectorOAuthClient("test-oauth", emptyEnv);
+    const oauthClient = getOauthAuthClient("test-oauth", emptyEnv);
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -1794,7 +1799,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("supports static public OAuth clients with only a client id", () => {
-    const oauthClient = getConnectorOAuthClient("test-oauth-device", emptyEnv);
+    const oauthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -1804,7 +1809,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("identifies static OAuth client variants", () => {
-    const staticOAuthClient = getConnectorOAuthClient("github", (name) => {
+    const staticAuthClient = getOauthAuthClient("github", (name) => {
       return (
         {
           GH_OAUTH_CLIENT_ID: "github-client-id",
@@ -1812,31 +1817,28 @@ describe("getRuntimeAvailableConnectorTypes", () => {
         } as Record<string, string>
       )[name];
     });
-    if (!staticOAuthClient) {
+    if (!staticAuthClient) {
       throw new Error("Expected GitHub OAuth client");
     }
-    expect(isStaticConnectorOAuthClient(staticOAuthClient)).toBeTruthy();
+    expect(isStaticConnectorAuthClient(staticAuthClient)).toBeTruthy();
     expect(
-      isStaticConfidentialConnectorOAuthClient(staticOAuthClient),
+      isStaticConfidentialConnectorAuthClient(staticAuthClient),
     ).toBeTruthy();
-    if (isStaticConfidentialConnectorOAuthClient(staticOAuthClient)) {
-      const clientSecret: string = staticOAuthClient.clientSecret;
+    if (isStaticConfidentialConnectorAuthClient(staticAuthClient)) {
+      const clientSecret: string = staticAuthClient.clientSecret;
       expect(clientSecret).toBe("github-client-secret");
     }
 
-    const publicOAuthClient = getConnectorOAuthClient(
-      "test-oauth-device",
-      emptyEnv,
-    );
-    if (!publicOAuthClient) {
+    const publicAuthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
+    if (!publicAuthClient) {
       throw new Error("Expected public OAuth client");
     }
-    expect(isStaticConnectorOAuthClient(publicOAuthClient)).toBeTruthy();
+    expect(isStaticConnectorAuthClient(publicAuthClient)).toBeTruthy();
     expect(
-      isStaticConfidentialConnectorOAuthClient(publicOAuthClient),
+      isStaticConfidentialConnectorAuthClient(publicAuthClient),
     ).toBeFalsy();
-    if (isStaticConnectorOAuthClient(publicOAuthClient)) {
-      const clientId: string = publicOAuthClient.clientId;
+    if (isStaticConnectorAuthClient(publicAuthClient)) {
+      const clientId: string = publicAuthClient.clientId;
       expect(clientId).toBe("test-oauth-device-client");
     }
   });
@@ -1926,6 +1928,9 @@ describe("connector OAuth lifecycle grant helpers", () => {
       kind: "auth-code",
       tokenUrl: "https://github.com/login/oauth/access_token",
       scopes: ["repo", "project", "workflow"],
+    });
+    expect("client" in getConnectorAuthCodeGrantConfig("github")).toBe(false);
+    expect(method).toMatchObject({
       client: {
         clientRegistration: "static",
         clientType: "confidential",
@@ -1945,33 +1950,39 @@ describe("connector OAuth lifecycle grant helpers", () => {
       kind: "device-auth",
       deviceAuthUrl: "/api/test/oauth-provider/device/code",
       tokenUrl: "/api/test/oauth-provider/token",
+      scopes: ["read"],
+    });
+    expect(getConnectorAuthMethod("test-oauth-device", "oauth")).toMatchObject({
       client: {
         clientRegistration: "static",
         clientType: "public",
         clientId: "test-oauth-device-client",
       },
-      scopes: ["read"],
     });
     expect(getConnectorDeviceAuthGrantConfig("base44")).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://app.base44.com/oauth/device/code",
       tokenUrl: "https://app.base44.com/oauth/token",
+      scopes: ["apps:read", "apps:write", "offline"],
+    });
+    expect(getConnectorAuthMethod("base44", "oauth")).toMatchObject({
       client: {
         clientRegistration: "static",
         clientType: "public",
         clientId: "base44_cli",
       },
-      scopes: ["apps:read", "apps:write", "offline"],
     });
     expect(getConnectorDeviceAuthGrantConfig("slock")).toMatchObject({
       kind: "device-auth",
       deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
       tokenUrl: "https://api.slock.ai/api/auth/device/token",
+      scopes: [],
+    });
+    expect(getConnectorAuthMethod("slock", "oauth")).toMatchObject({
       client: {
         clientRegistration: "dynamic",
         clientType: "public",
       },
-      scopes: [],
     });
   });
 
@@ -2027,12 +2038,14 @@ describe("connector OAuth device authorization config", () => {
       kind: "device-auth",
       deviceAuthUrl: "/api/test/oauth-provider/device/code",
       tokenUrl: "/api/test/oauth-provider/token",
+      scopes: ["read"],
+    });
+    expect(getConnectorAuthMethod("test-oauth-device", "oauth")).toMatchObject({
       client: {
         clientRegistration: "static",
         clientType: "public",
         clientId: "test-oauth-device-client",
       },
-      scopes: ["read"],
     });
   });
 
@@ -2042,12 +2055,14 @@ describe("connector OAuth device authorization config", () => {
       kind: "device-auth",
       deviceAuthUrl: "https://app.base44.com/oauth/device/code",
       tokenUrl: "https://app.base44.com/oauth/token",
+      scopes: ["apps:read", "apps:write", "offline"],
+    });
+    expect(getConnectorAuthMethod("base44", "oauth")).toMatchObject({
       client: {
         clientRegistration: "static",
         clientType: "public",
         clientId: "base44_cli",
       },
-      scopes: ["apps:read", "apps:write", "offline"],
     });
   });
 
@@ -2057,11 +2072,13 @@ describe("connector OAuth device authorization config", () => {
       kind: "device-auth",
       deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
       tokenUrl: "https://api.slock.ai/api/auth/device/token",
+      scopes: [],
+    });
+    expect(getConnectorAuthMethod("slock", "oauth")).toMatchObject({
       client: {
         clientRegistration: "dynamic",
         clientType: "public",
       },
-      scopes: [],
     });
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -7,9 +7,9 @@ import type {
 import {
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   hasConnectorAuthCodeGrant,
-  isStaticConfidentialConnectorOAuthClient,
-  isStaticConnectorOAuthClient,
-  type ConnectorOAuthClient,
+  isStaticConfidentialConnectorAuthClient,
+  isStaticConnectorAuthClient,
+  type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   getAuthProviderSecretMetadata,
@@ -155,24 +155,24 @@ function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
 }
 
 function connectorAuthProviderClientArgs(
-  oauthClient: ConnectorOAuthClient,
+  authClient: ConnectorAuthClient,
 ): ConnectorAuthProviderClientArgs {
-  if (!isStaticConnectorOAuthClient(oauthClient)) {
+  if (!isStaticConnectorAuthClient(authClient)) {
     return {};
   }
-  if (isStaticConfidentialConnectorOAuthClient(oauthClient)) {
+  if (isStaticConfidentialConnectorAuthClient(authClient)) {
     return {
-      clientId: oauthClient.clientId,
-      clientSecret: oauthClient.clientSecret,
+      clientId: authClient.clientId,
+      clientSecret: authClient.clientSecret,
     };
   }
-  return { clientId: oauthClient.clientId };
+  return { clientId: authClient.clientId };
 }
 
 export function getConnectorAuthProviderClientArgs(
-  oauthClient: ConnectorOAuthClient,
+  authClient: ConnectorAuthClient,
 ): ConnectorAuthProviderClientArgs {
-  return connectorAuthProviderClientArgs(oauthClient);
+  return connectorAuthProviderClientArgs(authClient);
 }
 
 const AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS: AuthCodeConnectorOAuthProviderMap = {
@@ -279,14 +279,14 @@ export async function buildConnectorOAuthAuthUrl<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
   return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.buildAuthUrl({
-    ...connectorAuthProviderClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.authClient),
     redirectUri: args.redirectUri,
     state: args.state,
   } as ConnectorOAuthAuthorizeArgs<T>);
@@ -296,7 +296,7 @@ export async function exchangeConnectorOAuthCode<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -306,7 +306,7 @@ export async function exchangeConnectorOAuthCode<
   return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.exchangeCode({
-    ...connectorAuthProviderClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.authClient),
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,
@@ -319,13 +319,13 @@ export async function startConnectorOAuthDeviceAuth<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
 }): Promise<OAuthDeviceAuthStartResult> {
   const grant = getDeviceAuthGrantConfig(args.type);
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.startDeviceAuth({
-    ...connectorAuthProviderClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.authClient),
     scopes: grant.scopes,
   } as ConnectorOAuthDeviceAuthStartArgs<T>);
 }
@@ -334,13 +334,13 @@ export async function pollConnectorOAuthDeviceAuth<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
   return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
     args.type
   ].grant.pollDeviceAuth({
-    ...connectorAuthProviderClientArgs(args.oauthClient),
+    ...connectorAuthProviderClientArgs(args.authClient),
     deviceCode: args.deviceCode,
   } as ConnectorOAuthDeviceAuthPollArgs<T>);
 }
@@ -370,7 +370,7 @@ export async function revokeConnectorOAuthToken<
   T extends ConnectorAuthProviderType,
 >(args: {
   readonly type: T;
-  readonly oauthClient: ConnectorOAuthClient;
+  readonly authClient: ConnectorAuthClient;
   readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorOAuthRevokeResult> {
   const revoke = connectorRevokeProviderFor(args.type);
@@ -381,7 +381,7 @@ export async function revokeConnectorOAuthToken<
 
     case "token-revoke":
       await revoke.revokeToken({
-        ...connectorAuthProviderClientArgs(args.oauthClient),
+        ...connectorAuthProviderClientArgs(args.authClient),
         accessToken: await args.loadAccessToken(),
       } as ConnectorOAuthRevokeArgs<T>);
       return { status: "revoked" };

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getConnectorOAuthClient } from "../../../../connector-utils";
+import { getConnectorAuthMethodClient } from "../../../../connector-utils";
 import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
@@ -48,7 +48,7 @@ describe("connector/providers/google-ads", () => {
       };
 
       expect(
-        getConnectorOAuthClient("google-ads", (name) => {
+        getConnectorAuthMethodClient("google-ads", "oauth", (name) => {
           return env[name];
         }),
       ).toMatchObject({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getConnectorAuthMethodClient } from "../../../../connector-utils";
+import { resolveConnectorAuthClientForMethod } from "../../../../connector-utils";
 import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
@@ -48,7 +48,7 @@ describe("connector/providers/google-ads", () => {
       };
 
       expect(
-        getConnectorAuthMethodClient("google-ads", "oauth", (name) => {
+        resolveConnectorAuthClientForMethod("google-ads", "oauth", (name) => {
           return env[name];
         }),
       ).toMatchObject({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getConnectorOAuthClient } from "../../../../connector-utils";
+import { getConnectorAuthMethodClient } from "../../../../connector-utils";
 import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import {
   buildMetaAdsAuthorizationUrl,
@@ -160,7 +160,7 @@ describe("connector/providers/meta-ads", () => {
       };
 
       expect(
-        getConnectorOAuthClient("meta-ads", (name) => {
+        getConnectorAuthMethodClient("meta-ads", "oauth", (name) => {
           return env[name];
         }),
       ).toMatchObject({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getConnectorAuthMethodClient } from "../../../../connector-utils";
+import { resolveConnectorAuthClientForMethod } from "../../../../connector-utils";
 import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import {
   buildMetaAdsAuthorizationUrl,
@@ -160,7 +160,7 @@ describe("connector/providers/meta-ads", () => {
       };
 
       expect(
-        getConnectorAuthMethodClient("meta-ads", "oauth", (name) => {
+        resolveConnectorAuthClientForMethod("meta-ads", "oauth", (name) => {
           return env[name];
         }),
       ).toMatchObject({

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,6 +1,6 @@
 import type {
   CONNECTOR_TYPES,
-  ConnectorOAuthClientConfig,
+  ConnectorAuthClientConfig,
   ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
@@ -128,26 +128,26 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorOAuthClientFor<T extends ConnectorAuthProviderType> = {
+type ConnectorAuthClientFor<T extends ConnectorAuthProviderType> = {
   [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
+    readonly client: infer Client;
     readonly grant: {
       readonly kind: "auth-code" | "device-auth";
-      readonly client: infer Client;
     };
   }
     ? Client
     : never;
 }[keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]] &
-  ConnectorOAuthClientConfig;
+  ConnectorAuthClientConfig;
 
 type NoClientCredentialArgs = Record<never, never>;
 
-type StaticClientIdArgs<Client extends ConnectorOAuthClientConfig> =
+type StaticClientIdArgs<Client extends ConnectorAuthClientConfig> =
   Client extends { readonly clientRegistration: "static" }
     ? { readonly clientId: string }
     : NoClientCredentialArgs;
 
-type TokenCredentialArgs<Client extends ConnectorOAuthClientConfig> =
+type TokenCredentialArgs<Client extends ConnectorAuthClientConfig> =
   Client extends {
     readonly clientRegistration: "static";
     readonly clientType: "confidential";
@@ -161,23 +161,23 @@ type TokenCredentialArgs<Client extends ConnectorOAuthClientConfig> =
       : NoClientCredentialArgs;
 
 export type ConnectorOAuthAuthorizeArgs<T extends ConnectorAuthProviderType> =
-  OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
+  OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorAuthClientFor<T>>;
 
 export type ConnectorOAuthExchangeArgs<T extends ConnectorAuthProviderType> =
-  OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+  OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
 
 export type ConnectorOAuthRefreshArgs<T extends ConnectorAuthProviderType> =
-  OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+  OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
 
 export type ConnectorOAuthRevokeArgs<T extends ConnectorAuthProviderType> =
-  OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+  OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
 
 export type ConnectorOAuthDeviceAuthStartArgs<
   T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthStartFlowArgs &
-  StaticClientIdArgs<ConnectorOAuthClientFor<T>>;
+  StaticClientIdArgs<ConnectorAuthClientFor<T>>;
 
 export type ConnectorOAuthDeviceAuthPollArgs<
   T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthPollFlowArgs &
-  TokenCredentialArgs<ConnectorOAuthClientFor<T>>;
+  TokenCredentialArgs<ConnectorAuthClientFor<T>>;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -476,7 +476,7 @@ export function isStaticConfidentialConnectorAuthClient(
   );
 }
 
-export function getConnectorAuthMethodClientConfig(
+export function getConnectorAuthClientConfigForMethod(
   type: ConnectorType,
   authMethod: string,
 ): ConnectorAuthClientConfig | undefined {
@@ -529,12 +529,12 @@ export function resolveConnectorAuthClient(
   };
 }
 
-export function getConnectorAuthMethodClient(
+export function resolveConnectorAuthClientForMethod(
   type: ConnectorType,
   authMethod: string,
   readEnv: ConnectorEnvReader,
 ): ConnectorAuthClient | undefined {
-  const clientConfig = getConnectorAuthMethodClientConfig(type, authMethod);
+  const clientConfig = getConnectorAuthClientConfigForMethod(type, authMethod);
   if (!clientConfig) {
     return undefined;
   }
@@ -550,7 +550,7 @@ function hasRuntimeAvailableAuthMethod(
     switch (method?.grant.kind) {
       case "auth-code":
       case "device-auth": {
-        if (getConnectorAuthMethodClient(type, authMethod, readEnv)) {
+        if (resolveConnectorAuthClientForMethod(type, authMethod, readEnv)) {
           return true;
         }
         break;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -5,12 +5,12 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorAccessConfig,
   type ConnectorAuthCodeGrantConfig,
+  type ConnectorAuthClientConfig,
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorEnvBindings,
   type ConnectorGenerationType,
   type ConnectorGrantConfig,
   type ConnectorGrantKind,
-  type ConnectorOAuthClientConfig,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type ConnectorAuthProviderType,
@@ -435,63 +435,58 @@ export function getAvailableConnectorAuthMethods(
 
 export type ConnectorEnvReader = (name: string) => string | undefined;
 
-export type StaticConfidentialConnectorOAuthClient = {
+export type StaticConfidentialConnectorAuthClient = {
   readonly clientRegistration: "static";
   readonly clientType: "confidential";
   readonly clientId: string;
   readonly clientSecret: string;
 };
 
-export type StaticPublicConnectorOAuthClient = {
+export type StaticPublicConnectorAuthClient = {
   readonly clientRegistration: "static";
   readonly clientType: "public";
   readonly clientId: string;
 };
 
-export type DynamicPublicConnectorOAuthClient = {
+export type DynamicPublicConnectorAuthClient = {
   readonly clientRegistration: "dynamic";
   readonly clientType: "public";
 };
 
-export type StaticConnectorOAuthClient =
-  | StaticConfidentialConnectorOAuthClient
-  | StaticPublicConnectorOAuthClient;
+export type StaticConnectorAuthClient =
+  | StaticConfidentialConnectorAuthClient
+  | StaticPublicConnectorAuthClient;
 
-export type ConnectorOAuthClient =
-  | StaticConnectorOAuthClient
-  | DynamicPublicConnectorOAuthClient;
+export type ConnectorAuthClient =
+  | StaticConnectorAuthClient
+  | DynamicPublicConnectorAuthClient;
 
-export function isStaticConnectorOAuthClient(
-  oauthClient: ConnectorOAuthClient,
-): oauthClient is StaticConnectorOAuthClient {
-  return oauthClient.clientRegistration === "static";
+export function isStaticConnectorAuthClient(
+  authClient: ConnectorAuthClient,
+): authClient is StaticConnectorAuthClient {
+  return authClient.clientRegistration === "static";
 }
 
-export function isStaticConfidentialConnectorOAuthClient(
-  oauthClient: ConnectorOAuthClient,
-): oauthClient is StaticConfidentialConnectorOAuthClient {
+export function isStaticConfidentialConnectorAuthClient(
+  authClient: ConnectorAuthClient,
+): authClient is StaticConfidentialConnectorAuthClient {
   return (
-    isStaticConnectorOAuthClient(oauthClient) &&
-    oauthClient.clientType === "confidential"
+    isStaticConnectorAuthClient(authClient) &&
+    authClient.clientType === "confidential"
   );
 }
 
-function getConnectorOAuthClientConfig(
-  type: ConnectorAuthProviderType,
-): ConnectorOAuthClientConfig;
-function getConnectorOAuthClientConfig(
+export function getConnectorAuthMethodClientConfig(
   type: ConnectorType,
-): ConnectorOAuthClientConfig | undefined;
-function getConnectorOAuthClientConfig(
-  type: ConnectorType,
-): ConnectorOAuthClientConfig | undefined {
-  return getConnectorOAuthGrantConfig(type)?.client;
+  authMethod: string,
+): ConnectorAuthClientConfig | undefined {
+  return getConnectorAuthMethod(type, authMethod)?.client;
 }
 
-function resolveConnectorOAuthClient(
-  client: ConnectorOAuthClientConfig,
+export function resolveConnectorAuthClient(
+  client: ConnectorAuthClientConfig,
   readEnv: ConnectorEnvReader,
-): ConnectorOAuthClient | undefined {
+): ConnectorAuthClient | undefined {
   if (client.clientRegistration === "dynamic") {
     return { clientRegistration: "dynamic", clientType: "public" };
   }
@@ -534,22 +529,42 @@ function resolveConnectorOAuthClient(
   };
 }
 
-export function getConnectorOAuthClient(
+export function getConnectorAuthMethodClient(
   type: ConnectorType,
+  authMethod: string,
   readEnv: ConnectorEnvReader,
-): ConnectorOAuthClient | undefined {
-  const client = getConnectorOAuthClientConfig(type);
-  if (!client) {
+): ConnectorAuthClient | undefined {
+  const clientConfig = getConnectorAuthMethodClientConfig(type, authMethod);
+  if (!clientConfig) {
     return undefined;
   }
-  return resolveConnectorOAuthClient(client, readEnv);
+  return resolveConnectorAuthClient(clientConfig, readEnv);
 }
 
-function hasConfiguredOAuth(
+function hasRuntimeAvailableAuthMethod(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
-  return getConnectorOAuthClient(type, readEnv) !== undefined;
+  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+    const method = getConnectorAuthMethod(type, authMethod);
+    switch (method?.grant.kind) {
+      case "auth-code":
+      case "device-auth": {
+        if (getConnectorAuthMethodClient(type, authMethod, readEnv)) {
+          return true;
+        }
+        break;
+      }
+      case "manual": {
+        return true;
+      }
+      case "managed":
+      case undefined: {
+        break;
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -557,8 +572,8 @@ function hasConfiguredOAuth(
  *
  * This is not user connected state and it does not evaluate feature switches.
  * It includes connectors with user-entered manual grant methods because they
- * do not require a server OAuth client, while OAuth connectors require their
- * runtime OAuth client env to exist unless their client config is static inline.
+ * do not require a server auth client, while auth-provider methods require
+ * their runtime client env to exist unless their client config is static inline.
  */
 export function getRuntimeAvailableConnectorTypes(
   readEnv: ConnectorEnvReader,
@@ -566,12 +581,7 @@ export function getRuntimeAvailableConnectorTypes(
   const runtimeAvailable = new Set<ConnectorType>();
 
   for (const type of CONNECTOR_TYPE_KEYS) {
-    if (
-      hasConfiguredOAuth(readEnv, type) ||
-      connectorAuthMethodValues(type).some((method) => {
-        return method.grant.kind === "manual";
-      })
-    ) {
+    if (hasRuntimeAvailableAuthMethod(readEnv, type)) {
       runtimeAvailable.add(type);
     }
   }

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -259,7 +259,7 @@ export interface ConnectorManualGrantFieldConfig {
   storage?: "secret" | "variable";
 }
 
-export type ConnectorOAuthClientConfig =
+export type ConnectorAuthClientConfig =
   | {
       readonly clientRegistration: "static";
       readonly clientType: "confidential";
@@ -287,33 +287,33 @@ export type ConnectorOAuthClientConfig =
       readonly clientType: "public";
     };
 
-export type StaticConfidentialConnectorOAuthClientConfig = Extract<
-  ConnectorOAuthClientConfig,
+export type StaticConfidentialConnectorAuthClientConfig = Extract<
+  ConnectorAuthClientConfig,
   {
     readonly clientRegistration: "static";
     readonly clientType: "confidential";
   }
 >;
 
-export type StaticPublicConnectorOAuthClientConfig = Extract<
-  ConnectorOAuthClientConfig,
+export type StaticPublicConnectorAuthClientConfig = Extract<
+  ConnectorAuthClientConfig,
   {
     readonly clientRegistration: "static";
     readonly clientType: "public";
   }
 >;
 
-export type DynamicPublicConnectorOAuthClientConfig = Extract<
-  ConnectorOAuthClientConfig,
+export type DynamicPublicConnectorAuthClientConfig = Extract<
+  ConnectorAuthClientConfig,
   {
     readonly clientRegistration: "dynamic";
     readonly clientType: "public";
   }
 >;
 
-export type PublicConnectorOAuthClientConfig =
-  | StaticPublicConnectorOAuthClientConfig
-  | DynamicPublicConnectorOAuthClientConfig;
+export type PublicConnectorAuthClientConfig =
+  | StaticPublicConnectorAuthClientConfig
+  | DynamicPublicConnectorAuthClientConfig;
 
 export type ConnectorGrantKind =
   | "manual"
@@ -329,7 +329,6 @@ export interface ConnectorManualGrantConfig {
 export interface ConnectorAuthCodeGrantConfig {
   readonly kind: "auth-code";
   readonly tokenUrl: string;
-  readonly client: ConnectorOAuthClientConfig;
   readonly scopes: string[];
 }
 
@@ -337,7 +336,6 @@ export interface ConnectorDeviceAuthGrantConfig {
   readonly kind: "device-auth";
   readonly deviceAuthUrl: string;
   readonly tokenUrl: string;
-  readonly client: PublicConnectorOAuthClientConfig;
   readonly scopes: string[];
 }
 
@@ -386,20 +384,37 @@ export type ConnectorRevokeConfig =
       readonly kind: "token-revoke";
     };
 
-/**
- * Auth method configuration for user-selectable connector connection flows.
- */
-export interface ConnectorAuthMethodConfig {
+interface ConnectorAuthMethodConfigBase {
   label: string;
   helpText?: string;
   /** When set, this auth method is only available while the feature is enabled. */
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */
   showExperimentalLabel?: boolean;
-  readonly grant: ConnectorGrantConfig;
-  readonly access: ConnectorAccessConfig;
-  readonly revoke: ConnectorRevokeConfig;
 }
+
+/**
+ * Auth method configuration for user-selectable connector connection flows.
+ */
+export type ConnectorAuthMethodConfig =
+  | (ConnectorAuthMethodConfigBase & {
+      readonly client: ConnectorAuthClientConfig;
+      readonly grant: ConnectorAuthCodeGrantConfig;
+      readonly access: ConnectorAccessConfig;
+      readonly revoke: ConnectorRevokeConfig;
+    })
+  | (ConnectorAuthMethodConfigBase & {
+      readonly client: PublicConnectorAuthClientConfig;
+      readonly grant: ConnectorDeviceAuthGrantConfig;
+      readonly access: ConnectorAccessConfig;
+      readonly revoke: ConnectorRevokeConfig;
+    })
+  | (ConnectorAuthMethodConfigBase & {
+      readonly client?: ConnectorAuthClientConfig;
+      readonly grant: ConnectorManualGrantConfig | ConnectorManagedGrantConfig;
+      readonly access: ConnectorAccessConfig;
+      readonly revoke: ConnectorRevokeConfig;
+    });
 
 /**
  * Connector auth method ids exposed as configured connection flows.

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -426,6 +426,14 @@ export type ConnectorAuthMethodId = "oauth" | "api-token" | "api";
 
 type AssertNever<T extends never> = T;
 
+type IsUnion<T, U = T> = [T] extends [never]
+  ? false
+  : T extends unknown
+    ? [U] extends [T]
+      ? false
+      : true
+    : false;
+
 export type ConnectorDisplayCategory =
   | "ai-general-models"
   | "ai-image-video"
@@ -924,6 +932,33 @@ type InvalidAuthMethodRevokeKindConnectorType = {
 }[ConnectorType];
 export type ConnectorAuthMethodRevokeKindsMatchKeys =
   AssertNever<InvalidAuthMethodRevokeKindConnectorType>;
+
+type ConnectorAuthMethodIdsByGrantKind<
+  Type extends ConnectorType,
+  Kind extends ConnectorGrantKind,
+> = {
+  [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
+    readonly grant: { readonly kind: Kind };
+  }
+    ? Method
+    : never;
+}[ConnectorAuthMethodKeys<Type>];
+
+type ConnectorTypeWithMultipleAuthMethodsForGrantKind<
+  Kind extends ConnectorGrantKind,
+> = {
+  [Type in ConnectorType]: IsUnion<
+    ConnectorAuthMethodIdsByGrantKind<Type, Kind>
+  > extends true
+    ? Type
+    : never;
+}[ConnectorType];
+export type ConnectorAuthCodeGrantMethodsAreSingle = AssertNever<
+  ConnectorTypeWithMultipleAuthMethodsForGrantKind<"auth-code">
+>;
+export type ConnectorDeviceAuthGrantMethodsAreSingle = AssertNever<
+  ConnectorTypeWithMultipleAuthMethodsForGrantKind<"device-auth">
+>;
 
 export type ConnectorTypesByGrantKind<Kind extends ConnectorGrantKind> = {
   [Type in ConnectorType]: {

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -12,15 +12,15 @@ export const ahrefs = {
         featureFlag: FeatureSwitchKey.AhrefsConnector,
         label: "OAuth",
         helpText: "Sign in with Ahrefs to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "AHREFS_OAUTH_CLIENT_ID",
+          clientSecretEnv: "AHREFS_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://app.ahrefs.com/api/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "AHREFS_OAUTH_CLIENT_ID",
-            clientSecretEnv: "AHREFS_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["api"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -10,15 +10,15 @@ export const airtable = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Airtable to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "AIRTABLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "AIRTABLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://airtable.com/oauth2/v1/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "AIRTABLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "AIRTABLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "data.records:read",
             "data.records:write",

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -10,15 +10,15 @@ export const asana = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Asana to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "ASANA_OAUTH_CLIENT_ID",
+          clientSecretEnv: "ASANA_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://app.asana.com/-/oauth_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "ASANA_OAUTH_CLIENT_ID",
-            clientSecretEnv: "ASANA_OAUTH_CLIENT_SECRET",
-          },
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/base44.ts
+++ b/turbo/packages/connectors/src/connectors/base44.ts
@@ -10,15 +10,15 @@ export const base44 = {
       oauth: {
         label: "OAuth",
         helpText: "Sign in with Base44 to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "public",
+          clientId: "base44_cli",
+        },
         grant: {
           kind: "device-auth",
           deviceAuthUrl: "https://app.base44.com/oauth/device/code",
           tokenUrl: "https://app.base44.com/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "public",
-            clientId: "base44_cli",
-          },
           scopes: ["apps:read", "apps:write", "offline"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -12,15 +12,15 @@ export const canva = {
         featureFlag: FeatureSwitchKey.CanvaConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Canva to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "CANVA_OAUTH_CLIENT_ID",
+          clientSecretEnv: "CANVA_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.canva.com/rest/v1/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "CANVA_OAUTH_CLIENT_ID",
-            clientSecretEnv: "CANVA_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "asset:read",
             "asset:write",

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -12,15 +12,15 @@ export const close = {
         featureFlag: FeatureSwitchKey.CloseConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Close to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "CLOSE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "CLOSE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.close.com/oauth2/token/",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "CLOSE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "CLOSE_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["all.full_access", "offline_access"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -12,15 +12,15 @@ export const deel = {
         featureFlag: FeatureSwitchKey.DeelConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Deel to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "DEEL_OAUTH_CLIENT_ID",
+          clientSecretEnv: "DEEL_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://app.deel.com/oauth2/tokens",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "DEEL_OAUTH_CLIENT_ID",
-            clientSecretEnv: "DEEL_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "contracts:read",
             "people:read",

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -12,15 +12,15 @@ export const docusign = {
         featureFlag: FeatureSwitchKey.DocuSignConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with DocuSign to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "DOCUSIGN_OAUTH_CLIENT_ID",
+          clientSecretEnv: "DOCUSIGN_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://account-d.docusign.com/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "DOCUSIGN_OAUTH_CLIENT_ID",
-            clientSecretEnv: "DOCUSIGN_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["signature", "extended", "openid"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -11,15 +11,15 @@ export const dropbox = {
         featureFlag: FeatureSwitchKey.DropboxConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Dropbox to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "DROPBOX_OAUTH_CLIENT_ID",
+          clientSecretEnv: "DROPBOX_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.dropboxapi.com/oauth2/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "DROPBOX_OAUTH_CLIENT_ID",
-            clientSecretEnv: "DROPBOX_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "account_info.read",
             "files.metadata.read",

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -11,15 +11,15 @@ export const figma = {
         featureFlag: FeatureSwitchKey.FigmaConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Figma to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "FIGMA_OAUTH_CLIENT_ID",
+          clientSecretEnv: "FIGMA_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.figma.com/v1/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "FIGMA_OAUTH_CLIENT_ID",
-            clientSecretEnv: "FIGMA_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "current_user:read",
             "file_content:read",

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -12,15 +12,15 @@ export const garminConnect = {
         featureFlag: FeatureSwitchKey.GarminConnectConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Garmin Connect to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://diauth.garmin.com/di-oauth2-service/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
-          },
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -11,15 +11,15 @@ export const github = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with GitHub to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GH_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://github.com/login/oauth/access_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GH_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["repo", "project", "workflow"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -10,15 +10,15 @@ export const gmail = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Gmail access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["https://www.googleapis.com/auth/gmail.modify"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -12,15 +12,15 @@ export const googleAds = {
         showExperimentalLabel: false,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Ads access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "https://www.googleapis.com/auth/adwords",
             "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -11,15 +11,15 @@ export const googleCalendar = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Calendar access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "https://www.googleapis.com/auth/calendar",
             "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -9,15 +9,15 @@ export const googleDocs = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Docs access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "https://www.googleapis.com/auth/documents",
             "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -9,15 +9,15 @@ export const googleDrive = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Drive access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "https://www.googleapis.com/auth/drive",
             "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -10,15 +10,15 @@ export const googleMeet = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Meet access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "https://www.googleapis.com/auth/meetings.space.created",
             // Use meetings.space.readonly (not meetings.conferencerecords.readonly) — confirmed

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -9,15 +9,15 @@ export const googleSheets = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Sheets access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.googleapis.com/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "https://www.googleapis.com/auth/spreadsheets",
             "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -11,15 +11,15 @@ export const gumroad = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Gumroad to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "GUMROAD_OAUTH_CLIENT_ID",
+          clientSecretEnv: "GUMROAD_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://gumroad.com/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "GUMROAD_OAUTH_CLIENT_ID",
-            clientSecretEnv: "GUMROAD_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "view_profile",
             "edit_products",

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -10,15 +10,15 @@ export const hubspot = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with HubSpot to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "HUBSPOT_OAUTH_CLIENT_ID",
+          clientSecretEnv: "HUBSPOT_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.hubapi.com/oauth/v1/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "HUBSPOT_OAUTH_CLIENT_ID",
-            clientSecretEnv: "HUBSPOT_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "crm.objects.contacts.read",
             "crm.objects.contacts.write",

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -10,15 +10,15 @@ export const intervalsIcu = {
       oauth: {
         label: "OAuth",
         helpText: "Sign in with Intervals.icu to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "INTERVALS_ICU_OAUTH_CLIENT_ID",
+          clientSecretEnv: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://intervals.icu/api/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "INTERVALS_ICU_OAUTH_CLIENT_ID",
-            clientSecretEnv: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["ACTIVITY", "WELLNESS", "CALENDAR", "SETTINGS", "LIBRARY"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -10,15 +10,15 @@ export const linear = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Linear to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "LINEAR_OAUTH_CLIENT_ID",
+          clientSecretEnv: "LINEAR_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.linear.app/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "LINEAR_OAUTH_CLIENT_ID",
-            clientSecretEnv: "LINEAR_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "read",
             "write",

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -12,15 +12,15 @@ export const mailchimp = {
         featureFlag: FeatureSwitchKey.MailchimpConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Mailchimp to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "MAILCHIMP_OAUTH_CLIENT_ID",
+          clientSecretEnv: "MAILCHIMP_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://login.mailchimp.com/oauth2/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "MAILCHIMP_OAUTH_CLIENT_ID",
-            clientSecretEnv: "MAILCHIMP_OAUTH_CLIENT_SECRET",
-          },
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -12,15 +12,15 @@ export const mercury = {
         featureFlag: FeatureSwitchKey.MercuryConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Mercury to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "MERCURY_OAUTH_CLIENT_ID",
+          clientSecretEnv: "MERCURY_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.mercury.com/oauth2/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "MERCURY_OAUTH_CLIENT_ID",
-            clientSecretEnv: "MERCURY_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["offline_access"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -12,15 +12,15 @@ export const metaAds = {
         featureFlag: FeatureSwitchKey.MetaAdsConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Facebook to grant access to Ads Manager.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "META_ADS_OAUTH_CLIENT_ID",
+          clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "META_ADS_OAUTH_CLIENT_ID",
-            clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["ads_management", "ads_read", "business_management"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -10,15 +10,15 @@ export const monday = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Monday.com to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "MONDAY_OAUTH_CLIENT_ID",
+          clientSecretEnv: "MONDAY_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://auth.monday.com/oauth2/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "MONDAY_OAUTH_CLIENT_ID",
-            clientSecretEnv: "MONDAY_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "me:read",
             "boards:read",

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -12,15 +12,15 @@ export const neon = {
         featureFlag: FeatureSwitchKey.NeonConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Neon to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "NEON_OAUTH_CLIENT_ID",
+          clientSecretEnv: "NEON_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://oauth2.neon.tech/oauth2/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "NEON_OAUTH_CLIENT_ID",
-            clientSecretEnv: "NEON_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "openid",
             "offline_access",

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -10,15 +10,15 @@ export const notion = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Notion to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "NOTION_OAUTH_CLIENT_ID",
+          clientSecretEnv: "NOTION_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.notion.com/v1/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "NOTION_OAUTH_CLIENT_ID",
-            clientSecretEnv: "NOTION_OAUTH_CLIENT_SECRET",
-          },
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -12,16 +12,16 @@ export const outlookCalendar = {
         featureFlag: FeatureSwitchKey.OutlookCalendarConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Microsoft to grant Outlook Calendar access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
+          clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl:
             "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
-            clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["Calendars.ReadWrite", "User.Read", "offline_access"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -11,16 +11,16 @@ export const outlookMail = {
         featureFlag: FeatureSwitchKey.OutlookMailConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Microsoft to grant Outlook Mail access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
+          clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl:
             "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
-            clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "Mail.ReadWrite",
             "Mail.Send",

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -12,15 +12,15 @@ export const posthog = {
         featureFlag: FeatureSwitchKey.PosthogConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with PostHog to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "POSTHOG_OAUTH_CLIENT_ID",
+          clientSecretEnv: "POSTHOG_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://us.posthog.com/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "POSTHOG_OAUTH_CLIENT_ID",
-            clientSecretEnv: "POSTHOG_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "openid",
             "profile",

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -12,15 +12,15 @@ export const reddit = {
         featureFlag: FeatureSwitchKey.RedditConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Reddit to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "REDDIT_OAUTH_CLIENT_ID",
+          clientSecretEnv: "REDDIT_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://www.reddit.com/api/v1/access_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "REDDIT_OAUTH_CLIENT_ID",
-            clientSecretEnv: "REDDIT_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["identity", "read"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -10,15 +10,15 @@ export const sentry = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Sentry to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "SENTRY_OAUTH_CLIENT_ID",
+          clientSecretEnv: "SENTRY_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://sentry.io/oauth/token/",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "SENTRY_OAUTH_CLIENT_ID",
-            clientSecretEnv: "SENTRY_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "org:read",
             "project:read",

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -10,15 +10,15 @@ export const slack = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Slack to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "SLACK_OAUTH_CLIENT_ID",
+          clientSecretEnv: "SLACK_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://slack.com/api/oauth.v2.access",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "SLACK_OAUTH_CLIENT_ID",
-            clientSecretEnv: "SLACK_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             // Channels
             "channels:read",

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -12,14 +12,14 @@ export const slock = {
       oauth: {
         label: "OAuth Device Authorization",
         helpText: "Sign in with Slock using a device code.",
+        client: {
+          clientRegistration: "dynamic",
+          clientType: "public",
+        },
         grant: {
           kind: "device-auth",
           deviceAuthUrl: `${SLOCK_API_BASE_URL}/api/auth/device/authorize`,
           tokenUrl: `${SLOCK_API_BASE_URL}/api/auth/device/token`,
-          client: {
-            clientRegistration: "dynamic",
-            clientType: "public",
-          },
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -12,15 +12,15 @@ export const spotify = {
         featureFlag: FeatureSwitchKey.SpotifyConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Spotify to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "SPOTIFY_OAUTH_CLIENT_ID",
+          clientSecretEnv: "SPOTIFY_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://accounts.spotify.com/api/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "SPOTIFY_OAUTH_CLIENT_ID",
-            clientSecretEnv: "SPOTIFY_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "ugc-image-upload",
             "user-read-playback-state",

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -10,15 +10,15 @@ export const strava = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Strava to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "STRAVA_OAUTH_CLIENT_ID",
+          clientSecretEnv: "STRAVA_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://www.strava.com/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "STRAVA_OAUTH_CLIENT_ID",
-            clientSecretEnv: "STRAVA_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "read",
             "profile:read_all",

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -13,15 +13,15 @@ export const stripe = {
         featureFlag: FeatureSwitchKey.StripeConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Stripe to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "STRIPE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "STRIPE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://connect.stripe.com/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "STRIPE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "STRIPE_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["read_write"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -12,15 +12,15 @@ export const supabase = {
         featureFlag: FeatureSwitchKey.SupabaseConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Supabase to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "SUPABASE_OAUTH_CLIENT_ID",
+          clientSecretEnv: "SUPABASE_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.supabase.com/v1/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "SUPABASE_OAUTH_CLIENT_ID",
-            clientSecretEnv: "SUPABASE_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "organizations:read",
             "projects:read",

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -12,15 +12,15 @@ export const testOauthDevice = {
         featureFlag: FeatureSwitchKey.TestOauthConnector,
         label: "OAuth Device Authorization",
         helpText: "Test-only OAuth device provider.",
+        client: {
+          clientRegistration: "static",
+          clientType: "public",
+          clientId: "test-oauth-device-client",
+        },
         grant: {
           kind: "device-auth",
           deviceAuthUrl: "/api/test/oauth-provider/device/code",
           tokenUrl: "/api/test/oauth-provider/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "public",
-            clientId: "test-oauth-device-client",
-          },
           scopes: ["read"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -12,15 +12,15 @@ export const testOauth = {
         featureFlag: FeatureSwitchKey.TestOauthConnector,
         label: "OAuth",
         helpText: "Test-only OAuth provider. Only reachable in dev/preview.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientId: "test-oauth-client",
+          clientSecret: "test-oauth-secret",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "/api/test/oauth-provider/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientId: "test-oauth-client",
-            clientSecret: "test-oauth-secret",
-          },
           scopes: ["read"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -10,15 +10,15 @@ export const todoist = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Todoist to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "TODOIST_OAUTH_CLIENT_ID",
+          clientSecretEnv: "TODOIST_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://todoist.com/oauth/access_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "TODOIST_OAUTH_CLIENT_ID",
-            clientSecretEnv: "TODOIST_OAUTH_CLIENT_SECRET",
-          },
           scopes: ["data:read_write", "data:delete", "project:delete"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -10,15 +10,15 @@ export const vercel = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Vercel to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
+          clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
-            clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
-          },
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -12,15 +12,15 @@ export const webflow = {
         featureFlag: FeatureSwitchKey.WebflowConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Webflow to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "WEBFLOW_OAUTH_CLIENT_ID",
+          clientSecretEnv: "WEBFLOW_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.webflow.com/oauth/access_token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "WEBFLOW_OAUTH_CLIENT_ID",
-            clientSecretEnv: "WEBFLOW_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "authorized_user:read",
             "sites:read",

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -10,15 +10,15 @@ export const x = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with X to grant read access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "X_OAUTH_CLIENT_ID",
+          clientSecretEnv: "X_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.x.com/2/oauth2/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "X_OAUTH_CLIENT_ID",
-            clientSecretEnv: "X_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "tweet.read", // All the Tweets you can view, including Tweets from protected accounts.
             "tweet.write", // Tweet and Retweet for you.

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -10,15 +10,15 @@ export const xero = {
       oauth: {
         label: "OAuth (Recommended)",
         helpText: "Sign in with Xero to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "XERO_OAUTH_CLIENT_ID",
+          clientSecretEnv: "XERO_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://identity.xero.com/connect/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "XERO_OAUTH_CLIENT_ID",
-            clientSecretEnv: "XERO_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "openid",
             "profile",

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -12,15 +12,15 @@ export const zoom = {
         featureFlag: FeatureSwitchKey.ZoomConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Zoom to grant access.",
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: "ZOOM_OAUTH_CLIENT_ID",
+          clientSecretEnv: "ZOOM_OAUTH_CLIENT_SECRET",
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://zoom.us/oauth/token",
-          client: {
-            clientRegistration: "static",
-            clientType: "confidential",
-            clientIdEnv: "ZOOM_OAUTH_CLIENT_ID",
-            clientSecretEnv: "ZOOM_OAUTH_CLIENT_SECRET",
-          },
           scopes: [
             "user:read:user",
             "meeting:read:list_meetings",


### PR DESCRIPTION
## Summary
- Move connector auth client config from grant config to auth method config
- Resolve auth provider clients by connector type plus selected auth method across auth-code, device-auth, refresh, and revoke paths
- Update connector/provider tests for method-owned static confidential, static public, and dynamic public clients

Closes #15376

## Verification
- pnpm format
- pnpm check-types
- pnpm turbo run lint
- pnpm knip
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts