### PR TITLE
fix: disable GitHub label session continuity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
@@ -7,6 +7,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
@@ -17,7 +18,7 @@ import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { mockOptionalEnv } from "../../../lib/env";
-import { now, nowDate } from "../../../lib/time";
+import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
@@ -48,6 +49,7 @@ interface GitHubIssuesPayload {
   readonly issueNumber: number;
   readonly agentId: string;
   readonly existingSessionId?: string;
+  readonly sessionContinuityEnabled?: boolean;
   readonly triggerCommentId?: string;
   readonly triggerReactionId?: string;
   readonly triggerCommentBody?: string;
@@ -200,7 +202,11 @@ async function seedGithubInstallation(args: {
 async function seedRunAndCallback(args: {
   readonly fixture: GitHubIssuesFixture;
   readonly payload: GitHubIssuesPayload;
-}): Promise<{ readonly runId: string; readonly callbackId: string }> {
+}): Promise<{
+  readonly runId: string;
+  readonly callbackId: string;
+  readonly sessionId: string;
+}> {
   const createdAt = new Date(now() - 60_000);
   const { runId } = await store.set(
     seedRun$,
@@ -215,6 +221,15 @@ async function seedRunAndCallback(args: {
     },
     context.signal,
   );
+  const writeDb = store.set(writeDb$);
+  const [run] = await writeDb
+    .select({ sessionId: agentRuns.sessionId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  if (!run) {
+    throw new Error("seedRunAndCallback: run not found");
+  }
   const { callbackId } = await store.set(
     seedAgentRunCallback$,
     {
@@ -224,7 +239,7 @@ async function seedRunAndCallback(args: {
     },
     context.signal,
   );
-  return { runId, callbackId };
+  return { runId, callbackId, sessionId: run.sessionId };
 }
 
 async function seedAgentSession(
@@ -237,7 +252,6 @@ async function seedAgentSession(
       userId: fixture.userId,
       orgId: fixture.orgId,
       agentComposeId: fixture.composeId,
-      updatedAt: nowDate(),
     })
     .returning({ id: agentSessions.id });
   if (!row) {
@@ -803,11 +817,10 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       issueNumber: 42,
       agentId: fixture.composeId,
     };
-    const { runId, callbackId } = await seedRunAndCallback({
+    const { runId, callbackId, sessionId } = await seedRunAndCallback({
       fixture,
       payload,
     });
-    const session = await seedAgentSession(fixture);
     completedOutput();
 
     const response = await postSignedCallback({
@@ -824,7 +837,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       issueNumber: payload.issueNumber,
     });
     expect(issueSession).not.toBeNull();
-    expect(issueSession!.agentSessionId).toBe(session.id);
+    expect(issueSession!.agentSessionId).toBe(sessionId);
     expect(issueSession!.userId).toBe(fixture.userId);
     expect(issueSession!.lastCommentId).toBe(GITHUB_COMMENT_ID);
   });
@@ -854,11 +867,10 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       agentSessionId: staleSession.id,
       lastCommentId: "old-comment-id",
     });
-    const { runId, callbackId } = await seedRunAndCallback({
+    const { runId, callbackId, sessionId } = await seedRunAndCallback({
       fixture,
       payload,
     });
-    const newSession = await seedAgentSession(fixture);
     completedOutput();
 
     const response = await postSignedCallback({
@@ -875,8 +887,58 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       issueNumber: payload.issueNumber,
     });
     expect(issueSession).not.toBeNull();
-    expect(issueSession!.agentSessionId).toBe(newSession.id);
+    expect(issueSession!.agentSessionId).toBe(sessionId);
     expect(issueSession!.lastCommentId).toBe(GITHUB_COMMENT_ID);
+  });
+
+  it("does not replace a GitHub issue session when session continuity is disabled", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    setupGithubApiMocks(installation.installationId);
+    const staleSession = await seedAgentSession(fixture);
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+      sessionContinuityEnabled: false,
+    };
+    await seedIssueSession({
+      userId: fixture.userId,
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+      agentSessionId: staleSession.id,
+      lastCommentId: "old-comment-id",
+    });
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    const issueSession = await findIssueSession({
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+    });
+    expect(issueSession).not.toBeNull();
+    expect(issueSession!.agentSessionId).toBe(staleSession.id);
+    expect(issueSession!.lastCommentId).toBe("old-comment-id");
   });
 
   it("updates lastCommentId for an existing issue session on completed runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -1398,7 +1398,7 @@ describe("POST /api/webhooks/github", () => {
     expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
   });
 
-  it("continues an existing session for the same GitHub issue", async () => {
+  it("starts a new session for label triggers on a GitHub issue with an existing session", async () => {
     const fixture = await trackGitHub(
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
@@ -1455,7 +1455,8 @@ describe("POST /api/webhooks/github", () => {
     expect(response.status).toBe(200);
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
-    expect(runs[0]?.sessionId).toBe(session.id);
+    expect(runs[0]?.sessionId).toStrictEqual(expect.any(String));
+    expect(runs[0]?.sessionId).not.toBe(session.id);
     expect(runs[0]?.appendSystemPrompt).toContain("Earlier discussion");
     expect(runs[0]?.appendSystemPrompt).toContain("New detail");
     expect(runs[0]?.appendSystemPrompt).toContain("- MSG_ID: issue:42");
@@ -1464,8 +1465,9 @@ describe("POST /api/webhooks/github", () => {
 
     const callbacks = await selectGitHubCallbacks(runs[0]?.id ?? "");
     expect(callbacks[0]?.payload).toMatchObject({
-      existingSessionId: session.id,
+      sessionContinuityEnabled: false,
     });
+    expect(callbacks[0]?.payload).not.toHaveProperty("existingSessionId");
   });
 
   it("dispatches pull requests with a matching label listener", async () => {

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
@@ -472,18 +472,20 @@ const handleGithubIssuesCallback$ = command(
       signal.throwIfAborted();
     }
 
-    await saveIssueSession({
-      db,
-      runId,
-      agentId,
-      installationId,
-      repo,
-      issueNumber,
-      existingSessionId,
-      commentId,
-      status,
-      signal,
-    });
+    if (payload.sessionContinuityEnabled ?? true) {
+      await saveIssueSession({
+        db,
+        runId,
+        agentId,
+        installationId,
+        repo,
+        issueNumber,
+        existingSessionId,
+        commentId,
+        status,
+        signal,
+      });
+    }
 
     L.debug("GitHub issues callback processed successfully", {
       runId,

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -154,6 +154,7 @@ interface DispatchParams {
   readonly prompt: string;
   readonly matchedLabelName?: string;
   readonly triggerDescription?: string;
+  readonly sessionContinuityEnabled: boolean;
   readonly commentId?: string;
   readonly comment?: GitHubComment;
   readonly apiStartTime: number;
@@ -984,6 +985,7 @@ function buildCallbackPayload(args: {
   readonly issueNumber: number;
   readonly composeId: string;
   readonly existingSessionId: string | undefined;
+  readonly sessionContinuityEnabled: boolean;
   readonly reactionId: string | undefined;
 }): GitHubIssuesCallbackPayload {
   return githubIssuesCallbackPayloadSchema.parse({
@@ -992,6 +994,7 @@ function buildCallbackPayload(args: {
     issueNumber: args.issueNumber,
     agentId: args.composeId,
     existingSessionId: args.existingSessionId,
+    sessionContinuityEnabled: args.sessionContinuityEnabled,
     triggerCommentId: args.params.commentId,
     triggerCommentBody: args.params.commentId
       ? args.params.comment?.body
@@ -1282,6 +1285,7 @@ const dispatchMatchingLabelListener$ = command(
         composeId: listener.composeId,
         prompt: listener.prompt,
         matchedLabelName: listener.labelName,
+        sessionContinuityEnabled: false,
         apiStartTime: args.apiStartTime,
       },
       signal,
@@ -1444,6 +1448,7 @@ export const handleGithubIssueCommentEvent$ = command(
         composeId: installation.defaultComposeId,
         prompt,
         triggerDescription: `${githubAppBotUsername() ?? "GitHub App"} mention`,
+        sessionContinuityEnabled: true,
         commentId: String(payload.comment.id),
         comment: payload.comment,
         apiStartTime: args.apiStartTime,
@@ -1493,22 +1498,25 @@ const dispatchGithubAgentRun$ = command(
     );
     signal.throwIfAborted();
 
-    const sessionResult = await resolveExistingSession({
-      db,
-      installationDbId: installation.id,
-      repo: params.repo,
-      issueNumber,
-      composeId: target.composeId,
-      vm0UserId: params.vm0UserId,
-      commentId: params.commentId,
-      modelRoute,
-      signal,
-    });
-    if (sessionResult.kind === "duplicate") {
-      return;
+    let existingSessionId: string | undefined;
+    if (params.sessionContinuityEnabled) {
+      const sessionResult = await resolveExistingSession({
+        db,
+        installationDbId: installation.id,
+        repo: params.repo,
+        issueNumber,
+        composeId: target.composeId,
+        vm0UserId: params.vm0UserId,
+        commentId: params.commentId,
+        modelRoute,
+        signal,
+      });
+      if (sessionResult.kind === "duplicate") {
+        return;
+      }
+      existingSessionId = sessionResult.sessionId;
     }
 
-    const existingSessionId = sessionResult.sessionId;
     const prompt = replaceGithubFileReferencesForContext(params.prompt);
     signal.throwIfAborted();
     const issueContext = await buildIssueContextForRun({
@@ -1530,6 +1538,7 @@ const dispatchGithubAgentRun$ = command(
       issueNumber,
       composeId: target.composeId,
       existingSessionId,
+      sessionContinuityEnabled: params.sessionContinuityEnabled,
       reactionId,
     });
 

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-github-issues.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-github-issues.ts
@@ -17,6 +17,7 @@ export const githubIssuesCallbackPayloadSchema = z
     issueNumber: z.number(),
     agentId: z.string(),
     existingSessionId: z.string().optional(),
+    sessionContinuityEnabled: z.boolean().optional(),
     triggerCommentId: z.string().optional(),
     triggerReactionId: z.string().optional(),
     triggerCommentBody: z.string().optional(),


### PR DESCRIPTION
## Summary
- start fresh sessions for GitHub label listener runs instead of reusing issue session mappings
- skip saving/replacing GitHub issue session mappings from label-triggered callbacks
- keep mention/comment-triggered session continuity behavior unchanged

## Tests
- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types
- pnpm exec vitest run apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts