### PR TITLE
feat(onboarding): curate connector picker to adopted + famous tools

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -259,6 +259,133 @@ export const allConnectorTypes$ = computed(async (get) => {
 });
 
 // ---------------------------------------------------------------------------
+// Onboarding connector curation
+//
+// The onboarding picker used to render the entire connector catalog (200+),
+// which buries the handful of tools real teams actually use. We curate it to
+// two sources: connectors external teams have actually connected (from a
+// masked production snapshot) plus a short list of famous tools. The full
+// catalog stays available from the connectors page after onboarding.
+// ---------------------------------------------------------------------------
+
+/**
+ * Connector types external (non-vm0) teams have actually connected, ordered by
+ * adoption (distinct external orgs). Generated from a masked production
+ * snapshot on 2026-05-30; refresh periodically against mask-db.
+ */
+const EXTERNAL_ADOPTED_ONBOARDING_TYPES: readonly string[] = [
+  "github",
+  "gmail",
+  "notion",
+  "x",
+  "slack",
+  "google-drive",
+  "google-calendar",
+  "google-sheets",
+  "agentmail",
+  "openai",
+  "cloudflare",
+  "deepseek",
+  "discord",
+  "intervals-icu",
+  "lark",
+  "google-docs",
+  "linear",
+  "serpapi",
+  "strava",
+  "tavily",
+  "vercel",
+  "discord-webhook",
+  "e2b",
+  "exa",
+  "figma",
+  "groq",
+  "hugging-face",
+  "minimax",
+  "apify",
+  "base44",
+  "browser-use",
+  "browserless",
+  "clickup",
+  "db9",
+  "drive9",
+  "dropbox",
+  "elevenlabs",
+  "fal",
+  "firecrawl",
+  "google-ads",
+  "google-meet",
+  "heygen",
+  "hubspot",
+  "jira",
+  "luma",
+  "luma-ai",
+  "mem0",
+  "neon",
+  "openweather",
+  "pdf4me",
+  "perplexity",
+  "railway",
+  "runway",
+  "sentry",
+  "slack-webhook",
+  "supabase",
+  "supadata",
+  "todoist",
+  "youtube",
+];
+
+/**
+ * Recognizable, commonly-used connectors we always surface during onboarding
+ * even when external adoption is still low.
+ */
+const FEATURED_ONBOARDING_TYPES: readonly string[] = [
+  "google-sheets",
+  "google-meet",
+  "dropbox",
+  "discord",
+  "zoom",
+  "calendly",
+  "asana",
+  "clickup",
+  "gitlab",
+  "salesforce",
+  "shopify",
+  "canva",
+  "perplexity",
+  "x",
+];
+
+const ONBOARDING_CONNECTOR_TYPE_SET: ReadonlySet<string> = new Set<string>([
+  ...EXTERNAL_ADOPTED_ONBOARDING_TYPES,
+  ...FEATURED_ONBOARDING_TYPES,
+]);
+
+/**
+ * Connector list shown in the onboarding picker: curated to external adoption
+ * plus famous tools, most-adopted first. Unknown ids are ignored because this
+ * intersects with the live catalog from {@link allConnectorTypes$}.
+ */
+export const onboardingConnectorTypes$ = computed(async (get) => {
+  const all = await get(allConnectorTypes$);
+  const adoptionRank = new Map<string, number>(
+    EXTERNAL_ADOPTED_ONBOARDING_TYPES.map((type, index) => {
+      return [type, index];
+    }),
+  );
+  return all
+    .filter((connector) => {
+      return ONBOARDING_CONNECTOR_TYPE_SET.has(connector.type);
+    })
+    .sort((a, b) => {
+      const ra = adoptionRank.get(a.type) ?? Number.MAX_SAFE_INTEGER;
+      const rb = adoptionRank.get(b.type) ?? Number.MAX_SAFE_INTEGER;
+      return ra - rb;
+    });
+});
+
+
+// ---------------------------------------------------------------------------
 // Hidden connector types (removed from list by user; persisted in localStorage)
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -356,11 +356,6 @@ const FEATURED_ONBOARDING_TYPES: readonly string[] = [
   "x",
 ];
 
