### PR TITLE
fix: include query auth secrets in firewall metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -943,6 +943,45 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("reports secrets resolved only from auth base and query templates", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            BASE_TOKEN: "base-token",
+            QUERY_TOKEN: "query-token",
+          }),
+          authHeaders: {},
+          authBase: `https://api.example.com/${secretTemplate("BASE_TOKEN")}`,
+          authQuery: {
+            api_key: secretTemplate("QUERY_TOKEN"),
+            workspace: varTemplate("WORKSPACE_ID"),
+          },
+          vars: {
+            WORKSPACE_ID: "workspace-1",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      headers: {},
+      base: "https://api.example.com/base-token",
+      query: {
+        api_key: "query-token",
+        workspace: "workspace-1",
+      },
+      expiresAt: null,
+      resolvedSecrets: ["BASE_TOKEN", "QUERY_TOKEN"],
+      refreshedConnectors: [],
+      refreshedSecrets: [],
+    });
+  });
+
   it("resolves basic auth template edge cases", async () => {
     const fixture = await track(seedFixture());
     const encode = (value: string): string => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2316,17 +2316,20 @@ function resolveTemplates(
     headers[name] = resolved;
   }
 
+  const base = authBase ? resolveSimple(authBase) : undefined;
+  const query = authQuery
+    ? Object.fromEntries(
+        Object.entries(authQuery).map(([key, value]) => {
+          return [key, resolveSimple(value)];
+        }),
+      )
+    : undefined;
+
   return {
     headers,
     resolvedSecrets: [...resolvedKeys].sort(),
-    base: authBase ? resolveSimple(authBase) : undefined,
-    query: authQuery
-      ? Object.fromEntries(
-          Object.entries(authQuery).map(([key, value]) => {
-            return [key, resolveSimple(value)];
-          }),
-        )
-      : undefined,
+    base,
+    query,
   };
 }
 


### PR DESCRIPTION
## Summary
- resolve auth.base and auth.query templates before building firewall auth resolvedSecrets metadata
- report secrets that are referenced only from auth.base/auth.query
- add a regression test for base/query-only secret templates

## Tests
- pnpm -F @vm0/db db:migrate
- pnpm -F @vm0/firewalls-generator generate:tripo (local setup for latest main generated firewall)
- pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts --run
- pnpm -F api lint
- pnpm -F api check-types
- git diff --check
- pre-commit hook: prettier, knip, check-types, commitlint