### PR TITLE
ci: run runner e2e for api changes

### DIFF
--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -236,6 +236,7 @@ turbo_consumer() {
   local consumer="false"
   if [ "$EVENT_NAME" != "push" ] && {
     is_true "${WEB_CHANGED:-false}" ||
+    is_true "${API_CHANGED:-false}" ||
     is_true "${CLI_CHANGED:-false}" ||
     is_true "${CRATES_CHANGED:-false}" ||
     is_true "${CI_CHANGED:-false}" ||

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -83,13 +83,19 @@ assert_fails "turbo-consumer requires EVENT_NAME" \
   WEB_CHANGED=true \
   "$CONTEXT" turbo-consumer
 
-for flag in WEB_CHANGED CLI_CHANGED CRATES_CHANGED CI_CHANGED E2E_CHANGED; do
+for flag in WEB_CHANGED API_CHANGED CLI_CHANGED CRATES_CHANGED CI_CHANGED E2E_CHANGED; do
   out=$(run_clean \
     EVENT_NAME=pull_request \
     "${flag}=true" \
     "$CONTEXT" turbo-consumer)
   assert_contains "$out" "turbo-runner-consumer-needed=true"
 done
+
+out=$(run_clean \
+  EVENT_NAME=merge_group \
+  API_CHANGED=true \
+  "$CONTEXT" turbo-consumer)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
 
 out=$(run_clean \
   EVENT_NAME=push \

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -71,6 +71,7 @@ jobs:
           set -euo pipefail
           CHANGES_JSON=$(./scripts/changed.sh "$BASE_REF")
           web_changed=$(echo "$CHANGES_JSON" | jq -r '."web" // false')
+          api_changed=$(echo "$CHANGES_JSON" | jq -r '."api" // false')
           cli_changed=$(echo "$CHANGES_JSON" | jq -r '."@vm0/cli" // false')
 
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^crates/"; then
@@ -93,6 +94,7 @@ jobs:
 
           EVENT_NAME="${{ github.event_name }}" \
           WEB_CHANGED="$web_changed" \
+          API_CHANGED="$api_changed" \
           CLI_CHANGED="$cli_changed" \
           CRATES_CHANGED="$crates_changed" \
           CI_CHANGED="$ci_changed" \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -224,6 +224,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           WEB_CHANGED: ${{ steps.detect.outputs.web-changed }}
+          API_CHANGED: ${{ steps.detect.outputs.api-changed }}
           CLI_CHANGED: ${{ steps.detect.outputs.cli-changed }}
           CRATES_CHANGED: ${{ steps.detect.outputs.crates-changed }}
           CI_CHANGED: ${{ steps.detect.outputs.ci-changed }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1349,6 +1349,7 @@ jobs:
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
+        needs.prepare.outputs.api-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true' ||
         needs.prepare.outputs.ci-changed == 'true' ||


### PR DESCRIPTION
## Summary
- include API changes in the Turbo runner E2E consumer decision
- pass API change detection through both Turbo and Runner Image workflows
- cover API-only merge queue behavior in runner image context tests

## Tests
- bash .github/scripts/tests/runner-image-context-test.sh
- git diff --check
- EVENT_NAME=merge_group API_CHANGED=true .github/scripts/runner-image-context.sh turbo-consumer