### PR TITLE
fix: filter unavailable connector types from agent user-connectors GET

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors.test.ts
@@ -221,4 +221,50 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
 
     expect(response.body).toStrictEqual({ enabledTypes: ["github"] });
   });
+
+  it("ignores connector grants for feature-flag-disabled types", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    // `spotify` is a valid connector type but gated behind a feature switch
+    // that is off by default, so it must not be returned to the client. If it
+    // were, the client would replay it on the next update and the update
+    // endpoint would reject the whole request as unavailable.
+    await store.set(
+      seedUserConnector$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorType: "spotify",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedUserConnector$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorType: "github",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        params: { id: agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ enabledTypes: ["github"] });
+  });
 });

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -568,7 +568,24 @@ const getAgentUserConnectorsInner$ = computed(async (get) => {
       agentId: params.id,
     }),
   );
-  return { status: 200 as const, body: { enabledTypes: [...enabledTypes] } };
+  // Filter out connector types that are no longer available to the user (e.g.
+  // a connector gated behind a feature switch that has since been turned off).
+  // The update endpoint validates the entire submitted set and rejects it
+  // wholesale if any one type is unavailable; since the client replays the set
+  // returned here when authorizing a new connector, a stale unavailable type
+  // would otherwise block the user from authorizing any other connector on
+  // this agent.
+  const availability = await get(
+    userConnectorAvailability(auth.orgId, auth.userId),
+  );
+  const availableEnabledTypes = enabledTypes.filter((type) => {
+    const parsed = connectorTypeSchema.safeParse(type);
+    return parsed.success && availability.isConnectorTypeAvailable(parsed.data);
+  });
+  return {
+    status: 200 as const,
+    body: { enabledTypes: availableEnabledTypes },
+  };
 });
 
 const getAgentCustomConnectorsInner$ = computed(async (get) => {


### PR DESCRIPTION
## Problem

Authorizing **any** connector on an agent can fail with:

```
Connector types are not available: spotify
```

even when the user is not touching Spotify.

### Root cause

1. When the `SpotifyConnector` feature switch was on, the user authorized Spotify on an agent, persisting a `spotify` row in `userConnectors` (org/user/agent scoped).
2. `GET /agents/:id/user-connectors` (`zeroAgentEnabledConnectorTypes`) returned that row **unfiltered** — it only dropped types that fail `connectorTypeSchema` parsing, not types that are valid-but-unavailable (feature-flag gated).
3. The client (`authorizeConnector$` → `syncAuthorizedConnectors$`) replays the **full** `enabledTypes` set plus the newly authorized connector on update — it's a replace, not a merge.
4. The update endpoint validates **every** type and rejects the whole request once `spotify` is unavailable (its feature switch is now off).

Net effect: a stale, now-unavailable persisted connector blocks the user from authorizing **any** other connector on that agent.

## Fix

Filter the GET response by user connector availability, mirroring the existing availability filtering already done on the connector list endpoint (`storedConnectorTypeIsVisible`). The client therefore never receives — and never replays — a type that the update endpoint would reject.

## Test

Adds a case to `GET /api/zero/agents/:id/user-connectors`: a persisted `spotify` grant (feature switch off by default) is excluded from the response while `github` is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
