### PR TITLE
refactor: clean connector oauth naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1202,7 +1202,7 @@ describe("POST /api/agent/runs", () => {
     ).toBeTruthy();
   });
 
-  it("accepts OAuth connector-provided env secrets during compose validation", async () => {
+  it("accepts connector-provided env secrets during compose validation", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
     await db.insert(connectors).values({

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -1859,7 +1859,7 @@ describe("CLI auth routes", () => {
       ).resolves.toBeUndefined();
     });
 
-    it("seeds OAuth connector token state for the test user org", async () => {
+    it("seeds connector token state for the test user org", async () => {
       const userId = trackUser(`user_${randomUUID()}`);
       const orgId = trackOrg(`org_${randomUUID()}`);
       await seedOrgMembership({ orgId, userId, slug: "connector-org" });

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1499,7 +1499,7 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(session?.errorMessage).toContain("GitHub user API failed");
   });
 
-  it("stores a GitHub OAuth connector and completes the CLI session", async () => {
+  it("stores a GitHub connector token connection and completes the CLI session", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
@@ -2173,7 +2173,7 @@ describe("GET /api/connectors/:type/callback", () => {
   });
 
   it.each(providerSuccessCases)(
-    "stores $type OAuth connector data through the API callback route",
+    "stores $type connector token data through the API callback route",
     async (providerCase) => {
       const orgId = `org_${randomUUID()}`;
       const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -983,7 +983,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "github connector auth client not configured",
+        message: "github OAuth not configured",
         code: "INTERNAL_SERVER_ERROR",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -683,7 +683,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(revokeBody).toContain('"access_token":"gh-access-token"');
   });
 
-  it("skips provider revoke for OAuth connectors without revoke support", async () => {
+  it("skips provider revoke for connectors without revoke support", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     orgIds.push(orgId);
@@ -983,7 +983,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "github OAuth not configured",
+        message: "github connector auth client not configured",
         code: "INTERNAL_SERVER_ERROR",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
@@ -268,7 +268,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     });
   });
 
-  it("deletes an OAuth connector row", async () => {
+  it("deletes a connector row", async () => {
     const fixture = await track(seedFixture());
     await seedOAuthConnector(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -286,7 +286,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     await expect(remainingConnectorCount(fixture)).resolves.toBe(0);
   });
 
-  it("deletes OAuth connector secrets", async () => {
+  it("deletes connector token secrets", async () => {
     const fixture = await track(seedFixture());
     await seedSlockOAuthConnectorState(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -706,7 +706,7 @@ describe("OAuth device authorization connector routes", () => {
     expect((await onlySession(session.id)).intervalSeconds).toBe(10);
   });
 
-  it("completes a session through OAuth connector persistence without leaking tokens", async () => {
+  it("completes a session through connector token persistence without leaking tokens", async () => {
     const { userId, orgId } = await setupUser();
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -234,7 +234,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(connector?.authMethods).toStrictEqual(["oauth"]);
   });
 
-  it("shows Base44 as an OAuth connector without a feature switch", async () => {
+  it("shows Base44 as a connector without a feature switch", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
@@ -253,7 +253,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(connector?.authMethods).toStrictEqual(["oauth"]);
   });
 
-  it("shows Slock as an OAuth connector without a feature switch", async () => {
+  it("shows Slock as a connector without a feature switch", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1464,7 +1464,7 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.secretConnectorMetadataMap).toBeNull();
   });
 
-  it("injects authorized OAuth connector secrets and refresh metadata", async () => {
+  it("injects authorized connector token secrets and refresh metadata", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
     const agent = await seedRunnableZeroAgent({
@@ -1549,7 +1549,7 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.billableFirewalls).toContain("x");
   });
 
-  it("maps static OAuth connector env aliases", async () => {
+  it("maps static connector env aliases", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);
     const agent = await seedRunnableZeroAgent({ fixture: fx });
@@ -1864,7 +1864,7 @@ describe("POST /api/zero/runs", () => {
     });
   });
 
-  it("adds the Google Ads developer token for authorized OAuth connector runs", async () => {
+  it("adds the Google Ads developer token for authorized connector runs", async () => {
     mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token");
     const fx = await fixture();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -40,7 +40,7 @@ import {
   testUserOrgId,
   ensureTestOrg$,
 } from "../services/cli-auth.service";
-import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
 import { upsertOrgMultiAuthModelProvider$ } from "../services/zero-model-provider.service";
 import {
   isCodexAuthJsonFreePlanError,
@@ -240,7 +240,7 @@ const createTestConnector$ = command(
       throw new Error(`${grantConnectorType} connector has no auth method`);
     }
     await set(
-      upsertOAuthConnector$,
+      upsertConnectorTokenConnection$,
       {
         orgId,
         userId,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -32,7 +32,7 @@ import {
   getConnectorOAuthStateStatus,
   type StoredOAuthState,
 } from "../services/connector-oauth-state.service";
-import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
 import {
   linkGithubVm0User,
   loadActiveGithubInstallationForOrg,
@@ -106,7 +106,7 @@ type ClaimedCallbackState =
       readonly response: Response;
     };
 
-type ResolvedOAuthConnectorType =
+type ResolvedAuthCodeConnectorType =
   | {
       readonly ok: true;
       readonly connectorType: AuthCodeGrantConnectorType;
@@ -186,7 +186,9 @@ async function exchangeTokenForConnector(args: {
     optionalEnv,
   );
   if (!authClient) {
-    throw new Error(`${args.connectorType} OAuth not configured`);
+    throw new Error(
+      `${args.connectorType} connector auth client not configured`,
+    );
   }
 
   return await exchangeConnectorAuthCode({
@@ -207,10 +209,10 @@ function getRequestedScopes(
   return getConnectorAuthMethodGrantScopes(connectorType, authMethod);
 }
 
-function resolveOAuthConnectorType(
+function resolveAuthCodeConnectorType(
   origin: string,
   type: string,
-): ResolvedOAuthConnectorType {
+): ResolvedAuthCodeConnectorType {
   const typeResult = connectorTypeSchema.safeParse(type);
   if (!typeResult.success) {
     return {
@@ -398,7 +400,7 @@ const completeOAuthCallback$ = command(
     signal.throwIfAborted();
 
     const result = await set(
-      upsertOAuthConnector$,
+      upsertConnectorTokenConnection$,
       {
         orgId: args.identity.orgId,
         userId: args.identity.userId,
@@ -506,7 +508,7 @@ const resolveCallbackState$ = command(
 
 const callbackConnectorInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const params = get(pathParamsOf(connectorsTypeCallbackContract.callback));
+    const { type } = get(pathParamsOf(connectorsTypeCallbackContract.callback));
     const query = get(queryOf(connectorsTypeCallbackContract.callback));
     const request = get(request$).raw;
     const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrl(request);
@@ -515,7 +517,7 @@ const callbackConnectorInner$ = command(
     }
     const origin = getConnectorOAuthOrigin(request);
 
-    const connectorTypeResult = resolveOAuthConnectorType(origin, params.type);
+    const connectorTypeResult = resolveAuthCodeConnectorType(origin, type);
     if (!connectorTypeResult.ok) {
       return connectorTypeResult.response;
     }
@@ -534,7 +536,7 @@ const callbackConnectorInner$ = command(
       db: writeDb,
       connectorType,
       origin,
-      type: params.type,
+      type,
       signal,
     };
 
@@ -551,7 +553,7 @@ const callbackConnectorInner$ = command(
       }
       return redirectWithError(
         origin,
-        params.type,
+        type,
         query.error_description || query.error || "OAuth authorization failed",
         true,
       );
@@ -570,11 +572,11 @@ const callbackConnectorInner$ = command(
           return invalidStateResponse;
         }
       }
-      return missingAuthorizationCodeRedirectResponse(origin, params.type);
+      return missingAuthorizationCodeRedirectResponse(origin, type);
     }
 
     if (!state) {
-      return missingStateRedirectResponse(origin, params.type);
+      return missingStateRedirectResponse(origin, type);
     }
 
     const claimedState = await claimStoredOAuthStateForCallback({
@@ -590,7 +592,7 @@ const callbackConnectorInner$ = command(
       resolveCallbackState$,
       {
         origin,
-        type: params.type,
+        type,
         savedState,
         state,
         sessionId,
@@ -619,7 +621,7 @@ const callbackConnectorInner$ = command(
           identity: resolvedState.identity,
           sessionId: resolvedState.sessionId,
           origin,
-          type: params.type,
+          type,
         },
         signal,
       ),
@@ -638,7 +640,7 @@ const callbackConnectorInner$ = command(
     );
     return redirectWithError(
       origin,
-      params.type,
+      type,
       "OAuth authorization failed. Please try again.",
       true,
     );

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -186,9 +186,7 @@ async function exchangeTokenForConnector(args: {
     optionalEnv,
   );
   if (!authClient) {
-    throw new Error(
-      `${args.connectorType} connector auth client not configured`,
-    );
+    throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
   return await exchangeConnectorAuthCode({

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -5,8 +5,8 @@ import {
 } from "@vm0/api-contracts/contracts/github-oauth";
 import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import {
+  getConnectorAuthMethodGrantScopes,
   resolveConnectorAuthClientForMethod,
-  getConnectorOAuthScopes,
   isStaticConfidentialConnectorAuthClient,
   type StaticConfidentialConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
@@ -43,7 +43,7 @@ import {
   verifyGithubConnectSignature,
 } from "../services/github-oauth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
-import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
 import { settle } from "../utils";
 import type { RouteEntry } from "../route";
 import {
@@ -53,6 +53,7 @@ import {
 
 const REDIRECT_STATUS = 307;
 const GITHUB_CONNECTOR_TYPE = "github" satisfies AuthCodeGrantConnectorType;
+const GITHUB_CONNECTOR_AUTH_METHOD = "oauth";
 const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
 const L = logger("GithubOAuthRoute");
 
@@ -89,8 +90,8 @@ function githubUserOauthClient():
   | StaticConfidentialConnectorAuthClient
   | undefined {
   const authClient = resolveConnectorAuthClientForMethod(
-    "github",
-    "oauth",
+    GITHUB_CONNECTOR_TYPE,
+    GITHUB_CONNECTOR_AUTH_METHOD,
     optionalEnv,
   );
   if (!authClient) {
@@ -380,18 +381,21 @@ const connectGithubUserAfterSetup$ = command(
       });
 
       await set(
-        upsertOAuthConnector$,
+        upsertConnectorTokenConnection$,
         {
           orgId: args.orgId,
           userId: vm0UserId,
-          type: "github",
-          authMethod: "oauth",
+          type: GITHUB_CONNECTOR_TYPE,
+          authMethod: GITHUB_CONNECTOR_AUTH_METHOD,
           accessToken,
           userInfo,
           oauthScopes:
             scopes.length > 0
               ? scopes
-              : getConnectorOAuthScopes(GITHUB_CONNECTOR_TYPE),
+              : getConnectorAuthMethodGrantScopes(
+                  GITHUB_CONNECTOR_TYPE,
+                  GITHUB_CONNECTOR_AUTH_METHOD,
+                ),
         },
         signal,
       );
@@ -760,15 +764,18 @@ const callbackGithubUserOauth$ = command(
     }
 
     await set(
-      upsertOAuthConnector$,
+      upsertConnectorTokenConnection$,
       {
         orgId: state.orgId,
         userId: state.vm0UserId,
-        type: "github",
-        authMethod: "oauth",
+        type: GITHUB_CONNECTOR_TYPE,
+        authMethod: GITHUB_CONNECTOR_AUTH_METHOD,
         accessToken: token.accessToken,
         userInfo: token.userInfo,
-        oauthScopes: getConnectorOAuthScopes(GITHUB_CONNECTOR_TYPE),
+        oauthScopes: getConnectorAuthMethodGrantScopes(
+          GITHUB_CONNECTOR_TYPE,
+          GITHUB_CONNECTOR_AUTH_METHOD,
+        ),
         extraConnectorSecrets: token.extraConnectorSecrets,
       },
       signal,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -389,10 +389,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {
-      return jsonResponse(
-        { error: `${type} connector auth client not configured` },
-        500,
-      );
+      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
@@ -464,9 +461,7 @@ const startConnectorOauthInner$ = command(
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {
-      return internalServerError(
-        `${type} connector auth client not configured`,
-      );
+      return internalServerError(`${type} OAuth not configured`);
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -389,7 +389,10 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {
-      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
+      return jsonResponse(
+        { error: `${type} connector auth client not configured` },
+        500,
+      );
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
@@ -461,7 +464,9 @@ const startConnectorOauthInner$ = command(
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {
-      return internalServerError(`${type} OAuth not configured`);
+      return internalServerError(
+        `${type} connector auth client not configured`,
+      );
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -71,7 +71,7 @@ describe("zeroConnectorList", () => {
     expect(list.connectorProvidedEnvNames).not.toContain("OPENAI_TOKEN");
   });
 
-  it("returns OAuth connector env names only when the access secret exists", async () => {
+  it("returns connector token env names only when the access secret exists", async () => {
     const orgId = `org_${randomUUID()}`;
     const userWithoutSecret = `user_${randomUUID()}`;
     const userWithSecret = `user_${randomUUID()}`;
@@ -168,7 +168,7 @@ describe("zeroConnectorList", () => {
     expect(list.configuredTypes).toContain("amplitude");
   });
 
-  it("keeps a stored oauth connector visible when another auth method is ungated", async () => {
+  it("keeps a stored connector auth-provider connection visible when another auth method is ungated", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -590,7 +590,7 @@ async function completeSessionResponse(args: {
   const connector = await args.connectorLoader();
   args.signal.throwIfAborted();
   if (!connector) {
-    throw new Error("Completed connector not found");
+    throw new Error("Completed OAuth connector not found");
   }
   return { status: 200, body: { status: "complete", connector } };
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -41,7 +41,7 @@ import {
 } from "./crypto.utils";
 import { userConnectorAvailability } from "./connector-availability.service";
 import {
-  upsertOAuthConnector$,
+  upsertConnectorTokenConnection$,
   zeroConnectorByType,
 } from "./zero-connector-data.service";
 
@@ -590,7 +590,7 @@ async function completeSessionResponse(args: {
   const connector = await args.connectorLoader();
   args.signal.throwIfAborted();
   if (!connector) {
-    throw new Error("Completed OAuth connector not found");
+    throw new Error("Completed connector not found");
   }
   return { status: 200, body: { status: "complete", connector } };
 }
@@ -910,7 +910,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       signal,
       persistConnector: async ({ result }) => {
         const connectorResult = await set(
-          upsertOAuthConnector$,
+          upsertConnectorTokenConnection$,
           {
             orgId: args.orgId,
             userId: args.userId,

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,4 +1,4 @@
-import type { ConnectorAuthProviderType } from "@vm0/connectors/connectors";
+import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
@@ -21,7 +21,7 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: ConnectorAuthProviderType;
+    readonly connectorType: AuthCodeGrantConnectorType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
@@ -55,7 +55,7 @@ export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: ConnectorAuthProviderType;
+    readonly connectorType: AuthCodeGrantConnectorType;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateClaimResult> {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -119,7 +119,7 @@ interface OmittedApiTokenFieldNames {
   readonly omittedVariableNames: readonly string[];
 }
 
-interface EncryptedOAuthConnectorSecret {
+interface EncryptedConnectorTokenSecret {
   readonly name: string;
   readonly encryptedValue: string;
   readonly description: string;
@@ -1119,12 +1119,12 @@ export const connectApiTokenConnector$ = command(
   },
 );
 
-async function encryptedOAuthConnectorSecret(args: {
+async function encryptedConnectorTokenSecret(args: {
   readonly name: string;
   readonly value: string;
   readonly description: string;
   readonly featureSwitchContext: FeatureSwitchContext;
-}): Promise<EncryptedOAuthConnectorSecret> {
+}): Promise<EncryptedConnectorTokenSecret> {
   return {
     name: args.name,
     encryptedValue: await encryptStoredSecretValue(
@@ -1238,14 +1238,14 @@ function connectorTokenSecretMetadataForAuthMethod(args: {
   }
 }
 
-function allowedOAuthConnectorSecretNames(
+function allowedConnectorTokenSecretNames(
   type: ConnectorAuthProviderType,
   authMethod: ConnectorAuthMethodId,
 ): Set<string> {
   return new Set(getConnectorSecretNames(type, authMethod));
 }
 
-function isOAuthPrimaryTokenSecret(args: {
+function isPrimaryConnectorTokenSecret(args: {
   readonly name: string;
   readonly accessSecretName: string;
   readonly refreshSecretName: string | undefined;
@@ -1255,7 +1255,7 @@ function isOAuthPrimaryTokenSecret(args: {
   );
 }
 
-function validateExtraOAuthConnectorSecrets(args: {
+function validateExtraConnectorTokenSecrets(args: {
   readonly type: ConnectorAuthProviderType;
   readonly authMethod: ConnectorAuthMethodId;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
@@ -1267,25 +1267,25 @@ function validateExtraOAuthConnectorSecrets(args: {
     return [];
   }
 
-  const allowedSecretNames = allowedOAuthConnectorSecretNames(
+  const allowedSecretNames = allowedConnectorTokenSecretNames(
     args.type,
     args.authMethod,
   );
   for (const [name] of extraSecrets) {
     if (
-      isOAuthPrimaryTokenSecret({
+      isPrimaryConnectorTokenSecret({
         name,
         accessSecretName: args.accessSecretName,
         refreshSecretName: args.refreshSecretName,
       })
     ) {
       throw new Error(
-        `${args.type} OAuth provider returned primary token ${name} in extra connector secrets`,
+        `${args.type} connector provider returned primary token ${name} in extra connector secrets`,
       );
     }
     if (!allowedSecretNames.has(name)) {
       throw new Error(
-        `${args.type} OAuth provider returned unsupported connector secret ${name}`,
+        `${args.type} connector provider returned unsupported connector secret ${name}`,
       );
     }
   }
@@ -1293,19 +1293,19 @@ function validateExtraOAuthConnectorSecrets(args: {
   return extraSecrets;
 }
 
-async function encryptExtraOAuthConnectorSecrets(args: {
+async function encryptExtraConnectorTokenSecrets(args: {
   readonly type: ConnectorAuthProviderType;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
-}): Promise<readonly EncryptedOAuthConnectorSecret[]> {
-  const encryptedSecrets: EncryptedOAuthConnectorSecret[] = [];
+}): Promise<readonly EncryptedConnectorTokenSecret[]> {
+  const encryptedSecrets: EncryptedConnectorTokenSecret[] = [];
   for (const [name, value] of args.extraSecrets) {
     encryptedSecrets.push(
-      await encryptedOAuthConnectorSecret({
+      await encryptedConnectorTokenSecret({
         name,
         value,
-        description: `OAuth connector secret for ${args.type}: ${name}`,
+        description: `Connector token secret for ${args.type}: ${name}`,
         featureSwitchContext: args.featureSwitchContext,
       }),
     );
@@ -1314,7 +1314,7 @@ async function encryptExtraOAuthConnectorSecrets(args: {
   return encryptedSecrets;
 }
 
-async function encryptOAuthConnectorSecretSet(args: {
+async function encryptConnectorTokenSecretSet(args: {
   readonly type: ConnectorAuthProviderType;
   readonly accessSecretName: string;
   readonly accessToken: string;
@@ -1323,45 +1323,45 @@ async function encryptOAuthConnectorSecretSet(args: {
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
-}): Promise<readonly EncryptedOAuthConnectorSecret[]> {
-  const encryptedOAuthSecrets: EncryptedOAuthConnectorSecret[] = [
-    await encryptedOAuthConnectorSecret({
+}): Promise<readonly EncryptedConnectorTokenSecret[]> {
+  const encryptedConnectorTokenSecrets: EncryptedConnectorTokenSecret[] = [
+    await encryptedConnectorTokenSecret({
       name: args.accessSecretName,
       value: args.accessToken,
-      description: `OAuth token for ${args.type} connector`,
+      description: `Connector access token for ${args.type}`,
       featureSwitchContext: args.featureSwitchContext,
     }),
   ];
   args.signal.throwIfAborted();
 
   if (args.refreshToken && args.refreshSecretName) {
-    encryptedOAuthSecrets.push(
-      await encryptedOAuthConnectorSecret({
+    encryptedConnectorTokenSecrets.push(
+      await encryptedConnectorTokenSecret({
         name: args.refreshSecretName,
         value: args.refreshToken,
-        description: `OAuth refresh token for ${args.type} connector`,
+        description: `Connector refresh token for ${args.type}`,
         featureSwitchContext: args.featureSwitchContext,
       }),
     );
     args.signal.throwIfAborted();
   }
 
-  encryptedOAuthSecrets.push(
-    ...(await encryptExtraOAuthConnectorSecrets({
+  encryptedConnectorTokenSecrets.push(
+    ...(await encryptExtraConnectorTokenSecrets({
       type: args.type,
       extraSecrets: args.extraSecrets,
       featureSwitchContext: args.featureSwitchContext,
       signal: args.signal,
     })),
   );
-  return encryptedOAuthSecrets;
+  return encryptedConnectorTokenSecrets;
 }
 
-async function upsertOAuthConnectorSecrets(args: {
+async function upsertConnectorTokenSecrets(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly secrets: readonly EncryptedOAuthConnectorSecret[];
+  readonly secrets: readonly EncryptedConnectorTokenSecret[];
   readonly signal: AbortSignal;
 }): Promise<void> {
   if (args.secrets.length === 0) {
@@ -1404,7 +1404,7 @@ async function loadExistingConnectorAuthMethod(
   return existingConnector?.authMethod ?? null;
 }
 
-async function upsertOAuthConnectorRow(
+async function upsertConnectorTokenConnectionRow(
   db: Db,
   args: {
     readonly orgId: string;
@@ -1464,7 +1464,7 @@ async function upsertOAuthConnectorRow(
   return connectorRow;
 }
 
-async function deleteObsoleteConnectorScopedStateForOAuthConnect(
+async function deleteObsoleteConnectorScopedStateForTokenConnect(
   db: Db,
   args: {
     readonly orgId: string;
@@ -1511,7 +1511,7 @@ async function deleteObsoleteConnectorScopedStateForOAuthConnect(
   });
 }
 
-export const upsertOAuthConnector$ = command(
+export const upsertConnectorTokenConnection$ = command(
   async (
     { get, set },
     args: {
@@ -1545,7 +1545,7 @@ export const upsertOAuthConnector$ = command(
       isRefreshable: secretMetadata.isRefreshable,
       expiresIn: args.expiresIn,
     });
-    const extraSecrets = validateExtraOAuthConnectorSecrets({
+    const extraSecrets = validateExtraConnectorTokenSecrets({
       type: args.type,
       authMethod: args.authMethod,
       extraConnectorSecrets: args.extraConnectorSecrets,
@@ -1557,16 +1557,18 @@ export const upsertOAuthConnector$ = command(
     );
     signal.throwIfAborted();
 
-    const encryptedOAuthSecrets = await encryptOAuthConnectorSecretSet({
-      type: args.type,
-      accessSecretName: secretMetadata.accessSecretName,
-      accessToken: args.accessToken,
-      refreshSecretName: secretMetadata.refreshSecretName,
-      refreshToken: args.refreshToken,
-      extraSecrets,
-      featureSwitchContext,
-      signal,
-    });
+    const encryptedConnectorTokenSecrets = await encryptConnectorTokenSecretSet(
+      {
+        type: args.type,
+        accessSecretName: secretMetadata.accessSecretName,
+        accessToken: args.accessToken,
+        refreshSecretName: secretMetadata.refreshSecretName,
+        refreshToken: args.refreshToken,
+        extraSecrets,
+        featureSwitchContext,
+        signal,
+      },
+    );
     signal.throwIfAborted();
 
     const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
@@ -1586,16 +1588,16 @@ export const upsertOAuthConnector$ = command(
         signal,
       });
 
-      await upsertOAuthConnectorSecrets({
+      await upsertConnectorTokenSecrets({
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
-        secrets: encryptedOAuthSecrets,
+        secrets: encryptedConnectorTokenSecrets,
         signal,
       });
       signal.throwIfAborted();
 
-      const row = await upsertOAuthConnectorRow(tx, {
+      const row = await upsertConnectorTokenConnectionRow(tx, {
         orgId: args.orgId,
         userId: args.userId,
         type: args.type,
@@ -1606,7 +1608,7 @@ export const upsertOAuthConnector$ = command(
         signal,
       });
 
-      await deleteObsoleteConnectorScopedStateForOAuthConnect(tx, {
+      await deleteObsoleteConnectorScopedStateForTokenConnect(tx, {
         orgId: args.orgId,
         userId: args.userId,
         type: args.type,

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -449,7 +449,7 @@ describe("connectConnectorOAuthAuthCode$", () => {
     expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 
-  it("rejects device-auth OAuth connectors before opening popup or starting auth-code OAuth", async () => {
+  it("rejects device-auth connectors before opening popup or starting auth-code flow", async () => {
     detachedSetupPage({
       context,
       path: "/",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -44,7 +44,7 @@ import {
   getConnectorDeviceAuthGrantConfig,
   getConnectorTypeForSecretName,
   getConnectorEnvBindings,
-  getConnectorOAuthScopes,
+  getConnectorGrantScopes,
   getConnectorManualGrantFieldNames,
   getRuntimeAvailableConnectorTypes,
   getConnectorSecretNames,
@@ -227,7 +227,7 @@ type ConnectorConfigAuthMethodIds<Config extends ConnectorConfig> = Extract<
 >;
 
 describe("hasRequiredScopes", () => {
-  it("returns true for non-OAuth connector type", () => {
+  it("returns true for connector type without grant scopes", () => {
     expect(hasRequiredScopes("cloudinary", null)).toBe(true);
     expect(
       hasRequiredConnectorAuthMethodScopes("cloudinary", "api-token", null),
@@ -505,7 +505,7 @@ describe("connector provider capability checks", () => {
     });
   });
 
-  it("does not expose refresh-token access providers for non-refreshable OAuth connectors", () => {
+  it("does not expose refresh-token access providers for non-refreshable auth methods", () => {
     expect(hasConnectorRefreshTokenAccessProvider("github")).toBe(false);
     expect(
       getConnectorAuthMethodAccessMetadata("github", "oauth")?.kind,
@@ -569,7 +569,7 @@ describe("connector provider capability checks", () => {
     expect(body).toBe(JSON.stringify({ access_token: "gh-access-token" }));
   });
 
-  it("returns unsupported for OAuth connectors without revoke support", async () => {
+  it("returns unsupported for connectors without revoke support", async () => {
     const oauthClient = getOauthAuthClient("notion", (name) => {
       if (name === "NOTION_OAUTH_CLIENT_ID") {
         return "test-notion-client";
@@ -1606,10 +1606,10 @@ describe("getConnectorEnvBindings", () => {
     expect(firewall.apis[0]?.permissions).toStrictEqual([]);
   });
 
-  it("OAuth connectors have consistent secrets and envBindings naming", () => {
+  it("authorization-grant auth methods have consistent secrets and envBindings naming", () => {
     // All naming derives from a single prefix XXX:
     //   oauth secrets:      XXX_ACCESS_TOKEN (required), XXX_REFRESH_TOKEN (optional)
-    //   envBindings: values -> declared OAuth connector secrets
+    //   envBindings: values -> declared connector secrets
     //   api-token secrets:  XXX_TOKEN (if api-token auth method exists)
     for (const type of connectorTypeSchema.options) {
       if (!hasConnectorAuthorizationGrant(type)) continue;
@@ -1766,7 +1766,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(runtimeAvailableTypes).toContain("test-oauth-device");
   });
 
-  it("includes OAuth connectors only when client id and secret are configured", () => {
+  it("includes auth-code connectors only when client id and secret are configured", () => {
     const env = new Map([
       ["AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id"],
       ["AIRTABLE_OAUTH_CLIENT_SECRET", "airtable-client-secret"],
@@ -1901,7 +1901,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     );
   });
 
-  it("includes active OAuth connectors when their runtime env is configured", () => {
+  it("includes active authorization-grant connectors when their runtime env is configured", () => {
     const activeOAuthTypes = connectorTypeSchema.options.filter(
       hasConnectorAuthorizationGrant,
     );
@@ -1931,10 +1931,10 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 });
 
-describe("getConnectorOAuthScopes - google-meet scopes", () => {
+describe("getConnectorGrantScopes - google-meet scopes", () => {
   it("uses meetings.space.readonly for google meet oauth scopes", () => {
     const grant = getConnectorAuthCodeGrantConfig("google-meet");
-    const scopes = getConnectorOAuthScopes("google-meet");
+    const scopes = getConnectorGrantScopes("google-meet");
     expect(scopes).toStrictEqual(grant?.scopes);
     expect(scopes).toContain(
       "https://www.googleapis.com/auth/meetings.space.readonly",
@@ -1944,7 +1944,7 @@ describe("getConnectorOAuthScopes - google-meet scopes", () => {
     );
 
     scopes.push("test-mutated-scope");
-    expect(getConnectorOAuthScopes("google-meet")).not.toContain(
+    expect(getConnectorGrantScopes("google-meet")).not.toContain(
       "test-mutated-scope",
     );
   });
@@ -1976,7 +1976,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
     });
   });
 
-  it("returns device-auth grant config for device OAuth connectors", () => {
+  it("returns device-auth grant config for device-auth connectors", () => {
     expectTypeOf(
       getConnectorDeviceAuthGrantConfig("test-oauth-device"),
     ).toEqualTypeOf<ConnectorDeviceAuthGrantConfig>();
@@ -2022,16 +2022,16 @@ describe("connector OAuth lifecycle grant helpers", () => {
     });
   });
 
-  it("returns undefined for connectors without OAuth grants", () => {
+  it("returns undefined for connectors without authorization grants", () => {
     expect(hasConnectorAuthorizationGrant("axiom")).toBe(false);
-    expect(getConnectorOAuthScopes("axiom")).toStrictEqual([]);
+    expect(getConnectorGrantScopes("axiom")).toStrictEqual([]);
     expect(getConnectorAuthCodeGrantConfig("base44")).toBeUndefined();
     expect(getConnectorDeviceAuthGrantConfig("github")).toBeUndefined();
   });
 });
 
-describe("connector OAuth authorization-code config", () => {
-  it("declares the current auth-code OAuth connectors with auth-code grants", () => {
+describe("connector authorization-code grant config", () => {
+  it("declares the current auth-code grant connectors with auth-code grants", () => {
     for (const type of connectorTypeSchema.options) {
       if (!hasConnectorAuthCodeGrant(type)) {
         continue;

--- a/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
@@ -160,7 +160,7 @@ function connectorPlaceholderKeys(connectorType: ConnectorType): Set<string> {
  * Verify that every builtin firewall's placeholder names match the
  * secret-backed environment names exposed by the connector that references it.
  *
- * OAuth connectors expose environment names via derived env bindings (e.g. SLACK_TOKEN).
+ * Connector auth-provider methods expose environment names via derived env bindings (e.g. SLACK_TOKEN).
  * API-token connectors expose manual grant fields.
  * The firewall's `placeholders` keys must be a subset of these secret names,
  * otherwise the proxy won't find the secret to inject.

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -217,14 +217,14 @@ function authMethodAccessPriority(method: ConnectorAuthMethodConfig): number {
   }
 }
 
-type ConnectorGrantConfigWithScopes =
+type ConnectorScopeBearingGrantConfig =
   | ConnectorAuthCodeGrantConfig
   | ConnectorDeviceAuthGrantConfig;
 
-function isConnectorGrantConfigWithScopes(
+function isConnectorScopeBearingGrantConfig(
   method: ConnectorAuthMethodConfig,
 ): method is ConnectorAuthMethodConfig & {
-  readonly grant: ConnectorGrantConfigWithScopes;
+  readonly grant: ConnectorScopeBearingGrantConfig;
 } {
   switch (method.grant.kind) {
     case "auth-code":
@@ -236,17 +236,17 @@ function isConnectorGrantConfigWithScopes(
   }
 }
 
-function getConnectorOAuthGrantConfig(
+function getConnectorScopeBearingGrantConfig(
   type: ConnectorAuthProviderType,
-): ConnectorGrantConfigWithScopes;
-function getConnectorOAuthGrantConfig(
+): ConnectorScopeBearingGrantConfig;
+function getConnectorScopeBearingGrantConfig(
   type: ConnectorType,
-): ConnectorGrantConfigWithScopes | undefined;
-function getConnectorOAuthGrantConfig(
+): ConnectorScopeBearingGrantConfig | undefined;
+function getConnectorScopeBearingGrantConfig(
   type: ConnectorType,
-): ConnectorGrantConfigWithScopes | undefined {
+): ConnectorScopeBearingGrantConfig | undefined {
   for (const method of connectorAuthMethodValues(type)) {
-    if (isConnectorGrantConfigWithScopes(method)) {
+    if (isConnectorScopeBearingGrantConfig(method)) {
       return method.grant;
     }
   }
@@ -320,8 +320,8 @@ export function getConnectorDeviceAuthGrantConfig(
   return undefined;
 }
 
-export function getConnectorOAuthScopes(type: ConnectorType): string[] {
-  return [...connectorGrantScopes(getConnectorOAuthGrantConfig(type))];
+export function getConnectorGrantScopes(type: ConnectorType): string[] {
+  return [...connectorGrantScopes(getConnectorScopeBearingGrantConfig(type))];
 }
 
 export function getConnectorAuthMethodGrantScopes(
@@ -807,7 +807,7 @@ export function hasRequiredScopes(
   storedScopes: string[] | null,
 ): boolean {
   return hasRequiredGrantScopes(
-    getConnectorOAuthScopes(connectorType),
+    getConnectorGrantScopes(connectorType),
     storedScopes,
   );
 }
@@ -831,7 +831,7 @@ export function getScopeDiff(
   connectorType: ConnectorType,
   storedScopes: string[] | null,
 ): ScopeDiff {
-  return scopeDiff(getConnectorOAuthScopes(connectorType), storedScopes);
+  return scopeDiff(getConnectorGrantScopes(connectorType), storedScopes);
 }
 
 export function getConnectorAuthMethodScopeDiff(


### PR DESCRIPTION
## Summary

- rename upper-layer connector OAuth helpers to grant/auth-code/token terminology
- use method-aware GitHub grant scopes where the selected auth method is known
- narrow connector OAuth state service inputs to auth-code grant connector types
- refresh test descriptions that used OAuth as a connector category

Closes #15427

## Tests

- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts src/__tests__/firewall-secret-consistency.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/cli-auth.test.ts src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts
- pre-commit: pnpm knip, pnpm check-types
