### PR TITLE
fix: clarify mitm body capture invariant error

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -456,10 +456,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
             if stream_buf:
                 if not isinstance(stream_state, dict) or "truncated" not in stream_state:
-                    state_keys = (
-                        sorted(str(key) for key in stream_state)
+                    state_description = (
+                        f"keys={sorted(str(key) for key in stream_state)}"
                         if isinstance(stream_state, dict)
-                        else []
+                        else f"type={type(stream_state).__name__}"
                     )
                     raise RuntimeError(
                         "Invalid response body capture metadata: stream_buffer is "
@@ -467,7 +467,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                         "stream_buffer_state is missing the truncated flag. "
                         "response_streaming.configure_response_stream() must set "
                         "stream_buffer and stream_buffer_state together "
-                        f"(stream_buffer_state keys={state_keys})."
+                        f"(stream_buffer_state {state_description})."
                     )
                 stream_truncated = bool(stream_state["truncated"])
             elif stream_state:

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -417,9 +417,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     buffer metadata exists.
 
     Non-empty ``stream_buffer`` values must have a matching
-    ``stream_buffer_state`` with a ``truncated`` flag. Missing or malformed
-    state is an internal metadata invariant violation and raises ``RuntimeError``
-    instead of silently falling back.
+    ``stream_buffer_state`` with a ``truncated`` flag. Empty stream buffers do
+    not require the flag, but present state must still be a mapping. Missing or
+    malformed state is an internal metadata invariant violation and raises
+    ``RuntimeError`` instead of silently falling back.
 
     Truncation from the streaming buffer is carried as ``already_truncated`` into
     ``_set_body_fields()``, where it is combined with the decompressed body size.
@@ -470,6 +471,12 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                         f"(stream_buffer_state {state_description})."
                     )
                 stream_truncated = bool(stream_state["truncated"])
