### PR TITLE
test(mitm-addon): cover invalid utf8 ndjson lines

### DIFF
--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -62,6 +62,14 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
         assert state["lines_failed"] == 1
 
+    def test_invalid_utf8_line_increments_failures_and_continues(self):
+        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse(b'\x80{"data":{"id":"bad"}}\n{"data":{"id":"after"}}\n')
+
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 1
+
     def test_truncated_trailing_line_not_counted(self):
         """Connection drops mid-line — partial trailing line stays in buf, not counted."""
         parse, state = usage_x_connector.create_ndjson_extractor()


### PR DESCRIPTION
## Summary

- add coverage for invalid UTF-8 NDJSON lines in the X streaming parser
- verify a malformed UTF-8 line increments `lines_failed`
- verify the parser continues to parse a following valid line in the same chunk

Closes #15491

## Tests

- `python3 -m pip install --target /tmp/vm2-mitm-addon-pydeps-15491 '.[test]'`
- `PYTHONPATH="/tmp/vm2-mitm-addon-pydeps-15491:src" python3 -m pytest tests/test_response_streaming.py -q` (38 passed)
- `python3 -m py_compile src/usage/providers/connectors/x.py tests/test_response_streaming.py`
- pre-commit: `ruff-fmt`, `ruff-check`