### PR TITLE
docs: document mitm registry cache fallback

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -69,12 +69,12 @@ def load_registry(registry_path: str) -> dict:
     """Load the proxy registry, reusing cached data when possible.
 
     The registry is reloaded only when file stat metadata changes. If stat
-    fails, the current registry cache is returned and the failure is
-    warning-logged once. If reading/parsing/normalizing/compiling a changed
-    file fails, the current cache is preserved and returned, and that file
-    state is recorded as processed so repeated reads do not re-warn until a
-    successful reload clears the error state. A successful reload also evicts
-    firewall-auth cache entries for run IDs no longer present in the registry.
+    fails, the current registry cache is returned. If processing a changed file
+    fails, the current cache is preserved and returned, and that file state is
+    recorded as processed so repeated reads short-circuit on the same stat key.
+    Failures are warning-logged at most once until a successful reload clears
+    the error state. A successful reload also evicts firewall-auth cache
+    entries for run IDs no longer present in the registry.
     """
     global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
     global _registry_cache_key

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -69,11 +69,12 @@ def load_registry(registry_path: str) -> dict:
     """Load the proxy registry, reusing cached data when possible.
 
     The registry is reloaded only when file stat metadata changes. If stat
-    fails, or if reading/parsing/normalizing/compiling the changed file fails,
-    the last valid registry cache is returned and the failure is warning-logged
-    once until a successful reload clears the error state. A successful reload
-    also evicts firewall-auth cache entries for run IDs no longer present in
-    the registry.
+    fails, the current registry cache is returned and the failure is
+    warning-logged once. If reading/parsing/normalizing/compiling a changed
+    file fails, the current cache is preserved and returned, and that file
+    state is recorded as processed so repeated reads do not re-warn until a
+    successful reload clears the error state. A successful reload also evicts
+    firewall-auth cache entries for run IDs no longer present in the registry.
     """
     global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
     global _registry_cache_key

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -66,7 +66,15 @@ def _normalize_registry_vms(raw_registry: object) -> tuple[dict, int]:
 
 
 def load_registry(registry_path: str) -> dict:
-    """Load the proxy registry from file, with stat-based cache invalidation."""
+    """Load the proxy registry, reusing cached data when possible.
+
+    The registry is reloaded only when file stat metadata changes. If stat
+    fails, or if reading/parsing/normalizing/compiling the changed file fails,
+    the last valid registry cache is returned and the failure is warning-logged
+    once until a successful reload clears the error state. A successful reload
+    also evicts firewall-auth cache entries for run IDs no longer present in
+    the registry.
+    """
     global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
     global _registry_cache_key
     global _registry_load_error_logged


### PR DESCRIPTION
## Summary

- Expand `load_registry()` docstring to document stat-key reload behavior
- Document cached fallback behavior for stat/read/parse/normalize/compile failures
- Document the successful-reload side effect that evicts stale firewall-auth cache entries

Closes #15414

## Tests

- `python3 -m ruff check src/registry.py`
- `python3 -m pytest tests/test_registry.py`
- `pnpm -F @vm0/db db:migrate`