### PR TITLE
fix: serialize runtime oauth refresh

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1354,6 +1354,85 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("serializes concurrent forced connector OAuth refreshes", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-force-concurrent-notion-token",
+      refreshToken: "force-concurrent-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+    });
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", async () => {
+        refreshCallCount += 1;
+        if (refreshCallCount === 1) {
+          firstRefreshStarted.resolve();
+          await firstRefreshRelease.promise;
+        }
+        return HttpResponse.json({
+          access_token: "fresh-force-concurrent-notion-token",
+          refresh_token: "rotated-force-concurrent-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const refreshRequest = () => {
+      return accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets({
+              NOTION_TOKEN: "current-force-concurrent-notion-token",
+            }),
+            authHeaders: {
+              Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+            },
+            secretConnectorMap: {
+              NOTION_TOKEN: "notion",
+            },
+            forceRefresh: true,
+          },
+          headers: authHeaders(fixture),
+        }),
+        [200],
+      );
+    };
+
+    const firstResponsePromise = refreshRequest();
+    await firstRefreshStarted.promise;
+    const secondResponsePromise = refreshRequest();
+    firstRefreshRelease.resolve();
+
+    const responses = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    for (const response of responses) {
+      expect(response.body.headers.Authorization).toBe(
+        "Bearer fresh-force-concurrent-notion-token",
+      );
+    }
+    expect(
+      responses.map((response) => {
+        return response.body.refreshedConnectors;
+      }),
+    ).toStrictEqual([["notion"], []]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_REFRESH_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("rotated-force-concurrent-notion-refresh-token");
+  });
+
   it("refreshes dynamic public connector OAuth tokens without env client credentials", async () => {
     const dynamicOAuth = useDynamicTestOAuthRefresh();
     restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -24,6 +24,7 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
+import { upsertOrgMultiAuthModelProvider$ } from "../../services/zero-model-provider.service";
 import {
   deleteUsageInsightFixture$,
   seedCompose$,
@@ -2496,6 +2497,110 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "model-provider",
       }),
     ).resolves.toBe("rotated-concurrent-chatgpt-refresh");
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+  });
+
+  it("preserves model-provider reauth that races with runtime OAuth refresh", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredCodexModelProvider(fixture);
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async () => {
+        refreshCallCount += 1;
+        firstRefreshStarted.resolve();
+        await firstRefreshRelease.promise;
+        return HttpResponse.json({
+          access_token: "runtime-refreshed-chatgpt-token",
+          refresh_token: "runtime-rotated-chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const refreshResponsePromise = accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    await firstRefreshStarted.promise;
+    const reauthPromise = store.set(
+      upsertOrgMultiAuthModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "codex-oauth-token",
+        authMethod: "auth_json",
+        secretValues: {
+          CHATGPT_ACCESS_TOKEN: "reauth-chatgpt-token",
+          CHATGPT_REFRESH_TOKEN: "reauth-chatgpt-refresh",
+          CHATGPT_ACCOUNT_ID: "reauth-chatgpt-account",
+          CHATGPT_ID_TOKEN: "reauth-chatgpt-id-token",
+        },
+        metadata: {
+          tokenExpiresAt: new Date(now() + 3_600_000),
+          workspaceName: "Reauth workspace",
+          planType: "plus",
+        },
+      },
+      context.signal,
+    );
+    firstRefreshRelease.resolve();
+
+    const [refreshResponse, reauthResult] = await Promise.all([
+      refreshResponsePromise,
+      reauthPromise,
+    ]);
+
+    if (!("provider" in reauthResult)) {
+      throw new Error("Expected model provider reauth to succeed");
+    }
+
+    expect(refreshCallCount).toBe(1);
+    expect(refreshResponse.body.headers.Authorization).toBe(
+      "Bearer runtime-refreshed-chatgpt-token",
+    );
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: ORG_SENTINEL_USER_ID,
+        name: "CHATGPT_ACCESS_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("reauth-chatgpt-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: ORG_SENTINEL_USER_ID,
+        name: "CHATGPT_REFRESH_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("reauth-chatgpt-refresh");
     await expect(codexProviderState(fixture)).resolves.toMatchObject({
       needsReconnect: false,
       lastRefreshErrorCode: null,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1433,6 +1433,83 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     ).resolves.toBe("rotated-force-concurrent-notion-refresh-token");
   });
 
+  it("serializes concurrent forced connector OAuth refreshes without access snapshots", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-force-missing-snapshot-notion-token",
+      refreshToken: "force-missing-snapshot-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+    });
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", async () => {
+        refreshCallCount += 1;
+        if (refreshCallCount === 1) {
+          firstRefreshStarted.resolve();
+          await firstRefreshRelease.promise;
+        }
+        return HttpResponse.json({
+          access_token: "fresh-force-missing-snapshot-notion-token",
+          refresh_token: "rotated-force-missing-snapshot-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const refreshRequest = () => {
+      return accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets({}),
+            authHeaders: {
+              Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+            },
+            secretConnectorMap: {
+              NOTION_TOKEN: "notion",
+            },
+            forceRefresh: true,
+          },
+          headers: authHeaders(fixture),
+        }),
+        [200],
+      );
+    };
+
+    const firstResponsePromise = refreshRequest();
+    await firstRefreshStarted.promise;
+    const secondResponsePromise = refreshRequest();
+    firstRefreshRelease.resolve();
+
+    const responses = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    for (const response of responses) {
+      expect(response.body.headers.Authorization).toBe(
+        "Bearer fresh-force-missing-snapshot-notion-token",
+      );
+    }
+    expect(
+      responses.map((response) => {
+        return response.body.refreshedConnectors;
+      }),
+    ).toStrictEqual([["notion"], []]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_REFRESH_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("rotated-force-missing-snapshot-notion-refresh-token");
+  });
+
   it("refreshes dynamic public connector OAuth tokens without env client credentials", async () => {
     const dynamicOAuth = useDynamicTestOAuthRefresh();
     restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -90,6 +90,20 @@ function basicTemplate(first: string, second: string): string {
   return `\${{ basic(${first}, ${second}) }}`;
 }
 
+function deferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) {
+    throw new Error("Failed to create deferred promise");
+  }
+  return { promise, resolve: resolvePromise };
+}
+
 function firewallClient() {
   return setupApp({ context })(webhookFirewallAuthContract);
 }
@@ -1249,6 +1263,97 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(connector.tokenExpiresAt?.getTime()).toBeGreaterThan(now());
   });
 
