### PR TITLE
feat(cli): add zero generate sprite command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/sprite.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/sprite.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for zero generate sprite command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): none for the source-selection path
+ * - Real (internal): prompt parsing, enum validation, and packet generation
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import chalk from "chalk";
+import { generateCommand } from "../index";
+import { spriteCommand } from "../sprite";
+
+describe("zero generate sprite command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("should print a source selection packet with the resolved plan", async () => {
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "sprite",
+      "--prompt",
+      "A green slime monster idle loop",
+      "--asset-type",
+      "creature",
+      "--action",
+      "idle",
+      "--sheet",
+      "3x3",
+      "--name",
+      "green-slime",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("# Zero generate sprite");
+    expect(stdout).toContain("federated generation source-selection packet");
+    expect(stdout).toContain("A green slime monster idle loop");
+    expect(stdout).toContain("- Asset type: creature");
+    expect(stdout).toContain("- Action: idle");
+    expect(stdout).toContain("- Sheet / grid: 3x3");
+    expect(stdout).toContain("Output name: green-slime");
+    expect(stdout).toContain("0x0funky/agent-sprite-forge@main");
+    expect(stdout).toContain(
+      "Write the bundle under `./generated/sprites/green-slime/`.",
+    );
+  });
+
+  it("should default unset flags to agent decides and recommend gpt-image-2", async () => {
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "sprite",
+      "--prompt",
+      "A fireball projectile",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("- Asset type: agent decides");
+    expect(stdout).toContain("- Sheet / grid: auto");
+    expect(stdout).toContain("Use `gpt-image-2`");
+  });
+
+  it("should reject an unknown asset type", async () => {
+    await expect(async () => {
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "sprite",
+        "--prompt",
+        "A thing",
+        "--asset-type",
+        "definitely-not-an-asset-type",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("--asset-type must be one of");
+  });
+
+  it("should reject an invalid frame count", async () => {
+    await expect(async () => {
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "sprite",
+        "--prompt",
+        "A thing",
+        "--frames",
+        "999",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("--frames must be 'auto' or an integer");
+  });
+
+  it("should expose the sprite-specific flags in help", () => {
+    let helpOutput = "";
+    spriteCommand.configureOutput({
+      writeOut: (str: string) => {
+        helpOutput += str;
+      },
+    });
+
+    spriteCommand.outputHelp();
+
+    expect(helpOutput).toContain("--prompt <text>");
+    expect(helpOutput).toContain("--asset-type <type>");
+    expect(helpOutput).toContain("--action <action>");
+    expect(helpOutput).toContain("--view <view>");
+    expect(helpOutput).toContain("--sheet <grid>");
+    expect(helpOutput).toContain("--bundle <preset>");
+    expect(helpOutput).toContain("--art-style <style>");
+    expect(helpOutput).not.toContain("--provider");
+    expect(helpOutput).not.toContain("--all");
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/index.ts
@@ -8,6 +8,7 @@ import {
   reportCommand,
 } from "./artifacts";
 import { presentationCommand } from "./presentation";
+import { spriteCommand } from "./sprite";
 import { videoCommand } from "./video";
 import { websiteCommand } from "./website";
 import { voiceCommand } from "./voice";
@@ -45,6 +46,7 @@ function buildGenerateHelpText(): string {
     '  Generate docs:         zero generate docs-design --prompt "A setup guide"',
     '  Generate video:        zero generate video --prompt "A cinematic city shot"',
     '  Generate site:         zero generate website --prompt "A launch site"',
+    '  Generate sprite:       zero generate sprite --prompt "A slime monster idle loop"',
     '  Generate speech:       zero generate voice --prompt "Hello"',
     "  Show music choices:    zero generate music",
     "",
@@ -73,6 +75,7 @@ export const generateCommand = new Command()
   .addCommand(mobileAppDesignCommand)
   .addCommand(videoCommand)
   .addCommand(websiteCommand)
+  .addCommand(spriteCommand)
   .addCommand(voiceCommand)
   .addCommand(musicCommand)
   .addCommand(textCommand)

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -24,6 +24,7 @@ type BuiltInGenerationType =
   | "poster"
   | "presentation"
   | "report"
+  | "sprite"
   | "video"
   | "voice"
   | "website";
@@ -205,6 +206,11 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
     command: "zero generate website -h",
     models: "gpt-5.5",
   },
+  sprite: {
+    label: "Built-in sprite asset generation",
+    command: "zero generate sprite -h",
+    models: "gpt-image-2 (recommended) via built-in image generation",
+  },
   voice: {
     label: "Built-in voice generation",
     command: "zero generate voice --provider built-in -h",
@@ -234,6 +240,7 @@ const GENERATION_TYPE_LABELS: Record<GenerationType, string> = {
   poster: "Poster",
   presentation: "Presentation",
   report: "Report",
+  sprite: "Sprite",
   text: "Text",
   video: "Video",
   voice: "Voice",
@@ -277,6 +284,7 @@ function getConnectorGenerationType(
     case "poster":
     case "presentation":
     case "report":
+    case "sprite":
     case "website":
       return null;
     case "audio":

--- a/turbo/apps/cli/src/commands/zero/generate/sprite.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/sprite.ts
@@ -1,0 +1,241 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../../lib/command";
+import {
+  createSpriteAuthoringPacket,
+  type SpritePlan,
+} from "../shared/sprite-authoring";
+import { dispatchGenerate } from "./lib/dispatch";
+
+const SPRITE_USAGE_COMMAND = "zero generate sprite";
+const DEFAULT_MODEL = "gpt-image-2";
+const AGENT_DECIDES = "agent decides";
+
+const ASSET_TYPES = [
+  "player",
+  "npc",
+  "creature",
+  "character",
+  "spell",
+  "projectile",
+  "impact",
+  "prop",
+  "summon",
+  "fx",
+] as const;
+
+const ACTIONS = [
+  "single",
+  "idle",
+  "cast",
+  "attack",
+  "shoot",
+  "jump",
+  "hurt",
+  "combat",
+  "walk",
+  "run",
+  "hover",
+  "charge",
+  "projectile",
+  "impact",
+  "explode",
+  "death",
+] as const;
+
+const VIEWS = ["topdown", "side", "3-4"] as const;
+
+const SHEETS = [
+  "auto",
+  "2x2",
+  "2x3",
+  "2x4",
+  "3x3",
+  "3x4",
+  "4x4",
+  "5x5",
+  "strip-1x3",
+  "strip-1x4",
+  "custom",
+] as const;
+
+const BUNDLES = [
+  "single",
+  "unit",
+  "spell",
+  "combat",
+  "line",
+  "hero-action",
+  "engine-atlas",
+] as const;
+
+const ART_STYLES = [
+  "pixel-art",
+  "clean-hd",
+  "pixel-inspired",
+  "retro-pixel",
+  "map-style",
+  "project-native",
+] as const;
+
+const ANCHORS = ["center", "bottom", "feet"] as const;
+const MARGINS = ["tight", "normal", "safe"] as const;
+const EFFECT_POLICIES = ["all", "largest"] as const;
+
+interface SpriteOptions {
+  readonly prompt?: string;
+  readonly assetType?: string;
+  readonly action?: string;
+  readonly view?: string;
+  readonly sheet?: string;
+  readonly frames?: string;
+  readonly bundle?: string;
+  readonly artStyle?: string;
+  readonly anchor?: string;
+  readonly margin?: string;
+  readonly effectPolicy?: string;
+  readonly reference?: string;
+  readonly model: string;
+  readonly name?: string;
+}
+
+function validateEnum(
+  flag: string,
+  value: string | undefined,
+  allowed: readonly string[],
+): void {
+  if (value !== undefined && !allowed.includes(value)) {
+    throw new Error(
+      `${flag} must be one of: ${allowed.join(", ")} (got "${value}")`,
+    );
+  }
+}
+
+function resolveFrames(value: string | undefined): string {
+  if (value === undefined) {
+    return AGENT_DECIDES;
+  }
+  if (value === "auto") {
+    return value;
+  }
+  const frames = Number(value);
+  if (!Number.isInteger(frames) || frames < 1 || frames > 64) {
+    throw new Error("--frames must be 'auto' or an integer from 1 to 64");
+  }
+  return String(frames);
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .replace(/-{2,}/gu, "-")
+    .slice(0, 48)
+    .replace(/-+$/u, "");
+  return slug.length >= 3 ? slug : "sprite";
+}
+
+export const spriteCommand = new Command()
+  .name("sprite")
+  .description(
+    "Prepare 2D game sprite/asset authoring instructions from a prompt",
+  )
+  .option("--prompt <text>", "Sprite prompt/theme; can also be piped via stdin")
+  .option("--asset-type <type>", `Asset type: ${ASSET_TYPES.join(", ")}`)
+  .option("--action <action>", `Animation/action: ${ACTIONS.join(", ")}`)
+  .option(
+    "--view <view>",
+    `Camera view: ${VIEWS.join(", ")} (3-4 means 3/4 view)`,
+  )
+  .option("--sheet <grid>", `Sheet/grid shape: ${SHEETS.join(", ")}`, "auto")
+  .option("--frames <count>", "Frame count: 'auto' or an integer (1-64)")
+  .option("--bundle <preset>", `Bundle preset: ${BUNDLES.join(", ")}`)
+  .option(
+    "--art-style <style>",
+    `Sprite art style (the sprite analog of 'zero generate image --style'): ${ART_STYLES.join(", ")}`,
+  )
+  .option("--anchor <anchor>", `Frame anchor: ${ANCHORS.join(", ")}`)
+  .option("--margin <margin>", `Safe-area margin: ${MARGINS.join(", ")}`)
+  .option(
+    "--effect-policy <policy>",
+    `Detached-FX component policy: ${EFFECT_POLICIES.join(", ")}`,
+  )
+  .option(
+    "--reference <url>",
+    "Reference image URL for identity/style consistency",
+  )
+  .option(
+    "--model <model>",
+    "Recommended image model for raw sheets",
+    DEFAULT_MODEL,
+  )
+  .option("--name <slug>", "Output bundle name/slug")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Generate sprite:       ${SPRITE_USAGE_COMMAND} --prompt "A green slime monster idle loop"
+  Pick asset + action:   ${SPRITE_USAGE_COMMAND} --asset-type creature --action idle --sheet 3x3 --prompt "A fire dragon boss"
+  Hero action bundle:    ${SPRITE_USAGE_COMMAND} --asset-type player --bundle hero-action --view side --prompt "A knight with idle, run, attack, jump"
+  4-direction walk:      ${SPRITE_USAGE_COMMAND} --asset-type player --action walk --view topdown --sheet 4x4 --prompt "A 16-bit RPG villager"
+  Pixel art style:       ${SPRITE_USAGE_COMMAND} --art-style pixel-art --prompt "A retro fireball projectile" --sheet 2x2
+  Match a reference:     ${SPRITE_USAGE_COMMAND} --reference https://example.com/hero.png --action attack --prompt "Attack animation for this hero"
+  Pipe prompt:           cat brief.txt | ${SPRITE_USAGE_COMMAND}
+  Show choices:          ${SPRITE_USAGE_COMMAND}
+
+Output:
+  Prints a sprite source-selection packet for the current agent: the resolved
+  plan, the recommended image model, the upstream sprite skill to resolve, and
+  the hard containment rules for grids, identity, and FX.
+  With no --prompt and no piped input, prints the generation choices instead.
+
+Notes:
+  - The agent generates each raw sheet with built-in image generation
+    (gpt-image-2 recommended) on a solid magenta background, then runs the
+    sprite skill's local processor for chroma-key cleanup, frame extraction,
+    alignment, QC, and transparent/GIF export.
+  - Raw sprite art must originate from image generation, never from code-drawn
+    primitives (Three.js/Canvas/SVG/HTML/PIL).
+  - Unset flags resolve to "agent decides"; the agent infers them from the
+    prompt and the skill's modes reference.`,
+  )
+  .action(
+    withErrorHandler(async (options: SpriteOptions) => {
+      validateEnum("--asset-type", options.assetType, ASSET_TYPES);
+      validateEnum("--action", options.action, ACTIONS);
+      validateEnum("--view", options.view, VIEWS);
+      validateEnum("--sheet", options.sheet, SHEETS);
+      validateEnum("--bundle", options.bundle, BUNDLES);
+      validateEnum("--art-style", options.artStyle, ART_STYLES);
+      validateEnum("--anchor", options.anchor, ANCHORS);
+      validateEnum("--margin", options.margin, MARGINS);
+      validateEnum("--effect-policy", options.effectPolicy, EFFECT_POLICIES);
+      const frames = resolveFrames(options.frames);
+
+      const dispatch = await dispatchGenerate({
+        generationType: "sprite",
+        prompt: options.prompt,
+      });
+      if (dispatch.outcome === "handled") return;
+      const prompt = dispatch.prompt;
+
+      const plan: SpritePlan = {
+        assetType: options.assetType ?? AGENT_DECIDES,
+        action: options.action ?? AGENT_DECIDES,
+        view: options.view ?? AGENT_DECIDES,
+        sheet: options.sheet ?? "auto",
+        frames,
+        bundle: options.bundle ?? AGENT_DECIDES,
+        artStyle: options.artStyle ?? AGENT_DECIDES,
+        anchor: options.anchor ?? AGENT_DECIDES,
+        margin: options.margin ?? AGENT_DECIDES,
+        effectPolicy: options.effectPolicy ?? AGENT_DECIDES,
+        reference: options.reference ?? "none",
+        model: options.model,
+        name: slugify(options.name ?? prompt),
+      };
+
+      const packet = createSpriteAuthoringPacket({ prompt, plan });
+      console.log(packet.instructions);
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/shared/sprite-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/sprite-authoring.ts
@@ -1,0 +1,180 @@
+/**
+ * Sprite generation source-selection packet.
+ *
+ * `zero generate sprite` does not run a server-side pipeline. Like the website
+ * and styled-image commands, it "bounces" a structured authoring packet back to
+ * the calling agent: the resolved sprite plan, the recommended image model, the
+ * upstream sprite skill to resolve, and the hard containment rules the agent
+ * must honor when it drives built-in image generation plus local postprocessing.
+ */
+
+export interface SpritePlan {
+  readonly assetType: string;
+  readonly action: string;
+  readonly view: string;
+  readonly sheet: string;
+  readonly frames: string;
+  readonly bundle: string;
+  readonly artStyle: string;
+  readonly anchor: string;
+  readonly margin: string;
+  readonly effectPolicy: string;
+  readonly reference: string;
+  readonly model: string;
+  readonly name: string;
+}
+
+interface SpriteAuthoringOptions {
+  readonly prompt: string;
+  readonly plan: SpritePlan;
+}
+
+interface SpriteAuthoringPacket {
+  readonly type: "generation-source-selection";
+  readonly kind: "sprite";
+  readonly prompt: string;
+  readonly plan: SpritePlan;
+  readonly model: string;
+  readonly outputDir: string;
+  readonly skill: {
+    readonly repo: string;
+    readonly ref: string;
+    readonly skillPath: string;
+    readonly references: readonly string[];
+    readonly script: string;
+  };
+  readonly instructions: string;
+}
+
+const SPRITE_SKILL = {
+  repo: "0x0funky/agent-sprite-forge",
+  ref: "main",
+  skillPath: "skills/generate2dsprite/SKILL.md",
+  references: [
+    "skills/generate2dsprite/references/prompt-rules.md",
+    "skills/generate2dsprite/references/modes.md",
+  ],
+  script: "skills/generate2dsprite/scripts/generate2dsprite.py",
+} as const;
+
+const CORE_INVARIANTS = [
+  "Every raw sprite image must come from built-in image generation. Never draw raw sprite art with Three.js, Canvas, SVG, HTML/CSS, PIL shapes, procedural geometry, placeholder primitives, or code-rendered screenshots. Code may only assemble layout guides, postprocess generated images, or display finished assets at runtime.",
+  "Background is 100% solid flat magenta `#FF00FF` with no gradient, so the local processor can chroma-key it to transparency. Keep this rule unless the user explicitly wants a different processing workflow.",
+  "No text, labels, UI, speech bubbles, borders, or frames between cells. Generate the exact requested grid count only.",
+  "Keep the same asset identity, the same bounding box, and the same pixel scale across every frame.",
+  "Containment: the entire subject fits fully inside each cell with magenta margin on all four sides. No limb, weapon, tail, wing tip, orb, spark, or trail may cross a cell edge.",
+  "Do not use raw single-row sheets (1x4, 1x6, 1x8, 1xN) for any body subject — players, heroes, creatures, NPCs, enemies, summons, or animated props. Use centered multi-row grids: 4 frames -> 2x2, 6 -> 2x3, 8 -> 2x4, 9 -> 3x3, 12 -> 3x4 or 4x3, 16 -> 4x4.",
+  "For controllable heroes and main characters, attack/shoot/cast body sheets are body-only by default and must preserve idle/run body scale and the feet/bottom anchor. Generate slash arcs, weapon trails, muzzle flashes, projectiles, dust, and impacts as separate fx/projectile/impact sheets unless the runtime explicitly supports wider per-action cells plus per-action origins.",
+  "For map prop packs, classify props first. Square 2x2/3x3/4x4 packs are only for compact props. Floors, platforms, bridges, walls, ladders, gates, doors, long hazards, wide/tall props, collision-bearing objects, and tileset/strip pieces use one-by-one generation, 1x3/1x4 strips, custom wide cells, or a tileset-like atlas instead.",
+  "Mixed-action atlases (4x4, 5x5, custom) are a deterministic delivery step assembled from separate per-action sheets after each passes QC — never one raw mixed-action image. Raw multi-cell grids are valid only for one coherent action family, canonical directional locomotion, prop packs, or tileset-like atlases.",
+] as const;
+
+const WORKFLOW = [
+  "1. Resolve the upstream skill below, then infer or confirm the asset plan. Pick the smallest useful output and do not pad unrelated actions into one raw sheet.",
+  "2. Write the art prompt by hand using the skill's prompt-rules. Lock the art style, the exact sheet shape, the solid magenta background, the identity, and the containment rules. Do not delegate prompt writing to a script.",
+  "3. Generate each raw sheet with built-in image generation using the recommended model below. If a reference is involved, make it visible to the model first (view a local file before generating); never pass a bare filesystem path as the visual reference.",
+  "4. Postprocess each raw sheet locally with the skill's processor script: magenta cleanup, frame extraction, alignment, shared-scale normalization, component filtering, QC metadata, transparent sheet export, and GIF export.",
+  "5. QC each sheet: no frame touches a cell edge, scale is consistent, detached FX did not become noise, the sheet reads as one coherent animation, and hero/player body height matches the accepted idle/run scale within ~10-15%. Reprocess or regenerate if it fails.",
+  "6. Return the bundle for the resolved plan (single sheet, unit/spell/combat bundle, line bundle, or hero action bundle with separate FX assets and an optional assembled engine atlas after per-action QC).",
+] as const;
+
+const EXPECTED_OUTPUTS = [
+  "`raw-sheet.png` (and one raw sheet per action for bundles)",
+  "`raw-sheet-clean.png` (magenta cleaned)",
+  "`sheet-transparent.png`",
+  "per-frame PNGs",
+  "`animation.gif` (per direction/action where applicable)",
+  "`prompt-used.txt`",
+  "`pipeline-meta.json`",
+] as const;
+
+export function createSpriteAuthoringPacket(
+  options: SpriteAuthoringOptions,
+): SpriteAuthoringPacket {
+  const { prompt, plan } = options;
+  const outputDir = `./generated/sprites/${plan.name}`;
+
+  const planEntries: ReadonlyArray<readonly [string, string]> = [
+    ["Asset type", plan.assetType],
+    ["Action", plan.action],
+    ["View", plan.view],
+    ["Sheet / grid", plan.sheet],
+    ["Frames", plan.frames],
+    ["Bundle", plan.bundle],
+    ["Art style", plan.artStyle],
+    ["Anchor", plan.anchor],
+    ["Margin", plan.margin],
+    ["Effect policy", plan.effectPolicy],
+    ["Reference", plan.reference],
+  ];
+
+  const instructions = [
+    "# Zero generate sprite",
+    "",
+    "This is a federated generation source-selection packet for the current agent.",
+    "Zero is not generating these sprites on the server. You resolve the sprite skill below, write the art prompt yourself, generate each raw sheet with built-in image generation, then run the skill's local processor for chroma-key cleanup, frame extraction, alignment, QC, and transparent/GIF export.",
+    "",
+    "## User Prompt",
+    prompt,
+    "",
+    "## Sprite Plan",
+    "These parameters were resolved from the command. `agent decides` means the flag was not set — infer the best value from the prompt and the skill's modes reference; do not force the user to spell it out.",
+    "",
+    ...planEntries.map(([label, value]) => {
+      return `- ${label}: ${value}`;
+    }),
+    `- Output name: ${plan.name}`,
+    "",
+    "## Recommended Model",
+    `- Use \`${plan.model}\` for every raw sheet via built-in image generation (\`zero generate image --provider built-in --model ${plan.model} --skip-style --prompt "..."\`, or the in-context image tool).`,
+    "- gpt-image-2 is recommended for sprite sheets: it accepts flexible WIDTHxHEIGHT sizes and high quality for crisp, evenly-spaced grids. It does not emit transparent backgrounds, which is expected here — the solid magenta background is chroma-keyed by the local processor.",
+    "- Pick a sheet-friendly square or grid-aligned size (for example 1024x1024 for 2x2/3x3/4x4) so each cell stays evenly spaced.",
+    "",
+    "## Workflow Skill",
+    "Resolve this skill before authoring; it is the authority for sprite prompt patterns, sheet/bundle selection, and the postprocessing primitive.",
+    "",
+    `- Repo: \`${SPRITE_SKILL.repo}@${SPRITE_SKILL.ref}\``,
+    `- Skill: \`${SPRITE_SKILL.skillPath}\``,
+    `- References: ${SPRITE_SKILL.references
+      .map((ref) => {
+        return `\`${ref}\``;
+      })
+      .join(", ")}`,
+    `- Processor script: \`${SPRITE_SKILL.script}\``,
+    "- For map props that must match a tile map, prefer the sibling `generate2dmap` skill in the same repo.",
+    "- If a source file cannot be fetched, state that limitation and fall back to the core invariants below.",
+    "",
+    "## Core Invariants",
+    ...CORE_INVARIANTS.map((rule) => {
+      return `- ${rule}`;
+    }),
+    "",
+    "## Workflow",
+    ...WORKFLOW,
+    "",
+    "## Output Contract",
+    `- Write the bundle under \`${outputDir}/\`.`,
+    "- Keep the original generated images and produce, per sheet:",
+    ...EXPECTED_OUTPUTS.map((item) => {
+      return `  - ${item}`;
+    }),
+    "- For bundles, create one subfolder per asset and keep the per-action FX/projectile/impact sheets separate.",
+    "",
+    "## Verification",
+    "- Confirm each transparent sheet and its frames are nonblank and free of magenta fringing.",
+    "- Confirm no frame touches a cell edge and that scale and identity stay consistent across frames.",
+    "- For hero/player body actions, confirm body height matches the accepted idle/run scale within ~10-15%.",
+    "- Report the output directory, the final assets, and the resolved plan.",
+  ].join("\n");
+
+  return {
+    type: "generation-source-selection",
+    kind: "sprite",
+    prompt,
+    plan,
+    model: plan.model,
+    outputDir,
+    skill: SPRITE_SKILL,
+    instructions,
+  };
+}


### PR DESCRIPTION
## What

Adds a new `zero generate sprite` subcommand for 2D game asset (sprite) generation.

Like `zero generate website` and the `zero generate image --style` path, it does **not** run a server-side pipeline. It prints a **source-selection "bounce" packet** for the calling agent: resolve the upstream skill → hand-write the art prompt → generate raw sheets with built-in image generation → postprocess locally → QC → return the bundle.

## Why

Sprite generation is inherently multi-step (raw image generation on a solid-magenta background + local chroma-key cleanup, frame extraction, alignment, QC, transparent/GIF export). That workflow lives in the [`0x0funky/agent-sprite-forge`](https://github.com/0x0funky/agent-sprite-forge) `generate2dsprite` skill, so the command reflects the resolved plan and rules back to the agent instead of executing on the server.

## Prompt "bounce" parameters

Distilled from the `generate2dsprite` skill, mirroring the image `--style` / website `--template`/`--design-system` patterns:

- `--asset-type` — player · npc · creature · character · spell · projectile · impact · prop · summon · fx
- `--action` — idle · walk · run · attack · shoot · cast · jump · hurt · combat · death · …
- `--view` — topdown · side · 3-4
- `--sheet` — auto · 2x2 · 2x3 · 2x4 · 3x3 · 3x4 · 4x4 · 5x5 · strip-1x3 · strip-1x4 · custom
- `--frames` — auto or 1–64
- `--bundle` — single · unit · spell · combat · line · hero-action · engine-atlas
- `--art-style` — pixel-art · clean-hd · pixel-inspired · retro-pixel · map-style · project-native (the sprite analog of `image --style`)
- `--anchor` · `--margin` · `--effect-policy` · `--reference` · `--name`
- `--model` — defaults to **`gpt-image-2`** (recommended); flexible sizes + crisp grids, transparent-bg not needed since magenta is chroma-keyed

Unset flags resolve to `agent decides`. The packet also carries the hard invariants (solid `#FF00FF` background, exact grid, identity/scale consistency, no single-row body sheets, body-only hero actions, prop-pack classification, raw art from image generation only).

## Files

- **Added** `shared/sprite-authoring.ts` — packet builder
- **Added** `generate/sprite.ts` — command + flag validation
- **Added** `generate/__tests__/sprite.test.ts` — 5 tests
- **Wired** `generate/index.ts` (register + help example) and `generate/lib/lister.ts` (type union, label, exhaustive switch, built-in command entry)

## Validation

- ✅ `pnpm -F @vm0/cli lint` — 0 errors
- ✅ `pnpm -F @vm0/cli check-types` — clean
- ✅ 61/61 generate tests pass (5 new)
- ✅ knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)