### PR TITLE
refactor: rename connector auth provider apis

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -5,7 +5,7 @@ import type {
   ConnectorAuthClientConfig,
 } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
-import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
+import { getConnectorAuthProviderSecretMetadata } from "@vm0/connectors/auth-providers";
 import { testOauthProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
@@ -2222,7 +2222,9 @@ describe("GET /api/connectors/:type/callback", () => {
         needsReconnect: false,
       });
 
-      const secretMetadata = getConnectorOAuthSecretMetadata(providerCase.type);
+      const secretMetadata = getConnectorAuthProviderSecretMetadata(
+        providerCase.type,
+      );
       await expect(
         findDecryptedSecret({
           orgId,

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -11,7 +11,7 @@ import {
   connectorTypeSchema,
   type DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorOAuthSecretMetadata } from "@vm0/connectors/auth-providers";
+import { getConnectorAuthProviderSecretMetadata } from "@vm0/connectors/auth-providers";
 import {
   getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
@@ -240,7 +240,8 @@ const createTestConnector$ = command(
     if (!authMethod) {
       throw new Error(`${grantConnectorType} connector has no auth method`);
     }
-    const secretMetadata = getConnectorOAuthSecretMetadata(grantConnectorType);
+    const secretMetadata =
+      getConnectorAuthProviderSecretMetadata(grantConnectorType);
     const refreshSecretName = secretMetadata.isRefreshable
       ? secretMetadata.refreshSecretName
       : undefined;

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -11,7 +11,7 @@ import type {
   ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  buildConnectorOAuthAuthUrl,
+  buildConnectorAuthCodeAuthorizationUrl,
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 
@@ -93,7 +93,7 @@ export async function buildResolvedConnectorAuthCodeAuthUrl(args: {
   readonly state: string;
 }): Promise<AuthUrlResult> {
   return normalizeAuthUrlResult(
-    await buildConnectorOAuthAuthUrl({
+    await buildConnectorAuthCodeAuthorizationUrl({
       type: args.type,
       authClient: args.authClient,
       redirectUri: args.redirectUri,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -14,8 +14,8 @@ import {
   type ConnectorAuthMethodId,
 } from "@vm0/connectors/connectors";
 import {
-  exchangeConnectorOAuthCode,
-  getConnectorOAuthSecretMetadata,
+  exchangeConnectorAuthCode,
+  getConnectorAuthProviderSecretMetadata,
   type OAuthTokenResult,
 } from "@vm0/connectors/auth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -190,7 +190,7 @@ async function exchangeTokenForConnector(args: {
     throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
-  return await exchangeConnectorOAuthCode({
+  return await exchangeConnectorAuthCode({
     type: args.connectorType,
     authClient,
     code: args.code,
@@ -398,7 +398,9 @@ const completeOAuthCallback$ = command(
     });
     signal.throwIfAborted();
 
-    const secretMetadata = getConnectorOAuthSecretMetadata(args.connectorType);
+    const secretMetadata = getConnectorAuthProviderSecretMetadata(
+      args.connectorType,
+    );
     const result = await set(
       upsertOAuthConnector$,
       {

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -10,7 +10,7 @@ import {
   isStaticConfidentialConnectorAuthClient,
   type StaticConfidentialConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
-import { exchangeConnectorOAuthCode } from "@vm0/connectors/auth-providers";
+import { exchangeConnectorAuthCode } from "@vm0/connectors/auth-providers";
 import {
   exchangeGitHubCode,
   fetchGitHubUserInfo,
@@ -738,7 +738,7 @@ const callbackGithubUserOauth$ = command(
 
     const origin = getOAuthWebOrigin(request);
     const redirectUri = githubUserConnectCallbackRedirectUri(origin);
-    const token = await exchangeConnectorOAuthCode({
+    const token = await exchangeConnectorAuthCode({
       type: "github",
       authClient,
       code: query.code,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -18,9 +18,9 @@ import {
   type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
-  getConnectorOAuthSecretMetadata,
-  pollConnectorOAuthDeviceAuth,
-  startConnectorOAuthDeviceAuth,
+  getConnectorAuthProviderSecretMetadata,
+  pollConnectorDeviceAuthorization,
+  startConnectorDeviceAuthorization,
 } from "@vm0/connectors/auth-providers";
 import type {
   OAuthDeviceAuthCompleteResult,
@@ -603,7 +603,7 @@ async function runClaimedSession(
     session: args.session,
     type: args.type,
   });
-  const pollResult = await pollConnectorOAuthDeviceAuth({
+  const pollResult = await pollConnectorDeviceAuthorization({
     type: args.type,
     authClient: args.authClient,
     deviceCode: providerState.deviceCode,
@@ -720,7 +720,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return authClient;
     }
 
-    const startResult = await startConnectorOAuthDeviceAuth({
+    const startResult = await startConnectorDeviceAuthorization({
       type: resolvedType.type,
       authClient,
     });
@@ -910,7 +910,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       claimStartedAt,
       signal,
       persistConnector: async ({ result }) => {
-        const secretMetadata = getConnectorOAuthSecretMetadata(
+        const secretMetadata = getConnectorAuthProviderSecretMetadata(
           resolvedType.type,
         );
         const connectorResult = await set(

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -8,7 +8,7 @@ import {
 
 import { and, eq } from "drizzle-orm";
 import {
-  buildConnectorOAuthAuthUrl,
+  buildConnectorAuthCodeAuthorizationUrl,
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -382,7 +382,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/github/callback`;
   const authResult = normalizeAuthUrlResult(
-    await buildConnectorOAuthAuthUrl({
+    await buildConnectorAuthCodeAuthorizationUrl({
       type: "github",
       authClient,
       redirectUri,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -19,8 +19,8 @@ import {
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import {
-  getConnectorOAuthSecretMetadata,
-  revokeConnectorOAuthToken,
+  getConnectorAuthProviderSecretMetadata,
+  revokeConnectorAuthProviderAccessToken,
 } from "@vm0/connectors/auth-providers";
 import {
   CONNECTOR_TYPE_KEYS,
@@ -515,7 +515,7 @@ async function loadPendingConnectorTokenRevoke(args: {
   readonly signal: AbortSignal;
 }): Promise<PendingConnectorTokenRevoke | null> {
   const connectorType = args.type;
-  const secretMetadata = getConnectorOAuthSecretMetadata(connectorType);
+  const secretMetadata = getConnectorAuthProviderSecretMetadata(connectorType);
   const accessTokenName = secretMetadata.accessSecretName;
 
   const [accessTokenSecret] = await args.db
@@ -558,7 +558,7 @@ async function revokePendingConnectorToken(args: {
 
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
-    revokeConnectorOAuthToken({
+    revokeConnectorAuthProviderAccessToken({
       type: args.pending.type,
       authClient,
       loadAccessToken: () => {
@@ -1475,7 +1475,7 @@ export const upsertOAuthConnector$ = command(
     readonly created: boolean;
   }> => {
     const writeDb = set(writeDb$);
-    const secretMetadata = getConnectorOAuthSecretMetadata(args.type);
+    const secretMetadata = getConnectorAuthProviderSecretMetadata(args.type);
     const tokenExpiresAt = connectorTokenExpiresAt({
       isRefreshable: secretMetadata.isRefreshable,
       expiresIn: args.expiresIn,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -56,15 +56,15 @@ import {
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
-  buildConnectorOAuthAuthUrl,
+  buildConnectorAuthCodeAuthorizationUrl,
   getConnectorAuthProviderClientArgs,
   hasConnectorAuthCodeGrantProvider,
   hasConnectorDeviceAuthGrantProvider,
-  getConnectorOAuthSecretMetadata,
-  pollConnectorOAuthDeviceAuth,
+  getConnectorAuthProviderSecretMetadata,
+  pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
-  revokeConnectorOAuthToken,
-  startConnectorOAuthDeviceAuth,
+  revokeConnectorAuthProviderAccessToken,
+  startConnectorDeviceAuthorization,
 } from "../auth-providers/connector-auth";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../auth-providers/oauth/google-connectors";
 import { buildGoogleAuthorizationUrl } from "../auth-providers/oauth/google";
@@ -457,12 +457,12 @@ describe("connector grant provider capability checks", () => {
   });
 
   it("exposes connector OAuth secret metadata without provider access", () => {
-    expect(getConnectorOAuthSecretMetadata("test-oauth")).toEqual({
+    expect(getConnectorAuthProviderSecretMetadata("test-oauth")).toEqual({
       accessSecretName: "TEST_OAUTH_ACCESS_TOKEN",
       refreshSecretName: "TEST_OAUTH_REFRESH_TOKEN",
       isRefreshable: true,
     });
-    expect(getConnectorOAuthSecretMetadata("github")).toEqual({
+    expect(getConnectorAuthProviderSecretMetadata("github")).toEqual({
       accessSecretName: "GITHUB_ACCESS_TOKEN",
       isRefreshable: false,
     });
@@ -523,7 +523,7 @@ describe("connector grant provider capability checks", () => {
     );
 
     await expect(
-      revokeConnectorOAuthToken({
+      revokeConnectorAuthProviderAccessToken({
         type: "github",
         authClient: oauthClient,
         loadAccessToken: () => {
@@ -556,7 +556,7 @@ describe("connector grant provider capability checks", () => {
     let loadedAccessToken = false;
 
     await expect(
-      revokeConnectorOAuthToken({
+      revokeConnectorAuthProviderAccessToken({
         type: "notion",
         authClient: oauthClient,
         loadAccessToken: () => {
@@ -590,7 +590,7 @@ describe("connector grant provider capability checks", () => {
         if (!oauthClient) {
           throw new Error(`${type} OAuth client not found`);
         }
-        const authResult = await buildConnectorOAuthAuthUrl({
+        const authResult = await buildConnectorAuthCodeAuthorizationUrl({
           type,
           authClient: oauthClient,
           redirectUri: "https://app.test/callback",
@@ -692,7 +692,7 @@ describe("connector grant provider capability checks", () => {
       throw new Error("Expected test-oauth-device OAuth client");
     }
 
-    const startResult = await startConnectorOAuthDeviceAuth({
+    const startResult = await startConnectorDeviceAuthorization({
       type: "test-oauth-device",
       authClient: oauthClient,
     });
@@ -707,21 +707,21 @@ describe("connector grant provider capability checks", () => {
     });
 
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: "slow-down",
       }),
     ).resolves.toStrictEqual({ status: "slow_down" });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: "denied",
@@ -732,7 +732,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "User denied the device authorization request",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: "expired",
@@ -743,7 +743,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "Device authorization expired",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: "error",
@@ -754,7 +754,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "Synthetic device authorization error",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: "invalid-grant",
@@ -765,7 +765,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "Unknown device authorization code",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
         authClient: oauthClient,
         deviceCode: startResult.deviceCode,
@@ -896,7 +896,7 @@ describe("connector grant provider capability checks", () => {
     }
 
     await expect(
-      startConnectorOAuthDeviceAuth({
+      startConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
       }),
@@ -911,21 +911,21 @@ describe("connector grant provider capability checks", () => {
     });
 
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
         deviceCode: "slow-down",
       }),
     ).resolves.toStrictEqual({ status: "slow_down" });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
         deviceCode: "denied",
@@ -936,7 +936,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "User denied Base44 access",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
         deviceCode: "expired",
@@ -947,7 +947,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "Base44 device authorization expired",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
         deviceCode: "temporarily-unavailable",
@@ -958,7 +958,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "Base44 is temporarily unavailable",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "base44",
         authClient: oauthClient,
         deviceCode: "base44-device-code",
@@ -1176,7 +1176,7 @@ describe("connector grant provider capability checks", () => {
     }
 
     await expect(
-      startConnectorOAuthDeviceAuth({
+      startConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
       }),
@@ -1190,14 +1190,14 @@ describe("connector grant provider capability checks", () => {
     });
 
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "pending",
       }),
     ).resolves.toStrictEqual({ status: "pending" });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "denied",
@@ -1208,7 +1208,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "User denied Slock access",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "expired",
@@ -1219,7 +1219,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "Slock device authorization expired",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "no-servers",
@@ -1230,7 +1230,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription: "No Slock servers found for this account",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "missing-refresh",
@@ -1240,7 +1240,7 @@ describe("connector grant provider capability checks", () => {
       error: "token_response_invalid",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "server-error",
@@ -1252,7 +1252,7 @@ describe("connector grant provider capability checks", () => {
         "Unable to load Slock account metadata after authorization.",
     });
     await expect(
-      pollConnectorOAuthDeviceAuth({
+      pollConnectorDeviceAuthorization({
         type: "slock",
         authClient: oauthClient,
         deviceCode: "userinfo-error",
@@ -1263,7 +1263,7 @@ describe("connector grant provider capability checks", () => {
       errorDescription:
         "Unable to load Slock account metadata after authorization.",
     });
-    const completeResult = await pollConnectorOAuthDeviceAuth({
+    const completeResult = await pollConnectorDeviceAuthorization({
       type: "slock",
       authClient: oauthClient,
       deviceCode: "slock-device-code",
@@ -1297,7 +1297,7 @@ describe("connector grant provider capability checks", () => {
       SLOCK_ACCESS_TOKEN_TTL_SECONDS,
     );
 
-    const malformedCompleteResult = await pollConnectorOAuthDeviceAuth({
+    const malformedCompleteResult = await pollConnectorDeviceAuthorization({
       type: "slock",
       authClient: oauthClient,
       deviceCode: "malformed-token",
@@ -1452,7 +1452,7 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
         continue;
       }
 
-      const providerMetadata = getConnectorOAuthSecretMetadata(type);
+      const providerMetadata = getConnectorAuthProviderSecretMetadata(type);
       if (!providerMetadata) {
         throw new Error(`${type}: OAuth provider metadata is missing`);
       }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -23,12 +23,12 @@ import type {
 } from "./types";
 import {
   type AuthUrlResult,
-  type ConnectorOAuthAuthorizeArgs,
-  type ConnectorOAuthDeviceAuthPollArgs,
-  type ConnectorOAuthDeviceAuthStartArgs,
-  type ConnectorOAuthExchangeArgs,
-  type ConnectorOAuthRefreshArgs,
-  type ConnectorOAuthRevokeArgs,
+  type ConnectorAuthCodeAuthorizeArgs,
+  type ConnectorDeviceAuthorizationPollArgs,
+  type ConnectorDeviceAuthorizationStartArgs,
+  type ConnectorAuthCodeExchangeArgs,
+  type ConnectorAuthProviderRefreshArgs,
+  type ConnectorAuthProviderRevokeArgs,
   type OAuthAuthorizeArgs,
   type OAuthDeviceAuthPollArgs,
   type OAuthDeviceAuthPollResult,
@@ -105,19 +105,19 @@ export type {
 export type { ProviderEnv };
 export { providerEnvFromObject };
 
-export type ConnectorOAuthRevokeResult =
+export type ConnectorAuthProviderAccessTokenRevokeResult =
   | { readonly status: "revoked" }
   | { readonly status: "unsupported" };
 
-type AuthCodeConnectorOAuthProviderMap = {
+type AuthCodeConnectorAuthProviderMap = {
   readonly [Type in AuthCodeGrantConnectorType]: AuthCodeConnectorAuthProvider<Type>;
 };
 
-type DeviceAuthConnectorOAuthProviderMap = {
+type DeviceAuthConnectorAuthProviderMap = {
   readonly [Type in DeviceAuthGrantConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
-export type ConnectorOAuthSecretMetadata = AuthProviderSecretMetadata;
+export type ConnectorAuthProviderSecretMetadata = AuthProviderSecretMetadata;
 
 export interface ConnectorAuthProviderClientArgs {
   readonly clientId?: string;
@@ -126,15 +126,15 @@ export interface ConnectorAuthProviderClientArgs {
 
 function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   type: T,
-): DeviceAuthConnectorOAuthProviderMap[T] {
-  return DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type];
+): DeviceAuthConnectorAuthProviderMap[T] {
+  return DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type];
 }
 
 function connectorAccessProviderFor<T extends ConnectorAuthProviderType>(
   type: T,
 ): ConnectorAuthProviderAccess<T> {
   if (hasConnectorAuthCodeGrant(type)) {
-    return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type]
+    return AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type]
       .access as ConnectorAuthProviderAccess<T>;
   }
 
@@ -146,7 +146,7 @@ function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
   type: T,
 ): ConnectorAuthProviderRevoke<T> {
   if (hasConnectorAuthCodeGrant(type)) {
-    return AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type]
+    return AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type]
       .revoke as ConnectorAuthProviderRevoke<T>;
   }
 
@@ -175,7 +175,7 @@ export function getConnectorAuthProviderClientArgs(
   return connectorAuthProviderClientArgs(authClient);
 }
 
-const AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS: AuthCodeConnectorOAuthProviderMap = {
+const AUTH_CODE_CONNECTOR_AUTH_PROVIDERS: AuthCodeConnectorAuthProviderMap = {
   ahrefs: ahrefsProvider,
   airtable: airtableProvider,
   asana: asanaProvider,
@@ -223,7 +223,7 @@ const AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS: AuthCodeConnectorOAuthProviderMap = {
   "test-oauth": testOauthProvider,
 };
 
-const DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS: DeviceAuthConnectorOAuthProviderMap =
+const DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS: DeviceAuthConnectorAuthProviderMap =
   {
     base44: base44Provider,
     slock: slockProvider,
@@ -242,40 +242,40 @@ export function hasConnectorAuthProvider(
 export function hasConnectorAuthCodeGrantProvider(
   type: string,
 ): type is AuthCodeGrantConnectorType {
-  return Object.hasOwn(AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS, type);
+  return Object.hasOwn(AUTH_CODE_CONNECTOR_AUTH_PROVIDERS, type);
 }
 
 export function hasConnectorDeviceAuthGrantProvider(
   type: string,
 ): type is DeviceAuthGrantConnectorType {
-  return Object.hasOwn(DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS, type);
+  return Object.hasOwn(DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS, type);
 }
 
-export function getConnectorOAuthSecretMetadata(
+export function getConnectorAuthProviderSecretMetadata(
   type: ConnectorAuthProviderType,
-): ConnectorOAuthSecretMetadata;
-export function getConnectorOAuthSecretMetadata(
+): ConnectorAuthProviderSecretMetadata;
+export function getConnectorAuthProviderSecretMetadata(
   type: string,
-): ConnectorOAuthSecretMetadata | undefined;
-export function getConnectorOAuthSecretMetadata(
+): ConnectorAuthProviderSecretMetadata | undefined;
+export function getConnectorAuthProviderSecretMetadata(
   type: string,
-): ConnectorOAuthSecretMetadata | undefined {
+): ConnectorAuthProviderSecretMetadata | undefined {
   if (hasConnectorAuthCodeGrantProvider(type)) {
     return getAuthProviderSecretMetadata(
-      AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[type],
+      AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type],
     );
   }
 
   if (hasConnectorDeviceAuthGrantProvider(type)) {
     return getAuthProviderSecretMetadata(
-      DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[type],
+      DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type],
     );
   }
 
   return undefined;
 }
 
-export async function buildConnectorOAuthAuthUrl<
+export async function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
@@ -283,16 +283,16 @@ export async function buildConnectorOAuthAuthUrl<
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
-  return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
-    args.type
-  ].grant.buildAuthUrl({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    redirectUri: args.redirectUri,
-    state: args.state,
-  } as ConnectorOAuthAuthorizeArgs<T>);
+  return await AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[args.type].grant.buildAuthUrl(
+    {
+      ...connectorAuthProviderClientArgs(args.authClient),
+      redirectUri: args.redirectUri,
+      state: args.state,
+    } as ConnectorAuthCodeAuthorizeArgs<T>,
+  );
 }
 
-export async function exchangeConnectorOAuthCode<
+export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
@@ -303,46 +303,46 @@ export async function exchangeConnectorOAuthCode<
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  return await AUTH_CODE_CONNECTOR_OAUTH_PROVIDERS[
-    args.type
-  ].grant.exchangeCode({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    code: args.code,
-    redirectUri: args.redirectUri,
-    state: args.state,
-    codeVerifier: args.codeVerifier,
-    oauthContext: args.oauthContext,
-  } as ConnectorOAuthExchangeArgs<T>);
+  return await AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[args.type].grant.exchangeCode(
+    {
+      ...connectorAuthProviderClientArgs(args.authClient),
+      code: args.code,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      codeVerifier: args.codeVerifier,
+      oauthContext: args.oauthContext,
+    } as ConnectorAuthCodeExchangeArgs<T>,
+  );
 }
 
-export async function startConnectorOAuthDeviceAuth<
+export async function startConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly authClient: ConnectorAuthClient;
 }): Promise<OAuthDeviceAuthStartResult> {
   const grant = getDeviceAuthGrantConfig(args.type);
-  return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
+  return await DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[
     args.type
   ].grant.startDeviceAuth({
     ...connectorAuthProviderClientArgs(args.authClient),
     scopes: grant.scopes,
-  } as ConnectorOAuthDeviceAuthStartArgs<T>);
+  } as ConnectorDeviceAuthorizationStartArgs<T>);
 }
 
-export async function pollConnectorOAuthDeviceAuth<
+export async function pollConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
   readonly authClient: ConnectorAuthClient;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  return await DEVICE_AUTH_CONNECTOR_OAUTH_PROVIDERS[
+  return await DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[
     args.type
   ].grant.pollDeviceAuth({
     ...connectorAuthProviderClientArgs(args.authClient),
     deviceCode: args.deviceCode,
-  } as ConnectorOAuthDeviceAuthPollArgs<T>);
+  } as ConnectorDeviceAuthorizationPollArgs<T>);
 }
 
 export async function refreshConnectorAuthProviderAccessToken<
@@ -362,17 +362,17 @@ export async function refreshConnectorAuthProviderAccessToken<
       return await access.refreshToken({
         ...args.clientArgs,
         refreshToken: args.refreshToken,
-      } as ConnectorOAuthRefreshArgs<T>);
+      } as ConnectorAuthProviderRefreshArgs<T>);
   }
 }
 
-export async function revokeConnectorOAuthToken<
+export async function revokeConnectorAuthProviderAccessToken<
   T extends ConnectorAuthProviderType,
 >(args: {
   readonly type: T;
   readonly authClient: ConnectorAuthClient;
   readonly loadAccessToken: () => string | Promise<string>;
-}): Promise<ConnectorOAuthRevokeResult> {
+}): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
   const revoke = connectorRevokeProviderFor(args.type);
 
   switch (revoke.kind) {
@@ -383,7 +383,7 @@ export async function revokeConnectorOAuthToken<
       await revoke.revokeToken({
         ...connectorAuthProviderClientArgs(args.authClient),
         accessToken: await args.loadAccessToken(),
-      } as ConnectorOAuthRevokeArgs<T>);
+      } as ConnectorAuthProviderRevokeArgs<T>);
       return { status: "revoked" };
   }
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -160,24 +160,27 @@ type TokenCredentialArgs<Client extends ConnectorAuthClientConfig> =
       ? { readonly clientId: string }
       : NoClientCredentialArgs;
 
-export type ConnectorOAuthAuthorizeArgs<T extends ConnectorAuthProviderType> =
-  OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorAuthClientFor<T>>;
+export type ConnectorAuthCodeAuthorizeArgs<
+  T extends ConnectorAuthProviderType,
+> = OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorAuthClientFor<T>>;
 
-export type ConnectorOAuthExchangeArgs<T extends ConnectorAuthProviderType> =
+export type ConnectorAuthCodeExchangeArgs<T extends ConnectorAuthProviderType> =
   OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
 
-export type ConnectorOAuthRefreshArgs<T extends ConnectorAuthProviderType> =
-  OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
+export type ConnectorAuthProviderRefreshArgs<
+  T extends ConnectorAuthProviderType,
+> = OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
 
-export type ConnectorOAuthRevokeArgs<T extends ConnectorAuthProviderType> =
-  OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
+export type ConnectorAuthProviderRevokeArgs<
+  T extends ConnectorAuthProviderType,
+> = OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
 
-export type ConnectorOAuthDeviceAuthStartArgs<
+export type ConnectorDeviceAuthorizationStartArgs<
   T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthStartFlowArgs &
   StaticClientIdArgs<ConnectorAuthClientFor<T>>;
 
-export type ConnectorOAuthDeviceAuthPollArgs<
+export type ConnectorDeviceAuthorizationPollArgs<
   T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthPollFlowArgs &
   TokenCredentialArgs<ConnectorAuthClientFor<T>>;

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -5,12 +5,12 @@ import type {
 } from "../connectors";
 import type {
   AuthUrlResult,
-  ConnectorOAuthAuthorizeArgs,
-  ConnectorOAuthDeviceAuthPollArgs,
-  ConnectorOAuthDeviceAuthStartArgs,
-  ConnectorOAuthExchangeArgs,
-  ConnectorOAuthRefreshArgs,
-  ConnectorOAuthRevokeArgs,
+  ConnectorAuthCodeAuthorizeArgs,
+  ConnectorDeviceAuthorizationPollArgs,
+  ConnectorDeviceAuthorizationStartArgs,
+  ConnectorAuthCodeExchangeArgs,
+  ConnectorAuthProviderRefreshArgs,
+  ConnectorAuthProviderRevokeArgs,
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
   OAuthRefreshResult,
@@ -25,9 +25,11 @@ interface NoneGrantProvider {
 export interface AuthCodeGrantProvider<T extends AuthCodeGrantConnectorType> {
   readonly kind: "auth-code";
   buildAuthUrl(
-    args: ConnectorOAuthAuthorizeArgs<T>,
+    args: ConnectorAuthCodeAuthorizeArgs<T>,
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
-  exchangeCode(args: ConnectorOAuthExchangeArgs<T>): Promise<OAuthTokenResult>;
+  exchangeCode(
+    args: ConnectorAuthCodeExchangeArgs<T>,
+  ): Promise<OAuthTokenResult>;
 }
 
 export interface DeviceAuthGrantProvider<
@@ -35,10 +37,10 @@ export interface DeviceAuthGrantProvider<
 > {
   readonly kind: "device-auth";
   startDeviceAuth(
-    args: ConnectorOAuthDeviceAuthStartArgs<T>,
+    args: ConnectorDeviceAuthorizationStartArgs<T>,
   ): Promise<OAuthDeviceAuthStartResult>;
   pollDeviceAuth(
-    args: ConnectorOAuthDeviceAuthPollArgs<T>,
+    args: ConnectorDeviceAuthorizationPollArgs<T>,
   ): Promise<OAuthDeviceAuthPollResult>;
 }
 
@@ -53,7 +55,9 @@ export interface RefreshTokenAccessProvider<
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
   getRefreshSecretName(): string;
-  refreshToken(args: ConnectorOAuthRefreshArgs<T>): Promise<OAuthRefreshResult>;
+  refreshToken(
+    args: ConnectorAuthProviderRefreshArgs<T>,
+  ): Promise<OAuthRefreshResult>;
 }
 
 export type ConnectorAuthProviderAccess<T extends ConnectorAuthProviderType> =
@@ -66,7 +70,7 @@ interface NoneRevokeProvider {
 
 interface TokenRevokeProvider<T extends ConnectorAuthProviderType> {
   readonly kind: "token-revoke";
-  revokeToken(args: ConnectorOAuthRevokeArgs<T>): Promise<void>;
+  revokeToken(args: ConnectorAuthProviderRevokeArgs<T>): Promise<void>;
 }
 
 export type ConnectorAuthProviderRevoke<T extends ConnectorAuthProviderType> =


### PR DESCRIPTION
## Summary

- Rename connector-facing auth-provider facade APIs away from broad OAuth terminology
- Rename connector auth-provider argument wrapper types and provider registry internals
- Update API call sites and tests to use auth-code, device authorization, and auth-provider names

Closes #15407

## Tests

- pnpm exec prettier --write packages/connectors/src/auth-providers/oauth/types.ts packages/connectors/src/auth-providers/types.ts packages/connectors/src/auth-providers/connector-auth.ts packages/connectors/src/__tests__/connectors.test.ts apps/api/src/signals/services/connector-oauth-device-auth.service.ts apps/api/src/signals/services/github-oauth.service.ts apps/api/src/signals/services/zero-connector-data.service.ts apps/api/src/signals/routes/cli-auth-test.ts apps/api/src/signals/routes/connector-auth-code-start.ts apps/api/src/signals/routes/connectors-type-callback.ts apps/api/src/signals/routes/github-oauth.ts apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F api check-types
- pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F api lint
- lefthook pre-commit: pnpm knip; pnpm check-types
