### PR TITLE
fix: skip non-billable connector response parsers

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -96,7 +96,10 @@ def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponsePa
 
     The returned parser is wired into the response stream and may publish
     connector-owned ``flow.metadata`` state for ``report_connector_usage``.
+    Non-billable flows never need connector billing parser state.
     """
+    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
+        return None
     firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
     factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
     if factory is None:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -262,8 +262,6 @@ def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | Non
             flow.metadata[metadata_keys.X_NDJSON_STATE] = ndjson_state
             return ConnectorResponseParser(feed=parser_fn)
 
-    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
-        return None
     if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
         return None
 

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -3,6 +3,7 @@
 import gzip
 import json
 
+import pytest
 from mitmproxy.test import tutils
 
 import body_utils
@@ -496,14 +497,18 @@ class TestResponseHeadersHandler:
         assert "x_ndjson_state" not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
-    def test_non_billable_x_stream_uses_bounded_forensic_buffer_only(self, real_flow, headers):
+    @pytest.mark.parametrize("firewall_billable", [False, None])
+    def test_non_billable_x_stream_uses_bounded_forensic_buffer_only(
+        self, real_flow, headers, firewall_billable
+    ):
         """Non-billable X streams should not attach the billable NDJSON parser."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "x"
-        flow.metadata["firewall_billable"] = False
+        if firewall_billable is not None:
+            flow.metadata["firewall_billable"] = firewall_billable
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
 
         mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -156,6 +156,7 @@ class TestResponseHeadersHandler:
         """
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
@@ -175,6 +176,7 @@ class TestResponseHeadersHandler:
         """Stream endpoint must NOT buffer multi-MB bodies — uses 64 KB cap."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
@@ -221,6 +223,7 @@ class TestResponseHeadersHandler:
             with_response=False, host="api.x.com", path="/2/tweets/search/stream/rules"
         )
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream/rules"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
@@ -268,6 +271,7 @@ class TestResponseHeadersHandler:
 
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
         flow.response = tutils.tresp(
             status_code=200,
@@ -483,6 +487,29 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         callback = response_stream(flow)
+        callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
+
+        buf = flow.metadata["stream_buffer"]
+        state = flow.metadata["stream_buffer_state"]
+        assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
+        assert state["truncated"]
+        assert "x_ndjson_state" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
+
+    def test_non_billable_x_stream_uses_bounded_forensic_buffer_only(self, real_flow, headers):
+        """Non-billable X streams should not attach the billable NDJSON parser."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
+        flow.response = tutils.tresp(
+            status_code=200, headers=header_map({"content-type": "application/json"})
+        )
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = False
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+
+        mitm_addon.responseheaders(flow)
+
+        callback = response_stream(flow)
+        callback(b'{"data":{"id":"1"}}\n')
         callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
 
         buf = flow.metadata["stream_buffer"]


### PR DESCRIPTION
## Summary

- Gate connector response parser creation on `FIREWALL_BILLABLE` in the dispatcher.
- Remove the redundant billable guard from the X parser factory now that the invariant is enforced before dispatch.
- Add coverage for non-billable X streams to ensure they keep the capped forensic buffer without attaching the NDJSON billing parser.

Fixes #15492.

## Tests

- `pytest crates/runner/mitm-addon/tests/test_response_headers_handler.py`
- `pytest crates/runner/mitm-addon/tests/test_response_streaming.py`
- `pytest crates/runner/mitm-addon/tests/test_connector_usage.py`
- `pytest crates/runner/mitm-addon/tests`
- `ruff check crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py crates/runner/mitm-addon/src/usage/providers/connectors/x.py crates/runner/mitm-addon/tests/test_response_headers_handler.py`
- `python3 -m py_compile crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py crates/runner/mitm-addon/src/usage/providers/connectors/x.py crates/runner/mitm-addon/tests/test_response_headers_handler.py`
- `git diff --check -- crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py crates/runner/mitm-addon/src/usage/providers/connectors/x.py crates/runner/mitm-addon/tests/test_response_headers_handler.py`
