### PR TITLE
fix(computer-use): require editable focus for type-text

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -83,8 +83,11 @@ Notes:
   Write commands are sent to the connected Desktop host and may wait for local
   approval before they run. Coordinate fallbacks use screenshot coordinates from
   get-app-state; pass the matching --snapshot-id when acting on a prior snapshot.
-  type-text sends literal keyboard input to the target app's current focus. Use
-  set-value when you need deterministic accessibility value assignment.
+  type-text sends literal keyboard input to the target app's current focus. It
+  first verifies the focused element is editable and fails with
+  element_not_editable when it is not (for example a focused table or list), so
+  click into a text field before typing. Use set-value when you need
+  deterministic accessibility value assignment.
   press-key accepts xdotool-style names such as shift+semicolon, Control_L+J,
   ctrl+alt+n, and BackSpace, plus existing macOS-style forms such as Command+L.
   type-text and press-key accept the same --snapshot-id as the element actions:

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -4474,11 +4474,41 @@ func handleElementPerformAction(_ request: [String: Any], session: ComputerUseRu
     }
 }
 
+// type-text dispatches synthesized keystrokes to whatever element currently holds
+// keyboard focus in the target app. When that element is not editable (for example a
+// table or list, as in Things on launch) the keystrokes are consumed as navigation
+// instead of being entered as text, so the input silently disappears. Resolve the
+// focused element up front and refuse with a clear error so the caller knows to focus
+// an editable field before typing.
+func ensureFocusedElementEditable(appName: String) throws {
+    let root = try appElement(named: appName)
+    guard let focused = axElementValue(attribute(root, kAXFocusedUIElementAttribute as CFString)) else {
+        throw HelperFailure(
+            code: "element_not_editable",
+            message:
+                "No element in \(appName) currently has keyboard focus. "
+                + "Click into a text field or editable area before typing."
+        )
+    }
+    guard attributeIsSettable(focused, kAXValueAttribute as CFString) == true else {
+        let roleSuffix = role(focused).map { focusedRole in
+            " The focused element role is \(focusedRole)."
+        } ?? ""
+        throw HelperFailure(
+            code: "element_not_editable",
+            message:
+                "The focused element in \(appName) is not editable.\(roleSuffix) "
+                + "Click into a text field or editable area before typing."
+        )
+    }
+}
+
 func handleTypeText(_ request: [String: Any], session: ComputerUseRuntimeSession?) throws -> [String: Any] {
     let appName = try requiredString(request, "app")
     let inputText = try requiredString(request, "text")
     let policy = try foregroundRecoveryPolicy(request)
     let snapshotId = optionalString(request, "snapshotId")
+    try ensureFocusedElementEditable(appName: appName)
     return try performBackgroundTextInput(
         appName: appName,
         inputText: inputText,

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -164,6 +164,7 @@ export interface ComputerUseCommandFailure {
       | "permission_denied"
       | "accessibility_unavailable"
       | "element_action_unsupported"
+      | "element_not_editable"
       | "window_unavailable"
       | "screen_recording_unavailable"
       | "app_not_found"

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -409,6 +409,10 @@ describe("computer use native backend", () => {
     ["app_not_found", "Unable to open Things: Unable to find application"],
     ["app_open_failed", "Unable to open Things"],
     ["element_action_unsupported", "Element does not support a primary click"],
+    [
+      "element_not_editable",
+      "The focused element in Things is not editable. Click into a text field or editable area before typing.",
+    ],
     ["window_unavailable", "Unable to resolve a background window target"],
   ])("preserves %s helper failures", async (code, message) => {
     const helper = await createHelper({

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -169,6 +169,7 @@ function responseErrorCode(value: unknown): ComputerUseNativeErrorCode {
     value === "permission_denied" ||
     value === "accessibility_unavailable" ||
     value === "element_action_unsupported" ||
+    value === "element_not_editable" ||
     value === "window_unavailable" ||
     value === "screen_recording_unavailable" ||
     value === "app_not_found" ||


### PR DESCRIPTION
## Summary

`type-text` synthesizes keystrokes to whatever element currently holds keyboard focus in the target app — it resolves only the *window* and never checks the element that will actually receive the input. When the focused element is not editable (for example the focused table/list in Things on launch), the keystrokes are consumed as navigation/type-select instead of being entered as text, and the input silently disappears. This was flagged in the validation notes on #15194 ("type-text may still fail in Things unless the app is first put into an editing state").

This PR makes `type-text` resolve the app's focused UI element up front and refuse with a clear `element_not_editable` error when that element is not value-settable, instead of blindly posting keystrokes into a non-editable container.

## Changes

- **Native helper** (`main.swift`): `handleTypeText` now calls a new `ensureFocusedElementEditable` precondition that reads the app's `kAXFocusedUIElement` and verifies `AXUIElementIsAttributeSettable(kAXValueAttribute)`. If nothing is focused, or the focused element is not editable, it throws `element_not_editable` with a message telling the caller to focus a text field first (including the focused element's role for diagnostics).
- **TS bridge**: added `element_not_editable` to the `ComputerUseCommandFailure` error-code union and the `responseErrorCode` whitelist so the dedicated code/message round-trips instead of being coerced to `accessibility_unavailable`.
- **CLI help**: documented that `type-text` requires an editable focus and fails with `element_not_editable` otherwise.

## Design notes

- The editability check reuses the **same signal** already surfaced per-element as `valueSettable` in app-state (`AXUIElementIsAttributeSettable(kAXValueAttribute)`). So what an agent sees as `valueSettable` in app-state is exactly what `type-text` will accept — consistent and predictable.
- This is the strict "editable → type, else clear error" model (matching `EYHN/kwwk-computer-use-core`), deliberately chosen over a silent keystroke-synthesis fallback (`trycua/cua`). Known trade-off: elements that accept keystrokes but don't report `kAXValue` settable (some web/Electron `contentEditable` areas) would now error rather than work. A follow-up could add a cua-style "attempt write → read-back verify → fall back to synthesis" path if that proves necessary.

## Testing

- Added `element_not_editable` to the helper-failure-propagation integration test, verifying the new code round-trips through the native bridge.
- `pnpm -F @vm0/desktop test` (104 passed), `pnpm -F @vm0/cli` computer-use tests (13 passed), Swift native helper tests (12 passed), type-check + lint + knip clean on both workspaces.
- The Swift focus-resolution logic itself requires a TCC-granted Accessibility context to run end-to-end (the standalone helper invoked outside the Desktop host reports `accessibility:false`), so it is validated by code trace + the shared `valueSettable` signal rather than a live GUI test, consistent with the existing helper test coverage.

Refs: #15194

🤖 Generated with [Claude Code](https://claude.com/claude-code)