### PR TITLE
test: align e2e cli timeout with bats timeout

### DIFF
--- a/e2e/helpers/trace-vm0.sh
+++ b/e2e/helpers/trace-vm0.sh
@@ -8,9 +8,19 @@
 #
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
-# whole group). CLI_TIMEOUT defaults to 90s, leaving headroom for
-# BATS_TEST_TIMEOUT (typically 120s) to handle cleanup.
-CLI_TIMEOUT="${CLI_TIMEOUT:-90}"
+# whole group). CLI_TIMEOUT defaults to BATS_TEST_TIMEOUT minus cleanup
+# headroom when Bats provides a timeout, so runner tests do not get cut short
+# by a fixed wrapper timeout.
+default_cli_timeout() {
+  local bats_timeout="${BATS_TEST_TIMEOUT:-}"
+  if [[ "$bats_timeout" =~ ^[0-9]+$ ]] && ((bats_timeout > 15)); then
+    echo $((bats_timeout - 10))
+    return
+  fi
+  echo 90
+}
+
+CLI_TIMEOUT="${CLI_TIMEOUT:-$(default_cli_timeout)}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START vm0 $*" >> /tmp/e2e-trace.log 2>/dev/null
 START=$SECONDS

--- a/e2e/helpers/trace-vm0.sh
+++ b/e2e/helpers/trace-vm0.sh
@@ -8,16 +8,19 @@
 #
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
-# whole group). CLI_TIMEOUT defaults to BATS_TEST_TIMEOUT minus cleanup
-# headroom when Bats provides a timeout, so runner tests do not get cut short
-# by a fixed wrapper timeout.
+# whole group). CLI_TIMEOUT stays at 90s unless Bats provides a larger timeout
+# budget, then it leaves headroom for setup, diagnostics, and timeout's
+# kill-after window.
+DEFAULT_CLI_TIMEOUT=90
+CLI_TIMEOUT_HEADROOM=20
+
 default_cli_timeout() {
   local bats_timeout="${BATS_TEST_TIMEOUT:-}"
-  if [[ "$bats_timeout" =~ ^[0-9]+$ ]] && ((bats_timeout > 15)); then
-    echo $((bats_timeout - 10))
+  if [[ "$bats_timeout" =~ ^[0-9]+$ ]] && ((bats_timeout > DEFAULT_CLI_TIMEOUT + CLI_TIMEOUT_HEADROOM)); then
+    echo $((bats_timeout - CLI_TIMEOUT_HEADROOM))
     return
   fi
-  echo 90
+  echo "$DEFAULT_CLI_TIMEOUT"
 }
 
 CLI_TIMEOUT="${CLI_TIMEOUT:-$(default_cli_timeout)}"

--- a/e2e/helpers/trace-zero.sh
+++ b/e2e/helpers/trace-zero.sh
@@ -8,16 +8,19 @@
 #
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
-# whole group). CLI_TIMEOUT defaults to BATS_TEST_TIMEOUT minus cleanup
-# headroom when Bats provides a timeout, so runner tests do not get cut short
-# by a fixed wrapper timeout.
+# whole group). CLI_TIMEOUT stays at 90s unless Bats provides a larger timeout
+# budget, then it leaves headroom for setup, diagnostics, and timeout's
+# kill-after window.
+DEFAULT_CLI_TIMEOUT=90
+CLI_TIMEOUT_HEADROOM=20
+
 default_cli_timeout() {
   local bats_timeout="${BATS_TEST_TIMEOUT:-}"
-  if [[ "$bats_timeout" =~ ^[0-9]+$ ]] && ((bats_timeout > 15)); then
-    echo $((bats_timeout - 10))
+  if [[ "$bats_timeout" =~ ^[0-9]+$ ]] && ((bats_timeout > DEFAULT_CLI_TIMEOUT + CLI_TIMEOUT_HEADROOM)); then
+    echo $((bats_timeout - CLI_TIMEOUT_HEADROOM))
     return
   fi
-  echo 90
+  echo "$DEFAULT_CLI_TIMEOUT"
 }
 
 CLI_TIMEOUT="${CLI_TIMEOUT:-$(default_cli_timeout)}"

--- a/e2e/helpers/trace-zero.sh
+++ b/e2e/helpers/trace-zero.sh
@@ -8,9 +8,19 @@
 #
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
-# whole group). CLI_TIMEOUT defaults to 90s, leaving headroom for
-# BATS_TEST_TIMEOUT (typically 120s) to handle cleanup.
-CLI_TIMEOUT="${CLI_TIMEOUT:-90}"
+# whole group). CLI_TIMEOUT defaults to BATS_TEST_TIMEOUT minus cleanup
+# headroom when Bats provides a timeout, so runner tests do not get cut short
+# by a fixed wrapper timeout.
+default_cli_timeout() {
+  local bats_timeout="${BATS_TEST_TIMEOUT:-}"
+  if [[ "$bats_timeout" =~ ^[0-9]+$ ]] && ((bats_timeout > 15)); then
+    echo $((bats_timeout - 10))
+    return
+  fi
+  echo 90
+}
+
+CLI_TIMEOUT="${CLI_TIMEOUT:-$(default_cli_timeout)}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START zero $*" >> /tmp/e2e-trace.log 2>/dev/null
 START=$SECONDS


### PR DESCRIPTION
## Summary
- derive e2e trace wrapper CLI_TIMEOUT from BATS_TEST_TIMEOUT when available
- keep the existing 90s fallback and explicit CLI_TIMEOUT override
- apply the same timeout budgeting to vm0 and zero wrappers

## Testing
- bash -n e2e/helpers/trace-vm0.sh e2e/helpers/trace-zero.sh
- git diff --check -- e2e/helpers/trace-vm0.sh e2e/helpers/trace-zero.sh
- shellcheck e2e/helpers/trace-vm0.sh e2e/helpers/trace-zero.sh