### PR TITLE
refactor: bind connector revoke providers to auth method

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
@@ -4,7 +4,6 @@ import {
   zeroConnectorApiTokenContract,
   zeroConnectorsByTypeContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
-import { stripeProvider } from "@vm0/connectors/auth-providers/oauth/providers/stripe-provider";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
@@ -15,9 +14,7 @@ import { and, eq } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
-import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -28,10 +25,6 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
-const stripeProviderWithMutableRevoke = stripeProvider as {
-  revoke: typeof stripeProvider.revoke;
-};
-const originalStripeRevoke = stripeProviderWithMutableRevoke.revoke;
 
 async function seedAuthenticatedFixture(): Promise<OrgMembershipFixture> {
   const fixture = await store.set(
@@ -108,8 +101,6 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
   const fixtures: OrgMembershipFixture[] = [];
 
   afterEach(async () => {
-    stripeProviderWithMutableRevoke.revoke = originalStripeRevoke;
-
     while (fixtures.length > 0) {
       const fixture = fixtures.pop();
       if (fixture) {
@@ -274,67 +265,6 @@ describe("POST /api/zero/connectors/:type/api-token", () => {
       [200],
     );
     expect(getResponse.body.authMethod).toBe("api-token");
-  });
-
-  it("keeps local API-token replacement when remote OAuth revoke fails", async () => {
-    const fixture = await seedFixture();
-    mockOptionalEnv("STRIPE_OAUTH_CLIENT_ID", "stripe-client-id");
-    mockOptionalEnv("STRIPE_OAUTH_CLIENT_SECRET", "stripe-client-secret");
-
-    stripeProviderWithMutableRevoke.revoke = {
-      kind: "token-revoke",
-      revokeToken: () => {
-        return Promise.reject(new Error("forced revoke failure"));
-      },
-    };
-
-    const db = store.set(writeDb$);
-    await db.insert(connectors).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      type: "stripe",
-      authMethod: "oauth",
-    });
-    await db.insert(secrets).values([
-      {
-        orgId: fixture.orgId,
-        userId: fixture.userId,
-        name: "STRIPE_ACCESS_TOKEN",
-        encryptedValue: encryptSecretForTests("stripe-access-token"),
-        type: "connector",
-      },
-      {
-        orgId: fixture.orgId,
-        userId: fixture.userId,
-        name: "STRIPE_REFRESH_TOKEN",
-        encryptedValue: encryptSecretForTests("stripe-refresh-token"),
-        type: "connector",
-      },
-    ]);
-
-    const client = setupApp({ context })(zeroConnectorApiTokenContract);
-    const response = await accept(
-      client.connect({
-        params: { type: "stripe" },
-        body: { values: { STRIPE_TOKEN: "sk_test_key" } },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body.authMethod).toBe("api-token");
-    await expect(connectorRows(fixture, "stripe")).resolves.toMatchObject([
-      { authMethod: "api-token" },
-    ]);
-    await expect(
-      secretRows(fixture, "STRIPE_ACCESS_TOKEN", "connector"),
-    ).resolves.toHaveLength(0);
-    await expect(
-      secretRows(fixture, "STRIPE_REFRESH_TOKEN", "connector"),
-    ).resolves.toHaveLength(0);
-    await expect(
-      secretRows(fixture, "STRIPE_TOKEN", "connector"),
-    ).resolves.toHaveLength(1);
   });
 
   it("deletes omitted optional API-token fields on replacement", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
@@ -6,9 +6,13 @@ import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -284,6 +288,58 @@ describe("DELETE /api/zero/connectors/:type", () => {
 
     expect(response.body).toBeUndefined();
     await expect(remainingConnectorCount(fixture)).resolves.toBe(0);
+  });
+
+  it("keeps local deletion authoritative when remote token revoke fails", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(connectors).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      type: "github",
+      authMethod: "oauth",
+    });
+    await writeDb.insert(secrets).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "GITHUB_ACCESS_TOKEN",
+      encryptedValue: encryptSecretForTests("gh-access-token"),
+      type: "connector",
+    });
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
+    mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "test-client-secret");
+    server.use(
+      http.delete(
+        "https://api.github.com/applications/test-client-id/grant",
+        () => {
+          return HttpResponse.json(
+            { error: "forced revoke failure" },
+            {
+              status: 500,
+            },
+          );
+        },
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+    await expect(remainingConnectorCount(fixture)).resolves.toBe(0);
+    await expect(
+      remainingSecretAndVariableState(fixture),
+    ).resolves.toStrictEqual({
+      secrets: 0,
+      variables: 0,
+    });
   });
 
   it("deletes connector token secrets", async () => {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -19,7 +19,7 @@ import {
   getRuntimeAvailableConnectorTypes,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
-import { revokeConnectorAuthProviderAccessToken } from "@vm0/connectors/auth-providers";
+import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -557,8 +557,9 @@ async function revokePendingConnectorToken(args: {
 
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
-    revokeConnectorAuthProviderAccessToken({
+    revokeConnectorAuthMethodAccessToken({
       type: args.pending.type,
+      authMethod: args.pending.authMethod,
       authClient,
       loadAccessToken: () => {
         return decryptStoredSecretValue(

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -9,7 +9,6 @@ import {
   connectorAuthMethodSupportsTokenRevoke,
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethodAccessMetadata,
-  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
@@ -546,21 +545,12 @@ async function loadPendingConnectorTokenRevoke(args: {
 async function revokePendingConnectorToken(args: {
   readonly pending: PendingConnectorTokenRevoke;
 }): Promise<void> {
-  const authClient = resolveConnectorAuthClientForMethod(
-    args.pending.type,
-    args.pending.authMethod,
-    optionalEnv,
-  );
-  if (!authClient) {
-    return;
-  }
-
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
     revokeConnectorAuthMethodAccessToken({
       type: args.pending.type,
       authMethod: args.pending.authMethod,
-      authClient,
+      readEnv: optionalEnv,
       loadAccessToken: () => {
         return decryptStoredSecretValue(
           args.pending.encryptedAccessToken,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -543,7 +543,7 @@ describe("connector provider capability checks", () => {
   });
 
   it("revokes OAuth tokens through the provider registry", async () => {
-    const oauthClient = getOauthAuthClient("github", (name) => {
+    const readEnv: ConnectorEnvReader = (name) => {
       if (name === "GH_OAUTH_CLIENT_ID") {
         return "test-github-client";
       }
@@ -551,12 +551,7 @@ describe("connector provider capability checks", () => {
         return "test-github-secret";
       }
       return undefined;
-    });
-    expect(oauthClient).toBeDefined();
-
-    if (!oauthClient) {
-      throw new Error("Expected github OAuth client");
-    }
+    };
 
     let authorization: string | null = null;
     let body = "";
@@ -575,7 +570,7 @@ describe("connector provider capability checks", () => {
       revokeConnectorAuthMethodAccessToken({
         type: "github",
         authMethod: "oauth",
-        authClient: oauthClient,
+        readEnv,
         loadAccessToken: () => {
           return "gh-access-token";
         },
@@ -588,28 +583,15 @@ describe("connector provider capability checks", () => {
   });
 
   it("returns unsupported for connectors without revoke support", async () => {
-    const oauthClient = getOauthAuthClient("notion", (name) => {
-      if (name === "NOTION_OAUTH_CLIENT_ID") {
-        return "test-notion-client";
-      }
-      if (name === "NOTION_OAUTH_CLIENT_SECRET") {
-        return "test-notion-secret";
-      }
-      return undefined;
-    });
-    expect(oauthClient).toBeDefined();
-
-    if (!oauthClient) {
-      throw new Error("Expected notion OAuth client");
-    }
-
     let loadedAccessToken = false;
 
     await expect(
       revokeConnectorAuthMethodAccessToken({
         type: "notion",
         authMethod: "oauth",
-        authClient: oauthClient,
+        readEnv: () => {
+          return undefined;
+        },
         loadAccessToken: () => {
           loadedAccessToken = true;
           return "notion-access-token";
@@ -620,28 +602,34 @@ describe("connector provider capability checks", () => {
   });
 
   it("returns unsupported for selected auth methods without token revoke", async () => {
-    const oauthClient = getOauthAuthClient("github", (name) => {
-      if (name === "GH_OAUTH_CLIENT_ID") {
-        return "test-github-client";
-      }
-      if (name === "GH_OAUTH_CLIENT_SECRET") {
-        return "test-github-secret";
-      }
-      return undefined;
-    });
-    expect(oauthClient).toBeDefined();
-
-    if (!oauthClient) {
-      throw new Error("Expected github OAuth client");
-    }
-
     let loadedAccessToken = false;
 
     await expect(
       revokeConnectorAuthMethodAccessToken({
         type: "github",
         authMethod: "api-token",
-        authClient: oauthClient,
+        readEnv: () => {
+          return undefined;
+        },
+        loadAccessToken: () => {
+          loadedAccessToken = true;
+          return "gh-access-token";
+        },
+      }),
+    ).resolves.toStrictEqual({ status: "unsupported" });
+    expect(loadedAccessToken).toBe(false);
+  });
+
+  it("returns unsupported without loading access token when revoke client env is missing", async () => {
+    let loadedAccessToken = false;
+
+    await expect(
+      revokeConnectorAuthMethodAccessToken({
+        type: "github",
+        authMethod: "oauth",
+        readEnv: () => {
+          return undefined;
+        },
         loadAccessToken: () => {
           loadedAccessToken = true;
           return "gh-access-token";

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -24,6 +24,7 @@ import {
   type ConnectorType,
   type AuthCodeGrantConnectorType,
   type RefreshTokenAccessConnectorType,
+  type TokenRevokeConnectorType,
 } from "../connectors";
 import {
   connectorAuthMethodSupportsRefreshTokenAccess,
@@ -63,9 +64,10 @@ import {
   hasConnectorAuthCodeGrantProvider,
   hasConnectorDeviceAuthGrantProvider,
   hasConnectorRefreshTokenAccessProvider,
+  hasConnectorTokenRevokeProvider,
   pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
-  revokeConnectorAuthProviderAccessToken,
+  revokeConnectorAuthMethodAccessToken,
   startConnectorDeviceAuthorization,
 } from "../auth-providers/connector-auth";
 import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../auth-providers/oauth/google-connectors";
@@ -480,7 +482,35 @@ describe("connector provider capability checks", () => {
     }
   });
 
-  it("detects token revoke support from provider capability", () => {
+  it("matches exactly the auth methods that declare token revoke", () => {
+    expectTypeOf<"github">().toMatchTypeOf<TokenRevokeConnectorType>();
+    expectTypeOf<"notion">().not.toMatchTypeOf<TokenRevokeConnectorType>();
+
+    const tokenRevokeTypes = new Set<ConnectorType>(
+      connectorTypeSchema.options.filter((type) => {
+        return getConfiguredConnectorAuthMethods(type).some((authMethod) => {
+          return connectorAuthMethodSupportsTokenRevoke(type, authMethod);
+        });
+      }),
+    );
+
+    for (const type of connectorTypeSchema.options) {
+      expect(hasConnectorTokenRevokeProvider(type)).toBe(
+        tokenRevokeTypes.has(type),
+      );
+      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+        const supportsTokenRevoke = connectorAuthMethodSupportsTokenRevoke(
+          type,
+          authMethod,
+        );
+        expect(hasConnectorTokenRevokeProvider(type, authMethod)).toBe(
+          supportsTokenRevoke,
+        );
+      }
+    }
+  });
+
+  it("detects token revoke support from selected auth method config", () => {
     expect(connectorAuthMethodSupportsTokenRevoke("github", "oauth")).toBe(
       true,
     );
@@ -542,8 +572,9 @@ describe("connector provider capability checks", () => {
     );
 
     await expect(
-      revokeConnectorAuthProviderAccessToken({
+      revokeConnectorAuthMethodAccessToken({
         type: "github",
+        authMethod: "oauth",
         authClient: oauthClient,
         loadAccessToken: () => {
           return "gh-access-token";
@@ -575,12 +606,45 @@ describe("connector provider capability checks", () => {
     let loadedAccessToken = false;
 
     await expect(
-      revokeConnectorAuthProviderAccessToken({
+      revokeConnectorAuthMethodAccessToken({
         type: "notion",
+        authMethod: "oauth",
         authClient: oauthClient,
         loadAccessToken: () => {
           loadedAccessToken = true;
           return "notion-access-token";
+        },
+      }),
+    ).resolves.toStrictEqual({ status: "unsupported" });
+    expect(loadedAccessToken).toBe(false);
+  });
+
+  it("returns unsupported for selected auth methods without token revoke", async () => {
+    const oauthClient = getOauthAuthClient("github", (name) => {
+      if (name === "GH_OAUTH_CLIENT_ID") {
+        return "test-github-client";
+      }
+      if (name === "GH_OAUTH_CLIENT_SECRET") {
+        return "test-github-secret";
+      }
+      return undefined;
+    });
+    expect(oauthClient).toBeDefined();
+
+    if (!oauthClient) {
+      throw new Error("Expected github OAuth client");
+    }
+
+    let loadedAccessToken = false;
+
+    await expect(
+      revokeConnectorAuthMethodAccessToken({
+        type: "github",
+        authMethod: "api-token",
+        authClient: oauthClient,
+        loadAccessToken: () => {
+          loadedAccessToken = true;
+          return "gh-access-token";
         },
       }),
     ).resolves.toStrictEqual({ status: "unsupported" });

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -361,7 +361,7 @@ export function hasConnectorRefreshTokenAccessProvider(
 export function hasConnectorTokenRevokeProvider(
   type: string,
   authMethod?: string,
-): type is ConnectorTokenRevokeProviderType {
+): type is TokenRevokeConnectorType {
   if (!Object.hasOwn(CONNECTOR_TOKEN_REVOKE_PROVIDERS, type)) {
     return false;
   }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,16 +1,17 @@
-import type {
-  ConnectorType,
-  AuthCodeGrantConnectorType,
-  ConnectorAuthMethodIdsByRevokeKind,
-  ConnectorAuthProviderType,
-  DeviceAuthGrantConnectorType,
-  ConnectorAuthMethodIdsByAccessKind,
-  RefreshTokenAccessConnectorType,
-  TokenRevokeConnectorType,
+import {
+  connectorTypeSchema,
+  type ConnectorType,
+  type AuthCodeGrantConnectorType,
+  type ConnectorAuthProviderType,
+  type DeviceAuthGrantConnectorType,
+  type ConnectorAuthMethodIdsByAccessKind,
+  type RefreshTokenAccessConnectorType,
+  type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   connectorAuthMethodSupportsRefreshTokenAccess,
   connectorAuthMethodSupportsTokenRevoke,
+  getConfiguredConnectorAuthMethods,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
@@ -19,7 +20,6 @@ import {
 import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
-  ConnectorAuthProviderRevoke,
   RefreshTokenAccessProvider,
 } from "./types";
 import {
@@ -29,7 +29,6 @@ import {
   type ConnectorDeviceAuthorizationStartArgs,
   type ConnectorAuthCodeExchangeArgs,
   type ConnectorAuthProviderRefreshArgs,
-  type ConnectorAuthProviderRevokeArgs,
   type OAuthAuthorizeArgs,
   type OAuthDeviceAuthPollArgs,
   type OAuthDeviceAuthPollResult,
@@ -131,31 +130,6 @@ type ConnectorRefreshTokenAccessProviderMap = {
   readonly [Type in RefreshTokenAccessConnectorType]: ConnectorRefreshTokenAccessProviderEntries<Type>;
 };
 
-type ConnectorTokenRevokeProviderType = Extract<
-  TokenRevokeConnectorType,
-  ConnectorAuthProviderType
->;
-
-type ConnectorTokenRevokeProvider<
-  Type extends ConnectorTokenRevokeProviderType,
-> = Extract<
-  ConnectorAuthProviderRevoke<Type>,
-  { readonly kind: "token-revoke" }
->;
-
-type ConnectorTokenRevokeProviderEntries<
-  Type extends ConnectorTokenRevokeProviderType,
-> = {
-  readonly [Method in ConnectorAuthMethodIdsByRevokeKind<
-    Type,
-    "token-revoke"
-  >]: ConnectorTokenRevokeProvider<Type>;
-};
-
-type ConnectorTokenRevokeProviderMap = {
-  readonly [Type in ConnectorTokenRevokeProviderType]: ConnectorTokenRevokeProviderEntries<Type>;
-};
-
 export interface ConnectorAuthProviderClientArgs {
   readonly clientId?: string;
   readonly clientSecret?: string;
@@ -168,28 +142,6 @@ function connectorRefreshTokenAccessProviderFor<
     Record<string, RefreshTokenAccessProvider<T>>
   >;
   return providers[authMethod];
-}
-
-function connectorTokenRevokeProviderFor<
-  T extends ConnectorTokenRevokeProviderType,
->(type: T, authMethod: string): ConnectorTokenRevokeProvider<T> | undefined {
-  const providers = CONNECTOR_TOKEN_REVOKE_PROVIDERS[type] as Readonly<
-    Record<string, ConnectorTokenRevokeProvider<T>>
-  >;
-  return providers[authMethod];
-}
-
-function tokenRevokeProvider<Type extends ConnectorTokenRevokeProviderType>(
-  type: Type,
-  authMethod: ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
-  provider: ConnectorAuthProviderRevoke<Type>,
-): ConnectorTokenRevokeProvider<Type> {
-  if (provider.kind !== "token-revoke") {
-    throw new Error(
-      `${type} connector auth method ${authMethod} has no token-revoke provider`,
-    );
-  }
-  return provider;
 }
 
 function connectorAuthProviderClientArgs(
@@ -207,10 +159,46 @@ function connectorAuthProviderClientArgs(
   return { clientId: authClient.clientId };
 }
 
+function staticConfidentialConnectorAuthProviderClientArgs(
+  authClient: ConnectorAuthClient,
+): { readonly clientId: string; readonly clientSecret: string } {
+  if (!isStaticConfidentialConnectorAuthClient(authClient)) {
+    throw new Error("Connector token revoke requires a confidential client");
+  }
+  return {
+    clientId: authClient.clientId,
+    clientSecret: authClient.clientSecret,
+  };
+}
+
 export function getConnectorAuthProviderClientArgs(
   authClient: ConnectorAuthClient,
 ): ConnectorAuthProviderClientArgs {
   return connectorAuthProviderClientArgs(authClient);
+}
+
+async function revokeTokenRevokeConnectorAccessToken(args: {
+  readonly type: TokenRevokeConnectorType;
+  readonly authClient: ConnectorAuthClient;
+  readonly loadAccessToken: () => string | Promise<string>;
+}): Promise<void> {
+  const clientArgs = staticConfidentialConnectorAuthProviderClientArgs(
+    args.authClient,
+  );
+  const accessToken = await args.loadAccessToken();
+  switch (args.type) {
+    case "github":
+      await githubProvider.revoke.revokeToken({ ...clientArgs, accessToken });
+      return;
+    case "linear":
+      await linearProvider.revoke.revokeToken({ ...clientArgs, accessToken });
+      return;
+    case "slack":
+      await slackProvider.revoke.revokeToken({ ...clientArgs, accessToken });
+      return;
+  }
+  const exhaustive: never = args.type;
+  return exhaustive;
 }
 
 const AUTH_CODE_CONNECTOR_AUTH_PROVIDERS: AuthCodeConnectorAuthProviderMap = {
@@ -311,16 +299,6 @@ const CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS: ConnectorRefreshTokenAccessProvi
     zoom: { oauth: zoomProvider.access },
   };
 
-const CONNECTOR_TOKEN_REVOKE_PROVIDERS: ConnectorTokenRevokeProviderMap = {
-  github: {
-    oauth: tokenRevokeProvider("github", "oauth", githubProvider.revoke),
-  },
-  linear: {
-    oauth: tokenRevokeProvider("linear", "oauth", linearProvider.revoke),
-  },
-  slack: { oauth: tokenRevokeProvider("slack", "oauth", slackProvider.revoke) },
-};
-
 export function hasConnectorAuthProvider(
   type: string,
 ): type is ConnectorAuthProviderType {
@@ -362,16 +340,21 @@ export function hasConnectorTokenRevokeProvider(
   type: string,
   authMethod?: string,
 ): type is TokenRevokeConnectorType {
-  if (!Object.hasOwn(CONNECTOR_TOKEN_REVOKE_PROVIDERS, type)) {
+  const connectorType = connectorTypeSchema.safeParse(type);
+  if (!connectorType.success) {
     return false;
   }
   if (authMethod === undefined) {
-    return true;
+    return getConfiguredConnectorAuthMethods(connectorType.data).some(
+      (configuredAuthMethod) => {
+        return hasConnectorTokenRevokeProvider(
+          connectorType.data,
+          configuredAuthMethod,
+        );
+      },
+    );
   }
-  const providers = CONNECTOR_TOKEN_REVOKE_PROVIDERS[
-    type as ConnectorTokenRevokeProviderType
-  ] as Readonly<Record<string, unknown>>;
-  return Object.hasOwn(providers, authMethod);
+  return connectorAuthMethodSupportsTokenRevoke(connectorType.data, authMethod);
 }
 
 export async function buildConnectorAuthCodeAuthorizationUrl<
@@ -486,20 +469,11 @@ export async function revokeConnectorAuthMethodAccessToken<
     return { status: "unsupported" };
   }
 
-  const type = args.type as Extract<T, ConnectorTokenRevokeProviderType>;
-  const revoke = connectorTokenRevokeProviderFor(type, args.authMethod);
-  if (!revoke) {
-    throw new Error(
-      `${args.type} connector auth method ${args.authMethod} has no token-revoke provider`,
-    );
-  }
-
-  await revoke.revokeToken({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    accessToken: await args.loadAccessToken(),
-  } as ConnectorAuthProviderRevokeArgs<
-    Extract<T, ConnectorTokenRevokeProviderType>
-  >);
+  await revokeTokenRevokeConnectorAccessToken({
+    type: args.type,
+    authClient: args.authClient,
+    loadAccessToken: args.loadAccessToken,
+  });
   return { status: "revoked" };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -12,7 +12,6 @@ import {
   connectorAuthMethodSupportsRefreshTokenAccess,
   connectorAuthMethodSupportsTokenRevoke,
   getConfiguredConnectorAuthMethods,
-  getRuntimeAvailableConnectorTypesFromReader,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
   type ConnectorAuthClient,
@@ -475,17 +474,4 @@ export async function revokeConnectorAuthMethodAccessToken<
     loadAccessToken: args.loadAccessToken,
   });
   return { status: "revoked" };
-}
-
-/**
- * Returns connector types the current runtime environment can offer as
- * connection candidates.
- */
-export function getRuntimeAvailableConnectorTypes(
-  currentEnv: ProviderEnv,
-): ConnectorType[] {
-  return getRuntimeAvailableConnectorTypesFromReader((name) => {
-    const value = currentEnv[name];
-    return typeof value === "string" ? value : undefined;
-  });
 }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -14,7 +14,9 @@ import {
   getConfiguredConnectorAuthMethods,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
+  resolveConnectorAuthClientForMethod,
   type ConnectorAuthClient,
+  type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeConnectorAuthProvider,
@@ -158,18 +160,6 @@ function connectorAuthProviderClientArgs(
   return { clientId: authClient.clientId };
 }
 
-function staticConfidentialConnectorAuthProviderClientArgs(
-  authClient: ConnectorAuthClient,
-): { readonly clientId: string; readonly clientSecret: string } {
-  if (!isStaticConfidentialConnectorAuthClient(authClient)) {
-    throw new Error("Connector token revoke requires a confidential client");
-  }
-  return {
-    clientId: authClient.clientId,
-    clientSecret: authClient.clientSecret,
-  };
-}
-
 export function getConnectorAuthProviderClientArgs(
   authClient: ConnectorAuthClient,
 ): ConnectorAuthProviderClientArgs {
@@ -178,23 +168,58 @@ export function getConnectorAuthProviderClientArgs(
 
 async function revokeTokenRevokeConnectorAccessToken(args: {
   readonly type: TokenRevokeConnectorType;
-  readonly authClient: ConnectorAuthClient;
+  readonly readEnv: ConnectorEnvReader;
   readonly loadAccessToken: () => string | Promise<string>;
-}): Promise<void> {
-  const clientArgs = staticConfidentialConnectorAuthProviderClientArgs(
-    args.authClient,
-  );
-  const accessToken = await args.loadAccessToken();
+}): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
   switch (args.type) {
-    case "github":
-      await githubProvider.revoke.revokeToken({ ...clientArgs, accessToken });
-      return;
-    case "linear":
-      await linearProvider.revoke.revokeToken({ ...clientArgs, accessToken });
-      return;
-    case "slack":
-      await slackProvider.revoke.revokeToken({ ...clientArgs, accessToken });
-      return;
+    case "github": {
+      const authClient = resolveConnectorAuthClientForMethod(
+        "github",
+        "oauth",
+        args.readEnv,
+      );
+      if (!authClient) {
+        return { status: "unsupported" };
+      }
+      await githubProvider.revoke.revokeToken({
+        clientId: authClient.clientId,
+        clientSecret: authClient.clientSecret,
+        accessToken: await args.loadAccessToken(),
+      });
+      return { status: "revoked" };
+    }
+    case "linear": {
+      const authClient = resolveConnectorAuthClientForMethod(
+        "linear",
+        "oauth",
+        args.readEnv,
+      );
+      if (!authClient) {
+        return { status: "unsupported" };
+      }
+      await linearProvider.revoke.revokeToken({
+        clientId: authClient.clientId,
+        clientSecret: authClient.clientSecret,
+        accessToken: await args.loadAccessToken(),
+      });
+      return { status: "revoked" };
+    }
+    case "slack": {
+      const authClient = resolveConnectorAuthClientForMethod(
+        "slack",
+        "oauth",
+        args.readEnv,
+      );
+      if (!authClient) {
+        return { status: "unsupported" };
+      }
+      await slackProvider.revoke.revokeToken({
+        clientId: authClient.clientId,
+        clientSecret: authClient.clientSecret,
+        accessToken: await args.loadAccessToken(),
+      });
+      return { status: "revoked" };
+    }
   }
   const exhaustive: never = args.type;
   return exhaustive;
@@ -461,17 +486,16 @@ export async function revokeConnectorAuthMethodAccessToken<
 >(args: {
   readonly type: T;
   readonly authMethod: string;
-  readonly authClient: ConnectorAuthClient;
+  readonly readEnv: ConnectorEnvReader;
   readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
   if (!connectorAuthMethodSupportsTokenRevoke(args.type, args.authMethod)) {
     return { status: "unsupported" };
   }
 
-  await revokeTokenRevokeConnectorAccessToken({
+  return await revokeTokenRevokeConnectorAccessToken({
     type: args.type,
-    authClient: args.authClient,
+    readEnv: args.readEnv,
     loadAccessToken: args.loadAccessToken,
   });
-  return { status: "revoked" };
 }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -12,7 +12,7 @@ import {
   connectorAuthMethodSupportsRefreshTokenAccess,
   connectorAuthMethodSupportsTokenRevoke,
   getConfiguredConnectorAuthMethods,
-  getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
+  getRuntimeAvailableConnectorTypesFromReader,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
   type ConnectorAuthClient,
@@ -484,7 +484,7 @@ export async function revokeConnectorAuthMethodAccessToken<
 export function getRuntimeAvailableConnectorTypes(
   currentEnv: ProviderEnv,
 ): ConnectorType[] {
-  return getRuntimeAvailableConnectorTypesFromEnv((name) => {
+  return getRuntimeAvailableConnectorTypesFromReader((name) => {
     const value = currentEnv[name];
     return typeof value === "string" ? value : undefined;
   });

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,15 +1,17 @@
 import type {
   ConnectorType,
   AuthCodeGrantConnectorType,
+  ConnectorAuthMethodIdsByRevokeKind,
   ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
   ConnectorAuthMethodIdsByAccessKind,
   RefreshTokenAccessConnectorType,
+  TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   connectorAuthMethodSupportsRefreshTokenAccess,
+  connectorAuthMethodSupportsTokenRevoke,
   getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv,
-  hasConnectorAuthCodeGrant,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
   type ConnectorAuthClient,
@@ -129,15 +131,34 @@ type ConnectorRefreshTokenAccessProviderMap = {
   readonly [Type in RefreshTokenAccessConnectorType]: ConnectorRefreshTokenAccessProviderEntries<Type>;
 };
 
+type ConnectorTokenRevokeProviderType = Extract<
+  TokenRevokeConnectorType,
+  ConnectorAuthProviderType
+>;
+
+type ConnectorTokenRevokeProvider<
+  Type extends ConnectorTokenRevokeProviderType,
+> = Extract<
+  ConnectorAuthProviderRevoke<Type>,
+  { readonly kind: "token-revoke" }
+>;
+
+type ConnectorTokenRevokeProviderEntries<
+  Type extends ConnectorTokenRevokeProviderType,
+> = {
+  readonly [Method in ConnectorAuthMethodIdsByRevokeKind<
+    Type,
+    "token-revoke"
+  >]: ConnectorTokenRevokeProvider<Type>;
+};
+
+type ConnectorTokenRevokeProviderMap = {
+  readonly [Type in ConnectorTokenRevokeProviderType]: ConnectorTokenRevokeProviderEntries<Type>;
+};
+
 export interface ConnectorAuthProviderClientArgs {
   readonly clientId?: string;
   readonly clientSecret?: string;
-}
-
-function deviceAuthConnectorProviderFor<T extends DeviceAuthGrantConnectorType>(
-  type: T,
-): DeviceAuthConnectorAuthProviderMap[T] {
-  return DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type];
 }
 
 function connectorRefreshTokenAccessProviderFor<
@@ -149,16 +170,26 @@ function connectorRefreshTokenAccessProviderFor<
   return providers[authMethod];
 }
 
-function connectorRevokeProviderFor<T extends ConnectorAuthProviderType>(
-  type: T,
-): ConnectorAuthProviderRevoke<T> {
-  if (hasConnectorAuthCodeGrant(type)) {
-    return AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type]
-      .revoke as ConnectorAuthProviderRevoke<T>;
-  }
+function connectorTokenRevokeProviderFor<
+  T extends ConnectorTokenRevokeProviderType,
+>(type: T, authMethod: string): ConnectorTokenRevokeProvider<T> | undefined {
+  const providers = CONNECTOR_TOKEN_REVOKE_PROVIDERS[type] as Readonly<
+    Record<string, ConnectorTokenRevokeProvider<T>>
+  >;
+  return providers[authMethod];
+}
 
-  return deviceAuthConnectorProviderFor(type)
-    .revoke as ConnectorAuthProviderRevoke<T>;
+function tokenRevokeProvider<Type extends ConnectorTokenRevokeProviderType>(
+  type: Type,
+  authMethod: ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
+  provider: ConnectorAuthProviderRevoke<Type>,
+): ConnectorTokenRevokeProvider<Type> {
+  if (provider.kind !== "token-revoke") {
+    throw new Error(
+      `${type} connector auth method ${authMethod} has no token-revoke provider`,
+    );
+  }
+  return provider;
 }
 
 function connectorAuthProviderClientArgs(
@@ -280,6 +311,16 @@ const CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS: ConnectorRefreshTokenAccessProvi
     zoom: { oauth: zoomProvider.access },
   };
 
+const CONNECTOR_TOKEN_REVOKE_PROVIDERS: ConnectorTokenRevokeProviderMap = {
+  github: {
+    oauth: tokenRevokeProvider("github", "oauth", githubProvider.revoke),
+  },
+  linear: {
+    oauth: tokenRevokeProvider("linear", "oauth", linearProvider.revoke),
+  },
+  slack: { oauth: tokenRevokeProvider("slack", "oauth", slackProvider.revoke) },
+};
+
 export function hasConnectorAuthProvider(
   type: string,
 ): type is ConnectorAuthProviderType {
@@ -313,6 +354,22 @@ export function hasConnectorRefreshTokenAccessProvider(
   }
   const providers = CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS[
     type as RefreshTokenAccessConnectorType
+  ] as Readonly<Record<string, unknown>>;
+  return Object.hasOwn(providers, authMethod);
+}
+
+export function hasConnectorTokenRevokeProvider(
+  type: string,
+  authMethod?: string,
+): type is ConnectorTokenRevokeProviderType {
+  if (!Object.hasOwn(CONNECTOR_TOKEN_REVOKE_PROVIDERS, type)) {
+    return false;
+  }
+  if (authMethod === undefined) {
+    return true;
+  }
+  const providers = CONNECTOR_TOKEN_REVOKE_PROVIDERS[
+    type as ConnectorTokenRevokeProviderType
   ] as Readonly<Record<string, unknown>>;
   return Object.hasOwn(providers, authMethod);
 }
@@ -417,26 +474,33 @@ export async function refreshConnectorAuthProviderAccessToken<
   } as ConnectorAuthProviderRefreshArgs<T>);
 }
 
-export async function revokeConnectorAuthProviderAccessToken<
-  T extends ConnectorAuthProviderType,
+export async function revokeConnectorAuthMethodAccessToken<
+  T extends ConnectorType,
 >(args: {
   readonly type: T;
+  readonly authMethod: string;
   readonly authClient: ConnectorAuthClient;
   readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
-  const revoke = connectorRevokeProviderFor(args.type);
-
-  switch (revoke.kind) {
-    case "none":
-      return { status: "unsupported" };
-
-    case "token-revoke":
-      await revoke.revokeToken({
-        ...connectorAuthProviderClientArgs(args.authClient),
-        accessToken: await args.loadAccessToken(),
-      } as ConnectorAuthProviderRevokeArgs<T>);
-      return { status: "revoked" };
+  if (!connectorAuthMethodSupportsTokenRevoke(args.type, args.authMethod)) {
+    return { status: "unsupported" };
   }
+
+  const type = args.type as Extract<T, ConnectorTokenRevokeProviderType>;
+  const revoke = connectorTokenRevokeProviderFor(type, args.authMethod);
+  if (!revoke) {
+    throw new Error(
+      `${args.type} connector auth method ${args.authMethod} has no token-revoke provider`,
+    );
+  }
+
+  await revoke.revokeToken({
+    ...connectorAuthProviderClientArgs(args.authClient),
+    accessToken: await args.loadAccessToken(),
+  } as ConnectorAuthProviderRevokeArgs<
+    Extract<T, ConnectorTokenRevokeProviderType>
+  >);
+  return { status: "revoked" };
 }
 
 /**

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -4,6 +4,7 @@ import type {
   ConnectorType,
   DeviceAuthGrantConnectorType,
   RefreshTokenAccessConnectorType,
+  TokenRevokeConnectorType,
 } from "../connectors";
 import type {
   AuthUrlResult,
@@ -77,8 +78,9 @@ interface TokenRevokeProvider<T extends ConnectorAuthProviderType> {
 }
 
 export type ConnectorAuthProviderRevoke<T extends ConnectorAuthProviderType> =
-  | NoneRevokeProvider
-  | TokenRevokeProvider<T>;
+  T extends TokenRevokeConnectorType
+    ? TokenRevokeProvider<T>
+    : NoneRevokeProvider;
 
 export interface AuthProvider<TGrant, TAccess, TRevoke> {
   readonly grant: TGrant;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -3,6 +3,8 @@ import {
   CONNECTOR_TYPES,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorAuthMethodIds,
+  type ConnectorAuthMethodClientConfig,
   type ConnectorAccessConfig,
   type ConnectorAuthCodeGrantConfig,
   type ConnectorAuthClientConfig,
@@ -16,7 +18,10 @@ import {
   type ConnectorAuthProviderType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
+  type DynamicPublicConnectorAuthClientConfig,
   type RefreshTokenAccessConnectorType,
+  type StaticConfidentialConnectorAuthClientConfig,
+  type StaticPublicConnectorAuthClientConfig,
   type TokenRevokeConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
@@ -471,6 +476,21 @@ export type ConnectorAuthClient =
   | StaticConnectorAuthClient
   | DynamicPublicConnectorAuthClient;
 
+export type ConnectorAuthClientForConfig<
+  Client extends ConnectorAuthClientConfig,
+> = Client extends StaticConfidentialConnectorAuthClientConfig
+  ? StaticConfidentialConnectorAuthClient
+  : Client extends StaticPublicConnectorAuthClientConfig
+    ? StaticPublicConnectorAuthClient
+    : Client extends DynamicPublicConnectorAuthClientConfig
+      ? DynamicPublicConnectorAuthClient
+      : never;
+
+export type ConnectorAuthClientForMethod<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+> = ConnectorAuthClientForConfig<ConnectorAuthMethodClientConfig<Type, Method>>;
+
 export function isStaticConnectorAuthClient(
   authClient: ConnectorAuthClient,
 ): authClient is StaticConnectorAuthClient {
@@ -486,6 +506,17 @@ export function isStaticConfidentialConnectorAuthClient(
   );
 }
 
+export function getConnectorAuthClientConfigForMethod<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+>(
+  type: Type,
+  authMethod: Method,
+): ConnectorAuthMethodClientConfig<Type, Method> | undefined;
+export function getConnectorAuthClientConfigForMethod(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorAuthClientConfig | undefined;
 export function getConnectorAuthClientConfigForMethod(
   type: ConnectorType,
   authMethod: string,
@@ -493,6 +524,12 @@ export function getConnectorAuthClientConfigForMethod(
   return getConnectorAuthMethod(type, authMethod)?.client;
 }
 
+export function resolveConnectorAuthClient<
+  Client extends ConnectorAuthClientConfig,
+>(
+  client: Client,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthClientForConfig<Client> | undefined;
 export function resolveConnectorAuthClient(
   client: ConnectorAuthClientConfig,
   readEnv: ConnectorEnvReader,
@@ -539,6 +576,19 @@ export function resolveConnectorAuthClient(
   };
 }
 
+export function resolveConnectorAuthClientForMethod<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+>(
+  type: Type,
+  authMethod: Method,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthClientForMethod<Type, Method> | undefined;
+export function resolveConnectorAuthClientForMethod(
+  type: ConnectorType,
+  authMethod: string,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthClient | undefined;
 export function resolveConnectorAuthClientForMethod(
   type: ConnectorType,
   authMethod: string,

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -585,7 +585,7 @@ function hasRuntimeAvailableAuthMethod(
  * do not require a server auth client, while auth-provider methods require
  * their runtime client env to exist unless their client config is static inline.
  */
-export function getRuntimeAvailableConnectorTypesFromReader(
+export function getRuntimeAvailableConnectorTypes(
   readEnv: ConnectorEnvReader,
 ): ConnectorType[] {
   const runtimeAvailable = new Set<ConnectorType>();
@@ -597,12 +597,6 @@ export function getRuntimeAvailableConnectorTypesFromReader(
   }
 
   return [...runtimeAvailable].sort();
-}
-
-export function getRuntimeAvailableConnectorTypes(
-  readEnv: ConnectorEnvReader,
-): ConnectorType[] {
-  return getRuntimeAvailableConnectorTypesFromReader(readEnv);
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -585,7 +585,7 @@ function hasRuntimeAvailableAuthMethod(
  * do not require a server auth client, while auth-provider methods require
  * their runtime client env to exist unless their client config is static inline.
  */
-export function getRuntimeAvailableConnectorTypes(
+export function getRuntimeAvailableConnectorTypesFromReader(
   readEnv: ConnectorEnvReader,
 ): ConnectorType[] {
   const runtimeAvailable = new Set<ConnectorType>();
@@ -597,6 +597,12 @@ export function getRuntimeAvailableConnectorTypes(
   }
 
   return [...runtimeAvailable].sort();
+}
+
+export function getRuntimeAvailableConnectorTypes(
+  readEnv: ConnectorEnvReader,
+): ConnectorType[] {
+  return getRuntimeAvailableConnectorTypesFromReader(readEnv);
 }
 
 /**

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -1025,6 +1025,22 @@ export type TokenRevokeConnectorType =
 export type TokenRevokeConnectorTypesUseAuthProviders = AssertNever<
   Exclude<TokenRevokeConnectorType, ConnectorAuthProviderType>
 >;
+type TokenRevokeConnectorTypeWithNonConfidentialClient = {
+  [Type in TokenRevokeConnectorType]: {
+    [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
+      readonly revoke: { readonly kind: "token-revoke" };
+      readonly client: StaticConfidentialConnectorAuthClientConfig;
+    }
+      ? never
+      : ConnectorAuthMethodsOf<Type>[Method] extends {
+            readonly revoke: { readonly kind: "token-revoke" };
+          }
+        ? Type
+        : never;
+  }[ConnectorAuthMethodKeys<Type>];
+}[TokenRevokeConnectorType];
+export type TokenRevokeConnectorAuthMethodsUseConfidentialClients =
+  AssertNever<TokenRevokeConnectorTypeWithNonConfidentialClient>;
 
 export type ConnectorInvalidDefaultAuthMethodType<
   Configs extends Record<string, ConnectorConfig>,

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -837,6 +837,14 @@ export type ConnectorAuthMethodIds<Type extends ConnectorType> = Extract<
   keyof ConnectorAuthMethodsOf<Type>,
   string
 >;
+export type ConnectorAuthMethodClientConfig<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+> = "client" extends keyof ConnectorAuthMethodsOf<Type>[Method]
+  ? ConnectorAuthMethodsOf<Type>[Method]["client"] extends ConnectorAuthClientConfig
+    ? ConnectorAuthMethodsOf<Type>[Method]["client"]
+    : never
+  : never;
 type ConnectorAuthMethodKeys<Type extends ConnectorType> =
   ConnectorAuthMethodIds<Type> & keyof ConnectorAuthMethodGrantKindById;
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -955,17 +955,6 @@ export type ConnectorAuthMethodIdsByAccessKind<
     : never;
 }[ConnectorAuthMethodKeys<Type>];
 
-export type ConnectorAuthMethodIdsByRevokeKind<
-  Type extends ConnectorType,
-  Kind extends ConnectorRevokeKind,
-> = {
-  [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
-    readonly revoke: { readonly kind: Kind };
-  }
-    ? Method
-    : never;
-}[ConnectorAuthMethodKeys<Type>];
-
 type ConnectorTypeWithMultipleAuthMethodsForGrantKind<
   Kind extends ConnectorGrantKind,
 > = {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -955,6 +955,17 @@ export type ConnectorAuthMethodIdsByAccessKind<
     : never;
 }[ConnectorAuthMethodKeys<Type>];
 
+export type ConnectorAuthMethodIdsByRevokeKind<
+  Type extends ConnectorType,
+  Kind extends ConnectorRevokeKind,
+> = {
+  [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
+    readonly revoke: { readonly kind: Kind };
+  }
+    ? Method
+    : never;
+}[ConnectorAuthMethodKeys<Type>];
+
 type ConnectorTypeWithMultipleAuthMethodsForGrantKind<
   Kind extends ConnectorGrantKind,
 > = {
@@ -1011,6 +1022,9 @@ export type RefreshTokenAccessConnectorType =
   ConnectorTypesByAccessKind<"refresh-token">;
 export type TokenRevokeConnectorType =
   ConnectorTypesByRevokeKind<"token-revoke">;
+export type TokenRevokeConnectorTypesUseAuthProviders = AssertNever<
+  Exclude<TokenRevokeConnectorType, ConnectorAuthProviderType>
+>;
 
 export type ConnectorInvalidDefaultAuthMethodType<
   Configs extends Record<string, ConnectorConfig>,

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -1022,9 +1022,6 @@ export type RefreshTokenAccessConnectorType =
   ConnectorTypesByAccessKind<"refresh-token">;
 export type TokenRevokeConnectorType =
   ConnectorTypesByRevokeKind<"token-revoke">;
-export type TokenRevokeConnectorTypesUseAuthProviders = AssertNever<
-  Exclude<TokenRevokeConnectorType, ConnectorAuthProviderType>
->;
 type TokenRevokeConnectorTypeWithNonConfidentialClient = {
   [Type in TokenRevokeConnectorType]: {
     [Method in ConnectorAuthMethodKeys<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {


### PR DESCRIPTION
Closes #15435

## Summary
- add revoke-kind auth-method typing and a method-aware token revoke provider registry
- replace type-only revoke execution with `revokeConnectorAuthMethodAccessToken(type, authMethod, ...)`
- pass the stored connector auth method through API pending token revoke and cover unsupported-method behavior without loading tokens

## Tests
- `cd turbo && pnpm -F @vm0/connectors check-types`
- `cd turbo && pnpm -F @vm0/connectors lint`
- `cd turbo && pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts`
- `cd turbo && pnpm format && pnpm lint && pnpm check-types`
- `cd turbo && pnpm test` *(fails only in `@vm0/desktop src/computer-use-native.test.ts` macOS-only native CLI cases on this Linux container: `Desktop Computer Use is currently implemented for macOS`)*