### PR TITLE
refactor: move connector response parser dispatch

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -628,7 +628,7 @@ def response(flow: http.HTTPFlow) -> None:
     _report_model_provider_usage_once(flow, run_id)
 
     # Billable connector usage observation (issue #9504, stage 0).
-    response_streaming.finalize_x_json_state(flow)
+    response_streaming.finalize_connector_response_state(flow)
     usage.report_connector_usage(flow, run_id)
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers.

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -1,6 +1,5 @@
 """Response streaming setup and parser state for the mitmproxy addon."""
 
-import urllib.parse
 from collections.abc import Callable
 
 from mitmproxy import http
@@ -10,17 +9,13 @@ import flow_metadata_keys as metadata_keys
 import usage
 from logging_utils import log_proxy_entry
 
-# HTTP 2xx success range (RFC 9110).  Also defined in
-# ``usage.providers.connectors.x`` for local response-phase classification.
-_HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
-_HTTP_STATUS_REDIRECT_MIN = 300
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
+_CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
-_X_JSON_RESPONSE_FINISH = "x_json_response_finish"
 
 _ResponseChunkParser = Callable[[bytes], None]
 _SseUsageParseErrorLogger = Callable[[str, str], None]
@@ -79,31 +74,6 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     # and the incremental response parsers used for billing payload extraction.
     is_billable_flow = flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False)
     is_billable_model_provider = is_model_provider and is_billable_flow
-    # X-specific NDJSON stream classification — tied to the x firewall itself,
-    # not to billing.  Kept separate so a future non-x billable connector
-    # doesn't accidentally inherit X stream parsing.
-    is_x_flow = firewall_name == "x"
-
-    # Classify X NDJSON streams early so we can register an incremental parser
-    # and avoid buffering the (potentially multi-GB) stream body.  Only a
-    # cheap path-only check happens here — full request metadata is parsed
-    # later in response() by report_connector_usage.
-    #
-    # Gated on 2xx status so error responses (4xx/5xx on stream endpoints
-    # return JSON, not NDJSON) skip the billing parser and only use the capped
-    # forensic stream buffer.  report_connector_usage already skips non-2xx
-    # responses so no billing record is affected either way.
-    #
-    # Reads ``original_url`` with no fallback — kept consistent with
-    # :func:`usage.x._parse_request_metadata` so the log entry's
-    # ``is_stream`` field cannot diverge from the parser registration
-    # decision.  For any x firewall flow, ``request()`` has already
-    # populated ``original_url`` before ``responseheaders`` fires.
-    is_x_stream = False
-    if is_x_flow and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN:
-        stream_path = urllib.parse.urlparse(flow.metadata.get(metadata_keys.ORIGINAL_URL, "")).path
-        is_x_stream = usage.x.is_stream_path(stream_path)
-
     if (
         is_billable_model_provider
         and flow.response.status_code == _HTTP_STATUS_SWITCHING_PROTOCOLS
@@ -139,21 +109,12 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
             extractor = usage.create_anthropic_messages_json_usage_extractor()
         flow.metadata[_MODEL_JSON_USAGE_FINISH] = extractor.finish
         return _make_response_chunk_parser(extractor.feed, flow.response.headers)
-    if is_x_stream:
-        parser_fn, ndjson_state = usage.x.create_ndjson_extractor()
-        # Deliberately NOT "model_provider_usage" — that key would route through
-        # report_model_provider_usage and trigger the model-provider webhook.
-        # x_ndjson_state is only consumed by report_connector_usage.
-        flow.metadata[metadata_keys.X_NDJSON_STATE] = ndjson_state
-        return _make_response_chunk_parser(parser_fn, flow.response.headers)
-    if (
-        is_x_flow
-        and is_billable_flow
-        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
-    ):
-        extractor = usage.x.create_json_response_extractor()
-        flow.metadata[_X_JSON_RESPONSE_FINISH] = extractor.finish
-        return _make_response_chunk_parser(extractor.feed, flow.response.headers)
+
+    connector_parser = usage.create_connector_response_parser(flow)
+    if connector_parser is not None:
+        if connector_parser.finish is not None:
+            flow.metadata[_CONNECTOR_RESPONSE_FINISH] = connector_parser.finish
+        return _make_response_chunk_parser(connector_parser.feed, flow.response.headers)
 
     return None
 
@@ -246,14 +207,10 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     usage.merge_openai_responses_usage_result(usage_target, usage_result)
 
 
-def finalize_x_json_state(flow: http.HTTPFlow) -> None:
-    finish = flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)
-    if finish is None:
-        return
-    state, error = finish()
-    if error:
-        state["parse_error"] = error
-    flow.metadata[metadata_keys.X_JSON_STATE] = state
+def finalize_connector_response_state(flow: http.HTTPFlow) -> None:
+    finish = flow.metadata.pop(_CONNECTOR_RESPONSE_FINISH, None)
+    if finish is not None:
+        finish()
 
 
 def release_response_stream_state(flow: http.HTTPFlow) -> None:
