### PR TITLE
fix: make computer-use --app accept bundle id only

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -170,7 +170,9 @@ describe("computer-use command visibility", () => {
 
     expect(helpOutput).toContain("Workflow:");
     expect(helpOutput).toContain("zero computer-use list-apps");
-    expect(helpOutput).toContain("zero computer-use get-app-state --app <app>");
+    expect(helpOutput).toContain(
+      "zero computer-use get-app-state --app <bundleId>",
+    );
     expect(helpOutput).toContain("--snapshot-id desktop_abc --element-index 7");
     expect(helpOutput).toContain("/tmp/vm0/computer-use");
     expect(helpOutput).toContain("overwrites the same files");

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -68,8 +68,10 @@ const DATA_URL_PATTERN = /^data:([^;,]+);base64,(.*)$/s;
 const COMPUTER_USE_HELP_TEXT = `
 Workflow:
   1. Start the Zero Desktop app and make sure Computer Use is online.
-  2. Run "zero computer-use list-apps" to find the target app name or bundle id.
-  3. Run "zero computer-use get-app-state --app <app>" to get a screenshot,
+  2. Run "zero computer-use list-apps" to find the target app's bundleId.
+     --app accepts a bundle id only (e.g. com.google.Chrome); the name is for
+     display. Apps listed without a bundleId cannot be targeted.
+  3. Run "zero computer-use get-app-state --app <bundleId>" to get a screenshot,
      snapshotId, visible element indexes, and accessibility state.
   4. Prefer element actions with --snapshot-id and --element-index. Use --x/--y
      only when the target is visible in the returned screenshot but has no useful
@@ -97,22 +99,22 @@ Examples:
     zero computer-use list-apps
 
   Inspect Safari state:
-    zero computer-use get-app-state --app Safari
+    zero computer-use get-app-state --app com.apple.Safari
 
   Click element index 7 from snapshot desktop_abc:
-    zero computer-use click --app Safari --snapshot-id desktop_abc --element-index 7
+    zero computer-use click --app com.apple.Safari --snapshot-id desktop_abc --element-index 7
 
   Click screenshot coordinate (320, 240) from snapshot desktop_abc:
-    zero computer-use click --app Safari --snapshot-id desktop_abc --x 320 --y 240
+    zero computer-use click --app com.apple.Safari --snapshot-id desktop_abc --x 320 --y 240
 
   Type text into the snapshot desktop_abc window in Safari:
-    zero computer-use type-text --app Safari --snapshot-id desktop_abc --text "Hello"
+    zero computer-use type-text --app com.apple.Safari --snapshot-id desktop_abc --text "Hello"
 
   Press a keyboard shortcut in the snapshot desktop_abc window:
-    zero computer-use press-key --app Safari --snapshot-id desktop_abc --key shift+semicolon
+    zero computer-use press-key --app com.apple.Safari --snapshot-id desktop_abc --key shift+semicolon
 
   Open an app without activating the current foreground app:
-    zero computer-use open-app --app Things`;
+    zero computer-use open-app --app com.culturedcode.ThingsMac`;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -416,7 +418,10 @@ function addTargetOptions(command: Command): Command {
 }
 
 function appOption(command: Command): Command {
-  return command.requiredOption("--app <name>", "Target app name or bundle id");
+  return command.requiredOption(
+    "--app <bundleId>",
+    "Target app bundle id (e.g. com.google.Chrome); run list-apps to find it",
+  );
 }
 
 const listAppsCommand = addTargetOptions(

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1625,40 +1625,41 @@ func optionalRectPayload(_ request: [String: Any], _ key: String) throws -> CGRe
     return try rectPayload(request, key)
 }
 
-func findRunningApp(named appName: String) -> NSRunningApplication? {
-    let apps = NSWorkspace.shared.runningApplications.filter { app in
-        !app.isTerminated
+/// Resolves a running application from a bundle id.
+///
+/// `--app` accepts a bundle id only (e.g. `com.google.Chrome`). The bundle id is
+/// the stable, unique key for an application; the localized name is not and could
+/// resolve to an arbitrary process whose window tree differs from the user-facing
+/// app. Selection is delegated to the shared `selectRunningApp` policy.
+func findRunningApp(named bundleId: String) -> NSRunningApplication? {
+    let runningApplications = NSWorkspace.shared.runningApplications
+    let candidates = runningApplications.map { app in
+        RunningAppCandidate(
+            processIdentifier: Int(app.processIdentifier),
+            bundleId: app.bundleIdentifier,
+            isTerminated: app.isTerminated,
+            isRegularActivationPolicy: app.activationPolicy == .regular
+        )
     }
+    guard let selected = selectRunningApp(bundleId: bundleId, from: candidates) else {
+        return nil
+    }
+    return runningApplications.first { app in
+        Int(app.processIdentifier) == selected.processIdentifier
+    }
+}
 
-    if let exactBundle = apps.first(where: { app in
-        app.bundleIdentifier == appName
-    }) {
-        return exactBundle
-    }
-
-    let normalized = appName.lowercased()
-    if let bundleMatch = apps.first(where: { app in
-        app.bundleIdentifier?.lowercased() == normalized
-    }) {
-        return bundleMatch
-    }
-
-    if let exactName = apps.first(where: { app in
-        app.localizedName == appName
-    }) {
-        return exactName
-    }
-
-    return apps.first { app in
-        app.localizedName?.lowercased() == normalized
-    }
+/// Message shown when `--app` does not resolve to a running application.
+func appNotRunningMessage(_ bundleId: String) -> String {
+    "App is not running: \(bundleId). --app expects a bundle id "
+        + "(e.g. com.google.Chrome); run list-apps to find it."
 }
 
 func resolveRunningApp(named appName: String) throws -> NSRunningApplication {
     guard let app = findRunningApp(named: appName) else {
         throw HelperFailure(
             code: "accessibility_unavailable",
-            message: "App is not running: \(appName)"
+            message: appNotRunningMessage(appName)
         )
     }
     return app
@@ -1673,16 +1674,6 @@ func trimmedPipeOutput(_ pipe: Pipe) -> String {
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     return String(data: data, encoding: .utf8)?
         .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-}
-
-func appOpenFailureCode(_ stderr: String) -> String {
-    let normalized = stderr.lowercased()
-    if normalized.contains("unable to find application") ||
-        normalized.contains("does not exist")
-    {
-        return "app_not_found"
-    }
-    return "app_open_failed"
 }
 
 func attribute(_ element: AXUIElement, _ name: CFString) -> Any? {
@@ -2508,44 +2499,17 @@ func applicationNames(for url: URL) -> [String] {
     return names
 }
 
-func applicationURL(named appName: String) -> URL? {
-    let trimmed = appName.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmed.isEmpty {
+/// Resolves the on-disk URL for an application from its bundle id, used to launch
+/// it when it is not already running. `--app` accepts a bundle id only.
+func applicationURL(forBundleId bundleId: String) -> URL? {
+    let trimmed = bundleId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
         return nil
     }
-    if trimmed.hasPrefix("/") || trimmed.hasPrefix("~") {
-        let expanded = (trimmed as NSString).expandingTildeInPath
-        if FileManager.default.fileExists(atPath: expanded) {
-            return URL(fileURLWithPath: expanded)
-        }
-    }
-    if trimmed.contains("."),
-       let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: trimmed)
-    {
-        return url
-    }
-
-    let candidates = discoveredApplicationURLs()
-    if let exactBundleID = candidates.first(where: { url in
-        Bundle(url: url)?.bundleIdentifier?.localizedCaseInsensitiveCompare(trimmed) == .orderedSame
-    }) {
-        return exactBundleID
-    }
-    if let exactName = candidates.first(where: { url in
-        applicationNames(for: url).contains { name in
-            name.localizedCaseInsensitiveCompare(trimmed) == .orderedSame
-        }
-    }) {
-        return exactName
-    }
-    return candidates.first { url in
-        applicationNames(for: url).contains { name in
-            name.localizedCaseInsensitiveContains(trimmed)
-        }
-    }
+    return NSWorkspace.shared.urlForApplication(withBundleIdentifier: trimmed)
 }
 
-func applicationURL(for app: NSRunningApplication, fallbackName: String) -> URL? {
+func applicationURL(for app: NSRunningApplication, fallbackBundleId: String) -> URL? {
     if let bundleURL = app.bundleURL {
         return bundleURL
     }
@@ -2554,35 +2518,7 @@ func applicationURL(for app: NSRunningApplication, fallbackName: String) -> URL?
     {
         return url
     }
-    return applicationURL(named: fallbackName)
-}
-
-func openWithCommandInBackground(named appName: String) throws {
-    let process = Process()
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-    process.arguments = ["-g", "-a", appName]
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
-    do {
-        try process.run()
-    } catch {
-        throw HelperFailure(
-            code: "app_open_failed",
-            message: "Unable to request opening \(appName): \(error)"
-        )
-    }
-    process.waitUntilExit()
-    _ = trimmedPipeOutput(stdoutPipe)
-    if process.terminationStatus != 0 {
-        let stderr = trimmedPipeOutput(stderrPipe)
-        let detail = stderr.isEmpty ? "" : ": \(stderr)"
-        throw HelperFailure(
-            code: appOpenFailureCode(stderr),
-            message: "Unable to open \(appName)\(detail)"
-        )
-    }
+    return applicationURL(forBundleId: fallbackBundleId)
 }
 
 func openApplication(at url: URL, named appName: String, activates: Bool) throws -> NSRunningApplication? {
@@ -2603,15 +2539,6 @@ func openApplication(at url: URL, named appName: String, activates: Bool) throws
         )
     }
     return launchResult.app
-}
-
-func openApplicationWithoutActivation(named appName: String) throws -> NSRunningApplication? {
-    guard let url = applicationURL(named: appName) else {
-        try openWithCommandInBackground(named: appName)
-        return nil
-    }
-
-    return try openApplication(at: url, named: appName, activates: false)
 }
 
 @discardableResult
@@ -2780,7 +2707,7 @@ func foregroundActivateRunningApp(appName: String, app: NSRunningApplication) th
             return "apple_script_activate_app_name"
         }
     }
-    guard let appURL = applicationURL(for: app, fallbackName: appName) else {
+    guard let appURL = applicationURL(for: app, fallbackBundleId: appName) else {
         return "apple_script_activate_failed"
     }
     _ = try openApplication(at: appURL, named: appName, activates: true)
@@ -2905,7 +2832,7 @@ func withForegroundRecovery(
         recoveryResult = try waitForForegroundRecoveredTarget(resolveTarget: resolveTarget)
     } catch let failure as HelperFailure where failure.code == "window_unavailable" {
         if (activationMethod.contains("apple_script_activate") || activationMethod.hasPrefix("skylight_set_current_space")),
-           let appURL = applicationURL(for: app, fallbackName: appName)
+           let appURL = applicationURL(for: app, fallbackBundleId: appName)
         {
             _ = try openApplication(at: appURL, named: appName, activates: true)
             activationMethod = "workspace_open_application"
@@ -3563,7 +3490,7 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
     guard let runningApp = findRunningApp(named: appName) else {
         throw HelperFailure(
             code: "app_not_found",
-            message: "App is not running: \(appName)"
+            message: appNotRunningMessage(appName)
         )
     }
 
@@ -3653,30 +3580,26 @@ func handleAppOpen(_ request: [String: Any]) throws -> [String: Any] {
             return (targetPID: runningApp.processIdentifier, result: ["windowReady": true])
         }
 
-        let appURL = runningApp.flatMap { app in
-            applicationURL(for: app, fallbackName: appName)
-        } ?? applicationURL(named: appName)
-
-        var targetApp: NSRunningApplication?
-        if let appURL {
-            targetApp = try openApplication(at: appURL, named: appName, activates: false) ??
-                runningApp ??
-                waitForRunningApp(named: appName)
-        } else {
-            try openWithCommandInBackground(named: appName)
-            targetApp = runningApp ?? waitForRunningApp(named: appName)
+        guard let appURL = runningApp.flatMap({ app in
+            applicationURL(for: app, fallbackBundleId: appName)
+        }) ?? applicationURL(forBundleId: appName) else {
+            throw HelperFailure(
+                code: "app_not_found",
+                message: "No installed app found for bundle id: \(appName). "
+                    + "--app expects a bundle id (e.g. com.google.Chrome); run list-apps to find it."
+            )
         }
+
+        var targetApp = try openApplication(at: appURL, named: appName, activates: false) ??
+            runningApp ??
+            waitForRunningApp(named: appName)
 
         guard let launchedApp = targetApp else {
             throw HelperFailure(code: "app_open_failed", message: "Unable to find launched app: \(appName)")
         }
 
         if waitForWindowTarget(app: launchedApp, timeout: 2) == nil {
-            if let appURL {
-                targetApp = try openApplication(at: appURL, named: appName, activates: true) ?? launchedApp
-            } else {
-                _ = launchedApp.activate(options: [.activateIgnoringOtherApps])
-            }
+            targetApp = try openApplication(at: appURL, named: appName, activates: true) ?? launchedApp
         }
 
         guard let appWithWindow = targetApp else {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/AppIdentifierPolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/AppIdentifierPolicy.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Describes a running application as seen by the helper, reduced to the fields
+/// required to select a target by bundle id.
+public struct RunningAppCandidate: Sendable, Equatable {
+    public let processIdentifier: Int
+    public let bundleId: String?
+    public let isTerminated: Bool
+    public let isRegularActivationPolicy: Bool
+
+    public init(
+        processIdentifier: Int,
+        bundleId: String?,
+        isTerminated: Bool,
+        isRegularActivationPolicy: Bool
+    ) {
+        self.processIdentifier = processIdentifier
+        self.bundleId = bundleId
+        self.isTerminated = isTerminated
+        self.isRegularActivationPolicy = isRegularActivationPolicy
+    }
+}
+
+/// Selects the running application that matches `bundleId`.
+///
+/// The `--app` argument accepts a bundle id only. A bundle id is the fixed,
+/// locale-independent identifier for an application, unlike the localized name
+/// which is presentation-only and can resolve to an arbitrary process. Matching
+/// is case-insensitive because Launch Services treats bundle ids that way.
+///
+/// A single bundle id can still have multiple running instances (e.g. launched
+/// with `open -n`). When that happens a regular (UI) instance is preferred over
+/// background/agent instances so that a controllable window can be resolved.
+public func selectRunningApp(
+    bundleId: String,
+    from candidates: [RunningAppCandidate]
+) -> RunningAppCandidate? {
+    let normalized = bundleId
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+    guard !normalized.isEmpty else {
+        return nil
+    }
+    let matches = candidates.filter { candidate in
+        !candidate.isTerminated && candidate.bundleId?.lowercased() == normalized
+    }
+    if matches.isEmpty {
+        return nil
+    }
+    return matches.first { candidate in
+        candidate.isRegularActivationPolicy
+    } ?? matches.first
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/AppIdentifierPolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/AppIdentifierPolicyTests.swift
@@ -1,0 +1,102 @@
+import Testing
+
+@testable import ComputerUseHelperCore
+
+struct AppIdentifierPolicyTests {
+    private func candidate(
+        pid: Int,
+        bundleId: String?,
+        terminated: Bool = false,
+        regular: Bool = true
+    ) -> RunningAppCandidate {
+        RunningAppCandidate(
+            processIdentifier: pid,
+            bundleId: bundleId,
+            isTerminated: terminated,
+            isRegularActivationPolicy: regular
+        )
+    }
+
+    @Test
+    func matchesBundleIdCaseInsensitively() {
+        let candidates = [
+            candidate(pid: 1, bundleId: "com.apple.Safari"),
+            candidate(pid: 2, bundleId: "com.google.Chrome"),
+        ]
+
+        let selected = selectRunningApp(bundleId: "COM.GOOGLE.chrome", from: candidates)
+
+        #expect(selected?.processIdentifier == 2)
+    }
+
+    @Test
+    func trimsSurroundingWhitespace() {
+        let candidates = [candidate(pid: 7, bundleId: "com.google.Chrome")]
+
+        let selected = selectRunningApp(bundleId: "  com.google.Chrome\n", from: candidates)
+
+        #expect(selected?.processIdentifier == 7)
+    }
+
+    @Test
+    func returnsNilForNonBundleIdInput() {
+        let candidates = [candidate(pid: 1, bundleId: "com.google.Chrome")]
+
+        #expect(selectRunningApp(bundleId: "Google Chrome", from: candidates) == nil)
+    }
+
+    @Test
+    func returnsNilForEmptyInput() {
+        let candidates = [candidate(pid: 1, bundleId: "com.google.Chrome")]
+
+        #expect(selectRunningApp(bundleId: "   ", from: candidates) == nil)
+    }
+
+    @Test
+    func ignoresTerminatedInstances() {
+        let candidates = [
+            candidate(pid: 1, bundleId: "com.google.Chrome", terminated: true),
+            candidate(pid: 2, bundleId: "com.google.Chrome", terminated: false),
+        ]
+
+        let selected = selectRunningApp(bundleId: "com.google.Chrome", from: candidates)
+
+        #expect(selected?.processIdentifier == 2)
+    }
+
+    @Test
+    func prefersRegularInstanceWhenBundleIdHasMultipleInstances() {
+        let candidates = [
+            candidate(pid: 10, bundleId: "com.google.Chrome", regular: false),
+            candidate(pid: 11, bundleId: "com.google.Chrome", regular: true),
+        ]
+
+        let selected = selectRunningApp(bundleId: "com.google.Chrome", from: candidates)
+
+        #expect(selected?.processIdentifier == 11)
+    }
+
+    @Test
+    func fallsBackToFirstMatchWhenNoRegularInstance() {
+        let candidates = [
+            candidate(pid: 20, bundleId: "com.google.Chrome", regular: false),
+            candidate(pid: 21, bundleId: "com.google.Chrome", regular: false),
+        ]
+
+        let selected = selectRunningApp(bundleId: "com.google.Chrome", from: candidates)
+
+        #expect(selected?.processIdentifier == 20)
+    }
+
+    @Test
+    func skipsCandidatesWithoutBundleId() {
+        let candidates = [
+            candidate(pid: 30, bundleId: nil),
+            candidate(pid: 31, bundleId: "com.google.Chrome"),
+        ]
+
+        let selected = selectRunningApp(bundleId: "com.google.Chrome", from: candidates)
+
+        #expect(selected?.processIdentifier == 31)
+    }
+}

--- a/turbo/apps/desktop/src/vm0-computer.ts
+++ b/turbo/apps/desktop/src/vm0-computer.ts
@@ -110,14 +110,17 @@ function usage(): string {
   vm0-computer daemon stop [--daemon-dir DIR]
   vm0-computer daemon status [--daemon-dir DIR]
   vm0-computer list-apps [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer get-app-state --app APP [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer open-app --app APP [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer click --app APP (--element-index N | --element ID | --x X --y Y) [--snapshot-id ID] [--button left|right|middle] [--click-count N] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer scroll --app APP (--element-index N | --element ID) --direction up|down|left|right [--snapshot-id ID] [--pages N] [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer set-value --app APP (--element-index N | --element ID) --value VALUE [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer perform-action --app APP (--element-index N | --element ID) --action ACTION [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer type-text --app APP --text TEXT [--snapshot-id ID] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
-  vm0-computer press-key --app APP --key KEY [--snapshot-id ID] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]`;
+  vm0-computer get-app-state --app BUNDLE_ID [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer open-app --app BUNDLE_ID [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer click --app BUNDLE_ID (--element-index N | --element ID | --x X --y Y) [--snapshot-id ID] [--button left|right|middle] [--click-count N] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer scroll --app BUNDLE_ID (--element-index N | --element ID) --direction up|down|left|right [--snapshot-id ID] [--pages N] [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer set-value --app BUNDLE_ID (--element-index N | --element ID) --value VALUE [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer perform-action --app BUNDLE_ID (--element-index N | --element ID) --action ACTION [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer type-text --app BUNDLE_ID --text TEXT [--snapshot-id ID] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
+  vm0-computer press-key --app BUNDLE_ID --key KEY [--snapshot-id ID] [--foreground-recovery never|on-window-unavailable|always] [--timeout SECONDS] [--daemon-dir DIR]
+
+  BUNDLE_ID is an app bundle id (e.g. com.google.Chrome); run list-apps to find it.
+  Apps listed without a bundleId cannot be targeted.`;
 }
 
 function fail(message: string, code = 1): never {


### PR DESCRIPTION
## Summary

Fixes #15275. The computer-use `--app` selector matched apps by **localized name** as a fallback, but `localizedName` is presentation-only and not unique. It could resolve to an arbitrary `NSRunningApplication` (wrong pid) whose Accessibility window tree differs from the user-facing app — surfacing as `window_unavailable`. This is why `--app 'Google Chrome'` failed while `--app com.google.Chrome` worked in the same run.

Per the discussion on #15275, `--app` now accepts a **bundle id only** — the stable, locale-independent, (effectively) unique key.

## Changes

- **`ComputerUseHelperCore`** — new pure `selectRunningApp(bundleId:from:)` policy (+ `RunningAppCandidate`). Matches by bundle id (case-insensitive), and when a bundle id has multiple running instances, prefers a `.regular` (UI) instance so a controllable window can be resolved. Fully unit-tested.
- **`findRunningApp`** — delegates selection to the Core policy; name/path matching removed.
- **App launch path** — `applicationURL(forBundleId:)` resolves via `urlForApplication(withBundleIdentifier:)`; `handleAppOpen` launches by bundle id. Removed the name-based `open -a` launch helpers (`openWithCommandInBackground`, `openApplicationWithoutActivation`, `appOpenFailureCode`).
- **Errors** — `--app` that doesn't resolve now returns a message pointing to bundle id + `list-apps`.
- **CLI help** — `zero computer-use` (option description, workflow, examples) and `vm0-computer` usage document bundle-id-only selection. Apps listed without a `bundleId` are not targetable. (This is the agent-facing guidance, since the agent reads the CLI help.)

A bundle id can still map to multiple running instances (`runningApplications(withBundleIdentifier:)` returns an array), which is why the multi-instance selection is retained. Apps without a bundle id (nil `bundleIdentifier`) are intentionally non-targetable.

## Breaking change

`--app` no longer accepts app names or paths. Callers/agents must pass a bundle id from `list-apps`.

## Testing

- `swift build` + `swift test` — 20 tests pass (8 new `AppIdentifierPolicyTests`).
- `@vm0/cli` + `@vm0/desktop`: lint, check-types, vitest (cli 13, desktop window-policy 59), knip — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)