### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.156"
+CLAUDE_CODE_VERSION="2.1.158"
 CODEX_CLI_VERSION="0.135.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Updated pinned rootfs package/tool versions in `crates/runner/scripts/build-template.sh`.

Updates:
- `CLAUDE_CODE_VERSION`: `2.1.156` -> `2.1.158`

Verification:
- Checked Go, Node.js LTS, Codex CLI, Google Workspace CLI, xurl, agent-browser, pnpm, Ubuntu/PostgreSQL, and Debian Chromium sources; no other updates were applied.
- Ran `bash -n crates/runner/scripts/build-template.sh`.