@@ -262,6 +219,6 @@ def release_response_stream_state(flow: http.HTTPFlow) -> None:
     flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
     flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
     flow.metadata.pop(_MODEL_SSE_USAGE_FINISH, None)
-    flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)
+    flow.metadata.pop(_CONNECTOR_RESPONSE_FINISH, None)
     if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
         flow.response.stream = False

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -11,7 +11,8 @@ Two paths:
   platform upload via ``/api/webhooks/agent/usage-event`` — see
   :mod:`usage.providers.connectors`.
 
-This package exposes the stable surface consumed by ``mitm_addon.py``.
+This package exposes the stable surface consumed by ``mitm_addon.py`` and
+``response_streaming.py``.
 For test patching, target the submodule that **reads** the name (e.g.
 ``usage.webhook._opener`` rather than ``usage._opener``) — Python's
 ``from X import Y`` creates a module-local binding that facade-level
@@ -47,7 +48,7 @@ from .openai_responses import (
     extract_openai_responses_usage_with_error_from_json,
     merge_openai_responses_usage_result,
 )
-from .providers.connectors import report_connector_usage, x
+from .providers.connectors import create_connector_response_parser, report_connector_usage
 from .providers.model_provider import report_model_provider_usage
 
 __all__ = [
@@ -56,6 +57,7 @@ __all__ = [
     "configure_usage_buffer",
     "create_anthropic_messages_json_usage_extractor",
     "create_anthropic_messages_sse_usage_extractor",
+    "create_connector_response_parser",
     "create_openai_responses_json_usage_extractor",
     "create_openai_responses_sse_usage_extractor",
     "decrement_in_flight_flows",
@@ -74,5 +76,4 @@ __all__ = [
     "set_pending_path",
     "webhook",
     "write_pending_snapshot",
-    "x",
 ]

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -1,4 +1,4 @@
-"""Per-connector billing dispatcher + module registry.
+"""Per-connector billing and response parser dispatch.
 
 One file per billable connector under this package owns the connector's
 domain-specific request / response parsing.  :func:`report_connector_usage`
@@ -8,8 +8,9 @@ billable by the web layer, firewall has a registered handler) and
 delegates to the matching per-connector ``report_usage`` function.
 
 Adding a new billable connector = add a new file here + register it in
-:data:`_HANDLERS`.  The dispatcher already enforces the cross-connector
-invariants.
+:data:`_HANDLERS`. Connectors that need incremental response-body parsing
+also register a parser factory in :data:`_RESPONSE_PARSER_FACTORIES`.
+The dispatcher already enforces the cross-connector invariants.
 """
 
 from collections.abc import Callable
@@ -20,6 +21,7 @@ import flow_metadata_keys as metadata_keys
 from logging_utils import log_proxy_entry
 
 from . import x
+from .response_parser import ConnectorResponseParser
 
 # Map firewall_name → per-connector report_usage handler.  A handler is only
 # invoked when ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True, so the
@@ -29,6 +31,12 @@ from . import x
 # dropped billing record plus a missing handler in test coverage.)
 _HANDLERS: dict[str, Callable[[http.HTTPFlow, str], None]] = {
     "x": x.report_usage,
+}
+
+_ResponseParserFactory = Callable[[http.HTTPFlow], ConnectorResponseParser | None]
+
+_RESPONSE_PARSER_FACTORIES: dict[str, _ResponseParserFactory] = {
+    "x": x.create_response_parser,
 }
 
 # One-shot guard: first time we see a billable firewall_name with no
@@ -76,3 +84,12 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
             )
         return
     handler(flow, run_id)
+
+
+def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
+    """Create the connector-specific response parser for this flow, if registered."""
+    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+    factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
+    if factory is None:
+        return None
+    return factory(flow)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -1,0 +1,11 @@
+"""Connector response parser result types."""
+
+from collections.abc import Callable
+from typing import NamedTuple
+
+
+class ConnectorResponseParser(NamedTuple):
+    """Incremental parser hooks for connector response bodies."""
+
+    feed: Callable[[bytes], None]
+    finish: Callable[[], None] | None = None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -21,6 +21,7 @@ from logging_utils import log_proxy_entry
 from ...buffer import UsageEvent, buffer_usage_events
 from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR
 from ...json_selective import JsonSelectiveExtractor, ScalarField
+from .response_parser import ConnectorResponseParser
 from .x_billing import (
     classify_bucket,
     classify_includes_bucket,
@@ -238,6 +239,43 @@ class XJsonResponseExtractor:
 
 def create_json_response_extractor() -> XJsonResponseExtractor:
     return XJsonResponseExtractor()
+
+
+def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
+    """Create the X response-body parser needed for this flow, if any."""
+    if not flow.response:
+        return None
+
+    status_code = flow.response.status_code
+    if _HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN:
+        # Reads ``original_url`` with no fallback — kept consistent with
+        # ``_parse_request_metadata`` so the log entry's ``is_stream`` field
+        # cannot diverge from the parser registration decision.  For any x
+        # firewall flow, ``request()`` has already populated ``original_url``
+        # before ``responseheaders`` fires.
+        stream_path = urllib.parse.urlparse(flow.metadata.get(metadata_keys.ORIGINAL_URL, "")).path
+        if is_stream_path(stream_path):
+            parser_fn, ndjson_state = create_ndjson_extractor()
+            # Deliberately NOT "model_provider_usage" — that key routes through
+            # report_model_provider_usage and triggers the model-provider webhook.
+            # x_ndjson_state is only consumed by report_connector_usage.
+            flow.metadata[metadata_keys.X_NDJSON_STATE] = ndjson_state
+            return ConnectorResponseParser(feed=parser_fn)
+
+    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
+        return None
+    if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
+        return None
+
+    extractor = create_json_response_extractor()
+
+    def finish_json_state() -> None:
+        state, error = extractor.finish()
+        if error:
+            state["parse_error"] = error
+        flow.metadata[metadata_keys.X_JSON_STATE] = state
+
+    return ConnectorResponseParser(feed=extractor.feed, finish=finish_json_state)
 
 
 def _count_non_empty_comma_segments(values: Iterable[str]) -> int | None:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -24,22 +24,22 @@ class TestIsStreamPath:
     """Tests for is_stream_path predicate (issue #9534)."""
 
     def test_all_five_stream_endpoints_match(self):
-        assert usage.x.is_stream_path("/2/tweets/search/stream") is True
-        assert usage.x.is_stream_path("/2/tweets/sample/stream") is True
-        assert usage.x.is_stream_path("/2/tweets/sample10/stream") is True
-        assert usage.x.is_stream_path("/2/tweets/compliance/stream") is True
-        assert usage.x.is_stream_path("/2/users/compliance/stream") is True
+        assert usage_x_connector.is_stream_path("/2/tweets/search/stream") is True
+        assert usage_x_connector.is_stream_path("/2/tweets/sample/stream") is True
+        assert usage_x_connector.is_stream_path("/2/tweets/sample10/stream") is True
+        assert usage_x_connector.is_stream_path("/2/tweets/compliance/stream") is True
+        assert usage_x_connector.is_stream_path("/2/users/compliance/stream") is True
 
     def test_stream_rules_is_not_stream(self):
         # Rules management is a regular JSON request/response endpoint.
-        assert usage.x.is_stream_path("/2/tweets/search/stream/rules") is False
+        assert usage_x_connector.is_stream_path("/2/tweets/search/stream/rules") is False
 
     def test_non_stream_paths_do_not_match(self):
-        assert usage.x.is_stream_path("/2/tweets/search/recent") is False
-        assert usage.x.is_stream_path("/2/users/by") is False
-        assert usage.x.is_stream_path("/2/tweets/1") is False
-        assert usage.x.is_stream_path("") is False
-        assert usage.x.is_stream_path("/") is False
+        assert usage_x_connector.is_stream_path("/2/tweets/search/recent") is False
+        assert usage_x_connector.is_stream_path("/2/users/by") is False
+        assert usage_x_connector.is_stream_path("/2/tweets/1") is False
+        assert usage_x_connector.is_stream_path("") is False
+        assert usage_x_connector.is_stream_path("/") is False
 
 
 class TestReportConnectorUsage:
@@ -1253,7 +1253,7 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
         assert "x_ndjson_state" in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
         # 2. Stream chunks (including keep-alives and a mid-line split)
         chunks = [
@@ -1308,7 +1308,7 @@ class TestReportConnectorUsage:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}')
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -1330,7 +1330,7 @@ class TestReportConnectorUsage:
         assert entry["body_truncated"] is False
         assert isinstance(entry["parse_error"], str)
         assert entry["parse_error"]
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
     def test_response_logs_x_json_parse_error_after_forensic_buffer_truncates(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
@@ -1375,7 +1375,7 @@ class TestReportConnectorUsage:
         assert entry["level"] == "error"
         assert entry["body_truncated"] is False
         assert entry["parse_error"] == "incomplete json"
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
     def test_response_uses_request_hints_for_incremental_x_json_parse_error(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
@@ -1399,7 +1399,7 @@ class TestReportConnectorUsage:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}')
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
         mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
@@ -1419,4 +1419,4 @@ class TestReportConnectorUsage:
         assert all(entry["level"] != "error" for entry in entries)
         assert all("unparseable" not in entry["message"].lower() for entry in entries)
         assert all("parse_error" not in entry for entry in entries)
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -76,7 +76,7 @@ class TestErrorHandler:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}')
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
         flow.error = Error("connection reset")
 
         with mitm_ctx():
@@ -85,7 +85,7 @@ class TestErrorHandler:
         assert flow.response.stream is False
         assert "stream_buffer" not in flow.metadata
         assert "stream_buffer_state" not in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
     def test_error_does_not_bill_partial_x_json_response(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
@@ -121,7 +121,7 @@ class TestErrorHandler:
         mock_opener.open.assert_not_called()
         assert flow.response.stream is False
         assert "stream_buffer" not in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
     def test_skips_log_when_no_metadata(self, real_flow, mitm_ctx):
         flow = real_flow(with_response=False)

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -454,14 +454,14 @@ class TestResponseHandler:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}]}')
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
         mitm_addon.response(flow)
 
         assert flow.response.stream is False
         assert "stream_buffer" not in flow.metadata
         assert "stream_buffer_state" not in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
     def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
         """Early-returning SSE flows should not retain parser closures."""

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -7,6 +7,7 @@ from mitmproxy.test import tutils
 
 import body_utils
 import mitm_addon
