### PR TITLE
web: forward ad attribution from homepage CTAs into the app

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -5,6 +5,7 @@ import NextLink from "next/link";
 import { useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 import { getAppUrl } from "../../src/lib/zero/url";
+import { buildSignupHref } from "../../src/lib/adAttribution";
 import { Footer } from "./Footer";
 import Image from "next/image";
 import { AvatarCustomizer } from "./AvatarCustomizer";
@@ -826,8 +827,16 @@ export function LandingPage({ initialIsSignedIn = false }: LandingPageProps) {
   const revealRef = useScrollReveal();
   const t = useTranslations("landing");
 
+  // Forward inbound ad attribution (gclid/utm) from the homepage into the app
+  // so paid campaigns landing here keep their attribution into Stripe/Clerk.
+  const appUrl = getAppUrl();
+  const [landingSearch, setLandingSearch] = useState("");
+  useEffect(() => {
+    setLandingSearch(window.location.search);
+  }, []);
+
   const ctaText = isSignedIn ? t("hero.ctaOpenApp") : t("hero.ctaGetStarted");
-  const ctaHref = isSignedIn ? getAppUrl() : "/sign-up";
+  const ctaHref = isSignedIn ? appUrl : buildSignupHref(appUrl, landingSearch);
 
   return (
     <div

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -23,6 +23,7 @@ import { LanguageSwitcher } from "./LanguageSwitcher";
 import { NavMenu, type NavMenuItem } from "./NavMenu";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { getAppUrl } from "../../src/lib/zero/url";
+import { buildSignupHref } from "../../src/lib/adAttribution";
 import { isBlogEnabled } from "../../src/env";
 
 interface NavbarProps {
@@ -305,6 +306,14 @@ export function Navbar({
   const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
   const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
   const { signOut } = useClerk();
+  // Forward inbound ad attribution (gclid/utm) from the homepage into the app
+  // for the signed-out "Get started" CTAs; organic visits keep /sign-up.
+  const appUrl = getAppUrl();
+  const [landingSearch, setLandingSearch] = useState("");
+  useEffect(() => {
+    setLandingSearch(window.location.search);
+  }, []);
+  const signupHref = buildSignupHref(appUrl, landingSearch);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const desktopNavRef = useRef<HTMLDivElement | null>(null);
   const {
@@ -489,7 +498,7 @@ export function Navbar({
                   {t("contact")}
                 </a>
                 <NextLink
-                  href="/sign-up"
+                  href={signupHref}
                   className="btn-get-access nav-desktop"
                 >
                   {t("joinWaitlist")}
@@ -581,7 +590,7 @@ export function Navbar({
             </a>
             {!isSignedIn && (
               <NextLink
-                href="/sign-up"
+                href={signupHref}
                 className="mobile-menu-link mobile-menu-cta"
                 onClick={closeMobile}
               >

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -49,7 +49,9 @@ const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
 //   on them surviving the Clerk redirect.
 export function buildSignupHref(appUrl: string, landingSearch: string): string {
   const params = new URLSearchParams(landingSearch);
-  const isAdTraffic = AD_TRAFFIC_MARKERS.some((param) => params.has(param));
+  const isAdTraffic = AD_TRAFFIC_MARKERS.some((param) => {
+    return params.has(param);
+  });
   if (!isAdTraffic) {
     return "/sign-up";
   }

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -1,0 +1,66 @@
+// Forward inbound ad attribution from the www.vm0.ai marketing pages into the
+// app, so paid campaigns that land on the homepage (e.g. the "Ha"/"Hb" Google
+// Ads campaigns hitting https://www.vm0.ai/?gclid=...&utm_campaign=ha) keep
+// their attribution all the way into Clerk private_metadata + Stripe checkout
+// metadata.
+//
+// The app's capture layer (apps/platform recordAdAttribution) is entirely
+// driven by the inbound URL query, so the only thing missing is forwarding the
+// params onto the CTA href. The so.vm0.ai landing pages already do this via
+// buildPresentationRemixHref; this is the homepage equivalent.
+
+// Params forwarded verbatim. Mirrors apps/platform ad-attribution.ts and the
+// presentation LP helper so the same keys flow through end to end.
+const AD_ATTRIBUTION_PARAMS = [
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "vm0_experiment",
+  "vm0_variant",
+  "lp_variant",
+] as const;
+
+// Presence of any of these marks the visit as paid/campaign traffic. We only
+// reroute + stamp those visits, leaving the organic homepage /sign-up flow
+// untouched.
+const AD_TRAFFIC_MARKERS = [
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "utm_source",
+  "utm_campaign",
+] as const;
+
+const ATTRIBUTION_SOURCE_PARAM = "vm0_source";
+const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
+
+// Build the signed-out CTA href.
+// - Organic visits (no ad params): return the existing relative "/sign-up" so
+//   the homepage flow is unchanged.
+// - Ad/campaign visits: route straight to the app's /onboarding with the ad
+//   params forwarded (and vm0_source=homepage), matching how the so.vm0.ai
+//   landing pages work. Going direct to the app means recordAdAttribution fires
+//   on first app load and stores the params before sign-up, instead of relying
+//   on them surviving the Clerk redirect.
+export function buildSignupHref(appUrl: string, landingSearch: string): string {
+  const params = new URLSearchParams(landingSearch);
+  const isAdTraffic = AD_TRAFFIC_MARKERS.some((param) => params.has(param));
+  if (!isAdTraffic) {
+    return "/sign-up";
+  }
+
+  const url = new URL("/onboarding", appUrl);
+  url.searchParams.set(ATTRIBUTION_SOURCE_PARAM, HOMEPAGE_ATTRIBUTION_VALUE);
+  for (const param of AD_ATTRIBUTION_PARAMS) {
+    for (const value of params.getAll(param)) {
+      url.searchParams.append(param, value);
+    }
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
## Problem

The **www.vm0.ai homepage** is the landing page for our Google Ads **Ha/Hb** campaigns (ads land on `https://www.vm0.ai/?gclid=...&utm_source=google&utm_medium=cpc&utm_campaign=ha`). But the signed-out **"Get started"** CTAs hardcode `href="/sign-up"`, which **drops the entire ad query string** at the homepage → app handoff.

Result (verified in Stripe): so.vm0.ai landing-page checkout sessions carry full `gclid + utm_* + vm0_source` metadata, while **homepage-origin (Ha/Hb) sessions carry no attribution at all** — so we can't attribute a single trial or paid conversion back to those campaigns.

Root cause is purely the missing forward: `apps/platform`'s `recordAdAttribution()` is entirely **inbound-URL-driven** (reads the query → sessionStorage → Stripe checkout metadata + Clerk `private_metadata`). The capture side already works; the homepage just never passes the params along. (There's also a secondary stripper: after Clerk sign-up, `app/layout.tsx` `signUpFallbackRedirectUrl={getAppUrl()}` redirects with no query — which is why we route directly to the app, see below.)

## Fix

New helper `turbo/apps/web/src/lib/adAttribution.ts` → `buildSignupHref(appUrl, search)`:

- **Organic visits (no ad params): unchanged.** Returns the existing relative `/sign-up`. Zero behavior change for non-ad traffic.
- **Ad/campaign visits (gclid/gbraid/wbraid/utm_source/utm_campaign present):** routes the signed-out CTA straight to `app /onboarding` with the ad params forwarded (+ `vm0_source=homepage`), mirroring how the so.vm0.ai landing pages work. Going direct to the app means `recordAdAttribution` fires on first app load and stores the params **before** sign-up, sidestepping the Clerk-redirect query stripping.

Wired into the signed-out CTAs in `LandingPage.tsx` (hero + bottom) and `Navbar.tsx` (desktop + mobile). No allowlist concern: `apps/platform/.../ad-attribution.ts` records `vm0_source` verbatim (no validation).

## Scope / risk
- 3 files, +87/-3. Only the **signed-out, ad-tagged** homepage path changes; organic `/sign-up` and the signed-in "Open app" path are untouched.
- `vm0_source=homepage` is a new source value (no allowlist to update) so homepage-origin paid conversions become sliceable, distinct from `presentation`.

## Note for reviewers (product/web)
This changes the signed-out homepage CTA **destination for ad traffic** from on-site `/sign-up` to app `/onboarding` (same as every paid LP). If you'd prefer to keep ad traffic on the on-site `/sign-up` page, the alternative is to also thread the params through the Clerk `signUpFallbackRedirectUrl` — happy to switch approaches. Flagging since the homepage is your surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)