### PR TITLE
fix(web): allow paid-onboarding origin in Clerk allowedRedirectOrigins

### DIFF
--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -13,7 +13,7 @@ import {
   getClerkFrontendApiHost,
   getClerkPublishableKey,
 } from "../src/lib/shared/clerk-config";
-import { getAppUrl } from "../src/lib/zero/url";
+import { getAllowedRedirectOrigins, getAppUrl } from "../src/lib/zero/url";
 import { SafeGoogleOneTap } from "./components/SafeGoogleOneTap";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { env } from "../src/env";
@@ -154,7 +154,7 @@ export default async function RootLayout({
       signUpUrl="/sign-up"
       signInFallbackRedirectUrl={getAppUrl()}
       signUpFallbackRedirectUrl={getAppUrl()}
-      allowedRedirectOrigins={[getAppUrl()]}
+      allowedRedirectOrigins={getAllowedRedirectOrigins()}
     >
       <SafeGoogleOneTap redirectUrl={getAppUrl()} />
       <html lang={htmlLang} data-theme="dark" suppressHydrationWarning>

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -272,6 +272,9 @@ function initEnv() {
       NEXT_PUBLIC_STRAPI_URL: z.url().optional(),
       // App UI URL (for settings page links, Navbar, LandingPage)
       NEXT_PUBLIC_APP_URL: z.url(),
+      // Paid-onboarding origin (e.g. so.vm0.ai) allowed to receive post-auth
+      // redirects from Clerk. Set per environment; omit to keep app-only.
+      NEXT_PUBLIC_PAID_ONBOARDING_URL: z.url().optional(),
       // Analytics (Plausible)
       NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL: z.url().optional(),
     },
@@ -422,6 +425,8 @@ function initEnv() {
       GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
       GITHUB_APP_WEBHOOK_SECRET: process.env.GITHUB_APP_WEBHOOK_SECRET,
       NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+      NEXT_PUBLIC_PAID_ONBOARDING_URL:
+        process.env.NEXT_PUBLIC_PAID_ONBOARDING_URL,
       RESEND_API_KEY: process.env.RESEND_API_KEY,
       RESEND_WEBHOOK_SECRET: process.env.RESEND_WEBHOOK_SECRET,
       RESEND_FROM_DOMAIN: process.env.RESEND_FROM_DOMAIN,

--- a/turbo/apps/web/src/lib/zero/url.ts
+++ b/turbo/apps/web/src/lib/zero/url.ts
@@ -3,3 +3,12 @@ import { env } from "../../env";
 export function getAppUrl(): string {
   return env().NEXT_PUBLIC_APP_URL;
 }
+
+// Origins Clerk is allowed to redirect back to after sign-in/sign-up. Always
+// includes the app; optionally includes the paid-onboarding origin (so.vm0.ai)
+// when configured per environment, so a paid onboarding flow hosted on a
+// sibling *.vm0.ai subdomain can run auth on www and return to itself.
+export function getAllowedRedirectOrigins(): string[] {
+  const paidOnboardingUrl = env().NEXT_PUBLIC_PAID_ONBOARDING_URL;
+  return paidOnboardingUrl ? [getAppUrl(), paidOnboardingUrl] : [getAppUrl()];
+}


### PR DESCRIPTION
## What

Makes the Clerk `allowedRedirectOrigins` on www configurable so it can include the **paid-onboarding origin** (`so.vm0.ai`) in addition to the app.

- New optional client env `NEXT_PUBLIC_PAID_ONBOARDING_URL`.
- New helper `getAllowedRedirectOrigins()` in `src/lib/zero/url.ts` returning `[app]` or `[app, paidOnboarding]`.
- `app/layout.tsx` ClerkProvider now uses `getAllowedRedirectOrigins()` instead of the hardcoded `[getAppUrl()]`.

## Why

We're building a paid-channel-specific onboarding flow hosted directly on `so.vm0.ai` (repo `vm0-ai/vm0-marketing`), so paid-ads users go straight into an experiment-friendly onboarding without changing two projects. That flow is client-only, shares the root `.vm0.ai` Clerk session cookie, and gets a Bearer token via `getToken()` exactly like `app.vm0.ai` (no satellite — see #8564). Sign-in/sign-up stays on www; after auth the user must be redirected **back to so.vm0.ai**.

Today `allowedRedirectOrigins` is the single value `[getAppUrl()]` (= `app.vm0.ai`), so Clerk drops any redirect back to `so.vm0.ai` and falls through to the app fallback. This is the one and only main-repo change required; everything else (token, org/setup, connectors, checkout) needs no code change.

## Behavior / rollout

- **Unset (default): no behavior change** — origins remain app-only.
- Set per environment in Vercel:
  - prod web: `NEXT_PUBLIC_PAID_ONBOARDING_URL=https://so.vm0.ai`
  - staging web: the staging marketing origin (so the test Clerk instance can validate the round-trip)

Env-driven (rather than hardcoding `so.vm0.ai`) specifically so staging — which runs on the **test** Clerk publishable key — can allow its own staging origin without leaking prod into staging.

## Test plan

- `NEXT_PUBLIC_PAID_ONBOARDING_URL` unset → `allowedRedirectOrigins === [app]` (unchanged).
- Set → `[app, paidOnboarding]`; www sign-up with `redirect_url` on that origin returns there instead of the app fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)