### PR TITLE
refactor: split connector access provider registry

### DIFF
--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -11,7 +11,6 @@ import {
   connectorTypeSchema,
   type DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorAuthProviderSecretMetadata } from "@vm0/connectors/auth-providers";
 import {
   getConnectorAuthMethodIdForGrantKind,
   hasConnectorAuthCodeGrant,
@@ -240,11 +239,6 @@ const createTestConnector$ = command(
     if (!authMethod) {
       throw new Error(`${grantConnectorType} connector has no auth method`);
     }
-    const secretMetadata =
-      getConnectorAuthProviderSecretMetadata(grantConnectorType);
-    const refreshSecretName = secretMetadata.isRefreshable
-      ? secretMetadata.refreshSecretName
-      : undefined;
     await set(
       upsertOAuthConnector$,
       {
@@ -260,7 +254,6 @@ const createTestConnector$ = command(
         },
         oauthScopes: [],
         refreshToken: bodyResult.data.refreshToken,
-        refreshSecretName,
         expiresIn: bodyResult.data.expiresIn,
       },
       signal,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -15,7 +15,6 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorAuthCode,
-  getConnectorAuthProviderSecretMetadata,
   type OAuthTokenResult,
 } from "@vm0/connectors/auth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -398,9 +397,6 @@ const completeOAuthCallback$ = command(
     });
     signal.throwIfAborted();
 