+            elif stream_state is not None and not isinstance(stream_state, dict):
+                raise RuntimeError(
+                    "Invalid response body capture metadata: stream_buffer is "
+                    "empty but stream_buffer_state is not a mapping "
+                    f"(stream_buffer_state type={type(stream_state).__name__})."
+                )
             elif stream_state:
                 stream_truncated = bool(stream_state.get("truncated", False))
             body = decompress_body(

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -418,7 +418,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
 
     Non-empty ``stream_buffer`` values must have a matching
     ``stream_buffer_state`` with a ``truncated`` flag. Empty stream buffers do
-    not require the flag, but present state must still be a mapping. Missing or
+    not require the flag, but present state must still be a dict. Missing or
     malformed state is an internal metadata invariant violation and raises
     ``RuntimeError`` instead of silently falling back.
 
@@ -474,7 +474,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             elif stream_state is not None and not isinstance(stream_state, dict):
                 raise RuntimeError(
                     "Invalid response body capture metadata: stream_buffer is "
-                    "empty but stream_buffer_state is not a mapping "
+                    "empty but stream_buffer_state is not a dict "
                     f"(stream_buffer_state type={type(stream_state).__name__})."
                 )
             elif stream_state:

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -35,8 +35,8 @@ _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 
 # Decompression cap for production model-provider and connector JSON usage
 # fallback paths. Keep this larger than STREAM_BUFFER_LIMIT so diagnostic
-# fallbacks can parse complete usage payloads while still bounding
-# decompression bombs.
+# and silent usage fallbacks can parse complete usage payloads while still
+# bounding decompression bombs.
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
 # Python's brotli binding has no max-output API, and one process() call can

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -33,10 +33,10 @@ _UTF8_LEAD_MAX_1BYTE = 0x80  # ASCII: 0xxxxxxx
 _UTF8_LEAD_MAX_2BYTE = 0xE0  # 2-byte lead: 110xxxxx
 _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 
-# Decompression cap for legacy/test one-shot usage extraction fallbacks.
-# Production billable JSON paths use streaming decompression plus selective
-# extraction; this remains larger than STREAM_BUFFER_LIMIT for direct helper
-# calls while still bounding decompression bombs.
+# Decompression cap for production model-provider and connector JSON usage
+# fallback paths. Keep this larger than STREAM_BUFFER_LIMIT so diagnostic
+# fallbacks can parse complete usage payloads while still bounding
+# decompression bombs.
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
 # Python's brotli binding has no max-output API, and one process() call can
@@ -277,6 +277,10 @@ def decompress_json_usage_body(
         return body, None
     if encoding == "zstd":
         try:
+            # First use stream_reader().read(max_output) as the bounded-output
+            # primary path. For zstd, an incomplete frame can read as empty
+            # without proving whether the frame is a valid empty payload, so
+            # only the empty-output case needs a second state check below.
             with zstandard.ZstdDecompressor().stream_reader(data) as reader:
                 body = reader.read(max_output)
         except zstandard.ZstdError as exc:
@@ -286,6 +290,10 @@ def decompress_json_usage_body(
             return b"", "invalid compressed body"
         if data and not body:
             try:
+                # A fresh decompressobj exposes eof, which distinguishes a
+                # complete empty zstd frame from an incomplete prefix. The
+                # gzip/deflate and brotli branches already get equivalent
+                # completion signals through their codec-specific helpers.
                 obj = zstandard.ZstdDecompressor().decompressobj()
                 obj.decompress(data)
             except zstandard.ZstdError:
@@ -395,12 +403,28 @@ def _set_body_fields(
 
 
 def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
-    """Add request/response headers and bodies to a log entry.
+    """Add capture-mode request/response fields to ``log_entry`` in place.
 
     # [NETWORK_LOG_FIELDS] — capture-only fields in the shared network log schema.
     # Fields: request_headers, request_body, request_body_encoding,
     #         request_body_truncated, response_headers, response_body,
     #         response_body_encoding, response_body_truncated
+
+    Response bodies prefer the streaming metadata populated by
+    ``response_streaming.configure_response_stream()`` because that path keeps a
+    bounded raw wire-byte buffer and records whether it was truncated. The
+    mitmproxy ``flow.response.content`` fallback is used only when no stream
+    buffer metadata exists.
+
+    Non-empty ``stream_buffer`` values must have a matching
+    ``stream_buffer_state`` with a ``truncated`` flag. Missing or malformed
+    state is an internal metadata invariant violation and raises ``RuntimeError``
+    instead of silently falling back.
+
+    Truncation from the streaming buffer is carried as ``already_truncated`` into
+    ``_set_body_fields()``, where it is combined with the decompressed body size.
+    A ``None`` body means no response body could be obtained; ``b""`` is a valid
+    empty body and normally produces no body fields.
     """
     # Request headers (always available)
     log_entry["request_headers"] = _redact_headers(flow.request.headers)
@@ -431,8 +455,20 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         if stream_buf is not None:
             # stream_buffer may already be truncated at STREAM_BUFFER_LIMIT.
             if stream_buf:
-                if not stream_state:
-                    raise KeyError("truncated")
+                if not isinstance(stream_state, dict) or "truncated" not in stream_state:
+                    state_keys = (
+                        sorted(str(key) for key in stream_state)
+                        if isinstance(stream_state, dict)
+                        else []
+                    )
+                    raise RuntimeError(
+                        "Invalid response body capture metadata: stream_buffer is "
+                        f"present and non-empty (len={len(stream_buf)}) but "
+                        "stream_buffer_state is missing the truncated flag. "
+                        "response_streaming.configure_response_stream() must set "
+                        "stream_buffer and stream_buffer_state together "
+                        f"(stream_buffer_state keys={state_keys})."
+                    )
                 stream_truncated = bool(stream_state["truncated"])
             elif stream_state:
                 stream_truncated = bool(stream_state.get("truncated", False))

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -707,6 +707,24 @@ class TestAddCaptureFields:
         ):
             add_capture_fields(flow, entry)
 
+    def test_non_empty_stream_buffer_requires_dict_state(self, real_flow):
+        body = b'{"ok": true}'
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = ["truncated"]
+        entry = {}
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*stream_buffer_state.*truncated.*type=list",
+        ):
+            add_capture_fields(flow, entry)
+
     def test_non_empty_compressed_stream_buffer_requires_state(self, real_flow):
         flow = real_flow(
             method="POST",

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -672,6 +672,23 @@ class TestAddCaptureFields:
         assert "response_body_encoding" not in entry
         assert "response_headers" in entry
 
+    def test_empty_stream_buffer_requires_dict_state_when_present(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata["stream_buffer"] = bytearray()
+        flow.metadata["stream_buffer_state"] = ["truncated"]
+        entry = {}
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*empty.*stream_buffer_state.*type=list",
+        ):
+            add_capture_fields(flow, entry)
+
     def test_non_empty_stream_buffer_requires_state(self, real_flow):
         body = b'{"ok": true}'
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -683,7 +683,10 @@ class TestAddCaptureFields:
         )
         flow.metadata["stream_buffer"] = bytearray(body)
         entry = {}
-        with pytest.raises(KeyError, match="truncated"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*stream_buffer_state.*truncated",
+        ):
             add_capture_fields(flow, entry)
 
     def test_non_empty_stream_buffer_requires_non_empty_state(self, real_flow):
@@ -698,7 +701,10 @@ class TestAddCaptureFields:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {}
         entry = {}
-        with pytest.raises(KeyError, match="truncated"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*stream_buffer_state.*truncated",
+        ):
             add_capture_fields(flow, entry)
 
     def test_non_empty_compressed_stream_buffer_requires_state(self, real_flow):
@@ -712,7 +718,10 @@ class TestAddCaptureFields:
         )
         flow.metadata["stream_buffer"] = bytearray(gzip.compress(b""))
         entry = {}
-        with pytest.raises(KeyError, match="truncated"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*stream_buffer_state.*truncated",
+        ):
             add_capture_fields(flow, entry)
 
     def test_non_empty_compressed_stream_buffer_requires_truncated_state(self, real_flow):
@@ -728,7 +737,10 @@ class TestAddCaptureFields:
         flow.metadata["stream_buffer"] = bytearray(compressed)
         flow.metadata["stream_buffer_state"] = {"total_bytes": len(compressed)}
         entry = {}
-        with pytest.raises(KeyError, match="truncated"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*stream_buffer_state.*truncated",
+        ):
             add_capture_fields(flow, entry)
 
     def test_non_empty_stream_buffer_requires_truncated_state(self, real_flow):
@@ -743,7 +755,10 @@ class TestAddCaptureFields:
         flow.metadata["stream_buffer"] = bytearray(body)
         flow.metadata["stream_buffer_state"] = {"total_bytes": len(body)}
         entry = {}
-        with pytest.raises(KeyError, match="truncated"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"stream_buffer.*stream_buffer_state.*truncated",
+        ):
             add_capture_fields(flow, entry)
 
     def test_stream_buffer_truncated_marks_truncation(self, real_flow):


### PR DESCRIPTION
## Summary
- clarify the mitm body capture contract for streamed response buffers
- replace the misleading missing `truncated` KeyError with a descriptive RuntimeError
- update body capture tests to assert the clearer invariant failure

Fixes #15412

## Tests
- `/tmp/vm0-mitm-addon-venv/bin/ruff check .`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/ -v`