### PR TITLE
refactor(desktop): extract desktop-auth-session and make token refresh explicit (R3+R4)

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import type { DesktopSessionCookieSource } from "./desktop-session-cookies";
+
+const TOKEN_URL = "https://www.vm0.ai/desktop-auth/token";
+const SELECT_ORG_URL = "https://www.vm0.ai/desktop-auth/select-org";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function createSession() {
+  const onChange = vi.fn();
+  const onAuthCompleted = vi.fn(async () => {});
+  const cookieSource: DesktopSessionCookieSource = {
+    cookies: {
+      async get() {
+        return [];
+      },
+    },
+  };
+  const runAuthWindow = vi.fn(
+    async (_request: { readonly url: string; readonly visible: boolean }) => {},
+  );
+  const session = new DesktopAuthSession({
+    apiBaseUrl: "https://api.vm0.ai",
+    cookieUrls: [new URL("https://www.vm0.ai"), new URL("https://app.vm0.ai")],
+    cookieSource,
+    tokenUrl: TOKEN_URL,
+    consumeUrl: (code) =>
+      `https://www.vm0.ai/desktop-auth/consume?code=${code}`,
+    selectOrgUrl: SELECT_ORG_URL,
+    runAuthWindow,
+    onChange,
+    onAuthCompleted,
+  });
+  return { session, runAuthWindow, onChange, onAuthCompleted };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DesktopAuthSession", () => {
+  it("returns the cached token without opening a window", async () => {
+    const { session, runAuthWindow } = createSession();
+    session.completeSignIn("cached");
+
+    expect(await session.getToken()).toBe("cached");
+    expect(runAuthWindow).not.toHaveBeenCalled();
+  });
+
+  it("stores the token and fires onChange on completeSignIn", async () => {
+    const { session, onChange } = createSession();
+
+    session.completeSignIn("tok");
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(await session.getToken()).toBe("tok");
+  });
+
+  it("returns the freshly delivered token on a forced refresh", async () => {
+    const { session, runAuthWindow } = createSession();
+    runAuthWindow.mockImplementation(async () => {
+      session.completeSignIn("fresh");
+    });
+
+    const token = await session.getToken({ forceRefresh: true });
+
+    expect(token).toBe("fresh");
+    expect(runAuthWindow).toHaveBeenCalledWith({
+      url: TOKEN_URL,
+      visible: false,
+    });
+  });
+
+  it("returns null when the refresh window delivers no token (R3)", async () => {
+    const { session, runAuthWindow } = createSession();
+    // Window navigates to completion but never calls completeSignIn.
+    runAuthWindow.mockImplementation(async () => {});
+
+    const token = await session.getToken({ forceRefresh: true });
+
+    expect(token).toBeNull();
+    expect(runAuthWindow).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces concurrent refreshes and re-runs after settling", async () => {
+    const { session, runAuthWindow } = createSession();
+    let releaseWindow: () => void = () => {};
+    runAuthWindow.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseWindow = resolve;
+        }),
+    );
+
+    const first = session.getToken({ forceRefresh: true });
+    const second = session.getToken({ forceRefresh: true });
+    session.completeSignIn("fresh");
+    releaseWindow();
+    const [firstToken, secondToken] = await Promise.all([first, second]);
+
+    expect(firstToken).toBe("fresh");
+    expect(secondToken).toBe("fresh");
+    expect(runAuthWindow).toHaveBeenCalledOnce();
+
+    // The single-flight guard is cleared in `finally`, so a later refresh
+    // opens a new window instead of reusing the settled promise.
+    runAuthWindow.mockImplementation(async () => {
+      session.completeSignIn("fresh-2");
+    });
+    expect(await session.getToken({ forceRefresh: true })).toBe("fresh-2");
+    expect(runAuthWindow).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not restart dependent runtimes after a background refresh", async () => {
+    const { session, runAuthWindow, onAuthCompleted } = createSession();
+    runAuthWindow.mockImplementation(async () => {
+      session.completeSignIn("fresh");
+    });
+
+    await session.getToken({ forceRefresh: true });
+
+    expect(onAuthCompleted).not.toHaveBeenCalled();
+  });
+
+  it("runs onAuthCompleted after a consume flow", async () => {
+    const { session, runAuthWindow, onAuthCompleted } = createSession();
+
+    await session.consumeCode("code-123");
+
+    expect(runAuthWindow).toHaveBeenCalledWith({
+      url: "https://www.vm0.ai/desktop-auth/consume?code=code-123",
+      visible: false,
+    });
+    expect(onAuthCompleted).toHaveBeenCalledOnce();
+    expect(runAuthWindow.mock.invocationCallOrder[0]).toBeLessThan(
+      onAuthCompleted.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+
+  it("runs onAuthCompleted after a visible org-selection flow", async () => {
+    const { session, runAuthWindow, onAuthCompleted } = createSession();
+
+    await session.selectOrganization();
+
+    expect(runAuthWindow).toHaveBeenCalledWith({
+      url: SELECT_ORG_URL,
+      visible: true,
+    });
+    expect(onAuthCompleted).toHaveBeenCalledOnce();
+  });
+
+  it("derives signed-in state with an organization", async () => {
+    const { session } = createSession();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/api/auth/me")) {
+          return jsonResponse({ userId: "u1", email: "u@example.com" });
+        }
+        return jsonResponse({ id: "o1", name: "Org One", slug: "org-one" });
+      }),
+    );
+
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_in",
+      user: { userId: "u1", email: "u@example.com" },
+      organization: { id: "o1", name: "Org One", slug: "org-one" },
+    });
+  });
+
+  it("derives signed-in state with a null organization on 404", async () => {
+    const { session } = createSession();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/api/auth/me")) {
+          return jsonResponse({ userId: "u1", email: "u@example.com" });
+        }
+        return new Response(null, { status: 404 });
+      }),
+    );
+
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_in",
+      user: { userId: "u1", email: "u@example.com" },
+      organization: null,
+    });
+  });
+
+  it("clears the cached token when auth state returns 401", async () => {
+    const { session, runAuthWindow } = createSession();
+    session.completeSignIn("stale");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+
+    const state = await session.getAuthState();
+
+    expect(state).toEqual({
+      status: "signed_out",
+      user: null,
+      organization: null,
+    });
+    // Token was cleared, so a non-forced getToken now refreshes via the window.
+    await session.getToken();
+    expect(runAuthWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -1,0 +1,205 @@
+import type { DesktopAuthState } from "./desktop-bridge";
+import {
+  headersWithSessionCookies,
+  type DesktopSessionCookieSource,
+} from "./desktop-session-cookies";
+
+const AUTH_ME_PATH = "/api/auth/me";
+const ZERO_ORG_PATH = "/api/zero/org";
+
+interface AuthMeResponse {
+  readonly userId: string;
+  readonly email: string;
+}
+
+interface ZeroOrgResponse {
+  readonly id: string;
+  readonly name: string;
+  readonly slug?: string;
+}
+
+/**
+ * Injected auth-window driver: the core behavior seam, analogous to
+ * `ComputerUseHostRuntime`'s `sessionFetch`. The production implementation wraps
+ * all the Electron window machinery (create window, navigation policy, wait for
+ * the completion navigation, load the URL) and resolves once the window reaches
+ * a completion navigation. The token does NOT flow back through here — it is
+ * delivered out-of-band via `completeSignIn` (the single global auth IPC).
+ */
+type RunAuthWindow = (request: {
+  readonly url: string;
+  readonly visible: boolean;
+}) => Promise<void>;
+
+interface DesktopAuthSessionOptions {
+  /** Pre-resolved API base URL (`resolveComputerUseApiBaseUrl(platformUrl)`). */
+  readonly apiBaseUrl: string;
+  /**
+   * Cookie-merge URLs for auth-state requests, in precedence order
+   * (`[webUrl, platformUrl]`). The per-request URL is appended internally so
+   * its cookies win last, matching the original `[webUrl, platformUrl, requestUrl]`.
+   */
+  readonly cookieUrls: readonly URL[];
+  readonly cookieSource: DesktopSessionCookieSource;
+  /** `buildDesktopAuthTokenUrl(webUrl)`. */
+  readonly tokenUrl: string;
+  /** `buildDesktopAuthConsumeUrl(webUrl, code)`. */
+  readonly consumeUrl: (code: string) => string;
+  /** `buildDesktopAuthSelectOrgUrl(webUrl, true)`. */
+  readonly selectOrgUrl: string;
+  readonly runAuthWindow: RunAuthWindow;
+  /** Zero-arg "something changed" signal; defaults to a no-op. */
+  readonly onChange?: () => void;
+  /**
+   * Invoked after an interactive consume / org-selection flow completes, so the
+   * caller can restart dependent runtimes. Background token refresh does NOT
+   * trigger it.
+   */
+  readonly onAuthCompleted?: () => Promise<void> | void;
+}
+
+function signedOutDesktopAuthState(): DesktopAuthState {
+  return {
+    status: "signed_out",
+    user: null,
+    organization: null,
+  };
+}
+
+/**
+ * Owns the desktop auth token state machine, extracted from `main.ts` and kept
+ * free of Electron imports so it can be integration-tested by injecting fakes,
+ * mirroring `ComputerUseHostRuntime`'s dependency-injection shape.
+ */
+export class DesktopAuthSession {
+  private readonly apiBaseUrl: string;
+  private readonly cookieUrls: readonly URL[];
+  private readonly cookieSource: DesktopSessionCookieSource;
+  private readonly tokenUrl: string;
+  private readonly consumeUrl: (code: string) => string;
+  private readonly selectOrgUrl: string;
+  private readonly runAuthWindow: RunAuthWindow;
+  private readonly onChange: () => void;
+  private readonly onAuthCompleted: () => Promise<void> | void;
+
+  private token: string | null = null;
+  private tokenRefresh: Promise<string | null> | null = null;
+  private pendingCode: string | null = null;
+
+  constructor(options: DesktopAuthSessionOptions) {
+    this.apiBaseUrl = options.apiBaseUrl;
+    this.cookieUrls = options.cookieUrls;
+    this.cookieSource = options.cookieSource;
+    this.tokenUrl = options.tokenUrl;
+    this.consumeUrl = options.consumeUrl;
+    this.selectOrgUrl = options.selectOrgUrl;
+    this.runAuthWindow = options.runAuthWindow;
+    this.onChange = options.onChange ?? (() => {});
+    this.onAuthCompleted = options.onAuthCompleted ?? (() => {});
+  }
+
+  async getToken(options?: {
+    readonly forceRefresh?: boolean;
+  }): Promise<string | null> {
+    if (!options?.forceRefresh && this.token) {
+      return this.token;
+    }
+    return await this.refresh();
+  }
+
+  async getAuthState(): Promise<DesktopAuthState> {
+    const meUrl = new URL(AUTH_ME_PATH, this.apiBaseUrl);
+    const meResponse = await fetch(meUrl, {
+      headers: await this.headersFor(meUrl),
+    });
+    if (meResponse.status === 401) {
+      this.token = null;
+      return signedOutDesktopAuthState();
+    }
+    if (!meResponse.ok) {
+      throw new Error(`Desktop auth status failed: ${meResponse.status}`);
+    }
+
+    const user = (await meResponse.json()) as AuthMeResponse;
+    const orgUrl = new URL(ZERO_ORG_PATH, this.apiBaseUrl);
+    const orgResponse = await fetch(orgUrl, {
+      headers: await this.headersFor(orgUrl),
+    });
+    if (orgResponse.status === 401) {
+      this.token = null;
+      return signedOutDesktopAuthState();
+    }
+    if (orgResponse.status === 404) {
+      return { status: "signed_in", user, organization: null };
+    }
+    if (!orgResponse.ok) {
+      throw new Error(
+        `Desktop organization status failed: ${orgResponse.status}`,
+      );
+    }
+
+    const organization = (await orgResponse.json()) as ZeroOrgResponse;
+    return {
+      status: "signed_in",
+      user,
+      organization: {
+        id: organization.id,
+        name: organization.name,
+        slug: organization.slug ?? null,
+      },
+    };
+  }
+
+  completeSignIn(token: string): void {
+    this.token = token;
+    this.onChange();
+  }
+
+  async consumeCode(code: string): Promise<void> {
+    await this.runAuthWindow({ url: this.consumeUrl(code), visible: false });
+    await this.onAuthCompleted();
+  }
+
+  async selectOrganization(): Promise<void> {
+    await this.runAuthWindow({ url: this.selectOrgUrl, visible: true });
+    await this.onAuthCompleted();
+  }
+
+  queuePendingCode(code: string): void {
+    this.pendingCode = code;
+  }
+
+  takePendingCode(): string | null {
+    const code = this.pendingCode;
+    this.pendingCode = null;
+    return code;
+  }
+
+  private async refresh(): Promise<string | null> {
+    if (this.tokenRefresh) {
+      return await this.tokenRefresh;
+    }
+
+    this.tokenRefresh = (async () => {
+      await this.runAuthWindow({ url: this.tokenUrl, visible: false });
+      return this.token;
+    })();
+
+    try {
+      return await this.tokenRefresh;
+    } finally {
+      this.tokenRefresh = null;
+    }
+  }
+
+  private async headersFor(requestUrl: URL): Promise<Headers> {
+    const headers = await headersWithSessionCookies(this.cookieSource, [
+      ...this.cookieUrls,
+      requestUrl,
+    ]);
+    if (this.token) {
+      headers.set("authorization", `Bearer ${this.token}`);
+    }
+    return headers;
+  }
+}

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -181,8 +181,14 @@ export class DesktopAuthSession {
     }
 
     this.tokenRefresh = (async () => {
+      const before = this.token;
       await this.runAuthWindow({ url: this.tokenUrl, visible: false });
-      return this.token;
+      const after = this.token;
+      // completeSignIn() is the token's only write path. If the refresh window
+      // reached a completion navigation without ever delivering a token, the
+      // token is unchanged, so surface an explicit null instead of the stale
+      // value the 401 retry would otherwise resend.
+      return after === before ? null : after;
     })();
 
     try {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -27,7 +27,6 @@ import {
   hasRequiredComputerUsePermissions,
   type DesktopComputerUseState,
 } from "./computer-use-types";
-import type { DesktopAuthState } from "./desktop-bridge";
 import {
   getComputerUsePermissionState,
   refreshComputerUsePermissionState,
@@ -38,7 +37,7 @@ import {
 import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
-import { headersWithSessionCookies } from "./desktop-session-cookies";
+import { DesktopAuthSession } from "./desktop-auth-session";
 import {
   installDesktopAuthIpc,
   notifyDesktopAuthChanged,
@@ -82,20 +81,44 @@ const desktopAuthTokenUrl = buildDesktopAuthTokenUrl(config.webUrl);
 const localRendererUrl = desktopRendererUrl();
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const ELECTRON_ERR_ABORTED = -3;
-const AUTH_ME_PATH = "/api/auth/me";
-const ZERO_ORG_PATH = "/api/zero/org";
 const COMPUTER_USE_QUIT_STOP_TIMEOUT_MS = 1_000;
 let mainWindow: BrowserWindow | null = null;
-let pendingDesktopAuthCode: string | null = null;
 let appIsQuitting = false;
 let computerUseQuitStopStarted = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
-let desktopAuthToken: string | null = null;
-let desktopAuthTokenRefresh: Promise<string | null> | null = null;
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
 const computerUseNativeBackend = createComputerUseNativeBackend();
 setComputerUsePermissionNativeBackend(computerUseNativeBackend);
+
+async function runAuthWindow(request: {
+  readonly url: string;
+  readonly visible: boolean;
+}): Promise<void> {
+  const authWindow = new BrowserWindow({
+    ...browserWindowOptions(),
+    show: request.visible,
+    width: request.visible ? 520 : 480,
+    height: 640,
+    skipTaskbar: !request.visible,
+  });
+  installAuthConsumeWindowPolicy(authWindow);
+  const pending = waitForAuthConsumeWindow(authWindow);
+  await loadAuthUrl(authWindow, request.url);
+  await pending;
+}
+
+const authSession = new DesktopAuthSession({
+  apiBaseUrl: desktopApiBaseUrl,
+  cookieUrls: [config.webUrl, config.platformUrl],
+  cookieSource: session.fromPartition(config.sessionPartition),
+  tokenUrl: desktopAuthTokenUrl,
+  consumeUrl: (code) => buildDesktopAuthConsumeUrl(config.webUrl, code),
+  selectOrgUrl: desktopAuthSelectOrgUrl,
+  runAuthWindow,
+  onChange: notifyDesktopAuthChanged,
+  onAuthCompleted: maybeStartComputerUseAfterAuth,
+});
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -148,79 +171,6 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
   };
 }
 
-interface AuthMeResponse {
-  readonly userId: string;
-  readonly email: string;
-}
-
-interface ZeroOrgResponse {
-  readonly id: string;
-  readonly name: string;
-  readonly slug?: string;
-}
-
-function signedOutDesktopAuthState(): DesktopAuthState {
-  return {
-    status: "signed_out",
-    user: null,
-    organization: null,
-  };
-}
-
-async function desktopAuthHeadersFor(requestUrl: URL): Promise<Headers> {
-  const headers = await headersWithSessionCookies(
-    session.fromPartition(config.sessionPartition),
-    [config.webUrl, config.platformUrl, requestUrl],
-  );
-  if (desktopAuthToken) {
-    headers.set("authorization", `Bearer ${desktopAuthToken}`);
-  }
-  return headers;
-}
-
-async function getDesktopAuthState(): Promise<DesktopAuthState> {
-  const meUrl = new URL(AUTH_ME_PATH, desktopApiBaseUrl);
-  const meResponse = await fetch(meUrl, {
-    headers: await desktopAuthHeadersFor(meUrl),
-  });
-  if (meResponse.status === 401) {
-    desktopAuthToken = null;
-    return signedOutDesktopAuthState();
-  }
-  if (!meResponse.ok) {
-    throw new Error(`Desktop auth status failed: ${meResponse.status}`);
-  }
-
-  const user = (await meResponse.json()) as AuthMeResponse;
-  const orgUrl = new URL(ZERO_ORG_PATH, desktopApiBaseUrl);
-  const orgResponse = await fetch(orgUrl, {
-    headers: await desktopAuthHeadersFor(orgUrl),
-  });
-  if (orgResponse.status === 401) {
-    desktopAuthToken = null;
-    return signedOutDesktopAuthState();
-  }
-  if (orgResponse.status === 404) {
-    return { status: "signed_in", user, organization: null };
-  }
-  if (!orgResponse.ok) {
-    throw new Error(
-      `Desktop organization status failed: ${orgResponse.status}`,
-    );
-  }
-
-  const organization = (await orgResponse.json()) as ZeroOrgResponse;
-  return {
-    status: "signed_in",
-    user,
-    organization: {
-      id: organization.id,
-      name: organization.name,
-      slug: organization.slug ?? null,
-    },
-  };
-}
-
 async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
   const desktopSession = session.fromPartition(config.sessionPartition);
   if (!computerUseRuntime) {
@@ -231,7 +181,7 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
       sessionFetch: createDesktopComputerUseSessionFetch({
         platformUrl: config.platformUrl,
         session: desktopSession,
-        getAuthToken: getDesktopAuthToken,
+        getAuthToken: (options) => authSession.getToken(options),
       }),
       hostFetch: (input, init) => {
         return fetch(input, init);
@@ -308,12 +258,12 @@ async function stopComputerUseRuntimeForQuit(): Promise<void> {
 function installDesktopAuth(): void {
   installDesktopAuthIpc(
     {
-      getState: getDesktopAuthState,
+      getState: () => authSession.getAuthState(),
       openSignIn: () => {
         openExternal(desktopAuthStartUrl);
       },
-      openOrgSelection: openDesktopAuthSelectOrg,
-      completeSignIn: completeDesktopAuthSignIn,
+      openOrgSelection: () => authSession.selectOrganization(),
+      completeSignIn: (token) => authSession.completeSignIn(token),
     },
     {
       rendererUrl: localRendererUrl,
@@ -359,11 +309,6 @@ function logDesktopAuthError(error: unknown): void {
   console.error("Desktop auth flow failed", error);
 }
 
-function completeDesktopAuthSignIn(token: string): void {
-  desktopAuthToken = token;
-  notifyDesktopAuthChanged();
-}
-
 async function loadAuthUrl(window: BrowserWindow, url: string): Promise<void> {
   try {
     await window.loadURL(url);
@@ -372,42 +317,6 @@ async function loadAuthUrl(window: BrowserWindow, url: string): Promise<void> {
       throw error;
     }
   }
-}
-
-async function refreshDesktopAuthToken(): Promise<string | null> {
-  if (desktopAuthTokenRefresh) {
-    return await desktopAuthTokenRefresh;
-  }
-
-  desktopAuthTokenRefresh = (async () => {
-    const authWindow = new BrowserWindow({
-      ...browserWindowOptions(),
-      show: false,
-      width: 480,
-      height: 640,
-      skipTaskbar: true,
-    });
-    installAuthConsumeWindowPolicy(authWindow);
-    const pendingToken = waitForAuthConsumeWindow(authWindow);
-    await loadAuthUrl(authWindow, desktopAuthTokenUrl);
-    await pendingToken;
-    return desktopAuthToken;
-  })();
-
-  try {
-    return await desktopAuthTokenRefresh;
-  } finally {
-    desktopAuthTokenRefresh = null;
-  }
-}
-
-async function getDesktopAuthToken(options?: {
-  readonly forceRefresh?: boolean;
-}): Promise<string | null> {
-  if (!options?.forceRefresh && desktopAuthToken) {
-    return desktopAuthToken;
-  }
-  return await refreshDesktopAuthToken();
 }
 
 function openDesktopAuthStart(rawUrl: string): boolean {
@@ -430,11 +339,11 @@ function openDesktopAuthCallback(rawUrl: string): boolean {
   desktopAuthStartGate.suppressRetry();
 
   if (!app.isReady()) {
-    pendingDesktopAuthCode = callback.code;
+    authSession.queuePendingCode(callback.code);
     return true;
   }
 
-  void openDesktopAuthConsume(callback.code).catch(logDesktopAuthError);
+  void authSession.consumeCode(callback.code).catch(logDesktopAuthError);
   return true;
 }
 
@@ -664,37 +573,6 @@ async function maybeStartComputerUseAfterAuth(): Promise<void> {
   }
 }
 
-async function openDesktopAuthSelectOrg(): Promise<void> {
-  const authWindow = new BrowserWindow({
-    ...browserWindowOptions(),
-    show: true,
-    width: 520,
-    height: 640,
-    skipTaskbar: false,
-  });
-  installAuthConsumeWindowPolicy(authWindow);
-  const pendingSelection = waitForAuthConsumeWindow(authWindow);
-  await loadAuthUrl(authWindow, desktopAuthSelectOrgUrl);
-  await pendingSelection;
-  await maybeStartComputerUseAfterAuth();
-}
-
-async function openDesktopAuthConsume(code: string): Promise<void> {
-  const consumeUrl = buildDesktopAuthConsumeUrl(config.webUrl, code);
-  const authWindow = new BrowserWindow({
-    ...browserWindowOptions(),
-    show: false,
-    width: 480,
-    height: 640,
-    skipTaskbar: true,
-  });
-  installAuthConsumeWindowPolicy(authWindow);
-  const pendingConsume = waitForAuthConsumeWindow(authWindow);
-  await loadAuthUrl(authWindow, consumeUrl);
-  await pendingConsume;
-  await maybeStartComputerUseAfterAuth();
-}
-
 function handleDesktopAuthCallback(rawUrl: string): void {
   openDesktopAuthCallback(rawUrl);
 }
@@ -710,11 +588,11 @@ function handleDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
 
   desktopAuthStartGate.suppressRetry();
   if (!app.isReady()) {
-    pendingDesktopAuthCode = callback.code;
+    authSession.queuePendingCode(callback.code);
     return true;
   }
 
-  void openDesktopAuthConsume(callback.code).catch(logDesktopAuthError);
+  void authSession.consumeCode(callback.code).catch(logDesktopAuthError);
   return true;
 }
 
@@ -728,7 +606,7 @@ function queueDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
   }
 
   desktopAuthStartGate.suppressRetry();
-  pendingDesktopAuthCode = callback.code;
+  authSession.queuePendingCode(callback.code);
   return true;
 }
 
@@ -800,11 +678,10 @@ if (!hasSingleInstanceLock) {
     installDesktopAuth();
     queueDesktopAuthCallbackArgv(process.argv);
 
-    const pendingCode = pendingDesktopAuthCode;
-    pendingDesktopAuthCode = null;
+    const pendingCode = authSession.takePendingCode();
     await createMainWindow();
     if (pendingCode) {
-      void openDesktopAuthConsume(pendingCode).catch(logDesktopAuthError);
+      void authSession.consumeCode(pendingCode).catch(logDesktopAuthError);
     }
 
     app.on("activate", () => {


### PR DESCRIPTION
## Summary

Implements the R3 + R4 refactor tracked in #15394 for `turbo/apps/desktop` (the `@vm0/desktop` Electron shell).

- **R4 (structure):** extract the desktop auth token state machine out of the 820-line `main.ts` god file into a focused, Electron-free `DesktopAuthSession` class that mirrors `ComputerUseHostRuntime`'s dependency-injection shape, so the state machine becomes integration-testable.
- **R3 (behavior):** make token refresh return the token actually delivered during the refresh, and `null` on the navigated-but-no-token failure path, instead of returning the stale module-global.

The two are coupled — R3's fix lives inside the module R4 extracts.

## Commits (behavior-preserving first, then the isolated fix)

1. `refactor(desktop): extract desktop-auth-session module from main.ts` — pure move, no logic change. `main.ts` shrinks by ~120 lines; the Electron window machinery stays behind an injected `runAuthWindow` seam and `maybeStartComputerUseAfterAuth` is injected as `onAuthCompleted`.
2. `fix(desktop): surface null from token refresh when no token is delivered` — the one-line behavior change (before/after token compare) plus the new test file. Independently revertable.

## R3 mechanism

`completeSignIn` is the token's only write path, and its IPC handler is window-agnostic (`desktop-auth-electron.ts:83-90` carries no window identity), so the token cannot be plumbed back through the window driver. Instead `refresh` snapshots the token before opening the window and compares after:

```ts
const before = this.token;
await this.runAuthWindow({ url: this.tokenUrl, visible: false });
const after = this.token;
return after === before ? null : after;
```

The 401 retry in `desktop-computer-use-api.ts` then omits the `Bearer` header on `null` instead of resending a stale token.

## Open question — resolved

The issue flagged that this depends on `/desktop-auth/token` always calling `completeSignIn` when the session is valid. Verified in `apps/web`: `DesktopAuthTokenClient.tsx` calls `completeDesktopAuth(getToken)` (→ `window.vm0DesktopAuth.completeSignIn`) **before** `window.location.replace("/")` whenever signed in with an active org — i.e. before the home-path navigation the desktop treats as completion. So the normal refresh path still returns the fresh token; `null` only surfaces when no token was genuinely delivered.

## Concurrency note (documented, not a regression)

A fire-and-forget deep-link `consumeCode` overlapping a `forceRefresh` could let the refresh observe a token delivered by a different window. This equals today's module-global semantics — no regression — and a per-window mapping doesn't exist in the codebase, so per YAGNI it's left as-is.

## Tests

New `desktop-auth-session.test.ts` (mirrors `computer-use-host.test.ts`: injected `vi.fn` fakes, `vi.stubGlobal("fetch")`, no `vi.mock` of local modules) covering:
- cache hit (no window opened)
- `completeSignIn` sets token + fires `onChange`
- forced refresh returns the freshly delivered token
- **forced refresh returns `null` when no token is delivered (the previously untestable R3 failure path)**
- single-flight coalescing + re-run after settling
- background refresh does **not** trigger `onAuthCompleted`
- `consumeCode` / `selectOrganization` run `onAuthCompleted` after the window
- `getAuthState` derivation: signed-in with org, signed-in null-org (404), signed-out + token-clear (401)

## Verification

From `turbo/` against latest `origin/main`:

- `pnpm -F @vm0/desktop check-types` ✅
- `pnpm -F @vm0/desktop lint` ✅ (0 warnings)
- `pnpm -F @vm0/desktop exec vitest run` ✅ (114 tests, +11 new)
- `pnpm knip --workspace apps/desktop` ✅

Closes #15394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