+import response_streaming
 from tests.flow_helpers import header_map, response_stream
 
 
@@ -208,8 +209,8 @@ class TestResponseHeadersHandler:
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert "x_ndjson_state" not in flow.metadata
-        state, error = flow.metadata["x_json_response_finish"]()
-        assert error is None
+        response_streaming.finalize_connector_response_state(flow)
+        state = flow.metadata["x_json_state"]
         assert state["body_parsed"] is True
         assert state["response_data_count"] == 1
         assert state["response_includes"] == {"users": 1}
@@ -249,7 +250,7 @@ class TestResponseHeadersHandler:
 
         # No NDJSON parser — error body would fail NDJSON parsing anyway.
         assert "x_ndjson_state" not in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
         callback = response_stream(flow)
         error_body = b'{"title":"Unauthorized","detail":"' + b"x" * (200 * 1024) + b'"}'
         callback(error_body)
@@ -369,8 +370,8 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         response_stream(flow)(gzip.compress(body))
-        json_state, error = flow.metadata["x_json_response_finish"]()
-        assert error is None
+        response_streaming.finalize_connector_response_state(flow)
+        json_state = flow.metadata["x_json_state"]
         assert json_state["response_data_count"] == 2
         assert json_state["response_includes"] == {"users": 1}
         assert json_state["response_result_count"] == 2