-    const secretMetadata = getConnectorAuthProviderSecretMetadata(
-      args.connectorType,
-    );
     const result = await set(
       upsertOAuthConnector$,
       {
@@ -412,9 +408,6 @@ const completeOAuthCallback$ = command(
         userInfo: token.userInfo,
         oauthScopes: getRequestedScopes(args.connectorType, args.authMethod),
         refreshToken: token.refreshToken,
-        refreshSecretName: secretMetadata.isRefreshable
-          ? secretMetadata.refreshSecretName
-          : undefined,
         expiresIn: token.expiresIn,
         extraConnectorSecrets: token.extraConnectorSecrets,
       },

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -12,7 +12,7 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type ConnectorAuthProviderType,
+  type RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   parseBasicAuthTemplates,
@@ -23,7 +23,7 @@ import {
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
   getConnectorAuthProviderClientArgs,
-  hasConnectorAuthProvider,
+  hasConnectorRefreshTokenAccessProvider,
   refreshConnectorAuthProviderAccessToken,
   type ConnectorAuthProviderClientArgs,
   type ProviderEnv,
@@ -267,7 +267,7 @@ interface RefreshState {
 type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
-      readonly connectorType: ConnectorAuthProviderType;
+      readonly connectorType: RefreshTokenAccessConnectorType;
       readonly clientArgs: ConnectorAuthProviderClientArgs;
       readonly context: RefreshTokenContext;
     }
@@ -751,7 +751,7 @@ function prepareRefreshTokenContext(
   if (!parsedConnectorType.success) {
     return { ok: false, reason: "not-refreshable" };
   }
-  if (!hasConnectorAuthProvider(parsedConnectorType.data)) {
+  if (!hasConnectorRefreshTokenAccessProvider(parsedConnectorType.data)) {
     return { ok: false, reason: "not-refreshable" };
   }
   const authClient = resolveConnectorAuthClientForMethod(

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -268,6 +268,7 @@ type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
       readonly connectorType: RefreshTokenAccessConnectorType;
+      readonly authMethod: string;
       readonly clientArgs: ConnectorAuthProviderClientArgs;
       readonly context: RefreshTokenContext;
     }
@@ -751,7 +752,12 @@ function prepareRefreshTokenContext(
   if (!parsedConnectorType.success) {
     return { ok: false, reason: "not-refreshable" };
   }
-  if (!hasConnectorRefreshTokenAccessProvider(parsedConnectorType.data)) {
+  if (
+    !hasConnectorRefreshTokenAccessProvider(
+      parsedConnectorType.data,
+      connectorAccess.authMethod,
+    )
+  ) {
     return { ok: false, reason: "not-refreshable" };
   }
   const authClient = resolveConnectorAuthClientForMethod(
@@ -783,6 +789,7 @@ function prepareRefreshTokenContext(
     prepared: {
       sourceType: "connector",
       connectorType: parsedConnectorType.data,
+      authMethod: connectorAccess.authMethod,
       clientArgs: getConnectorAuthProviderClientArgs(authClient),
       context,
     },
@@ -1152,6 +1159,7 @@ async function refreshAccessTokenForSource(
       prepared.sourceType === "connector"
         ? refreshConnectorAuthProviderAccessToken({
             type: prepared.connectorType,
+            authMethod: prepared.authMethod,
             clientArgs: prepared.clientArgs,
             refreshToken: lockedState.refreshToken,
           })

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -18,7 +18,6 @@ import {
   type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
-  getConnectorAuthProviderSecretMetadata,
   pollConnectorDeviceAuthorization,
   startConnectorDeviceAuthorization,
 } from "@vm0/connectors/auth-providers";
@@ -910,9 +909,6 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       claimStartedAt,
       signal,
       persistConnector: async ({ result }) => {
-        const secretMetadata = getConnectorAuthProviderSecretMetadata(
-          resolvedType.type,
-        );
         const connectorResult = await set(
           upsertOAuthConnector$,
           {
@@ -924,9 +920,6 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
             userInfo: result.token.userInfo,
             oauthScopes: result.token.scopes,
             refreshToken: result.token.refreshToken,
-            refreshSecretName: secretMetadata.isRefreshable
-              ? secretMetadata.refreshSecretName
-              : undefined,
             expiresIn: result.token.expiresIn,
             extraConnectorSecrets: result.token.extraConnectorSecrets,
           },

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -8,6 +8,7 @@ import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zer
 import {
   connectorAuthMethodSupportsTokenRevoke,
   getAvailableConnectorAuthMethods,
+  getConnectorAuthMethodAccessMetadata,
   resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethodEnvBindings,
@@ -18,10 +19,7 @@ import {
   getRuntimeAvailableConnectorTypes,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
-import {
-  getConnectorAuthProviderSecretMetadata,
-  revokeConnectorAuthProviderAccessToken,
-} from "@vm0/connectors/auth-providers";
+import { revokeConnectorAuthProviderAccessToken } from "@vm0/connectors/auth-providers";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -30,6 +28,7 @@ import {
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type ConnectorAuthProviderType,
+  type ConnectorEnvBindings,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -87,6 +86,12 @@ interface ExternalUserInfo {
 interface PreparedApiTokenField {
   readonly name: string;
   readonly value: string;
+}
+
+interface ConnectorTokenSecretMetadata {
+  readonly accessSecretName: string;
+  readonly refreshSecretName: string | undefined;
+  readonly isRefreshable: boolean;
 }
 
 interface PreparedApiTokenConnect {
@@ -503,7 +508,13 @@ async function loadPendingConnectorTokenRevoke(args: {
   readonly signal: AbortSignal;
 }): Promise<PendingConnectorTokenRevoke | null> {
   const connectorType = args.type;
-  const secretMetadata = getConnectorAuthProviderSecretMetadata(connectorType);
+  const secretMetadata = connectorTokenSecretMetadataForAuthMethod({
+    type: connectorType,
+    authMethod: args.authMethod,
+  });
+  if (!secretMetadata) {
+    return null;
+  }
   const accessTokenName = secretMetadata.accessSecretName;
 
   const [accessTokenSecret] = await args.db
@@ -1167,6 +1178,66 @@ function connectorTokenExpiresAt(args: {
     : new Date(nowDate().getTime() + expiresInSecs * 1000);
 }
 
+function connectorSecretNameFromRef(valueRef: string): string | undefined {
+  return valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)
+    ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
+    : undefined;
+}
+
+function staticAccessSecretName(
+  envBindings: ConnectorEnvBindings,
+): string | undefined {
+  const secretNames = new Set<string>();
+  for (const valueRef of Object.values(envBindings)) {
+    const secretName = connectorSecretNameFromRef(valueRef);
+    if (secretName) {
+      secretNames.add(secretName);
+    }
+  }
+  if (secretNames.size !== 1) {
+    return undefined;
+  }
+  return [...secretNames][0];
+}
+
+function connectorTokenSecretMetadataForAuthMethod(args: {
+  readonly type: ConnectorType;
+  readonly authMethod: string;
+}): ConnectorTokenSecretMetadata | undefined {
+  const accessMetadata = getConnectorAuthMethodAccessMetadata(
+    args.type,
+    args.authMethod,
+  );
+
+  switch (accessMetadata?.kind) {
+    case "refresh-token": {
+      return {
+        accessSecretName: accessMetadata.accessToken,
+        refreshSecretName: accessMetadata.refreshToken,
+        isRefreshable: true,
+      };
+    }
+
+    case "static": {
+      const accessSecretName = staticAccessSecretName(
+        accessMetadata.envBindings,
+      );
+      return accessSecretName
+        ? {
+            accessSecretName,
+            refreshSecretName: undefined,
+            isRefreshable: false,
+          }
+        : undefined;
+    }
+
+    case "none":
+    case undefined: {
+      return undefined;
+    }
+  }
+}
+
 function allowedOAuthConnectorSecretNames(
   type: ConnectorAuthProviderType,
   authMethod: ConnectorAuthMethodId,
@@ -1452,7 +1523,6 @@ export const upsertOAuthConnector$ = command(
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];
       readonly refreshToken?: string | null;
-      readonly refreshSecretName?: string;
       readonly expiresIn?: number;
       readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
     },
@@ -1462,7 +1532,15 @@ export const upsertOAuthConnector$ = command(
     readonly created: boolean;
   }> => {
     const writeDb = set(writeDb$);
-    const secretMetadata = getConnectorAuthProviderSecretMetadata(args.type);
+    const secretMetadata = connectorTokenSecretMetadataForAuthMethod({
+      type: args.type,
+      authMethod: args.authMethod,
+    });
+    if (!secretMetadata) {
+      throw new Error(
+        `${args.type} connector auth method ${args.authMethod} does not expose an access token secret`,
+      );
+    }
     const tokenExpiresAt = connectorTokenExpiresAt({
       isRefreshable: secretMetadata.isRefreshable,
       expiresIn: args.expiresIn,
@@ -1472,9 +1550,7 @@ export const upsertOAuthConnector$ = command(
       authMethod: args.authMethod,
       extraConnectorSecrets: args.extraConnectorSecrets,
       accessSecretName: secretMetadata.accessSecretName,
-      refreshSecretName: secretMetadata.isRefreshable
-        ? secretMetadata.refreshSecretName
-        : undefined,
+      refreshSecretName: secretMetadata.refreshSecretName,
     });
     const featureSwitchContext = await get(
       userFeatureSwitchContext(args.orgId, args.userId),
@@ -1485,7 +1561,7 @@ export const upsertOAuthConnector$ = command(
       type: args.type,
       accessSecretName: secretMetadata.accessSecretName,
       accessToken: args.accessToken,
-      refreshSecretName: args.refreshSecretName,
+      refreshSecretName: secretMetadata.refreshSecretName,
       refreshToken: args.refreshToken,
       extraSecrets,
       featureSwitchContext,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -23,6 +23,7 @@ import {
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
+  type RefreshTokenAccessConnectorType,
 } from "../connectors";
 import {
   connectorAuthMethodSupportsTokenRevoke,
@@ -60,6 +61,7 @@ import {
   getConnectorAuthProviderClientArgs,
   hasConnectorAuthCodeGrantProvider,
   hasConnectorDeviceAuthGrantProvider,
+  hasConnectorRefreshTokenAccessProvider,
   getConnectorAuthProviderSecretMetadata,
   pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
@@ -425,7 +427,7 @@ describe("connector auth method config", () => {
   });
 });
 
-describe("connector grant provider capability checks", () => {
+describe("connector provider capability checks", () => {
   it("matches exactly the connector types that declare auth-code and device-auth grants", () => {
     const authCodeGrantTypes = new Set<ConnectorType>(
       connectorTypeSchema.options.filter(hasConnectorAuthCodeGrant),
@@ -440,6 +442,29 @@ describe("connector grant provider capability checks", () => {
       );
       expect(hasConnectorDeviceAuthGrantProvider(type)).toBe(
         deviceAuthGrantTypes.has(type),
+      );
+    }
+  });
+
+  it("matches exactly the connector types that declare refresh-token access", () => {
+    expectTypeOf<"base44">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
+    expectTypeOf<"notion">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
+    expectTypeOf<"github">().not.toMatchTypeOf<RefreshTokenAccessConnectorType>();
+
+    const refreshTokenAccessTypes = new Set<ConnectorType>(
+      connectorTypeSchema.options.filter((type) => {
+        return getConfiguredConnectorAuthMethods(type).some((authMethod) => {
+          return (
+            getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
+            "refresh-token"
+          );
+        });
+      }),
+    );
+
+    for (const type of connectorTypeSchema.options) {
+      expect(hasConnectorRefreshTokenAccessProvider(type)).toBe(
+        refreshTokenAccessTypes.has(type),
       );
     }
   });
@@ -468,29 +493,11 @@ describe("connector grant provider capability checks", () => {
     });
   });
 
-  it("rejects refresh for OAuth connectors without refresh-token access", async () => {
-    const oauthClient = getOauthAuthClient("github", (name) => {
-      if (name === "GH_OAUTH_CLIENT_ID") {
-        return "test-github-client";
-      }
-      if (name === "GH_OAUTH_CLIENT_SECRET") {
-        return "test-github-secret";
-      }
-      return undefined;
-    });
-    expect(oauthClient).toBeDefined();
-
-    if (!oauthClient) {
-      throw new Error("Expected github OAuth client");
-    }
-
-    await expect(
-      refreshConnectorAuthProviderAccessToken({
-        type: "github",
-        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
-        refreshToken: "refresh-token",
-      }),
-    ).rejects.toThrow("github connector does not support token refresh");
+  it("does not expose refresh-token access providers for non-refreshable OAuth connectors", () => {
+    expect(hasConnectorRefreshTokenAccessProvider("github")).toBe(false);
+    expect(
+      getConnectorAuthMethodAccessMetadata("github", "oauth")?.kind,
+    ).not.toBe("refresh-token");
   });
 
   it("revokes OAuth tokens through the provider registry", async () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -21,6 +21,7 @@ import {
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorInvalidDefaultAuthMethodType,
   type ConnectorManualGrantFieldConfig,
+  type ConnectorRefreshTokenAccessMethodsAreSingle,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
   type RefreshTokenAccessConnectorType,
@@ -447,6 +448,7 @@ describe("connector provider capability checks", () => {
   });
 
   it("matches exactly the connector types that declare refresh-token access", () => {
+    expectTypeOf<ConnectorRefreshTokenAccessMethodsAreSingle>().toEqualTypeOf<never>();
     expectTypeOf<"base44">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
     expectTypeOf<"notion">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
     expectTypeOf<"github">().not.toMatchTypeOf<RefreshTokenAccessConnectorType>();

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -26,6 +26,7 @@ import {
   type RefreshTokenAccessConnectorType,
 } from "../connectors";
 import {
+  connectorAuthMethodSupportsRefreshTokenAccess,
   connectorAuthMethodSupportsTokenRevoke,
   connectorAuthMethodHasGrantKind,
   getAvailableConnectorAuthMethods,
@@ -466,6 +467,17 @@ describe("connector provider capability checks", () => {
       expect(hasConnectorRefreshTokenAccessProvider(type)).toBe(
         refreshTokenAccessTypes.has(type),
       );
+      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+        const hasRefreshTokenAccess =
+          getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
+          "refresh-token";
+        expect(hasConnectorRefreshTokenAccessProvider(type, authMethod)).toBe(
+          hasRefreshTokenAccess,
+        );
+        expect(
+          connectorAuthMethodSupportsRefreshTokenAccess(type, authMethod),
+        ).toBe(hasRefreshTokenAccess);
+      }
     }
   });
 
@@ -498,6 +510,19 @@ describe("connector provider capability checks", () => {
     expect(
       getConnectorAuthMethodAccessMetadata("github", "oauth")?.kind,
     ).not.toBe("refresh-token");
+  });
+
+  it("rejects refresh when the selected auth method is not refreshable", async () => {
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "stripe",
+        authMethod: "api-token",
+        clientArgs: {},
+        refreshToken: "stripe-refresh-token",
+      }),
+    ).rejects.toThrow(
+      "stripe connector auth method api-token does not support token refresh",
+    );
   });
 
   it("revokes OAuth tokens through the provider registry", async () => {
@@ -988,6 +1013,7 @@ describe("connector provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "base44",
+        authMethod: "oauth",
         clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "base44-refresh-rotation",
       }),
@@ -999,6 +1025,7 @@ describe("connector provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "base44",
+        authMethod: "oauth",
         clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "base44-refresh-without-rotation",
       }),
@@ -1320,6 +1347,7 @@ describe("connector provider capability checks", () => {
 
     const refreshResult = await refreshConnectorAuthProviderAccessToken({
       type: "slock",
+      authMethod: "oauth",
       clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
       refreshToken: "slock-refresh-token",
     });
@@ -1339,6 +1367,7 @@ describe("connector provider capability checks", () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
         type: "slock",
+        authMethod: "oauth",
         clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "slock-refresh-malformed",
       }),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -21,7 +21,6 @@ import {
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorInvalidDefaultAuthMethodType,
   type ConnectorManualGrantFieldConfig,
-  type ConnectorRefreshTokenAccessMethodsAreSingle,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
   type RefreshTokenAccessConnectorType,
@@ -448,7 +447,6 @@ describe("connector provider capability checks", () => {
   });
 
   it("matches exactly the connector types that declare refresh-token access", () => {
-    expectTypeOf<ConnectorRefreshTokenAccessMethodsAreSingle>().toEqualTypeOf<never>();
     expectTypeOf<"base44">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
     expectTypeOf<"notion">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
     expectTypeOf<"github">().not.toMatchTypeOf<RefreshTokenAccessConnectorType>();

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -3,6 +3,7 @@ import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
+  RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
@@ -18,8 +19,9 @@ import {
 import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
-  ConnectorAuthProviderAccess,
   ConnectorAuthProviderRevoke,
+  NoneAccessProvider,
+  RefreshTokenAccessProvider,
 } from "./types";
 import {
   type AuthUrlResult,
@@ -117,6 +119,10 @@ type DeviceAuthConnectorAuthProviderMap = {
   readonly [Type in DeviceAuthGrantConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
+type ConnectorRefreshTokenAccessProviderMap = {
+  readonly [Type in RefreshTokenAccessConnectorType]: RefreshTokenAccessProvider<Type>;
+};
+
 export type ConnectorAuthProviderSecretMetadata = AuthProviderSecretMetadata;
 
 export interface ConnectorAuthProviderClientArgs {
@@ -130,16 +136,24 @@ function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   return DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type];
 }
 
-function connectorAccessProviderFor<T extends ConnectorAuthProviderType>(
+function expectRefreshTokenAccessProvider<
+  T extends RefreshTokenAccessConnectorType,
+>(
   type: T,
-): ConnectorAuthProviderAccess<T> {
-  if (hasConnectorAuthCodeGrant(type)) {
-    return AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type]
-      .access as ConnectorAuthProviderAccess<T>;
+  provider: {
+    readonly access: NoneAccessProvider | RefreshTokenAccessProvider<T>;
+  },
+): RefreshTokenAccessProvider<T> {
+  if (provider.access.kind === "refresh-token") {
+    return provider.access;
   }
+  throw new Error(`${type} connector does not use refresh-token access`);
+}
 
-  return deviceAuthConnectorProviderFor(type)
-    .access as ConnectorAuthProviderAccess<T>;
+function connectorRefreshTokenAccessProviderFor<
+  T extends RefreshTokenAccessConnectorType,
+>(type: T): ConnectorRefreshTokenAccessProviderMap[T] {
+  return CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS[type];
 }
 
 function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
@@ -230,6 +244,79 @@ const DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS: DeviceAuthConnectorAuthProviderMap =
     "test-oauth-device": testOauthDeviceProvider,
   };
 
+const CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS: ConnectorRefreshTokenAccessProviderMap =
+  {
+    ahrefs: expectRefreshTokenAccessProvider("ahrefs", ahrefsProvider),
+    airtable: expectRefreshTokenAccessProvider("airtable", airtableProvider),
+    asana: expectRefreshTokenAccessProvider("asana", asanaProvider),
+    base44: expectRefreshTokenAccessProvider("base44", base44Provider),
+    canva: expectRefreshTokenAccessProvider("canva", canvaProvider),
+    close: expectRefreshTokenAccessProvider("close", closeProvider),
+    deel: expectRefreshTokenAccessProvider("deel", deelProvider),
+    docusign: expectRefreshTokenAccessProvider("docusign", docusignProvider),
+    dropbox: expectRefreshTokenAccessProvider("dropbox", dropboxProvider),
+    figma: expectRefreshTokenAccessProvider("figma", figmaProvider),
+    "garmin-connect": expectRefreshTokenAccessProvider(
+      "garmin-connect",
+      garminConnectProvider,
+    ),
+    gmail: expectRefreshTokenAccessProvider("gmail", gmailProvider),
+    "google-ads": expectRefreshTokenAccessProvider(
+      "google-ads",
+      googleAdsProvider,
+    ),
+    "google-calendar": expectRefreshTokenAccessProvider(
+      "google-calendar",
+      googleCalendarProvider,
+    ),
+    "google-docs": expectRefreshTokenAccessProvider(
+      "google-docs",
+      googleDocsProvider,
+    ),
+    "google-drive": expectRefreshTokenAccessProvider(
+      "google-drive",
+      googleDriveProvider,
+    ),
+    "google-meet": expectRefreshTokenAccessProvider(
+      "google-meet",
+      googleMeetProvider,
+    ),
+    "google-sheets": expectRefreshTokenAccessProvider(
+      "google-sheets",
+      googleSheetsProvider,
+    ),
+    gumroad: expectRefreshTokenAccessProvider("gumroad", gumroadProvider),
+    hubspot: expectRefreshTokenAccessProvider("hubspot", hubspotProvider),
+    linear: expectRefreshTokenAccessProvider("linear", linearProvider),
+    mercury: expectRefreshTokenAccessProvider("mercury", mercuryProvider),
+    monday: expectRefreshTokenAccessProvider("monday", mondayProvider),
+    neon: expectRefreshTokenAccessProvider("neon", neonProvider),
+    notion: expectRefreshTokenAccessProvider("notion", notionProvider),
+    "outlook-calendar": expectRefreshTokenAccessProvider(
+      "outlook-calendar",
+      outlookCalendarProvider,
+    ),
+    "outlook-mail": expectRefreshTokenAccessProvider(
+      "outlook-mail",
+      outlookMailProvider,
+    ),
+    posthog: expectRefreshTokenAccessProvider("posthog", posthogProvider),
+    reddit: expectRefreshTokenAccessProvider("reddit", redditProvider),
+    sentry: expectRefreshTokenAccessProvider("sentry", sentryProvider),
+    slock: expectRefreshTokenAccessProvider("slock", slockProvider),
+    spotify: expectRefreshTokenAccessProvider("spotify", spotifyProvider),
+    strava: expectRefreshTokenAccessProvider("strava", stravaProvider),
+    stripe: expectRefreshTokenAccessProvider("stripe", stripeProvider),
+    supabase: expectRefreshTokenAccessProvider("supabase", supabaseProvider),
+    "test-oauth": expectRefreshTokenAccessProvider(
+      "test-oauth",
+      testOauthProvider,
+    ),
+    x: expectRefreshTokenAccessProvider("x", xProvider),
+    xero: expectRefreshTokenAccessProvider("xero", xeroProvider),
+    zoom: expectRefreshTokenAccessProvider("zoom", zoomProvider),
+  };
+
 export function hasConnectorAuthProvider(
   type: string,
 ): type is ConnectorAuthProviderType {
@@ -249,6 +336,12 @@ export function hasConnectorDeviceAuthGrantProvider(
   type: string,
 ): type is DeviceAuthGrantConnectorType {
   return Object.hasOwn(DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS, type);
+}
+
+export function hasConnectorRefreshTokenAccessProvider(
+  type: string,
+): type is RefreshTokenAccessConnectorType {
+  return Object.hasOwn(CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS, type);
 }
 
 export function getConnectorAuthProviderSecretMetadata(
@@ -346,24 +439,16 @@ export async function pollConnectorDeviceAuthorization<
 }
 
 export async function refreshConnectorAuthProviderAccessToken<
-  T extends ConnectorAuthProviderType,
+  T extends RefreshTokenAccessConnectorType,
 >(args: {
   readonly type: T;
   readonly clientArgs: ConnectorAuthProviderClientArgs;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  const access = connectorAccessProviderFor(args.type);
-
-  switch (access.kind) {
-    case "none":
-      throw new Error(`${args.type} connector does not support token refresh`);
-
-    case "refresh-token":
-      return await access.refreshToken({
-        ...args.clientArgs,
-        refreshToken: args.refreshToken,
-      } as ConnectorAuthProviderRefreshArgs<T>);
-  }
+  return await connectorRefreshTokenAccessProviderFor(args.type).refreshToken({
+    ...args.clientArgs,
+    refreshToken: args.refreshToken,
+  } as ConnectorAuthProviderRefreshArgs<T>);
 }
 
 export async function revokeConnectorAuthProviderAccessToken<

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -3,9 +3,11 @@ import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
+  ConnectorAuthMethodIdsByAccessKind,
   RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  connectorAuthMethodSupportsRefreshTokenAccess,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   hasConnectorAuthCodeGrant,
   isStaticConfidentialConnectorAuthClient,
@@ -118,8 +120,17 @@ type DeviceAuthConnectorAuthProviderMap = {
   readonly [Type in DeviceAuthGrantConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
+type ConnectorRefreshTokenAccessProviderEntries<
+  Type extends RefreshTokenAccessConnectorType,
+> = {
+  readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+    Type,
+    "refresh-token"
+  >]: RefreshTokenAccessProvider<Type>;
+};
+
 type ConnectorRefreshTokenAccessProviderMap = {
-  readonly [Type in RefreshTokenAccessConnectorType]: RefreshTokenAccessProvider<Type>;
+  readonly [Type in RefreshTokenAccessConnectorType]: ConnectorRefreshTokenAccessProviderEntries<Type>;
 };
 
 export type ConnectorAuthProviderSecretMetadata = AuthProviderSecretMetadata;
@@ -137,8 +148,11 @@ function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
 
 function connectorRefreshTokenAccessProviderFor<
   T extends RefreshTokenAccessConnectorType,
->(type: T): ConnectorRefreshTokenAccessProviderMap[T] {
-  return CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS[type];
+>(type: T, authMethod: string): RefreshTokenAccessProvider<T> | undefined {
+  const providers = CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS[type] as Readonly<
+    Record<string, RefreshTokenAccessProvider<T>>
+  >;
+  return providers[authMethod];
 }
 
 function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
@@ -231,45 +245,45 @@ const DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS: DeviceAuthConnectorAuthProviderMap =
 
 const CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS: ConnectorRefreshTokenAccessProviderMap =
   {
-    ahrefs: ahrefsProvider.access,
-    airtable: airtableProvider.access,
-    asana: asanaProvider.access,
-    base44: base44Provider.access,
-    canva: canvaProvider.access,
-    close: closeProvider.access,
-    deel: deelProvider.access,
-    docusign: docusignProvider.access,
-    dropbox: dropboxProvider.access,
-    figma: figmaProvider.access,
-    "garmin-connect": garminConnectProvider.access,
-    gmail: gmailProvider.access,
-    "google-ads": googleAdsProvider.access,
-    "google-calendar": googleCalendarProvider.access,
-    "google-docs": googleDocsProvider.access,
-    "google-drive": googleDriveProvider.access,
-    "google-meet": googleMeetProvider.access,
-    "google-sheets": googleSheetsProvider.access,
-    gumroad: gumroadProvider.access,
-    hubspot: hubspotProvider.access,
-    linear: linearProvider.access,
-    mercury: mercuryProvider.access,
-    monday: mondayProvider.access,
-    neon: neonProvider.access,
-    notion: notionProvider.access,
-    "outlook-calendar": outlookCalendarProvider.access,
-    "outlook-mail": outlookMailProvider.access,
-    posthog: posthogProvider.access,
-    reddit: redditProvider.access,
-    sentry: sentryProvider.access,
-    slock: slockProvider.access,
-    spotify: spotifyProvider.access,
-    strava: stravaProvider.access,
-    stripe: stripeProvider.access,
-    supabase: supabaseProvider.access,
-    "test-oauth": testOauthProvider.access,
-    x: xProvider.access,
-    xero: xeroProvider.access,
-    zoom: zoomProvider.access,
+    ahrefs: { oauth: ahrefsProvider.access },
+    airtable: { oauth: airtableProvider.access },
+    asana: { oauth: asanaProvider.access },
+    base44: { oauth: base44Provider.access },
+    canva: { oauth: canvaProvider.access },
+    close: { oauth: closeProvider.access },
+    deel: { oauth: deelProvider.access },
+    docusign: { oauth: docusignProvider.access },
+    dropbox: { oauth: dropboxProvider.access },
+    figma: { oauth: figmaProvider.access },
+    "garmin-connect": { oauth: garminConnectProvider.access },
+    gmail: { oauth: gmailProvider.access },
+    "google-ads": { oauth: googleAdsProvider.access },
+    "google-calendar": { oauth: googleCalendarProvider.access },
+    "google-docs": { oauth: googleDocsProvider.access },
+    "google-drive": { oauth: googleDriveProvider.access },
+    "google-meet": { oauth: googleMeetProvider.access },
+    "google-sheets": { oauth: googleSheetsProvider.access },
+    gumroad: { oauth: gumroadProvider.access },
+    hubspot: { oauth: hubspotProvider.access },
+    linear: { oauth: linearProvider.access },
+    mercury: { oauth: mercuryProvider.access },
+    monday: { oauth: mondayProvider.access },
+    neon: { oauth: neonProvider.access },
+    notion: { oauth: notionProvider.access },
+    "outlook-calendar": { oauth: outlookCalendarProvider.access },
+    "outlook-mail": { oauth: outlookMailProvider.access },
+    posthog: { oauth: posthogProvider.access },
+    reddit: { oauth: redditProvider.access },
+    sentry: { oauth: sentryProvider.access },
+    slock: { oauth: slockProvider.access },
+    spotify: { oauth: spotifyProvider.access },
+    strava: { oauth: stravaProvider.access },
+    stripe: { oauth: stripeProvider.access },
+    supabase: { oauth: supabaseProvider.access },
+    "test-oauth": { oauth: testOauthProvider.access },
+    x: { oauth: xProvider.access },
+    xero: { oauth: xeroProvider.access },
+    zoom: { oauth: zoomProvider.access },
   };
 
 export function hasConnectorAuthProvider(
@@ -295,8 +309,18 @@ export function hasConnectorDeviceAuthGrantProvider(
 
 export function hasConnectorRefreshTokenAccessProvider(
   type: string,
+  authMethod?: string,
 ): type is RefreshTokenAccessConnectorType {
-  return Object.hasOwn(CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS, type);
+  if (!Object.hasOwn(CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS, type)) {
+    return false;
+  }
+  if (authMethod === undefined) {
+    return true;
+  }
+  const providers = CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS[
+    type as RefreshTokenAccessConnectorType
+  ] as Readonly<Record<string, unknown>>;
+  return Object.hasOwn(providers, authMethod);
 }
 
 export function getConnectorAuthProviderSecretMetadata(
@@ -397,10 +421,27 @@ export async function refreshConnectorAuthProviderAccessToken<
   T extends RefreshTokenAccessConnectorType,
 >(args: {
   readonly type: T;
+  readonly authMethod: string;
   readonly clientArgs: ConnectorAuthProviderClientArgs;
   readonly refreshToken: string;
 }): Promise<OAuthRefreshResult> {
-  return await connectorRefreshTokenAccessProviderFor(args.type).refreshToken({
+  if (
+    !connectorAuthMethodSupportsRefreshTokenAccess(args.type, args.authMethod)
+  ) {
+    throw new Error(
+      `${args.type} connector auth method ${args.authMethod} does not support token refresh`,
+    );
+  }
+  const access = connectorRefreshTokenAccessProviderFor(
+    args.type,
+    args.authMethod,
+  );
+  if (!access) {
+    throw new Error(
+      `${args.type} connector auth method ${args.authMethod} has no refresh-token access provider`,
+    );
+  }
+  return await access.refreshToken({
     ...args.clientArgs,
     refreshToken: args.refreshToken,
   } as ConnectorAuthProviderRefreshArgs<T>);

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -20,7 +20,6 @@ import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
   ConnectorAuthProviderRevoke,
-  NoneAccessProvider,
   RefreshTokenAccessProvider,
 } from "./types";
 import {
@@ -136,20 +135,6 @@ function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
   return DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type];
 }
 
-function expectRefreshTokenAccessProvider<
-  T extends RefreshTokenAccessConnectorType,
->(
-  type: T,
-  provider: {
-    readonly access: NoneAccessProvider | RefreshTokenAccessProvider<T>;
-  },
-): RefreshTokenAccessProvider<T> {
-  if (provider.access.kind === "refresh-token") {
-    return provider.access;
-  }
-  throw new Error(`${type} connector does not use refresh-token access`);
-}
-
 function connectorRefreshTokenAccessProviderFor<
   T extends RefreshTokenAccessConnectorType,
 >(type: T): ConnectorRefreshTokenAccessProviderMap[T] {
@@ -246,75 +231,45 @@ const DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS: DeviceAuthConnectorAuthProviderMap =
 
 const CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS: ConnectorRefreshTokenAccessProviderMap =
   {
-    ahrefs: expectRefreshTokenAccessProvider("ahrefs", ahrefsProvider),
-    airtable: expectRefreshTokenAccessProvider("airtable", airtableProvider),
-    asana: expectRefreshTokenAccessProvider("asana", asanaProvider),
-    base44: expectRefreshTokenAccessProvider("base44", base44Provider),
-    canva: expectRefreshTokenAccessProvider("canva", canvaProvider),
-    close: expectRefreshTokenAccessProvider("close", closeProvider),
-    deel: expectRefreshTokenAccessProvider("deel", deelProvider),
-    docusign: expectRefreshTokenAccessProvider("docusign", docusignProvider),
-    dropbox: expectRefreshTokenAccessProvider("dropbox", dropboxProvider),
-    figma: expectRefreshTokenAccessProvider("figma", figmaProvider),
-    "garmin-connect": expectRefreshTokenAccessProvider(
-      "garmin-connect",
-      garminConnectProvider,
-    ),
-    gmail: expectRefreshTokenAccessProvider("gmail", gmailProvider),
-    "google-ads": expectRefreshTokenAccessProvider(
-      "google-ads",
-      googleAdsProvider,
-    ),
-    "google-calendar": expectRefreshTokenAccessProvider(
-      "google-calendar",
-      googleCalendarProvider,
-    ),
-    "google-docs": expectRefreshTokenAccessProvider(
-      "google-docs",
-      googleDocsProvider,
-    ),
-    "google-drive": expectRefreshTokenAccessProvider(
-      "google-drive",
-      googleDriveProvider,
-    ),
-    "google-meet": expectRefreshTokenAccessProvider(
-      "google-meet",
-      googleMeetProvider,
-    ),
-    "google-sheets": expectRefreshTokenAccessProvider(
-      "google-sheets",
-      googleSheetsProvider,
-    ),
-    gumroad: expectRefreshTokenAccessProvider("gumroad", gumroadProvider),
-    hubspot: expectRefreshTokenAccessProvider("hubspot", hubspotProvider),
-    linear: expectRefreshTokenAccessProvider("linear", linearProvider),
-    mercury: expectRefreshTokenAccessProvider("mercury", mercuryProvider),
-    monday: expectRefreshTokenAccessProvider("monday", mondayProvider),
-    neon: expectRefreshTokenAccessProvider("neon", neonProvider),
-    notion: expectRefreshTokenAccessProvider("notion", notionProvider),
-    "outlook-calendar": expectRefreshTokenAccessProvider(
-      "outlook-calendar",
-      outlookCalendarProvider,
-    ),
-    "outlook-mail": expectRefreshTokenAccessProvider(
-      "outlook-mail",
-      outlookMailProvider,
-    ),
-    posthog: expectRefreshTokenAccessProvider("posthog", posthogProvider),
-    reddit: expectRefreshTokenAccessProvider("reddit", redditProvider),
-    sentry: expectRefreshTokenAccessProvider("sentry", sentryProvider),
-    slock: expectRefreshTokenAccessProvider("slock", slockProvider),
-    spotify: expectRefreshTokenAccessProvider("spotify", spotifyProvider),
-    strava: expectRefreshTokenAccessProvider("strava", stravaProvider),
-    stripe: expectRefreshTokenAccessProvider("stripe", stripeProvider),
-    supabase: expectRefreshTokenAccessProvider("supabase", supabaseProvider),
-    "test-oauth": expectRefreshTokenAccessProvider(
-      "test-oauth",
-      testOauthProvider,
-    ),
-    x: expectRefreshTokenAccessProvider("x", xProvider),
-    xero: expectRefreshTokenAccessProvider("xero", xeroProvider),
-    zoom: expectRefreshTokenAccessProvider("zoom", zoomProvider),
+    ahrefs: ahrefsProvider.access,
+    airtable: airtableProvider.access,
+    asana: asanaProvider.access,
+    base44: base44Provider.access,
+    canva: canvaProvider.access,
+    close: closeProvider.access,
+    deel: deelProvider.access,
+    docusign: docusignProvider.access,
+    dropbox: dropboxProvider.access,
+    figma: figmaProvider.access,
+    "garmin-connect": garminConnectProvider.access,
+    gmail: gmailProvider.access,
+    "google-ads": googleAdsProvider.access,
+    "google-calendar": googleCalendarProvider.access,
+    "google-docs": googleDocsProvider.access,
+    "google-drive": googleDriveProvider.access,
+    "google-meet": googleMeetProvider.access,
+    "google-sheets": googleSheetsProvider.access,
+    gumroad: gumroadProvider.access,
+    hubspot: hubspotProvider.access,
+    linear: linearProvider.access,
+    mercury: mercuryProvider.access,
+    monday: mondayProvider.access,
+    neon: neonProvider.access,
+    notion: notionProvider.access,
+    "outlook-calendar": outlookCalendarProvider.access,
+    "outlook-mail": outlookMailProvider.access,
+    posthog: posthogProvider.access,
+    reddit: redditProvider.access,
+    sentry: sentryProvider.access,
+    slock: slockProvider.access,
+    spotify: spotifyProvider.access,
+    strava: stravaProvider.access,
+    stripe: stripeProvider.access,
+    supabase: supabaseProvider.access,
+    "test-oauth": testOauthProvider.access,
+    x: xProvider.access,
+    xero: xeroProvider.access,
+    zoom: zoomProvider.access,
   };
 
 export function hasConnectorAuthProvider(

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,8 +1,10 @@
 import type {
+  AuthCodeGrantConnectorType,
   CONNECTOR_TYPES,
   ConnectorAuthClientConfig,
   ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
+  RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 
 export interface OAuthTokenResult {
@@ -128,11 +130,37 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorAuthClientFor<T extends ConnectorAuthProviderType> = {
+type ConnectorGrantProviderClientFor<T extends ConnectorAuthProviderType> = {
   [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
     readonly client: infer Client;
     readonly grant: {
       readonly kind: "auth-code" | "device-auth";
+    };
+  }
+    ? Client
+    : never;
+}[keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]] &
+  ConnectorAuthClientConfig;
+
+type ConnectorAccessProviderClientFor<
+  T extends RefreshTokenAccessConnectorType,
+> = {
+  [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
+    readonly client: infer Client;
+    readonly access: {
+      readonly kind: "refresh-token";
+    };
+  }
+    ? Client
+    : never;
+}[keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]] &
+  ConnectorAuthClientConfig;
+
+type ConnectorRevokeProviderClientFor<T extends ConnectorAuthProviderType> = {
+  [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
+    readonly client: infer Client;
+    readonly revoke: {
+      readonly kind: "token-revoke";
     };
   }
     ? Client
@@ -161,26 +189,31 @@ type TokenCredentialArgs<Client extends ConnectorAuthClientConfig> =
       : NoClientCredentialArgs;
 
 export type ConnectorAuthCodeAuthorizeArgs<
-  T extends ConnectorAuthProviderType,
-> = OAuthAuthorizeFlowArgs & StaticClientIdArgs<ConnectorAuthClientFor<T>>;
+  T extends AuthCodeGrantConnectorType,
+> = OAuthAuthorizeFlowArgs &
+  StaticClientIdArgs<ConnectorGrantProviderClientFor<T>>;
 
-export type ConnectorAuthCodeExchangeArgs<T extends ConnectorAuthProviderType> =
-  OAuthExchangeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
+export type ConnectorAuthCodeExchangeArgs<
+  T extends AuthCodeGrantConnectorType,
+> = OAuthExchangeFlowArgs &
+  TokenCredentialArgs<ConnectorGrantProviderClientFor<T>>;
 
 export type ConnectorAuthProviderRefreshArgs<
-  T extends ConnectorAuthProviderType,
-> = OAuthRefreshFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
+  T extends RefreshTokenAccessConnectorType,
+> = OAuthRefreshFlowArgs &
+  TokenCredentialArgs<ConnectorAccessProviderClientFor<T>>;
 
 export type ConnectorAuthProviderRevokeArgs<
   T extends ConnectorAuthProviderType,
-> = OAuthRevokeFlowArgs & TokenCredentialArgs<ConnectorAuthClientFor<T>>;
+> = OAuthRevokeFlowArgs &
+  TokenCredentialArgs<ConnectorRevokeProviderClientFor<T>>;
 
 export type ConnectorDeviceAuthorizationStartArgs<
   T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthStartFlowArgs &
-  StaticClientIdArgs<ConnectorAuthClientFor<T>>;
+  StaticClientIdArgs<ConnectorGrantProviderClientFor<T>>;
 
 export type ConnectorDeviceAuthorizationPollArgs<
   T extends DeviceAuthGrantConnectorType,
 > = OAuthDeviceAuthPollFlowArgs &
-  TokenCredentialArgs<ConnectorAuthClientFor<T>>;
+  TokenCredentialArgs<ConnectorGrantProviderClientFor<T>>;

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -64,7 +64,7 @@ export interface RefreshTokenAccessProvider<
 
 export type ConnectorAuthProviderAccess<T extends ConnectorType> =
   T extends RefreshTokenAccessConnectorType
-    ? NoneAccessProvider | RefreshTokenAccessProvider<T>
+    ? RefreshTokenAccessProvider<T>
     : NoneAccessProvider;
 
 interface NoneRevokeProvider {

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,7 +1,9 @@
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthProviderType,
+  ConnectorType,
   DeviceAuthGrantConnectorType,
+  RefreshTokenAccessConnectorType,
 } from "../connectors";
 import type {
   AuthUrlResult,
@@ -50,7 +52,7 @@ export interface NoneAccessProvider {
 }
 
 export interface RefreshTokenAccessProvider<
-  T extends ConnectorAuthProviderType,
+  T extends RefreshTokenAccessConnectorType,
 > {
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
@@ -60,9 +62,10 @@ export interface RefreshTokenAccessProvider<
   ): Promise<OAuthRefreshResult>;
 }
 
-export type ConnectorAuthProviderAccess<T extends ConnectorAuthProviderType> =
-  | NoneAccessProvider
-  | RefreshTokenAccessProvider<T>;
+export type ConnectorAuthProviderAccess<T extends ConnectorType> =
+  T extends RefreshTokenAccessConnectorType
+    ? NoneAccessProvider | RefreshTokenAccessProvider<T>
+    : NoneAccessProvider;
 
 interface NoneRevokeProvider {
   readonly kind: "none";

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -16,6 +16,7 @@ import {
   type ConnectorAuthProviderType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
+  type RefreshTokenAccessConnectorType,
   type TokenRevokeConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
@@ -338,6 +339,15 @@ export function connectorAuthMethodSupportsTokenRevoke(
 ): type is TokenRevokeConnectorType {
   return (
     getConnectorAuthMethod(type, authMethod)?.revoke.kind === "token-revoke"
+  );
+}
+
+export function connectorAuthMethodSupportsRefreshTokenAccess(
+  type: ConnectorType,
+  authMethod: string,
+): type is RefreshTokenAccessConnectorType {
+  return (
+    getConnectorAuthMethod(type, authMethod)?.access.kind === "refresh-token"
   );
 }
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -960,30 +960,6 @@ export type ConnectorDeviceAuthGrantMethodsAreSingle = AssertNever<
   ConnectorTypeWithMultipleAuthMethodsForGrantKind<"device-auth">
 >;
 
-type ConnectorAuthMethodIdsByAccessKind<
-  Type extends ConnectorType,
-  Kind extends ConnectorAccessKind,
-> = {
-  [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
-    readonly access: { readonly kind: Kind };
-  }
-    ? Method
-    : never;
-}[ConnectorAuthMethodKeys<Type>];
-
-type ConnectorTypeWithMultipleAuthMethodsForAccessKind<
-  Kind extends ConnectorAccessKind,
-> = {
-  [Type in ConnectorType]: IsUnion<
-    ConnectorAuthMethodIdsByAccessKind<Type, Kind>
-  > extends true
-    ? Type
-    : never;
-}[ConnectorType];
-export type ConnectorRefreshTokenAccessMethodsAreSingle = AssertNever<
-  ConnectorTypeWithMultipleAuthMethodsForAccessKind<"refresh-token">
->;
-
 export type ConnectorTypesByGrantKind<Kind extends ConnectorGrantKind> = {
   [Type in ConnectorType]: {
     [Method in keyof ConnectorAuthMethodsOf<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -996,6 +996,8 @@ export type ConnectorAuthProviderType = ConnectorTypesByGrantKind<
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;
 export type DeviceAuthGrantConnectorType =
   ConnectorTypesByGrantKind<"device-auth">;
+export type RefreshTokenAccessConnectorType =
+  ConnectorTypesByAccessKind<"refresh-token">;
 export type TokenRevokeConnectorType =
   ConnectorTypesByRevokeKind<"token-revoke">;
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -960,6 +960,30 @@ export type ConnectorDeviceAuthGrantMethodsAreSingle = AssertNever<
   ConnectorTypeWithMultipleAuthMethodsForGrantKind<"device-auth">
 >;
 
+type ConnectorAuthMethodIdsByAccessKind<
+  Type extends ConnectorType,
+  Kind extends ConnectorAccessKind,
+> = {
+  [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
+    readonly access: { readonly kind: Kind };
+  }
+    ? Method
+    : never;
+}[ConnectorAuthMethodKeys<Type>];
+
+type ConnectorTypeWithMultipleAuthMethodsForAccessKind<
+  Kind extends ConnectorAccessKind,
+> = {
+  [Type in ConnectorType]: IsUnion<
+    ConnectorAuthMethodIdsByAccessKind<Type, Kind>
+  > extends true
+    ? Type
+    : never;
+}[ConnectorType];
+export type ConnectorRefreshTokenAccessMethodsAreSingle = AssertNever<
+  ConnectorTypeWithMultipleAuthMethodsForAccessKind<"refresh-token">
+>;
+
 export type ConnectorTypesByGrantKind<Kind extends ConnectorGrantKind> = {
   [Type in ConnectorType]: {
     [Method in keyof ConnectorAuthMethodsOf<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -944,6 +944,17 @@ type ConnectorAuthMethodIdsByGrantKind<
     : never;
 }[ConnectorAuthMethodKeys<Type>];
 
+export type ConnectorAuthMethodIdsByAccessKind<
+  Type extends ConnectorType,
+  Kind extends ConnectorAccessKind,
+> = {
+  [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
+    readonly access: { readonly kind: Kind };
+  }
+    ? Method
+    : never;
+}[ConnectorAuthMethodKeys<Type>];
+
 type ConnectorTypeWithMultipleAuthMethodsForGrantKind<
   Kind extends ConnectorGrantKind,
 > = {


### PR DESCRIPTION
## Summary
- split connector refresh-token access providers from grant provider membership
- make connector refresh execution require the selected stored `authMethod`
- resolve connector access/refresh token secret names from selected auth method access metadata
- add method-aware `type -> authMethod -> refresh-token access provider` registration
- bind grant, access, and revoke provider client arg types to their lifecycle-specific provider boundary

Closes #15426

## Follow-ups
- #15435: bind connector revoke providers to selected auth method
- #15436: route manual connector grants by grant config
- #15437: derive auth-code connector entrypoints from grant methods
- #15438: centralize connector lifecycle provider registry

## Tests
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/cli-auth.test.ts src/signals/routes/__tests__/zero-connectors-authorize.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts`
- commit hook: prettier, knip, full `pnpm check-types`
