### PR TITLE
fix(cli): simplify html generate flags

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -88,35 +88,6 @@ describe("zero generate source-backed artifact commands", () => {
     },
   );
 
-  it("prints JSON metadata for mobile-app-design", async () => {
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "mobile-app-design",
-      "--prompt",
-      "A mobile review screen",
-      "--site-slug",
-      "mobile-review",
-      "--json",
-    ]);
-
-    const parsed = JSON.parse(output()) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      type: "generation-source-selection",
-      kind: "mobile-app-design",
-      prompt: "A mobile review screen",
-      outputDir: "./generated/mockups/mobile-review",
-      site: "mobile-review",
-      artifact: {
-        outputMode: "primary-artifact-with-supporting-assets",
-        primaryArtifact: {
-          kind: "mobile-app-design",
-          path: "./generated/mockups/mobile-review/index.html",
-        },
-      },
-    });
-  });
-
   it("exposes the shared HTML artifact flags in report help", () => {
     let helpOutput = "";
     reportCommand.configureOutput({
@@ -132,6 +103,7 @@ describe("zero generate source-backed artifact commands", () => {
     expect(helpOutput).toContain("--title <text>");
     expect(helpOutput).toContain("--design-system <id>");
     expect(helpOutput).toContain("--template <id>");
+    expect(helpOutput).not.toContain("--json");
     expect(helpOutput).not.toContain("--provider");
     expect(helpOutput).not.toContain("--all");
     expect(helpOutput).not.toContain("--audience");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import chalk from "chalk";
 import { generateCommand } from "../index";
+import { reportCommand } from "../artifacts";
 import { selectResourceCandidates } from "../../shared/resource-registry";
 
 describe("zero generate source-backed artifact commands", () => {
@@ -114,6 +115,27 @@ describe("zero generate source-backed artifact commands", () => {
         },
       },
     });
+  });
+
+  it("exposes the shared HTML artifact flags in report help", () => {
+    let helpOutput = "";
+    reportCommand.configureOutput({
+      writeOut: (str: string) => {
+        helpOutput += str;
+      },
+    });
+
+    reportCommand.outputHelp();
+
+    expect(helpOutput).toContain("--prompt <text>");
+    expect(helpOutput).toContain("--site-slug <slug>");
+    expect(helpOutput).toContain("--title <text>");
+    expect(helpOutput).toContain("--design-system <id>");
+    expect(helpOutput).toContain("--template <id>");
+    expect(helpOutput).not.toContain("--provider");
+    expect(helpOutput).not.toContain("--all");
+    expect(helpOutput).not.toContain("--audience");
+    expect(helpOutput).not.toContain("--site <slug>");
   });
 
   it("returns every registered skill grouped by kind", () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
@@ -285,41 +285,6 @@ describe("zero generate image command", () => {
     expect(stdout).toContain("Provider: fal");
   });
 
-  it("should print JSON metadata when --json is provided", async () => {
-    server.use(
-      http.post(IMAGE_URL, () => {
-        return HttpResponse.json(IMAGE_RESULT);
-      }),
-    );
-
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "image",
-      "--skip-style",
-      "--prompt",
-      "JSON please",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      id: IMAGE_RESULT.id,
-      filename: IMAGE_RESULT.filename,
-      contentType: "image/png",
-      size: IMAGE_RESULT.size,
-      url: IMAGE_RESULT.url,
-      creditsCharged: 65,
-      model: IMAGE_RESULT.model,
-      provider: "fal",
-      imageSize: "1024x1024",
-      quality: "medium",
-      outputFormat: "png",
-      moderation: "auto",
-    });
-  });
-
   it("should print styled image resource selection instructions with --style", async () => {
     await generateCommand.parseAsync([
       "node",
@@ -342,75 +307,6 @@ describe("zero generate image command", () => {
     expect(stdout).toContain("vm0-ai/vm0-skills");
     expect(stdout).toContain("notion-illustration");
     expect(stdout).toContain("## Stage 3: Generate Image");
-  });
-
-  it("should lock the selected style in the JSON packet candidate slice", async () => {
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "image",
-      "--style",
-      "image-style:notion-illustration",
-      "--prompt",
-      "Notion illustration of a product manager mapping a launch plan",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      type: "generation-source-selection",
-      kind: "image",
-      prompt: "Notion illustration of a product manager mapping a launch plan",
-      outputDir: "./generated/images",
-    });
-    const selection = parsed.selection as {
-      candidates: { imageStyles: { id: string }[] };
-    };
-    expect(selection.candidates.imageStyles).toHaveLength(1);
-    expect(selection.candidates.imageStyles[0]).toEqual(
-      expect.objectContaining({
-        id: "image-style:notion-illustration",
-        source: {
-          repo: "vm0-ai/vm0-skills",
-          ref: "main",
-          path: "illustration-template/notion-illustration",
-        },
-      }),
-    );
-    expect(parsed.instructions).toEqual(
-      expect.stringContaining("## Stage 2: Resolve Selected Resources"),
-    );
-  });
-
-  it("should lock vm0 illustration when selected via --style", async () => {
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "image",
-      "--style",
-      "image-style:vm0-illustration",
-      "--prompt",
-      "vm0 style in-app illustration for an empty billing state",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    const selection = parsed.selection as {
-      candidates: { imageStyles: { id: string }[] };
-    };
-    expect(selection.candidates.imageStyles).toHaveLength(1);
-    expect(selection.candidates.imageStyles[0]).toEqual(
-      expect.objectContaining({
-        id: "image-style:vm0-illustration",
-        source: {
-          repo: "vm0-ai/vm0-skills",
-          ref: "main",
-          path: "illustration-template/vm0-illustration",
-        },
-      }),
-    );
   });
 
   it("should fail with style listing when neither --style nor --skip-style is provided", async () => {
@@ -549,6 +445,7 @@ describe("zero generate image command", () => {
     expect(helpOutput).toContain("Nano Banana 2 accepts up to 14");
     expect(helpOutput).toContain("--style <id>");
     expect(helpOutput).toContain("--skip-style");
+    expect(helpOutput).not.toContain("--json");
     expect(helpOutput).not.toContain("--styled ");
     expect(helpOutput).toContain("provider");
     expect(helpOutput).toContain("default");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -300,9 +300,7 @@ describe("zero generate lister", () => {
     expect(text).toContain("Built-in command:");
     expect(text).toContain("Built-in presentation generation");
     expect(text).toContain("Models: gpt-5.5");
-    expect(text).toContain(
-      "Use: zero generate presentation --provider built-in -h",
-    );
+    expect(text).toContain("Use: zero generate presentation -h");
     expect(text).not.toContain("Model: gpt-5.5");
     expect(text).not.toContain("Fallback option:");
     expect(text).not.toContain("Official provider:");
@@ -323,7 +321,7 @@ describe("zero generate lister", () => {
     expect(text).toContain("Built-in command:");
     expect(text).toContain("Built-in website generation");
     expect(text).toContain("Models: gpt-5.5");
-    expect(text).toContain("Use: zero generate website --provider built-in -h");
+    expect(text).toContain("Use: zero generate website -h");
     expect(text).toContain("Context:");
     expect(text).toContain(
       "Standalone static website artifacts can be authored locally and published with zero host for a public URL.",
@@ -349,11 +347,15 @@ describe("zero generate lister", () => {
 
     const json = JSON.parse(output()) as {
       builtInCommand: { command: string } | null;
+      builtInProvider: unknown;
+      builtInProviders: unknown[];
       generationContext: { lines: string[] } | null;
     };
     expect(json.builtInCommand).toMatchObject({
-      command: "zero generate website --provider built-in -h",
+      command: "zero generate website -h",
     });
+    expect(json.builtInProvider).toBeNull();
+    expect(json.builtInProviders).toEqual([]);
     expect(json.generationContext?.lines).toEqual(
       expect.arrayContaining([
         "Standalone static website artifacts can be authored locally and published with zero host for a public URL.",
@@ -390,7 +392,7 @@ describe("zero generate lister", () => {
     expect(text).toContain("Built-in command:");
     expect(text).toContain(commandLabel);
     expect(text).toContain("Models: gpt-5.5");
-    expect(text).toContain(`Use: zero generate ${type} --provider built-in -h`);
+    expect(text).toContain(`Use: zero generate ${type} -h`);
   });
 
   it("suggests the built-in voice command when no voice connector is ready", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -173,56 +173,6 @@ describe("zero generate lister", () => {
     );
   });
 
-  it("outputs machine-readable JSON", async () => {
-    server.use(
-      stubConnectors([connector("fal", "fal-user"), connector("replicate")]),
-      stubUserConnectors(["fal"]),
-    );
-
-    await generateCommand.parseAsync(["node", "cli", "image", "--json"]);
-
-    const json = JSON.parse(output()) as {
-      generationType: string;
-      agentId: string;
-      choices: Array<{ type: string; status: string }>;
-      otherCandidates: Array<{ type: string; status: string }>;
-    };
-    expect(json.generationType).toBe("image");
-    expect(json.agentId).toBe(AGENT_ID);
-    expect(json.choices).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ type: "fal", status: "ready" }),
-      ]),
-    );
-    expect(json.otherCandidates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "replicate",
-          status: "not-authorized",
-        }),
-      ]),
-    );
-    expect(json).toMatchObject({
-      builtInProvider: {
-        label: "Built-in fal.ai",
-        model: "gpt-image-1",
-        command:
-          "zero generate image --provider built-in --model gpt-image-1 -h",
-      },
-    });
-    expect(json).toMatchObject({
-      builtInProviders: expect.arrayContaining([
-        expect.objectContaining({ model: "gpt-image-1.5" }),
-        expect.objectContaining({ model: "fal-ai/flux-pro/v1.1" }),
-        expect.objectContaining({ model: "fal-ai/qwen-image" }),
-        expect.objectContaining({
-          model: "fal-ai/bytedance/seedream/v4/text-to-image",
-        }),
-        expect.objectContaining({ model: "fal-ai/nano-banana-2" }),
-      ]),
-    });
-  });
-
   it("does not mark runtime-configured but unavailable connectors as connectable", async () => {
     server.use(
       stubConnectorsWithConfiguredTypes([], ["bentoml"]),
@@ -230,25 +180,12 @@ describe("zero generate lister", () => {
       stubUserConnectors([]),
     );
 
-    await generateCommand.parseAsync(["node", "cli", "text", "--json"]);
+    await generateCommand.parseAsync(["node", "cli", "text", "--all"]);
 
-    const json = JSON.parse(output()) as {
-      otherCandidates: Array<{
-        type: string;
-        status: string;
-        reason: string;
-        actionUrl?: string;
-      }>;
-    };
-    const bentoml = json.otherCandidates.find((candidate) => {
-      return candidate.type === "bentoml";
-    });
-    expect(bentoml).toMatchObject({
-      type: "bentoml",
-      status: "not-available",
-      reason: "not available for this account",
-    });
-    expect(bentoml?.actionUrl).toBeUndefined();
+    const text = output();
+    expect(text).toContain("bentoml");
+    expect(text).toContain("not available for this account");
+    expect(text).not.toContain("/connectors/bentoml");
   });
 
   it("suggests the built-in video command when no video connector is ready", async () => {
@@ -337,33 +274,6 @@ describe("zero generate lister", () => {
     expect(text).not.toContain("Official provider:");
   });
 
-  it("includes website context in machine-readable JSON", async () => {
-    server.use(
-      stubConnectorsWithConfiguredTypes([], []),
-      stubUserConnectors([]),
-    );
-
-    await generateCommand.parseAsync(["node", "cli", "website", "--json"]);
-
-    const json = JSON.parse(output()) as {
-      builtInCommand: { command: string } | null;
-      builtInProvider: unknown;
-      builtInProviders: unknown[];
-      generationContext: { lines: string[] } | null;
-    };
-    expect(json.builtInCommand).toMatchObject({
-      command: "zero generate website -h",
-    });
-    expect(json.builtInProvider).toBeNull();
-    expect(json.builtInProviders).toEqual([]);
-    expect(json.generationContext?.lines).toEqual(
-      expect.arrayContaining([
-        "Standalone static website artifacts can be authored locally and published with zero host for a public URL.",
-        "zero host is for static directories with index.html; it is not a general deploy system for apps that need a backend, database, worker, or long-running process.",
-      ]),
-    );
-  });
-
   it.each([
     ["report", "Report", "Built-in report generation"],
     ["docs-design", "Docs design", "Built-in docs design generation"],
@@ -446,9 +356,31 @@ describe("zero generate lister", () => {
     expect(text).not.toContain("Model: gpt-4o-mini-tts");
   });
 
+  it("lists music as the public audio connector-backed subtype", async () => {
+    server.use(
+      stubConnectorsWithConfiguredTypes(
+        [connector("elevenlabs", "elevenlabs-user")],
+        ["elevenlabs", "minimax"],
+      ),
+      stubUserConnectors(["elevenlabs"]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", "music"]);
+
+    const text = output();
+    expect(text).toContain("Music generation choices for current agent");
+    expect(text).toContain("Connectors:");
+    expect(text).toContain("ElevenLabs");
+    expect(text).toContain("@elevenlabs-user");
+    expect(text).not.toContain("Built-in command:");
+  });
+
   it("rejects unknown generation types via Commander", async () => {
     await expect(
       generateCommand.parseAsync(["node", "cli", "spaceship"]),
+    ).rejects.toThrow();
+    await expect(
+      generateCommand.parseAsync(["node", "cli", "audio"]),
     ).rejects.toThrow();
   });
 });

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -66,46 +66,6 @@ describe("zero generate presentation command", () => {
     expect(stdout).toContain("Use a fixed 1920x1080 slide canvas");
   });
 
-  it("should print JSON resource selection metadata when --json is provided", async () => {
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "presentation",
-      "--prompt",
-      "JSON please",
-      "--site-slug",
-      "api-migration-plan",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      type: "generation-source-selection",
-      kind: "presentation",
-      prompt: "JSON please",
-      outputDir: "./generated/mockups/api-migration-plan",
-      site: "api-migration-plan",
-      hostCommand:
-        "zero host ./generated/mockups/api-migration-plan --site api-migration-plan",
-    });
-    expect(parsed.registryVersion).toEqual("v1");
-    expect(parsed.selection).toEqual(
-      expect.objectContaining({
-        candidates: expect.objectContaining({
-          skills: expect.arrayContaining([
-            expect.objectContaining({ id: "skill:article-magazine" }),
-          ]),
-          templates: expect.any(Array),
-          designSystems: expect.any(Array),
-        }),
-      }),
-    );
-    expect(parsed.instructions).toEqual(
-      expect.stringContaining("## Stage 2: Resolve Selected Resources"),
-    );
-  });
-
   it("should expose only base artifact flags plus slides in help", () => {
     let helpOutput = "";
     presentationCommand.configureOutput({
@@ -122,6 +82,7 @@ describe("zero generate presentation command", () => {
     expect(helpOutput).toContain("--design-system <id>");
     expect(helpOutput).toContain("--template <id>");
     expect(helpOutput).toContain("--slides <count>");
+    expect(helpOutput).not.toContain("--json");
     expect(helpOutput).not.toContain("--provider");
     expect(helpOutput).not.toContain("--all");
     expect(helpOutput).not.toContain("--images");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -43,10 +43,6 @@ describe("zero generate presentation command", () => {
       "API migration plan",
       "--slides",
       "10",
-      "--images",
-      "8",
-      "--image-model",
-      "gpt-image-1.5",
       "--title",
       "API Migration Plan",
     ]);
@@ -110,7 +106,7 @@ describe("zero generate presentation command", () => {
     );
   });
 
-  it("should describe the default image model in help", () => {
+  it("should expose only base artifact flags plus slides in help", () => {
     let helpOutput = "";
     presentationCommand.configureOutput({
       writeOut: (str: string) => {
@@ -120,8 +116,16 @@ describe("zero generate presentation command", () => {
 
     presentationCommand.outputHelp();
 
-    expect(helpOutput).toContain("Image model for generated visuals (default:");
-    expect(helpOutput).toContain("gpt-image-1): gpt-image-2");
+    expect(helpOutput).toContain("--prompt <text>");
+    expect(helpOutput).toContain("--site-slug <slug>");
+    expect(helpOutput).toContain("--title <text>");
+    expect(helpOutput).toContain("--design-system <id>");
+    expect(helpOutput).toContain("--template <id>");
+    expect(helpOutput).toContain("--slides <count>");
+    expect(helpOutput).not.toContain("--provider");
+    expect(helpOutput).not.toContain("--all");
+    expect(helpOutput).not.toContain("--images");
+    expect(helpOutput).not.toContain("--image-model");
     expect(helpOutput).not.toContain("--style");
     expect(helpOutput).not.toContain("--theme");
   });

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -179,39 +179,6 @@ describe("zero generate video command", () => {
     );
   });
 
-  it("should print JSON metadata when --json is provided", async () => {
-    server.use(
-      http.post(VIDEO_URL, () => {
-        return HttpResponse.json(VIDEO_RESULT);
-      }),
-    );
-
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "video",
-      "--prompt",
-      "JSON please",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      id: VIDEO_RESULT.id,
-      filename: VIDEO_RESULT.filename,
-      contentType: "video/mp4",
-      size: VIDEO_RESULT.size,
-      url: VIDEO_RESULT.url,
-      creditsCharged: 720,
-      model: "dreamina-seedance-2-0-fast-260128",
-      duration: "6s",
-      resolution: "1080p",
-      aspectRatio: "9:16",
-      generateAudio: false,
-    });
-  });
-
   it("should describe video generation models in help", () => {
     let helpOutput = "";
     videoCommand.configureOutput({
@@ -234,6 +201,7 @@ describe("zero generate video command", () => {
     expect(helpOutput).toContain("--image-url");
     expect(helpOutput).toContain("--first-frame-image-url");
     expect(helpOutput).toContain("--last-frame-image-url");
+    expect(helpOutput).not.toContain("--json");
   });
 
   it("should surface API errors", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
@@ -39,6 +39,7 @@ describe("zero generate voice command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("ZERO_TOKEN", "test-token");
   });
 
   afterEach(() => {
@@ -78,37 +79,6 @@ describe("zero generate voice command", () => {
     expect(stdout).toContain(`File: ${VOICE_RESULT.filename}`);
     expect(stdout).toContain("Duration: 3s");
     expect(stdout).toContain("Credits charged: 1");
-  });
-
-  it("should print JSON metadata when --json is provided", async () => {
-    server.use(
-      http.post(SPEECH_URL, () => {
-        return HttpResponse.json({ ...VOICE_RESULT, voice: "marin" });
-      }),
-    );
-
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "voice",
-      "--text",
-      "JSON please",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      id: VOICE_RESULT.id,
-      filename: VOICE_RESULT.filename,
-      contentType: "audio/wav",
-      size: VOICE_RESULT.size,
-      url: VOICE_RESULT.url,
-      durationSeconds: 3,
-      creditsCharged: 1,
-      model: "gpt-4o-mini-tts",
-      voice: "marin",
-    });
   });
 
   it("should surface API errors", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -121,47 +121,6 @@ describe("zero generate website command", () => {
     expect(stderr).toContain("Unknown design system");
   });
 
-  it("should print JSON resource selection metadata when --json is provided", async () => {
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "website",
-      "--prompt",
-      "observability launch site",
-      "--site-slug",
-      "clearpath-demo",
-      "--json",
-    ]);
-
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      type: "generation-source-selection",
-      kind: "website",
-      prompt: "observability launch site",
-      outputDir: "./generated/mockups/clearpath-demo",
-      site: "clearpath-demo",
-      hostCommand:
-        "zero host ./generated/mockups/clearpath-demo --site clearpath-demo --spa",
-    });
-    expect(parsed.selection).toEqual(
-      expect.objectContaining({
-        candidates: expect.objectContaining({
-          skills: expect.any(Array),
-          templates: expect.arrayContaining([
-            expect.objectContaining({
-              id: "template:web-prototype-taste-editorial",
-            }),
-          ]),
-          designSystems: expect.any(Array),
-        }),
-      }),
-    );
-    expect(parsed.instructions).toEqual(
-      expect.stringContaining("## Stage 3: Author Artifact"),
-    );
-  });
-
   it("should expose the shared HTML artifact flags in help", () => {
     let helpOutput = "";
     websiteCommand.configureOutput({
@@ -177,6 +136,7 @@ describe("zero generate website command", () => {
     expect(helpOutput).toContain("--title <text>");
     expect(helpOutput).toContain("--design-system <id>");
     expect(helpOutput).toContain("--template <id>");
+    expect(helpOutput).not.toContain("--json");
     expect(helpOutput).not.toContain("--provider");
     expect(helpOutput).not.toContain("--all");
     expect(helpOutput).not.toContain("--images");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import chalk from "chalk";
 import { generateCommand } from "../index";
+import { websiteCommand } from "../website";
 
 describe("zero generate website command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {
@@ -159,5 +160,29 @@ describe("zero generate website command", () => {
     expect(parsed.instructions).toEqual(
       expect.stringContaining("## Stage 3: Author Artifact"),
     );
+  });
+
+  it("should expose the shared HTML artifact flags in help", () => {
+    let helpOutput = "";
+    websiteCommand.configureOutput({
+      writeOut: (str: string) => {
+        helpOutput += str;
+      },
+    });
+
+    websiteCommand.outputHelp();
+
+    expect(helpOutput).toContain("--prompt <text>");
+    expect(helpOutput).toContain("--site-slug <slug>");
+    expect(helpOutput).toContain("--title <text>");
+    expect(helpOutput).toContain("--design-system <id>");
+    expect(helpOutput).toContain("--template <id>");
+    expect(helpOutput).not.toContain("--provider");
+    expect(helpOutput).not.toContain("--all");
+    expect(helpOutput).not.toContain("--images");
+    expect(helpOutput).not.toContain("--image-model");
+    expect(helpOutput).not.toContain("--template-direction");
+    expect(helpOutput).not.toContain("--audience");
+    expect(helpOutput).not.toContain("--site <slug>");
   });
 });

--- a/turbo/apps/cli/src/commands/zero/generate/artifacts.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/artifacts.ts
@@ -17,7 +17,7 @@ export const reportCommand = createArtifactGenerateCommand({
   usageCommand: "zero generate report",
   examples: `  Generate report:      zero generate report --prompt "A Q2 usage report for the API team"
   Stable hosted slug:    zero generate report --site-slug api-usage-q2 --prompt "A Q2 usage report"
-  List providers:        zero generate report`,
+  Show choices:          zero generate report`,
   details: standardDetails("report"),
   artifactRules: [
     "Produce an analytical report, not a marketing page.",
@@ -35,7 +35,7 @@ export const docsDesignCommand = createArtifactGenerateCommand({
   usageCommand: "zero generate docs-design",
   examples: `  Generate docs design: zero generate docs-design --prompt "Docs for adding artifact targets"
   Stable hosted slug:    zero generate docs-design --site-slug artifact-target-docs --prompt "Artifact target docs"
-  List providers:        zero generate docs-design`,
+  Show choices:          zero generate docs-design`,
   details: standardDetails("docs-design"),
   artifactRules: [
     "Produce a documentation design mockup, not a production documentation system.",
@@ -53,7 +53,7 @@ export const posterCommand = createArtifactGenerateCommand({
   usageCommand: "zero generate poster",
   examples: `  Generate poster:      zero generate poster --prompt "A launch poster for artifact targets"
   Stable hosted slug:    zero generate poster --site-slug artifact-poster --prompt "A launch poster"
-  List providers:        zero generate poster`,
+  Show choices:          zero generate poster`,
   details: standardDetails("poster"),
   artifactRules: [
     "Produce a poster-style HTML artifact with strong hierarchy and composition.",
@@ -71,7 +71,7 @@ export const dashboardDesignCommand = createArtifactGenerateCommand({
   usageCommand: "zero generate dashboard-design",
   examples: `  Generate dash design: zero generate dashboard-design --prompt "An ops dashboard for generation runs"
   Stable hosted slug:    zero generate dashboard-design --site-slug generation-ops --prompt "A generation ops dashboard"
-  List providers:        zero generate dashboard-design`,
+  Show choices:          zero generate dashboard-design`,
   details: standardDetails("dashboard-design"),
   artifactRules: [
     "Produce a dashboard design mockup, not a live operational dashboard.",
@@ -89,7 +89,7 @@ export const mobileAppDesignCommand = createArtifactGenerateCommand({
   usageCommand: "zero generate mobile-app-design",
   examples: `  Generate mobile UI:   zero generate mobile-app-design --prompt "A mobile review screen for generation artifacts"
   Stable hosted slug:    zero generate mobile-app-design --site-slug generation-mobile-review --prompt "A mobile review screen"
-  List providers:        zero generate mobile-app-design`,
+  Show choices:          zero generate mobile-app-design`,
   details: standardDetails("mobile-app-design"),
   artifactRules: [
     "Produce a design prototype, not a runnable or installable mobile app.",

--- a/turbo/apps/cli/src/commands/zero/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/index.ts
@@ -13,11 +13,10 @@ import { websiteCommand } from "./website";
 import { voiceCommand } from "./voice";
 import { createListerOnlyCommand } from "./lister-only";
 
-const audioCommand = createListerOnlyCommand({
-  name: "audio",
-  generationType: "audio",
-  description:
-    "List connectors that provide audio generation (alias of voice for non-speech audio)",
+const musicCommand = createListerOnlyCommand({
+  name: "music",
+  generationType: "music",
+  description: "List connectors that provide music generation",
 });
 
 const textCommand = createListerOnlyCommand({
@@ -47,6 +46,7 @@ function buildGenerateHelpText(): string {
     '  Generate video:        zero generate video --prompt "A cinematic city shot"',
     '  Generate site:         zero generate website --prompt "A launch site"',
     '  Generate speech:       zero generate voice --prompt "Hello"',
+    "  Show music choices:    zero generate music",
     "",
     "  Show image choices:    zero generate image",
     "  Show report choices:   zero generate report",
@@ -74,7 +74,7 @@ export const generateCommand = new Command()
   .addCommand(videoCommand)
   .addCommand(websiteCommand)
   .addCommand(voiceCommand)
-  .addCommand(audioCommand)
+  .addCommand(musicCommand)
   .addCommand(textCommand)
   .addCommand(codeCommand)
   .addCommand(documentCommand)

--- a/turbo/apps/cli/src/commands/zero/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/index.ts
@@ -48,12 +48,15 @@ function buildGenerateHelpText(): string {
     '  Generate site:         zero generate website --prompt "A launch site"',
     '  Generate speech:       zero generate voice --prompt "Hello"',
     "",
-    "  List image providers:  zero generate image",
+    "  Show image choices:    zero generate image",
+    "  Show report choices:   zero generate report",
     "  Use a connector:       zero generate video --provider heygen",
     "  Force built-in:        zero generate image --provider built-in --model gpt-image-1.5 --prompt ...",
   ];
 
-  return `\nExamples:\n${examples.join("\n")}\n\nNotes:\n  - Run "zero generate <type>" with no --prompt to list every provider available for that type.\n  - --provider built-in (default when --prompt is provided) runs the vm0-hosted pipeline.\n  - --provider <connector-name> prints how to invoke that connector's skill instead.`;
+  return `\nExamples:\n${examples.join("\n")}\n\nNotes:\n  - Run "zero generate <type>" with no --prompt to list generation choices for that type.
+  - Media and connector-backed generation types may expose --provider for vm0 or connector execution guidance.
+  - HTML artifact types use registry-backed --design-system and --template selection.`;
 }
 
 export const generateCommand = new Command()

--- a/turbo/apps/cli/src/commands/zero/generate/lib/connector-guidance.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/connector-guidance.ts
@@ -11,6 +11,7 @@ function toConnectorGenerationType(
 ): string | null {
   switch (generationType) {
     case "voice":
+    case "music":
       return "audio";
     case "dashboard-design":
     case "docs-design":

--- a/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
@@ -7,7 +7,6 @@ interface DispatchOptions {
   readonly provider?: string;
   readonly prompt?: string;
   readonly all?: boolean;
-  readonly json?: boolean;
 }
 
 /**
@@ -35,7 +34,6 @@ export async function dispatchGenerate(
   if (resolvedPrompt === null) {
     await runLister(options.generationType, {
       all: options.all,
-      json: options.json,
     });
     return { outcome: "handled" };
   }

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -109,62 +109,6 @@ const BUILT_IN_GENERATION_PROVIDERS: Partial<
       reason: "available without connector setup",
     },
   ],
-  presentation: [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate presentation --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
-  report: [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate report --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
-  "docs-design": [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate docs-design --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
-  poster: [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate poster --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
-  "dashboard-design": [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate dashboard-design --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
-  "mobile-app-design": [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate mobile-app-design --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
-  website: [
-    {
-      label: "Built-in",
-      model: "gpt-5.5",
-      command: "zero generate website --provider built-in -h",
-      reason: "available without connector setup",
-    },
-  ],
   video: [
     {
       label: "Built-in",
@@ -227,37 +171,37 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
   },
   presentation: {
     label: "Built-in presentation generation",
-    command: "zero generate presentation --provider built-in -h",
+    command: "zero generate presentation -h",
     models: "gpt-5.5",
   },
   report: {
     label: "Built-in report generation",
-    command: "zero generate report --provider built-in -h",
+    command: "zero generate report -h",
     models: "gpt-5.5",
   },
   "docs-design": {
     label: "Built-in docs design generation",
-    command: "zero generate docs-design --provider built-in -h",
+    command: "zero generate docs-design -h",
     models: "gpt-5.5",
   },
   poster: {
     label: "Built-in poster generation",
-    command: "zero generate poster --provider built-in -h",
+    command: "zero generate poster -h",
     models: "gpt-5.5",
   },
   "dashboard-design": {
     label: "Built-in dashboard design generation",
-    command: "zero generate dashboard-design --provider built-in -h",
+    command: "zero generate dashboard-design -h",
     models: "gpt-5.5",
   },
   "mobile-app-design": {
     label: "Built-in mobile app design generation",
-    command: "zero generate mobile-app-design --provider built-in -h",
+    command: "zero generate mobile-app-design -h",
     models: "gpt-5.5",
   },
   website: {
     label: "Built-in website generation",
-    command: "zero generate website --provider built-in -h",
+    command: "zero generate website -h",
     models: "gpt-5.5",
   },
   voice: {
@@ -346,16 +290,16 @@ function getConnectorGenerationType(
     case "docs-design":
     case "mobile-app-design":
     case "poster":
+    case "presentation":
     case "report":
+    case "website":
       return null;
     case "audio":
     case "code":
     case "document":
     case "image":
-    case "presentation":
     case "text":
     case "video":
-    case "website":
       return generationType;
   }
 }
@@ -389,6 +333,7 @@ function getAvailableGenerationTypes(): GenerationType[] {
   return GENERATION_TYPE_ORDER.filter((type) => {
     const connectorGenerationType = getConnectorGenerationType(type);
     return (
+      getBuiltInCommand(type) !== null ||
       getBuiltInProviders(type).length > 0 ||
       (connectorGenerationType !== null &&
         available.has(connectorGenerationType))

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -20,6 +20,7 @@ type BuiltInGenerationType =
   | "docs-design"
   | "image"
   | "mobile-app-design"
+  | "music"
   | "poster"
   | "presentation"
   | "report"
@@ -221,23 +222,6 @@ const GENERATION_CONTEXT: Partial<Record<GenerationType, GenerationContext>> = {
   },
 };
 
-const GENERATION_TYPE_ORDER: readonly GenerationType[] = [
-  "image",
-  "video",
-  "audio",
-  "voice",
-  "text",
-  "code",
-  "document",
-  "presentation",
-  "website",
-  "report",
-  "docs-design",
-  "poster",
-  "dashboard-design",
-  "mobile-app-design",
-];
-
 const GENERATION_TYPE_LABELS: Record<GenerationType, string> = {
   audio: "Audio",
   code: "Code",
@@ -246,6 +230,7 @@ const GENERATION_TYPE_LABELS: Record<GenerationType, string> = {
   "docs-design": "Docs design",
   image: "Image",
   "mobile-app-design": "Mobile app design",
+  music: "Music",
   poster: "Poster",
   presentation: "Presentation",
   report: "Report",
@@ -266,7 +251,6 @@ type CandidateStatus =
 
 interface ListerOptions {
   all?: boolean;
-  json?: boolean;
 }
 
 interface GenerationCandidate {
@@ -285,6 +269,7 @@ function getConnectorGenerationType(
 ): ConnectorGenerationType | null {
   switch (generationType) {
     case "voice":
+    case "music":
       return "audio";
     case "dashboard-design":
     case "docs-design":
@@ -320,25 +305,6 @@ function getGenerationContext(
   generationType: GenerationType,
 ): GenerationContext | null {
   return GENERATION_CONTEXT[generationType] ?? null;
-}
-
-function getAvailableGenerationTypes(): GenerationType[] {
-  const available = new Set<ConnectorGenerationType>();
-  for (const type of CONNECTOR_TYPE_KEYS) {
-    for (const generationType of getConnectorGenerationTypes(type)) {
-      available.add(generationType);
-    }
-  }
-
-  return GENERATION_TYPE_ORDER.filter((type) => {
-    const connectorGenerationType = getConnectorGenerationType(type);
-    return (
-      getBuiltInCommand(type) !== null ||
-      getBuiltInProviders(type).length > 0 ||
-      (connectorGenerationType !== null &&
-        available.has(connectorGenerationType))
-    );
-  });
 }
 
 function getGenerationConnectors(
@@ -646,30 +612,6 @@ export async function runLister(
   const other = candidates.filter((candidate) => {
     return candidate.status !== "ready";
   });
-  const builtInProviders = getBuiltInProviders(generationType);
-
-  if (options.json) {
-    console.log(
-      JSON.stringify(
-        {
-          generationType,
-          connectorGenerationType,
-          availableTypes: getAvailableGenerationTypes(),
-          agentId: agentId ?? null,
-          choices: ready,
-          otherCandidates: other,
-          builtInCommand: getBuiltInCommand(generationType),
-          generationContext: getGenerationContext(generationType),
-          builtInProvider: builtInProviders[0] ?? null,
-          builtInProviders,
-        },
-        null,
-        2,
-      ),
-    );
-    return;
-  }
-
   renderText({
     generationType,
     agentId,

--- a/turbo/apps/cli/src/commands/zero/generate/lister-only.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lister-only.ts
@@ -6,7 +6,6 @@ import { runLister, type GenerationType } from "./lib/lister";
 interface ListerOnlyOptions {
   readonly provider?: string;
   readonly all?: boolean;
-  readonly json?: boolean;
 }
 
 interface ListerOnlyConfig {
@@ -29,7 +28,6 @@ export function createListerOnlyCommand(config: ListerOnlyConfig): Command {
       "Connector name; prints that connector's skill-invocation guidance",
     )
     .option("--all", "Include unavailable or not-yet-authorized connectors")
-    .option("--json", "Print the provider list as JSON")
     .addHelpText(
       "after",
       `
@@ -57,7 +55,6 @@ Notes:
         }
         await runLister(config.generationType, {
           all: options.all,
-          json: options.json,
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/generate/presentation.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/presentation.ts
@@ -6,7 +6,7 @@ export const presentationCommand = createPresentationGenerateCommand({
   usageCommand: "zero generate presentation",
   examples: `  Generate deck:         zero generate presentation --prompt "A strategy deck for reducing support volume"
   Pipe prompt:           cat brief.txt | zero generate presentation
-  Generated visuals:     zero generate presentation --slides 10 --images 8 --image-model gpt-image-1.5 --prompt "A product launch narrative"
+  Pick slide count:      zero generate presentation --slides 10 --prompt "A product launch narrative"
   Stable hosted slug:    zero generate presentation --site-slug api-migration-plan --prompt "API migration plan"
-  List providers:        zero generate presentation`,
+  Show choices:          zero generate presentation`,
 });

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -61,16 +61,16 @@ export const websiteCommand = new Command()
   .name("website")
   .description("Prepare website authoring instructions from a prompt")
   .option("--prompt <text>", "Website prompt; can also be piped via stdin")
-  .option(
-    "--template <id>",
-    "Template id from the registry, scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
-  )
+  .option("--site-slug <slug>", "Hosted site slug override")
+  .option("--title <text>", "Requested site title or name")
   .option(
     "--design-system <id>",
     "Design system id from the registry (see Design Systems below). Accepts either 'apple' or 'design-system:apple'.",
   )
-  .option("--site-slug <slug>", "Hosted site slug override")
-  .option("--title <text>", "Requested site title or name")
+  .option(
+    "--template <id>",
+    "Template id from the registry, scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
+  )
   .option("--json", "Print metadata as JSON")
   .addHelpText("after", () => {
     const designSystems = listDesignSystems();

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -22,7 +22,6 @@ interface WebsiteOptions {
   readonly designSystem?: string;
   readonly siteSlug?: string;
   readonly title?: string;
-  readonly json?: boolean;
 }
 
 function unknownDesignSystemError(id: string): Error {
@@ -71,7 +70,6 @@ export const websiteCommand = new Command()
     "--template <id>",
     "Template id from the registry, scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
   )
-  .option("--json", "Print metadata as JSON")
   .addHelpText("after", () => {
     const designSystems = listDesignSystems();
     const templates = listTemplates(WEBSITE_TARGET);
@@ -103,7 +101,6 @@ ${formatRegistryListing(templates, "website templates")}`;
       const dispatch = await dispatchGenerate({
         generationType: "website",
         prompt: options.prompt,
-        json: options.json,
       });
       if (dispatch.outcome === "handled") return;
       const prompt = dispatch.prompt;
@@ -157,10 +154,6 @@ ${formatRegistryListing(templates, "website templates")}`;
         ],
       });
 
-      if (options.json) {
-        console.log(JSON.stringify(packet));
-        return;
-      }
       console.log(packet.instructions);
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -1,4 +1,4 @@
-import { Command, InvalidArgumentError } from "commander";
+import { Command } from "commander";
 import { withErrorHandler } from "../../../lib/command";
 import { createHtmlArtifactAuthoringPacket } from "../shared/html-artifact-authoring";
 import {
@@ -13,38 +13,16 @@ import {
 } from "../shared/resource-listing";
 import { dispatchGenerate } from "./lib/dispatch";
 
-const WEBSITE_MAX_IMAGES = 3;
 const WEBSITE_TARGET = "website";
 const WEBSITE_USAGE_COMMAND = "zero generate website";
 
 interface WebsiteOptions {
   readonly prompt?: string;
-  readonly provider?: string;
   readonly template?: string;
   readonly designSystem?: string;
-  readonly images: number;
-  readonly imageModel?: string;
   readonly siteSlug?: string;
   readonly title?: string;
-  readonly all?: boolean;
   readonly json?: boolean;
-}
-
-function parseImageCount(value: string): number {
-  const imageCount = Number(value);
-  if (!Number.isInteger(imageCount)) {
-    throw new InvalidArgumentError("images must be an integer");
-  }
-  if (
-    !Number.isSafeInteger(imageCount) ||
-    imageCount < 0 ||
-    imageCount > WEBSITE_MAX_IMAGES
-  ) {
-    throw new InvalidArgumentError(
-      `images must be between 0 and ${WEBSITE_MAX_IMAGES}`,
-    );
-  }
-  return imageCount;
 }
 
 function unknownDesignSystemError(id: string): Error {
@@ -84,30 +62,12 @@ export const websiteCommand = new Command()
   .description("Prepare website authoring instructions from a prompt")
   .option("--prompt <text>", "Website prompt; can also be piped via stdin")
   .option(
-    "--provider <name>",
-    "Provider: 'built-in' to run vm0's pipeline, or a connector name to get its skill-invocation guidance",
-  )
-  .option(
-    "--all",
-    "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
-  )
-  .option(
     "--template <id>",
     "Template id from the registry, scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
   )
   .option(
     "--design-system <id>",
     "Design system id from the registry (see Design Systems below). Accepts either 'apple' or 'design-system:apple'.",
-  )
-  .option(
-    "--images <count>",
-    `Generated website image count: 0-${WEBSITE_MAX_IMAGES}`,
-    parseImageCount,
-    1,
-  )
-  .option(
-    "--image-model <model>",
-    "Image model for generated visuals (default: gpt-image-1): gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
   )
   .option("--site-slug <slug>", "Hosted site slug override")
   .option("--title <text>", "Requested site title or name")
@@ -122,11 +82,11 @@ Examples:
   Pick design system:    zero generate website --design-system stripe --prompt "Pricing page for a SaaS"
   Stable hosted slug:    zero generate website --site-slug api-migration-demo --prompt "An internal migration microsite"
   Pipe prompt:           cat brief.txt | zero generate website
-  List providers:        zero generate website
+  Show choices:          zero generate website
 
 Output:
   Prints a source-selection packet for the current agent.
-  With no --prompt and no piped input, prints the provider menu instead.
+  With no --prompt and no piped input, prints the generation choices instead.
 
 Notes:
   - Authenticates via ZERO_TOKEN
@@ -142,9 +102,7 @@ ${formatRegistryListing(templates, "website templates")}`;
     withErrorHandler(async (options: WebsiteOptions) => {
       const dispatch = await dispatchGenerate({
         generationType: "website",
-        provider: options.provider,
         prompt: options.prompt,
-        all: options.all,
         json: options.json,
       });
       if (dispatch.outcome === "handled") return;
@@ -179,10 +137,6 @@ ${formatRegistryListing(templates, "website templates")}`;
         slugSource: options.title,
         siteSlug: options.siteSlug,
         details: [
-          `Suggested generated visual count: ${options.images}`,
-          `Image model preference if visuals are generated separately: ${
-            options.imageModel ?? "default"
-          }`,
           `Requested title/site name: ${options.title ?? "not specified"}`,
           `Selected design system: ${
             resolvedDesignSystem

--- a/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
@@ -18,12 +18,10 @@ import type { GenerationType } from "../generate/lib/lister";
 
 interface ArtifactOptions {
   prompt?: string;
-  provider?: string;
   siteSlug?: string;
   title?: string;
   designSystem?: string;
   template?: string;
-  all?: boolean;
   json?: boolean;
 }
 
@@ -81,14 +79,6 @@ export function createArtifactGenerateCommand(
     .name(config.name)
     .description(config.description)
     .option("--prompt <text>", "Artifact prompt; can also be piped via stdin")
-    .option(
-      "--provider <name>",
-      "Provider: 'built-in' to run vm0's pipeline, or a connector name to get its skill-invocation guidance",
-    )
-    .option(
-      "--all",
-      "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
-    )
     .option("--site-slug <slug>", "Hosted site slug override")
     .option("--title <text>", "Requested artifact title or name")
     .option(
@@ -110,7 +100,7 @@ ${config.examples}
 Output:
   Prints a source-selection packet for the current agent. The
   agent authors a static HTML artifact and hosts it with zero host. With no
-  --prompt and no piped input, prints the provider menu instead.
+  --prompt and no piped input, prints the generation choices instead.
 
 Notes:
   - Authenticates via ZERO_TOKEN
@@ -125,9 +115,7 @@ ${formatRegistryListing(templates, `${config.target} templates`)}`;
       withErrorHandler(async (options: ArtifactOptions) => {
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
-          provider: options.provider,
           prompt: options.prompt,
-          all: options.all,
           json: options.json,
         });
         if (dispatch.outcome === "handled") return;

--- a/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
@@ -22,7 +22,6 @@ interface ArtifactOptions {
   title?: string;
   designSystem?: string;
   template?: string;
-  json?: boolean;
 }
 
 interface ArtifactCommandConfig {
@@ -89,7 +88,6 @@ export function createArtifactGenerateCommand(
       "--template <id>",
       `Template id from the registry, scoped to ${config.target} (see Templates below). Accepts either short id or full 'template:<id>'.`,
     )
-    .option("--json", "Print metadata as JSON")
     .addHelpText("after", () => {
       const designSystems = listDesignSystems();
       const templates = listTemplates(config.target);
@@ -116,7 +114,6 @@ ${formatRegistryListing(templates, `${config.target} templates`)}`;
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
           prompt: options.prompt,
-          json: options.json,
         });
         if (dispatch.outcome === "handled") return;
         const prompt = dispatch.prompt;
@@ -175,11 +172,6 @@ ${formatRegistryListing(templates, `${config.target} templates`)}`;
           details: [...config.details(options), ...extraDetails],
           artifactRules: config.artifactRules,
         });
-
-        if (options.json) {
-          console.log(JSON.stringify(packet));
-          return;
-        }
 
         console.log(packet.instructions);
       }),

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -28,7 +28,6 @@ interface ImageOptions {
   style?: string;
   skipStyle?: boolean;
   all?: boolean;
-  json?: boolean;
 }
 
 interface ImageGenerateCommandConfig {
@@ -186,7 +185,6 @@ export function createImageGenerateCommand(
       "--skip-style",
       "Opt out of styled image generation for this invocation",
     )
-    .option("--json", "Print metadata as JSON")
     .addHelpText("after", () => {
       const styles = listImageStyles();
       return `
@@ -245,7 +243,6 @@ ${formatRegistryListing(styles, "image styles")}`;
           provider: options.provider,
           prompt: options.prompt,
           all: options.all,
-          json: options.json,
         });
         if (dispatch.outcome === "handled") return;
         const prompt = dispatch.prompt;
@@ -280,11 +277,6 @@ ${formatRegistryListing(styles, "image styles")}`;
             ],
           });
 
-          if (options.json) {
-            console.log(JSON.stringify(packet));
-            return;
-          }
-
           console.log(packet.instructions);
           return;
         }
@@ -316,11 +308,6 @@ ${formatRegistryListing(styles, "image styles")}`;
           inputFidelity,
           imagePromptStrength,
         });
-
-        if (options.json) {
-          console.log(JSON.stringify(result));
-          return;
-        }
 
         console.log(chalk.green(`✓ Image generated: ${result.url}`));
         console.log(chalk.dim(`  File: ${result.filename}`));

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -23,7 +23,6 @@ interface PresentationOptions {
   siteSlug?: string;
   designSystem?: string;
   template?: string;
-  json?: boolean;
 }
 
 interface PresentationGenerateCommandConfig {
@@ -98,7 +97,6 @@ export function createPresentationGenerateCommand(
       "Template id from the registry, scoped to presentation (see Templates below). Accepts either 'html-ppt-pitch-deck' or 'template:html-ppt-pitch-deck'.",
     )
     .option("--slides <count>", "Slide count: 4-20", parseSlideCount, 8)
-    .option("--json", "Print metadata as JSON")
     .addHelpText("after", () => {
       const designSystems = listDesignSystems();
       const templates = listTemplates(PRESENTATION_TARGET);
@@ -124,7 +122,6 @@ ${formatRegistryListing(templates, "presentation templates")}`;
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
           prompt: options.prompt,
-          json: options.json,
         });
         if (dispatch.outcome === "handled") return;
         const prompt = dispatch.prompt;
@@ -190,10 +187,6 @@ ${formatRegistryListing(templates, "presentation templates")}`;
           ],
         });
 
-        if (options.json) {
-          console.log(JSON.stringify(packet));
-          return;
-        }
         console.log(packet.instructions);
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -14,20 +14,15 @@ import {
 import { dispatchGenerate } from "../generate/lib/dispatch";
 import type { GenerationType } from "../generate/lib/lister";
 
-const PRESENTATION_MAX_IMAGES = 8;
 const PRESENTATION_TARGET = "presentation";
 
 interface PresentationOptions {
   prompt?: string;
-  provider?: string;
   slides: number;
-  images: number;
-  imageModel?: string;
   title?: string;
   siteSlug?: string;
   designSystem?: string;
   template?: string;
-  all?: boolean;
   json?: boolean;
 }
 
@@ -44,23 +39,6 @@ function parseSlideCount(value: string): number {
     throw new InvalidArgumentError("slides must be an integer");
   }
   return slideCount;
-}
-
-function parseImageCount(value: string): number {
-  const imageCount = Number(value);
-  if (!Number.isInteger(imageCount)) {
-    throw new InvalidArgumentError("images must be an integer");
-  }
-  if (
-    !Number.isSafeInteger(imageCount) ||
-    imageCount < 0 ||
-    imageCount > PRESENTATION_MAX_IMAGES
-  ) {
-    throw new InvalidArgumentError(
-      `images must be between 0 and ${PRESENTATION_MAX_IMAGES}`,
-    );
-  }
-  return imageCount;
 }
 
 function unknownDesignSystemError(id: string, usageCommand: string): Error {
@@ -109,25 +87,7 @@ export function createPresentationGenerateCommand(
       "--prompt <text>",
       "Presentation prompt; can also be piped via stdin",
     )
-    .option(
-      "--provider <name>",
-      "Provider: 'built-in' to run vm0's pipeline, or a connector name to get its skill-invocation guidance",
-    )
-    .option(
-      "--all",
-      "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
-    )
     .option("--slides <count>", "Slide count: 4-20", parseSlideCount, 8)
-    .option(
-      "--images <count>",
-      `Generated image count: 0-${PRESENTATION_MAX_IMAGES}`,
-      parseImageCount,
-      2,
-    )
-    .option(
-      "--image-model <model>",
-      "Image model for generated visuals (default: gpt-image-1): gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
-    )
     .option("--title <text>", "Requested deck title")
     .option("--site-slug <slug>", "Hosted site slug override")
     .option(
@@ -163,9 +123,7 @@ ${formatRegistryListing(templates, "presentation templates")}`;
       withErrorHandler(async (options: PresentationOptions) => {
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
-          provider: options.provider,
           prompt: options.prompt,
-          all: options.all,
           json: options.json,
         });
         if (dispatch.outcome === "handled") return;
@@ -211,10 +169,6 @@ ${formatRegistryListing(templates, "presentation templates")}`;
           siteSlug: options.siteSlug,
           details: [
             `Slide count: ${options.slides}`,
-            `Suggested generated visual count: ${options.images}`,
-            `Image model preference if visuals are generated separately: ${
-              options.imageModel ?? "default"
-            }`,
             `Requested deck title: ${options.title ?? "not specified"}`,
             `Selected design system: ${
               resolvedDesignSystem

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -87,9 +87,8 @@ export function createPresentationGenerateCommand(
       "--prompt <text>",
       "Presentation prompt; can also be piped via stdin",
     )
-    .option("--slides <count>", "Slide count: 4-20", parseSlideCount, 8)
-    .option("--title <text>", "Requested deck title")
     .option("--site-slug <slug>", "Hosted site slug override")
+    .option("--title <text>", "Requested deck title")
     .option(
       "--design-system <id>",
       "Design system id from the registry (see Design Systems below). Accepts either 'apple' or 'design-system:apple'.",
@@ -98,6 +97,7 @@ export function createPresentationGenerateCommand(
       "--template <id>",
       "Template id from the registry, scoped to presentation (see Templates below). Accepts either 'html-ppt-pitch-deck' or 'template:html-ppt-pitch-deck'.",
     )
+    .option("--slides <count>", "Slide count: 4-20", parseSlideCount, 8)
     .option("--json", "Print metadata as JSON")
     .addHelpText("after", () => {
       const designSystems = listDesignSystems();

--- a/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
@@ -23,7 +23,6 @@ interface VideoOptions {
   firstFrameImageUrl?: string;
   lastFrameImageUrl?: string;
   all?: boolean;
-  json?: boolean;
 }
 
 interface VideoGenerateCommandConfig {
@@ -355,7 +354,6 @@ export function createVideoGenerateCommand(
     )
     .option("--first-frame-image-url <url>", "First frame image URL")
     .option("--last-frame-image-url <url>", "Last frame image URL")
-    .option("--json", "Print metadata as JSON")
     .addHelpText(
       "after",
       `
@@ -390,7 +388,6 @@ Models:
           provider: options.provider,
           prompt: options.prompt,
           all: options.all,
-          json: options.json,
         });
         if (dispatch.outcome === "handled") return;
         const prompt = dispatch.prompt;
@@ -413,11 +410,6 @@ Models:
           firstFrameImageUrl: options.firstFrameImageUrl,
           lastFrameImageUrl: options.lastFrameImageUrl,
         });
-
-        if (options.json) {
-          console.log(JSON.stringify(result));
-          return;
-        }
 
         console.log(chalk.green(`✓ Video generated: ${result.url}`));
         console.log(chalk.dim(`  File: ${result.filename}`));

--- a/turbo/apps/cli/src/commands/zero/shared/voice-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/voice-generate.ts
@@ -12,7 +12,6 @@ interface VoiceOptions {
   voice: string;
   instructions?: string;
   all?: boolean;
-  json?: boolean;
 }
 
 interface VoiceGenerateCommandConfig {
@@ -40,7 +39,6 @@ export function createVoiceGenerateCommand(
     )
     .option("--voice <voice>", "OpenAI voice to use", "marin")
     .option("--instructions <text>", "Voice style instructions")
-    .option("--json", "Print metadata as JSON")
     .addHelpText(
       "after",
       `
@@ -63,7 +61,6 @@ Notes:
           provider: options.provider,
           prompt: options.prompt ?? options.text,
           all: options.all,
-          json: options.json,
         });
         if (dispatch.outcome === "handled") return;
         const text = dispatch.prompt;
@@ -73,11 +70,6 @@ Notes:
           voice: options.voice,
           instructions: options.instructions,
         });
-
-        if (options.json) {
-          console.log(JSON.stringify(result));
-          return;
-        }
 
         console.log(chalk.green(`✓ Voice generated: ${result.url}`));
         console.log(chalk.dim(`  File: ${result.filename}`));


### PR DESCRIPTION
## Summary
- make website, report, docs-design, poster, dashboard-design, and mobile-app-design share the same HTML artifact params: `--prompt`, `--site-slug`, `--title`, `--design-system`, `--template`
- make presentation use the same base params plus only `--slides`
- remove HTML artifact `--provider`, `--all`, `--images`, and `--image-model` flags
- remove `--json` from all `zero generate` commands
- keep subtypes exposed as first-level commands; replace public `zero generate audio` with connector-backed `zero generate music` while keeping `zero generate voice`
- make no-prompt HTML artifact choices use built-in command output with target-filtered templates and design-system descriptions
- align website and presentation help ordering with the shared HTML artifact surface

## Verification
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/image.test.ts src/commands/zero/generate/__tests__/video.test.ts src/commands/zero/generate/__tests__/voice.test.ts src/commands/zero/generate/__tests__/presentation.test.ts src/commands/zero/generate/__tests__/website.test.ts src/commands/zero/generate/__tests__/artifacts.test.ts src/commands/zero/generate/__tests__/lister.test.ts`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/cli build`

## Report
- https://generate-parameter-distribution-715f6d07.sites.vm0.io