### PR TITLE
fix(desktop): serialize native computer-use helper requests

### DIFF
--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -159,6 +159,75 @@ process.stdin.on("data", (chunk) => {
   return { dir, helperPath, requestLogPath };
 }
 
+// A serve-mode helper that makes concurrency observable: it logs how many
+// requests are in flight when each one arrives, defers its response so overlap
+// would be visible, records every process launch, and never answers a request
+// for the "HANG" app so the client-side timeout/respawn path can be exercised.
+async function createConcurrencyHelper(responseDelayMs: number): Promise<{
+  readonly dir: string;
+  readonly helperPath: string;
+  readonly requestLogPath: string;
+  readonly startLogPath: string;
+}> {
+  const dir = await mkdtemp(path.join(tmpdir(), "computer-use-helper-"));
+  const helperPath = path.join(dir, "helper");
+  const requestLogPath = path.join(dir, "requests.ndjson");
+  const startLogPath = path.join(dir, "starts.log");
+  await writeFile(
+    helperPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const requestLogPath = ${JSON.stringify(requestLogPath)};
+const startLogPath = ${JSON.stringify(startLogPath)};
+const responseDelayMs = ${responseDelayMs.toString()};
+fs.appendFileSync(startLogPath, String(process.pid) + "\\n");
+let inFlight = 0;
+let buffer = "";
+
+function handleLine(line) {
+  if (line.trim().length === 0) return;
+  const request = JSON.parse(line);
+  inFlight += 1;
+  fs.appendFileSync(
+    requestLogPath,
+    JSON.stringify({ id: request.id, app: request.payload.app, inFlight }) + "\\n"
+  );
+  const app = request.payload.app;
+  if (app === "HANG") return;
+  setTimeout(() => {
+    inFlight -= 1;
+    if (app === "FAIL") {
+      process.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          status: "failed",
+          error: { code: "app_open_failed", message: "Unable to open " + app }
+        }) + "\\n"
+      );
+      return;
+    }
+    process.stdout.write(
+      JSON.stringify({ id: request.id, status: "succeeded", result: {} }) + "\\n"
+    );
+  }, responseDelayMs);
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (buffer.includes("\\n")) {
+    const index = buffer.indexOf("\\n");
+    const line = buffer.slice(0, index);
+    buffer = buffer.slice(index + 1);
+    handleLine(line);
+  }
+});
+`,
+  );
+  await chmod(helperPath, 0o755);
+  return { dir, helperPath, requestLogPath, startLogPath };
+}
+
 async function createDaemonDir(): Promise<string> {
   return await mkdtemp(path.join(tmpdir(), "vm0-computer-daemon-"));
 }
@@ -510,6 +579,128 @@ describe("computer use native backend", () => {
           button: "right",
         },
       });
+    } finally {
+      backend.dispose();
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes concurrent native requests to one in-flight at a time", async () => {
+    const helper = await createConcurrencyHelper(40);
+    const backend = createComputerUseNativeBackend({
+      helperPath: helper.helperPath,
+    });
+
+    try {
+      const apps = Array.from({ length: 8 }, (_, index) => {
+        return `app${index.toString()}`;
+      });
+      await Promise.all(
+        apps.map((app) => {
+          return backend.openApp(app);
+        }),
+      );
+
+      const requests = (await readFile(helper.requestLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          return JSON.parse(line) as {
+            readonly id: string;
+            readonly app: string;
+            readonly inFlight: number;
+          };
+        });
+
+      expect(requests).toHaveLength(8);
+      // Serialization means the helper never sees more than one request at once.
+      expect(
+        Math.max(
+          ...requests.map((request) => {
+            return request.inFlight;
+          }),
+        ),
+      ).toBe(1);
+      // The helper receives requests in submission order (FIFO queue).
+      expect(
+        requests.map((request) => {
+          return request.app;
+        }),
+      ).toStrictEqual(apps);
+      expect(
+        requests.map((request) => {
+          return request.id;
+        }),
+      ).toStrictEqual(
+        Array.from({ length: 8 }, (_, index) => {
+          return `desktop_${(index + 1).toString()}`;
+        }),
+      );
+    } finally {
+      backend.dispose();
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the serialized queue alive when one request fails", async () => {
+    const helper = await createConcurrencyHelper(20);
+    const backend = createComputerUseNativeBackend({
+      helperPath: helper.helperPath,
+    });
+
+    try {
+      const results = await Promise.allSettled([
+        backend.openApp("ok-a"),
+        backend.openApp("ok-b"),
+        backend.openApp("FAIL"),
+        backend.openApp("ok-c"),
+        backend.openApp("ok-d"),
+      ]);
+
+      expect(
+        results.map((result) => {
+          return result.status;
+        }),
+      ).toStrictEqual([
+        "fulfilled",
+        "fulfilled",
+        "rejected",
+        "fulfilled",
+        "fulfilled",
+      ]);
+      const failed = results[2];
+      if (failed?.status !== "rejected") {
+        throw new Error("expected the FAIL request to reject");
+      }
+      expect(failed.reason).toMatchObject({ code: "app_open_failed" });
+    } finally {
+      backend.dispose();
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers by respawning the helper after a request times out", async () => {
+    const helper = await createConcurrencyHelper(20);
+    // Generous enough that a legitimate request (which must cold-start a fresh
+    // helper process after the kill) never trips it, while the never-answered
+    // "HANG" request always does.
+    const backend = createComputerUseNativeBackend({
+      helperPath: helper.helperPath,
+      requestTimeoutMs: 600,
+    });
+
+    try {
+      await expect(backend.openApp("HANG")).rejects.toMatchObject({
+        code: "accessibility_unavailable",
+        message: expect.stringContaining("timed out running app.open"),
+      });
+      // The next request runs on a freshly spawned helper, not the killed one.
+      await expect(backend.openApp("ok")).resolves.toEqual({});
+
+      const starts = (await readFile(helper.startLogPath, "utf8"))
+        .trim()
+        .split("\n");
+      expect(starts).toHaveLength(2);
     } finally {
       backend.dispose();
       await rm(helper.dir, { recursive: true, force: true });

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -148,6 +148,7 @@ interface ResolveComputerUseHelperPathOptions {
 interface RunComputerUseHelperOptions {
   readonly helperPath?: string;
   readonly mode?: "serve" | "oneshot";
+  readonly requestTimeoutMs?: number;
 }
 
 export class ComputerUseNativeHelperError extends Error {
@@ -431,6 +432,12 @@ function runtimePayload(
   return payload;
 }
 
+// macOS funnels screen capture through a single WindowServer broker that fails
+// transiently when two captures overlap, so the helper must run one request at
+// a time. This is the backstop that keeps a wedged helper from blocking the
+// whole serialized queue forever; on timeout the helper is killed and respawned.
+const DEFAULT_RUNTIME_REQUEST_TIMEOUT_MS = 60_000;
+
 class ComputerUseNativeRuntimeClient {
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
@@ -438,8 +445,12 @@ class ComputerUseNativeRuntimeClient {
   private closed = false;
   private stderr = "";
   private readonly pending = new Map<string, PendingRuntimeRequest>();
+  private queueTail: Promise<void> = Promise.resolve();
 
-  constructor(private readonly helperPath: string) {}
+  constructor(
+    private readonly helperPath: string,
+    private readonly requestTimeoutMs: number,
+  ) {}
 
   request(request: ComputerUseNativeRequest): Promise<Record<string, unknown>> {
     if (this.closed) {
@@ -450,15 +461,57 @@ class ComputerUseNativeRuntimeClient {
         ),
       );
     }
+    // Serialize every request so at most one capture is in flight. The tail
+    // tracks completion only and swallows the outcome so a single rejected
+    // request never poisons the chain for the requests queued behind it.
+    const run = this.queueTail.then(() => this.dispatch(request));
+    this.queueTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private dispatch(
+    request: ComputerUseNativeRequest,
+  ): Promise<Record<string, unknown>> {
     const child = this.ensureChild();
     const id = `desktop_${(this.requestCounter += 1).toString()}`;
-    return new Promise((resolve, reject) => {
-      this.pending.set(id, { kind: request.kind, resolve, reject });
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (!this.pending.delete(id)) {
+          return;
+        }
+        // A wedged helper would block every queued request behind it. Detach
+        // and kill it so the next request starts on a fresh process; the
+        // detach makes the stale child's later "close" a no-op (see ensureChild).
+        if (this.child === child) {
+          this.child = null;
+        }
+        child.kill("SIGKILL");
+        reject(
+          new ComputerUseNativeHelperError(
+            "accessibility_unavailable",
+            `Native Computer Use runtime timed out running ${request.kind}`,
+          ),
+        );
+      }, this.requestTimeoutMs);
+      this.pending.set(id, {
+        kind: request.kind,
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
       child.stdin.write(
         `${JSON.stringify({ id, kind: request.kind, payload: runtimePayload(request) })}\n`,
         (error) => {
-          if (error) {
-            this.pending.delete(id);
+          if (error && this.pending.delete(id)) {
+            clearTimeout(timer);
             reject(
               new ComputerUseNativeHelperError(
                 "accessibility_unavailable",
@@ -494,6 +547,8 @@ class ComputerUseNativeRuntimeClient {
       stdio: ["pipe", "pipe", "pipe"],
     });
     this.child = child;
+    this.stderr = "";
+    this.stdoutBuffer = "";
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
@@ -504,14 +559,22 @@ class ComputerUseNativeRuntimeClient {
       this.stderr += chunk;
     });
     child.on("error", (error) => {
-      this.rejectAll(
-        new ComputerUseNativeHelperError(
-          "accessibility_unavailable",
-          `Unable to start native Computer Use runtime: ${error.message}`,
-        ),
-      );
+      if (this.child === child && !this.closed) {
+        this.rejectAll(
+          new ComputerUseNativeHelperError(
+            "accessibility_unavailable",
+            `Unable to start native Computer Use runtime: ${error.message}`,
+          ),
+        );
+      }
     });
     child.on("close", (code) => {
+      // A helper we already replaced (e.g. after a timeout kill) closes with its
+      // pending request already settled; ignore it so we neither clear the new
+      // child reference nor reject the request now running on the new child.
+      if (this.child !== child) {
+        return;
+      }
       this.child = null;
       if (!this.closed) {
         this.rejectAll(
@@ -593,7 +656,10 @@ export function createComputerUseNativeBackend(
   const runtime =
     options.mode === "oneshot"
       ? null
-      : new ComputerUseNativeRuntimeClient(helperPath);
+      : new ComputerUseNativeRuntimeClient(
+          helperPath,
+          options.requestTimeoutMs ?? DEFAULT_RUNTIME_REQUEST_TIMEOUT_MS,
+        );
   const run = async (
     request: ComputerUseNativeRequest,
   ): Promise<Record<string, unknown>> => {


### PR DESCRIPTION
## Problem

Closes part of #15194. The native computer-use helper funnels screen capture through the single macOS **WindowServer** broker (via the deprecated `CGWindowListCreateImage`), which fails transiently with `screen_recording_unavailable: Unable to capture target window screenshot` when two captures overlap. Running the same operations serially is stable.

The local daemon socket already serialized the *CLI-via-daemon* path (`vm0-computer.ts` `commandQueue`), but that queue only covers that one path. **Every** TypeScript caller ultimately funnels through `ComputerUseNativeRuntimeClient.request()`, which assigned an id and wrote each request to the shared helper's stdin **immediately** — no serialization. So the Electron host path (multiple host instances share one client) and any concurrent caller could still drive overlapping captures into the helper.

## Change

- **Single-flight serialization** in `ComputerUseNativeRuntimeClient`: every `request()` is chained onto a FIFO promise tail so at most one request is in flight to the helper at a time. The tail tracks completion only and swallows the outcome, so a rejected request never poisons the chain for requests queued behind it.
- **Per-request timeout with kill + respawn**: serialization means a single wedged op would otherwise block the whole queue (and every host sharing the client) forever. On timeout the helper is detached and `SIGKILL`ed; the next request cold-starts a fresh process via `ensureChild()`. A staleness guard (`this.child === child`) on the `close`/`error` handlers makes the killed helper's later `close` a no-op so it can't reject the request now running on the replacement. Default timeout 60s, overridable via `requestTimeoutMs`.
- Keyboard/mouse ops are serialized too (not just captures): a write command already fans out into a trailing capture (`withPostActionAppState`), and an input landing mid-capture is itself a source of window-state churn.

The daemon's existing `commandQueue` is left as a harmless outer gate.

## Tests

Three integration tests in `computer-use-native.test.ts` driving a fake serve-mode helper (real child process, temp dir):

- **serializes concurrent requests** — fires 8 concurrent `openApp` calls; asserts the helper never sees more than one request in flight and receives them in FIFO submission order.
- **keeps the queue alive when one request fails** — a failed request in the middle rejects, the others still resolve.
- **recovers by respawning the helper after a request times out** — a never-answered request times out, then the next request succeeds on a freshly spawned helper (verified via a per-process start log).

All 23 tests in the file pass; lint, `tsc --noEmit`, prettier, and knip are clean.

## Out of scope (tracked separately, see #15194)

Cross-process serialization for oneshot mode, retry-on-transient as a complementary mitigation, migrating off the deprecated `CGWindowListCreateImage` to `SCScreenshotManager`, and a pre-existing daemon socket single-newline parsing nit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)