+  it("serializes concurrent connector OAuth refreshes for rotated refresh tokens", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredNotionConnector(fixture);
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", async () => {
+        refreshCallCount += 1;
+        if (refreshCallCount === 1) {
+          firstRefreshStarted.resolve();
+          await firstRefreshRelease.promise;
+        }
+        return HttpResponse.json({
+          access_token: "fresh-concurrent-notion-token",
+          refresh_token: "rotated-concurrent-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const refreshRequest = () => {
+      return accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets({
+              NOTION_TOKEN: "stale-notion-token",
+            }),
+            authHeaders: {
+              Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+            },
+            secretConnectorMap: {
+              NOTION_TOKEN: "notion",
+            },
+          },
+          headers: authHeaders(fixture),
+        }),
+        [200],
+      );
+    };
+
+    const firstResponsePromise = refreshRequest();
+    await firstRefreshStarted.promise;
+    const secondResponsePromise = refreshRequest();
+    firstRefreshRelease.resolve();
+
+    const responses = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    for (const response of responses) {
+      expect(response.body.headers.Authorization).toBe(
+        "Bearer fresh-concurrent-notion-token",
+      );
+      expect(response.body.expiresAt).toBeGreaterThan(currentSecond());
+    }
+    expect(
+      responses.map((response) => {
+        return response.body.refreshedConnectors;
+      }),
+    ).toStrictEqual([["notion"], []]);
+    expect(
+      responses.map((response) => {
+        return response.body.refreshedSecrets;
+      }),
+    ).toStrictEqual([["NOTION_TOKEN"], []]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("fresh-concurrent-notion-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_REFRESH_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("rotated-concurrent-notion-refresh-token");
+    await expect(notionConnectorState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+    });
+  });
+
   it("refreshes dynamic public connector OAuth tokens without env client credentials", async () => {
     const dynamicOAuth = useDynamicTestOAuthRefresh();
     restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;
@@ -2136,6 +2241,105 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "model-provider",
       }),
     ).resolves.toBe("fresh-chatgpt-token");
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+  });
+
+  it("serializes concurrent model-provider OAuth refreshes for rotated refresh tokens", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredCodexModelProvider(fixture);
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async () => {
+        refreshCallCount += 1;
+        if (refreshCallCount === 1) {
+          firstRefreshStarted.resolve();
+          await firstRefreshRelease.promise;
+        }
+        return HttpResponse.json({
+          access_token: "fresh-concurrent-chatgpt-token",
+          refresh_token: "rotated-concurrent-chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const refreshRequest = () => {
+      return accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets({
+              CHATGPT_ACCESS_TOKEN: "stale-chatgpt-token",
+            }),
+            authHeaders: {
+              Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+            },
+            secretConnectorMap: {
+              CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+            },
+            secretConnectorMetadataMap: {
+              CHATGPT_ACCESS_TOKEN: {
+                sourceType: "model-provider",
+                sourceUserId: ORG_SENTINEL_USER_ID,
+                metadataKey: "codex-oauth-token",
+              },
+            },
+          },
+          headers: authHeaders(fixture),
+        }),
+        [200],
+      );
+    };
+
+    const firstResponsePromise = refreshRequest();
+    await firstRefreshStarted.promise;
+    const secondResponsePromise = refreshRequest();
+    firstRefreshRelease.resolve();
+
+    const responses = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    for (const response of responses) {
+      expect(response.body.headers.Authorization).toBe(
+        "Bearer fresh-concurrent-chatgpt-token",
+      );
+      expect(response.body.expiresAt).toBeGreaterThan(currentSecond());
+    }
+    expect(
+      responses.map((response) => {
+        return response.body.refreshedConnectors;
+      }),
+    ).toStrictEqual([["codex-oauth-token"], []]);
+    expect(
+      responses.map((response) => {
+        return response.body.refreshedSecrets;
+      }),
+    ).toStrictEqual([["CHATGPT_ACCESS_TOKEN"], []]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: ORG_SENTINEL_USER_ID,
+        name: "CHATGPT_ACCESS_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("fresh-concurrent-chatgpt-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: ORG_SENTINEL_USER_ID,
+        name: "CHATGPT_REFRESH_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("rotated-concurrent-chatgpt-refresh");
     await expect(codexProviderState(fixture)).resolves.toMatchObject({
       needsReconnect: false,
       lastRefreshErrorCode: null,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -325,7 +325,6 @@ interface RefreshBatchContext {
   readonly orgId: string;
   readonly userId: string;
   readonly secrets: Record<string, string>;
-  readonly expiryMap: Map<string, number | null>;
   readonly forceRefresh: boolean;
   readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
@@ -1870,7 +1869,6 @@ async function refreshExpiredTokens(
     orgId: args.orgId,
     userId: args.auth.userId,
     secrets: args.secrets,
-    expiryMap,
     forceRefresh: args.forceRefresh,
     metadataByConnector,
     connectorAccessByType: args.connectorAccessByType,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -245,8 +245,8 @@ interface SecretTokenLookupArgs {
 
 interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
   readonly connectorSecrets: Record<string, string>;
+  readonly accessEnvVars: readonly string[];
   readonly forceRefresh: boolean;
-  readonly initialTokenExpiresAt: number | null | undefined;
 }
 
 interface RefreshTokenContext {
@@ -255,7 +255,7 @@ interface RefreshTokenContext {
   readonly secretUserId: string;
 }
 
-interface LockedRefreshState {
+interface RefreshState {
   readonly accessToken: string | null;
   readonly refreshToken: string | null;
   readonly tokenExpiresAt: Date | null;
@@ -800,7 +800,8 @@ function currentSecond(): number {
 function shouldUseLockedCurrentAccess(args: {
   readonly refreshArgs: RefreshAccessTokenArgs;
   readonly context: RefreshTokenContext;
-  readonly state: LockedRefreshState;
+  readonly initialState: RefreshState | null;
+  readonly state: RefreshState;
 }): boolean {
   if (!args.state.accessToken) {
     return false;
@@ -812,29 +813,48 @@ function shouldUseLockedCurrentAccess(args: {
     return true;
   }
 
-  const snapshotAccessToken =
-    args.refreshArgs.connectorSecrets[args.context.accessTokenSecret];
+  const snapshotAccessTokens = [
+    args.refreshArgs.connectorSecrets[args.context.accessTokenSecret],
+    ...args.refreshArgs.accessEnvVars.map((envVar) => {
+      return args.refreshArgs.connectorSecrets[envVar];
+    }),
+  ];
   if (
-    snapshotAccessToken !== undefined &&
-    snapshotAccessToken !== args.state.accessToken
+    snapshotAccessTokens.some((accessToken) => {
+      return (
+        accessToken !== undefined && accessToken !== args.state.accessToken
+      );
+    })
   ) {
     return true;
   }
 
-  const currentExpiresAt = args.state.tokenExpiresAt
+  if (!args.initialState) {
+    return true;
+  }
+
+  if (args.initialState.accessToken !== args.state.accessToken) {
+    return true;
+  }
+
+  if (args.initialState.refreshToken !== args.state.refreshToken) {
+    return true;
+  }
+
+  const initialExpiresAt = args.initialState.tokenExpiresAt
+    ? Math.floor(args.initialState.tokenExpiresAt.getTime() / 1000)
+    : null;
+  const lockedExpiresAt = args.state.tokenExpiresAt
     ? Math.floor(args.state.tokenExpiresAt.getTime() / 1000)
     : null;
-  return (
-    args.refreshArgs.initialTokenExpiresAt !== undefined &&
-    args.refreshArgs.initialTokenExpiresAt !== currentExpiresAt
-  );
+  return initialExpiresAt !== lockedExpiresAt;
 }
 
-async function loadLockedRefreshState(
+async function loadRefreshState(
   db: Db,
   args: RefreshAccessTokenArgs,
   context: RefreshTokenContext,
-): Promise<LockedRefreshState | null> {
+): Promise<RefreshState | null> {
   const [row] =
     args.sourceType === "model-provider"
       ? await db
@@ -1003,6 +1023,9 @@ async function refreshAccessTokenForSource(
     return { ok: false, reason: preparation.reason };
   }
   const { prepared } = preparation;
+  const initialState = args.forceRefresh
+    ? await loadRefreshState(args.db, args, prepared.context)
+    : null;
 
   return await args.db.transaction(async (tx) => {
     if (prepared.sourceType === "connector") {
@@ -1019,11 +1042,7 @@ async function refreshAccessTokenForSource(
       });
     }
 
-    const lockedState = await loadLockedRefreshState(
-      tx,
-      args,
-      prepared.context,
-    );
+    const lockedState = await loadRefreshState(tx, args, prepared.context);
     if (!lockedState) {
       L.warn(`${args.connectorType} token refresh source missing`, {
         connectorType: args.connectorType,
@@ -1040,6 +1059,7 @@ async function refreshAccessTokenForSource(
       shouldUseLockedCurrentAccess({
         refreshArgs: args,
         context: prepared.context,
+        initialState,
         state: lockedState,
       })
     ) {
@@ -1658,8 +1678,8 @@ async function refreshSelectedTokens(
         sourceUserId: metadata.sourceUserId,
         metadataKey: metadata.metadataKey,
         connectorSecrets: context.secrets,
+        accessEnvVars: context.envVarsByConnector.get(connectorType) ?? [],
         forceRefresh: context.forceRefresh,
-        initialTokenExpiresAt: context.expiryMap.get(connectorType),
         connectorAccessByType: context.connectorAccessByType,
         featureSwitchContext: context.featureSwitchContext,
       });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1018,7 +1018,7 @@ async function markRefreshFailure(
       .set({
         needsReconnect: true,
         lastRefreshErrorCode: errorCode,
-        updatedAt: nowDate(),
+        updatedAt: sql`clock_timestamp()`,
       })
       .where(
         and(
@@ -1034,7 +1034,7 @@ async function markRefreshFailure(
     .update(connectors)
     .set({
       needsReconnect: true,
-      updatedAt: nowDate(),
+      updatedAt: sql`clock_timestamp()`,
     })
     .where(
       and(

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -54,6 +54,10 @@ import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
+import {
+  lockConnectorState,
+  lockModelProviderState,
+} from "./auth-state-lock.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
@@ -84,7 +88,7 @@ interface RefreshResult {
 
 interface RefreshExecutionResult {
   readonly connectorType: string;
-  readonly status: "refreshed" | "failed";
+  readonly status: "current" | "refreshed" | "failed";
 }
 
 interface ReferencedAuthKeys {
@@ -241,13 +245,20 @@ interface SecretTokenLookupArgs {
 
 interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
   readonly connectorSecrets: Record<string, string>;
+  readonly forceRefresh: boolean;
+  readonly initialTokenExpiresAt: number | null | undefined;
 }
 
 interface RefreshTokenContext {
   readonly refreshTokenSecret: string;
-  readonly currentRefreshToken: string;
   readonly accessTokenSecret: string;
   readonly secretUserId: string;
+}
+
+interface LockedRefreshState {
+  readonly accessToken: string | null;
+  readonly refreshToken: string | null;
+  readonly tokenExpiresAt: Date | null;
 }
 
 type PreparedRefreshTokenContext =
@@ -280,6 +291,7 @@ type PrepareRefreshTokenContextResult =
 type RefreshAccessTokenResult =
   | {
       readonly ok: true;
+      readonly status: "current" | "refreshed";
       readonly accessToken: string;
     }
   | {
@@ -290,17 +302,6 @@ type RefreshAccessTokenResult =
         | "refresh-failed"
         | "refresh-token-missing";
     };
-
-interface SyncRefreshTokensArgs {
-  readonly db: Db;
-  readonly connectorTypes: readonly string[];
-  readonly orgId: string;
-  readonly userId: string;
-  readonly secrets: Record<string, string>;
-  readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
-  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
-  readonly featureSwitchContext: FeatureSwitchContext;
-}
 
 interface RefreshExpiredTokensArgs {
   readonly db: Db;
@@ -323,6 +324,8 @@ interface RefreshBatchContext {
   readonly orgId: string;
   readonly userId: string;
   readonly secrets: Record<string, string>;
+  readonly expiryMap: Map<string, number | null>;
+  readonly forceRefresh: boolean;
   readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly envVarsByConnector: Map<string, readonly string[]>;
@@ -507,29 +510,6 @@ function getAccessSecretNameForSource(args: {
     : undefined;
 }
 
-async function getConnectorRefreshToken(
-  args: SecretTokenLookupArgs,
-): Promise<{ readonly secretName: string; readonly token: string } | null> {
-  const secretName = getRefreshSecretNameForSource(args);
-  if (!secretName) {
-    return null;
-  }
-
-  const token = await getSecretValue({
-    db: args.db,
-    orgId: args.orgId,
-    userId: resolveSecretUserId(
-      args.sourceType,
-      args.userId,
-      args.sourceUserId,
-    ),
-    name: secretName,
-    type: args.sourceType,
-    featureSwitchContext: args.featureSwitchContext,
-  });
-  return token ? { secretName, token } : null;
-}
-
 async function getConnectorAccessToken(
   args: SecretTokenLookupArgs,
 ): Promise<string | null> {
@@ -550,36 +530,6 @@ async function getConnectorAccessToken(
     type: args.sourceType,
     featureSwitchContext: args.featureSwitchContext,
   });
-}
-
-async function syncRefreshTokensFromDb(
-  args: SyncRefreshTokensArgs,
-): Promise<void> {
-  const results = await Promise.all(
-    args.connectorTypes.map((connectorType) => {
-      const metadata = resolveRefreshMetadata(
-        connectorType,
-        args.metadataByConnector.get(connectorType),
-      );
-      return getConnectorRefreshToken({
-        db: args.db,
-        connectorType,
-        orgId: args.orgId,
-        userId: args.userId,
-        sourceType: metadata.sourceType,
-        sourceUserId: metadata.sourceUserId,
-        metadataKey: metadata.metadataKey,
-        connectorAccessByType: args.connectorAccessByType,
-        featureSwitchContext: args.featureSwitchContext,
-      });
-    }),
-  );
-
-  for (const result of results) {
-    if (result) {
-      args.secrets[result.secretName] = result.token;
-    }
-  }
 }
 
 async function loadConnectorAccessStates(
@@ -751,13 +701,6 @@ function prepareRefreshTokenContext(
       );
     }
 
-    const refreshTokenSecret = secretMetadata.refreshSecretName;
-    const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
-    if (!currentRefreshToken) {
-      L.debug(`No ${args.connectorType} refresh token available, skipping`);
-      return { ok: false, reason: "refresh-token-missing" };
-    }
-
     const env = currentProviderEnv();
     if (
       !isModelProviderOAuthRefreshConfigured({
@@ -772,8 +715,7 @@ function prepareRefreshTokenContext(
     }
 
     const context: RefreshTokenContext = {
-      refreshTokenSecret,
-      currentRefreshToken,
+      refreshTokenSecret: secretMetadata.refreshSecretName,
       accessTokenSecret: secretMetadata.accessSecretName,
       secretUserId: resolveSecretUserId(
         args.sourceType,
@@ -822,16 +764,8 @@ function prepareRefreshTokenContext(
     return { ok: false, reason: "client-unconfigured" };
   }
 
-  const refreshTokenSecret = accessMetadata.refreshToken;
-  const currentRefreshToken = args.connectorSecrets[refreshTokenSecret];
-  if (!currentRefreshToken) {
-    L.debug(`No ${args.connectorType} refresh token available, skipping`);
-    return { ok: false, reason: "refresh-token-missing" };
-  }
-
   const context: RefreshTokenContext = {
-    refreshTokenSecret,
-    currentRefreshToken,
+    refreshTokenSecret: accessMetadata.refreshToken,
     accessTokenSecret: accessMetadata.accessToken,
     secretUserId: resolveSecretUserId(
       args.sourceType,
@@ -848,6 +782,111 @@ function prepareRefreshTokenContext(
       clientArgs: getConnectorAuthProviderClientArgs(authClient),
       context,
     },
+  };
+}
+
+function tokenExpiresAtNeedsRefresh(tokenExpiresAt: Date | null): boolean {
+  if (tokenExpiresAt === null) {
+    return true;
+  }
+  const expiresAtSeconds = Math.floor(tokenExpiresAt.getTime() / 1000);
+  return expiresAtSeconds <= currentSecond() + REFRESH_BUFFER_SECS;
+}
+
+function currentSecond(): number {
+  return Math.floor(nowDate().getTime() / 1000);
+}
+
+function shouldUseLockedCurrentAccess(args: {
+  readonly refreshArgs: RefreshAccessTokenArgs;
+  readonly context: RefreshTokenContext;
+  readonly state: LockedRefreshState;
+}): boolean {
+  if (!args.state.accessToken) {
+    return false;
+  }
+  if (tokenExpiresAtNeedsRefresh(args.state.tokenExpiresAt)) {
+    return false;
+  }
+  if (!args.refreshArgs.forceRefresh) {
+    return true;
+  }
+
+  const snapshotAccessToken =
+    args.refreshArgs.connectorSecrets[args.context.accessTokenSecret];
+  if (
+    snapshotAccessToken !== undefined &&
+    snapshotAccessToken !== args.state.accessToken
+  ) {
+    return true;
+  }
+
+  const currentExpiresAt = args.state.tokenExpiresAt
+    ? Math.floor(args.state.tokenExpiresAt.getTime() / 1000)
+    : null;
+  return (
+    args.refreshArgs.initialTokenExpiresAt !== undefined &&
+    args.refreshArgs.initialTokenExpiresAt !== currentExpiresAt
+  );
+}
+
+async function loadLockedRefreshState(
+  db: Db,
+  args: RefreshAccessTokenArgs,
+  context: RefreshTokenContext,
+): Promise<LockedRefreshState | null> {
+  const [row] =
+    args.sourceType === "model-provider"
+      ? await db
+          .select({ tokenExpiresAt: modelProviders.tokenExpiresAt })
+          .from(modelProviders)
+          .where(
+            and(
+              eq(modelProviders.orgId, args.orgId),
+              eq(modelProviders.userId, context.secretUserId),
+              eq(modelProviders.type, args.metadataKey ?? ""),
+            ),
+          )
+          .limit(1)
+      : await db
+          .select({ tokenExpiresAt: connectors.tokenExpiresAt })
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, args.orgId),
+              eq(connectors.userId, args.userId),
+              eq(connectors.type, args.connectorType),
+            ),
+          )
+          .limit(1);
+
+  if (!row) {
+    return null;
+  }
+
+  const [accessToken, refreshToken] = await Promise.all([
+    getSecretValue({
+      db,
+      orgId: args.orgId,
+      userId: context.secretUserId,
+      name: context.accessTokenSecret,
+      type: args.sourceType,
+      featureSwitchContext: args.featureSwitchContext,
+    }),
+    getSecretValue({
+      db,
+      orgId: args.orgId,
+      userId: context.secretUserId,
+      name: context.refreshTokenSecret,
+      type: args.sourceType,
+      featureSwitchContext: args.featureSwitchContext,
+    }),
+  ]);
+
+  return {
+    accessToken,
+    refreshToken,
+    tokenExpiresAt: row.tokenExpiresAt,
   };
 }
 
@@ -906,6 +945,7 @@ async function markRefreshSuccess(
     .update(connectors)
     .set({
       tokenExpiresAt: expiresAt,
+      needsReconnect: false,
       updatedAt: nowDate(),
     })
     .where(
@@ -964,45 +1004,105 @@ async function refreshAccessTokenForSource(
   }
   const { prepared } = preparation;
 
-  const refreshPromise =
-    prepared.sourceType === "connector"
-      ? refreshConnectorAuthProviderAccessToken({
-          type: prepared.connectorType,
-          clientArgs: prepared.clientArgs,
-          refreshToken: prepared.context.currentRefreshToken,
-        })
-      : refreshModelProviderOAuthToken({
-          providerKey: prepared.providerKey,
-          currentEnv: prepared.currentEnv,
-          refreshToken: prepared.context.currentRefreshToken,
-        });
-  const refreshResult = await settle(refreshPromise);
+  return await args.db.transaction(async (tx) => {
+    if (prepared.sourceType === "connector") {
+      await lockConnectorState(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: prepared.connectorType,
+      });
+    } else {
+      await lockModelProviderState(tx, {
+        orgId: args.orgId,
+        userId: prepared.context.secretUserId,
+        type: args.metadataKey ?? prepared.providerKey,
+      });
+    }
 
-  if (!refreshResult.ok) {
-    const error = refreshResult.error;
-    const message = error instanceof Error ? error.message : "Unknown error";
-    const errorCode = isChatgptRefreshError(error) ? error.code : null;
-    L.warn(`${args.connectorType} token refresh failed: ${message}`, {
-      connectorType: args.connectorType,
-      orgId: args.orgId,
-      userId: args.userId,
-      errorCode,
-    });
+    const lockedState = await loadLockedRefreshState(
+      tx,
+      args,
+      prepared.context,
+    );
+    if (!lockedState) {
+      L.warn(`${args.connectorType} token refresh source missing`, {
+        connectorType: args.connectorType,
+        orgId: args.orgId,
+        userId: args.userId,
+        sourceType: args.sourceType,
+      });
+      return { ok: false, reason: "refresh-token-missing" };
+    }
 
-    await markRefreshFailure(args, prepared.context, errorCode);
-    return { ok: false, reason: "refresh-failed" };
-  }
+    const currentAccessToken = lockedState.accessToken;
+    if (
+      currentAccessToken &&
+      shouldUseLockedCurrentAccess({
+        refreshArgs: args,
+        context: prepared.context,
+        state: lockedState,
+      })
+    ) {
+      return {
+        ok: true,
+        status: "current",
+        accessToken: currentAccessToken,
+      };
+    }
 
-  const result = refreshResult.value;
-  await markRefreshSuccess(args, prepared.context, result);
-  args.connectorSecrets[prepared.context.accessTokenSecret] =
-    result.accessToken;
-  if (result.refreshToken) {
-    args.connectorSecrets[prepared.context.refreshTokenSecret] =
-      result.refreshToken;
-  }
-  L.debug(`${args.connectorType} access token refreshed successfully`);
-  return { ok: true, accessToken: result.accessToken };
+    if (!lockedState.refreshToken) {
+      L.debug(`No ${args.connectorType} refresh token available, skipping`);
+      return { ok: false, reason: "refresh-token-missing" };
+    }
+
+    const refreshPromise =
+      prepared.sourceType === "connector"
+        ? refreshConnectorAuthProviderAccessToken({
+            type: prepared.connectorType,
+            clientArgs: prepared.clientArgs,
+            refreshToken: lockedState.refreshToken,
+          })
+        : refreshModelProviderOAuthToken({
+            providerKey: prepared.providerKey,
+            currentEnv: prepared.currentEnv,
+            refreshToken: lockedState.refreshToken,
+          });
+    const refreshResult = await settle(refreshPromise);
+
+    if (!refreshResult.ok) {
+      const error = refreshResult.error;
+      const message = error instanceof Error ? error.message : "Unknown error";
+      const errorCode = isChatgptRefreshError(error) ? error.code : null;
+      L.warn(`${args.connectorType} token refresh failed: ${message}`, {
+        connectorType: args.connectorType,
+        orgId: args.orgId,
+        userId: args.userId,
+        errorCode,
+      });
+
+      await markRefreshFailure(
+        { ...args, db: tx },
+        prepared.context,
+        errorCode,
+      );
+      return { ok: false, reason: "refresh-failed" };
+    }
+
+    const result = refreshResult.value;
+    await markRefreshSuccess({ ...args, db: tx }, prepared.context, result);
+    args.connectorSecrets[prepared.context.accessTokenSecret] =
+      result.accessToken;
+    if (result.refreshToken) {
+      args.connectorSecrets[prepared.context.refreshTokenSecret] =
+        result.refreshToken;
+    }
+    L.debug(`${args.connectorType} access token refreshed successfully`);
+    return {
+      ok: true,
+      status: "refreshed",
+      accessToken: result.accessToken,
+    };
+  });
 }
 
 function buildMetadataByConnector(
@@ -1558,6 +1658,8 @@ async function refreshSelectedTokens(
         sourceUserId: metadata.sourceUserId,
         metadataKey: metadata.metadataKey,
         connectorSecrets: context.secrets,
+        forceRefresh: context.forceRefresh,
+        initialTokenExpiresAt: context.expiryMap.get(connectorType),
         connectorAccessByType: context.connectorAccessByType,
         featureSwitchContext: context.featureSwitchContext,
       });
@@ -1578,7 +1680,7 @@ async function refreshSelectedTokens(
         []) {
         context.secrets[envVar] = refreshResult.accessToken;
       }
-      return { connectorType, status: "refreshed" };
+      return { connectorType, status: refreshResult.status };
     }),
   );
 }
@@ -1708,23 +1810,14 @@ async function refreshExpiredTokens(
   });
   const envVarsByConnector = buildEnvVarsByConnector(refreshable);
 
-  await syncRefreshTokensFromDb({
-    db: args.db,
-    connectorTypes: toRefresh,
-    orgId: args.orgId,
-    userId: args.auth.userId,
-    secrets: args.secrets,
-    metadataByConnector,
-    connectorAccessByType: args.connectorAccessByType,
-    featureSwitchContext: args.featureSwitchContext,
-  });
-
   const context = {
     db: args.db,
     auth: args.auth,
     orgId: args.orgId,
     userId: args.auth.userId,
     secrets: args.secrets,
+    expiryMap,
+    forceRefresh: args.forceRefresh,
     metadataByConnector,
     connectorAccessByType: args.connectorAccessByType,
     envVarsByConnector,
@@ -1737,29 +1830,30 @@ async function refreshExpiredTokens(
   await syncSkippedTokens(context, skippedTypes);
 
   const summary = summarizeRefreshResults(refreshResults, envVarsByConnector);
-  const finalConnectorAccessByType =
-    summary.refreshedConnectors.length > 0
-      ? new Map([
-          ...args.connectorAccessByType,
-          ...(await loadConnectorAccessStates(
-            args.db,
-            args.orgId,
-            args.auth.userId,
-            connectorTypes,
-          )),
-        ])
-      : args.connectorAccessByType;
-  const finalExpiryMap =
-    summary.refreshedConnectors.length > 0
-      ? await getExpiryByProviderKey({
-          db: args.db,
-          orgId: args.orgId,
-          userId: args.auth.userId,
+  const hasCurrentOrRefreshed = refreshResults.some((result) => {
+    return result.status === "current" || result.status === "refreshed";
+  });
+  const finalConnectorAccessByType = hasCurrentOrRefreshed
+    ? new Map([
+        ...args.connectorAccessByType,
+        ...(await loadConnectorAccessStates(
+          args.db,
+          args.orgId,
+          args.auth.userId,
           connectorTypes,
-          metadataByConnector,
-          connectorAccessByType: finalConnectorAccessByType,
-        })
-      : expiryMap;
+        )),
+      ])
+    : args.connectorAccessByType;
+  const finalExpiryMap = hasCurrentOrRefreshed
+    ? await getExpiryByProviderKey({
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.auth.userId,
+        connectorTypes,
+        metadataByConnector,
+        connectorAccessByType: finalConnectorAccessByType,
+      })
+    : expiryMap;
 
   return {
     expiresAt: earliestConnectorExpiry(connectorTypes, finalExpiryMap),

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -259,7 +259,7 @@ interface RefreshState {
   readonly accessToken: string | null;
   readonly refreshToken: string | null;
   readonly tokenExpiresAt: Date | null;
-  readonly updatedAt: Date;
+  readonly updatedAtMicros: bigint;
 }
 
 type PreparedRefreshTokenContext =
@@ -798,22 +798,22 @@ function currentSecond(): number {
   return Math.floor(nowDate().getTime() / 1000);
 }
 
-async function currentDatabaseTimestamp(db: Db): Promise<Date> {
-  const result = await db.execute<{ now: Date | string }>(
-    sql`SELECT clock_timestamp() AS now`,
+async function currentDatabaseTimestampMicros(db: Db): Promise<bigint> {
+  const result = await db.execute<{ now: bigint | number | string }>(
+    sql`SELECT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::bigint AS now`,
   );
   const row = result.rows[0];
   if (!row) {
     throw new Error("Failed to read database timestamp");
   }
-  return row.now instanceof Date ? row.now : new Date(row.now);
+  return BigInt(row.now);
 }
 
 function shouldUseLockedCurrentAccess(args: {
   readonly refreshArgs: RefreshAccessTokenArgs;
   readonly context: RefreshTokenContext;
   readonly initialState: RefreshState | null;
-  readonly requestStartedAt: Date | null;
+  readonly requestStartedAtMicros: bigint | null;
   readonly state: RefreshState;
 }): boolean {
   if (!args.state.accessToken) {
@@ -843,8 +843,8 @@ function shouldUseLockedCurrentAccess(args: {
   }
 
   if (
-    args.requestStartedAt &&
-    args.state.updatedAt.getTime() > args.requestStartedAt.getTime()
+    args.requestStartedAtMicros !== null &&
+    args.state.updatedAtMicros > args.requestStartedAtMicros
   ) {
     return true;
   }
@@ -869,7 +869,7 @@ function shouldUseLockedCurrentAccess(args: {
     : null;
   return (
     initialExpiresAt !== lockedExpiresAt ||
-    args.initialState.updatedAt.getTime() !== args.state.updatedAt.getTime()
+    args.initialState.updatedAtMicros !== args.state.updatedAtMicros
   );
 }
 
@@ -883,7 +883,7 @@ async function loadRefreshState(
       ? await db
           .select({
             tokenExpiresAt: modelProviders.tokenExpiresAt,
-            updatedAt: modelProviders.updatedAt,
+            updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`,
           })
           .from(modelProviders)
           .where(
@@ -897,7 +897,7 @@ async function loadRefreshState(
       : await db
           .select({
             tokenExpiresAt: connectors.tokenExpiresAt,
-            updatedAt: connectors.updatedAt,
+            updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`,
           })
           .from(connectors)
           .where(
@@ -936,7 +936,7 @@ async function loadRefreshState(
     accessToken,
     refreshToken,
     tokenExpiresAt: row.tokenExpiresAt,
-    updatedAt: row.updatedAt,
+    updatedAtMicros: BigInt(row.updatedAtMicros),
   };
 }
 
@@ -972,7 +972,6 @@ async function markRefreshSuccess(
     nowDate().getTime() +
       (result.expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
   );
-  const refreshedAt = await currentDatabaseTimestamp(args.db);
   if (args.sourceType === "model-provider") {
     await args.db
       .update(modelProviders)
@@ -980,7 +979,7 @@ async function markRefreshSuccess(
         tokenExpiresAt: expiresAt,
         needsReconnect: false,
         lastRefreshErrorCode: null,
-        updatedAt: refreshedAt,
+        updatedAt: sql`clock_timestamp()`,
       })
       .where(
         and(
@@ -997,7 +996,7 @@ async function markRefreshSuccess(
     .set({
       tokenExpiresAt: expiresAt,
       needsReconnect: false,
-      updatedAt: refreshedAt,
+      updatedAt: sql`clock_timestamp()`,
     })
     .where(
       and(
@@ -1054,8 +1053,8 @@ async function refreshAccessTokenForSource(
     return { ok: false, reason: preparation.reason };
   }
   const { prepared } = preparation;
-  const requestStartedAt = args.forceRefresh
-    ? await currentDatabaseTimestamp(args.db)
+  const requestStartedAtMicros = args.forceRefresh
+    ? await currentDatabaseTimestampMicros(args.db)
     : null;
   const initialState = args.forceRefresh
     ? await loadRefreshState(args.db, args, prepared.context)
@@ -1094,7 +1093,7 @@ async function refreshAccessTokenForSource(
         refreshArgs: args,
         context: prepared.context,
         initialState,
-        requestStartedAt,
+        requestStartedAtMicros,
         state: lockedState,
       })
     ) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -247,6 +247,7 @@ interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
   readonly connectorSecrets: Record<string, string>;
   readonly accessEnvVars: readonly string[];
   readonly forceRefresh: boolean;
+  readonly forceRefreshStartedAtMicros: bigint | null;
 }
 
 interface RefreshTokenContext {
@@ -317,6 +318,7 @@ interface RefreshExpiredTokensArgs {
   readonly referencedKeys: Set<string>;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly forceRefresh: boolean;
+  readonly forceRefreshStartedAtMicros: bigint | null;
 }
 
 interface RefreshBatchContext {
@@ -326,6 +328,7 @@ interface RefreshBatchContext {
   readonly userId: string;
   readonly secrets: Record<string, string>;
   readonly forceRefresh: boolean;
+  readonly forceRefreshStartedAtMicros: bigint | null;
   readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
   readonly envVarsByConnector: Map<string, readonly string[]>;
@@ -1053,7 +1056,7 @@ async function refreshAccessTokenForSource(
   }
   const { prepared } = preparation;
   const requestStartedAtMicros = args.forceRefresh
-    ? await currentDatabaseTimestampMicros(args.db)
+    ? args.forceRefreshStartedAtMicros
     : null;
   const initialState = args.forceRefresh
     ? await loadRefreshState(args.db, args, prepared.context)
@@ -1713,6 +1716,7 @@ async function refreshSelectedTokens(
         connectorSecrets: context.secrets,
         accessEnvVars: context.envVarsByConnector.get(connectorType) ?? [],
         forceRefresh: context.forceRefresh,
+        forceRefreshStartedAtMicros: context.forceRefreshStartedAtMicros,
         connectorAccessByType: context.connectorAccessByType,
         featureSwitchContext: context.featureSwitchContext,
       });
@@ -1870,6 +1874,7 @@ async function refreshExpiredTokens(
     userId: args.auth.userId,
     secrets: args.secrets,
     forceRefresh: args.forceRefresh,
+    forceRefreshStartedAtMicros: args.forceRefreshStartedAtMicros,
     metadataByConnector,
     connectorAccessByType: args.connectorAccessByType,
     envVarsByConnector,
@@ -2089,6 +2094,10 @@ export async function resolveFirewallAuth(
   auth: SandboxAuth,
   body: FirewallAuthBody,
 ): Promise<ResolveFirewallAuthResult> {
+  const forceRefreshStartedAtMicros =
+    body.forceRefresh === true
+      ? await currentDatabaseTimestampMicros(db)
+      : null;
   const decrypted = await decryptFirewallAuthSecrets(
     db,
     auth,
@@ -2154,6 +2163,7 @@ export async function resolveFirewallAuth(
       orgId: decrypted.orgId,
       featureSwitchContext: decrypted.featureSwitchContext,
       forceRefresh: body.forceRefresh ?? false,
+      forceRefreshStartedAtMicros,
     });
     expiresAt = result.expiresAt;
     refreshedConnectors = result.refreshedConnectors;

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -40,7 +40,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { connectors } from "@vm0/db/schema/connector";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { optionalEnv } from "../../lib/env";
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
@@ -259,6 +259,7 @@ interface RefreshState {
   readonly accessToken: string | null;
   readonly refreshToken: string | null;
   readonly tokenExpiresAt: Date | null;
+  readonly updatedAt: Date;
 }
 
 type PreparedRefreshTokenContext =
@@ -797,10 +798,22 @@ function currentSecond(): number {
   return Math.floor(nowDate().getTime() / 1000);
 }
 
+async function currentDatabaseTimestamp(db: Db): Promise<Date> {
+  const result = await db.execute<{ now: Date | string }>(
+    sql`SELECT clock_timestamp() AS now`,
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error("Failed to read database timestamp");
+  }
+  return row.now instanceof Date ? row.now : new Date(row.now);
+}
+
 function shouldUseLockedCurrentAccess(args: {
   readonly refreshArgs: RefreshAccessTokenArgs;
   readonly context: RefreshTokenContext;
   readonly initialState: RefreshState | null;
+  readonly requestStartedAt: Date | null;
   readonly state: RefreshState;
 }): boolean {
   if (!args.state.accessToken) {
@@ -829,6 +842,13 @@ function shouldUseLockedCurrentAccess(args: {
     return true;
   }
 
+  if (
+    args.requestStartedAt &&
+    args.state.updatedAt.getTime() > args.requestStartedAt.getTime()
+  ) {
+    return true;
+  }
+
   if (!args.initialState) {
     return true;
   }
@@ -847,7 +867,10 @@ function shouldUseLockedCurrentAccess(args: {
   const lockedExpiresAt = args.state.tokenExpiresAt
     ? Math.floor(args.state.tokenExpiresAt.getTime() / 1000)
     : null;
-  return initialExpiresAt !== lockedExpiresAt;
+  return (
+    initialExpiresAt !== lockedExpiresAt ||
+    args.initialState.updatedAt.getTime() !== args.state.updatedAt.getTime()
+  );
 }
 
 async function loadRefreshState(
@@ -858,7 +881,10 @@ async function loadRefreshState(
   const [row] =
     args.sourceType === "model-provider"
       ? await db
-          .select({ tokenExpiresAt: modelProviders.tokenExpiresAt })
+          .select({
+            tokenExpiresAt: modelProviders.tokenExpiresAt,
+            updatedAt: modelProviders.updatedAt,
+          })
           .from(modelProviders)
           .where(
             and(
@@ -869,7 +895,10 @@ async function loadRefreshState(
           )
           .limit(1)
       : await db
-          .select({ tokenExpiresAt: connectors.tokenExpiresAt })
+          .select({
+            tokenExpiresAt: connectors.tokenExpiresAt,
+            updatedAt: connectors.updatedAt,
+          })
           .from(connectors)
           .where(
             and(
@@ -907,6 +936,7 @@ async function loadRefreshState(
     accessToken,
     refreshToken,
     tokenExpiresAt: row.tokenExpiresAt,
+    updatedAt: row.updatedAt,
   };
 }
 
@@ -942,6 +972,7 @@ async function markRefreshSuccess(
     nowDate().getTime() +
       (result.expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
   );
+  const refreshedAt = await currentDatabaseTimestamp(args.db);
   if (args.sourceType === "model-provider") {
     await args.db
       .update(modelProviders)
@@ -949,7 +980,7 @@ async function markRefreshSuccess(
         tokenExpiresAt: expiresAt,
         needsReconnect: false,
         lastRefreshErrorCode: null,
-        updatedAt: nowDate(),
+        updatedAt: refreshedAt,
       })
       .where(
         and(
@@ -966,7 +997,7 @@ async function markRefreshSuccess(
     .set({
       tokenExpiresAt: expiresAt,
       needsReconnect: false,
-      updatedAt: nowDate(),
+      updatedAt: refreshedAt,
     })
     .where(
       and(
@@ -1023,6 +1054,9 @@ async function refreshAccessTokenForSource(
     return { ok: false, reason: preparation.reason };
   }
   const { prepared } = preparation;
+  const requestStartedAt = args.forceRefresh
+    ? await currentDatabaseTimestamp(args.db)
+    : null;
   const initialState = args.forceRefresh
     ? await loadRefreshState(args.db, args, prepared.context)
     : null;
@@ -1060,6 +1094,7 @@ async function refreshAccessTokenForSource(
         refreshArgs: args,
         context: prepared.context,
         initialState,
+        requestStartedAt,
         state: lockedState,
       })
     ) {

--- a/turbo/apps/api/src/signals/services/auth-state-lock.service.ts
+++ b/turbo/apps/api/src/signals/services/auth-state-lock.service.ts
@@ -1,0 +1,29 @@
+import { sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+export async function lockConnectorState(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: string;
+  },
+): Promise<void> {
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('connector_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type}))`,
+  );
+}
+
+export async function lockModelProviderState(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: string;
+  },
+): Promise<void> {
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('model_provider_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type}))`,
+  );
+}

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -39,7 +39,7 @@ import {
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
@@ -780,7 +780,6 @@ async function upsertApiTokenConnectorRow(
     readonly type: ConnectorType;
   },
 ): Promise<StoredConnectorRow> {
-  const updatedAt = nowDate();
   const [row] = await db
     .insert(connectors)
     .values({
@@ -805,7 +804,7 @@ async function upsertApiTokenConnectorRow(
         oauthScopes: null,
         tokenExpiresAt: null,
         needsReconnect: false,
-        updatedAt,
+        updatedAt: sql`clock_timestamp()`,
       },
     })
     .returning({
@@ -1371,7 +1370,7 @@ async function upsertOAuthConnectorRow(
         oauthScopes: JSON.stringify(args.oauthScopes),
         tokenExpiresAt: args.tokenExpiresAt,
         needsReconnect: false,
-        updatedAt: nowDate(),
+        updatedAt: sql`clock_timestamp()`,
       },
     })
     .returning({

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -39,7 +39,7 @@ import {
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
@@ -51,6 +51,7 @@ import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
+import { lockConnectorState } from "./auth-state-lock.service";
 import {
   userFeatureSwitchContext,
   userFeatureSwitchOverrides,
@@ -124,19 +125,6 @@ interface PendingConnectorTokenRevoke {
   readonly authMethod: string;
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
-}
-
-async function lockConnectorState(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly type: ConnectorType;
-  },
-): Promise<void> {
-  await db.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtext('connector_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type}))`,
-  );
 }
 
 function parseOauthScopes(value: string | null): string[] | null {

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -16,7 +16,7 @@ import {
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { db$, writeDb$, type Db } from "../external/db";
 import { badRequestMessage, notFound } from "../../lib/error";
@@ -366,7 +366,7 @@ function buildMultiAuthConflictSet(
   const base: Record<string, unknown> = {
     authMethod,
     selectedModel: selectedModel ?? null,
-    updatedAt: nowDate(),
+    updatedAt: sql`clock_timestamp()`,
   };
   if (!metadata) {
     return base;

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -23,6 +23,7 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../external/time";
 import { encryptStoredSecretValue } from "./crypto.utils";
+import { lockModelProviderState } from "./auth-state-lock.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const L = logger("zero-model-provider.service");
@@ -129,9 +130,8 @@ type NotFoundResponse = ReturnType<typeof notFound>;
  *   - Multi-auth providers: deletes the per-auth-method secrets by name,
  *     then deletes the model_provider row explicitly.
  *
- * Non-transactional. A partial failure (secret-delete succeeds,
- * provider-delete fails) would leave an orphan provider row; transactional
- * rewrite is a separate follow-up.
+ * Uses the same auth-state advisory lock as runtime OAuth refresh so a refresh
+ * cannot recreate secrets after a delete.
  */
 export const deleteUserModelProvider$ = command(
   async (
@@ -145,57 +145,66 @@ export const deleteUserModelProvider$ = command(
   ): Promise<NotFoundResponse | undefined> => {
     const writeDb = set(writeDb$);
 
-    const [provider] = await writeDb
-      .select({
-        id: modelProviders.id,
-        isDefault: modelProviders.isDefault,
-        secretId: modelProviders.secretId,
-        authMethod: modelProviders.authMethod,
-      })
-      .from(modelProviders)
-      .where(
-        and(
-          eq(modelProviders.orgId, args.orgId),
-          eq(modelProviders.userId, args.userId),
-          eq(modelProviders.type, args.type),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-
-    if (!provider) {
-      return notFound("Resource not found");
-    }
-
-    if (provider.secretId) {
-      await writeDb.delete(secrets).where(eq(secrets.id, provider.secretId));
+    return await writeDb.transaction(async (tx) => {
+      await lockModelProviderState(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+      });
       signal.throwIfAborted();
-    } else {
-      if (provider.authMethod) {
-        const secretNames = getSecretNamesForAuthMethod(
-          args.type,
-          provider.authMethod,
-        );
-        if (secretNames && secretNames.length > 0) {
-          await writeDb
-            .delete(secrets)
-            .where(
-              and(
-                eq(secrets.orgId, args.orgId),
-                eq(secrets.userId, args.userId),
-                inArray(secrets.name, [...secretNames]),
-              ),
-            );
-          signal.throwIfAborted();
-        }
+
+      const [provider] = await tx
+        .select({
+          id: modelProviders.id,
+          isDefault: modelProviders.isDefault,
+          secretId: modelProviders.secretId,
+          authMethod: modelProviders.authMethod,
+        })
+        .from(modelProviders)
+        .where(
+          and(
+            eq(modelProviders.orgId, args.orgId),
+            eq(modelProviders.userId, args.userId),
+            eq(modelProviders.type, args.type),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (!provider) {
+        return notFound("Resource not found");
       }
-      await writeDb
-        .delete(modelProviders)
-        .where(eq(modelProviders.id, provider.id));
-      signal.throwIfAborted();
-    }
 
-    return undefined;
+      if (provider.secretId) {
+        await tx.delete(secrets).where(eq(secrets.id, provider.secretId));
+        signal.throwIfAborted();
+      } else {
+        if (provider.authMethod) {
+          const secretNames = getSecretNamesForAuthMethod(
+            args.type,
+            provider.authMethod,
+          );
+          if (secretNames && secretNames.length > 0) {
+            await tx
+              .delete(secrets)
+              .where(
+                and(
+                  eq(secrets.orgId, args.orgId),
+                  eq(secrets.userId, args.userId),
+                  inArray(secrets.name, [...secretNames]),
+                ),
+              );
+            signal.throwIfAborted();
+          }
+        }
+        await tx
+          .delete(modelProviders)
+          .where(eq(modelProviders.id, provider.id));
+        signal.throwIfAborted();
+      }
+
+      return undefined;
+    });
   },
 );
 
@@ -319,7 +328,14 @@ interface MultiAuthMetadata {
   readonly planType?: string | null;
 }
 
+interface EncryptedMultiAuthSecret {
+  readonly name: string;
+  readonly encryptedValue: string;
+  readonly description: string;
+}
+
 type MultiAuthInsertValues = typeof modelProviders.$inferInsert;
+type ModelProviderRow = typeof modelProviders.$inferSelect;
 
 function buildMultiAuthInsertValues(args: {
   type: ModelProviderType;
@@ -401,25 +417,17 @@ async function cleanupOldAuthMethodSecrets(
 
 async function upsertMultiAuthSecret(
   writeDb: Db,
-  args: {
+  args: EncryptedMultiAuthSecret & {
     readonly orgId: string;
     readonly userId: string;
-    readonly name: string;
-    readonly value: string;
-    readonly description: string;
-    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(
-    args.value,
-    args.featureSwitchContext,
-  );
   await writeDb
     .insert(secrets)
     .values({
       userId: args.userId,
       name: args.name,
-      encryptedValue,
+      encryptedValue: args.encryptedValue,
       type: "model-provider",
       description: args.description,
       orgId: args.orgId,
@@ -427,7 +435,7 @@ async function upsertMultiAuthSecret(
     .onConflictDoUpdate({
       target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
       set: {
-        encryptedValue,
+        encryptedValue: args.encryptedValue,
         description: args.description,
         updatedAt: nowDate(),
       },
@@ -577,8 +585,30 @@ export const upsertUserModelProvider$ = command(
   },
 );
 
+async function encryptMultiAuthSecrets(
+  args: {
+    readonly type: ModelProviderType;
+    readonly authMethod: string;
+    readonly secretValues: Record<string, string>;
+    readonly featureSwitchContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<readonly EncryptedMultiAuthSecret[]> {
+  const description = `${MODEL_PROVIDER_TYPES[args.type].label} secret (${args.authMethod})`;
+  const encryptedSecrets: EncryptedMultiAuthSecret[] = [];
+  for (const [name, value] of Object.entries(args.secretValues)) {
+    const encryptedValue = await encryptStoredSecretValue(
+      value,
+      args.featureSwitchContext,
+    );
+    signal.throwIfAborted();
+    encryptedSecrets.push({ name, encryptedValue, description });
+  }
+  return encryptedSecrets;
+}
+
 /**
- * Loop over `secretValues` and persist each via `upsertMultiAuthSecret`.
+ * Loop over encrypted secrets and persist each via `upsertMultiAuthSecret`.
  * Extracted so the Command body stays under the per-function lint ceiling.
  */
 async function persistMultiAuthSecrets(
@@ -586,25 +616,120 @@ async function persistMultiAuthSecrets(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: ModelProviderType;
-    readonly authMethod: string;
-    readonly secretValues: Record<string, string>;
-    readonly featureSwitchContext: FeatureSwitchContext;
+    readonly encryptedSecrets: readonly EncryptedMultiAuthSecret[];
   },
   signal: AbortSignal,
 ): Promise<void> {
-  const description = `${MODEL_PROVIDER_TYPES[args.type].label} secret (${args.authMethod})`;
-  for (const [name, value] of Object.entries(args.secretValues)) {
+  for (const secret of args.encryptedSecrets) {
     await upsertMultiAuthSecret(writeDb, {
       orgId: args.orgId,
       userId: args.userId,
-      name,
-      value,
-      description,
-      featureSwitchContext: args.featureSwitchContext,
+      ...secret,
     });
     signal.throwIfAborted();
   }
+}
+
+async function persistMultiAuthModelProvider(
+  writeDb: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly type: ModelProviderType;
+    readonly authMethod: string;
+    readonly selectedModel?: string;
+    readonly metadata?: MultiAuthMetadata;
+    readonly secretNames: readonly string[];
+    readonly encryptedSecrets: readonly EncryptedMultiAuthSecret[];
+  },
+  signal: AbortSignal,
+): Promise<{
+  readonly provider: ModelProviderRow;
+  readonly wasCreated: boolean;
+}> {
+  const result = await writeDb.transaction(async (tx) => {
+    await lockModelProviderState(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+    });
+    signal.throwIfAborted();
+
+    // Check if model provider already exists (needed for auth method switch cleanup).
+    const [existingProvider] = await tx
+      .select()
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, args.orgId),
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.type, args.type),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    // If switching auth methods, clean up old secrets that are no longer used.
+    if (existingProvider && existingProvider.authMethod !== args.authMethod) {
+      await cleanupOldAuthMethodSecrets(tx, {
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+        oldAuthMethod: existingProvider.authMethod ?? "",
+        newSecretNames: args.secretNames,
+      });
+      signal.throwIfAborted();
+    }
+
+    // Store/update all secrets atomically with the provider row.
+    await persistMultiAuthSecrets(
+      tx,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        encryptedSecrets: args.encryptedSecrets,
+      },
+      signal,
+    );
+
+    // Atomic model provider upsert; metadata-aware conflict set clears stale flags.
+    const conflictSet = buildMultiAuthConflictSet(
+      args.authMethod,
+      args.selectedModel,
+      args.metadata,
+    );
+    const insertValues = buildMultiAuthInsertValues({
+      type: args.type,
+      userId: args.userId,
+      authMethod: args.authMethod,
+      selectedModel: args.selectedModel,
+      orgId: args.orgId,
+      metadata: args.metadata,
+    });
+    const [provider] = await tx
+      .insert(modelProviders)
+      .values(insertValues)
+      .onConflictDoUpdate({
+        target: [
+          modelProviders.orgId,
+          modelProviders.userId,
+          modelProviders.type,
+        ],
+        set: conflictSet,
+      })
+      .returning();
+    signal.throwIfAborted();
+
+    if (!provider) {
+      throw new Error(
+        "Expected multi-auth model provider upsert to return a row",
+      );
+    }
+
+    return { provider, wasCreated: !existingProvider };
+  });
+  signal.throwIfAborted();
+  return result;
 }
 
 /**
@@ -690,82 +815,31 @@ export const upsertUserMultiAuthModelProvider$ = command(
     );
     signal.throwIfAborted();
 
-    L.debug("upserting multi-auth model provider", {
-      orgId: args.orgId,
-      type: args.type,
-      authMethod: args.authMethod,
-      secretNames: Object.keys(args.secretValues),
-    });
-
-    // Check if model provider already exists (needed for auth method switch cleanup).
-    const [existingProvider] = await writeDb
-      .select()
-      .from(modelProviders)
-      .where(
-        and(
-          eq(modelProviders.orgId, args.orgId),
-          eq(modelProviders.userId, args.userId),
-          eq(modelProviders.type, args.type),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-
-    // If switching auth methods, clean up old secrets that are no longer used.
-    if (existingProvider && existingProvider.authMethod !== args.authMethod) {
-      await cleanupOldAuthMethodSecrets(writeDb, {
-        orgId: args.orgId,
-        userId: args.userId,
-        type: args.type,
-        oldAuthMethod: existingProvider.authMethod ?? "",
-        newSecretNames: Object.keys(args.secretValues),
-      });
-      signal.throwIfAborted();
-    }
-
-    // Store/update all secrets atomically.
     const secretNames = Object.keys(args.secretValues);
-    await persistMultiAuthSecrets(
-      writeDb,
+    const encryptedSecrets = await encryptMultiAuthSecrets(
       { ...args, featureSwitchContext },
       signal,
     );
 
-    // Atomic model provider upsert; metadata-aware conflict set clears stale flags.
-    const insertValues = buildMultiAuthInsertValues({
-      type: args.type,
-      userId: args.userId,
-      authMethod: args.authMethod,
-      selectedModel: args.selectedModel,
+    L.debug("upserting multi-auth model provider", {
       orgId: args.orgId,
-      metadata: args.metadata,
+      type: args.type,
+      authMethod: args.authMethod,
+      secretNames,
     });
-    const conflictSet = buildMultiAuthConflictSet(
-      args.authMethod,
-      args.selectedModel,
-      args.metadata,
+
+    const result = await persistMultiAuthModelProvider(
+      writeDb,
+      {
+        ...args,
+        secretNames,
+        encryptedSecrets,
+      },
+      signal,
     );
-    const [provider] = await writeDb
-      .insert(modelProviders)
-      .values(insertValues)
-      .onConflictDoUpdate({
-        target: [
-          modelProviders.orgId,
-          modelProviders.userId,
-          modelProviders.type,
-        ],
-        set: conflictSet,
-      })
-      .returning();
     signal.throwIfAborted();
 
-    if (!provider) {
-      throw new Error(
-        "Expected multi-auth model provider upsert to return a row",
-      );
-    }
-
-    const wasCreated = !existingProvider;
+    const { provider } = result;
 
     return {
       provider: toModelProviderInfo({
@@ -784,7 +858,7 @@ export const upsertUserMultiAuthModelProvider$ = command(
         createdAt: provider.createdAt,
         updatedAt: provider.updatedAt,
       }),
-      created: wasCreated,
+      created: result.wasCreated,
     };
   },
 );


### PR DESCRIPTION
## Summary

- serialize runtime OAuth refresh per connector/model-provider source with transaction-scoped PostgreSQL advisory locks
- re-read DB access token, refresh token, and expiry inside the lock before deciding whether to call the provider
- return the current DB token to lock-waiting callers when another request refreshed first, without counting them as refreshed
- clear connector reconnect state after successful refresh and cover rotating refresh token races for connector and model-provider sources

## Tests

- pnpm -C turbo --filter api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts --maxWorkers=1
- pnpm -C turbo --filter api lint
- pnpm -C turbo --filter api check-types
- lefthook pre-commit: prettier, knip, check-types

Follow-up: #15402 tracks model-provider upsert/delete write-path serialization.

Closes #15382