### PR TITLE
feat: seed paid ads operator skill

### DIFF
--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -33,6 +33,7 @@ export const SEED_SKILLS: readonly string[] = [
   "legal-risk-scoring",
   "marketing-analytics",
   "nda-screening",
+  "paid-ads-operator",
   "period-close",
   "prd-writing",
   "privacy-compliance",


### PR DESCRIPTION
## Summary
- Add `paid-ads-operator` to the default zero seed skills list
- Makes the paid ads operating workflow available in default agent composes once the vm0-skills PR lands

Depends on vm0-skills PR: https://github.com/vm0-ai/vm0-skills/pull/241

## Validation
- `git diff --check`
- `pnpm -F @vm0/core check-types`

Per repo preference, I did not run full local vitest or start a dev server.