### PR TITLE
fix(web): feed NEXT_PUBLIC_PAID_ONBOARDING_URL through the deploy pipeline

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -147,6 +147,7 @@ runs:
         if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
           web_url="${INPUT_WEB_URL:-https://www.vm0.ai}"
           app_url="${INPUT_APP_URL:-https://app.vm0.ai}"
+          paid_onboarding_url="$(first_non_empty "$(repo_var PAID_ONBOARDING_URL)" "https://so.vm0.ai")"
           api_url="${INPUT_API_URL:-$(repo_var VM0_API_URL)}"
           api_backend_url="$(first_non_empty "$INPUT_API_BACKEND_URL" "$(repo_var VM0_API_BACKEND_URL)")"
           axiom_dataset_suffix="prod"
@@ -163,6 +164,13 @@ runs:
         else
           web_url="$INPUT_WEB_URL"
           app_url="$INPUT_APP_URL"
+          # Only the dedicated "staging" preview has a matching paid-onboarding
+          # origin; ad-hoc PR previews have none, so leave it unset there.
+          if [[ "$INPUT_JOB_REF" == "staging" ]]; then
+            paid_onboarding_url="$(first_non_empty "$(repo_var PAID_ONBOARDING_URL_STAGING)" "https://staging-so.vm6.ai")"
+          else
+            paid_onboarding_url=""
+          fi
           api_url="$INPUT_API_URL"
           api_backend_url="$INPUT_API_BACKEND_URL"
           axiom_dataset_suffix="dev"
@@ -315,6 +323,9 @@ runs:
         add_secret AGENTPHONE_WEBHOOK_SECRET AGENTPHONE_WEBHOOK_SECRET
         add_secret PLAIN_API_KEY PLAIN_API_KEY
         add_env APP_URL "$app_url"
+        if [[ -n "$paid_onboarding_url" ]]; then
+          add_env PAID_ONBOARDING_URL "$paid_onboarding_url"
+        fi
         add_secret RESEND_API_KEY RESEND_API_KEY
         add_secret RESEND_WEBHOOK_SECRET RESEND_WEBHOOK_SECRET
         add_var RESEND_FROM_DOMAIN RESEND_FROM_DOMAIN

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -104,6 +104,9 @@ const nextConfig = {
     // App URLs
     NEXT_PUBLIC_APP_URL: process.env.APP_URL,
 
+    // Paid-onboarding origin (so.vm0.ai) allowed as a post-auth redirect target
+    NEXT_PUBLIC_PAID_ONBOARDING_URL: process.env.PAID_ONBOARDING_URL,
+
     // Blog configuration
     NEXT_PUBLIC_BASE_URL: process.env.BLOG_BASE_URL,
     NEXT_PUBLIC_STRAPI_URL: process.env.STRAPI_URL,


### PR DESCRIPTION
## What

Follow-up to #15518 (merged). #15518 added the `NEXT_PUBLIC_PAID_ONBOARDING_URL` env + `getAllowedRedirectOrigins()` helper and wired the ClerkProvider prop — but nothing **feeds** that value at deploy time, so it was always undefined (app-only, no-op).

This PR completes the wiring:
- `turbo/apps/web/next.config.js`: map `PAID_ONBOARDING_URL` → `NEXT_PUBLIC_PAID_ONBOARDING_URL` (same clean-name convention as `APP_URL`/`CLERK_PUBLISHABLE_KEY`).
- `.github/actions/web-api-env/action.yml`: emit `PAID_ONBOARDING_URL` per environment — production → `https://so.vm0.ai`, the dedicated `staging` preview → `https://staging-so.vm6.ai`. Ad-hoc PR previews leave it unset (no matching paid-onboarding origin). Both have repo-var overrides (`PAID_ONBOARDING_URL`, `PAID_ONBOARDING_URL_STAGING`).

## Why

So a paid onboarding flow hosted on `so.vm0.ai` (and the `staging-so.vm6.ai` spike on the staging test Clerk instance) can run sign-in/sign-up on www and be redirected back to itself. Together with #15518 this is the complete, environment-correct change.

## Test plan

- Production build: `NEXT_PUBLIC_PAID_ONBOARDING_URL=https://so.vm0.ai` → `allowedRedirectOrigins=[app, so.vm0.ai]`.
- `staging` preview: `=https://staging-so.vm6.ai` → redirect back to the staging spike works.
- Other PR previews: unset → `allowedRedirectOrigins=[app]` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)