@@ -464,8 +465,8 @@ class TestResponseHeadersHandler:
         state = flow.metadata["stream_buffer_state"]
         assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
         assert state["truncated"]
-        json_state, error = flow.metadata["x_json_response_finish"]()
-        assert error is None
+        response_streaming.finalize_connector_response_state(flow)
+        json_state = flow.metadata["x_json_state"]
         assert json_state["response_data_count"] == 1
         assert json_state["response_result_count"] == 1
 
@@ -489,7 +490,7 @@ class TestResponseHeadersHandler:
         assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
         assert state["truncated"]
         assert "x_ndjson_state" not in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
     def test_non_x_billable_connector_uses_bounded_forensic_buffer(self, real_flow, headers):
         """Future billable connectors must not get unbounded buffers by default."""
@@ -512,4 +513,4 @@ class TestResponseHeadersHandler:
         assert state["truncated"]
         # And no X-specific state gets attached to a non-x flow.
         assert "x_ndjson_state" not in flow.metadata
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -7,15 +7,15 @@ from mitmproxy.test import tutils
 
 import mitm_addon
 import response_streaming
-import usage
 from tests.flow_helpers import header_map, response_stream
+from usage.providers.connectors import x as usage_x_connector
 
 
 class TestNdjsonExtractor:
     """Tests for create_ndjson_extractor incremental parser (issue #9534)."""
 
     def test_single_line(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         assert state["data_count"] == 1
         assert state["includes"] == {"users": 1}
@@ -23,7 +23,7 @@ class TestNdjsonExtractor:
         assert state["lines_failed"] == 0
 
     def test_multiple_lines_aggregate_counts(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         parse(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"},{"id":"u3"}]}}\n')
         assert state["data_count"] == 2
@@ -31,7 +31,7 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
 
     def test_chunked_line_split_mid_json(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":{"id":"1"},"include')
         parse(b's":{"users":[{"id":"u1"}]}}\n')
         assert state["data_count"] == 1
@@ -39,7 +39,7 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 1
 
     def test_keep_alive_blank_lines(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b"\n\n")
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"\n")
@@ -48,13 +48,13 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
 
     def test_crlf_line_endings(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":{"id":"1"}}\r\n{"data":{"id":"2"}}\r\n')
         assert state["data_count"] == 2
         assert state["lines_parsed"] == 2
 
     def test_malformed_line_increments_failures(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"not json at all\n")
         parse(b'{"data":{"id":"2"}}\n')
@@ -64,13 +64,13 @@ class TestNdjsonExtractor:
 
     def test_truncated_trailing_line_not_counted(self):
         """Connection drops mid-line — partial trailing line stays in buf, not counted."""
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')  # no trailing \n
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
 
     def test_empty_chunks_safe(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b"")
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"")
@@ -78,8 +78,8 @@ class TestNdjsonExtractor:
 
     def test_oversized_line_dropped(self):
         """Line > MAX_NDJSON_LINE_BYTES is dropped; subsequent lines parse normally."""
-        parse, state = usage.x.create_ndjson_extractor()
-        big = b"x" * (usage.x.MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = usage_x_connector.create_ndjson_extractor()
+        big = b"x" * (usage_x_connector.MAX_NDJSON_LINE_BYTES + 1024)
         parse(big)
         parse(b"\n")
         parse(b'{"data":{"id":"after"}}\n')
@@ -89,8 +89,8 @@ class TestNdjsonExtractor:
 
     def test_oversized_line_discards_until_newline(self):
         """A valid-looking tail of an overlong line must not be counted as its own row."""
-        parse, state = usage.x.create_ndjson_extractor()
-        big = b"x" * (usage.x.MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = usage_x_connector.create_ndjson_extractor()
+        big = b"x" * (usage_x_connector.MAX_NDJSON_LINE_BYTES + 1024)
         parse(big)
         parse(b'{"data":{"id":"tail"}}\n')
         parse(b'{"data":{"id":"next"}}\n')
@@ -101,8 +101,8 @@ class TestNdjsonExtractor:
 
     def test_oversized_line_with_newline_continues_in_same_chunk(self):
         """Dropping an overlong row should not discard valid later rows in the same chunk."""
-        parse, state = usage.x.create_ndjson_extractor()
-        big = b"x" * (usage.x.MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = usage_x_connector.create_ndjson_extractor()
+        big = b"x" * (usage_x_connector.MAX_NDJSON_LINE_BYTES + 1024)
         parse(big + b'\n{"data":{"id":"after"}}\n')
 
         assert state["data_count"] == 1
@@ -110,7 +110,7 @@ class TestNdjsonExtractor:
         assert state["lines_failed"] == 1
 
     def test_includes_multiple_keys(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(
             b'{"data":{"id":"1"},"includes":'
             b'{"users":[{"id":"u1"}],'
@@ -121,13 +121,13 @@ class TestNdjsonExtractor:
 
     def test_data_array_not_counted(self):
         """Line where top-level ``data`` is an array (not a dict) contributes 0 to data_count."""
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'{"data":[1,2,3]}\n')
         assert state["data_count"] == 0
         assert state["lines_parsed"] == 1
 
     def test_non_dict_top_level_skipped(self):
-        parse, state = usage.x.create_ndjson_extractor()
+        parse, state = usage_x_connector.create_ndjson_extractor()
         parse(b'"some string"\n')
         parse(b"42\n")
         parse(b'{"data":{"id":"1"}}\n')
@@ -152,54 +152,54 @@ class TestXJsonFinalize:
     def test_no_registered_x_json_finalizer_is_noop(self, real_flow):
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
 
-        response_streaming.finalize_x_json_state(flow)
+        response_streaming.finalize_connector_response_state(flow)
 
         assert "x_json_state" not in flow.metadata
 
     def test_finalizes_successful_x_json_state(self, real_flow):
         flow = self._billable_x_json_flow(real_flow)
         mitm_addon.responseheaders(flow)
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
         response_stream(flow)(b'{"data":[{"id":"1"}]}')
-        response_streaming.finalize_x_json_state(flow)
+        response_streaming.finalize_connector_response_state(flow)
 
         state = dict(flow.metadata["x_json_state"])
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
         assert state["body_parsed"] is True
         assert state["response_data_count"] == 1
         assert "parse_error" not in state
 
-        response_streaming.finalize_x_json_state(flow)
+        response_streaming.finalize_connector_response_state(flow)
         assert flow.metadata["x_json_state"] == state
 
     def test_finalizes_x_json_parse_error(self, real_flow):
         flow = self._billable_x_json_flow(real_flow)
         mitm_addon.responseheaders(flow)
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
         response_stream(flow)(b'{"data":[1')
-        response_streaming.finalize_x_json_state(flow)
+        response_streaming.finalize_connector_response_state(flow)
 
         state = dict(flow.metadata["x_json_state"])
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
         assert state["body_parsed"] is False
         assert isinstance(state["parse_error"], str)
         assert state["parse_error"]
 
-        response_streaming.finalize_x_json_state(flow)
+        response_streaming.finalize_connector_response_state(flow)
         assert flow.metadata["x_json_state"] == state
 
     def test_finalizes_non_object_x_json_without_parse_error(self, real_flow):
         flow = self._billable_x_json_flow(real_flow)
         mitm_addon.responseheaders(flow)
-        assert "x_json_response_finish" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
         response_stream(flow)(b"[1,2,3]")
-        response_streaming.finalize_x_json_state(flow)
+        response_streaming.finalize_connector_response_state(flow)
 
         state = flow.metadata["x_json_state"]
-        assert "x_json_response_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
         assert state["body_parsed"] is False
         assert "parse_error" not in state
 
@@ -489,7 +489,7 @@ class TestReleaseResponseStreamState:
                     "firewall_billable": True,
                     "original_url": "https://api.x.com/2/tweets",
                 },
-                "x_json_response_finish",
+                "connector_response_finish",
                 id="x-json",
             ),
         ],


### PR DESCRIPTION
## Summary

- remove the top-level `usage.x` facade export
- add a connector response parser dispatch path next to connector usage dispatch
- move X response parser selection into the X connector provider while keeping response streaming generic
- update tests to import X provider internals directly only when testing provider internals

Closes #15413

## Tests

- `python3 -m ruff check crates/runner/mitm-addon/src crates/runner/mitm-addon/tests`
- `python3 -m ruff format --check crates/runner/mitm-addon/src crates/runner/mitm-addon/tests`
- `git diff --check`
- `python3 -m pytest crates/runner/mitm-addon/tests`

## Notes

- `python3 -m basedpyright ...` is not a useful signal here because the mitm addon currently reports existing type errors unrelated to this change.
