### PR TITLE
Enable masked session replay scoped to onboarding

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -12,7 +12,14 @@ export function initPostHog(): void {
     api_host: "/ingest",
     autocapture: false,
     capture_pageview: false,
+    // Replay is off app-wide; it is enabled only for scoped flows (currently
+    // onboarding) via startOnboardingSessionRecording(). When it runs, this
+    // config masks all inputs and text so we capture behavior, not content.
     disable_session_recording: true,
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "*",
+    },
     persistence: "localStorage+cookie",
     sanitize_properties(properties, _event) {
       if (properties?.$current_url) {
@@ -44,6 +51,28 @@ export function clearPostHogUser(): void {
     return;
   }
   posthog.reset();
+}
+
+// ── Scoped session replay ──────────────────────────────────────────
+//
+// Replay is disabled at init (see initPostHog). These helpers turn it on for a
+// single flow — currently onboarding — so we can see where new users drop off
+// without recording the entire app. Inputs and text are masked (see the
+// session_recording config), so replays show behavior, not content. The
+// onboarding route setup starts recording on enter and stops it on unmount.
+
+export function startOnboardingSessionRecording(): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.startSessionRecording();
+}
+
+export function stopOnboardingSessionRecording(): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.stopSessionRecording();
 }
 
 // ── Navigation timing (ccstate-based) ──────────────────────────────

--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -19,6 +19,10 @@ import {
 } from "../zero-page/billing.ts";
 import { allConnectorTypes$ } from "../zero-page/settings/connectors.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import {
+  startOnboardingSessionRecording,
+  stopOnboardingSessionRecording,
+} from "../../lib/posthog.ts";
 export const setupOnboardingPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(OnboardingPage));
@@ -103,6 +107,13 @@ export const setupOnboardingPage$ = command(
       set(detachedNavigateTo$, "/", { replace: true });
       return;
     }
+
+    // Scope session replay to the onboarding flow so we can see where new users
+    // drop off. Masked (all inputs + text); stops when the route unmounts.
+    startOnboardingSessionRecording();
+    signal.addEventListener("abort", () => {
+      stopOnboardingSessionRecording();
+    });
 
     // Fire Google Ads conversion event: user arrived at onboarding after signup
     type GtagFn = (...args: unknown[]) => void;


### PR DESCRIPTION
## What

Enables **session replay scoped to the onboarding flow** (masked), so we can see where new users drop off during activation — the paid funnel's most important step — without recording the rest of the app.

## How

- `lib/posthog.ts`: replay stays disabled app-wide. Adds a privacy-hardened `session_recording` config (`maskAllInputs: true`, `maskTextSelector: "*"`) and two scoped helpers: `startOnboardingSessionRecording()` / `stopOnboardingSessionRecording()`.
- `signals/onboarding-page/onboarding-page-setup.ts`: starts replay when the onboarding route mounts and stops it on the route's `AbortSignal` (unmount). Replays cover **only** onboarding and mask all inputs and text — they capture behavior, not content.

## Why

app.vm0.ai already reports into PostHog project 337442. The so.vm0.ai paid landing pages are being added to the same project (vm0-marketing#4, consent-gated), so this closes the loop on a continuous **landing → onboarding** behavioral funnel with replay on the activation step.

## For reviewers (privacy / consent)

Please confirm this matches app.vm0.ai's consent posture for session replay. The app already initializes PostHog with cookies + manual capture; this adds replay on one masked flow. If replay requires explicit consent beyond what the app already applies, gate `startOnboardingSessionRecording` on that signal. Not merging without your sign-off — flagging the privacy decision.

Note: I could not build the full monorepo in my environment; the change is small and follows the existing ccstate `command` + `AbortSignal` cleanup pattern, but please let CI / a local run confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