-const ONBOARDING_CONNECTOR_TYPE_SET: ReadonlySet<string> = new Set<string>([
-  ...EXTERNAL_ADOPTED_ONBOARDING_TYPES,
-  ...FEATURED_ONBOARDING_TYPES,
-]);
-
 /**
  * Connector list shown in the onboarding picker: curated to external adoption
  * plus famous tools, most-adopted first. Unknown ids are ignored because this
@@ -368,6 +363,10 @@ const ONBOARDING_CONNECTOR_TYPE_SET: ReadonlySet<string> = new Set<string>([
  */
 export const onboardingConnectorTypes$ = computed(async (get) => {
   const all = await get(allConnectorTypes$);
+  const onboardingTypes = new Set<string>([
+    ...EXTERNAL_ADOPTED_ONBOARDING_TYPES,
+    ...FEATURED_ONBOARDING_TYPES,
+  ]);
   const adoptionRank = new Map<string, number>(
     EXTERNAL_ADOPTED_ONBOARDING_TYPES.map((type, index) => {
       return [type, index];
@@ -375,7 +374,7 @@ export const onboardingConnectorTypes$ = computed(async (get) => {
   );
   return all
     .filter((connector) => {
-      return ONBOARDING_CONNECTOR_TYPE_SET.has(connector.type);
+      return onboardingTypes.has(connector.type);
     })
     .sort((a, b) => {
       const ra = adoptionRank.get(a.type) ?? Number.MAX_SAFE_INTEGER;
@@ -383,7 +382,6 @@ export const onboardingConnectorTypes$ = computed(async (get) => {
       return ra - rb;
     });
 });
-
 
 // ---------------------------------------------------------------------------
 // Hidden connector types (removed from list by user; persisted in localStorage)

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -61,6 +61,7 @@ import {
 } from "../../signals/zero-page/zero-onboarding-actions.ts";
 import {
   allConnectorTypes$,
+  onboardingConnectorTypes$,
   connectConnectorOAuthAuthCode$,
   matchesConnectorSearch,
   pollingOAuthAuthCodeConnectorType$,
@@ -169,7 +170,7 @@ function SelectConnectorsContent() {
   const toggleConnector = useSet(toggleZeroConnector$);
   const search = useGet(connectorSearch$);
   const setSearch = useSet(setConnectorSearch$);
-  const connectorEntries = useLastResolved(allConnectorTypes$) ?? [];
+  const connectorEntries = useLastResolved(onboardingConnectorTypes$) ?? [];
 
   const filtered = connectorEntries.filter((connector) => {
     return matchesConnectorSearch(search, connector);


### PR DESCRIPTION
## What

The onboarding connector picker (`SelectConnectorsContent`) rendered the **entire connector catalog** (200+ types) in a grid, filtered only by search. Most of those have never been connected by a real external team, so the picker is noisy and buries the tools people actually use during their first run.

This curates the onboarding picker to two sources:

1. **Connectors external (non-vm0) teams have actually connected** — from a masked production snapshot (`mask-db`, `connectors` table, internal vm0 orgs + personal-email allowlist excluded), ordered by distinct external orgs.
2. **A short allowlist of famous, commonly-used tools** we always surface even where external adoption is still low.

The full catalog stays available from the connectors page after onboarding — only the onboarding picker is curated. Unknown ids in either list are ignored because the curation intersects with the live catalog from `allConnectorTypes$`.

## Data — external adoption (distinct external orgs), masked prod 2026-05-30

`github` (50), `gmail` (22), `notion` (17), `x` (15), `slack` (10), `google-drive` (9), `google-calendar` (8), `google-sheets` (8), `agentmail` (7), `openai` (6), `cloudflare` (4), `deepseek` (4), `discord` (4), `intervals-icu` (4), `lark` (4), `google-docs` (3), `linear` (3), `serpapi` (3), `strava` (3), `tavily` (3), `vercel` (3), `discord-webhook` (2), `e2b` (2), `exa` (2), `figma` (2), `groq` (2), `hugging-face` (2), `minimax` (2), `apify` (1), `base44` (1), `browser-use` (1), `browserless` (1), `clickup` (1), `db9` (1), `drive9` (1), `dropbox` (1), `elevenlabs` (1), `fal` (1), `firecrawl` (1), `google-ads` (1), `google-meet` (1), `heygen` (1), `hubspot` (1), `jira` (1), `luma` (1), `luma-ai` (1), `mem0` (1), `neon` (1), `openweather` (1), `pdf4me` (1), `perplexity` (1), `railway` (1), `runway` (1), `sentry` (1), `slack-webhook` (1), `supabase` (1), `supadata` (1), `todoist` (1), `youtube` (1)

**Featured (famous, surfaced regardless of adoption):** `google-sheets`, `google-meet`, `dropbox`, `discord`, `zoom`, `calendly`, `asana`, `clickup`, `gitlab`, `salesforce`, `shopify`, `canva`, `perplexity`, `x`

## Changes

- `settings/connectors.ts`: add `EXTERNAL_ADOPTED_ONBOARDING_TYPES` (adoption-ordered, generated from mask-db), `FEATURED_ONBOARDING_TYPES`, and a new `onboardingConnectorTypes$` computed that filters `allConnectorTypes$` to the union and orders by adoption.
- `zero-onboarding.tsx`: the picker now reads `onboardingConnectorTypes$` instead of `allConnectorTypes$`. The connect/trial/orbit steps still use the full list (they only render already-selected connectors).

## Notes

- The adopted list is a static snapshot baked into the source (the picker is a client component and can't query prod). Comments mark it for periodic refresh against mask-db.
- The **featured** list is a judgement call and easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
