### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -116,7 +116,7 @@ CODEX_CLI_VERSION="0.135.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.0"
-PNPM_VERSION="11.4.0"
+PNPM_VERSION="11.5.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Updates pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`.

Updated packages:
- `pnpm`: `11.4.0` -> `11.5.0`

Checked and left unchanged because they are already current or on the intended LTS line:
- Go: `1.26.3`
- Claude Code CLI: `2.1.156`
- OpenAI Codex CLI: `0.135.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- agent-browser: `0.27.0`
- NodeSource Node.js line: `24.x` (current LTS major)

## Verification

- Compared pinned versions against upstream Go release metadata, npm package metadata, Node.js LTS metadata, and NodeSource `node_24.x` package metadata.