### PR TITLE
fix: avoid stale access after refresh failure

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -105,16 +105,12 @@ function deferred(): {
   return { promise, resolve: resolvePromise };
 }
 
-async function hasWaitingConnectorStateLock(args: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorType: string;
-}): Promise<boolean> {
+async function hasWaitingAdvisoryLock(lockKey: string): Promise<boolean> {
   const db = store.set(writeDb$);
   const result = await db.execute<{ waiting: boolean }>(
     sql`
       WITH key AS (
-        SELECT hashtext('connector_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.connectorType}) AS value
+        SELECT hashtext(${lockKey}) AS value
       )
       SELECT EXISTS (
         SELECT 1
@@ -134,20 +130,36 @@ async function hasWaitingConnectorStateLock(args: {
   return result.rows[0]?.waiting ?? false;
 }
 
-async function waitForConnectorStateLockWaiter(args: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorType: string;
-}): Promise<void> {
+async function waitForAdvisoryLockWaiter(lockKey: string): Promise<void> {
   for (let attempt = 0; attempt < 1000; attempt += 1) {
-    if (await hasWaitingConnectorStateLock(args)) {
+    if (await hasWaitingAdvisoryLock(lockKey)) {
       return;
     }
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
   }
-  throw new Error("Timed out waiting for connector state lock waiter");
+  throw new Error(`Timed out waiting for advisory lock waiter: ${lockKey}`);
+}
+
+async function waitForConnectorStateLockWaiter(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorType: string;
+}): Promise<void> {
+  await waitForAdvisoryLockWaiter(
+    `connector_state:${args.orgId}:${args.userId}:${args.connectorType}`,
+  );
+}
+
+async function waitForModelProviderStateLockWaiter(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly providerType: string;
+}): Promise<void> {
+  await waitForAdvisoryLockWaiter(
+    `model_provider_state:${args.orgId}:${args.userId}:${args.providerType}`,
+  );
 }
 
 function firewallClient() {
@@ -2587,6 +2599,11 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const firstResponsePromise = refreshRequest();
     await firstRefreshStarted.promise;
     const secondResponsePromise = refreshRequest();
+    await waitForModelProviderStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: ORG_SENTINEL_USER_ID,
+      providerType: "codex-oauth-token",
+    });
     firstRefreshRelease.resolve();
 
     const responses = await Promise.all([
@@ -2630,6 +2647,91 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     await expect(codexProviderState(fixture)).resolves.toMatchObject({
       needsReconnect: false,
       lastRefreshErrorCode: null,
+    });
+  });
+
+  it("does not fall back to stale model-provider access after a concurrent forced refresh failure", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-force-failure-chatgpt-token",
+      refreshToken: "force-failure-chatgpt-refresh",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async () => {
+        refreshCallCount += 1;
+        firstRefreshStarted.resolve();
+        await firstRefreshRelease.promise;
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_expired",
+              message: "expired refresh token",
+            },
+          },
+          { status: 401 },
+        );
+      }),
+    );
+
+    const refreshRequest = () => {
+      return accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets({}),
+            authHeaders: {
+              Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+            },
+            secretConnectorMap: {
+              CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+            },
+            secretConnectorMetadataMap: {
+              CHATGPT_ACCESS_TOKEN: {
+                sourceType: "model-provider",
+                sourceUserId: ORG_SENTINEL_USER_ID,
+                metadataKey: "codex-oauth-token",
+              },
+            },
+            forceRefresh: true,
+          },
+          headers: authHeaders(fixture),
+        }),
+        [502],
+      );
+    };
+
+    const firstResponsePromise = refreshRequest();
+    await firstRefreshStarted.promise;
+    const secondResponsePromise = refreshRequest();
+    await waitForModelProviderStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: ORG_SENTINEL_USER_ID,
+      providerType: "codex-oauth-token",
+    });
+    firstRefreshRelease.resolve();
+
+    const responses = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    for (const response of responses) {
+      expect(response.body.error).toMatchObject({
+        code: "TOKEN_REFRESH_FAILED",
+        connectors: ["codex-oauth-token"],
+      });
+    }
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1538,6 +1538,11 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const firstResponsePromise = refreshRequest();
     await firstRefreshStarted.promise;
     const secondResponsePromise = refreshRequest();
+    await waitForConnectorStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "notion",
+    });
     firstRefreshRelease.resolve();
 
     const responses = await Promise.all([

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
@@ -103,6 +103,51 @@ function deferred(): {
     throw new Error("Failed to create deferred promise");
   }
   return { promise, resolve: resolvePromise };
+}
+
+async function hasWaitingConnectorStateLock(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorType: string;
+}): Promise<boolean> {
+  const db = store.set(writeDb$);
+  const result = await db.execute<{ waiting: boolean }>(
+    sql`
+      WITH key AS (
+        SELECT hashtext('connector_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.connectorType}) AS value
+      )
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_locks, key
+        WHERE locktype = 'advisory'
+          AND mode = 'ExclusiveLock'
+          AND granted = false
+          AND objsubid = 1
+          AND (
+            (key.value >= 0 AND classid::bigint = 0 AND objid::bigint = key.value::bigint)
+            OR
+            (key.value < 0 AND classid::bigint = 4294967295 AND objid::bigint = key.value::bigint + 4294967296)
+          )
+      ) AS waiting
+    `,
+  );
+  return result.rows[0]?.waiting ?? false;
+}
+
+async function waitForConnectorStateLockWaiter(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorType: string;
+}): Promise<void> {
+  for (let attempt = 0; attempt < 1000; attempt += 1) {
+    if (await hasWaitingConnectorStateLock(args)) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+  throw new Error("Timed out waiting for connector state lock waiter");
 }
 
 function firewallClient() {
@@ -1310,6 +1355,11 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const firstResponsePromise = refreshRequest();
     await firstRefreshStarted.promise;
     const secondResponsePromise = refreshRequest();
+    await waitForConnectorStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "notion",
+    });
     firstRefreshRelease.resolve();
 
     const responses = await Promise.all([
@@ -1406,6 +1456,11 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const firstResponsePromise = refreshRequest();
     await firstRefreshStarted.promise;
     const secondResponsePromise = refreshRequest();
+    await waitForConnectorStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "notion",
+    });
     firstRefreshRelease.resolve();
 
     const responses = await Promise.all([
@@ -1509,6 +1564,76 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "connector",
       }),
     ).resolves.toBe("rotated-force-missing-snapshot-notion-refresh-token");
+  });
+
+  it("does not fall back to stale access after a concurrent forced refresh failure", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "stale-after-force-failure-notion-token",
+      refreshToken: "force-failure-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+    });
+
+    let refreshCallCount = 0;
+    const firstRefreshStarted = deferred();
+    const firstRefreshRelease = deferred();
+
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", async () => {
+        refreshCallCount += 1;
+        firstRefreshStarted.resolve();
+        await firstRefreshRelease.promise;
+        return HttpResponse.json(
+          { error: "invalid_grant", error_description: "revoked" },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const refreshRequest = () => {
+      return accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets({}),
+            authHeaders: {
+              Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+            },
+            secretConnectorMap: {
+              NOTION_TOKEN: "notion",
+            },
+            forceRefresh: true,
+          },
+          headers: authHeaders(fixture),
+        }),
+        [502],
+      );
+    };
+
+    const firstResponsePromise = refreshRequest();
+    await firstRefreshStarted.promise;
+    const secondResponsePromise = refreshRequest();
+    await waitForConnectorStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "notion",
+    });
+    firstRefreshRelease.resolve();
+
+    const responses = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    for (const response of responses) {
+      expect(response.body.error).toMatchObject({
+        code: "TOKEN_REFRESH_FAILED",
+        connectors: ["notion"],
+      });
+    }
+    await expect(notionConnectorState(fixture)).resolves.toMatchObject({
+      needsReconnect: true,
+    });
   });
 
   it("refreshes dynamic public connector OAuth tokens without env client credentials", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -260,6 +260,7 @@ interface RefreshState {
   readonly accessToken: string | null;
   readonly refreshToken: string | null;
   readonly tokenExpiresAt: Date | null;
+  readonly needsReconnect: boolean;
   readonly updatedAtMicros: bigint;
 }
 
@@ -824,6 +825,9 @@ function shouldUseLockedCurrentAccess(args: {
   if (tokenExpiresAtNeedsRefresh(args.state.tokenExpiresAt)) {
     return false;
   }
+  if (args.state.needsReconnect) {
+    return false;
+  }
   if (!args.refreshArgs.forceRefresh) {
     return true;
   }
@@ -875,6 +879,23 @@ function shouldUseLockedCurrentAccess(args: {
   );
 }
 
+function didLockedRefreshFailDuringRequest(args: {
+  readonly initialState: RefreshState | null;
+  readonly requestStartedAtMicros: bigint | null;
+  readonly state: RefreshState;
+}): boolean {
+  if (!args.state.needsReconnect) {
+    return false;
+  }
+  if (args.initialState && !args.initialState.needsReconnect) {
+    return true;
+  }
+  return (
+    args.requestStartedAtMicros !== null &&
+    args.state.updatedAtMicros >= args.requestStartedAtMicros
+  );
+}
+
 async function loadRefreshState(
   db: Db,
   args: RefreshAccessTokenArgs,
@@ -885,6 +906,7 @@ async function loadRefreshState(
       ? await db
           .select({
             tokenExpiresAt: modelProviders.tokenExpiresAt,
+            needsReconnect: modelProviders.needsReconnect,
             updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`,
           })
           .from(modelProviders)
@@ -899,6 +921,7 @@ async function loadRefreshState(
       : await db
           .select({
             tokenExpiresAt: connectors.tokenExpiresAt,
+            needsReconnect: connectors.needsReconnect,
             updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`,
           })
           .from(connectors)
@@ -938,6 +961,7 @@ async function loadRefreshState(
     accessToken,
     refreshToken,
     tokenExpiresAt: row.tokenExpiresAt,
+    needsReconnect: row.needsReconnect,
     updatedAtMicros: BigInt(row.updatedAtMicros),
   };
 }
@@ -1089,6 +1113,16 @@ async function refreshAccessTokenForSource(
     }
 
     const currentAccessToken = lockedState.accessToken;
+    if (
+      didLockedRefreshFailDuringRequest({
+        initialState,
+        requestStartedAtMicros,
+        state: lockedState,
+      })
+    ) {
+      return { ok: false, reason: "refresh-failed" };
+    }
+
     if (
       currentAccessToken &&
       shouldUseLockedCurrentAccess({

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -887,12 +887,15 @@ function didLockedRefreshFailDuringRequest(args: {
   if (!args.state.needsReconnect) {
     return false;
   }
-  if (args.initialState && !args.initialState.needsReconnect) {
-    return true;
+  if (args.initialState) {
+    return (
+      !args.initialState.needsReconnect ||
+      args.initialState.updatedAtMicros !== args.state.updatedAtMicros
+    );
   }
   return (
     args.requestStartedAtMicros !== null &&
-    args.state.updatedAtMicros >= args.requestStartedAtMicros
+    args.state.updatedAtMicros > args.requestStartedAtMicros
   );
 }
 


### PR DESCRIPTION
## Summary
- prevent locked runtime OAuth refreshes from using stale access after another request marks the source as needing reconnect
- detect refresh failure while waiting by comparing locked state with the pre-lock state before falling back to timestamp ordering
- make concurrent refresh tests wait on the connector advisory lock so exact call-count assertions are deterministic

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm vitest run --project=api --shard=1/8
- pnpm -F api lint
- pnpm -F api check-types
- git diff --check