### PR TITLE
docs: document connector response parser lifecycle

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -8,9 +8,10 @@ billable by the web layer, firewall has a registered handler) and
 delegates to the matching per-connector ``report_usage`` function.
 
 Adding a new billable connector = add a new file here + register it in
-:data:`_HANDLERS`. Connectors that need incremental response-body parsing
-also register a parser factory in :data:`_RESPONSE_PARSER_FACTORIES`.
-The dispatcher already enforces the cross-connector invariants.
+:data:`_HANDLERS`. Connectors that need incremental response-body usage
+extraction also register a parser factory in
+:data:`_RESPONSE_PARSER_FACTORIES`. The dispatcher already enforces the
+cross-connector invariants.
 """
 
 from collections.abc import Callable
@@ -35,6 +36,9 @@ _HANDLERS: dict[str, Callable[[http.HTTPFlow, str], None]] = {
 
 _ResponseParserFactory = Callable[[http.HTTPFlow], ConnectorResponseParser | None]
 
+# Response parser factories are consulted at response-header time for billable
+# connector flows that need streamed response-body state before final usage
+# reporting. A factory returns None when the specific flow needs no parser.
 _RESPONSE_PARSER_FACTORIES: dict[str, _ResponseParserFactory] = {
     "x": x.create_response_parser,
 }
@@ -87,7 +91,11 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
 
 
 def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
-    """Create the connector-specific response parser for this flow, if registered."""
+    """Create the connector-specific response parser for this flow, if registered.
+
+    The returned parser is wired into the response stream and may publish
+    connector-owned ``flow.metadata`` state for ``report_connector_usage``.
+    """
     firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
     factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
     if factory is None:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -36,9 +36,10 @@ _HANDLERS: dict[str, Callable[[http.HTTPFlow, str], None]] = {
 
 _ResponseParserFactory = Callable[[http.HTTPFlow], ConnectorResponseParser | None]
 
-# Response parser factories are consulted at response-header time for billable
-# connector flows that need streamed response-body state before final usage
-# reporting. A factory returns None when the specific flow needs no parser.
+# Response parser factories are consulted at response-header time for registered
+# connector firewall flows that may need streamed response-body state before
+# final usage reporting. A factory returns None when the specific flow needs no
+# parser.
 _RESPONSE_PARSER_FACTORIES: dict[str, _ResponseParserFactory] = {
     "x": x.create_response_parser,
 }

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -5,7 +5,30 @@ from typing import NamedTuple
 
 
 class ConnectorResponseParser(NamedTuple):
-    """Incremental parser hooks for connector response bodies."""
+    """Incremental parser hooks for connector response-body usage extraction.
+
+    Connector parser factories registered in ``_RESPONSE_PARSER_FACTORIES``
+    return this value when a connector flow needs response-body parsing for
+    billable usage extraction. The response streaming layer wires ``feed`` into
+    the stream callback for that flow.
+
+    ``feed`` receives each streamed response-body chunk. For supported
+    ``Content-Encoding`` values (``gzip``, ``deflate``, ``br``, and ``zstd``),
+    the stream wrapper passes decompressed bytes to ``feed``. With no encoding,
+    ``identity``, or an unsupported encoding, the original chunk bytes are
+    passed through unchanged. Implementations must treat ``b""`` as a no-op:
+    incremental decompressors may produce no output for a source chunk, and
+    decompression failures intentionally suppress later parser input.
+
+    ``finish`` is optional. When provided, normal completed-response
+    finalization calls it once after streaming has fed all chunks and before
+    ``report_connector_usage`` consumes connector metadata. It should publish
+    final parser state to connector-owned ``flow.metadata`` keys through the
+    closure created by the connector parser factory. Cleanup and connection
+    error paths can release unfinished parser state without finalizing it, so
+    parser correctness must not rely on ``finish`` running for every interrupted
+    response.
+    """
 
     feed: Callable[[bytes], None]
     finish: Callable[[], None] | None = None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -9,7 +9,7 @@ class ConnectorResponseParser(NamedTuple):
 
     Connector parser factories registered in ``_RESPONSE_PARSER_FACTORIES``
     return this value when a connector flow needs response-body parsing for
-    billable usage extraction. The response streaming layer wires ``feed`` into
+    connector usage extraction. The response streaming layer wires ``feed`` into
     the stream callback for that flow.
 
     ``feed`` receives each streamed response-body chunk. For supported


### PR DESCRIPTION
## Summary

- Document the `ConnectorResponseParser` streaming lifecycle for billable connector usage extraction.
- Clarify when `feed` receives decompressed bytes, when it can receive empty chunks, and what `finish` should publish.
- Clarify the `_RESPONSE_PARSER_FACTORIES` registration point for connector response parsers.

Closes #15442

## Tests

- `/tmp/vm0-mitm-addon-venv/bin/ruff check .`
- `/tmp/vm0-mitm-addon-venv/bin/ruff format --check .`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_response_streaming.py tests/test_connector_usage.py -q`
- `git diff --check`
