### PR TITLE
refactor: retire connector auth provider secret metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 
 import type {
   AuthCodeGrantConnectorType,
+  ConnectorAuthMethodId,
   ConnectorAuthClientConfig,
 } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthMethod,
   getConnectorAuthMethodAccessMetadata,
+  getConnectorAuthMethodIdForGrantKind,
 } from "@vm0/connectors/connector-utils";
 import { testOauthProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -1034,10 +1036,21 @@ function staticAccessSecretName(
   return secretNames.size === 1 ? [...secretNames][0] : undefined;
 }
 
-function accessTokenSecretNameForOAuthMethod(
+function authCodeAuthMethodForTest(
   type: AuthCodeGrantConnectorType,
+): ConnectorAuthMethodId {
+  const authMethod = getConnectorAuthMethodIdForGrantKind(type, "auth-code");
+  if (!authMethod) {
+    throw new Error(`${type}: auth-code auth method is missing`);
+  }
+  return authMethod;
+}
+
+function accessTokenSecretNameForAuthCodeMethod(
+  type: AuthCodeGrantConnectorType,
+  authMethod: ConnectorAuthMethodId,
 ): string {
-  const accessMetadata = getConnectorAuthMethodAccessMetadata(type, "oauth");
+  const accessMetadata = getConnectorAuthMethodAccessMetadata(type, authMethod);
   switch (accessMetadata?.kind) {
     case "refresh-token": {
       return accessMetadata.accessToken;
@@ -1046,22 +1059,23 @@ function accessTokenSecretNameForOAuthMethod(
       const secretName = staticAccessSecretName(accessMetadata.envBindings);
       if (!secretName) {
         throw new Error(
-          `${type}: OAuth auth method has no static access secret`,
+          `${type}: auth-code auth method has no static access secret`,
         );
       }
       return secretName;
     }
     case "none":
     case undefined: {
-      throw new Error(`${type}: OAuth auth method has no access secret`);
+      throw new Error(`${type}: auth-code auth method has no access secret`);
     }
   }
 }
 
-function refreshTokenSecretNameForOAuthMethod(
+function refreshTokenSecretNameForAuthCodeMethod(
   type: AuthCodeGrantConnectorType,
+  authMethod: ConnectorAuthMethodId,
 ): string | undefined {
-  const accessMetadata = getConnectorAuthMethodAccessMetadata(type, "oauth");
+  const accessMetadata = getConnectorAuthMethodAccessMetadata(type, authMethod);
   return accessMetadata?.kind === "refresh-token"
     ? accessMetadata.refreshToken
     : undefined;
@@ -2261,17 +2275,19 @@ describe("GET /api/connectors/:type/callback", () => {
         userId,
         type: providerCase.type,
       });
+      const authMethod = authCodeAuthMethodForTest(providerCase.type);
       expect(connector).toMatchObject({
         type: providerCase.type,
-        authMethod: "oauth",
+        authMethod,
         externalId: providerCase.externalId,
         externalUsername: providerCase.externalUsername,
         externalEmail: providerCase.externalEmail,
         needsReconnect: false,
       });
 
-      const accessTokenSecretName = accessTokenSecretNameForOAuthMethod(
+      const accessTokenSecretName = accessTokenSecretNameForAuthCodeMethod(
         providerCase.type,
+        authMethod,
       );
       await expect(
         findDecryptedSecret({
@@ -2281,8 +2297,9 @@ describe("GET /api/connectors/:type/callback", () => {
         }),
       ).resolves.toBe(accessToken);
 
-      const refreshTokenSecretName = refreshTokenSecretNameForOAuthMethod(
+      const refreshTokenSecretName = refreshTokenSecretNameForAuthCodeMethod(
         providerCase.type,
+        authMethod,
       );
       if (refreshTokenSecretName) {
         await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -4,8 +4,10 @@ import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthClientConfig,
 } from "@vm0/connectors/connectors";
-import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
-import { getConnectorAuthProviderSecretMetadata } from "@vm0/connectors/auth-providers";
+import {
+  getConnectorAuthMethod,
+  getConnectorAuthMethodAccessMetadata,
+} from "@vm0/connectors/connector-utils";
 import { testOauthProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
@@ -33,6 +35,7 @@ const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 const BASE_URL = "https://app.vm0.test";
+const SECRET_REF_PREFIX = "$secrets.";
 const API_ORIGIN = "https://api.vm0.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -1017,6 +1020,51 @@ async function findDecryptedSecret(args: {
 }): Promise<string | undefined> {
   const secret = await findSecret(args);
   return secret ? decryptSecretForTests(secret.encryptedValue) : undefined;
+}
+
+function staticAccessSecretName(
+  envBindings: Readonly<Record<string, string>>,
+): string | undefined {
+  const secretNames = new Set<string>();
+  for (const valueRef of Object.values(envBindings)) {
+    if (valueRef.startsWith(SECRET_REF_PREFIX)) {
+      secretNames.add(valueRef.slice(SECRET_REF_PREFIX.length));
+    }
+  }
+  return secretNames.size === 1 ? [...secretNames][0] : undefined;
+}
+
+function accessTokenSecretNameForOAuthMethod(
+  type: AuthCodeGrantConnectorType,
+): string {
+  const accessMetadata = getConnectorAuthMethodAccessMetadata(type, "oauth");
+  switch (accessMetadata?.kind) {
+    case "refresh-token": {
+      return accessMetadata.accessToken;
+    }
+    case "static": {
+      const secretName = staticAccessSecretName(accessMetadata.envBindings);
+      if (!secretName) {
+        throw new Error(
+          `${type}: OAuth auth method has no static access secret`,
+        );
+      }
+      return secretName;
+    }
+    case "none":
+    case undefined: {
+      throw new Error(`${type}: OAuth auth method has no access secret`);
+    }
+  }
+}
+
+function refreshTokenSecretNameForOAuthMethod(
+  type: AuthCodeGrantConnectorType,
+): string | undefined {
+  const accessMetadata = getConnectorAuthMethodAccessMetadata(type, "oauth");
+  return accessMetadata?.kind === "refresh-token"
+    ? accessMetadata.refreshToken
+    : undefined;
 }
 
 interface ProviderSuccessCase {
@@ -2222,23 +2270,26 @@ describe("GET /api/connectors/:type/callback", () => {
         needsReconnect: false,
       });
 
-      const secretMetadata = getConnectorAuthProviderSecretMetadata(
+      const accessTokenSecretName = accessTokenSecretNameForOAuthMethod(
         providerCase.type,
       );
       await expect(
         findDecryptedSecret({
           orgId,
           userId,
-          name: secretMetadata.accessSecretName,
+          name: accessTokenSecretName,
         }),
       ).resolves.toBe(accessToken);
 
-      if (secretMetadata.isRefreshable) {
+      const refreshTokenSecretName = refreshTokenSecretNameForOAuthMethod(
+        providerCase.type,
+      );
+      if (refreshTokenSecretName) {
         await expect(
           findDecryptedSecret({
             orgId,
             userId,
-            name: secretMetadata.refreshSecretName,
+            name: refreshTokenSecretName,
           }),
         ).resolves.toBe(refreshToken);
         expect(connector?.tokenExpiresAt).toBeInstanceOf(Date);

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -63,7 +63,6 @@ import {
   hasConnectorAuthCodeGrantProvider,
   hasConnectorDeviceAuthGrantProvider,
   hasConnectorRefreshTokenAccessProvider,
-  getConnectorAuthProviderSecretMetadata,
   pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
   revokeConnectorAuthProviderAccessToken,
@@ -491,18 +490,6 @@ describe("connector provider capability checks", () => {
     expect(connectorAuthMethodSupportsTokenRevoke("stripe", "api-token")).toBe(
       false,
     );
-  });
-
-  it("exposes connector OAuth secret metadata without provider access", () => {
-    expect(getConnectorAuthProviderSecretMetadata("test-oauth")).toEqual({
-      accessSecretName: "TEST_OAUTH_ACCESS_TOKEN",
-      refreshSecretName: "TEST_OAUTH_REFRESH_TOKEN",
-      isRefreshable: true,
-    });
-    expect(getConnectorAuthProviderSecretMetadata("github")).toEqual({
-      accessSecretName: "GITHUB_ACCESS_TOKEN",
-      isRefreshable: false,
-    });
   });
 
   it("does not expose refresh-token access providers for non-refreshable auth methods", () => {
@@ -1480,42 +1467,6 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
     expect(
       getConnectorAuthMethodAccessMetadata("stripe", "missing"),
     ).toBeUndefined();
-  });
-
-  it("keeps OAuth provider secret metadata aligned with OAuth access metadata", () => {
-    for (const type of connectorTypeSchema.options) {
-      if (!hasConnectorAuthorizationGrant(type)) {
-        continue;
-      }
-
-      const providerMetadata = getConnectorAuthProviderSecretMetadata(type);
-      if (!providerMetadata) {
-        throw new Error(`${type}: OAuth provider metadata is missing`);
-      }
-
-      const accessMetadata = getConnectorAuthMethodAccessMetadata(
-        type,
-        "oauth",
-      );
-
-      if (providerMetadata.isRefreshable) {
-        expect(
-          accessMetadata,
-          `${type}: refreshable OAuth provider must use refresh-token access`,
-        ).toEqual(
-          expect.objectContaining({
-            kind: "refresh-token",
-            accessToken: providerMetadata.accessSecretName,
-            refreshToken: providerMetadata.refreshSecretName,
-          }),
-        );
-      } else {
-        expect(
-          accessMetadata,
-          `${type}: non-refreshable OAuth provider must not use refresh-token access`,
-        ).not.toEqual(expect.objectContaining({ kind: "refresh-token" }));
-      }
-    }
   });
 });
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -14,10 +14,6 @@ import {
   isStaticConnectorAuthClient,
   type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
-import {
-  getAuthProviderSecretMetadata,
-  type AuthProviderSecretMetadata,
-} from "./secret-metadata";
 import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
@@ -132,8 +128,6 @@ type ConnectorRefreshTokenAccessProviderEntries<
 type ConnectorRefreshTokenAccessProviderMap = {
   readonly [Type in RefreshTokenAccessConnectorType]: ConnectorRefreshTokenAccessProviderEntries<Type>;
 };
-
-export type ConnectorAuthProviderSecretMetadata = AuthProviderSecretMetadata;
 
 export interface ConnectorAuthProviderClientArgs {
   readonly clientId?: string;
@@ -321,30 +315,6 @@ export function hasConnectorRefreshTokenAccessProvider(
     type as RefreshTokenAccessConnectorType
   ] as Readonly<Record<string, unknown>>;
   return Object.hasOwn(providers, authMethod);
-}
-
-export function getConnectorAuthProviderSecretMetadata(
-  type: ConnectorAuthProviderType,
-): ConnectorAuthProviderSecretMetadata;
-export function getConnectorAuthProviderSecretMetadata(
-  type: string,
-): ConnectorAuthProviderSecretMetadata | undefined;
-export function getConnectorAuthProviderSecretMetadata(
-  type: string,
-): ConnectorAuthProviderSecretMetadata | undefined {
-  if (hasConnectorAuthCodeGrantProvider(type)) {
-    return getAuthProviderSecretMetadata(
-      AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type],
-    );
-  }
-
-  if (hasConnectorDeviceAuthGrantProvider(type)) {
-    return getAuthProviderSecretMetadata(
-      DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type],
-    );
-  }
-
-  return undefined;
 }
 
 export async function buildConnectorAuthCodeAuthorizationUrl<


### PR DESCRIPTION
## Summary
- remove the connector type-only auth provider secret metadata API
- update connector metadata tests to rely on auth-method access metadata
- update callback tests to derive expected access secrets from selected OAuth access metadata

## Tests
- cd turbo && pnpm -F @vm0/connectors check-types
- cd turbo && pnpm -F api check-types
- cd turbo && pnpm -F @vm0/connectors lint
- cd turbo && pnpm -F api lint
- cd turbo && pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts
- cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts
- git diff --check

Closes #15434